### PR TITLE
fix: Gemini保证偶数索引为用户消息，奇数索引为模型消息

### DIFF
--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -260,6 +260,20 @@ class ProviderGoogleGenAI(Provider):
                     )
                 )
 
+        # 保证偶数索引为用户消息，奇数索引为模型消息
+        content_num = len(gemini_contents)
+        for i in range(content_num):
+            expected_type = types.UserContent if i % 2 == 0 else types.ModelContent
+            if not isinstance(gemini_contents[i], expected_type):
+                for j in range(i + 1, content_num):
+                    if isinstance(gemini_contents[j], expected_type):
+                        logger.debug(f"交换索引 {i} 与 {j}")
+                        gemini_contents[i], gemini_contents[j] = (
+                            gemini_contents[j],
+                            gemini_contents[i],
+                        )
+                        break
+
         return gemini_contents
 
     @staticmethod

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -266,6 +266,9 @@ class ProviderGoogleGenAI(Provider):
                 else:
                     gemini_contents.append(types.UserContent(parts=parts))
 
+        if gemini_contents and isinstance(gemini_contents[0], types.ModelContent):
+            gemini_contents.pop()
+
         return gemini_contents
 
     @staticmethod

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -264,15 +264,16 @@ class ProviderGoogleGenAI(Provider):
         content_num = len(gemini_contents)
         for i in range(content_num):
             expected_type = types.UserContent if i % 2 == 0 else types.ModelContent
-            if not isinstance(gemini_contents[i], expected_type):
-                for j in range(i + 1, content_num):
-                    if isinstance(gemini_contents[j], expected_type):
-                        logger.debug(f"交换索引 {i} 与 {j}")
-                        gemini_contents[i], gemini_contents[j] = (
-                            gemini_contents[j],
-                            gemini_contents[i],
-                        )
-                        break
+            if isinstance(gemini_contents[i], expected_type):
+                continue
+            for j in range(i + 1, content_num):
+                if isinstance(gemini_contents[j], expected_type):
+                    logger.debug(f"交换索引 {i} 与 {j}")
+                    gemini_contents[i], gemini_contents[j] = (
+                        gemini_contents[j],
+                        gemini_contents[i],
+                    )
+                    break
 
         return gemini_contents
 


### PR DESCRIPTION
### Motivation

如果触发多个函数调用，openai的格式如下：
```
[
    {"role": "user", "content": "hello"},
    {"role": "assistant", "content": "calling tools", "tool_calls": [{"id": "1"}, {"id": "2"}]},
    {"role": "tool", "content": "response 1"},
    {"role": "tool", "content": "response 2"}
]
```
当转换为 Gemini Content 列表时会出现连续的ModelContent、UserContent

### Modifications

转换时合并连续相同类型的消息

### Check
- [x] 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 我新增/修复/优化的功能经过良好的测试

## Sourcery 总结

修改 Gemini 内容转换，以确保用户和模型消息类型交替出现

Bug 修复：
- 解决将 OpenAI 风格的消息列表转换为 Gemini 内容时，消息类型连续出现的问题，方法是重新排序内容列表

增强功能：
- 实施重新排序机制，以保证偶数索引的内容为用户消息，奇数索引的内容为模型消息

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modify Gemini content conversion to ensure alternating user and model message types

Bug Fixes:
- Resolve issue with consecutive message types when converting OpenAI-style message lists to Gemini content by reordering the content list

Enhancements:
- Implement a reordering mechanism to guarantee that even-indexed contents are user messages and odd-indexed contents are model messages

</details>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

修改 Gemini 内容转换，通过合并相同类型的连续消息，确保用户和模型消息类型交替出现。

Bug 修复：
- 解决将 OpenAI 风格的消息列表转换为 Gemini 内容时，连续消息类型的问题，方法是合并相同类型的连续消息。

增强功能：
- 实施重新排序机制，以保证偶数索引的内容为用户消息，奇数索引的内容为模型消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modify Gemini content conversion to ensure alternating user and model message types by merging consecutive messages of the same type

Bug Fixes:
- Resolve issue with consecutive message types when converting OpenAI-style message lists to Gemini content by merging consecutive messages of the same type

Enhancements:
- Implement a reordering mechanism to guarantee that even-indexed contents are user messages and odd-indexed contents are model messages

</details>