### PR TITLE
fix:为llm和model和provider指令添加了管理员权限检查

### DIFF
--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -140,7 +140,7 @@ class Main(star.Star):
 {notice}"""
 
         event.set_result(MessageEventResult().message(msg).use_t2i(False))
-
+    @filter.permission_type(filter.PermissionType.ADMIN)
     @filter.command("llm")
     async def llm(self, event: AstrMessageEvent):
         """开启/关闭 LLM"""
@@ -419,7 +419,8 @@ UID: {user_id} 此 ID 可用于设置管理员。
             event.set_result(MessageEventResult().message("删除白名单成功。"))
         except ValueError:
             event.set_result(MessageEventResult().message("此 SID 不在白名单内。"))
-
+    
+    @filter.permission_type(filter.PermissionType.ADMIN)
     @filter.command("provider")
     async def provider(
         self, event: AstrMessageEvent, idx: Union[str, int] = None, idx2: int = None
@@ -588,7 +589,8 @@ UID: {user_id} 此 ID 可用于设置管理员。
             ret += f"\n聊天增强: 已清除 {cnt} 条聊天记录。"
 
         message.set_result(MessageEventResult().message(ret))
-
+    
+    @filter.permission_type(filter.PermissionType.ADMIN)
     @filter.command("model")
     async def model_ls(
         self, message: AstrMessageEvent, idx_or_name: Union[int, str] = None


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了任何人都可以切换供应商，关闭llm功能以及切换模型的问题

### Motivation

今天发现机器人在某个群被用户切换到了claude4，产生了大量的api费用。

### Modifications

简单地添加了管理员权限的filter

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

需要管理员权限才能执行关键命令，以防止未经授权的用户切换 LLM 功能、切换模型或更改提供商。

Bug 修复：
- 仅限管理员使用 "llm" 命令
- 仅限管理员使用 "provider" 命令
- 仅限管理员使用 "model" 命令

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Require administrator permissions for critical commands to prevent unauthorized users from toggling LLM functionality, switching models, or changing providers.

Bug Fixes:
- Restrict the "llm" command to administrators only
- Restrict the "provider" command to administrators only
- Restrict the "model" command to administrators only

</details>