### PR TITLE
修复有关llm函数上下文的问题

### DIFF
--- a/astrbot/core/conversation_mgr.py
+++ b/astrbot/core/conversation_mgr.py
@@ -174,10 +174,13 @@ class ConversationManager:
         for record in history:
             if record["role"] == "user":
                 temp_contexts.append(f"User: {record['content']}")
-            elif record["role"] == "assistant":
-                temp_contexts.append(f"Assistant: {record['content']}")
-                contexts.insert(0, temp_contexts)
-                temp_contexts = []
+            elif record["role"] == "assistant":#排除tool_calls
+                if record.get("content") != None:
+                    temp_contexts.append(f"Assistant: {record['content']}")
+                    contexts.insert(0, temp_contexts)
+                    temp_contexts = []
+                else:
+                    continue
 
         # 展平 contexts 列表
         contexts = [item for sublist in contexts for item in sublist]

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -167,7 +167,14 @@ class ProviderOpenAIOfficial(Provider):
         for part in context_query:
             if "_no_save" in part:
                 del part["_no_save"]
-
+        context_query = [
+            msg for msg in context_query 
+            if not (
+                msg.get('role') == 'tool' 
+                or msg.get('tool_calls') 
+            )
+        ]
+        
         # tool calls result
         if tool_calls_result:
             context_query.extend(tool_calls_result.to_openai_messages())


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
修复了 #1166

### Motivation
修改使用中出现的bug
<!--解释为什么要改动-->

### Modifications
1、让tool和tool_calls不进入上下文中
2、让history函数跳过无content的对话
<!--简单解释你的改动-->

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

改进 LLM 对话的上下文处理，方法是过滤掉与工具相关的消息和空的助手回复

Bug 修复：
- 阻止 tool 和 tool_calls 消息包含在对话上下文中
- 在生成对话历史记录时，跳过没有内容的助手消息

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve context handling for LLM conversations by filtering out tool-related messages and empty assistant responses

Bug Fixes:
- Prevent tool and tool_calls messages from being included in the conversation context
- Skip assistant messages without content when generating conversation history

</details>