### PR TITLE
feat: wechatpadpro对接获取联系人信息的2个接口

### DIFF
--- a/astrbot/core/platform/sources/wechatpadpro/wechatpadpro_adapter.py
+++ b/astrbot/core/platform/sources/wechatpadpro/wechatpadpro_adapter.py
@@ -627,3 +627,68 @@ class WeChatPadProAdapter(Platform):
         )
         # 调用实例方法 send
         await sending_event.send(message_chain)
+
+
+    async def get_contact_list(self):
+        """
+        获取联系人列表。
+        """
+        url = f"{self.base_url}/friend/GetContactList"
+        params = {"key": self.auth_key}
+        payload = {
+            "CurrentChatRoomContactSeq": 0,
+            "CurrentWxcontactSeq": 0
+        }
+        async with aiohttp.ClientSession() as session:
+            try:
+                async with session.post(url, params=params, json=payload) as response:
+                    if response.status == 200:
+                        result = await response.json()
+                        if result.get("Code") == 200 and result.get("Data"):
+                            contact_list = result.get("Data", {}).get("ContactList", {}).get("contactUsernameList", [])
+                            return contact_list
+                        else:
+                            logger.error(f"获取联系人列表失败: {result}")
+                            return None
+                    else:
+                        logger.error(f"获取联系人列表失败: {response.status}")
+                        return None
+            except aiohttp.ClientConnectorError as e:
+                logger.error(f"连接到 WeChatPadPro 服务失败: {e}")
+                return None
+            except Exception as e:
+                logger.error(f"获取联系人列表时发生错误: {e}")
+                return None
+            
+    async def get_contact_details_list(self, room_wx_id_list: [str] = [], user_names : [str] = []) -> Optional[dict]:
+        """
+        获取联系人详情列表。
+        """
+        url = f"{self.base_url}/friend/GetContactDetailsList"
+        params = {"key": self.auth_key}
+        payload = {
+            "RoomWxIDList": room_wx_id_list,
+            "UserNames": user_names
+        }
+        async with aiohttp.ClientSession() as session:
+            try:
+                async with session.post(url, params=params, json=payload) as response:
+                    if response.status == 200:
+                        result = await response.json()
+                        if result.get("Code") == 200 and result.get("Data"):
+                            contact_list = result.get("Data", {}).get("contactList", {})
+                            return contact_list
+                        else:
+                            logger.error(f"获取联系人详情列表失败: {result}")
+                            return None
+                    else:
+                        logger.error(f"获取联系人详情列表失败: {response.status}")
+                        return None
+            except aiohttp.ClientConnectorError as e:
+                logger.error(f"连接到 WeChatPadPro 服务失败: {e}")
+                return None
+            except Exception as e:
+                logger.error(f"获取联系人详情列表时发生错误: {e}")
+                return None
+            
+        


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
对应插件 https://github.com/AstrBotDevs/AstrBot/issues/1587
为了实现根据群名获取群id功能

### Motivation
为了实现通过群名获取群id功能

### Modifications
 增加了WechatPadPro的获取联系人id列表和根据id列表获取详细信息的接口

### Check

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 摘要：

## Sourcery 总结

添加两个用于获取联系人列表和联系人详情的 WechatPadPro 适配器方法

新特性：
- 实现 `get_contact_list` 以从 WeChatPadPro 服务检索联系人 ID 列表
- 实现 `get_contact_details_list` 以通过房间 ID 列表或用户名获取详细的联系人信息

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add two WechatPadPro adapter methods for fetching contact list and contact details

New Features:
- Implement get_contact_list to retrieve a list of contact IDs from the WeChatPadPro service
- Implement get_contact_details_list to fetch detailed contact information by room ID list or usernames

</details>