### PR TITLE
feat: StarTools添加数据目录获取接口

### DIFF
--- a/astrbot/core/star/star_tools.py
+++ b/astrbot/core/star/star_tools.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import Union, Awaitable, List, Optional, ClassVar
 from astrbot.core.message.components import BaseMessageComponent
 from astrbot.core.message.message_event_result import MessageChain
@@ -6,7 +7,6 @@ from astrbot.core.platform.astr_message_event import MessageSesion
 from astrbot.core.star.context import Context
 from astrbot.core.star.star import star_map
 from pathlib import Path
-import inspect
 
 
 class StarTools:

--- a/astrbot/core/star/star_tools.py
+++ b/astrbot/core/star/star_tools.py
@@ -4,6 +4,9 @@ from astrbot.core.message.message_event_result import MessageChain
 from astrbot.api.platform import MessageMember, AstrBotMessage
 from astrbot.core.platform.astr_message_event import MessageSesion
 from astrbot.core.star.context import Context
+from astrbot.core.star.star import star_map
+from pathlib import Path
+import inspect
 
 
 class StarTools:
@@ -142,3 +145,32 @@ class StarTools:
             name (str): 工具名称
         """
         cls._context.unregister_llm_tool(name)
+
+    @classmethod
+    def get_data_dir(cls) -> Path:
+        """
+        为调用者创建并返回数据目录路径。
+
+        Returns:
+            Path: 数据目录的绝对路径
+        """
+
+        frame = inspect.currentframe().f_back
+        module = inspect.getmodule(frame)
+
+        if not module:
+            raise RuntimeError("无法获取调用者模块信息")
+
+        metadata = star_map.get(module.__name__, None)
+
+        if not metadata:
+            raise RuntimeError(f"无法获取模块 {module.__name__} 的元数据信息")
+
+        data_dir = Path("data/plugin_data") / metadata.name
+
+        try:
+            data_dir.mkdir(parents=True, exist_ok=True)
+        except PermissionError:
+            raise RuntimeError(f"无法创建目录 {data_dir}：权限不足")
+
+        return data_dir.resolve()


### PR DESCRIPTION
### Motivation

为插件添加统一的数据目录获取接口

### Modifications

添加接口

### Check
- [x] 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 我新增/修复/优化的功能经过良好的测试

## Sourcery 总结

为 StarTools 添加统一的数据目录检索接口，以帮助插件管理其数据存储

新特性：
- 实现一个类方法 `get_data_dir()`，该方法自动创建并返回一个插件特定的数据目录路径

增强功能：
- 通过提供一种基于插件元数据检索和创建数据目录的标准化方法，来增强插件数据管理

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a unified data directory retrieval interface for StarTools to help plugins manage their data storage

New Features:
- Implement a class method `get_data_dir()` that automatically creates and returns a plugin-specific data directory path

Enhancements:
- Enhance plugin data management by providing a standardized way to retrieve and create data directories based on plugin metadata

</details>