### PR TITLE
fix:使 begin_dialogs ,预设对话，不会多次插入

### DIFF
--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -1232,7 +1232,7 @@ UID: {user_id} 此 ID 可用于设置管理员。
                 if mood_dialogs := persona["_mood_imitation_dialogs_processed"]:
                     req.system_prompt += "\nHere are few shots of dialogs, you need to imitate the tone of 'B' in the following dialogs to respond:\n"
                     req.system_prompt += mood_dialogs
-                if begin_dialogs := persona["_begin_dialogs_processed"]:
+                if (begin_dialogs := persona["_begin_dialogs_processed"]) and not req.contexts:
                     req.contexts[:0] = begin_dialogs
 
         if quote and quote.message_str:


### PR DESCRIPTION
修复了 #1200 

### Motivation

观察到，如果配置了预设对话
用户每一次LLM请求，都会在历史消息的开头插入预设对话
这可能并非这项配置的本意

### Modifications

增加了一个条件判断
只有当上下文为空时，才会进行插入操作

### Check

好的，这是将给定的 Pull Request 总结翻译成中文的结果：

## Sourcery 总结

Bug 修复：
- 阻止预设对话框被多次插入，仅在上下文为空时添加它们

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent preset dialogs from being inserted multiple times by only adding them when the context is empty

</details>