### PR TITLE
Feature: 添加测试文本生成供应商可用功能

### DIFF
--- a/astrbot/dashboard/routes/config.py
+++ b/astrbot/dashboard/routes/config.py
@@ -9,7 +9,7 @@ from astrbot.core.platform.register import platform_registry
 from astrbot.core.provider.register import provider_registry
 from astrbot.core.star.star import star_registry
 from astrbot.core import logger
-import asyncio # 用于并发执行获取供应商请求
+import asyncio
 
 
 def try_cast(value: str, type_: str):
@@ -188,7 +188,7 @@ class ConfigRoute(Route):
         logger.debug(f"Attempting to check provider: {status_info['name']} (ID: {status_info['id']}, Type: {status_info['type']}, Model: {status_info['model']})")
         try:
             logger.debug(f"Sending 'Ping' to provider: {status_info['name']}")
-            response = await asyncio.wait_for(provider.text_chat(prompt="Ping"), timeout=20.0) #超时二十秒
+            response = await asyncio.wait_for(provider.text_chat(prompt="Ping"), timeout=20.0) # 超时 20 秒
             logger.debug(f"Received response from {status_info['name']}: {response}")
             # 只要 text_chat 调用成功返回一个 LLMResponse 对象 (即 response 不为 None)，就认为可用
             if response is not None:

--- a/astrbot/dashboard/routes/config.py
+++ b/astrbot/dashboard/routes/config.py
@@ -173,7 +173,7 @@ class ConfigRoute(Route):
     async def _test_single_provider(self, provider): 
         """辅助函数：测试单个 provider 的可用性"""
         meta = provider.meta()
-        provider_name = provider.provider_config.get("name", meta.id if meta else meta.id)
+        provider_name = provider.provider_config.get("id", "Unknown Provider")
         if not provider_name and meta: 
             provider_name = meta.id
         elif not provider_name: 

--- a/astrbot/dashboard/routes/config.py
+++ b/astrbot/dashboard/routes/config.py
@@ -9,6 +9,7 @@ from astrbot.core.platform.register import platform_registry
 from astrbot.core.provider.register import provider_registry
 from astrbot.core.star.star import star_registry
 from astrbot.core import logger
+import asyncio # 用于并发执行获取供应商请求
 
 
 def try_cast(value: str, type_: str):
@@ -164,8 +165,82 @@ class ConfigRoute(Route):
             "/config/provider/update": ("POST", self.post_update_provider),
             "/config/provider/delete": ("POST", self.post_delete_provider),
             "/config/llmtools": ("GET", self.get_llm_tools),
+            "/config/provider/check_status": ("GET", self.check_all_providers_status), 
         }
         self.register_routes()
+
+    async def _test_single_provider(self, provider): 
+        """辅助函数：测试单个 provider 的可用性"""
+        meta = provider.meta()
+        provider_name = provider.provider_config.get("name", meta.id if meta else meta.id)
+        if not provider_name and meta: 
+            provider_name = meta.id
+        elif not provider_name: 
+            provider_name = "Unknown Provider"
+        status_info = {
+            "id": meta.id if meta else "Unknown ID",
+            "model": meta.model if meta else "Unknown Model",
+            "type": meta.type if meta else "Unknown Type",
+            "name": provider_name,
+            "status": "unavailable", # 默认为不可用
+            "error": None,
+        }
+        logger.debug(f"Attempting to check provider: {status_info['name']} (ID: {status_info['id']}, Type: {status_info['type']}, Model: {status_info['model']})")
+        try:
+            logger.debug(f"Sending 'Ping' to provider: {status_info['name']}")
+            response = await asyncio.wait_for(provider.text_chat(prompt="Ping"), timeout=20.0) #超时二十秒
+            logger.debug(f"Received response from {status_info['name']}: {response}")
+            # 只要 text_chat 调用成功返回一个 LLMResponse 对象 (即 response 不为 None)，就认为可用
+            if response is not None:
+                status_info["status"] = "available"
+                response_text_snippet = ""
+                if hasattr(response, 'completion_text') and response.completion_text:
+                    response_text_snippet = response.completion_text[:70] + "..." if len(response.completion_text) > 70 else response.completion_text
+                elif hasattr(response, 'result_chain') and response.result_chain:
+                    try:
+                        response_text_snippet = response.result_chain.get_plain_text()[:70] + "..." if len(response.result_chain.get_plain_text()) > 70 else response.result_chain.get_plain_text()
+                    except: 
+                        pass
+                logger.info(f"Provider {status_info['name']} (ID: {status_info['id']}) is available. Response snippet: '{response_text_snippet}'")
+            else:
+                # 这个分支理论上不应该被走到，除非 text_chat 实现可能返回 None
+                status_info["error"] = "Test call returned None, but expected an LLMResponse object."
+                logger.warning(f"Provider {status_info['name']} (ID: {status_info['id']}) test call returned None.")
+
+        except asyncio.TimeoutError:
+            status_info["error"] = "Connection timed out after 10 seconds during test call."
+            logger.warning(f"Provider {status_info['name']} (ID: {status_info['id']}) timed out.")
+        except Exception as e:
+            error_message = str(e)
+            status_info["error"] = error_message
+            logger.warning(f"Provider {status_info['name']} (ID: {status_info['id']}) is unavailable. Error: {error_message}")
+            logger.debug(f"Traceback for {status_info['name']}:\n{traceback.format_exc()}")
+        return status_info
+
+    async def check_all_providers_status(self):
+        """
+        API 接口: 检查所有 LLM Providers 的状态
+        """
+        logger.info("API call received: /config/provider/check_status")
+        try:
+            all_providers: typing.List = self.core_lifecycle.star_context.get_all_providers() 
+            logger.debug(f"Found {len(all_providers)} providers to check.")
+
+            if not all_providers:
+                logger.info("No providers found to check.")
+                return Response().ok([]).__dict__
+
+            tasks = [self._test_single_provider(p) for p in all_providers]
+            logger.debug(f"Created {len(tasks)} tasks for concurrent provider checks.")
+            
+            results = await asyncio.gather(*tasks)
+            logger.info(f"Provider status check completed. Results: {results}")
+            
+            return Response().ok(results).__dict__ 
+        except Exception as e:
+            logger.error(f"Critical error in check_all_providers_status: {str(e)}")
+            logger.error(traceback.format_exc())
+            return Response().error(f"检查 Provider 状态时发生严重错误: {str(e)}").__dict__ 
 
     async def get_configs(self):
         # plugin_name 为空时返回 AstrBot 配置

