### PR TITLE
fix: residual configuration items after plugin configuration modification

### DIFF
--- a/astrbot/core/config/astrbot_config.py
+++ b/astrbot/core/config/astrbot_config.py
@@ -99,6 +99,12 @@ class AstrBotConfig(dict):
                     has_new |= self.check_config_integrity(
                         value, conf[key], path + "." + key if path else key
                     )
+        for key in list(conf.keys()):
+            if key not in refer_conf:
+                path_ = path + "." + key if path else key
+                logger.info(f"检查到配置项 {path_} 不存在，将从当前配置中删除")
+                del conf[key]
+                has_new = True
         return has_new
 
     def save_config(self, replace_config: Dict = None):

--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -451,11 +451,11 @@ class PluginManager:
                             metadata.repo = metadata_yaml.repo
                     except Exception:
                         pass
-
+                    metadata.config = plugin_config
                     if path not in inactivated_plugins:
                         # 只有没有禁用插件时才实例化插件类
                         if plugin_config:
-                            metadata.config = plugin_config
+                            # metadata.config = plugin_config
                             try:
                                 metadata.star_cls = metadata.star_cls_type(
                                     context=self.context, config=plugin_config


### PR DESCRIPTION
### Motivation
问题发生在插件开发和使用过程中，若插件的可配置项发生变动，多余的配置项未被移除。
由于**插件开发原则**中提及：
> 但是 AstrBot 不会删除配置文件中多余的配置项，即使这个配置项在新的 Schema 中不存在

我不确定这是否是有意为之，但多余的配置项有些碍眼
<!--解释为什么要改动-->

### Modifications
```astrbot/core/config/astrbot_config.py```中的改动用于检测多余配置项并移除。
但这导致在"禁用插件"后修改配置并应用后，再次点开“插件配置”显示无配置项（实际上存在，在重新启用后出现），也就是无法在禁用状态下多次修改配置。这一点在```astrbot/core/star/star_manager.py```的改动中修复。
<!--简单解释你的改动-->

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

在模式更改后删除过时的插件配置项，并修复禁用插件的配置处理

Bug 修复：
- 在加载禁用的插件时保留插件配置，以允许重复的配置更改

增强功能：
- 在完整性检查期间自动删除模式中不再存在的配置条目

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove obsolete plugin config items after schema changes and fix config handling for disabled plugins

Bug Fixes:
- Preserve plugin configuration when loading disabled plugins to allow repeated configuration changes

Enhancements:
- Automatically remove configuration entries that no longer exist in the schema during integrity checks

</details>