### PR TITLE
TTS : add text output alongside voice (Fix #1085)

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -61,6 +61,7 @@ DEFAULT_CONFIG = {
     "provider_tts_settings": {
         "enable": False,
         "provider_id": "",
+        "dual_output": False,
     },
     "provider_ltm_settings": {
         "group_icl_enable": False,
@@ -1101,6 +1102,12 @@ CONFIG_METADATA_2 = {
                         "description": "提供商 ID，不填则默认第一个TTS提供商",
                         "type": "string",
                         "hint": "文本转语音提供商 ID。如果不填写将使用载入的第一个提供商。",
+                    },
+                    "dual_output": {
+                        "description": "启用语音和文字双输出",
+                        "type": "bool",
+                        "hint": "启用后，Bot 将同时输出语音和文字消息。",
+                        "obvious_hint": True,
                     },
                 },
             },

--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -184,6 +184,8 @@ class ResultDecorateStage(Stage):
                                 new_chain.append(
                                     Record(file=audio_path, url=audio_path)
                                 )
+                                if(self.ctx.astrbot_config["provider_tts_settings"]["dual_output"]):
+                                    new_chain.append(comp)
                             else:
                                 logger.error(
                                     f"由于 TTS 音频文件没找到，消息段转语音失败: {comp.text}"


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
修复了 #1085

### Motivation

添加了开启tts功能情况下，可以选择是否同时输出语音文字的选项。

### Modifications

在config/default.py 中添加bool类型dual_output
在pipeline/result_decorate/stage.py 中添加判断dual_output开启情况，增加文字文本到chain中的代码
![dual_output](https://github.com/user-attachments/assets/48927d45-85d0-4ad8-8bd5-0dbda7df7a21)


### Check
- [✔] 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [✔] 我新增/修复/优化的功能经过良好的测试

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

添加在启用 TTS 时同时输出文本和语音的选项

新特性：
- 引入 TTS 的 'dual_output' 配置选项，允许同时输出文本和语音

Bug 修复：
- 通过实现文本和语音双重输出功能，解决问题 #1085

增强功能：
- 修改 TTS 管道以支持可选的文本和语音双重输出

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an option to output both text and voice when TTS is enabled

New Features:
- Introduce a 'dual_output' configuration option for TTS that allows simultaneous text and voice output

Bug Fixes:
- Resolve issue #1085 by implementing text and voice dual output functionality

Enhancements:
- Modify TTS pipeline to support optional dual text and voice output

</details>