### PR TITLE
Refactor: 重构转发节点等消息段的 toDict 相关逻辑

### DIFF
--- a/astrbot/core/message/components.py
+++ b/astrbot/core/message/components.py
@@ -584,7 +584,7 @@ class Node(BaseMessageComponent):
     id: T.Optional[int] = 0  # 忽略
     name: T.Optional[str] = ""  # qq昵称
     uin: T.Optional[str] = "0"  # qq号
-    content: T.Optional[list[BaseMessageComponent]] = None
+    content: T.Optional[list[BaseMessageComponent]] = []
     seq: T.Optional[T.Union[str, list]] = ""  # 忽略
     time: T.Optional[int] = 0  # 忽略
 

--- a/astrbot/core/message/components.py
+++ b/astrbot/core/message/components.py
@@ -572,8 +572,9 @@ class Node(BaseMessageComponent):
     seq: T.Optional[T.Union[str, list]] = ""  # 忽略
     time: T.Optional[int] = 0  # 忽略
 
-    def __init__(self, content: list[BaseMessageComponent] | "Node", **_):
+    def __init__(self, content: list[BaseMessageComponent], **_):
         if isinstance(content, Node):
+            # back
             content = [content]
         super().__init__(content=content, **_)
 
@@ -596,6 +597,9 @@ class Node(BaseMessageComponent):
             elif isinstance(comp, (Node, Nodes)):
                 # For Node segments, we recursively convert them to dict
                 d = await comp.to_dict()
+                data_content.append(d)
+            else:
+                d = comp.toDict()
                 data_content.append(d)
         return {
             "type": "node",
@@ -627,9 +631,11 @@ class Nodes(BaseMessageComponent):
     async def to_dict(self):
         """将 Nodes 转换为字典格式，适用于 OneBot JSON 格式"""
         ret = {
-            "type": "nodes",
-            "data": {"nodes": [await node.to_dict() for node in self.nodes]},
+            "messages": []
         }
+        for node in self.nodes:
+            d = await node.to_dict()
+            ret["messages"].append(d)
         return ret
 
 

--- a/astrbot/core/message/components.py
+++ b/astrbot/core/message/components.py
@@ -118,6 +118,9 @@ class Plain(BaseMessageComponent):
             self.text.replace("&", "&amp;").replace("[", "&#91;").replace("]", "&#93;")
         )
 
+    def toDict(self):
+        return {"type": "text", "data": {"text": self.text.strip()}}
+
 
 class Face(BaseMessageComponent):
     type: ComponentType = "Face"
@@ -303,6 +306,12 @@ class At(BaseMessageComponent):
 
     def __init__(self, **_):
         super().__init__(**_)
+
+    def toDict(self):
+        return {
+            "type": "at",
+            "data": {"qq": str(self.qq)},
+        }
 
 
 class AtAll(At):
@@ -559,27 +568,43 @@ class Node(BaseMessageComponent):
     id: T.Optional[int] = 0  # 忽略
     name: T.Optional[str] = ""  # qq昵称
     uin: T.Optional[str] = "0"  # qq号
-    content: T.Optional[T.Union[str, list, dict]] = ""  # 子消息段列表
+    content: T.Optional[list[BaseMessageComponent]] = None
     seq: T.Optional[T.Union[str, list]] = ""  # 忽略
     time: T.Optional[int] = 0  # 忽略
 
-    def __init__(self, content: T.Union[str, list, dict, "Node", T.List["Node"]], **_):
-        if isinstance(content, list):
-            _content = None
-            if all(isinstance(item, Node) for item in content):
-                _content = [node.toDict() for node in content]
-            else:
-                _content = ""
-                for chain in content:
-                    _content += chain.toString()
-            content = _content
-        elif isinstance(content, Node):
-            content = content.toDict()
+    def __init__(self, content: list[BaseMessageComponent] | "Node", **_):
+        if isinstance(content, Node):
+            content = [content]
         super().__init__(content=content, **_)
 
