### PR TITLE
优化 plugin 指令的权限

### DIFF
--- a/astrbot/core/pipeline/waking_check/stage.py
+++ b/astrbot/core/pipeline/waking_check/stage.py
@@ -137,7 +137,7 @@ class WakingCheckStage(Stage):
                     if self.no_permission_reply:
                         await event.send(
                             MessageChain().message(
-                                f"ID {event.get_sender_id()} 权限不足。通过 /sid 获取 ID 并请管理员添加。"
+                                f"您(ID: {event.get_sender_id()})的权限不足以使用此指令。通过 /sid 获取 ID 并请管理员添加。"
                             )
                         )
                         await event._post_send()

--- a/astrbot/core/star/filter/command_group.py
+++ b/astrbot/core/star/filter/command_group.py
@@ -113,7 +113,7 @@ class CommandGroupFilter(HandlerFilter):
                 + self.print_cmd_tree(self.sub_command_filters, event=event, cfg=cfg)
             )
             raise ValueError(
-                f"指令组 {self.group_name} 未填写完全。这个指令组下有如下指令：\n"
+                f"参数不足。{self.group_name} 指令组下有如下指令，请参考：\n"
                 + tree
             )
 

--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -207,105 +207,118 @@ class Main(star.Star):
             self.context.deactivate_llm_tool(tool.name)
         event.set_result(MessageEventResult().message("停用所有工具成功。"))
 
-    @filter.command("plugin")
-    async def plugin(
-        self, event: AstrMessageEvent, oper1: str = None, oper2: str = None
-    ):
-        """插件管理"""
-        if oper1 is None:
-            plugin_list_info = "已加载的插件：\n"
-            for plugin in self.context.get_all_stars():
-                plugin_list_info += (
-                    f"- `{plugin.name}` By {plugin.author}: {plugin.desc}"
-                )
-                if not plugin.activated:
-                    plugin_list_info += " (未启用)"
-                plugin_list_info += "\n"
-            if plugin_list_info.strip() == "":
-                plugin_list_info = "没有加载任何插件。"
+    @filter.command_group("plugin")
+    def plugin(self):
+        pass
 
