### PR TITLE
perf: 为不支持流式输出的平台提供fallback。

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -52,6 +52,7 @@ DEFAULT_CONFIG = {
         "max_context_length": -1,
         "dequeue_context_length": 1,
         "streaming_response": False,
+        "streaming_segmented": False,
     },
     "provider_stt_settings": {
         "enable": False,
@@ -1007,6 +1008,11 @@ CONFIG_METADATA_2 = {
                         "description": "启用流式回复",
                         "type": "bool",
                         "hint": "启用后，将会流式输出 LLM 的响应。目前仅支持 OpenAI API提供商 以及 Telegram、QQ Official 私聊 两个平台",
+                    },
+                    "streaming_segmented": {
+                        "description": "不支持流式回复的平台分段输出",
+                        "type": "bool",
+                        "hint": "启用后，若平台不支持流式回复，会分段输出。目前仅支持 aiocqhttp 和 gewechat 两个平台，不支持或无需使用流式分段输出的平台会静默忽略此选项",
                     },
                 },
             },

--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -146,9 +146,12 @@ class RespondStage(Stage):
 
         if result.result_content_type == ResultContentType.STREAMING_RESULT:
             # 流式结果直接交付平台适配器处理
+            use_fallback = self.config.get("provider_settings", {}).get(
+                "streaming_segmented", False
+            )
             logger.info(f"应用流式输出({event.get_platform_name()})")
             await event._pre_send()
-            await event.send_streaming(result.async_stream)
+            await event.send_streaming(result.async_stream, use_fallback)
             await event._post_send()
             return
         elif len(result.chain) > 0:
@@ -159,7 +162,7 @@ class RespondStage(Stage):
                         # 支持 File 消息段的路径映射。
                         component.file = path_Mapping(mappings, component.file)
                         event.get_result().chain[idx] = component
-            
+
             await event._pre_send()
 
             # 检查消息链是否为空

--- a/astrbot/core/platform/astr_message_event.py
+++ b/astrbot/core/platform/astr_message_event.py
@@ -217,7 +217,7 @@ class AstrMessageEvent(abc.ABC):
             matched_text = match.group()
             await self.send(MessageChain([Plain(matched_text)]))
             buffer = buffer[match.end() :]
-            await asyncio.sleep(0.8)  # 限速
+            await asyncio.sleep(1.5)  # 限速
         return buffer
 
     async def send_streaming(self, generator: AsyncGenerator[MessageChain, None]):

--- a/astrbot/core/platform/astr_message_event.py
+++ b/astrbot/core/platform/astr_message_event.py
@@ -220,9 +220,12 @@ class AstrMessageEvent(abc.ABC):
             await asyncio.sleep(1.5)  # 限速
         return buffer
 