-    def toString(self):
-        # logger.warn("Protocol: node doesn't support stringify")
-        return ""
+    async def to_dict(self):
+        data_content = []
+        for comp in self.content:
+            if isinstance(comp, (Image, Record)):
+                # For Image and Record segments, we convert them to base64
+                bs64 = await comp.convert_to_base64()
+                data_content.append(
+                    {
+                        "type": comp.type.lower(),
+                        "data": {"file": f"base64://{bs64}"},
+                    }
+                )
+            elif isinstance(comp, File):
+                # For File segments, we need to handle the file differently
+                d = await comp.to_dict()
+                data_content.append(d)
+            elif isinstance(comp, (Node, Nodes)):
+                # For Node segments, we recursively convert them to dict
+                d = await comp.to_dict()
+                data_content.append(d)
+        return {
+            "type": "node",
+            "data": {
+                "user_id": str(self.uin),
+                "nickname": self.name,
+                "content": data_content,
+            },
+        }
 
 
 class Nodes(BaseMessageComponent):
@@ -590,13 +615,21 @@ class Nodes(BaseMessageComponent):
         super().__init__(nodes=nodes, **_)
 
     def toDict(self):
+        """Deprecated. Use to_dict instead"""
         ret = {
             "messages": [],
         }
         for node in self.nodes:
             d = node.toDict()
-            d["data"]["uin"] = str(node.uin)  # 转为字符串
             ret["messages"].append(d)
+        return ret
+
+    async def to_dict(self):
+        """将 Nodes 转换为字典格式，适用于 OneBot JSON 格式"""
+        ret = {
+            "type": "nodes",
+            "data": {"nodes": [await node.to_dict() for node in self.nodes]},
+        }
         return ret
 
 
@@ -767,6 +800,26 @@ class File(BaseMessageComponent):
         logger.debug(f"已注册：{callback_host}/api/file/{token}")
 
         return f"{callback_host}/api/file/{token}"
+
+    async def to_dict(self):
+        """需要和 toDict 区分开，toDict 是同步方法"""
+        url_or_path = await self.get_file(allow_return_url=True)
+        if url_or_path.startswith("http"):
+            payload_file = url_or_path
+        elif callback_host := astrbot_config.get("callback_api_base"):
+            callback_host = str(callback_host).removesuffix("/")
+            token = await file_token_service.register_file(url_or_path)
+            payload_file = f"{callback_host}/api/file/{token}"
+            logger.debug(f"Generated file callback link: {payload_file}")
+        else:
+            payload_file = url_or_path
+        return {
+            "type": "file",
+            "data": {
+                "name": self.name,
+                "file": payload_file,
+            },
+        }
 
 
 class WechatEmoji(BaseMessageComponent):

--- a/astrbot/core/message/components.py
+++ b/astrbot/core/message/components.py
@@ -102,6 +102,10 @@ class BaseMessageComponent(BaseModel):
             data[k] = v
         return {"type": self.type.lower(), "data": data}
 
+    async def to_dict(self) -> dict:
+        # 默认情况下，回退到旧的同步 toDict()
+        return self.toDict()
+
 
 class Plain(BaseMessageComponent):
     type: ComponentType = "Plain"

--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -29,9 +29,7 @@ class RespondStage(Stage):
         Comp.Image: lambda comp: bool(comp.file),  # 图片
         Comp.Reply: lambda comp: bool(comp.id) and comp.sender_id is not None,  # 回复
         Comp.Poke: lambda comp: comp.id != 0 and comp.qq != 0,  # 戳一戳
-        Comp.Node: lambda comp: bool(comp.name)
-        and comp.uin != 0
-        and bool(comp.content),  # 一个转发节点
+        Comp.Node: lambda comp: bool(comp.content),  # 转发节点
         Comp.Nodes: lambda comp: bool(comp.nodes),  # 多个转发节点
         Comp.File: lambda comp: bool(comp.file_ or comp.url),
     }

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
@@ -9,6 +9,7 @@ from astrbot.api.message_components import (
     Nodes,
     Plain,
     Record,
+    Video,
     File,
     BaseMessageComponent,
 )
@@ -36,6 +37,9 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
             }
         elif isinstance(segment, File):
             # For File segments, we need to handle the file differently
+            d = await segment.to_dict()
+            return d
+        elif isinstance(segment, Video):
             d = await segment.to_dict()
             return d
         else:

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
@@ -3,9 +3,16 @@ import re
 from typing import AsyncGenerator, Dict, List
 from aiocqhttp import CQHttp
 from astrbot.api.event import AstrMessageEvent, MessageChain
-from astrbot.api.message_components import At, Image, Node, Nodes, Plain, Record, File
+from astrbot.api.message_components import (
+    Image,
+    Node,
+    Nodes,
+    Plain,
+    Record,
+    File,
+    BaseMessageComponent,
+)
 from astrbot.api.platform import Group, MessageMember
