### PR TITLE
feat: 添加aiocqhttp对Token设置的支持

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -140,6 +140,7 @@ CONFIG_METADATA_2 = {
                         "enable": False,
                         "ws_reverse_host": "0.0.0.0",
                         "ws_reverse_port": 6199,
+                        "ws_reverse_token": "",
                     },
                     "gewechat(微信)": {
                         "id": "gwchat",
@@ -188,7 +189,7 @@ CONFIG_METADATA_2 = {
                         "telegram_file_base_url": "https://api.telegram.org/file/bot",
                         "telegram_command_register": True,
                         "telegram_command_auto_refresh": True,
-                        "telegram_command_register_interval": 300
+                        "telegram_command_register_interval": 300,
                     },
                 },
                 "items": {
@@ -257,6 +258,11 @@ CONFIG_METADATA_2 = {
                         "description": "反向 Websocket 端口",
                         "type": "int",
                         "hint": "aiocqhttp 适配器的反向 Websocket 端口。",
+                    },
+                    "ws_reverse_token": {
+                        "description": "反向 Websocket Token",
+                        "type": "string",
+                        "hint": "aiocqhttp 适配器的反向 Websocket Token。未设置则不启用 Token 验证。",
                     },
                     "lark_bot_name": {
                         "description": "飞书机器人的名字",

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -46,7 +46,10 @@ class AiocqhttpAdapter(Platform):
         )
 
         self.bot = CQHttp(
-            use_ws_reverse=True, import_name="aiocqhttp", api_timeout_sec=180
+            use_ws_reverse=True,
+            import_name="aiocqhttp",
+            api_timeout_sec=180,
+            access_token=platform_config["ws_reverse_token"],
         )
 
         @self.bot.on_request()


### PR DESCRIPTION
### Motivation

aiocqhttp支持token设置

### Modifications

aiocqhttp添加token设置支持

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

为 `aiocqhttp` 适配器添加对反向 WebSocket 连接的访问令牌身份验证的支持。

新特性：
- 为 `aiocqhttp` 平台适配器引入 `ws_reverse_token` 配置选项。
- 使用配置的令牌来验证反向 WebSocket 连接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for access token authentication for reverse WebSocket connections in the `aiocqhttp` adapter.

New Features:
- Introduce the `ws_reverse_token` configuration option for the `aiocqhttp` platform adapter.
- Utilize the configured token for authenticating reverse WebSocket connections.

</details>