### PR TITLE
perf: 优化无对话情况下设置人格的反馈；若禁用提供商，自动切换到另一个可用的提供商

### DIFF
--- a/astrbot/core/provider/manager.py
+++ b/astrbot/core/provider/manager.py
@@ -306,10 +306,42 @@ class ProviderManager:
 
         if len(self.provider_insts) == 0:
             self.curr_provider_inst = None
+        elif (
+            self.curr_provider_inst is None
+            and len(self.provider_insts) > 0
+            and self.provider_enabled
+        ):
+            self.curr_provider_inst = self.provider_insts[0]
+            self.selected_provider_id = self.curr_provider_inst.meta().id
+            logger.info(
+                f"自动选择 {self.curr_provider_inst.meta().id} 作为当前提供商适配器。"
+            )
+
         if len(self.stt_provider_insts) == 0:
             self.curr_stt_provider_inst = None
+        elif (
+            self.curr_stt_provider_inst is None
+            and len(self.stt_provider_insts) > 0
+            and self.stt_enabled
+        ):
+            self.curr_stt_provider_inst = self.stt_provider_insts[0]
+            self.selected_stt_provider_id = self.curr_stt_provider_inst.meta().id
+            logger.info(
+                f"自动选择 {self.curr_stt_provider_inst.meta().id} 作为当前语音转文本提供商适配器。"
+            )
+
         if len(self.tts_provider_insts) == 0:
             self.curr_tts_provider_inst = None
+        elif (
+            self.curr_tts_provider_inst is None
+            and len(self.tts_provider_insts) > 0
+            and self.tts_enabled
+        ):
+            self.curr_tts_provider_inst = self.tts_provider_insts[0]
+            self.selected_tts_provider_id = self.curr_tts_provider_inst.meta().id
+            logger.info(
+                f"自动选择 {self.curr_tts_provider_inst.meta().id} 作为当前文本转语音提供商适配器。"
+            )
 
     def get_insts(self):
         return self.provider_insts

--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -1018,6 +1018,13 @@ UID: {user_id} 此 ID 可用于设置管理员。
             message.set_result(MessageEventResult().message("取消人格成功。"))
         else:
             ps = "".join(l[1:]).strip()
+            if not cid:
+                message.set_result(
+                    MessageEventResult().message(
+                        "当前没有对话，请先开始对话或使用 /new 创建一个对话。"
+                    )
+                )
+                return
             if persona := next(
                 builtins.filter(
                     lambda persona: persona["name"] == ps,


### PR DESCRIPTION
修复了 #1055

### Motivation

无对话情况下提示不明确。禁用提供商没有自动切换

### Modifications

提前判断是否存在对话。若禁用提供商，自动切换到另一个可用的提供商。