-    async def send_streaming(self, generator: AsyncGenerator[MessageChain, None]):
+    async def send_streaming(
+        self, generator: AsyncGenerator[MessageChain, None], use_fallback: bool = False
+    ):
         """发送流式消息到消息平台，使用异步生成器。
         目前仅支持: telegram，qq official 私聊。
+        Fallback仅支持 aiocqhttp, gewechat。
         """
         asyncio.create_task(
             Metric.upload(msg_event_tick=1, adapter_name=self.platform_meta.name)

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
@@ -1,5 +1,7 @@
 import asyncio
-import typing
+from typing import AsyncGenerator
+import re
+
 from astrbot.api.event import AstrMessageEvent, MessageChain
 from astrbot.api.platform import Group, MessageMember
 from astrbot.api.message_components import Plain, Image, Record, At, Node, Nodes
@@ -82,17 +84,30 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
 
         await super().send(message)
 
-    async def send_streaming(self, generator):
-        buffer = None
+    async def send_streaming(self, generator: AsyncGenerator):
+        buffer = ""
+        pattern = r"[^。？！~…]+[。？！~…]+"
+
         async for chain in generator:
-            if not buffer:
-                buffer = chain
-            else:
-                buffer.chain.extend(chain.chain)
-        if not buffer:
-            return
-        buffer.squash_plain()
-        await self.send(buffer)
+            if isinstance(chain, MessageChain):
+                for comp in chain.chain:
+                    if isinstance(comp, Plain):
+                        buffer += comp.text
+
+                        if any(p in buffer for p in "。？！~…"):
+                            while True:
+                                match = re.search(pattern, buffer)
+                                if not match:
+                                    break
+                                matched_text = match.group()
+                                await self.send(MessageChain([Plain(matched_text)]))
+                                buffer = buffer[match.end() :]
+                                await asyncio.sleep(0.5)  # 限速
+                    else:
+                        await self.send(MessageChain(chain=[comp]))
+
+        if buffer.strip():
+            await self.send(MessageChain([Plain(buffer)]))
         return await super().send_streaming(generator)
 
     async def get_group(self, group_id=None, **kwargs):

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
@@ -1,11 +1,10 @@
 import asyncio
-from typing import AsyncGenerator, List, Dict
 import re
-
-from astrbot.api.event import AstrMessageEvent, MessageChain
-from astrbot.api.platform import Group, MessageMember
-from astrbot.api.message_components import Plain, Image, Record, At, Node, Nodes
+from typing import AsyncGenerator, Dict, List
 from aiocqhttp import CQHttp
+from astrbot.api.event import AstrMessageEvent, MessageChain
+from astrbot.api.message_components import At, Image, Node, Nodes, Plain, Record
+from astrbot.api.platform import Group, MessageMember
 
 
 class AiocqhttpMessageEvent(AstrMessageEvent):
@@ -84,17 +83,6 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
 
         await super().send(message)
 
-    async def process_buffer(self, buffer: str, pattern: re.Pattern) -> str:
-        while True:
-            match = re.search(pattern, buffer)
-            if not match:
-                break
-            matched_text = match.group()
-            await self.send(MessageChain([Plain(matched_text)]))
-            buffer = buffer[match.end() :]
-            await asyncio.sleep(0.5)  # 限速
-        return buffer
-
     async def send_streaming(self, generator: AsyncGenerator):
         buffer = ""
         pattern = re.compile(r"[^。？！~…]+[。？！~…]+")
@@ -108,6 +96,7 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
                             buffer = await self.process_buffer(buffer, pattern)
                     else:
                         await self.send(MessageChain(chain=[comp]))
+                        await asyncio.sleep(0.8)  # 限速
 
         if buffer.strip():
             await self.send(MessageChain([Plain(buffer)]))

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
@@ -96,7 +96,7 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
                             buffer = await self.process_buffer(buffer, pattern)
                     else:
                         await self.send(MessageChain(chain=[comp]))
-                        await asyncio.sleep(0.8)  # 限速
+                        await asyncio.sleep(1.5)  # 限速
 
         if buffer.strip():
             await self.send(MessageChain([Plain(buffer)]))

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import AsyncGenerator
+from typing import AsyncGenerator, List, Dict
 import re
 
 from astrbot.api.event import AstrMessageEvent, MessageChain
@@ -126,7 +126,7 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
             group_id=group_id,
         )
 
