### PR TITLE
修复了 `event.get_sender_id()` 返回值与函数注释不一致的问题

### DIFF
--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -109,7 +109,7 @@ class AiocqhttpAdapter(Platform):
         """OneBot V11 请求类事件"""
         abm = AstrBotMessage()
         abm.self_id = str(event.self_id)
-        abm.sender = MessageMember(user_id=event.user_id, nickname=event.user_id)
+        abm.sender = MessageMember(user_id=str(event.user_id), nickname=event.user_id)
         abm.type = MessageType.OTHER_MESSAGE
         if "group_id" in event and event["group_id"]:
             abm.type = MessageType.GROUP_MESSAGE
@@ -129,7 +129,7 @@ class AiocqhttpAdapter(Platform):
         """OneBot V11 通知类事件"""
         abm = AstrBotMessage()
         abm.self_id = str(event.self_id)
-        abm.sender = MessageMember(user_id=event.user_id, nickname=event.user_id)
+        abm.sender = MessageMember(user_id=str(event.user_id), nickname=event.user_id)
         abm.type = MessageType.OTHER_MESSAGE
         if "group_id" in event and event["group_id"]:
             abm.group_id = str(event.group_id)


### PR DESCRIPTION
### Motivation

遇到`get_sender_id()`返回值与注释不一致的问题，这会导致在`==`或`!=`对比时与预期出现偏差，问题代码段：
```python
    def get_sender_id(self) -> str:
        """
        获取消息发送者的id。
        """
        return self.message_obj.sender.user_id
```
函数注释指出返回`type`应为`str`，实际返回`int`

问题测试代码与日志：
```python
logger.info(event.get_sender_id())
logger.info(event.get_self_id())
logger.info(event.get_sender_id() == event.get_self_id())
logger.info(str(event.get_sender_id()) == str(event.get_self_id()))
logger.info(f"sender_id repr: {repr(event.get_sender_id())}")
logger.info(f"self_id repr: {repr(event.get_self_id())}")
logger.info(f"sender_id: {event.get_sender_id()} ({type(event.get_sender_id())})")
logger.info(f"self_id: {event.get_self_id()} ({type(event.get_self_id())})")
```

```log
astrbot  |  [23:56:50] [Plug] [INFO] [my_plugin.main:89]: 123123123 
astrbot  |  [23:56:50] [Plug] [INFO] [my_plugin.main:90]: 123123123 
astrbot  |  [23:56:50] [Plug] [INFO] [my_plugin.main:91]: False 
astrbot  |  [23:56:50] [Plug] [INFO] [my_plugin.main:92]: True 
astrbot  |  [23:56:50] [Plug] [INFO] [my_plugin.main:93]: sender_id repr: 123123123 
astrbot  |  [23:56:50] [Plug] [INFO] [my_plugin.main:94]: self_id repr: '123123123' 
astrbot  |  [23:56:50] [Plug] [INFO] [my_plugin.main:95]: sender_id: 123123123 (<class 'int'>) 
astrbot  |  [23:56:50] [Plug] [INFO] [my_plugin.main:96]: self_id: 123123123 (<class 'str'>)
```

### Modifications

新建`MessageMember`实例时强制进行类型转换，使其与函数标注一致。

### Check
- [x] 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 我新增/修复/优化的功能经过良好的测试

## Sourcery 总结

Bug 修复:
- 修复 `get_sender_id()` 方法中的类型不匹配问题，确保在创建 MessageMember 实例时，用户 ID 被转换为字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve type mismatch in `get_sender_id()` method by ensuring user ID is converted to a string when creating MessageMember instances

</details>