### PR TITLE
修复:dequeue_context_length的配置项的实际行为与描述不一致；调用函数工具可能导致400错误

### DIFF
--- a/astrbot/core/pipeline/process_stage/method/llm_request.py
+++ b/astrbot/core/pipeline/process_stage/method/llm_request.py
@@ -148,6 +148,10 @@ class LLMRequestSubStage(Stage):
             req.contexts = req.contexts[
                 -(self.max_context_length - self.dequeue_context_length + 1) * 2 :
             ]
+            # 找到第一个role 为 user 的索引，确保上下文格式正确
+            index = next((i for i, item in enumerate(req.contexts) if item.get("role") == "user"), None)
+            if index is not None and index > 0:
+                req.contexts = req.contexts[index:]
 
         # session_id
         if not req.session_id:

--- a/astrbot/core/pipeline/process_stage/method/llm_request.py
+++ b/astrbot/core/pipeline/process_stage/method/llm_request.py
@@ -146,7 +146,7 @@ class LLMRequestSubStage(Stage):
         ):
             logger.debug("上下文长度超过限制，将截断。")
             req.contexts = req.contexts[
-                -(self.max_context_length - self.dequeue_context_length) * 2 :
+                -(self.max_context_length - self.dequeue_context_length + 1) * 2 :
             ]
 
         # session_id


### PR DESCRIPTION
修复了 #1243 

### Motivation

1.配置项 丢弃对话数量(条) (dequeue_context_length) 的行为不符合预期，比预期多丢弃1条消息
2.调用函数工具可能导致400错误

### Modifications

1.在抛弃旧消息时，添加修正值
2.添加逻辑，在抛弃旧消息后检查新的历史上下文，如果新的上下文，第1个元素role不为user，则额外抛弃一些旧消息

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

修复消息处理中的上下文截断行为和潜在的函数调用错误

Bug 修复:
- 修正了上下文长度截断机制，以准确丢弃预期数量的消息
- 确保在截断后正确处理上下文历史记录，以保持正确的消息角色顺序

增强功能:
- 改进了上下文截断逻辑，以防止意外的消息丢弃
- 增加了验证，以确保上下文中第一条消息具有“user”角色

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix context truncation behavior and potential function call errors in message processing

Bug Fixes:
- Corrected the context length truncation mechanism to accurately discard the expected number of messages
- Ensured proper handling of context history after truncation to maintain correct message role sequence

Enhancements:
- Improved context truncation logic to prevent unexpected message discarding
- Added validation to ensure the first message in the context has a 'user' role

</details>