### PR TITLE
Use system local time zone instead of hardcoded UTC+8

### DIFF
--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -1089,7 +1089,9 @@ UID: {user_id} 此 ID 可用于设置管理员。/op <UID> 授权管理员, /deo
             req.prompt = user_info + req.prompt
 
         if self.enable_datetime:
-            current_time = datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M")
+            current_time = (
+                datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M")
+            )
             req.system_prompt += f"\nCurrent datetime: {current_time}\n"
 
         if req.conversation:


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->

### Motivation
当提问涉及时间或调用工具涉及时间时，海外用户无法使用正确的当地时间

### Modifications
开启 datetime_system_prompt 时，使用 datetime.astimezone() 获取系统本地时区时间