### PR TITLE
Improve: 优化 QQ 下自动下载文件的问题

### DIFF
--- a/astrbot/core/message/components.py
+++ b/astrbot/core/message/components.py
@@ -29,7 +29,7 @@ import uuid
 import typing as T
 from enum import Enum
 from pydantic.v1 import BaseModel
-from astrbot.core.utils.io import download_image_by_url, file_to_base64
+from astrbot.core.utils.io import download_image_by_url, file_to_base64, download_file
 
 
 class ComponentType(Enum):
@@ -552,15 +552,16 @@ class Unknown(BaseMessageComponent):
 
 class File(BaseMessageComponent):
     """
-    目前此消息段只适配了 Napcat。
+    文件消息段
     """
 
     type: ComponentType = "File"
     name: T.Optional[str] = ""  # 名字
-    file: T.Optional[str] = ""  # url（本地路径）
+    file: T.Optional[str] = ""  # url 或者本地路径
 
     def __init__(self, name: str, file: str):
         super().__init__(name=name, file=file)
+
 
 
 class WechatEmoji(BaseMessageComponent):

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -1,4 +1,3 @@
-import os
 import time
 import asyncio
 import logging
@@ -21,7 +20,6 @@ from .aiocqhttp_message_event import AiocqhttpMessageEvent
 from astrbot.core.platform.astr_message_event import MessageSesion
 from ...register import register_platform_adapter
 from aiocqhttp.exceptions import ActionFailed
-from astrbot.core.utils.io import download_file
 
 
 @register_platform_adapter(
@@ -242,8 +240,8 @@ class AiocqhttpAdapter(Platform):
                                     action="get_private_file_url",
                                     file_id=event.message[0]["data"]["file_id"],
                                 )
-                            if ret and "data" in ret and "url" in ret["data"]:
-                                file_url = ret["data"]["url"]  # https
+                            if ret and "url" in ret:
+                                file_url = ret["url"]  # https
                                 a = File(name="", file=file_url)
                                 abm.message.append(a)
                             else:

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -163,7 +163,9 @@ class AiocqhttpAdapter(Platform):
 
         if "sub_type" in event:
             if event["sub_type"] == "poke" and "target_id" in event:
-                abm.message.append(Poke(qq=str(event["target_id"]), type="poke"))  # noqa: F405
+                abm.message.append(
+                    Poke(qq=str(event["target_id"]), type="poke")
+                )  # noqa: F405
 
         return abm
 
@@ -224,7 +226,7 @@ class AiocqhttpAdapter(Platform):
                         # Lagrange
                         logger.info("guessing lagrange")
                         file_name = m["data"].get("file_name", "file")
-                        abm.message.append(File(name=file_name, file=m["data"]["url"]))
+                        abm.message.append(File(name=file_name, url=m["data"]["url"]))
                     else:
                         try:
                             # Napcat
@@ -242,7 +244,7 @@ class AiocqhttpAdapter(Platform):
                                 )
                             if ret and "url" in ret:
                                 file_url = ret["url"]  # https
-                                a = File(name="", file=file_url)
+                                a = File(name="", url=file_url)
                                 abm.message.append(a)
                             else:
                                 logger.error(f"获取文件失败: {ret}")

--- a/astrbot/core/platform/sources/telegram/tg_adapter.py
+++ b/astrbot/core/platform/sources/telegram/tg_adapter.py
@@ -58,8 +58,12 @@ class TelegramPlatformAdapter(Platform):
 
         self.base_url = base_url
 
-        self.enable_command_register = self.config.get("telegram_command_register", True)
-        self.enable_command_refresh = self.config.get("telegram_command_auto_refresh", True)
+        self.enable_command_register = self.config.get(
+            "telegram_command_register", True
+        )
+        self.enable_command_refresh = self.config.get(
+            "telegram_command_auto_refresh", True
+        )
         self.last_command_hash = None
 
         self.application = (
@@ -123,7 +127,9 @@ class TelegramPlatformAdapter(Platform):
             commands = self.collect_commands()
 
             if commands:
-                current_hash = hash(tuple((cmd.command, cmd.description) for cmd in commands))
+                current_hash = hash(
+                    tuple((cmd.command, cmd.description) for cmd in commands)
+                )
                 if current_hash == self.last_command_hash:
                     return
                 self.last_command_hash = current_hash


### PR DESCRIPTION
### Motivation

现在 AstrBot 会下载每一个 QQ 协议端下发的文件并且没有定期消费机制，长期堆积可能导致用户磁盘被占满。


### Modifications

‼️ BREAKING CHANGE: File 消息段的 `file` 字段将可能将下发 https 协议的链接。

### Check

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是将拉取请求摘要翻译成中文的结果：

## Sourcery 总结

优化 QQ 协议适配器的文件处理方式，更改文件处理和检索方式

新特性：
- 支持直接从 QQ 协议适配器检索文件 URL

Bug 修复：
- 避免不必要的本地文件下载
- 移除潜在的磁盘空间累积问题

增强功能：
- 修改 File 消息组件以支持基于 URL 的文件处理
- 改进不同消息类型（群消息和好友消息）的文件检索

日常维护：
- 更新文件处理逻辑，使其对不同的 QQ 协议客户端更具灵活性

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize file handling for QQ protocol adapters by changing how files are processed and retrieved

New Features:
- Support for retrieving file URLs directly from QQ protocol adapters

Bug Fixes:
- Prevent unnecessary local file downloads
- Remove potential disk space accumulation issues

Enhancements:
- Modify File message component to support URL-based file handling
- Improve file retrieval for different message types (group and friend messages)

Chores:
- Update file handling logic to be more flexible with different QQ protocol clients

</details>