### PR TITLE
perf: shared_preferences加载失败时自动删除无效文件

### DIFF
--- a/astrbot/core/utils/shared_preferences.py
+++ b/astrbot/core/utils/shared_preferences.py
@@ -8,9 +8,11 @@ class SharedPreferences:
         self._data = self._load_preferences()
 
     def _load_preferences(self):
-        if os.path.exists(self.path):
+        try:
             with open(self.path, "r") as f:
                 return json.load(f)
+        except json.JSONDecodeError:
+            os.remove(self.path)
         return {}
 
     def _save_preferences(self):


### PR DESCRIPTION
This PR fixes #1246 

### Motivation

见 #1246

### Modifications

shared_preferences加载失败时自动删除无效文件

### Check
- [x] 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 我新增/修复/优化的功能经过良好的测试

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 自动删除损坏的 shared preferences JSON 文件，防止持续加载错误。当文件加载失败时，会自动删除该文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Automatically delete corrupted shared preferences JSON file when it fails to load, preventing persistent loading errors

</details>