### PR TITLE
将一项优化插件的简单逻辑，适配到Core中

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -998,7 +998,7 @@ CONFIG_METADATA_2 = {
                     "dequeue_context_length": {
                         "description": "丢弃对话数量(条)",
                         "type": "int",
-                        "hint": "超出 最多携带对话数量(条) 时，丢弃多少条记录，用户和AI的一轮聊天记为 1 条。",
+                        "hint": "超出 最多携带对话数量(条) 时，丢弃多少条记录，用户和AI的一轮聊天记为 1 条。适宜的配置，可以提高超长上下文对话 deepseek 命中缓存效果，理想情况下计费将降低到1/3以下",
                     },
                     "streaming_response": {
                         "description": "启用流式回复",

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -50,6 +50,7 @@ DEFAULT_CONFIG = {
         "default_personality": "default",
         "prompt_prefix": "",
         "max_context_length": -1,
+        "dequeue_context_length": 1,
         "streaming_response": False,
     },
     "provider_stt_settings": {
@@ -993,6 +994,11 @@ CONFIG_METADATA_2 = {
                         "description": "最多携带对话数量(条)",
                         "type": "int",
                         "hint": "超出这个数量时将丢弃最旧的部分，用户和AI的一轮聊天记为 1 条。-1 表示不限制，默认为不限制。",
+                    },
+                    "dequeue_context_length": {
+                        "description": "丢弃对话数量(条)",
+                        "type": "int",
+                        "hint": "超出 最多携带对话数量(条) 时，丢弃多少条记录，用户和AI的一轮聊天记为 1 条。",
                     },
                     "streaming_response": {
                         "description": "启用流式回复",

--- a/astrbot/core/pipeline/process_stage/method/llm_request.py
+++ b/astrbot/core/pipeline/process_stage/method/llm_request.py
@@ -38,6 +38,9 @@ class LLMRequestSubStage(Stage):
         self.max_context_length = ctx.astrbot_config["provider_settings"][
             "max_context_length"
         ]  # int
+        self.dequeue_context_length = ctx.astrbot_config["provider_settings"][
+            "dequeue_context_length"
+        ]  # int
         self.streaming_response = ctx.astrbot_config["provider_settings"][
             "streaming_response"
         ]  # bool
@@ -135,7 +138,7 @@ class LLMRequestSubStage(Stage):
             and len(req.contexts) // 2 > self.max_context_length
         ):
             logger.debug("上下文长度超过限制，将截断。")
-            req.contexts = req.contexts[-self.max_context_length * 2 :]
+            req.contexts = req.contexts[-(self.max_context_length - self.dequeue_context_length) * 2 :]
 
         # session_id
         if not req.session_id:

--- a/astrbot/core/pipeline/process_stage/method/llm_request.py
+++ b/astrbot/core/pipeline/process_stage/method/llm_request.py
@@ -38,9 +38,10 @@ class LLMRequestSubStage(Stage):
         self.max_context_length = ctx.astrbot_config["provider_settings"][
             "max_context_length"
         ]  # int
-        self.dequeue_context_length = ctx.astrbot_config["provider_settings"][
-            "dequeue_context_length"
-        ]  # int
+        self.dequeue_context_length = min(
+            max(1,ctx.astrbot_config["provider_settings"]["dequeue_context_length"]),
+            self.max_context_length - 1
+        )  # int
         self.streaming_response = ctx.astrbot_config["provider_settings"][
             "streaming_response"
         ]  # bool


### PR DESCRIPTION
关于 #1147 

### Motivation

在使用deepseek 时，这项配置可以极大提高，长对话情境下的，命中缓存的效率
最理想情况下，可以使计费降低到原本的1/3以下

### Modifications

允许用户配置，当消息上下文长度，超过最大携带的消息条数时，可以一次性丢弃多条旧消息

好的，这是将pull request summary翻译成中文的结果：

## Sourcery 总结

通过添加一个可配置的选项来控制当上下文长度超过最大限制时丢弃的消息数量，从而增强长对话的上下文管理。

新特性：
- 添加一个新的配置参数 'dequeue_context_length'，用于控制当上下文长度超过最大限制时丢弃的消息数量

增强：
- 改进上下文截断逻辑，允许在长对话中更灵活地删除消息
- 优化长对话场景的缓存效率

日常维护：
- 更新默认配置模式，以包含新的 dequeue_context_length 参数

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance context management for long conversations by adding a configurable option to control the number of messages discarded when context length exceeds the maximum limit

New Features:
- Add a new configuration parameter 'dequeue_context_length' to control the number of messages discarded when context length exceeds the maximum limit

Enhancements:
- Improve context truncation logic to allow more flexible message removal in long conversations
- Optimize caching efficiency for long dialogue scenarios

Chores:
- Update default configuration schema to include the new dequeue_context_length parameter

</details>