-        members: typing.List[typing.Dict] = await self.bot.call_action(
+        members: List[Dict] = await self.bot.call_action(
             "get_group_member_list",
             group_id=group_id,
         )

--- a/astrbot/core/platform/sources/dingtalk/dingtalk_event.py
+++ b/astrbot/core/platform/sources/dingtalk/dingtalk_event.py
@@ -61,7 +61,7 @@ class DingtalkMessageEvent(AstrMessageEvent):
         await self.send_with_client(self.client, message)
         await super().send(message)
 
-    async def send_streaming(self, generator):
+    async def send_streaming(self, generator, use_fallback: bool = False):
         buffer = None
         async for chain in generator:
             if not buffer:
@@ -72,4 +72,4 @@ class DingtalkMessageEvent(AstrMessageEvent):
             return
         buffer.squash_plain()
         await self.send(buffer)
-        return await super().send_streaming(generator)
+        return await super().send_streaming(generator, use_fallback)

--- a/astrbot/core/platform/sources/dingtalk/dingtalk_event.py
+++ b/astrbot/core/platform/sources/dingtalk/dingtalk_event.py
@@ -1,8 +1,12 @@
 import asyncio
+import re
+from typing import AsyncGenerator
+
 import dingtalk_stream
 import astrbot.api.message_components as Comp
 from astrbot.api.event import AstrMessageEvent, MessageChain
 from astrbot import logger
+from astrbot.core.message.components import Plain
 
 
 class DingtalkMessageEvent(AstrMessageEvent):
@@ -61,15 +65,27 @@ class DingtalkMessageEvent(AstrMessageEvent):
         await self.send_with_client(self.client, message)
         await super().send(message)
 
-    async def send_streaming(self, generator):
-        buffer = None
+    async def send_streaming(self, generator: AsyncGenerator):
+        buffer = ""
+        pattern = r"[^。？！~…]+[。？！~…]+"
+
         async for chain in generator:
-            if not buffer:
-                buffer = chain
-            else:
-                buffer.chain.extend(chain.chain)
-        if not buffer:
-            return
-        buffer.squash_plain()
-        await self.send(buffer)
+            if isinstance(chain, MessageChain):
+                for comp in chain.chain:
+                    if isinstance(comp, Plain):
+                        buffer += comp.text
+
+                        if any(p in buffer for p in "。？！~…"):
+                            while True:
+                                match = re.search(pattern, buffer)
+                                if not match:
+                                    break
+                                matched_text = match.group()
+                                await self.send(MessageChain([Plain(matched_text)]))
+                                buffer = buffer[match.end() :]
+                                await asyncio.sleep(0.5)  # 限速
+                    else:
+                        await self.send(MessageChain(chain=[comp]))
+        if buffer.strip():
+            await self.send(MessageChain([Plain(buffer)]))
         return await super().send_streaming(generator)

--- a/astrbot/core/platform/sources/dingtalk/dingtalk_event.py
+++ b/astrbot/core/platform/sources/dingtalk/dingtalk_event.py
@@ -65,27 +65,31 @@ class DingtalkMessageEvent(AstrMessageEvent):
         await self.send_with_client(self.client, message)
         await super().send(message)
 
+    async def process_buffer(self, buffer: str, pattern: re.Pattern) -> str:
+        while True:
+            match = re.search(pattern, buffer)
+            if not match:
+                break
+            matched_text = match.group()
+            await self.send(MessageChain([Plain(matched_text)]))
+            buffer = buffer[match.end() :]
+            await asyncio.sleep(0.5)  # 限速
+        return buffer
+
     async def send_streaming(self, generator: AsyncGenerator):
         buffer = ""
-        pattern = r"[^。？！~…]+[。？！~…]+"
+        pattern = re.compile(r"[^。？！~…]+[。？！~…]+")
 
         async for chain in generator:
             if isinstance(chain, MessageChain):
                 for comp in chain.chain:
                     if isinstance(comp, Plain):
                         buffer += comp.text
-
                         if any(p in buffer for p in "。？！~…"):
-                            while True:
-                                match = re.search(pattern, buffer)
-                                if not match:
-                                    break
-                                matched_text = match.group()
-                                await self.send(MessageChain([Plain(matched_text)]))
-                                buffer = buffer[match.end() :]
-                                await asyncio.sleep(0.5)  # 限速
+                            buffer = await self.process_buffer(buffer, pattern)
                     else:
                         await self.send(MessageChain(chain=[comp]))
+
         if buffer.strip():
             await self.send(MessageChain([Plain(buffer)]))
         return await super().send_streaming(generator)

--- a/astrbot/core/platform/sources/gewechat/gewechat_event.py
+++ b/astrbot/core/platform/sources/gewechat/gewechat_event.py
@@ -233,7 +233,7 @@ class GewechatPlatformEvent(AstrMessageEvent):
                             buffer = await self.process_buffer(buffer, pattern)
                     else:
                         await self.send(MessageChain(chain=[comp]))
-                        await asyncio.sleep(0.8)  # 限速
+                        await asyncio.sleep(1.5)  # 限速
 
         if buffer.strip():
             await self.send(MessageChain([Plain(buffer)]))

--- a/astrbot/core/platform/sources/gewechat/gewechat_event.py
+++ b/astrbot/core/platform/sources/gewechat/gewechat_event.py
@@ -4,8 +4,8 @@ import wave
 import uuid
 import traceback
 import os
-from typing import AsyncGenerator
 
+from typing import AsyncGenerator
 from astrbot.core.utils.io import save_temp_img, download_file
 from astrbot.core.utils.tencent_record_helper import wav_to_tencent_silk
 from astrbot.api import logger
@@ -220,17 +220,6 @@ class GewechatPlatformEvent(AstrMessageEvent):
             members=members,
         )
 
