### PR TITLE
修改分段回复的分割逻辑

### DIFF
--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -151,9 +151,7 @@ class ResultDecorateStage(Stage):
                                 # 不分段回复
                                 new_chain.append(comp)
                                 continue
-                            split_response = []
-                            for line in comp.text.split("\n"):
-                                split_response.extend(re.findall(self.regex, line))
+                            split_response = re.findall(self.regex, comp.text, re.DOTALL)
                             if not split_response:
                                 new_chain.append(comp)
                                 continue

--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -151,7 +151,9 @@ class ResultDecorateStage(Stage):
                                 # 不分段回复
                                 new_chain.append(comp)
                                 continue
-                            split_response = re.findall(self.regex, comp.text, re.DOTALL)
+                            split_response = re.findall(
+                                self.regex, comp.text, re.DOTALL | re.MULTILINE
+                            )
                             if not split_response:
                                 new_chain.append(comp)
                                 continue


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
修复了 #1270 

### Motivation

<!--解释为什么要改动-->
让用户能自行决定是否在换行处分段，以实现例如**使LLM自主控制如何分段回复**
（例如，当正则表达式为`.*?[■]+|.+$`时，只需在prompt中提示`■`可以把消息断开为多个气泡，LLM便能自主控制，以实现其自主 唤起其他bot/使用指令/美化回复 等效果）
### Modifications

<!--简单解释你的改动-->
在分段回复时删去先在`\n`处分割的步骤，并在后面添加`re.DOTALL`标志以正则匹配`\n`

### Check
- [x] 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 我新增/修复/优化的功能经过良好的测试

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

修改文本分割逻辑，以允许使用正则表达式进行更灵活的消息拆分

Bug 修复：
- 解决 #1270 问题，改进文本分割方法

增强功能：
- 更新基于正则表达式的文本拆分，使用 `re.DOTALL` 标志，以便更全面地跨行匹配

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modify text segmentation logic to allow more flexible message splitting using regex

Bug Fixes:
- Resolve issue #1270 by improving text segmentation approach

Enhancements:
- Update regex-based text splitting to use re.DOTALL flag for more comprehensive matching across lines

</details>