-from astrbot.core import file_token_service, astrbot_config, logger
 
 
 class AiocqhttpMessageEvent(AstrMessageEvent):
@@ -16,27 +23,34 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
         self.bot = bot
 
     @staticmethod
+    async def _from_segment_to_dict(segment: BaseMessageComponent) -> dict:
+        """修复部分字段"""
+        if isinstance(segment, (Image, Record)):
+            # For Image and Record segments, we convert them to base64
+            bs64 = await segment.convert_to_base64()
+            return {
+                "type": segment.type.lower(),
+                "data": {
+                    "file": f"base64://{bs64}",
+                },
+            }
+        elif isinstance(segment, File):
+            # For File segments, we need to handle the file differently
+            d = await segment.to_dict()
+            return d
+        else:
+            # For other segments, we simply convert them to a dict by calling toDict
+            return segment.toDict()
+
+    @staticmethod
     async def _parse_onebot_json(message_chain: MessageChain):
         """解析成 OneBot json 格式"""
         ret = []
         for segment in message_chain.chain:
-            d = segment.toDict()
             if isinstance(segment, Plain):
-                d["type"] = "text"
-                d["data"]["text"] = segment.text.strip()
-                # 如果是空文本或者只带换行符的文本，不发送
-                if not d["data"]["text"]:
+                if not segment.text.strip():
                     continue
-            elif isinstance(segment, (Image, Record)):
-                # convert to base64
-                bs64 = await segment.convert_to_base64()
-                d["data"] = {
-                    "file": f"base64://{bs64}",
-                }
-            elif isinstance(segment, At):
-                d["data"] = {
-                    "qq": str(segment.qq),  # 转换为字符串
-                }
+            d = await AiocqhttpMessageEvent._from_segment_to_dict(segment)
             ret.append(d)
         return ret
 
@@ -54,7 +68,8 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
                         nodes = Nodes([seg])
                         seg = nodes
 
-                    payload = seg.toDict()
+                    payload = await seg.to_dict()
+
                     if self.get_group_id():
                         payload["group_id"] = self.get_group_id()
                         await self.bot.call_action("send_group_forward_msg", **payload)
@@ -64,21 +79,7 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
                             "send_private_forward_msg", **payload
                         )
                 elif isinstance(seg, File):
-                    d = seg.toDict()
-                    url_or_path = await seg.get_file(allow_return_url=True)
-                    if url_or_path.startswith("http"):
-                        payload_file = url_or_path
-                    elif callback_host := astrbot_config.get("callback_api_base"):
-                        callback_host = str(callback_host).removesuffix("/")
-                        token = await file_token_service.register_file(url_or_path)
-                        payload_file = f"{callback_host}/api/file/{token}"
-                        logger.debug(f"Generated file callback link: {payload_file}")
-                    else:
-                        payload_file = url_or_path
-                    d["data"] = {
-                        "name": seg.name,
-                        "file": payload_file,
-                    }
+                    d = await AiocqhttpMessageEvent._from_segment_to_dict(seg)
                     await self.bot.send(
                         self.message_obj.raw_message,
                         [d],


### PR DESCRIPTION
### Motivation

<!--解释为什么要改动-->

目前的代码没有考虑到合并转发消息中的Image、File等消息段的预处理

### Modifications

<!--简单解释你的改动-->

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构消息组件的序列化逻辑，以统一和扩展字典转换，用于转发节点和其他片段

Bug 修复：
- 修复合并转发消息时，Image、File 和其他片段缺少预处理的问题

增强功能：
- 在 Node、Nodes、File、At 和 Plain 组件上引入异步 to_dict 方法，以替换和简化 toDict
- 统一 Image 和 Record 的 base64 转换，以及 File 的回调 URL 生成（在异步序列化路径中）
- 更新 AiocqhttpMessageEvent 的解析和发送方法，以利用新的异步转换助手
- 通过仅检查内容是否存在来简化 RespondStage 中的转发节点谓词

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the serialization logic for message components to unify and extend dict conversion for forwarding nodes and other segments

Bug Fixes:
- Fix missing preprocessing of Image, File, and other segments when merging forwarded messages

Enhancements:
- Introduce async to_dict methods on Node, Nodes, File, At, and Plain components to replace and simplify toDict
- Unify base64 conversion for Image and Record and callback URL generation for File in the async serialization path
- Update AiocqhttpMessageEvent parsing and send methods to leverage the new async conversion helper
- Simplify forwarding node predicate in RespondStage by checking only content presence

</details>