### PR TITLE
fix: 回退至os.execl以兼容docker，改用双引号处理路径空格

### DIFF
--- a/astrbot/core/updator.py
+++ b/astrbot/core/updator.py
@@ -2,7 +2,6 @@ import os
 import psutil
 import sys
 import time
-import subprocess
 from .zip_updator import ReleaseInfo, RepoZipUpdator
 from astrbot.core import logger
 from astrbot.core.config.default import VERSION
@@ -43,9 +42,9 @@ class AstrBotUpdator(RepoZipUpdator):
             pass
 
     def _reboot(self, delay: int = 3):
-        """
-        重启当前程序，使用 subprocess.Popen 启动新进程并退出旧进程
+        """重启当前程序
         在指定的延迟后，终止所有子进程并重新启动程序
+        这里只能使用 os.execl 来重启程序
         """
         time.sleep(delay)
         self.terminate_child_processes()
@@ -53,17 +52,15 @@ class AstrBotUpdator(RepoZipUpdator):
 
         try:
             if "astrbot" in os.path.basename(sys.argv[0]):  # 兼容cli
-                cmd = [py, "-m", "astrbot.cli.__main__"] + sys.argv[1:]
+                args = [
+                    f'"{arg}"' if " " in arg else arg for arg in sys.argv[1:]
+                ]
+                os.execl(py, f'"{py}"', "-m", "astrbot.cli.__main__", *args)
             else:
-                cmd = [py] + sys.argv
-
-            subprocess.Popen(cmd, start_new_session=True)
-
+                os.execl(py, f'"{py}"', *sys.argv)
         except Exception as e:
-            logger.error(f"重启失败（{py} {cmd}，错误：{e}），请尝试手动重启。")
+            logger.error(f"重启失败（{py}, {e}），请尝试手动重启。")
             raise e
-
-        os._exit(0)
 
     async def check_update(self, url: str, current_version: str) -> ReleaseInfo:
         """检查更新"""

--- a/astrbot/core/updator.py
+++ b/astrbot/core/updator.py
@@ -44,20 +44,26 @@ class AstrBotUpdator(RepoZipUpdator):
     def _reboot(self, delay: int = 3):
         """重启当前程序
         在指定的延迟后，终止所有子进程并重新启动程序
-        这里只能使用 os.execl 来重启程序
+        这里只能使用 os.exec* 来重启程序
         """
         time.sleep(delay)
         self.terminate_child_processes()
-        py = sys.executable
+        if os.name == "nt":
+            py = f'"{sys.executable}"'
+        else:
+            py = sys.executable
 
         try:
             if "astrbot" in os.path.basename(sys.argv[0]):  # 兼容cli
-                args = [
-                    f'"{arg}"' if " " in arg else arg for arg in sys.argv[1:]
-                ]
-                os.execl(py, f'"{py}"', "-m", "astrbot.cli.__main__", *args)
+                if os.name == "nt":
+                    args = [
+                        f'"{arg}"' if " " in arg else arg for arg in sys.argv[1:]
+                    ]
+                else:
+                    args = sys.argv[1:]
+                os.execl(sys.executable, py, "-m", "astrbot.cli.__main__", *args)
             else:
-                os.execl(py, f'"{py}"', *sys.argv)
+                os.execl(sys.executable, py, *sys.argv)
         except Exception as e:
             logger.error(f"重启失败（{py}, {e}），请尝试手动重启。")
             raise e


### PR DESCRIPTION
Fixes #1537 

### Motivation

Docker容器会在容器内的主进程结束后自动停止

### Modifications

回退至os.execl

### References

https://stackoverflow.com/questions/35902655/how-to-restart-python-3-5-script-with-space-in-path-in-windows/46439592

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

### Tested Platform
- [x] Windows
- [x] Linux（Multipass Ubuntu 24.04 LTS）
- [x]  MacOS（Docker-OSX MacOS 12 Monterey）
- [x] Docker

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

恢复重启实现，使用带有引用路径的 `os.execl`，以实现 Docker 兼容性并正确处理参数中的空格

Bug 修复：
- 修复容器自动退出问题，通过使用 `os.execl` 而不是 `subprocess.Popen` 来重启进程

增强功能：
- 调用 `os.execl` 时，引用包含空格的可执行文件和参数
- 移除过时的 `subprocess.Popen` 逻辑和重启方法中的退出调用

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revert the restart implementation to use os.execl with quoted paths for Docker compatibility and proper handling of spaces in arguments

Bug Fixes:
- Fix container auto-exit issue by using os.execl instead of subprocess.Popen for process reboot

Enhancements:
- Quote executable and arguments containing spaces when calling os.execl
- Remove obsolete subprocess.Popen logic and exit call in reboot method

</details>

好的，这是将 pull request 总结翻译成中文的结果：

## Sourcery 总结

恢复重启逻辑，使用 `os.execl` 以便在 Docker 中实现可靠的进程重启，并正确处理包含空格的可执行文件路径和参数。

Bug 修复：
- 通过将 `subprocess.Popen` 替换为 `os.execl` 进行进程重启，防止 Docker 容器过早退出。

增强功能：
- 在 Windows 上调用 `os.execl` 时，使用引号将 Python 可执行文件和包含空格的参数引起来。
- 从重启方法中删除过时的 `subprocess.Popen` 逻辑和 `os._exit` 调用。
- 改进错误日志记录，以显示可执行文件路径和异常消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revert the restart logic to use os.execl for reliable process reboots in Docker and correctly handle executable paths and arguments containing spaces.

Bug Fixes:
- Prevent Docker containers from exiting prematurely by replacing subprocess.Popen with os.execl for process reboot.

Enhancements:
- Quote the Python executable and arguments with spaces on Windows when invoking os.execl.
- Remove obsolete subprocess.Popen logic and os._exit call from the reboot method.
- Improve error logging to display the executable path and exception message.

</details>