### PR TITLE
feat: 😽对reset在不同情况下的权限特殊处理, 使其兼容alter_cmd 🤠为new指令增加清理上下文选项, 默认为清理, 更符合直觉

### DIFF
--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -763,8 +763,13 @@ UID: {user_id} 此 ID 可用于设置管理员。
         return
 
     @filter.command("new")
-    async def new_conv(self, message: AstrMessageEvent):
-        """创建新对话"""
+    async def new_conv(self, message: AstrMessageEvent, clean: bool = True):
+        """
+        创建新对话
+
+        Args:
+            clean(bool): 是否清理当前对话的上下文, 默认为 True.
+        """
         provider = self.context.get_using_provider()
         if provider and provider.meta().type == "dify":
             assert isinstance(provider, ProviderDify)
@@ -777,6 +782,20 @@ UID: {user_id} 此 ID 可用于设置管理员。
         cid = await self.context.conversation_manager.new_conversation(
             message.unified_msg_origin
         )
+
+        # 判断是否清理上下文
+        if clean:
+            await self.context.conversation_manager.update_conversation(
+                message.unified_msg_origin, cid, []
+            )
+
+            # 长期记忆
+            if self.ltm:
+                try:
+                    await self.ltm.remove_session(event=message)
+                except BaseException as e:
+                    logger.error(f"清理聊天增强记录失败: {e}")
+
         message.set_result(
             MessageEventResult().message(f"切换到新对话: 新对话({cid[:4]})。")
         )

--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -775,12 +775,9 @@ UID: {user_id} 此 ID 可用于设置管理员。
         return
 
     @filter.command("new")
-    async def new_conv(self, message: AstrMessageEvent, clean: bool = True):
+    async def new_conv(self, message: AstrMessageEvent):
         """
         创建新对话
-
-        Args:
-            clean(bool): 是否清理当前对话的上下文, 默认为 True.
         """
         provider = self.context.get_using_provider()
         if provider and provider.meta().type == "dify":
@@ -794,19 +791,6 @@ UID: {user_id} 此 ID 可用于设置管理员。
         cid = await self.context.conversation_manager.new_conversation(
             message.unified_msg_origin
         )
-
-        # 判断是否清理上下文
-        if clean:
-            await self.context.conversation_manager.update_conversation(
-                message.unified_msg_origin, cid, []
-            )
-
-            # 长期记忆
-            if self.ltm:
-                try:
-                    await self.ltm.remove_session(event=message)
-                except Exception as e:
-                    logger.error(f"清理聊天增强记录失败: {e}")
 
         message.set_result(
             MessageEventResult().message(f"切换到新对话: 新对话({cid[:4]})。")

--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -792,6 +792,13 @@ UID: {user_id} 此 ID 可用于设置管理员。
             message.unified_msg_origin
         )
 
+        # 长期记忆
+        if self.ltm:
+            try:
+                await self.ltm.remove_session(event=message)
+            except Exception as e:
+                logger.error(f"清理聊天增强记录失败: {e}")
+
         message.set_result(
             MessageEventResult().message(f"切换到新对话: 新对话({cid[:4]})。")
         )

--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -805,7 +805,7 @@ UID: {user_id} 此 ID 可用于设置管理员。
             if self.ltm:
                 try:
                     await self.ltm.remove_session(event=message)
-                except BaseException as e:
+                except Exception as e:
                     logger.error(f"清理聊天增强记录失败: {e}")
 
         message.set_result(

--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -35,7 +35,29 @@ from typing import Union
 class Main(star.Star):
 
     SCENE_MAP = {1: "group_unique_on", 2: "group_unique_off", 3: "private"}
-    SCENE_NAMES = {1: "群聊+会话隔离开启", 2: "群聊+会话隔离关闭", 3: "私聊"}
+class RstScene(Enum):
+    GROUP_UNIQUE_ON = ("group_unique_on", "群聊+会话隔离开启")
+    GROUP_UNIQUE_OFF = ("group_unique_off", "群聊+会话隔离关闭")
+    PRIVATE = ("private", "私聊")
+
+    @property
+    def key(self) -> str:
+        return self.value[0]
+
+    @property
+    def name(self) -> str:
+        return self.value[1]
+
+    @classmethod
+    def from_index(cls, index: int) -> "RstScene":
+        mapping = {1: cls.GROUP_UNIQUE_ON, 2: cls.GROUP_UNIQUE_OFF, 3: cls.PRIVATE}
+        return mapping[index]
+
+    @classmethod
+    def get_scene(cls, is_group: bool, is_unique_session: bool) -> "RstScene":
+        if is_group:
+            return cls.GROUP_UNIQUE_ON if is_unique_session else cls.GROUP_UNIQUE_OFF
+        return cls.PRIVATE
 
     def __init__(self, context: star.Context) -> None:
         self.context = context


### PR DESCRIPTION
修复了 #1360 

### Motivation

1. alter_cmd指令无法修改reset指令权限, 这是反直觉的
2. new指令通常需要搭配reset使用才能清理上下文, 默认情况下应当自动清理

### Modifications

1. 对alter_cmd和reset进行特殊处理, 来针对不同配置情况下设置权限
2. 对new指令进行修改, 提供一个参数选择是否清理上下文(默认清理)

### Check
- [x] 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 我新增/修复/优化的功能经过良好的测试

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

增强 reset 和 new 命令的权限和上下文管理，以改善用户体验并提供更灵活的配置选项。

新功能：
- 为不同场景（具有/不具有唯一会话的群组、私聊）的 reset 命令添加细粒度的权限配置
- 为 new 命令引入一个可选的上下文清理参数

增强功能：
- 改进 reset 命令权限逻辑，以支持更细致的访问控制
- 通过默认为清理，使 new 命令上下文清理行为更加直观

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the permission and context management for reset and new commands to improve user experience and provide more flexible configuration options

New Features:
- Add granular permission configuration for reset command across different scenarios (group with/without unique session, private chat)
- Introduce an optional context cleaning parameter for new command

Enhancements:
- Improve reset command permission logic to support more nuanced access control
- Make new command context cleaning behavior more intuitive by defaulting to clean

</details>