### PR TITLE
✨ feat: 支持飞书平台下主动消息发送

### DIFF
--- a/astrbot/core/platform/sources/lark/lark_adapter.py
+++ b/astrbot/core/platform/sources/lark/lark_adapter.py
@@ -2,6 +2,7 @@ import base64
 import asyncio
 import json
 import re
+import uuid
 import astrbot.api.message_components as Comp
 
 from astrbot.api.platform import (
@@ -66,7 +67,41 @@ class LarkPlatformAdapter(Platform):
     async def send_by_session(
         self, session: MessageSesion, message_chain: MessageChain
     ):
-        raise NotImplementedError("Lark 适配器不支持 send_by_session")
+        res = await LarkMessageEvent._convert_to_lark(message_chain, self.lark_api)
+        wrapped = {
+            "zh_cn": {
+                "title": "",
+                "content": res,
+            }
+        }
+
+        if session.message_type == MessageType.GROUP_MESSAGE:
+            id_type = "chat_id"
+            if "%" in session.session_id:
+                session.session_id = session.session_id.split("%")[1]
+        else:
+            id_type = "open_id"
+
+        request = (
+            CreateMessageRequest.builder()
+            .receive_id_type(id_type)
+            .request_body(
+                CreateMessageRequestBody.builder()
+                .receive_id(session.session_id)
+                .content(json.dumps(wrapped))
+                .msg_type("post")
+                .uuid(str(uuid.uuid4()))
+                .build()
+            )
+            .build()
+        )
+
+        response = await self.lark_api.im.v1.message.acreate(request)
+
+        if not response.success():
+            logger.error(f"发送飞书消息失败({response.code}): {response.msg}")
+
+        await super().send_by_session(session, message_chain)
 
     def meta(self) -> PlatformMetadata:
         return PlatformMetadata(
@@ -166,7 +201,10 @@ class LarkPlatformAdapter(Platform):
             else:
                 abm.session_id = abm.sender.user_id
         else:
-            abm.session_id = abm.sender.user_id
+            if abm.type == MessageType.GROUP_MESSAGE:
+                abm.session_id = f"{abm.sender.user_id}%{abm.group_id}"  # 也保留群组id
+            else:
+                abm.session_id = abm.sender.user_id
 
         logger.debug(abm)
         await self.handle_msg(abm)


### PR DESCRIPTION
fixes: #1177

WARNING:
这个修复会导致开启对话隔离下飞书群组的对话记录丢失（但没有被删除）。

<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
修复了 #XYZ

### Motivation

<!--解释为什么要改动-->

### Modifications

<!--简单解释你的改动-->

### Check
- [x] 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 我新增/修复/优化的功能经过良好的测试

好的，这是将 pull request 总结翻译成中文的结果：

## Sourcery 总结

添加对飞书平台发送主动消息的支持

新特性：
- 实现飞书平台的主动消息发送功能
- 增加对在群聊和个人聊天上下文中发送消息的支持

Bug 修复：
- 改进群组消息的会话 ID 处理，以保留对话上下文

增强功能：
- 增强 Lark 适配器以支持通过 API 发送消息
- 实施强大的消息转换和发送机制

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for sending active messages on the Feishu (Lark) platform

New Features:
- Implement active message sending functionality for Feishu platform
- Add support for sending messages in both group and individual chat contexts

Bug Fixes:
- Improve session ID handling for group messages to preserve conversation context

Enhancements:
- Enhance Lark adapter to support message sending via API
- Implement robust message conversion and sending mechanism

</details>