### PR TITLE
bug: 修复gewechat在群组中无法获取被at人的wxid问题

### DIFF
--- a/astrbot/core/platform/astrbot_message.py
+++ b/astrbot/core/platform/astrbot_message.py
@@ -62,6 +62,8 @@ class AstrBotMessage:
     raw_message: object
     timestamp: int  # 消息时间戳
 
+    be_at_wxid: List[str] # gewechat用的群组内at信息，用于机器人获取被at的wxid
+
     def __init__(self) -> None:
         self.timestamp = int(time.time())
 

--- a/astrbot/core/platform/astrbot_message.py
+++ b/astrbot/core/platform/astrbot_message.py
@@ -62,8 +62,6 @@ class AstrBotMessage:
     raw_message: object
     timestamp: int  # 消息时间戳
 
-    be_at_wxid: List[str] # gewechat用的群组内at信息，用于机器人获取被at的wxid
-
     def __init__(self) -> None:
         self.timestamp = int(time.time())
 

--- a/astrbot/core/platform/sources/gewechat/client.py
+++ b/astrbot/core/platform/sources/gewechat/client.py
@@ -152,9 +152,13 @@ class SimpleGewechatClient:
                 # at
                 # content = content.split('\u2005')[1]
                 content = re.sub(r"@[^\u2005]*\u2005", "", content)
+                abm.be_at_wxid = re.findall(r'<atuserlist><!\[CDATA\[.*?(?:,|\b)([^,]+?)(?=,|\]\]></atuserlist>)',d["MsgSource"])
+            
             abm.group_id = from_user_name
             # at
             msg_source = d["MsgSource"]
+
+            
             if (
                 f"<atuserlist><![CDATA[,{abm.self_id}]]>" in msg_source
                 or f"<atuserlist><![CDATA[{abm.self_id}]]>" in msg_source

--- a/astrbot/core/platform/sources/gewechat/client.py
+++ b/astrbot/core/platform/sources/gewechat/client.py
@@ -143,22 +143,25 @@ class SimpleGewechatClient:
         content = d["Content"]["string"]  # 消息内容
 
         at_me = False
+        at_wxids = []
         if "@chatroom" in from_user_name:
             abm.type = MessageType.GROUP_MESSAGE
             _t = content.split(":\n")
             user_id = _t[0]
             content = _t[1]
+            # at
+            msg_source = d["MsgSource"]
             if "\u2005" in content:
                 # at
                 # content = content.split('\u2005')[1]
                 content = re.sub(r"@[^\u2005]*\u2005", "", content)
-                abm.be_at_wxid = re.findall(r'<atuserlist><!\[CDATA\[.*?(?:,|\b)([^,]+?)(?=,|\]\]></atuserlist>)',d["MsgSource"])
-            
-            abm.group_id = from_user_name
-            # at
-            msg_source = d["MsgSource"]
+                at_wxids = re.findall(
+                    r"<atuserlist><!\[CDATA\[.*?(?:,|\b)([^,]+?)(?=,|\]\]></atuserlist>)",
+                    msg_source,
+                )
 
-            
+            abm.group_id = from_user_name
+
             if (
                 f"<atuserlist><![CDATA[,{abm.self_id}]]>" in msg_source
                 or f"<atuserlist><![CDATA[{abm.self_id}]]>" in msg_source
@@ -176,8 +179,6 @@ class SimpleGewechatClient:
             return None
 
         abm.message = []
-        if at_me:
-            abm.message.insert(0, At(qq=abm.self_id))
 
         # 解析用户真实名字
         user_real_name = "unknown"
@@ -202,6 +203,13 @@ class SimpleGewechatClient:
                 user_real_name = self.userrealnames[abm.group_id][user_id]
         else:
             user_real_name = d.get("PushContent", "unknown : ").split(" : ")[0]
+
+        if at_me:
+            abm.message.insert(0, At(qq=abm.self_id, name=self.nickname))
+        for wxid in at_wxids:
+            # 群聊里 At 其他人的列表
+            _username = self.userrealnames.get(abm.group_id, {}).get(wxid, wxid)
+            abm.message.append(At(qq=wxid, name=_username))
 
         abm.sender = MessageMember(user_id, user_real_name)
         abm.raw_message = d


### PR DESCRIPTION
fixes #753 

<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
[https://github.com/AstrBotDevs/AstrBot/issues/753](url)
修复了 gewechat无法识别到被at人的wxid

### Motivation

在使用刮刮乐插件时，机器人无法对被at人做出反应，检查发现astrbot没有记录微信中被at人的wxid信息

### Modifications

astrbot/core/platform/sources/gewechat/client.py中
添加新的正则来获取xml中atuserlist包含的wxid来实现获取被at人的wxid信息
astrbot/core/platform/astrbot_message.py中
添加be_at_wxid字段保存wxid信息

### Check
- [x] 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 我新增/修复/优化的功能经过良好的测试

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

修复 gewechat 平台中 at 消息的 wxid 识别问题

Bug 修复：
- 增加对 gewechat 平台群聊消息中提及用户 wxid 的提取支持

增强功能：
- 扩展 AstrBotMessage 类，包含 be_at_wxid 字段，用于存储被提及用户的 wxid

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix wxid identification for at messages in gewechat platform

Bug Fixes:
- Add support for extracting wxid of users mentioned in group messages for gewechat platform

Enhancements:
- Extend AstrBotMessage class to include be_at_wxid field for storing mentioned user's wxid

</details>