### PR TITLE
feat: 自动注册指令到Telegram

### DIFF
--- a/astrbot/core/platform/sources/telegram/tg_adapter.py
+++ b/astrbot/core/platform/sources/telegram/tg_adapter.py
@@ -176,8 +176,8 @@ class TelegramPlatformAdapter(Platform):
 
                     command_dict[cmd_name] = description
 
-        commands_a = sorted(command_dict.keys())
-        commands = [BotCommand(cmd, command_dict[cmd]) for cmd in commands_a]
+        sorted_commands = sorted(command_dict.keys())
+        commands = [BotCommand(cmd, command_dict[cmd]) for cmd in sorted_commands]
         return commands
 
     async def start(self, update: Update, context: ContextTypes.DEFAULT_TYPE):

--- a/astrbot/core/platform/sources/telegram/tg_adapter.py
+++ b/astrbot/core/platform/sources/telegram/tg_adapter.py
@@ -247,6 +247,16 @@ class TelegramPlatformAdapter(Platform):
             # 处理文本消息
             plain_text = update.message.text
 
+            # 群聊场景命令特殊处理
+            if plain_text.startswith("/"):
+                command_parts = plain_text.split(" ", 1)
+                if "@" in command_parts[0]:
+                    command, bot_name = command_parts[0].split("@")
+                    if bot_name == self.client.username:
+                        plain_text = command + (
+                            f" {command_parts[1]}" if len(command_parts) > 1 else ""
+                        )
+
             if update.message.entities:
                 for entity in update.message.entities:
                     if entity.type == "mention":

--- a/astrbot/core/platform/sources/telegram/tg_adapter.py
+++ b/astrbot/core/platform/sources/telegram/tg_adapter.py
@@ -145,7 +145,10 @@ class TelegramPlatformAdapter(Platform):
                     isinstance(event_filter, CommandFilter)
                     and event_filter.command_name
                 ):
-                    if event_filter.parent_command_names:
+                    if (
+                        event_filter.parent_command_names
+                        and event_filter.parent_command_names != [""]
+                    ):
                         continue
                     cmd_name = event_filter.command_name
                 elif isinstance(event_filter, CommandGroupFilter):

--- a/astrbot/core/platform/sources/telegram/tg_adapter.py
+++ b/astrbot/core/platform/sources/telegram/tg_adapter.py
@@ -1,26 +1,31 @@
+import asyncio
 import sys
 import uuid
-import asyncio
-import astrbot.api.message_components as Comp
 
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from telegram import BotCommand, Update
+from telegram.constants import ChatType
+from telegram.ext import ApplicationBuilder, ContextTypes, ExtBot, filters
+from telegram.ext import MessageHandler as TelegramMessageHandler
+
+import astrbot.api.message_components as Comp
+from astrbot.api import logger
+from astrbot.api.event import MessageChain
 from astrbot.api.platform import (
-    Platform,
     AstrBotMessage,
     MessageMember,
-    PlatformMetadata,
     MessageType,
+    Platform,
+    PlatformMetadata,
+    register_platform_adapter,
 )
-from astrbot.api.event import MessageChain
 from astrbot.core.platform.astr_message_event import MessageSesion
-from astrbot.api.platform import register_platform_adapter
+from astrbot.core.star.filter.command import CommandFilter
+from astrbot.core.star.filter.command_group import CommandGroupFilter
+from astrbot.core.star.star import star_map
+from astrbot.core.star.star_handler import star_handlers_registry
 
-from telegram import Update
-from telegram.ext import ApplicationBuilder, ContextTypes, filters
-from telegram.constants import ChatType
-from telegram.ext import MessageHandler as TelegramMessageHandler
 from .tg_event import TelegramPlatformEvent
-from astrbot.api import logger
-from telegram.ext import ExtBot
 
 if sys.version_info >= (3, 12):
     from typing import override
@@ -67,6 +72,8 @@ class TelegramPlatformAdapter(Platform):
         self.client = self.application.bot
         logger.debug(f"Telegram base url: {self.client.base_url}")
 
