### PR TITLE
fix: 设置thinking_budget前，先检查是否存在

### DIFF
--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -189,6 +189,7 @@ class ProviderGoogleGenAI(Provider):
                 ),
             )
             if "gemini-2.5-flash" in self.get_model()
+            and hasattr(types.ThinkingConfig, "thinking_budget")
             else None,
             automatic_function_calling=types.AutomaticFunctionCallingConfig(
                 disable=True


### PR DESCRIPTION
Fixes #1503

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 总结

Bug 修复:
- 避免潜在错误，通过在使用 `thinking_budget` 属性之前，检查 `ThinkingConfig` 中是否存在该属性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent potential errors by checking if thinking_budget attribute exists in ThinkingConfig before using it

</details>