### PR TITLE
Fix issue 1460

### DIFF
--- a/astrbot/core/updator.py
+++ b/astrbot/core/updator.py
@@ -2,6 +2,7 @@ import os
 import psutil
 import sys
 import time
+import subprocess
 from .zip_updator import ReleaseInfo, RepoZipUpdator
 from astrbot.core import logger
 from astrbot.core.config.default import VERSION

--- a/astrbot/core/updator.py
+++ b/astrbot/core/updator.py
@@ -42,24 +42,30 @@ class AstrBotUpdator(RepoZipUpdator):
             pass
 
     def _reboot(self, delay: int = 3):
-        """重启当前程序
+        """
+        重启当前程序，使用 subprocess.Popen 启动新进程并退出旧进程
         在指定的延迟后，终止所有子进程并重新启动程序
         """
-        py = sys.executable
         time.sleep(delay)
         self.terminate_child_processes()
-        py = py.replace(" ", "\\ ")
+        py = sys.executable
+        
         try:
-            if "astrbot" in os.path.basename(sys.argv[0]):  # 兼容cli
-                args = [
-                    f'"{arg}"' if " " in arg else arg for arg in sys.argv[1:]
-                ]
-                os.execl(py, py, "-m", "astrbot.cli.__main__", *args)
+            if "astrbot" in os.path.basename(sys.argv[0]): # 兼容cli
+                cmd = [py, "-m", "astrbot.cli.__main__"] + sys.argv[1:]
             else:
-                os.execl(py, py, *sys.argv)
+                cmd = [py] + sys.argv
+                
+            subprocess.Popen(
+                cmd,
+                start_new_session=True
+            )
+            
         except Exception as e:
-            logger.error(f"重启失败（{py}, {e}），请尝试手动重启。")
+            logger.error(f"重启失败（{py} {cmd}，错误：{e}），请尝试手动重启。")
             raise e
+        
+        os._exit(0)
 
     async def check_update(self, url: str, current_version: str) -> ReleaseInfo:
         """检查更新"""

--- a/astrbot/core/updator.py
+++ b/astrbot/core/updator.py
@@ -50,22 +50,19 @@ class AstrBotUpdator(RepoZipUpdator):
         time.sleep(delay)
         self.terminate_child_processes()
         py = sys.executable
-        
+
         try:
-            if "astrbot" in os.path.basename(sys.argv[0]): # 兼容cli
+            if "astrbot" in os.path.basename(sys.argv[0]):  # 兼容cli
                 cmd = [py, "-m", "astrbot.cli.__main__"] + sys.argv[1:]
             else:
                 cmd = [py] + sys.argv
-                
-            subprocess.Popen(
-                cmd,
-                start_new_session=True
-            )
-            
+
+            subprocess.Popen(cmd, start_new_session=True)
+
         except Exception as e:
             logger.error(f"重启失败（{py} {cmd}，错误：{e}），请尝试手动重启。")
             raise e
-        
+
         os._exit(0)
 
     async def check_update(self, url: str, current_version: str) -> ReleaseInfo:
@@ -80,7 +77,7 @@ class AstrBotUpdator(RepoZipUpdator):
         file_url = None
 
         if os.environ.get("ASTRBOT_CLI"):
-            raise Exception("不支持更新CLI启动的AstrBot") # 避免版本管理混乱
+            raise Exception("不支持更新CLI启动的AstrBot")  # 避免版本管理混乱
 
         if latest:
             latest_version = update_data[0]["tag_name"]


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了 #1460

### Motivation

正常使用astrbot没有问题，python的安装和路径都没有问题，但是在重启的时候会报错，只能使用Ctrl+c强制退出，经过和大佬讨论研究，发现是文件\AstrBot\astrbot\core\updator.py中一个方法对于路径的读取问题，修改后解决

### Modifications

使用subprocess.Popen启动新进程，修复原方案识别路径空格的问题

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [ ] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] 👀 我的更改经过良好的测试
- [ ] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码