+        self.scheduler = AsyncIOScheduler()
+
     @override
     async def send_by_session(
         self, session: MessageSesion, message_chain: MessageChain
@@ -88,9 +95,87 @@ class TelegramPlatformAdapter(Platform):
     async def run(self):
         await self.application.initialize()
         await self.application.start()
+        await self.register_commands()
+
+        # TODO 使用更优雅的方式重新注册命令
+        self.scheduler.add_job(
+            self.register_commands,
+            "interval",
+            minutes=5,
+            id="telegram_command_register",
+            misfire_grace_time=60,
+        )
+        self.scheduler.start()
+
         queue = self.application.updater.start_polling()
         logger.info("Telegram Platform Adapter is running.")
         await queue
+
+    async def register_commands(self):
+        """收集所有注册的指令并注册到 Telegram"""
+        try:
+            await self.client.delete_my_commands()
+            commands = self.collect_commands()
+
+            if commands:
+                await self.client.set_my_commands(commands)
+                for cmd in commands:
+                    logger.debug(f"已注册指令: /{cmd.command} - {cmd.description}")
+
+        except Exception as e:
+            logger.error(f"向 Telegram 注册指令时发生错误: {e!s}")
+
+    def collect_commands(self) -> list[BotCommand]:
+        """从注册的处理器中收集所有指令"""
+
+        command_dict = {}
+        skip_commands = {"start"}
+
+        for handler_md in star_handlers_registry._handlers:
+            handler_metadata = handler_md[1]
+
+            if not star_map[handler_metadata.handler_module_path].activated:
+                continue
+
+            for event_filter in handler_metadata.event_filters:
+                cmd_name = None
+                is_group = False
+
+                if (
+                    isinstance(event_filter, CommandFilter)
+                    and event_filter.command_name
+                ):
+                    if event_filter.parent_command_names:
+                        continue
+                    cmd_name = event_filter.command_name
+                elif isinstance(event_filter, CommandGroupFilter):
+                    if event_filter.parent_group:
+                        continue
+                    cmd_name = event_filter.group_name
+                    is_group = True
+
+                if (
+                    cmd_name
+                    and cmd_name not in skip_commands
+                    and cmd_name not in command_dict
+                ):
+                    if handler_metadata.desc:
+                        description = handler_metadata.desc
+                    else:
+                        description = (
+                            f"指令组: {cmd_name} (包含多个子指令)"
+                            if is_group
+                            else f"指令: {cmd_name}"
+                        )
+
+                    if len(description) > 30:
+                        description = description[:30] + "..."
+
+                    command_dict[cmd_name] = description
+
+        commands_a = sorted(command_dict.keys())
+        commands = [BotCommand(cmd, command_dict[cmd]) for cmd in commands_a]
+        return commands
 
     async def start(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         await context.bot.send_message(
@@ -242,7 +327,11 @@ class TelegramPlatformAdapter(Platform):
 
     async def terminate(self):
         try:
+            if self.scheduler.running:
+                self.scheduler.shutdown()
+
             await self.application.stop()
+            await self.client.delete_my_commands()
 
             # 保险起见先判断是否存在updater对象
             if self.application.updater is not None:


### PR DESCRIPTION
This PR fixes #1160 

### Motivation

自动注册现有插件的指令到telegram

### Modifications

添加指令注册逻辑，添加定时任务以定时刷新指令

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

为 Telegram 机器人平台适配器实现自动命令注册

新特性：
- 为现有机器人插件添加自动命令注册机制
- 实现使用调度器的定期命令刷新

增强功能：
- 从已注册的处理程序动态收集和注册命令
- 为命令注册过程添加日志记录

杂项：
- 更新 Telegram 平台适配器以支持命令注册

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement automatic command registration for Telegram bot platform adapter

New Features:
- Add automatic command registration mechanism for existing bot plugins
- Implement periodic command refresh using a scheduler

Enhancements:
- Collect and register commands dynamically from registered handlers
- Add logging for command registration process

Chores:
- Update Telegram platform adapter to support command registration

</details>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

为 Telegram 机器人平台适配器实现自动命令注册，从而能够动态收集和注册来自现有机器人插件的命令。

新特性：
- 为现有机器人插件添加自动命令注册机制
- 使用调度器实现定期命令刷新

增强功能：
- 动态收集和注册来自已注册处理程序的命令
- 为命令注册过程添加日志记录

杂项：
- 更新 Telegram 平台适配器以支持命令注册

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement automatic command registration for Telegram bot platform adapter, enabling dynamic collection and registration of commands from existing bot plugins

New Features:
- Add automatic command registration mechanism for existing bot plugins
- Implement periodic command refresh using a scheduler

Enhancements:
- Dynamically collect and register commands from registered handlers
- Add logging for command registration process

Chores:
- Update Telegram platform adapter to support command registration

</details>