### PR TITLE
feat: 添加插件更新后自动刷新插件列表功能

### DIFF
--- a/dashboard/src/views/ExtensionPage.vue
+++ b/dashboard/src/views/ExtensionPage.vue
@@ -191,6 +191,17 @@ const updateExtension = async (extension_name) => {
 
     Object.assign(extension_data, res.data);
     onLoadingDialogResult(1, res.data.message);
+    setTimeout(async () => {
+      toast(`正在刷新插件列表...`, "info", 2000);
+      try {
+        await getExtensions();
+        toast("插件列表已刷新！", "success");
+
+      } catch (error) {
+        const errorMsg = error.response?.data?.message || error.message || String(error);
+        toast(`刷新插件列表时发生错误: ${errorMsg}`, "error");
+      }
+    }, 1000);
   } catch (err) {
     toast(err, "error");
   }


### PR DESCRIPTION
### Motivation

当前，在 AstrBot 的 WebUI 插件配置页中，当用户完成单个插件的更新操作后，插件列表并**不会自动刷新**。这导致用户需要**手动执行刷新操作**才能查看到最新的插件状态（例如版本变化或更新结果），影响了操作的流畅性和用户体验的即时反馈。

### Modifications

为了解决上述问题，我在 `updateExtension` 方法中，当单个插件通过接口成功更新并处理完本地数据（如 `extension_data`）后，**新增了对整个插件列表进行异步刷新的逻辑**。具体来说，会在1秒延迟后：
1.  提示用户“正在刷新插件列表...”。
2.  调用 `getExtensions()` 方法获取最新的插件列表数据。
3.  根据刷新结果向用户反馈“插件列表已刷新！”或相应的错误信息。

此修改确保了在插件更新后，用户界面能及时反映出最新的插件列表状态。

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [ ] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

在单个插件更新后自动刷新 WebUI 插件列表，以反映最新状态并提供用户反馈。

新功能：
- 增加在插件更新后异步刷新整个插件列表的功能，并有短暂的延迟。
- 在刷新期间显示信息提示框，并根据结果显示成功或错误提示框。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Automatically refresh the WebUI plugin list after a single plugin update to reflect the latest state and provide user feedback.

New Features:
- Add an asynchronous refresh of the entire plugin list with a brief delay after a plugin is updated.
- Show informational toast during the refresh and a success or error toast based on the result.

</details>