### PR TITLE
Fix: fixed a potential vulnerability in `/api/chat/get_file` endpoint.

### DIFF
--- a/astrbot/dashboard/routes/chat.py
+++ b/astrbot/dashboard/routes/chat.py
@@ -60,29 +60,26 @@ class ChatRoute(Route):
         if not filename:
             return Response().error("Missing key: filename").__dict__
 
-        # Prevent path traversal attacks by extracting just the basename
-        filename_ = os.path.basename(filename)
-
-        # Check if the filename contains suspicious patterns
-        if (
-            filename_ != filename
-            or ".." in filename
-            or "/" in filename
-            or "\\" in filename
-        ):
-            return Response().error("Invalid filename").__dict__
-
         try:
-            with open(os.path.join(self.imgs_dir, filename_), "rb") as f:
-                if filename_.endswith(".wav"):
+            file_path = os.path.join(self.imgs_dir, os.path.basename(filename))
+            real_file_path = os.path.realpath(file_path)
+            real_imgs_dir = os.path.realpath(self.imgs_dir)
+
+            if not real_file_path.startswith(real_imgs_dir):
+                return Response().error("Invalid file path").__dict__
+
+            with open(real_file_path, "rb") as f:
+                filename_ext = os.path.splitext(filename)[1].lower()
+
+                if filename_ext == ".wav":
                     return QuartResponse(f.read(), mimetype="audio/wav")
-                elif filename_.split(".")[-1] in self.supported_imgs:
+                elif filename_ext[1:] in self.supported_imgs:
                     return QuartResponse(f.read(), mimetype="image/jpeg")
                 else:
                     return QuartResponse(f.read())
 
-        except FileNotFoundError:
-            return Response().error("File not found").__dict__
+        except (FileNotFoundError, OSError):
+            return Response().error("File access error").__dict__
 
     async def post_image(self):
         post_data = await request.files
@@ -138,17 +135,15 @@ class ChatRoute(Route):
 
         self.curr_user_cid[username] = conversation_id
 
-        await web_chat_queue.put(
-            (
-                username,
-                conversation_id,
-                {
-                    "message": message,
-                    "image_url": image_url,  # list
-                    "audio_url": audio_url,
-                },
-            )
-        )
+        await web_chat_queue.put((
+            username,
+            conversation_id,
+            {
+                "message": message,
+                "image_url": image_url,  # list
+                "audio_url": audio_url,
+            },
+        ))
 
         # 持久化
         conversation = self.db.get_conversation_by_user_id(username, conversation_id)

--- a/astrbot/dashboard/routes/chat.py
+++ b/astrbot/dashboard/routes/chat.py
@@ -60,11 +60,23 @@ class ChatRoute(Route):
         if not filename:
             return Response().error("Missing key: filename").__dict__
 
+        # Prevent path traversal attacks by extracting just the basename
+        filename_ = os.path.basename(filename)
+
+        # Check if the filename contains suspicious patterns
+        if (
+            filename_ != filename
+            or ".." in filename
+            or "/" in filename
+            or "\\" in filename
+        ):
+            return Response().error("Invalid filename").__dict__
+
         try:
-            with open(os.path.join(self.imgs_dir, filename), "rb") as f:
-                if filename.endswith(".wav"):
+            with open(os.path.join(self.imgs_dir, filename_), "rb") as f:
+                if filename_.endswith(".wav"):
                     return QuartResponse(f.read(), mimetype="audio/wav")
-                elif filename.split(".")[-1] in self.supported_imgs:
+                elif filename_.split(".")[-1] in self.supported_imgs:
                     return QuartResponse(f.read(), mimetype="image/jpeg")
                 else:
                     return QuartResponse(f.read())

--- a/astrbot/dashboard/server.py
+++ b/astrbot/dashboard/server.py
@@ -70,13 +70,13 @@ class AstrBotDashboard:
         for api in registered_web_apis:
             route, view_handler, methods, _ = api
             if route == f"/{subpath}" and request.method in methods:
-                    return await view_handler(*args, **kwargs)
+                return await view_handler(*args, **kwargs)
         return jsonify(Response().error("未找到该路由").__dict__)
 
     async def auth_middleware(self):
         if not request.path.startswith("/api"):
             return
