### PR TITLE
为缺少session_id字段的aiocqhttp消息提供一个默认值，防止报错

### DIFF
--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -320,7 +320,7 @@ class AiocqhttpAdapter(Platform):
             message_str=message.message_str,
             message_obj=message,
             platform_meta=self.meta(),
-            session_id=message.session_id,
+            session_id=getattr(message, "session_id", "114514"),
             bot=self.bot,
         )
 


### PR DESCRIPTION
修复了aiocqhttp消息缺少session_id字段时导致报错

### Motivation

aiocqhttp的群邀请事件和加好友事件在构造成AiocqhttpMessageEvent时缺少session_id字段，导致报错，影响我写的插件

### Modifications
在构造AiocqhttpMessageEvent时，若session_id不存在则提供一个默认值来使用：
 async def handle_msg(self, message: AstrBotMessage):
        message_event = AiocqhttpMessageEvent(
            message_str=message.message_str,
            message_obj=message,
            platform_meta=self.meta(),
            session_id=getattr(message, "session_id", "114514"),
            bot=self.bot,
        )

### Check
- [x] 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 我新增/修复/优化的功能经过良好的测试

好的，这是翻译成中文的 pull request 摘要：

## Sourcery 总结

Bug 修复：
- 修复了 `aiocqhttp` 中由于缺少 `session_id` 字段而导致群邀请和好友请求事件出错的问题，通过添加默认值 `'114514'` 解决。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixed an issue where group invite and friend request events in aiocqhttp were causing errors due to missing session_id field by adding a default value of '114514'

</details>