### PR TITLE
perf: 适配 MCP 配置文件带 mcpServers 的情况(Cursor)

### DIFF
--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -95,11 +95,10 @@ class MCPClient:
             mcp_server_config (dict): Configuration for the MCP server. See https://modelcontextprotocol.io/quickstart/server
         """
         cfg = mcp_server_config.copy()
-        print(cfg)
-        if "mcpServers" in cfg:
+        if "mcpServers" in cfg and len(cfg["mcpServers"]) > 0:
             key_0 = list(cfg["mcpServers"].keys())[0]
             cfg = cfg["mcpServers"][key_0]
-        cfg.pop("active", None)
+        cfg.pop("active", None) # Remove active flag from config
         server_params = mcp.StdioServerParameters(
             **cfg,
         )
@@ -279,7 +278,7 @@ class FuncCall:
                     self.func_list = [
                         f
                         for f in self.func_list
-                        if not (f.origin == "mcp")
+                        if f.origin != "mcp"
                     ]
 
     async def _init_mcp_client_task_wrapper(

--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -95,6 +95,10 @@ class MCPClient:
             mcp_server_config (dict): Configuration for the MCP server. See https://modelcontextprotocol.io/quickstart/server
         """
         cfg = mcp_server_config.copy()
+        print(cfg)
+        if "mcpServers" in cfg:
+            key_0 = list(cfg["mcpServers"].keys())[0]
+            cfg = cfg["mcpServers"][key_0]
         cfg.pop("active", None)
         server_params = mcp.StdioServerParameters(
             **cfg,
@@ -260,6 +264,11 @@ class FuncCall:
                     if data["name"] in self.mcp_client_event:
                         self.mcp_client_event[data["name"]].set()
                         self.mcp_client_event.pop(data["name"], None)
+                        self.func_list = [
+                            f
+                            for f in self.func_list
+                            if not (f.origin == "mcp" and f.mcp_server_name == data["name"])
+                        ]
                 else:
                     for name in self.mcp_client_dict.keys():
                         # await self._terminate_mcp_client(name)
@@ -267,6 +276,11 @@ class FuncCall:
                         if name in self.mcp_client_event:
                             self.mcp_client_event[name].set()
                             self.mcp_client_event.pop(name, None)
+                    self.func_list = [
+                        f
+                        for f in self.func_list
+                        if not (f.origin == "mcp")
+                    ]
 
     async def _init_mcp_client_task_wrapper(
         self, name: str, cfg: dict, event: asyncio.Event

--- a/astrbot/dashboard/routes/tools.py
+++ b/astrbot/dashboard/routes/tools.py
@@ -107,7 +107,7 @@ class ToolsRoute(Route):
             for key, value in server_data.items():
                 if key not in ["name", "active", "tools"]:  # 排除特殊字段
                     if key == "mcpServers":
-                        key_0 = list(server_data["mcpServers"].keys())[0]
+                        key_0 = list(server_data["mcpServers"].keys())[0] # 不考虑为空的情况
                         server_config = server_data["mcpServers"][key_0]
                     else:
                         server_config[key] = value
@@ -168,7 +168,7 @@ class ToolsRoute(Route):
             for key, value in server_data.items():
                 if key not in ["name", "active", "tools"]:  # 排除特殊字段
                     if key == "mcpServers":
-                        key_0 = list(server_data["mcpServers"].keys())[0]
+                        key_0 = list(server_data["mcpServers"].keys())[0] # 不考虑为空的情况
                         server_config = server_data["mcpServers"][key_0]
                     else:
                         server_config[key] = value

--- a/astrbot/dashboard/routes/tools.py
+++ b/astrbot/dashboard/routes/tools.py
@@ -106,7 +106,11 @@ class ToolsRoute(Route):
             # 复制所有配置字段
             for key, value in server_data.items():
                 if key not in ["name", "active", "tools"]:  # 排除特殊字段
-                    server_config[key] = value
+                    if key == "mcpServers":
+                        key_0 = list(server_data["mcpServers"].keys())[0]
+                        server_config = server_data["mcpServers"][key_0]
+                    else:
+                        server_config[key] = value
                     has_valid_config = True
 
             if not has_valid_config:
@@ -163,7 +167,11 @@ class ToolsRoute(Route):
             # 复制所有配置字段
             for key, value in server_data.items():
                 if key not in ["name", "active", "tools"]:  # 排除特殊字段
-                    server_config[key] = value
+                    if key == "mcpServers":
+                        key_0 = list(server_data["mcpServers"].keys())[0]
+                        server_config = server_data["mcpServers"][key_0]
+                    else:
+                        server_config[key] = value
                     only_update_active = False
 
             # 如果只更新活动状态，保留原始配置

--- a/dashboard/src/views/ToolUsePage.vue
+++ b/dashboard/src/views/ToolUsePage.vue
@@ -408,7 +408,7 @@ export default {
     setInterval(() => {
       this.getServers();
       this.getTools();
-    }, 5000); // 每10秒刷新一次服务器列表
+    }, 5000); // 每 5 秒刷新一次服务器列表
     
   },
 

--- a/dashboard/src/views/ToolUsePage.vue
+++ b/dashboard/src/views/ToolUsePage.vue
@@ -32,6 +32,7 @@
         <v-card-title class="d-flex align-center py-3 px-4">
           <v-icon color="primary" class="me-2">mdi-server</v-icon>
           <span class="text-h6">MCP 服务器</span>
+          <v-progress-circular indeterminate color="primary" size="24" style="margin-left: 16px;" v-show="loading"></v-progress-circular>
           <v-spacer></v-spacer>
           <v-btn color="primary" prepend-icon="mdi-plus" variant="tonal" @click="showMcpServerDialog = true">
             新增服务器
@@ -404,6 +405,11 @@ export default {
   mounted() {
     this.getServers();
     this.getTools();
+    setInterval(() => {
+      this.getServers();
+      this.getTools();
+    }, 5000); // 每10秒刷新一次服务器列表
+    
   },
 
   methods: {
@@ -420,12 +426,15 @@ export default {
     },
     
     getServers() {
+      this.loading = true
       axios.get('/api/tools/mcp/servers')
         .then(response => {
           this.mcpServers = response.data.data || [];
+          this.loading = false
         })
         .catch(error => {
           this.showError("获取 MCP 服务器列表失败: " + error.message);
+          this.loading = false
         });
     },
     


### PR DESCRIPTION
1. 适配 MCP 配置文件带 mcpServers 的情况(Cursor)
2. fix: 关闭/删除 MCP 服务器后 Tools 没有清除的问题

### Check
- [x] 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 我新增/修复/优化的功能经过良好的测试

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

调整应用程序以处理包含 mcpServers 的 MCP 配置文件，并改进 MCP 服务器管理功能

**新功能：**

- 在前端添加定期服务器列表刷新
- 为 MCP 服务器列表添加加载指示器

**Bug 修复：**

- 修复了关闭或删除服务器时，Tools 未清除 MCP 服务器资源的问题

**增强功能：**

- 更新 MCP 服务器配置处理，以支持嵌套的 mcpServers 配置
- 改进前端和后端的 MCP 服务器管理

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adapt the application to handle MCP configuration files with mcpServers and improve MCP server management functionality

New Features:
- Add periodic server list refresh in the frontend
- Add loading indicator for MCP server list

Bug Fixes:
- Fix issue with Tools not clearing MCP server resources when closing or deleting servers

Enhancements:
- Update MCP server configuration handling to support nested mcpServers configuration
- Improve MCP server management in the frontend and backend

</details>