### PR TITLE
Changed the parameter in file: ./utils/t2i/io.py , function `remove_d…

### DIFF
--- a/astrbot/core/utils/io.py
+++ b/astrbot/core/utils/io.py
@@ -32,7 +32,7 @@ def on_error(func, path, exc_info):
 def remove_dir(file_path) -> bool:
     if not os.path.exists(file_path):
         return True
-    shutil.rmtree(file_path, onerror=on_error)
+    shutil.rmtree(file_path, onexec=on_error)
     return True
 
 


### PR DESCRIPTION
…ir`,

line 35: `shutil.rmtree(file_path, onerror=on_error)` => `shutil.rmtree(file_path, onexec=on_error)`

<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了 shutil.rmtree(file_path, onerror=on_error) `onerror` 参数的报错问题

### Motivation

<img width="516" alt="屏幕截图 2025-05-08 213641" src="https://github.com/user-attachments/assets/cfd4c6c9-0fab-4ba2-bd2d-c69bfb086403" />

### Modifications

把 `onerror` 参数变更为 `onexec`

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [ ] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复:
- 修复了 `shutil.rmtree()` 函数的参数问题，将 `onerror` 更改为 `onexec`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixed an issue with the `shutil.rmtree()` parameter by changing `onerror` to `onexec`

</details>