### PR TITLE
bug: 修复私聊中接收引用消息无法准确获取用户昵称的问题

### DIFF
--- a/astrbot/core/message/components.py
+++ b/astrbot/core/message/components.py
@@ -407,17 +407,15 @@ class Reply(BaseMessageComponent):
     id: T.Union[str, int]
     """所引用的消息 ID"""
     chain: T.Optional[T.List["BaseMessageComponent"]] = []
-    """引用的消息段列表"""
+    """被引用的消息段列表"""
     sender_id: T.Optional[int] | T.Optional[str] = 0
-    """引用的消息发送者 ID"""
+    """被引用的消息对应的发送者的 ID"""
     sender_nickname: T.Optional[str] = ""
-    """引用的消息发送者昵称"""
+    """被引用的消息对应的发送者的昵称"""
     time: T.Optional[int] = 0
-    """引用的消息发送时间"""
+    """被引用的消息发送时间"""
     message_str: T.Optional[str] = ""
-    """解析后的纯文本消息字符串"""
-    sender_str: T.Optional[str] = ""
-    """被引用的消息纯文本"""
+    """被引用的消息解析后的纯文本消息字符串"""
 
     text: T.Optional[str] = ""
     """deprecated"""

--- a/astrbot/core/platform/sources/gewechat/client.py
+++ b/astrbot/core/platform/sources/gewechat/client.py
@@ -252,6 +252,9 @@ class SimpleGewechatClient:
                 abm_data = data_parser.parse_mutil_49()
                 if abm_data:
                     abm.message.append(abm_data)
+                    abm.message_str = abm_data.message_str
+                    abm.message.append(Plain(abm_data.message_str))
+                    abm.message[-2].message_str = abm.message[-2].sender_str
             case 51:  # 帐号消息同步?
                 logger.info("消息类型(51)：帐号消息同步？")
             case 10000:  # 被踢出群聊/更换群主/修改群名称

--- a/astrbot/core/platform/sources/gewechat/client.py
+++ b/astrbot/core/platform/sources/gewechat/client.py
@@ -253,12 +253,12 @@ class SimpleGewechatClient:
                 logger.info("消息类型(48)：地理位置")
             case 49:  # 公众号/文件/小程序/引用/转账/红包/视频号/群聊邀请
                 data_parser = GeweDataParser(content, abm.group_id == "")
-                abm_data = data_parser.parse_mutil_49()
-                if abm_data:
-                    abm.message.append(abm_data)
-                    abm.message_str = abm_data.message_str
-                    abm.message.append(Plain(abm_data.message_str))
-                    abm.message[-2].message_str = abm.message[-2].sender_str
+                segments = data_parser.parse_mutil_49()
+                if segments:
+                    abm.message.extend(segments)
+                    for seg in segments:
+                        if isinstance(seg, Plain):
+                            abm.message_str += seg.text
             case 51:  # 帐号消息同步?
                 logger.info("消息类型(51)：帐号消息同步？")
             case 10000:  # 被踢出群聊/更换群主/修改群名称

--- a/astrbot/core/platform/sources/gewechat/client.py
+++ b/astrbot/core/platform/sources/gewechat/client.py
@@ -197,8 +197,12 @@ class SimpleGewechatClient:
             else:
                 user_real_name = self.userrealnames[abm.group_id][user_id]
         else:
-            info = (await self.get_user_or_group_info(user_id))["data"][0]
-            user_real_name = info["nickName"]
+            try:
+                info = (await self.get_user_or_group_info(user_id))["data"][0]
+                user_real_name = info["nickName"]
+            except Exception as e:
+                logger.debug(f"获取用户 {user_id} 昵称失败: {e}")
+                user_real_name = user_id
 
         abm.sender = MessageMember(user_id, user_real_name)
         abm.raw_message = d

--- a/astrbot/core/platform/sources/gewechat/client.py
+++ b/astrbot/core/platform/sources/gewechat/client.py
@@ -197,7 +197,8 @@ class SimpleGewechatClient:
             else:
                 user_real_name = self.userrealnames[abm.group_id][user_id]
         else:
-            user_real_name = d.get("PushContent", "unknown : ").split(" : ")[0]
+            info = (await self.get_user_or_group_info(user_id))["data"][0]
+            user_real_name = info["nickName"]
 
         abm.sender = MessageMember(user_id, user_real_name)
         abm.raw_message = d

--- a/astrbot/core/platform/sources/gewechat/xml_data_parser.py
+++ b/astrbot/core/platform/sources/gewechat/xml_data_parser.py
@@ -62,9 +62,14 @@ class GeweDataParser:
                         try:
                             logger.debug("gewechat: Reference message is nested")
                             refer_root = eT.fromstring(refermsg_content.text)
-                            refermsg_content_title = refer_root.find("appmsg").find("title")
-                            logger.debug(f"gewechat: Reference message nesting: {refermsg_content_title.text}")
-                            replied_content = refermsg_content_title.text
+                            img=refer_root.find("img")
+                            if img is not None:
+                                replied_content = "[图片]"
+                            else:
+                                app_msg=refer_root.find("appmsg")
+                                refermsg_content_title = app_msg.find("title")
+                                logger.debug(f"gewechat: Reference message nesting: {refermsg_content_title.text}")
+                                replied_content = refermsg_content_title.text
                         except Exception as e:
                             logger.error(f"gewechat: nested failed, {e}")
                             # 处理异常情况

