### PR TITLE
✨ feat(wechatpadpro): 增强群聊消息中的@消息处理逻辑

### DIFF
--- a/astrbot/core/platform/sources/wechatpadpro/wechatpadpro_adapter.py
+++ b/astrbot/core/platform/sources/wechatpadpro/wechatpadpro_adapter.py
@@ -8,7 +8,7 @@ import aiohttp
 import websockets
 
 from astrbot import logger
-from astrbot.api.message_components import Plain, Image
+from astrbot.api.message_components import Plain, Image, At
 from astrbot.api.platform import Platform, PlatformMetadata
 from astrbot.core.message.message_event_result import MessageChain
 from astrbot.core.platform.astrbot_message import (
@@ -569,8 +569,46 @@ class WeChatPadProAdapter(Platform):
             if abm.type == MessageType.GROUP_MESSAGE:
                 parts = content.split(":\n", 1)
                 if len(parts) == 2:
-                    abm.message_str = parts[1]
-                    abm.message.append(Plain(abm.message_str))
+                    message_content = parts[1]
+                    abm.message_str = message_content
+                    
+                    # 检查是否@了机器人，参考 gewechat 的实现方式
+                    # 微信大部分客户端在@用户昵称后面，紧接着是一个\u2005字符（四分之一空格）
+                    at_me = False
+                    
+                    # 检查 msg_source 中是否包含机器人的 wxid
+                    # wechatpadpro 的格式: <atuserlist>wxid</atuserlist>
+                    # gewechat 的格式: <atuserlist><![CDATA[wxid]]></atuserlist>
+                    msg_source = raw_message.get("msg_source", "")
+                    if f"<atuserlist>{abm.self_id}</atuserlist>" in msg_source or f"<atuserlist>{abm.self_id}," in msg_source or f",{abm.self_id}</atuserlist>" in msg_source:
+                        at_me = True
+                    
+                    # 也检查 push_content 中是否有@提示
+                    push_content = raw_message.get("push_content", "")
+                    if "在群聊中@了你" in push_content:
+                        at_me = True
+                    
+                    if at_me:
+                        # 被@了，在消息开头插入At组件（参考gewechat的做法）
+                        bot_nickname = await self._get_group_member_nickname(abm.group_id, abm.self_id)
+                        abm.message.insert(0, At(qq=abm.self_id, name=bot_nickname or abm.self_id))
+                        
+                        # 只有当消息内容不仅仅是@时才添加Plain组件
+                        if "\u2005" in message_content:
+                            # 检查@之后是否还有其他内容
+                            parts = message_content.split("\u2005")
+                            if len(parts) > 1 and any(part.strip() for part in parts[1:]):
+                                abm.message.append(Plain(message_content))
+                        else:
+                            # 检查是否只包含@机器人
+                            is_pure_at = False
+                            if bot_nickname and message_content.strip() == f"@{bot_nickname}":
+                                is_pure_at = True
+                            if not is_pure_at:
+                                abm.message.append(Plain(message_content))
+                    else:
+                        # 没有@机器人，作为普通文本处理
+                        abm.message.append(Plain(message_content))
                 else:
                     abm.message.append(Plain(abm.message_str))
             else:  # 私聊消息


### PR DESCRIPTION
添加对群聊消息中@机器人场景的精确识别和处理，提升了消息解析的准确性。
支持多种@格式的检测，包括 msg_source 和 push_content 的判断。

<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了 #1584 #1687

### Motivation

<!--解释为什么要改动-->
解决 wechatpadpro 中，在群聊中无法 @机器人 触发回复消息的问题。
### Modifications

<!--简单解释你的改动-->

#### 消息解析：
增强了消息解析逻辑，能够检测到群聊中@到机器人。

- 检查 msg_source 格式中的@机器人（例如：<atuserlist>{abm.self_id}</atuserlist>）以及 push_content 中的提示（如“在群聊中@了你”）。
- 如果消息中提到了机器人，会在消息开头插入 At 组件。

- 进一步检查消息中是否仅包含@机器人，或者@后是否还有其他内容，并根据不同情况处理消息。

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 总结

增强了 wechatpadpro 消息适配器，以准确识别和处理群聊中的 @bot mentions，确保正确的消息解析和触发 bot 响应。

新特性：
- 通过检查 `msg_source` 和 `push_content` 字段，支持在 wechatpadpro 群聊中精确检测 @bot mentions

Bug 修复：
- 修复了在 wechatpadpro 群聊中被提及时无法触发 bot 回复的问题 (#1584, #1687)

增强：
- 当 bot 被提及时，在消息开头插入一个 At 组件，并且仅当 mention 之后有其他文本时才附加 Plain 内容

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the wechatpadpro message adapter to accurately recognize and process @bot mentions in group chats, ensuring correct message parsing and bot response triggering.

New Features:
- Support precise detection of @bot mentions in wechatpadpro group chats by inspecting msg_source and push_content fields

Bug Fixes:
- Fix inability to trigger bot replies when mentioned in wechatpadpro group chats (#1584, #1687)

Enhancements:
- Insert an At component at the start of messages when the bot is mentioned and append Plain content only if additional text follows the mention

</details>