### PR TITLE
Fix: 修复微信客服下接收消息时可能报错的问题

### DIFF
--- a/astrbot/core/platform/sources/wecom/wecom_adapter.py
+++ b/astrbot/core/platform/sources/wecom/wecom_adapter.py
@@ -302,6 +302,7 @@ class WecomPlatformAdapter(Platform):
         abm.sender = MessageMember(external_userid, external_userid)
         abm.session_id = external_userid
         abm.type = MessageType.FRIEND_MESSAGE
+        abm.message_id = msg.get("msgid", uuid.uuid4().hex[:8])
         if msgtype == "text":
             text = msg.get("text", {}).get("content", "").strip()
             abm.message = [Plain(text=text)]


### PR DESCRIPTION
fixes #1504

<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了 #XYZ

### Motivation

<!--解释为什么要改动-->

### Modifications

<!--简单解释你的改动-->

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 修复了在微信客服中接收消息时可能发生的错误，通过确保始终设置 `message_id` 来解决此问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix potential error when receiving messages in WeChat customer service by ensuring message_id is always set.

</details>