### PR TITLE
feature: 企业微信添加长文本分割功能以支持发送超过 2048 字符的消息

### DIFF
--- a/astrbot/core/platform/sources/wecom/wecom_event.py
+++ b/astrbot/core/platform/sources/wecom/wecom_event.py
@@ -45,7 +45,30 @@ class WecomPlatformEvent(AstrMessageEvent):
         if len(plain) <= 2048:
             return [plain]
         else:
-            return [plain[i : i + 2048] for i in range(0, len(plain), 2048)]
+            result = []
+            start = 0
+            while start < len(plain):
+                # 剩下的字符串长度<2048时结束
+                if start + 2048 >= len(plain):
+                    result.append(plain[start:])
+                    break
+                
+                # 向前搜索分割标点符号
+                end = min(start + 2048, len(plain))
+                cut_position = end
+                for i in range(end, start, -1):
+                    if i < len(plain) and plain[i-1] in ["。", "！", "？", ".", "!", "?", "\n", ";", "；"]:
+                        cut_position = i
+                        break
+                
+                # 没找到合适的位置分割, 直接切分
+                if cut_position == end and end < len(plain):
+                    cut_position = end
+                
+                result.append(plain[start:cut_position])
+                start = cut_position
+
+            return result
 
     async def send(self, message: MessageChain):
         message_obj = self.message_obj

--- a/astrbot/core/platform/sources/wecom/wecom_event.py
+++ b/astrbot/core/platform/sources/wecom/wecom_event.py
@@ -1,4 +1,5 @@
 import uuid
+import asyncio
 from astrbot.api.event import AstrMessageEvent, MessageChain
 from astrbot.api.platform import AstrBotMessage, PlatformMetadata
 from astrbot.api.message_components import Plain, Image, Record
@@ -33,14 +34,31 @@ class WecomPlatformEvent(AstrMessageEvent):
     ):
         pass
 
+    async def split_plain(self, plain: str) -> list[str]:
+        """将长文本分割成多个小文本, 每个小文本长度不超过 2048 字符
+
+        Args:
+            plain (str): 要分割的长文本
+        Returns:
+            list[str]: 分割后的文本列表
+        """
+        if len(plain) <= 2048:
+            return [plain]
+        else:
+            return [plain[i : i + 2048] for i in range(0, len(plain), 2048)]
+
     async def send(self, message: MessageChain):
         message_obj = self.message_obj
 
         for comp in message.chain:
             if isinstance(comp, Plain):
-                self.client.message.send_text(
-                    message_obj.self_id, message_obj.session_id, comp.text
-                )
+                # Split long text messages if needed
+                plain_chunks = await self.split_plain(comp.text)
+                for chunk in plain_chunks:
+                    self.client.message.send_text(
+                        message_obj.self_id, message_obj.session_id, chunk
+                    )
+                    await asyncio.sleep(0.5)  # Avoid sending too fast
             elif isinstance(comp, Image):
                 img_path = await comp.convert_to_file_path()
 


### PR DESCRIPTION
fixes: #564

<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
修复了 #XYZ

### Motivation

<!--解释为什么要改动-->

### Modifications

<!--简单解释你的改动-->

### Check
- [ ] 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] 我新增/修复/优化的功能经过良好的测试

好的，这是将拉取请求摘要翻译成中文的结果：

## Sourcery 总结

添加对企业微信发送长文本消息的支持，通过实现文本消息拆分功能

新特性:
- 增加文本消息拆分功能，消息块之间有延迟，以防止消息发送过快

Bug 修复:
- 修复了企业微信发送长文本消息的限制，通过动态拆分超过 2048 个字符的消息

增强功能:
- 实现了一种将长文本消息拆分成最大 2048 个字符块的方法，以支持发送超过平台字符限制的消息

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for sending long text messages in WeChat Work (Wecom) by implementing text message splitting functionality

New Features:
- Add text message splitting functionality with a delay between message chunks to prevent sending messages too quickly

Bug Fixes:
- Fix limitation of sending long text messages in WeChat Work by dynamically splitting messages that exceed 2048 characters

Enhancements:
- Implement a method to split long text messages into chunks of maximum 2048 characters to support sending messages longer than the platform's character limit

</details>