-    async def process_buffer(self, buffer: str, pattern: re.Pattern) -> str:
-        while True:
-            match = re.search(pattern, buffer)
-            if not match:
-                break
-            matched_text = match.group()
-            await self.send(MessageChain([Plain(matched_text)]))
-            buffer = buffer[match.end() :]
-            await asyncio.sleep(0.5)  # 限速
-        return buffer
-
     async def send_streaming(self, generator: AsyncGenerator):
         buffer = ""
         pattern = re.compile(r"[^。？！~…]+[。？！~…]+")
@@ -244,6 +233,7 @@ class GewechatPlatformEvent(AstrMessageEvent):
                             buffer = await self.process_buffer(buffer, pattern)
                     else:
                         await self.send(MessageChain(chain=[comp]))
+                        await asyncio.sleep(0.8)  # 限速
 
         if buffer.strip():
             await self.send(MessageChain([Plain(buffer)]))

--- a/astrbot/core/platform/sources/gewechat/gewechat_event.py
+++ b/astrbot/core/platform/sources/gewechat/gewechat_event.py
@@ -220,27 +220,31 @@ class GewechatPlatformEvent(AstrMessageEvent):
             members=members,
         )
 
+    async def process_buffer(self, buffer: str, pattern: re.Pattern) -> str:
+        while True:
+            match = re.search(pattern, buffer)
+            if not match:
+                break
+            matched_text = match.group()
+            await self.send(MessageChain([Plain(matched_text)]))
+            buffer = buffer[match.end() :]
+            await asyncio.sleep(0.5)  # 限速
+        return buffer
+
     async def send_streaming(self, generator: AsyncGenerator):
         buffer = ""
-        pattern = r"[^。？！~…]+[。？！~…]+"
+        pattern = re.compile(r"[^。？！~…]+[。？！~…]+")
 
         async for chain in generator:
             if isinstance(chain, MessageChain):
                 for comp in chain.chain:
                     if isinstance(comp, Plain):
                         buffer += comp.text
-
                         if any(p in buffer for p in "。？！~…"):
-                            while True:
-                                match = re.search(pattern, buffer)
-                                if not match:
-                                    break
-                                matched_text = match.group()
-                                await self.send(MessageChain([Plain(matched_text)]))
-                                buffer = buffer[match.end() :]
-                                await asyncio.sleep(0.5)  # 限速
+                            buffer = await self.process_buffer(buffer, pattern)
                     else:
                         await self.send(MessageChain(chain=[comp]))
+
         if buffer.strip():
             await self.send(MessageChain([Plain(buffer)]))
         return await super().send_streaming(generator)

--- a/astrbot/core/platform/sources/lark/lark_event.py
+++ b/astrbot/core/platform/sources/lark/lark_event.py
@@ -104,7 +104,7 @@ class LarkMessageEvent(AstrMessageEvent):
 
         await super().send(message)
 