--- a/astrbot/core/platform/sources/gewechat/xml_data_parser.py
+++ b/astrbot/core/platform/sources/gewechat/xml_data_parser.py
@@ -57,7 +57,20 @@ class GeweDataParser:
                 if displayname is not None:
                     replied_nickname = displayname.text
                 if refermsg_content is not None:
-                    replied_content = refermsg_content.text
+                    # 处理引用嵌套，包括嵌套公众号消息
+                    if refermsg_content.text.startswith("<msg>") or refermsg_content.text.startswith("<?xml"):
+                        try:
+                            logger.debug("gewechat: Reference message is nested")
+                            refer_root = eT.fromstring(refermsg_content.text)
+                            refermsg_content_title = refer_root.find("appmsg").find("title")
+                            logger.debug(f"gewechat: Reference message nesting: {refermsg_content_title.text}")
+                            replied_content = refermsg_content_title.text
+                        except Exception as e:
+                            logger.error(f"gewechat: nested failed, {e}")
+                            # 处理异常情况
+                            replied_content = refermsg_content.text
+                    else:
+                        replied_content = refermsg_content.text
 
                 # 提取引用者说的内容
             title = root.find(".//appmsg/title")

--- a/astrbot/core/platform/sources/gewechat/xml_data_parser.py
+++ b/astrbot/core/platform/sources/gewechat/xml_data_parser.py
@@ -1,6 +1,11 @@
 from defusedxml import ElementTree as eT
 from astrbot.api import logger
-from astrbot.api.message_components import WechatEmoji as Emoji, Reply, Plain
+from astrbot.api.message_components import (
+    WechatEmoji as Emoji,
+    Reply,
+    Plain,
+    BaseMessageComponent,
+)
 
 
 class GeweDataParser:
@@ -11,7 +16,7 @@ class GeweDataParser:
     def _format_to_xml(self):
         return eT.fromstring(self.data)
 
-    def parse_mutil_49(self):
+    def parse_mutil_49(self) -> list[BaseMessageComponent] | None:
         appmsg_type = self._format_to_xml().find(".//appmsg/type")
         if appmsg_type is None:
             return
@@ -34,13 +39,18 @@ class GeweDataParser:
         except Exception as e:
             logger.error(f"gewechat: parse_emoji failed, {e}")
 
-    def parse_reply(self) -> Reply | None:
+    def parse_reply(self) -> list[Reply, Plain] | None:
+        """解析引用消息
+
+        Returns:
+            list[Reply, Plain]: 一个包含两个元素的列表。Reply 消息对象和引用者说的文本内容。微信平台下引用消息时只能发送文本消息。
+        """
         try:
             replied_id = -1
             replied_uid = 0
             replied_nickname = ""
-            replied_content = ""
-            content = ""
+            replied_content = ""  # 被引用者说的内容
+            content = ""  # 引用者说的内容
 
             root = self._format_to_xml()
             refermsg = root.find(".//refermsg")
@@ -58,17 +68,21 @@ class GeweDataParser:
                     replied_nickname = displayname.text
                 if refermsg_content is not None:
                     # 处理引用嵌套，包括嵌套公众号消息
-                    if refermsg_content.text.startswith("<msg>") or refermsg_content.text.startswith("<?xml"):
+                    if refermsg_content.text.startswith(
+                        "<msg>"
+                    ) or refermsg_content.text.startswith("<?xml"):
                         try:
                             logger.debug("gewechat: Reference message is nested")
                             refer_root = eT.fromstring(refermsg_content.text)
-                            img=refer_root.find("img")
+                            img = refer_root.find("img")
                             if img is not None:
                                 replied_content = "[图片]"
                             else:
-                                app_msg=refer_root.find("appmsg")
+                                app_msg = refer_root.find("appmsg")
                                 refermsg_content_title = app_msg.find("title")
-                                logger.debug(f"gewechat: Reference message nesting: {refermsg_content_title.text}")
+                                logger.debug(
+                                    f"gewechat: Reference message nesting: {refermsg_content_title.text}"
+                                )
                                 replied_content = refermsg_content_title.text
                         except Exception as e:
                             logger.error(f"gewechat: nested failed, {e}")
@@ -82,15 +96,15 @@ class GeweDataParser:
             if title is not None:
                 content = title.text
 
-            r = Reply(
+            reply_seg = Reply(
                 id=replied_id,
-                chain=[Plain(content)],
+                chain=[Plain(replied_content)],
                 sender_id=replied_uid,
                 sender_nickname=replied_nickname,
-                sender_str=replied_content,
-                message_str=content,
+                message_str=replied_content,
             )
-            return r
+            plain_seg = Plain(content)
+            return [reply_seg, plain_seg]
 
         except Exception as e:
             logger.error(f"gewechat: parse_reply failed, {e}")


### PR DESCRIPTION
### Motivation

在原来的代码中，如果私聊用户发送的是引用消息，则获取的昵称固定为"回复"。无法准确获取昵称。

### Modifications

更新用户真实姓名获取逻辑，改为从用户信息中提取，确保任何情况下都能获得准确的真实昵称。

### Check
- [x] 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 我新增/修复/优化的功能经过良好的测试

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 修改了昵称检索逻辑，以便在私聊场景中从用户信息中准确获取用户的真实姓名，替换了之前固定的 'reply' 占位符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Modify the nickname retrieval logic to accurately fetch the user's real name from user information in private chat scenarios, replacing the previous fixed 'reply' placeholder

</details>