### PR TITLE
Refactor: 采用 http 回调的方式上报文件消息段中的文件信息。

### DIFF
--- a/astrbot/core/__init__.py
+++ b/astrbot/core/__init__.py
@@ -7,27 +7,27 @@ from astrbot.core.utils.pip_installer import PipInstaller
 from astrbot.core.db.sqlite import SQLiteDatabase
 from astrbot.core.config.default import DB_PATH
 from astrbot.core.config import AstrBotConfig
+from astrbot.core.file_token_service import FileTokenService
 
 # 初始化数据存储文件夹
 os.makedirs("data", exist_ok=True)
+
+WEBUI_SK = "Advanced_System_for_Text_Response_and_Bot_Operations_Tool"
+DEMO_MODE = os.getenv("DEMO_MODE", False)
 
 astrbot_config = AstrBotConfig()
 t2i_base_url = astrbot_config.get("t2i_endpoint", "https://t2i.soulter.top/text2img")
 html_renderer = HtmlRenderer(t2i_base_url)
 logger = LogManager.GetLogger(log_name="astrbot")
-
-if os.environ.get("TESTING", ""):
-    logger.setLevel("DEBUG")
-
 db_helper = SQLiteDatabase(DB_PATH)
-sp = (
-    SharedPreferences()
-)  # 简单的偏好设置存储, 这里后续应该存储到数据库中, 一些部分可以存储到配置中
+# 简单的偏好设置存储, 这里后续应该存储到数据库中, 一些部分可以存储到配置中
+sp = SharedPreferences()
+# 文件令牌服务
+file_token_service = FileTokenService()
 pip_installer = PipInstaller(
     astrbot_config.get("pip_install_arg", ""),
     astrbot_config.get("pypi_index_url", None),
 )
 web_chat_queue = asyncio.Queue(maxsize=32)
 web_chat_back_queue = asyncio.Queue(maxsize=32)
-WEBUI_SK = "Advanced_System_for_Text_Response_and_Bot_Operations_Tool"
-DEMO_MODE = os.getenv("DEMO_MODE", False)
+

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -104,6 +104,7 @@ DEFAULT_CONFIG = {
     "knowledge_db": {},
     "persona": [],
     "timezone": "",
+    "callback_api_base": "",
 }
 
 
@@ -1282,6 +1283,12 @@ CONFIG_METADATA_2 = {
                 "type": "string",
                 "obvious_hint": True,
                 "hint": "时区设置。请填写 IANA 时区名称, 如 Asia/Shanghai, 为空时使用系统默认时区。所有时区请查看: https://data.iana.org/time-zones/tzdb-2021a/zone1970.tab",
+            },
+            "callback_api_base": {
+                "description": "对外可达的回调接口地址",
+                "type": "string",
+                "obvious_hint": True,
+                "hint": "外部服务可能会通过 AstrBot 生成的回调链接（如文件下载链接）访问 AstrBot 后端。由于 AstrBot 无法自动判断部署环境中对外可达的主机地址（host），因此需要通过此配置项显式指定 “外部服务如何访问 AstrBot” 的地址。如 http://localhost:6185，https://example.com 等。"
             },
             "log_level": {
                 "description": "控制台日志级别",

--- a/astrbot/core/file_token_service.py
+++ b/astrbot/core/file_token_service.py
@@ -1,0 +1,39 @@
+import asyncio
+import os
+import uuid
+
+
+class FileTokenService:
+    """维护一个简单的基于令牌的文件下载服务"""
+
+    def __init__(self):
+        self.lock = asyncio.Lock()
+        self.staged_files = {}
+
+    async def register_file(self, file_path: str) -> str:
+        """向令牌服务注册一个文件。
+
+        Args:
+            file_path(str): 文件路径
+
+        Returns:
+            str: 一个单次令牌
+
+        Raises:
+            FileNotFoundError: 当路径不存在时抛出。
+        """
+        async with self.lock:
+            if not os.path.exists(file_path):
+                raise FileNotFoundError(f"文件不存在: {file_path}")
+            file_token = str(uuid.uuid4())
+            self.staged_files[file_token] = file_path
+            return file_token
+
+    async def handle_file(self, file_token: str) -> str:
+        async with self.lock:
+            if file_token not in self.staged_files:
+                raise KeyError(f"无效文件 token: {file_token}")
+            file_path = self.staged_files.pop(file_token, None)
+            if not os.path.exists(file_path):
+                raise FileNotFoundError(f"文件不存在: {file_path}")
+            return file_path

--- a/astrbot/core/message/components.py
+++ b/astrbot/core/message/components.py
@@ -500,7 +500,7 @@ class Nodes(BaseMessageComponent):
         for node in self.nodes:
             d = node.toDict()
             d["data"]["uin"] = str(node.uin) # 转为字符串
-            ret["messages"].append(node.toDict())
+            ret["messages"].append(d)
         return ret
 
 class Xml(BaseMessageComponent):

--- a/astrbot/core/message/components.py
+++ b/astrbot/core/message/components.py
@@ -462,7 +462,7 @@ class Node(BaseMessageComponent):
     type: ComponentType = "Node"
     id: T.Optional[int] = 0  # 忽略
     name: T.Optional[str] = ""  # qq昵称
-    uin: T.Optional[str] = 0  # qq号
+    uin: T.Optional[str] = "0"  # qq号
     content: T.Optional[T.Union[str, list, dict]] = ""  # 子消息段列表
     seq: T.Optional[T.Union[str, list]] = ""  # 忽略
     time: T.Optional[int] = 0 # 忽略

--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -26,33 +26,14 @@ class RespondStage(Stage):
         Comp.Record: lambda comp: bool(comp.file),  # 语音
         Comp.Video: lambda comp: bool(comp.file),  # 视频
         Comp.At: lambda comp: bool(comp.qq) or bool(comp.name),  # @
-        Comp.AtAll: lambda comp: True,  # @所有人
-        Comp.RPS: lambda comp: True,  # 不知道是啥(未完成)
-        Comp.Dice: lambda comp: True,  # 骰子(未完成)
-        Comp.Shake: lambda comp: True,  # 摇一摇(未完成)
-        Comp.Anonymous: lambda comp: True,  # 匿名(未完成)
-        Comp.Share: lambda comp: bool(comp.url) and bool(comp.title),  # 分享
-        Comp.Contact: lambda comp: True,  # 联系人(未完成)
-        Comp.Location: lambda comp: bool(comp.lat and comp.lon),  # 位置
-        Comp.Music: lambda comp: bool(comp._type)
-        and bool(comp.url)
-        and bool(comp.audio),  # 音乐
         Comp.Image: lambda comp: bool(comp.file),  # 图片
         Comp.Reply: lambda comp: bool(comp.id) and comp.sender_id is not None,  # 回复
-        Comp.RedBag: lambda comp: bool(comp.title),  # 红包
         Comp.Poke: lambda comp: comp.id != 0 and comp.qq != 0,  # 戳一戳
-        Comp.Forward: lambda comp: bool(comp.id and comp.id.strip()),  # 转发
         Comp.Node: lambda comp: bool(comp.name)
         and comp.uin != 0
         and bool(comp.content),  # 一个转发节点
         Comp.Nodes: lambda comp: bool(comp.nodes),  # 多个转发节点
-        Comp.Xml: lambda comp: bool(comp.data and comp.data.strip()),  # XML
-        Comp.Json: lambda comp: bool(comp.data),  # JSON
-        Comp.CardImage: lambda comp: bool(comp.file),  # 卡片图片
-        Comp.TTS: lambda comp: bool(comp.text and comp.text.strip()),  # 语音合成
-        Comp.Unknown: lambda comp: bool(comp.text and comp.text.strip()),  # 未知消息
-        Comp.File: lambda comp: bool(comp.file),  # 文件
-        Comp.WechatEmoji: lambda comp: bool(comp.md5),  # 微信表情
+        Comp.File: lambda comp: bool(comp.file_ or comp.url),
     }
 
     async def initialize(self, ctx: PipelineContext):
