### PR TITLE
飞书回复新增思考过程，https://github.com/AstrBotDevs/AstrBot/issues/1415

### DIFF
--- a/astrbot/core/pipeline/process_stage/stage.py
+++ b/astrbot/core/pipeline/process_stage/stage.py
@@ -7,6 +7,7 @@ from astrbot.core.platform.astr_message_event import AstrMessageEvent
 from astrbot.core.star.star_handler import StarHandlerMetadata
 from astrbot.core.provider.entities import ProviderRequest
 from astrbot.core import logger
+from astrbot.core.message.message_event_result import MessageEventResult
 
 
 @register_stage
@@ -62,7 +63,14 @@ class ProcessStage(Stage):
 
                 if not provider:
                     logger.info("未找到可用的 LLM 提供商，请先前往配置服务提供商。")
+                    # 添加错误通知
+                    event.set_result(
+                        MessageEventResult().message(
+                            "未找到可用的提供商，请联系机器人管理员配置服务提供商。"
+                        )
+                    )
+                    yield
+                    event.stop_event()
                     return
-
                 async for _ in self.llm_request_sub_stage.process(event):
                     yield


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了 #1415

### Motivation

提高飞书交互体验。

<!--简单解释你的改动-->

* 调用LLM之前增加等待交互，LLM请求完成后更新等待内容。
* 未配置提供商时，有对应提示给用户。

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

通过在 Lark (飞书) 上显示“思考中”指示器来改善用户体验，以提示正在处理请求。

新功能：
- 在收到请求后立即在 Lark 上发送“思考中...”消息（在私信中或被提及时）。
- 完成后，将“思考中...”消息替换为最终回复。
- 对“思考中...”消息和最终回复均使用 Lark 互动卡片。
- 如果没有可用的 LLM 提供程序，则通过 Lark 通知用户。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the user experience on Lark (Feishu) by showing a "thinking" indicator while processing requests.

New Features:
- Send a "thinking..." message on Lark immediately upon receiving a request (in DMs or when mentioned).
- Replace the "thinking..." message with the final response upon completion.
- Utilize Lark interactive cards for both "thinking" messages and final replies.
- Notify the user via Lark if no LLM provider is available.

</details>