### PR TITLE
perf: 修改默认会话过滤器标识符为umo

### DIFF
--- a/astrbot/core/utils/session_waiter.py
+++ b/astrbot/core/utils/session_waiter.py
@@ -97,8 +97,8 @@ class SessionFilter:
 
 class DefaultSessionFilter(SessionFilter):
     def filter(self, event: AstrMessageEvent) -> str:
-        """默认实现，返回发送者的 ID 作为会话标识符"""
-        return event.get_sender_id()
+        """默认实现，返回统一消息来源字符串作为会话标识符"""
+        return event.unified_msg_origin
 
 
 class SessionWaiter:


### PR DESCRIPTION
### Motivation

避免默认标识符导致的跨会话问题

### Modifications

修改默认会话过滤器标识符为umo

## Sourcery 总结

修改默认会话过滤器标识符以使用统一的消息来源

Bug 修复：
- 通过使用统一的消息来源标识符，解决潜在的跨会话问题

增强功能：
- 更新默认会话过滤器以使用更一致的会话识别方法

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modify the default session filter identifier to use a unified message origin

Bug Fixes:
- Resolve potential cross-session issues by using a unified message origin identifier

Enhancements:
- Update the default session filter to use a more consistent session identification method

</details>