@@ -129,8 +110,6 @@ class RespondStage(Stage):
             if comp_type in self._component_validators:
                 if self._component_validators[comp_type](comp):
                     return False
-            else:
-                logger.info(f"空内容检查: 无法识别的组件类型: {comp_type.__name__}")
 
         # 如果所有组件都为空
         return True

--- a/astrbot/dashboard/routes/file.py
+++ b/astrbot/dashboard/routes/file.py
@@ -1,0 +1,26 @@
+from .route import Route, RouteContext
+from astrbot.core.core_lifecycle import AstrBotCoreLifecycle
+
+
+class FileRoute(Route):
+    def __init__(
+        self,
+        context: RouteContext,
+        core_lifecycle: AstrBotCoreLifecycle,
+    ) -> None:
+        super().__init__(context)
+        self.routes = {
+            "/file/<file_token>": ("GET", self.serve_file),
+        }
+        self.register_routes()
+
+    async def serve_file(file_token: str):
+        try:
+            file_path = await service.get_file_path(file_token)
+            return await send_file(file_path)
+        except FileNotFoundError as e:
+            logger.warning(str(e))
+            return abort(404)
+        except KeyError as e:
+            logger.warning(str(e))
+            return abort(404)

--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -1446,9 +1446,3 @@ UID: {user_id} 此 ID 可用于设置管理员。
         plugin_cfg["reset"] = reset_cfg
         alter_cmd_cfg["astrbot"] = plugin_cfg
         sp.put("alter_cmd", alter_cmd_cfg)
-
-    @filter.command("test")
-    async def test_tool(self, event: AstrMessageEvent):
-        """测试工具"""
-        from astrbot.api.message_components import File
-        yield event.chain_result([File(name="test.txt", file="data/astrbot-reminder.json")])

--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -1446,3 +1446,9 @@ UID: {user_id} 此 ID 可用于设置管理员。
         plugin_cfg["reset"] = reset_cfg
         alter_cmd_cfg["astrbot"] = plugin_cfg
         sp.put("alter_cmd", alter_cmd_cfg)
+
+    @filter.command("test")
+    async def test_tool(self, event: AstrMessageEvent):
+        """测试工具"""
+        from astrbot.api.message_components import File
+        yield event.chain_result([File(name="test.txt", file="data/astrbot-reminder.json")])


### PR DESCRIPTION
### Motivation

发送路径不可靠。

### Modifications

1. 添加了一个 FileTokenService 类；
2. 添加了一个配置项 callback_api_base 用于配置回调地址的 API Base，然后这是必要的；
3. 此外，还修复了 Lagrange 下发送合并转发消息报错的问题；
4. 此外，删除了一些极少使用的消息段的空内容检查。

ps: 从技术上来说，我认为接下来可以统一一下 Dashboard 后端服务与 Bot Core 服务之间的通信方式？现在至少有：webchat、file_token_service，mcp tool 的逻辑是需要这二者之间通信的，第一个和第三个还需要双向通信。

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码
