### PR TITLE
feat: 添加对Gemini原生搜索功能的支持

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -534,6 +534,7 @@ CONFIG_METADATA_2 = {
                             "model": "gemini-2.0-flash-exp",
                         },
                         "gm_resp_image_modal": False,
+                        "gm_native_search": False,
                         "gm_native_coderunner": False,
                         "gm_safety_settings": {
                             "harassment": "BLOCK_MEDIUM_AND_ABOVE",
@@ -710,6 +711,12 @@ CONFIG_METADATA_2 = {
                         "description": "启用图片模态",
                         "type": "bool",
                         "hint": "启用后，将支持返回图片内容。需要模型支持，否则会报错。具体支持模型请查看 Google Gemini 官方网站。温馨提示，如果您需要生成图片，请关闭 `启用群员识别` 配置获得更好的效果。",
+                    },
+                    "gm_native_search": {
+                        "description": "启用原生搜索功能",
+                        "type": "bool",
+                        "hint": "启用后所有函数工具将全部失效，免费次数限制请查阅官方文档",
+                        "obvious_hint": True,
                     },
                     "gm_native_coderunner": {
                         "description": "启用原生代码执行器",

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -140,10 +140,17 @@ class ProviderGoogleGenAI(Provider):
             modalities = ["Text"]
 
         tool_list = None
-        if self.provider_config.get("gm_native_coderunner", False):
+        native_coderunner = self.provider_config.get("gm_native_coderunner", False)
+        native_search = self.provider_config.get("gm_native_search", False)
+
+        if native_coderunner or native_search:
             if tools:
-                logger.warning("Gemini原生代码执行器已启用，函数工具将被忽略")
-            tool_list = [types.Tool(code_execution=types.ToolCodeExecution())]
+                logger.warning("Gemini原生工具已启用，函数工具将被忽略")
+            tool_list = []
+            if native_coderunner:
+                tool_list.append(types.Tool(code_execution=types.ToolCodeExecution()))
+            if native_search:
+                tool_list.append(types.Tool(google_search=types.GoogleSearch()))
         elif tools and (func_desc := tools.get_func_desc_google_genai_style()):
             tool_list = [
                 types.Tool(function_declarations=func_desc["function_declarations"])


### PR DESCRIPTION
This PR fixes #1302 

### Motivation

支持直接使用gemini自带的googlesearch

### Modifications

支持直接使用gemini自带的googlesearch

### Check
- [x] 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 我新增/修复/优化的功能经过良好的测试

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

添加对 Gemini 原生 Google 搜索功能的可选支持

新功能：
- 为 Gemini 提供者实现原生 Google 搜索支持，允许用户启用内置搜索功能

增强功能：
- 扩展提供者配置以支持切换原生搜索功能
- 更新工具选择逻辑，将原生搜索作为可选工具合并

杂务：
- 为新的原生搜索选项添加配置提示和描述

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for Gemini's native Google Search functionality as an optional feature

New Features:
- Implement native Google Search support for Gemini provider, allowing users to enable built-in search capabilities

Enhancements:
- Extend the provider configuration to support toggling native search functionality
- Update tool selection logic to incorporate native search as an optional tool

Chores:
- Add configuration hint and description for the new native search option

</details>