### PR TITLE
feat: 允许用户自定义telegram适配器指令注册行为，优化命令注册机制

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -186,6 +186,9 @@ CONFIG_METADATA_2 = {
                         "start_message": "Hello, I'm AstrBot!",
                         "telegram_api_base_url": "https://api.telegram.org/bot",
                         "telegram_file_base_url": "https://api.telegram.org/file/bot",
+                        "telegram_command_register": True,
+                        "telegram_command_auto_refresh": True,
+                        "telegram_command_register_interval": 300
                     },
                 },
                 "items": {
@@ -193,6 +196,21 @@ CONFIG_METADATA_2 = {
                         "description": "Bot Token",
                         "type": "string",
                         "hint": "如果你的网络环境为中国大陆，请在 `其他配置` 处设置代理或更改 api_base。",
+                    },
+                    "telegram_command_register": {
+                        "description": "Telegram 命令注册",
+                        "type": "bool",
+                        "hint": "启用后，AstrBot 将会自动注册 Telegram 命令。",
+                    },
+                    "telegram_command_auto_refresh": {
+                        "description": "Telegram 命令自动刷新",
+                        "type": "bool",
+                        "hint": "启用后，AstrBot 将会在运行时自动刷新 Telegram 命令。(单独设置此项无效)",
+                    },
+                    "telegram_command_register_interval": {
+                        "description": "Telegram 命令自动刷新间隔",
+                        "type": "int",
+                        "hint": "Telegram 命令自动刷新间隔，单位为秒。",
                     },
                     "id": {
                         "description": "ID",

--- a/astrbot/core/platform/sources/telegram/tg_adapter.py
+++ b/astrbot/core/platform/sources/telegram/tg_adapter.py
@@ -58,6 +58,10 @@ class TelegramPlatformAdapter(Platform):
 
         self.base_url = base_url
 
+        self.enable_command_register = self.config.get("telegram_command_register", True)
+        self.enable_command_refresh = self.config.get("telegram_command_auto_refresh", True)
+        self.last_command_hash = None
+
         self.application = (
             ApplicationBuilder()
             .token(self.config["telegram_token"])
@@ -95,17 +99,19 @@ class TelegramPlatformAdapter(Platform):
     async def run(self):
         await self.application.initialize()
         await self.application.start()
-        await self.register_commands()
 
-        # TODO 使用更优雅的方式重新注册命令
-        self.scheduler.add_job(
-            self.register_commands,
-            "interval",
-            minutes=5,
-            id="telegram_command_register",
-            misfire_grace_time=60,
-        )
-        self.scheduler.start()
+        if self.enable_command_register:
+            await self.register_commands()
+
+        if self.enable_command_refresh and self.enable_command_register:
+            self.scheduler.add_job(
+                self.register_commands,
+                "interval",
+                seconds=self.config.get("telegram_command_register_interval", 300),
+                id="telegram_command_register",
+                misfire_grace_time=60,
+            )
+            self.scheduler.start()
 
         queue = self.application.updater.start_polling()
         logger.info("Telegram Platform Adapter is running.")
@@ -114,10 +120,14 @@ class TelegramPlatformAdapter(Platform):
     async def register_commands(self):
         """收集所有注册的指令并注册到 Telegram"""
         try:
-            await self.client.delete_my_commands()
             commands = self.collect_commands()
 
             if commands:
+                current_hash = hash(tuple((cmd.command, cmd.description) for cmd in commands))
+                if current_hash == self.last_command_hash:
+                    return
+                self.last_command_hash = current_hash
+                await self.client.delete_my_commands()
                 await self.client.set_my_commands(commands)
 
         except Exception as e:
@@ -342,7 +352,9 @@ class TelegramPlatformAdapter(Platform):
                 self.scheduler.shutdown()
 
             await self.application.stop()
-            await self.client.delete_my_commands()
+
+            if self.enable_command_register:
+                await self.client.delete_my_commands()
 
             # 保险起见先判断是否存在updater对象
             if self.application.updater is not None:


### PR DESCRIPTION
fixes #1379 

### Motivation

现有指令注册机制未考虑到部分用户的需求

### Modifications

增加选项，允许用户自定义telegram适配器指令注册行为。

增加哈希计算机制，按需注册指令。

### Check
- [x] 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 我新增/修复/优化的功能经过良好的测试

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

增强 Telegram 适配器命令注册机制，提供可配置的命令注册和刷新行为选项

**新特性：**

- 增加可配置选项，用于控制 Telegram 命令注册和自动刷新行为
- 实现基于哈希的机制来优化命令注册过程

**增强：**

- 为 Telegram 命令注册引入灵活的配置
- 增加启用/禁用自动命令注册的选项
- 增加控制命令刷新间隔的选项

**杂项：**

- 更新默认配置模式以包含新的 Telegram 命令注册设置

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance Telegram adapter command registration mechanism with configurable options for command registration and refresh behavior

New Features:
- Add configurable options to control Telegram command registration and auto-refresh behavior
- Implement hash-based mechanism to optimize command registration process

Enhancements:
- Introduce flexible configuration for Telegram command registration
- Add option to enable/disable automatic command registration
- Add option to control command refresh interval

Chores:
- Update default configuration schema to include new Telegram command registration settings

</details>