### PR TITLE
🐛 修复飞书适配器转换消息过程中无法正确转化Base64图片

### DIFF
--- a/astrbot/core/message/components.py
+++ b/astrbot/core/message/components.py
@@ -193,6 +193,7 @@ class Record(BaseMessageComponent):
             bs64_data = file_to_base64(self.file)
         else:
             raise Exception(f"not a valid file: {self.file}")
+        bs64_data = bs64_data.removeprefix("base64://")
         return bs64_data
 
 
@@ -397,6 +398,7 @@ class Image(BaseMessageComponent):
             bs64_data = file_to_base64(url)
         else:
             raise Exception(f"not a valid file: {url}")
+        bs64_data = bs64_data.removeprefix("base64://")
         return bs64_data
 
 

--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -202,6 +202,7 @@ class RespondStage(Stage):
                 try:
                     await event.send(result)
                 except Exception as e:
+                    logger.error(traceback.format_exc())
                     logger.error(f"发送消息失败: {e} chain: {result.chain}")
             await event._post_send()
             logger.info(

--- a/astrbot/core/platform/sources/lark/lark_event.py
+++ b/astrbot/core/platform/sources/lark/lark_event.py
@@ -37,9 +37,12 @@ class LarkMessageEvent(AstrMessageEvent):
                     image_file_path = await download_image_by_url(comp.file)
                     file_path = image_file_path
                 elif comp.file and comp.file.startswith("base64://"):
-                    base64_str = comp.file[9:]
+                    base64_str = comp.file.removeprefix("base64://")
                     image_data = base64.b64decode(base64_str)
-                    image_file = BytesIO(image_data).getvalue()
+                    # save as temp file
+                    file_path = f"data/temp/{uuid.uuid4()}_test.jpg"
+                    with open(file_path, "wb") as f:
+                        f.write(BytesIO(image_data).getvalue())
                 else:
                     file_path = comp.file
 

--- a/astrbot/core/platform/sources/lark/lark_event.py
+++ b/astrbot/core/platform/sources/lark/lark_event.py
@@ -1,6 +1,8 @@
 import json
 import uuid
+import base64
 import lark_oapi as lark
+from io import BytesIO
 from typing import List
 from astrbot.api.event import AstrMessageEvent, MessageChain
 from astrbot.api.message_components import Plain, Image as AstrBotImage, At
@@ -27,22 +29,29 @@ class LarkMessageEvent(AstrMessageEvent):
                 _stage.append({"tag": "at", "user_id": comp.qq, "style": []})
             elif isinstance(comp, AstrBotImage):
                 file_path = ""
+                image_file = None
+
                 if comp.file and comp.file.startswith("file:///"):
                     file_path = comp.file.replace("file:///", "")
                 elif comp.file and comp.file.startswith("http"):
                     image_file_path = await download_image_by_url(comp.file)
                     file_path = image_file_path
                 elif comp.file and comp.file.startswith("base64://"):
-                    pass
+                    base64_str = comp.file[9:]
+                    image_data = base64.b64decode(base64_str)
+                    image_file = BytesIO(image_data).getvalue()
                 else:
                     file_path = comp.file
+
+                if image_file is None:
+                    image_file = open(file_path, "rb")
 
                 request = (
                     CreateImageRequest.builder()
                     .request_body(
                         CreateImageRequestBody.builder()
                         .image_type("message")
-                        .image(open(file_path, "rb"))
+                        .image(image_file)
                         .build()
                     )
                     .build()
@@ -51,7 +60,7 @@ class LarkMessageEvent(AstrMessageEvent):
                 if not response.success():
                     logger.error(f"无法上传飞书图片({response.code}): {response.msg}")
                 image_key = response.data.image_key
-                print(image_key)
+                logger.debug(image_key)
                 ret.append(_stage)
                 ret.append([{"tag": "img", "image_key": image_key}])
                 _stage.clear()


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
修复了 KimigaiiWuyi/astrbot_plugin_gscore_adapter#2

### Motivation

[现有的逻辑无法在飞书适配器上发送Base64图片](https://github.com/KimigaiiWuyi/astrbot_plugin_gscore_adapter/issues/2)

### Modifications

当图片为base64结构时，将`comp.file`转为bytes进行上传

### Check
- [ ] 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] 我新增/修复/优化的功能经过良好的测试
