### PR TITLE
feat:为QQ官方接口需要msg_seq的playload添加随机msg_seq

### DIFF
--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -11,6 +11,7 @@ from botpy import Client
 from botpy.http import Route
 from astrbot.api import logger
 from botpy.types import message
+import random
 
 
 class QQOfficialMessageEvent(AstrMessageEvent):
@@ -68,7 +69,6 @@ class QQOfficialMessageEvent(AstrMessageEvent):
         return await super().send_streaming(generator)
 
     async def _post_send(self, stream: dict = None):
-        """QQ 官方 API 仅支持回复一次"""
         if not self.send_buffer:
             return
 
@@ -96,6 +96,9 @@ class QQOfficialMessageEvent(AstrMessageEvent):
             "content": plain_text,
             "msg_id": self.message_obj.message_id,
         }
+
+        if not isinstance(source, (botpy.message.Message,botpy.message.DirectMessage)):
+            payload["msg_seq"] = random.randint(1, 10000)
 
         match type(source):
             case botpy.message.GroupMessage:


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
修复了 #1170 

### Motivation
在非频道使用情况下
QQ官方机器人接口对相同msg_id回复多条信息需要请求体包含不同msg_seq
### Modifications

为非频道的请求体添加了随机数作为msg_seq
### Check

- [x]  我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)

- [x] 我新增/修复/优化的功能经过良好的测试

## Summary by Sourcery

为QQ官方机器人API请求在非频道场景中添加随机msg_seq

新功能：
- 实现QQ官方机器人API请求的动态msg_seq生成，以支持使用相同消息ID的多条消息回复

错误修复：
- 通过为非频道消息请求添加随机消息序列号解决问题#1170

增强功能：
- 修改消息发送逻辑，在非频道上下文中生成随机msg_seq

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add random msg_seq for QQ official bot API requests in non-channel scenarios

New Features:
- Implement dynamic msg_seq generation for QQ official bot API requests to support multiple message replies with the same message ID

Bug Fixes:
- Resolve issue #1170 by adding a random message sequence number for non-channel message requests

Enhancements:
- Modify message sending logic to generate a random msg_seq when not in a channel context

</details>