### PR TITLE
针对gewechat feat: 新增解析公众号功能, fix:修复引用视频号时无法正常显示的问题

### DIFF
--- a/astrbot/core/platform/sources/gewechat/xml_data_parser.py
+++ b/astrbot/core/platform/sources/gewechat/xml_data_parser.py
@@ -43,6 +43,11 @@ class GeweDataParser:
             logger.error(f"gewechat: parse_emoji failed, {e}")
 
     def parse_officialAccounts(self) -> list[Share] | None:
+        """解析公众号消息
+
+        Returns:
+            list[Share]: 一个包含 Share 消息对象的列表。
+        """
         try:
             root = self._format_to_xml()
             url = root.find(".//url")


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
新增解析公众号功能，修复了之前引用视频号时无法正常显示的问题。

### Motivation

之前没有解析公众号的功能，插件中也无法做总结公众号的功能，不太方便。最近虽然gewechat已经寄了，但是先增加这个功能也能方便插件开发者提前准备需要处理公众号的插件。

### Modifications

增加对appmsg为5时的处理逻辑，公众号链接最终处理为share。
对于引用视频号的问题，当前gewechat无法正常解析，所以直接更换为固定文本。

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 摘要：

## Sourcery 总结

增强 gewechat 插件，增加对解析公众号的支持并修复视频号引用显示问题

**新特性：**

- 增加对公众号消息（appmsg type 5）的解析支持
- 将公众号链接转换为分享消息类型

**Bug 修复：**

- 当无法解析视频号引用时，将其替换为固定文本 '[视频号]'
- 改进对嵌套引用消息的处理

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance gewechat plugin by adding support for parsing official accounts and fixing video channel reference display

New Features:
- Add parsing support for official account messages (appmsg type 5)
- Convert official account links to Share message type

Bug Fixes:
- Replace video channel references with fixed text '[视频号]' when unable to parse
- Improve handling of nested reference messages

</details>