-            plugin_list_info += "\n使用 /plugin <插件名> 查看插件帮助和加载的指令。\n使用 /plugin on/off <插件名> 启用或者禁用插件。"
-            event.set_result(
-                MessageEventResult().message(f"{plugin_list_info}").use_t2i(False)
+    @plugin.command("ls")
+    async def plugin_ls(self, event: AstrMessageEvent):
+        """获取已经安装的插件列表。"""
+        plugin_list_info = "已加载的插件：\n"
+        for plugin in self.context.get_all_stars():
+            plugin_list_info += (
+                f"- `{plugin.name}` By {plugin.author}: {plugin.desc}"
             )
-        else:
-            if oper1 == "off":
-                # 禁用插件
-                if oper2 is None:
-                    event.set_result(
-                        MessageEventResult().message("/plugin off <插件名> 禁用插件。")
-                    )
-                    return
-                await self.context._star_manager.turn_off_plugin(oper2)
-                event.set_result(MessageEventResult().message(f"插件 {oper2} 已禁用。"))
-            elif oper1 == "on":
-                # 启用插件
-                if oper2 is None:
-                    event.set_result(
-                        MessageEventResult().message("/plugin on <插件名> 启用插件。")
-                    )
-                    return
-                await self.context._star_manager.turn_on_plugin(oper2)
-                event.set_result(MessageEventResult().message(f"插件 {oper2} 已启用。"))
-            elif oper1 == "get":
-                if not oper2:
-                    raise Exception("请输入插件地址。")
-                if not event.is_admin():
-                    raise Exception(
-                        "改指令限制仅管理员使用，且无法通过 /alter_cmd 更改。"
-                    )
-                if not oper2.startswith("http"):
-                    oper2 = f"https://github.com/{oper2}"
+            if not plugin.activated:
+                plugin_list_info += " (未启用)"
+            plugin_list_info += "\n"
+        if plugin_list_info.strip() == "":
+            plugin_list_info = "没有加载任何插件。"
 
-                logger.info(f"准备从 {oper2} 获取插件。")
+        plugin_list_info += "\n使用 /plugin <插件名> 查看插件帮助和加载的指令。\n使用 /plugin on/off <插件名> 启用或者禁用插件。"
+        event.set_result(
+            MessageEventResult().message(f"{plugin_list_info}").use_t2i(False)
+        )
 
-                if self.context._star_manager:
-                    star_mgr: PluginManager = self.context._star_manager
-                    try:
-                        await star_mgr.install_plugin(oper2)
-                        event.set_result(MessageEventResult().message("获取插件成功。"))
-                    except Exception as e:
-                        logger.error(f"获取插件失败: {e}")
-                        event.set_result(
-                            MessageEventResult().message(f"获取插件失败: {e}")
-                        )
-                        return
-            else:
-                # 获取插件帮助
-                plugin = self.context.get_registered_star(oper1)
-                if plugin is None:
-                    event.set_result(MessageEventResult().message("未找到此插件。"))
-                    return
-                help_msg = ""
-                help_msg += f"\n\n✨ 作者: {plugin.author}\n✨ 版本: {plugin.version}"
-                command_handlers = []
-                command_names = []
-                for handler in star_handlers_registry:
-                    assert isinstance(handler, StarHandlerMetadata)
-                    if handler.handler_module_path != plugin.module_path:
-                        continue
-                    for filter_ in handler.event_filters:
-                        if isinstance(filter_, CommandFilter):
-                            command_handlers.append(handler)
-                            command_names.append(filter_.command_name)
-                            break
-                        elif isinstance(filter_, CommandGroupFilter):
-                            command_handlers.append(handler)
-                            command_names.append(filter_.group_name)
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @plugin.command("off")
+    async def plugin_off(self, event: AstrMessageEvent, plugin_name: str = None):
+        """禁用插件"""
+        if not plugin_name:
+            event.set_result(
+                MessageEventResult().message("/plugin off <插件名> 禁用插件。")
+            )
+            return
+        await self.context._star_manager.turn_off_plugin(plugin_name)
+        event.set_result(MessageEventResult().message(f"插件 {plugin_name} 已禁用。"))
 
-                if len(command_handlers) > 0:
-                    help_msg += "\n\n🔧 指令列表：\n"
-                    for i in range(len(command_handlers)):
-                        help_msg += f"- {command_names[i]}"
-                        if command_handlers[i].desc:
-                            help_msg += f": {command_handlers[i].desc}"
-                        help_msg += "\n"
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @plugin.command("on")
+    async def plugin_on(self, event: AstrMessageEvent, plugin_name: str = None):
+        """启用插件"""
+        if not plugin_name:
+            event.set_result(
+                MessageEventResult().message("/plugin on <插件名> 启用插件。")
+            )
+            return
+        await self.context._star_manager.turn_on_plugin(plugin_name)
+        event.set_result(MessageEventResult().message(f"插件 {plugin_name} 已启用。"))
 
-                    help_msg += "\nTip: 指令的触发需要添加唤醒前缀，默认为 /。"
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @plugin.command("get")
+    async def plugin_get(self, event: AstrMessageEvent, plugin_repo: str = None):
+        """安装插件"""
+        if not plugin_repo:
+            event.set_result(
+                MessageEventResult().message("/plugin get <插件仓库地址> 安装插件")
+            )
+            return
+        logger.info(f"准备从 {plugin_repo} 安装插件。")
+        if self.context._star_manager:
+            star_mgr: PluginManager = self.context._star_manager
+            try:
+                await star_mgr.install_plugin(plugin_repo)
+                event.set_result(MessageEventResult().message("安装插件成功。"))
+            except Exception as e:
+                logger.error(f"安装插件失败: {e}")
+                event.set_result(
+                    MessageEventResult().message(f"安装插件失败: {e}")
+                )
+                return
 
-                ret = f"🧩 插件 {oper1} 帮助信息：\n" + help_msg
-                ret += "更多帮助信息请查看插件仓库 README。"
-                event.set_result(MessageEventResult().message(ret).use_t2i(False))
+    @plugin.command("help")
+    async def plugin_help(self, event: AstrMessageEvent, plugin_name: str = None):
+        """获取插件帮助"""
+        if not plugin_name:
+            event.set_result(
+                MessageEventResult().message("/plugin view <插件名> 查看插件信息。")
+            )
+            return
+        plugin = self.context.get_registered_star(plugin_name)
+        if plugin is None:
+            event.set_result(MessageEventResult().message("未找到此插件。"))
+            return
+        help_msg = ""
+        help_msg += f"\n\n✨ 作者: {plugin.author}\n✨ 版本: {plugin.version}"
+        command_handlers = []
+        command_names = []
+        for handler in star_handlers_registry:
+            assert isinstance(handler, StarHandlerMetadata)
+            if handler.handler_module_path != plugin.module_path:
+                continue
+            for filter_ in handler.event_filters:
+                if isinstance(filter_, CommandFilter):
+                    command_handlers.append(handler)
+                    command_names.append(filter_.command_name)
+                    break
+                elif isinstance(filter_, CommandGroupFilter):
+                    command_handlers.append(handler)
+                    command_names.append(filter_.group_name)
+
+        if len(command_handlers) > 0:
+            help_msg += "\n\n🔧 指令列表：\n"
+            for i in range(len(command_handlers)):
+                help_msg += f"- {command_names[i]}"
+                if command_handlers[i].desc:
+                    help_msg += f": {command_handlers[i].desc}"
+                help_msg += "\n"
+
+            help_msg += "\nTip: 指令的触发需要添加唤醒前缀，默认为 /。"
+
+        ret = f"🧩 插件 {plugin_name} 帮助信息：\n" + help_msg
+        ret += "更多帮助信息请查看插件仓库 README。"
+        event.set_result(MessageEventResult().message(ret).use_t2i(False))
+
 
     @filter.command("t2i")
     async def t2i(self, event: AstrMessageEvent):

--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -281,7 +281,7 @@ class Main(star.Star):
         """获取插件帮助"""
         if not plugin_name:
             event.set_result(
-                MessageEventResult().message("/plugin view <插件名> 查看插件信息。")
+                MessageEventResult().message("/plugin help <插件名> 查看插件信息。")
             )
             return
         plugin = self.context.get_registered_star(plugin_name)

--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -225,7 +225,7 @@ class Main(star.Star):
         if plugin_list_info.strip() == "":
             plugin_list_info = "没有加载任何插件。"
 
-        plugin_list_info += "\n使用 /plugin <插件名> 查看插件帮助和加载的指令。\n使用 /plugin on/off <插件名> 启用或者禁用插件。"
+        plugin_list_info += "\n使用 /plugin help <插件名> 查看插件帮助和加载的指令。\n使用 /plugin on/off <插件名> 启用或者禁用插件。"
         event.set_result(
             MessageEventResult().message(f"{plugin_list_info}").use_t2i(False)
         )


### PR DESCRIPTION
### Motivation

优化 plugin 指令的权限

### Modifications

分离 plugin 指令为指令组，将 on, off, get 子指令列为管理员指令。

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构插件命令，通过将其分离成具有不同子命令的命令组，来改进其权限管理和可用性

新特性：
- 为插件管理引入了命令组结构
- 为插件操作添加了单独的子命令

Bug 修复：
- 修复了不一致的插件管理界面

增强：
- 改进了插件命令的可用性
- 为插件管理添加了更精细的权限控制

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the plugin command to improve its permission management and usability by separating it into a command group with distinct subcommands

New Features:
- Introduced a command group structure for plugin management
- Added separate subcommands for plugin operations

Bug Fixes:
- Fixed inconsistent plugin management interface

Enhancements:
- Improved plugin command usability
- Added more granular permission controls for plugin management

</details>