### PR TITLE
fix: 移除TG注册命令时的调试信息，注册命令时添加合法性校验

### DIFF
--- a/astrbot/core/platform/sources/telegram/tg_adapter.py
+++ b/astrbot/core/platform/sources/telegram/tg_adapter.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 import sys
 import uuid
 
@@ -118,8 +119,6 @@ class TelegramPlatformAdapter(Platform):
 
             if commands:
                 await self.client.set_my_commands(commands)
-                for cmd in commands:
-                    logger.debug(f"已注册指令: /{cmd.command} - {cmd.description}")
 
         except Exception as e:
             logger.error(f"向 Telegram 注册指令时发生错误: {e!s}")
@@ -165,6 +164,10 @@ class TelegramPlatformAdapter(Platform):
             is_group = True
 
         if not cmd_name or cmd_name in skip_commands:
+            return None
+
+        if not re.match(r"^[a-z0-9_]+$", cmd_name) or len(cmd_name) > 32:
+            logger.warning(f"跳过无法注册的命令: {cmd_name}")
             return None
 
         # Build description.


### PR DESCRIPTION
尝试修复 #1273

### Motivation

长时间运行会输出过多无用调试信息

注册命令未校验命令是否合法

### Modifications

移除TG注册命令时的调试信息

注册命令时添加合法性校验

### Check
- [x] 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 我新增/修复/优化的功能经过良好的测试

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

改进 Telegram 命令注册，移除调试日志并添加命令名称验证

Bug 修复：
- 阻止长时间运行会话期间产生过多的调试日志
- 添加 Telegram 命令名称的验证，以确保它们符合平台要求

增强功能：
- 实施更严格的命令名称验证，以防止无效的命令注册

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Telegram command registration by removing debug logging and adding command name validation

Bug Fixes:
- Prevent excessive debug logging during long-running sessions
- Add validation for Telegram command names to ensure they meet platform requirements

Enhancements:
- Implement stricter command name validation to prevent invalid command registrations

</details>