-    async def send_streaming(self, generator):
+    async def send_streaming(self, generator, use_fallback: bool = False):
         buffer = None
         async for chain in generator:
             if not buffer:
@@ -115,4 +115,4 @@ class LarkMessageEvent(AstrMessageEvent):
             return
         buffer.squash_plain()
         await self.send(buffer)
-        return await super().send_streaming(generator)
+        return await super().send_streaming(generator, use_fallback)

--- a/astrbot/core/platform/sources/lark/lark_event.py
+++ b/astrbot/core/platform/sources/lark/lark_event.py
@@ -94,27 +94,31 @@ class LarkMessageEvent(AstrMessageEvent):
 
         await super().send(message)
 
+    async def process_buffer(self, buffer: str, pattern: re.Pattern) -> str:
+        while True:
+            match = re.search(pattern, buffer)
+            if not match:
+                break
+            matched_text = match.group()
+            await self.send(MessageChain([Plain(matched_text)]))
+            buffer = buffer[match.end() :]
+            await asyncio.sleep(0.5)  # 限速
+        return buffer
+
     async def send_streaming(self, generator: AsyncGenerator):
         buffer = ""
-        pattern = r"[^。？！~…]+[。？！~…]+"
+        pattern = re.compile(r"[^。？！~…]+[。？！~…]+")
 
         async for chain in generator:
             if isinstance(chain, MessageChain):
                 for comp in chain.chain:
                     if isinstance(comp, Plain):
                         buffer += comp.text
-
                         if any(p in buffer for p in "。？！~…"):
-                            while True:
-                                match = re.search(pattern, buffer)
-                                if not match:
-                                    break
-                                matched_text = match.group()
-                                await self.send(MessageChain([Plain(matched_text)]))
-                                buffer = buffer[match.end() :]
-                                await asyncio.sleep(0.5)  # 限速
+                            buffer = await self.process_buffer(buffer, pattern)
                     else:
                         await self.send(MessageChain(chain=[comp]))
+
         if buffer.strip():
             await self.send(MessageChain([Plain(buffer)]))
         return await super().send_streaming(generator)

--- a/astrbot/core/platform/sources/lark/lark_event.py
+++ b/astrbot/core/platform/sources/lark/lark_event.py
@@ -94,17 +94,6 @@ class LarkMessageEvent(AstrMessageEvent):
 
         await super().send(message)
 
-    async def process_buffer(self, buffer: str, pattern: re.Pattern) -> str:
-        while True:
-            match = re.search(pattern, buffer)
-            if not match:
-                break
-            matched_text = match.group()
-            await self.send(MessageChain([Plain(matched_text)]))
-            buffer = buffer[match.end() :]
-            await asyncio.sleep(0.5)  # 限速
-        return buffer
-
     async def send_streaming(self, generator: AsyncGenerator):
         buffer = ""
         pattern = re.compile(r"[^。？！~…]+[。？！~…]+")
@@ -118,6 +107,7 @@ class LarkMessageEvent(AstrMessageEvent):
                             buffer = await self.process_buffer(buffer, pattern)
                     else:
                         await self.send(MessageChain(chain=[comp]))
+                        await asyncio.sleep(0.8)  # 限速
 
         if buffer.strip():
             await self.send(MessageChain([Plain(buffer)]))

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -33,7 +33,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
         else:
             self.send_buffer.chain.extend(message.chain)
 
-    async def send_streaming(self, generator):
+    async def send_streaming(self, generator, use_fallback: bool = False):
         """流式输出仅支持消息列表私聊"""
         stream_payload = {"state": 1, "id": None, "index": 0, "reset": False}
         last_edit_time = 0  # 上次编辑消息的时间
@@ -66,7 +66,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
             logger.error(f"发送流式消息时出错: {e}", exc_info=True)
             self.send_buffer = None
 
