### PR TITLE
fix: qq_official适配器使用SessionController(会话控制)功能时机器人回复消息无法发送到聊天平台

### DIFF
--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -211,6 +211,10 @@ class RespondStage(Stage):
             logger.info(
                 f"AstrBot -> {event.get_sender_name()}/{event.get_sender_id()}: {event._outline_chain(result.chain)}"
             )
+        else:
+            # 对使用 qq_official 适配器的会话控制器发送消息的特殊处理
+            if event.get_platform_name() == "qq_official":
+                await event._post_send()
 
         handlers = star_handlers_registry.get_handlers_by_event_type(
             EventType.OnAfterMessageSentEvent, platform_id=event.get_platform_id()

--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -128,9 +128,7 @@ class RespondStage(Stage):
                 "streaming_segmented", False
             )
             logger.info(f"应用流式输出({event.get_platform_name()})")
-            await event._pre_send()
             await event.send_streaming(result.async_stream, use_fallback)
-            await event._post_send()
             return
         elif len(result.chain) > 0:
             # 检查路径映射
@@ -140,8 +138,6 @@ class RespondStage(Stage):
                         # 支持 File 消息段的路径映射。
                         component.file = path_Mapping(mappings, component.file)
                         event.get_result().chain[idx] = component
-
-            await event._pre_send()
 
             # 检查消息链是否为空
             try:
@@ -158,9 +154,14 @@ class RespondStage(Stage):
                 c for c in result.chain if not isinstance(c, Comp.Record)
             ]
 
-            if self.enable_seg and (
-                (self.only_llm_result and result.is_llm_result())
-                or not self.only_llm_result
+            if (
+                self.enable_seg
+                and (
+                    (self.only_llm_result and result.is_llm_result())
+                    or not self.only_llm_result
+                )
+                and event.get_platform_name()
+                not in ["qq_official", "weixin_official_account", "dingtalk"]
             ):
                 decorated_comps = []
                 if self.reply_with_mention:
@@ -207,14 +208,9 @@ class RespondStage(Stage):
                     logger.error(traceback.format_exc())
                     logger.error(f"发送消息失败: {e} chain: {result.chain}")
 
-            await event._post_send()
             logger.info(
                 f"AstrBot -> {event.get_sender_name()}/{event.get_sender_id()}: {event._outline_chain(result.chain)}"
             )
-        else:
-            # 对使用 qq_official 适配器的会话控制器发送消息的特殊处理
-            if event.get_platform_name() == "qq_official":
-                await event._post_send()
 
         handlers = star_handlers_registry.get_handlers_by_event_type(
             EventType.OnAfterMessageSentEvent, platform_id=event.get_platform_id()

--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -141,7 +141,11 @@ class ResultDecorateStage(Stage):
                         break
 
             # 分段回复
-            if self.enable_segmented_reply:
+            if self.enable_segmented_reply and event.get_platform_name() not in [
+                "qq_official",
+                "weixin_official_account",
+                "dingtalk",
+            ]:
                 if (
                     self.only_llm_result and result.is_llm_result()
                 ) or not self.only_llm_result:

--- a/astrbot/core/pipeline/waking_check/stage.py
+++ b/astrbot/core/pipeline/waking_check/stage.py
@@ -125,7 +125,6 @@ class WakingCheckStage(Stage):
                             f"插件 {star_map[handler.handler_module_path].name}: {e}"
                         )
                     )
-                    await event._post_send()
                     event.stop_event()
                     passed = False
                     break
@@ -140,7 +139,6 @@ class WakingCheckStage(Stage):
                                 f"您(ID: {event.get_sender_id()})的权限不足以使用此指令。通过 /sid 获取 ID 并请管理员添加。"
                             )
                         )
-                        await event._post_send()
                     logger.info(
                         f"触发 {star_map[handler.handler_module_path].name} 时, 用户(ID={event.get_sender_id()}) 权限不足。"
                     )