--- a/dashboard/src/views/ProviderPage.vue
+++ b/dashboard/src/views/ProviderPage.vue
@@ -61,6 +61,51 @@
         </v-card-text>
       </v-card>
 
+      <!-- 供应商状态部分 -->
+      <v-card class="mb-6" elevation="2">
+        <v-card-title class="d-flex align-center py-3 px-4">
+          <v-icon color="primary" class="me-2">mdi-heart-pulse</v-icon>
+          <span class="text-h6">供应商可用性</span>
+          <v-spacer></v-spacer>
+          <v-btn color="primary" variant="tonal" :loading="loadingStatus" @click="fetchProviderStatus">
+            <v-icon left>mdi-refresh</v-icon>
+            刷新状态
+          </v-btn>
+        </v-card-title>
+        <v-card-subtitle class="px-4 py-1 text-caption text-medium-emphasis">
+          通过测试模型对话可用性判断，可能产生API费用
+        </v-card-subtitle>
+
+        <v-divider></v-divider>
+
+        <v-card-text class="px-4 py-3">
+          <v-alert v-if="providerStatuses.length === 0" type="info" variant="tonal">
+            点击"刷新状态"按钮获取供应商可用性
+          </v-alert>
+          
+          <v-container v-else class="pa-0">
+            <v-row>
+              <v-col v-for="status in providerStatuses" :key="status.id" cols="12" sm="6" md="4">
+                <v-card variant="outlined" class="status-card">
+                  <v-card-item>
+                    <v-icon :color="status.status === 'available' ? 'success' : 'error'" class="me-2">
+                      {{ status.status === 'available' ? 'mdi-check-circle' : 'mdi-alert-circle' }}
+                    </v-icon>
+                    <span class="font-weight-bold">{{ status.id }}</span>
+                    <v-chip :color="status.status === 'available' ? 'success' : 'error'" size="small" class="ml-2">
+                      {{ status.status === 'available' ? '可用' : '不可用' }}
+                    </v-chip>
+                  </v-card-item>
+                  <v-card-text v-if="status.status === 'unavailable'" class="text-caption text-medium-emphasis">
+                    <span class="font-weight-bold">错误信息:</span> {{ status.error }}
+                  </v-card-text>
+                </v-card>
+              </v-col>
+            </v-row>
+          </v-container>
+        </v-card-text>
+      </v-card>
+
       <!-- 日志部分 -->
       <v-card elevation="2">
         <v-card-title class="d-flex align-center py-3 px-4">
@@ -221,6 +266,10 @@ export default {
       save_message_success: "success",
 
       showConsole: false,
+      
+      // 供应商状态相关
+      providerStatuses: [],
+      loadingStatus: false,
 
       // 新增提供商对话框相关
       showAddProviderDialog: false,
@@ -442,6 +491,22 @@ export default {
       this.save_message = message;
       this.save_message_success = "error";
       this.save_message_snack = true;
+    },
+    
+    // 获取供应商状态
+    fetchProviderStatus() {
+      this.loadingStatus = true;
+      axios.get('/api/config/provider/check_status').then((res) => {
+        if (res.data && res.data.status === 'ok') {
+          this.providerStatuses = res.data.data || [];
+        } else {
+          this.showError(res.data?.message || "获取供应商状态失败");
+        }
+        this.loadingStatus = false;
+      }).catch((err) => {
+        this.loadingStatus = false;
+        this.showError(err.response?.data?.message || err.message);
+      });
     }
   }
 }


### PR DESCRIPTION
### Motivation

目前缺少测试供应商可用性的方法，只能靠手动逐个对话来判断

### Modifications

添加了一个/config/provider/check_status的接口，并在前端写好了相应界面以及调用，允许一次性通过测试文本能否正常生成来判断全部的供应商可用性。
![image](https://github.com/user-attachments/assets/b5ae9ee6-ff0a-4c91-9151-8ba0b20d9893)


### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

添加批量供应商可用性测试，包含一个新的 API 接口，并集成一个 UI 部分来获取和展示 LLM 供应商状态。

新特性：
- 引入 `/config/provider/check_status` API 以并发测试并报告所有 LLM 供应商的可用性
- 在供应商页面添加一个前端卡片，用于刷新和显示供应商状态（可用/不可用），并显示错误详情

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add bulk provider availability testing with a new API endpoint and integrate a UI section for fetching and displaying LLM provider statuses

New Features:
- Introduce `/config/provider/check_status` API to concurrently test and report all LLM providers’ availability
- Add a front-end card on Provider page to refresh and display provider status (available/unavailable) with error details

</details>