-        return await super().send_streaming(generator)
+        return await super().send_streaming(generator, use_fallback)
 
     async def _post_send(self, stream: dict = None):
         if not self.send_buffer:
@@ -97,7 +97,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
             "msg_id": self.message_obj.message_id,
         }
 
-        if not isinstance(source, (botpy.message.Message,botpy.message.DirectMessage)):
+        if not isinstance(source, (botpy.message.Message, botpy.message.DirectMessage)):
             payload["msg_seq"] = random.randint(1, 10000)
 
         match type(source):

--- a/astrbot/core/platform/sources/telegram/tg_event.py
+++ b/astrbot/core/platform/sources/telegram/tg_event.py
@@ -91,7 +91,7 @@ class TelegramPlatformEvent(AstrMessageEvent):
             await self.send_with_client(self.client, message, self.get_sender_id())
         await super().send(message)
 
-    async def send_streaming(self, generator):
+    async def send_streaming(self, generator, use_fallback: bool = False):
         message_thread_id = None
 
         if self.get_message_type() == MessageType.GROUP_MESSAGE:
@@ -183,16 +183,14 @@ class TelegramPlatformEvent(AstrMessageEvent):
                         text=markdown_text,
                         chat_id=payload["chat_id"],
                         message_id=message_id,
-                        parse_mode="MarkdownV2"
+                        parse_mode="MarkdownV2",
                     )
                 except Exception as e:
                     logger.warning(f"Markdown转换失败，使用普通文本: {e!s}")
                     await self.client.edit_message_text(
-                        text=delta,
-                        chat_id=payload["chat_id"],
-                        message_id=message_id
+                        text=delta, chat_id=payload["chat_id"], message_id=message_id
                     )
         except Exception as e:
             logger.warning(f"编辑消息失败(streaming): {e!s}")
 
-        return await super().send_streaming(generator)
+        return await super().send_streaming(generator, use_fallback)

--- a/astrbot/core/platform/sources/webchat/webchat_event.py
+++ b/astrbot/core/platform/sources/webchat/webchat_event.py
@@ -106,7 +106,7 @@ class WebChatMessageEvent(AstrMessageEvent):
         )
         await super().send(message)
 
-    async def send_streaming(self, generator):
+    async def send_streaming(self, generator, use_fallback: bool = False):
         final_data = ""
         async for chain in generator:
             final_data += await WebChatMessageEvent._send(
@@ -121,4 +121,4 @@ class WebChatMessageEvent(AstrMessageEvent):
                 "cid": self.session_id.split("!")[-1],
             }
         )
-        await super().send_streaming(generator)
+        await super().send_streaming(generator, use_fallback)

--- a/astrbot/core/platform/sources/wecom/wecom_event.py
+++ b/astrbot/core/platform/sources/wecom/wecom_event.py
@@ -85,7 +85,7 @@ class WecomPlatformEvent(AstrMessageEvent):
 
         await super().send(message)
 
-    async def send_streaming(self, generator):
+    async def send_streaming(self, generator, use_fallback: bool = False):
         buffer = None
         async for chain in generator:
             if not buffer:
@@ -96,4 +96,4 @@ class WecomPlatformEvent(AstrMessageEvent):
             return
         buffer.squash_plain()
         await self.send(buffer)
-        return await super().send_streaming(generator)
+        return await super().send_streaming(generator, use_fallback)

--- a/astrbot/core/platform/sources/wecom/wecom_event.py
+++ b/astrbot/core/platform/sources/wecom/wecom_event.py
@@ -1,8 +1,4 @@
-import asyncio
-import re
 import uuid
-from typing import AsyncGenerator
-
 from astrbot.api.event import AstrMessageEvent, MessageChain
 from astrbot.api.platform import AstrBotMessage, PlatformMetadata
 from astrbot.api.message_components import Plain, Image, Record
@@ -89,31 +85,15 @@ class WecomPlatformEvent(AstrMessageEvent):
 
         await super().send(message)
 
