### PR TITLE
适配一个个人微信适配器——wechatpadpro

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -155,6 +155,14 @@ CONFIG_METADATA_2 = {
                         "host": "这里填写你的局域网IP或者公网服务器IP",
                         "port": 11451,
                     },
+                    "wechatpadpro(微信)": {
+                        "id": "wechatpadpro",
+                        "type": "wechatpadpro",
+                        "enable": False,
+                        "admin_key": "stay33",
+                        "host": "这里填写你的局域网IP或者公网服务器IP",
+                        "port": 8059,
+                    },
                     "weixin_official_account(微信公众平台)": {
                         "id": "weixin_official_account",
                         "type": "weixin_official_account",

--- a/astrbot/core/platform/manager.py
+++ b/astrbot/core/platform/manager.py
@@ -62,6 +62,10 @@ class PlatformManager:
                     from .sources.gewechat.gewechat_platform_adapter import (
                         GewechatPlatformAdapter,  # noqa: F401
                     )
+                case "wechatpadpro":
+                    from .sources.wechatpadpro.wechatpadpro_adapter import (
+                        WeChatPadProAdapter,
+                    )
                 case "lark":
                     from .sources.lark.lark_adapter import LarkPlatformAdapter  # noqa: F401
                 case "dingtalk":

--- a/astrbot/core/platform/sources/wechatpadpro/wechatpadpro_adapter.py
+++ b/astrbot/core/platform/sources/wechatpadpro/wechatpadpro_adapter.py
@@ -508,8 +508,3 @@ class WeChatPadProAdapter(Platform):
         通过会话发送消息。
         """
         logger.info(f"向会话 {session} 发送消息: {message_chain}")
-        # 在这里实现将 MessageChain 转换为 WeChatPadPro 消息格式并发送的逻辑
-        # 例如：
-        # message_text = "".join([comp.text for comp in message_chain if isinstance(comp, Plain)])
-        # await self.client.send_message(session.session_id, message_text)
-        pass # 待实现

--- a/astrbot/core/platform/sources/wechatpadpro/wechatpadpro_adapter.py
+++ b/astrbot/core/platform/sources/wechatpadpro/wechatpadpro_adapter.py
@@ -345,8 +345,10 @@ class WeChatPadProAdapter(Platform):
         # 先判断群聊/私聊并设置基本属性
         await self._process_chat_type(abm, raw_message, from_user_name, to_user_name, content)
 
-        # 如果是机器人自己发送的消息，忽略
-        if from_user_name == self.wxid:
+        # 如果是机器人自己发送的消息、回显消息或系统消息，忽略
+        is_echo = raw_message.get("is_echo", False) or raw_message.get("msg_source") == "send"
+        is_system = msg_type in ("system", "sys")
+        if from_user_name == self.wxid or to_user_name == self.wxid or is_echo or is_system:
              return None
 
         # 再根据消息类型处理消息内容

--- a/astrbot/core/platform/sources/wechatpadpro/wechatpadpro_message_event.py
+++ b/astrbot/core/platform/sources/wechatpadpro/wechatpadpro_message_event.py
@@ -1,4 +1,4 @@
-import time
+import asyncio
 import aiohttp
 from astrbot.core.platform.astr_message_event import AstrMessageEvent
 from astrbot.core.platform.astrbot_message import AstrBotMessage, MessageType
@@ -21,169 +21,77 @@ class WeChatPadProMessageEvent(AstrMessageEvent):
         # 添加平台特定的参数，例如适配器实例
         adapter: object, # 传递适配器实例
     ):
-        # logger.info(f"WeChatPadProMessageEvent __init__ called with:")
-        # logger.info(f"  message_str: {message_str}")
-        # logger.info(f"  message_obj: {message_obj}")
-        # logger.info(f"  message_obj.message: {message_obj.message}") # Log the message components list
-        # logger.info(f"  platform_meta: {platform_meta}")
-        # logger.info(f"  session_id: {session_id}")
-        # logger.info(f"  adapter: {adapter}")
-
-        # Pass the message components list to the parent class constructor
-        # Pass message_str to the parent class constructor, similar to gewechat adapter
-        # Pass message_str and message_obj to the parent class constructor, similar to fake adapter
         super().__init__(message_str, message_obj, platform_meta, session_id)
         self.message_obj = message_obj # Save the full message object
         self.adapter = adapter # Save the adapter instance
 
     async def send(self, message: MessageChain):
-        """
-        发送消息到 WeChatPadPro 平台。
-        """
-        # 在这里实现将 MessageChain 转换为 WeChatPadPro 消息格式并发送的逻辑
-        # 遍历消息链，处理不同类型的消息组件
-        for component in message.chain:
-            # logger.info(f"Processing component: {component}") # Log the component
-            # logger.info(f"Type of component: {type(component)}") # Log the type of the component
-            # logger.info(f"Image class in scope: {Image}") # Log the Image class itself
-            time.sleep(1)
-            if isinstance(component, Plain):
-                # 发送文本消息
-                message_text = component.text
-                # 实现 reply_with_mention 功能
-                if (
-                    self.message_obj.type == MessageType.GROUP_MESSAGE # 确保是群聊消息
-                    and self.adapter.settings.get("reply_with_mention", False) # 检查适配器设置是否启用 reply_with_mention
-                    and self.message_obj.sender # 确保有发送者信息
-                    and (self.message_obj.sender.user_id or self.message_obj.sender.nickname) # 确保发送者有 ID 或昵称
-                ):
-                    # 在文本消息前加上 @ 消息发送者的信息
-                    # 优先使用 nickname，如果没有则使用 user_id
-                    mention_text = self.message_obj.sender.nickname if self.message_obj.sender.nickname else self.message_obj.sender.user_id
-                    message_text = f"@{mention_text} {message_text}"
-                    logger.info(f"已添加 @ 信息: {message_text}")
+        async with aiohttp.ClientSession() as session:
+            for comp in message.chain:
+                await asyncio.sleep(1)
+                if isinstance(comp, Plain):
+                    await self._send_text(session, comp.text)
+                elif isinstance(comp, Image):
+                    await self._send_image(session, comp)
+        await super().send(message)
 
-                if message_text:
-                    payload = {
-                        "MsgItem": [
-                            {
-                                "MsgType": 1, # 1 for Text
-                                "TextContent": message_text,
-                                "ToUserName": self.session_id, # 接收者 wxid
-                            }
-                        ]
-                    }
-                    url = f"{self.adapter.base_url}/message/SendTextMessage" # 使用文本消息发送接口
-                    params = {"key": self.adapter.auth_key}
-                    async with aiohttp.ClientSession() as session:
-                        try:
-                            async with session.post(url, params=params, json=payload) as response:
-                                response_data = await response.json()
-                                if response.status == 200 and response_data.get("Code") == 200:
-                                    logger.info(f"成功发送文本消息到 {self.session_id}: {message_text}")
-                                else:
-                                    logger.error(f"发送文本消息失败到 {self.session_id}: {response.status}, {response_data}")
-                        except aiohttp.ClientConnectorError as e:
-                            logger.error(f"连接到 WeChatPadPro 服务失败: {e}")
-                        except Exception as e:
-                            logger.error(f"发送文本消息时发生错误: {e}")
+    async def _send_image(self, session: aiohttp.ClientSession, comp: Image):
+        b64 = await comp.convert_to_base64()
+        raw = self._validate_base64(b64)
+        b64c = self._compress_image(raw)
+        payload = {"MsgItem":[{"ImageContent": b64c, "MsgType":3, "ToUserName": self.session_id}]}
+        url = f"{self.adapter.base_url}/message/SendImageNewMessage"
+        await self._post(session, url, payload)
 
-            elif isinstance(component, Image):
-                # 发送图片消息
-                if hasattr(component, "convert_to_base64"):
-                    try:
-                        image_base64 = await component.convert_to_base64()
-                    except Exception as e:
-                        logger.error(f"Error converting image to base64: {e}")
-                        continue
-                else:
-                    logger.error("Image component missing convert_to_base64, skipping image send.")
-                    continue
-                    # logger.info(f"转换后的base64图片：{image_base64}")
+    async def _send_text(self, session: aiohttp.ClientSession, text: str):
+        if (
+                self.message_obj.type == MessageType.GROUP_MESSAGE  # 确保是群聊消息
+                and self.adapter.settings.get("reply_with_mention", False)  # 检查适配器设置是否启用 reply_with_mention
+                and self.message_obj.sender  # 确保有发送者信息
+                and (self.message_obj.sender.user_id or self.message_obj.sender.nickname)  # 确保发送者有 ID 或昵称
+        ):
+            # 优先使用 nickname，如果没有则使用 user_id
+            mention_text = self.message_obj.sender.nickname or self.message_obj.sender.user_id
+            message_text = f"@{mention_text} {text}"
+            logger.info(f"已添加 @ 信息: {message_text}")
 
-                    # Base64图片格式校验
-                    try:
-                        image_data = base64.b64decode(image_base64, validate=True)
-                        logger.info("Base64图片格式校验成功。")
-                    except (base64.binascii.Error, ValueError) as e:
-                        logger.error(f"Base64图片格式校验失败: {e}")
-                        await self.send(MessageChain([Plain("发送图片失败：图片编码格式不正确。")]))
-                        continue # 跳过发送此图片
+        payload = {"MsgItem": [{"MsgType": 1, "TextContent": text, "ToUserName": self.session_id}]}
+        url = f"{self.adapter.base_url}/message/SendTextMessage"
+        await self._post(session, url, payload)
 
-                    # 图片压缩处理
-                    try:
-                        img = PILImage.open(io.BytesIO(image_data)) # 使用别名 PILImage
+    @staticmethod
+    def _validate_base64(b64: str) -> bytes:
+        return base64.b64decode(b64, validate=True)
 
-                        # 示例压缩：对于 JPEG 格式，降低质量；对于其他格式，转换为 JPEG 并降低质量
-                        output_buffer = io.BytesIO()
-                        if img.format == 'JPEG':
-                            img.save(output_buffer, format='JPEG', quality=80) # 降低JPEG质量到80
-                        else:
-                            # 尝试转换为JPEG进行压缩，如果图片是透明的，先转换为RGB
-                            if img.mode in ('RGBA', 'P'):
-                                img = img.convert('RGB')
-                            img.save(output_buffer, format='JPEG', quality=80) # 转换为JPEG并降低质量
+    @staticmethod
+    def _compress_image(data: bytes) -> str:
+        img = PILImage.open(io.BytesIO(data))
+        buf = io.BytesIO()
+        if img.format == "JPEG":
+            img.save(buf, "JPEG", quality=80)
+        else:
+            if img.mode in ("RGBA","P"):
+                img = img.convert("RGB")
+            img.save(buf, "JPEG", quality=80)
+        # logger.info("图片处理完成！！！")
+        return base64.b64encode(buf.getvalue()).decode()
 
-                        compressed_image_base64 = base64.b64encode(output_buffer.getvalue()).decode('utf-8')
-                        logger.info(f"图片压缩成功，原大小: {len(image_base64)} bytes, 压缩后大小: {len(compressed_image_base64)} bytes")
-                        image_base64_to_send = compressed_image_base64 # 使用压缩后的base64
-                    except Exception as e:
-                        logger.error(f"图片压缩处理失败: {e}")
-                        # 如果压缩失败，可以选择发送原图或者跳过
-                        # 这里选择发送原图，或者可以根据需求发送错误消息并跳过
-                        image_base64_to_send = image_base64 # 压缩失败，发送原图
-                        logger.warning("图片压缩失败，将尝试发送原图。")
+    async def _post(self, session, url, payload):
+        params = {"key": self.adapter.auth_key}
+        try:
+            async with session.post(url, params=params, json=payload) as resp:
+                data = await resp.json()
+                if resp.status != 200 or data.get("Code") != 200:
+                    logger.error(f"{url} failed: {resp.status} {data}")
+        except Exception as e:
+            logger.error(f"{url} error: {e}")
 
 
-                    payload = {
-                        "MsgItem": [
-                            {
-                                "AtWxIDList": [], # 根据需要添加 @ 的用户 wxid 列表
-                                "ImageContent": image_base64_to_send, # 使用处理后的base64
-                                "MsgType": 3, # 图片消息类型
-                                "TextContent": "",
-                                "ToUserName": self.session_id, # 接收者 wxid
-                            }
-                        ]
-                    }
-                    url = f"{self.adapter.base_url}/message/SendImageNewMessage" # 使用新的图片发送接口
-                    params = {"key": self.adapter.auth_key}
-                    async with aiohttp.ClientSession() as session:
-                        try:
-                            async with session.post(url, params=params, json=payload) as response:
-                                response_data = await response.json()
-                                logger.info(response_data)
-                                if response.status == 200 and response_data.get("Code") == 200:
-                                    logger.info(f"成功发送图片消息到 {self.session_id}")
-                                else:
-                                    logger.error(f"发送图片消息失败到 {self.session_id}: {response.status}, {response_data}")
-                        except aiohttp.ClientConnectorError as e:
-                            logger.error(f"连接到 WeChatPadPro 服务失败: {e}")
-                        except Exception as e:
-                            logger.error(f"发送图片消息时发生错误: {e}")
-
-                except Exception as e:
-                    logger.error(f"处理图片消息失败: {e}")
-                    # 可以选择发送一个错误提示文本消息
-                    await self.send(MessageChain([Plain("发送图片失败。")]))
-            # TODO: 添加对其他消息组件类型的处理 (Record, Video, At等)
-            # elif isinstance(component, Record):
-            #     pass
-            # elif isinstance(component, Video):
-            #     pass
-            # elif isinstance(component, At):
-            #     pass
-            # ...
-
-        await super().send(message) # 调用父类的 send 方法进行指标上报等操作
-
-
-    # 根据 WeChatPadPro 的事件特点，可能需要重写 AstrMessageEvent 中的其他方法
-    # 例如：
-    # def get_sender_id(self) -> str:
-    #     # 从 self.message_obj 中获取发送者 ID
-    #     return self.message_obj.sender.user_id
-    #
-    # def is_private_chat(self) -> bool:
-    #     # 根据 self.message_obj 判断是否是私聊
-    #     return self.message_obj.type == MessageType.FRIEND_MESSAGE
+# TODO: 添加对其他消息组件类型的处理 (Record, Video, At等)
+# elif isinstance(component, Record):
+#     pass
+# elif isinstance(component, Video):
+#     pass
+# elif isinstance(component, At):
+#     pass
+# ...

--- a/astrbot/core/platform/sources/wechatpadpro/wechatpadpro_message_event.py
+++ b/astrbot/core/platform/sources/wechatpadpro/wechatpadpro_message_event.py
@@ -1,0 +1,183 @@
+import time
+import aiohttp
+from astrbot.core.platform.astr_message_event import AstrMessageEvent
+from astrbot.core.platform.astrbot_message import AstrBotMessage, MessageType
+from astrbot.core.platform.platform_metadata import PlatformMetadata
+from astrbot.core.message.message_event_result import MessageChain
+from astrbot.core.message.components import Plain, Image # Import Image
+from astrbot import logger
+import base64
+from PIL import Image as PILImage # 使用别名避免冲突
+import io
+
+
+class WeChatPadProMessageEvent(AstrMessageEvent):
+    def __init__(
+        self,
+        message_str: str,
+        message_obj: AstrBotMessage,
+        platform_meta: PlatformMetadata,
+        session_id: str,
+        # 添加平台特定的参数，例如适配器实例
+        adapter: object, # 传递适配器实例
+    ):
+        # logger.info(f"WeChatPadProMessageEvent __init__ called with:")
+        # logger.info(f"  message_str: {message_str}")
+        # logger.info(f"  message_obj: {message_obj}")
+        # logger.info(f"  message_obj.message: {message_obj.message}") # Log the message components list
+        # logger.info(f"  platform_meta: {platform_meta}")
+        # logger.info(f"  session_id: {session_id}")
+        # logger.info(f"  adapter: {adapter}")
+
+        # Pass the message components list to the parent class constructor
+        # Pass message_str to the parent class constructor, similar to gewechat adapter
+        # Pass message_str and message_obj to the parent class constructor, similar to fake adapter
+        super().__init__(message_str, message_obj, platform_meta, session_id)
+        self.message_obj = message_obj # Save the full message object
+        self.adapter = adapter # Save the adapter instance
+
+    async def send(self, message: MessageChain):
+        """
+        发送消息到 WeChatPadPro 平台。
+        """
+        # 在这里实现将 MessageChain 转换为 WeChatPadPro 消息格式并发送的逻辑
+        # 遍历消息链，处理不同类型的消息组件
+        for component in message.chain:
+            # logger.info(f"Processing component: {component}") # Log the component
+            # logger.info(f"Type of component: {type(component)}") # Log the type of the component
+            # logger.info(f"Image class in scope: {Image}") # Log the Image class itself
+            time.sleep(1)
+            if isinstance(component, Plain):
+                # 发送文本消息
+                message_text = component.text
+                # 实现 reply_with_mention 功能
+                if (
+                    self.message_obj.type == MessageType.GROUP_MESSAGE # 确保是群聊消息
+                    and self.adapter.settings.get("reply_with_mention", False) # 检查适配器设置是否启用 reply_with_mention
+                    and self.message_obj.sender # 确保有发送者信息
+                    and (self.message_obj.sender.user_id or self.message_obj.sender.nickname) # 确保发送者有 ID 或昵称
+                ):
+                    # 在文本消息前加上 @ 消息发送者的信息
+                    # 优先使用 nickname，如果没有则使用 user_id
+                    mention_text = self.message_obj.sender.nickname if self.message_obj.sender.nickname else self.message_obj.sender.user_id
+                    message_text = f"@{mention_text} {message_text}"
+                    logger.info(f"已添加 @ 信息: {message_text}")
+
+                if message_text:
+                    payload = {
+                        "MsgItem": [
+                            {
+                                "MsgType": 1, # 1 for Text
+                                "TextContent": message_text,
+                                "ToUserName": self.session_id, # 接收者 wxid
+                            }
+                        ]
+                    }
+                    url = f"{self.adapter.base_url}/message/SendTextMessage" # 使用文本消息发送接口
+                    params = {"key": self.adapter.auth_key}
+                    async with aiohttp.ClientSession() as session:
+                        try:
+                            async with session.post(url, params=params, json=payload) as response:
+                                response_data = await response.json()
+                                if response.status == 200 and response_data.get("Code") == 200:
+                                    logger.info(f"成功发送文本消息到 {self.session_id}: {message_text}")
+                                else:
+                                    logger.error(f"发送文本消息失败到 {self.session_id}: {response.status}, {response_data}")
+                        except aiohttp.ClientConnectorError as e:
+                            logger.error(f"连接到 WeChatPadPro 服务失败: {e}")
+                        except Exception as e:
+                            logger.error(f"发送文本消息时发生错误: {e}")
+
+            elif isinstance(component, Image):
+                # 发送图片消息
+                try:
+                    # 假设 Image 对象有 to_base64() 方法
+                    image_base64 = await component.convert_to_base64() # 需要 Image 组件支持转为 base64
+                    # logger.info(f"转换后的base64图片：{image_base64}")
+
+                    # Base64图片格式校验
+                    try:
+                        image_data = base64.b64decode(image_base64, validate=True)
+                        logger.info("Base64图片格式校验成功。")
+                    except (base64.binascii.Error, ValueError) as e:
+                        logger.error(f"Base64图片格式校验失败: {e}")
+                        await self.send(MessageChain([Plain("发送图片失败：图片编码格式不正确。")]))
+                        continue # 跳过发送此图片
+
+                    # 图片压缩处理
+                    try:
+                        img = PILImage.open(io.BytesIO(image_data)) # 使用别名 PILImage
+
+                        # 示例压缩：对于 JPEG 格式，降低质量；对于其他格式，转换为 JPEG 并降低质量
+                        output_buffer = io.BytesIO()
+                        if img.format == 'JPEG':
+                            img.save(output_buffer, format='JPEG', quality=80) # 降低JPEG质量到80
+                        else:
+                            # 尝试转换为JPEG进行压缩，如果图片是透明的，先转换为RGB
+                            if img.mode in ('RGBA', 'P'):
+                                img = img.convert('RGB')
+                            img.save(output_buffer, format='JPEG', quality=80) # 转换为JPEG并降低质量
+
+                        compressed_image_base64 = base64.b64encode(output_buffer.getvalue()).decode('utf-8')
+                        logger.info(f"图片压缩成功，原大小: {len(image_base64)} bytes, 压缩后大小: {len(compressed_image_base64)} bytes")
+                        image_base64_to_send = compressed_image_base64 # 使用压缩后的base64
+                    except Exception as e:
+                        logger.error(f"图片压缩处理失败: {e}")
+                        # 如果压缩失败，可以选择发送原图或者跳过
+                        # 这里选择发送原图，或者可以根据需求发送错误消息并跳过
+                        image_base64_to_send = image_base64 # 压缩失败，发送原图
+                        logger.warning("图片压缩失败，将尝试发送原图。")
+
+
+                    payload = {
+                        "MsgItem": [
+                            {
+                                "AtWxIDList": [], # 根据需要添加 @ 的用户 wxid 列表
+                                "ImageContent": image_base64_to_send, # 使用处理后的base64
+                                "MsgType": 3, # 图片消息类型
+                                "TextContent": "",
+                                "ToUserName": self.session_id, # 接收者 wxid
+                            }
+                        ]
+                    }
+                    url = f"{self.adapter.base_url}/message/SendImageNewMessage" # 使用新的图片发送接口
+                    params = {"key": self.adapter.auth_key}
+                    async with aiohttp.ClientSession() as session:
+                        try:
+                            async with session.post(url, params=params, json=payload) as response:
+                                response_data = await response.json()
+                                logger.info(response_data)
+                                if response.status == 200 and response_data.get("Code") == 200:
+                                    logger.info(f"成功发送图片消息到 {self.session_id}")
+                                else:
+                                    logger.error(f"发送图片消息失败到 {self.session_id}: {response.status}, {response_data}")
+                        except aiohttp.ClientConnectorError as e:
+                            logger.error(f"连接到 WeChatPadPro 服务失败: {e}")
+                        except Exception as e:
+                            logger.error(f"发送图片消息时发生错误: {e}")
+
+                except Exception as e:
+                    logger.error(f"处理图片消息失败: {e}")
+                    # 可以选择发送一个错误提示文本消息
+                    await self.send(MessageChain([Plain("发送图片失败。")]))
+            # TODO: 添加对其他消息组件类型的处理 (Record, Video, At等)
+            # elif isinstance(component, Record):
+            #     pass
+            # elif isinstance(component, Video):
+            #     pass
+            # elif isinstance(component, At):
+            #     pass
+            # ...
+
+        await super().send(message) # 调用父类的 send 方法进行指标上报等操作
+
+
+    # 根据 WeChatPadPro 的事件特点，可能需要重写 AstrMessageEvent 中的其他方法
+    # 例如：
+    # def get_sender_id(self) -> str:
+    #     # 从 self.message_obj 中获取发送者 ID
+    #     return self.message_obj.sender.user_id
+    #
+    # def is_private_chat(self) -> bool:
+    #     # 根据 self.message_obj 判断是否是私聊
+    #     return self.message_obj.type == MessageType.FRIEND_MESSAGE

--- a/astrbot/core/platform/sources/wechatpadpro/wechatpadpro_message_event.py
+++ b/astrbot/core/platform/sources/wechatpadpro/wechatpadpro_message_event.py
@@ -90,9 +90,15 @@ class WeChatPadProMessageEvent(AstrMessageEvent):
 
             elif isinstance(component, Image):
                 # 发送图片消息
-                try:
-                    # 假设 Image 对象有 to_base64() 方法
-                    image_base64 = await component.convert_to_base64() # 需要 Image 组件支持转为 base64
+                if hasattr(component, "convert_to_base64"):
+                    try:
+                        image_base64 = await component.convert_to_base64()
+                    except Exception as e:
+                        logger.error(f"Error converting image to base64: {e}")
+                        continue
+                else:
+                    logger.error("Image component missing convert_to_base64, skipping image send.")
+                    continue
                     # logger.info(f"转换后的base64图片：{image_base64}")
 
                     # Base64图片格式校验

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ google-genai
 click
 filelock
 watchfiles
+websockets


### PR DESCRIPTION
### Motivation

由于gewechat仓库停止维护，于是重新适配一个个人微信适配器——wechatpadpro

### Modifications

新增一个个人微信适配器——wechatpadpro

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是将 pull request 总结翻译成中文的结果：

## Sourcery 总结

添加一个新的个人微信适配器 'wechatpadpro'，以实现基于二维码的登录、消息同步以及通过 AstrBot 框架的双向消息传递。

新特性：
- 引入 WeChatPadProAdapter 用于身份验证、凭据持久化、WebSocket 消息同步和 AstrBotMessage 转换。
- 添加 WeChatPadProMessageEvent 来处理传入消息，并通过适配器发送文本/图像有效负载。

增强功能：
- 在默认设置中为 wechatpadpro 平台添加默认配置。
- 更新平台管理器以识别和加载 wechatpadpro 适配器。

<details>
<summary>Original summary in English</summary>

好的，这是将给定的 pull request 总结翻译成中文的结果：

## Sourcery 总结

在 AstrBot 中添加一个新的个人微信适配器 (wechatpadpro)，以启用二维码登录、持久凭据、基于 WebSocket 的消息同步和双向消息传递。

新功能：
- 实现 WeChatPadProAdapter，支持授权密钥生成、二维码登录流程、凭据持久化、在线状态检查和 WebSocket 消息流。
- 添加 WeChatPadProMessageEvent 来解析传入消息并发送文本和图像有效负载（包括 @-提及和图像压缩）。

增强功能：
- 为 wechatpadpro 平台添加默认配置条目。
- 更新平台管理器以识别和加载 wechatpadpro 适配器。
- 确保 requirements.txt 具有用于 watchfiles 依赖项的正确换行符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new personal WeChat adapter (wechatpadpro) to AstrBot to enable QR-code login, persistent credentials, WebSocket-based message synchronization, and two-way messaging.

New Features:
- Implement WeChatPadProAdapter with support for auth key generation, QR-code login flow, credential persistence, online status checks, and WebSocket message streaming.
- Add WeChatPadProMessageEvent to parse incoming messages and send text and image payloads (including @-mentions and image compression).

Enhancements:
- Add default configuration entries for the wechatpadpro platform.
- Update the platform manager to recognize and load the wechatpadpro adapter.
- Ensure requirements.txt has a proper newline for the watchfiles dependency.

</details>

</details>