### PR TITLE
feat(core): 在 MessageChain 类中添加 at 和 at_all 方法

### DIFF
--- a/astrbot/core/message/message_event_result.py
+++ b/astrbot/core/message/message_event_result.py
@@ -2,7 +2,13 @@ import enum
 
 from typing import List, Optional, Union
 from dataclasses import dataclass, field
-from astrbot.core.message.components import BaseMessageComponent, Plain, Image, At, AtAll
+from astrbot.core.message.components import (
+    BaseMessageComponent,
+    Plain,
+    Image,
+    At,
+    AtAll,
+)
 from typing_extensions import deprecated
 
 

--- a/astrbot/core/message/message_event_result.py
+++ b/astrbot/core/message/message_event_result.py
@@ -1,8 +1,8 @@
 import enum
 
-from typing import List, Optional
+from typing import List, Optional, Union
 from dataclasses import dataclass, field
-from astrbot.core.message.components import BaseMessageComponent, Plain, Image
+from astrbot.core.message.components import BaseMessageComponent, Plain, Image, At, AtAll
 from typing_extensions import deprecated
 
 
@@ -29,6 +29,30 @@ class MessageChain:
 
         """
         self.chain.append(Plain(message))
+        return self
+
+    def at(self, name: str, qq: Union[str, int]):
+        """添加一条 At 消息到消息链 `chain` 中。
+
+        Example:
+
+            CommandResult().at("张三", "12345678910")
+            # 输出 @张三
+
+        """
+        self.chain.append(At(name=name, qq=qq))
+        return self
+
+    def at_all(self):
+        """添加一条 AtAll 消息到消息链 `chain` 中。
+
+        Example:
+
+            CommandResult().at_all()
+            # 输出 @所有人
+
+        """
+        self.chain.append(AtAll())
         return self
 
     @deprecated("请使用 message 方法代替。")


### PR DESCRIPTION
- 新增 at 方法，用于添加 At 消息到消息链中
- 新增 at_all 方法，用于添加 AtAll 消息到消息链中

### 原因

在开发插件时发现使用event.send()发送消息时无法@对方，代码中添加上述方法后测试@能生效，后续我会分享相关插件

### 示例

await event.send(
                    MessageChain().at(user_name, user_id).message(f"您今日的AI访问次数已达上限({limit}次)，"
                                                                  f"请明天再试或联系管理员提升限额。")
                )