-    async def process_buffer(self, buffer: str, pattern: re.Pattern) -> str:
-        while True:
-            match = re.search(pattern, buffer)
-            if not match:
-                break
-            matched_text = match.group()
-            await self.send(MessageChain([Plain(matched_text)]))
-            buffer = buffer[match.end() :]
-            await asyncio.sleep(0.5)  # 限速
-        return buffer
-
-    async def send_streaming(self, generator: AsyncGenerator):
-        buffer = ""
-        pattern = re.compile(r"[^。？！~…]+[。？！~…]+")
-
+    async def send_streaming(self, generator):
+        buffer = None
         async for chain in generator:
-            if isinstance(chain, MessageChain):
-                for comp in chain.chain:
-                    if isinstance(comp, Plain):
-                        buffer += comp.text
-                        if any(p in buffer for p in "。？！~…"):
-                            buffer = await self.process_buffer(buffer, pattern)
-                    else:
-                        await self.send(MessageChain(chain=[comp]))
-
-        if buffer.strip():
-            await self.send(MessageChain([Plain(buffer)]))
+            if not buffer:
+                buffer = chain
+            else:
+                buffer.chain.extend(chain.chain)
+        if not buffer:
+            return
+        buffer.squash_plain()
+        await self.send(buffer)
         return await super().send_streaming(generator)

--- a/astrbot/core/platform/sources/wecom/wecom_event.py
+++ b/astrbot/core/platform/sources/wecom/wecom_event.py
@@ -89,27 +89,31 @@ class WecomPlatformEvent(AstrMessageEvent):
 
         await super().send(message)
 
+    async def process_buffer(self, buffer: str, pattern: re.Pattern) -> str:
+        while True:
+            match = re.search(pattern, buffer)
+            if not match:
+                break
+            matched_text = match.group()
+            await self.send(MessageChain([Plain(matched_text)]))
+            buffer = buffer[match.end() :]
+            await asyncio.sleep(0.5)  # 限速
+        return buffer
+
     async def send_streaming(self, generator: AsyncGenerator):
         buffer = ""
-        pattern = r"[^。？！~…]+[。？！~…]+"
+        pattern = re.compile(r"[^。？！~…]+[。？！~…]+")
 
         async for chain in generator:
             if isinstance(chain, MessageChain):
                 for comp in chain.chain:
                     if isinstance(comp, Plain):
                         buffer += comp.text
-
                         if any(p in buffer for p in "。？！~…"):
-                            while True:
-                                match = re.search(pattern, buffer)
-                                if not match:
-                                    break
-                                matched_text = match.group()
-                                await self.send(MessageChain([Plain(matched_text)]))
-                                buffer = buffer[match.end() :]
-                                await asyncio.sleep(0.5)  # 限速
+                            buffer = await self.process_buffer(buffer, pattern)
                     else:
                         await self.send(MessageChain(chain=[comp]))
+
         if buffer.strip():
             await self.send(MessageChain([Plain(buffer)]))
         return await super().send_streaming(generator)


### PR DESCRIPTION
### Motivation

不支持流式输出的平台需要Fallback

### Modifications

使用正则表达式匹配句子终止符，按句子终止符切分并逐段发送。

### Check
- [x] 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 我新增/修复/优化的功能经过良好的测试

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

实现不支持流式输出的平台的回退机制，方法是将消息拆分为句子并以增量方式发送

新特性：
- 引入了一种回退策略，用于跨多个平台事件处理程序流式传输消息输出

增强功能：
- 为流式传输能力有限的平台添加基于句子的消息拆分
- 实施一种基于正则表达式的方法来检测中文文本中的句子边界

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement a fallback mechanism for platforms that do not support streaming output by splitting messages into sentences and sending them incrementally

New Features:
- Introduce a fallback strategy for streaming message output across multiple platform event handlers

Enhancements:
- Add sentence-based message splitting for platforms with limited streaming capabilities
- Implement a regex-based approach to detect sentence boundaries in Chinese text

</details>