### PR TITLE
Improve: 优化 Gewechat 下文件回调逻辑

### DIFF
--- a/astrbot/core/platform/sources/gewechat/client.py
+++ b/astrbot/core/platform/sources/gewechat/client.py
@@ -328,9 +328,9 @@ class SimpleGewechatClient:
         if not os.path.exists(self.staged_files[file_token]):
             logger.warning(f"请求的文件 {self.staged_files[file_token]} 不存在。")
             return quart.abort(404)
-        file_token = self.staged_files[file_token]
+        file_path = self.staged_files[file_token]
         self.staged_files.pop(file_token, None)
-        return await quart.send_file(file_token)
+        return await quart.send_file(file_path)
 
     async def _set_callback_url(self):
         logger.info("设置回调，请等待...")

--- a/astrbot/core/platform/sources/gewechat/client.py
+++ b/astrbot/core/platform/sources/gewechat/client.py
@@ -85,6 +85,8 @@ class SimpleGewechatClient:
         self.staged_files = {}
         """存储了允许外部访问的文件列表。auth_token: file_path。通过 register_file 方法注册。"""
 
+        self.lock = asyncio.Lock()
+
     async def get_token_id(self):
         """获取 Gewechat Token。"""
         async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
优化了 #1182

### Motivation

当前 gewechat 适配器对文件、图片、语音、视频文件的发送逻辑强依赖于文件路径在 data/temp 文件夹下。对插件开发非常不友好，并且图片处理时，会将图片从原路径复制到 data/temp 下，导致文件重复。

### Modifications

引入了一个简单的注册令牌机制，发送文件、图片、语音、视频文件前需要向回调服务注册文件并获得单次文件令牌。然后通过令牌访问文件。

此举提高了安全性、减少了副作用。

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构 Gewechat 适配器的文件处理机制，使用基于令牌的系统，而不是依赖直接文件路径访问。

增强功能：
- 引入文件注册机制，使用一次性令牌通过回调服务器提供文件（图像、视频、语音、通用文件）。
- 移除发送文件前必须位于 `data/temp` 目录的要求。
- 避免在发送图像文件之前将其复制到 `data/temp` 目录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the Gewechat adapter's file handling mechanism to use a token-based system instead of relying on direct file path access.

Enhancements:
- Introduce a file registration mechanism using single-use tokens for serving files (images, videos, voice, general files) via the callback server.
- Remove the requirement for files to be located in the `data/temp` directory before sending.
- Avoid copying image files to the `data/temp` directory before sending.

</details>