--- a/astrbot/core/platform/astr_message_event.py
+++ b/astrbot/core/platform/astr_message_event.py
@@ -235,10 +235,10 @@ class AstrMessageEvent(abc.ABC):
         self._has_send_oper = True
 
     async def _pre_send(self):
-        """调度器会在执行 send() 前调用该方法"""
+        """调度器会在执行 send() 前调用该方法 deprecated in v3.5.18"""
 
     async def _post_send(self):
-        """调度器会在执行 send() 后调用该方法"""
+        """调度器会在执行 send() 后调用该方法 deprecated in v3.5.18"""
 
     def set_result(self, result: Union[MessageEventResult, str]):
         """设置消息事件的结果。

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -28,10 +28,8 @@ class QQOfficialMessageEvent(AstrMessageEvent):
         self.send_buffer = None
 
     async def send(self, message: MessageChain):
-        if not self.send_buffer:
-            self.send_buffer = message
-        else:
-            self.send_buffer.chain.extend(message.chain)
+        self.send_buffer = message
+        await self._post_send()
 
     async def send_streaming(self, generator, use_fallback: bool = False):
         """流式输出仅支持消息列表私聊"""

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -32,7 +32,6 @@ class QQOfficialMessageEvent(AstrMessageEvent):
             self.send_buffer = message
         else:
             self.send_buffer.chain.extend(message.chain)
-        await self._post_send()
 
     async def send_streaming(self, generator, use_fallback: bool = False):
         """流式输出仅支持消息列表私聊"""

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -32,6 +32,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
             self.send_buffer = message
         else:
             self.send_buffer.chain.extend(message.chain)
+        await self._post_send()
 
     async def send_streaming(self, generator, use_fallback: bool = False):
         """流式输出仅支持消息列表私聊"""


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
这个问题类似 #807 

### Motivation

如题,使用会话控制时,参照[AstrBot文档-会话控制](https://astrbot.app/dev/star/plugin.html#%E4%BC%9A%E8%AF%9D%E6%8E%A7%E5%88%B6-new)的描述,会话控制器内机器人发送消息是调用`await event.send(message_result) ` 方法的,但是实际qqofficial_message_event里的send方法缺少了`_post_send`的调用,所以消息发不出去

实例代码
```python
@filter.command("test")
    async def test(self, event: AstrMessageEvent):
        try:
            yield event.plain_result("请发送一个成语~")
            # 注册一个会话控制器，设置超时时间为 60 秒，不记录历史消息链
            @session_waiter(timeout=60, record_history_chains=False)  # type: ignore
            async def empty_mention_waiter(
                controller: SessionController, event: AstrMessageEvent
            ):
                message_result = event.make_result()
                message_result.message(
                    f"{randint(10**10, 20**10)}"
                )
                await event.send(message_result)
                controller.keep(timeout=60, reset_timeout=True)
            try:
                await empty_mention_waiter(event)
            except TimeoutError as _:  # 当超时后，会话控制器会抛出 TimeoutError
                yield event.plain_result("你超时了！")
            except Exception as e:
                yield event.plain_result(
                    "发生错误，请联系管理员: "
                    + str(e)
                )
            finally:
                event.stop_event()
        except Exception as e:
            logger.error("handle_empty_mention error: " + str(e))
```

### Modifications

修改了 qqofficial_message_event.QQOfficialMessageEvent的send方法,使其能调用self._post_send方法,能将消息发送至聊天平台

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->
我的commit message写的可能有亿点点随意了(

- [ ] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 摘要：

## Sourcery 总结

Bug 修复：
- 在 QQOfficialMessageEvent.send 中添加 await self._post_send()，以便消息能够真正发送到聊天平台。

<details>
<summary>Original summary in English</summary>

好的，这是将 pull request 总结翻译成中文的结果：

## Sourcery 总结

Bug 修复：
- 在 respond 阶段添加一个特殊分支，以便为 qq_official 事件调用 event._post_send，这样基于会话的回复才能真正被分发。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add a special branch in the respond stage to call event._post_send for qq_official events so session-based replies are actually dispatched

</details>

</details>