-        allowed_endpoints = ["/api/auth/login", "/api/chat/get_file", "/api/file"]
+        allowed_endpoints = ["/api/auth/login", "/api/file"]
         if any(request.path.startswith(prefix) for prefix in allowed_endpoints):
             return
         # claim jwt

--- a/dashboard/src/views/ChatPage.vue
+++ b/dashboard/src/views/ChatPage.vue
@@ -282,10 +282,7 @@ export default {
             try {
                 const response = await axios.get('/api/chat/get_file', {
                     params: { filename },
-                    responseType: 'blob',
-                    headers: {
-                        'Authorization': 'Bearer ' + localStorage.getItem('token')
-                    }
+                    responseType: 'blob'
                 });
                 
                 const blobUrl = URL.createObjectURL(response.data);
@@ -433,8 +430,7 @@ export default {
                 try {
                     const response = await axios.post('/api/chat/post_file', formData, {
                         headers: {
-                            'Content-Type': 'multipart/form-data',
-                            'Authorization': 'Bearer ' + localStorage.getItem('token')
+                            'Content-Type': 'multipart/form-data'
                         }
                     });
 
@@ -460,8 +456,7 @@ export default {
                     try {
                         const response = await axios.post('/api/chat/post_image', formData, {
                             headers: {
-                                'Content-Type': 'multipart/form-data',
-                                'Authorization': 'Bearer ' + localStorage.getItem('token')
+                                'Content-Type': 'multipart/form-data'
                             }
                         });
 

--- a/dashboard/src/views/ChatPage.vue
+++ b/dashboard/src/views/ChatPage.vue
@@ -282,7 +282,10 @@ export default {
             try {
                 const response = await axios.get('/api/chat/get_file', {
                     params: { filename },
-                    responseType: 'blob'
+                    responseType: 'blob',
+                    headers: {
+                        'Authorization': 'Bearer ' + localStorage.getItem('token')
+                    }
                 });
                 
                 const blobUrl = URL.createObjectURL(response.data);


### PR DESCRIPTION
I have fixed a potential vulnerability in the `/api/chat/get_file` endpoint that could allow unauthorized access to files by ensuring the request has a jwt token.

Fixes #1675 

### Motivation

The previous implementation did not enforce proper authentication for the /api/chat/get_file endpoint, which could allow unauthorized users to access sensitive files. This posed a security risk and needed to be addressed.

### Modifications

1. All requests to the /api/chat/get_file endpoint must now include a valid JWT token.
2. Added validation logic to verify the filename parameter in the route, preventing potential misuse or path traversal.

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是将 pull request 总结翻译成中文的结果：

## Sourcery 总结

使用 JWT 认证和路径遍历检查来保护 `/api/chat/get_file` 端点，并改进前端媒体处理，以使用具有适当生命周期管理的缓存 blob URL。

新特性：
- 在 ChatPage.vue 中通过新的 getMediaFile 方法缓存并提供媒体文件作为 blob URL

Bug 修复：
- `/api/chat/get_file` 需要有效的 JWT，并将其从未经身份验证的端点列表中删除
- 通过验证 `/api/chat/get_file` 端点中的 filename 参数来防止路径遍历

增强功能：
- 重构媒体暂存以单独存储文件名并按需生成 blob URL
- 引入 mediaCache 和 cleanupMediaCache 来管理 blob URL 缓存和撤销

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Secure the `/api/chat/get_file` endpoint with JWT authentication and path traversal checks, and revamp the frontend media handling to use cached blob URLs with proper lifecycle management.

New Features:
- Cache and serve media files as blob URLs in ChatPage.vue via a new getMediaFile method

Bug Fixes:
- Require a valid JWT for `/api/chat/get_file` and remove it from the unauthenticated endpoints list
- Prevent path traversal by validating the filename parameter in the `/api/chat/get_file` endpoint

Enhancements:
- Refactor media staging to store filenames separately and generate blob URLs on-demand
- Introduce mediaCache and cleanupMediaCache to manage blob URL caching and revocation

</details>