### PR TITLE
在lifecycle新增插件资源清理逻辑

### DIFF
--- a/astrbot/core/core_lifecycle.py
+++ b/astrbot/core/core_lifecycle.py
@@ -133,6 +133,16 @@ class AstrBotCoreLifecycle:
         for task in self.curr_tasks:
             task.cancel()
 
+        for plugin in self.plugin_manager.context.get_all_stars():
+            logger.info(f"正在终止插件 {plugin.name} ...")
+            try:
+                await self.plugin_manager._terminate_plugin(plugin)
+            except Exception as e:
+                logger.warning(traceback.format_exc())
+                logger.warning(
+                    f"插件 {plugin.name} 未被正常终止 {e!s}, 可能会导致资源泄露等问题。"
+                )
+
         await self.provider_manager.terminate()
         await self.platform_manager.terminate()
         self.dashboard_shutdown_event.set()

--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -558,7 +558,7 @@ class PluginManager:
 
     async def _terminate_plugin(self, star_metadata: StarMetadata):
         """终止插件，调用插件的 terminate() 和 __del__() 方法"""
-        logging.info(f"正在终止插件 {star_metadata.name} ...")
+        logger.info(f"正在终止插件 {star_metadata.name} ...")
 
         if not star_metadata.activated:
             # 说明之前已经被禁用了


### PR DESCRIPTION
修复了 #1039 

### Motivation

当通过CTRL+C终止Astrobot时未调用插件的terminate()方法，导致插件资源未能正常释放。

### Modifications

添加调用逻辑
