### PR TITLE
fix: missing ')'

### DIFF
--- a/astrbot/dashboard/routes/config.py
+++ b/astrbot/dashboard/routes/config.py
@@ -190,7 +190,7 @@ class ConfigRoute(Route):
         logger.debug(f"Attempting to check provider: {status_info['name']} (ID: {status_info['id']}, Type: {status_info['type']}, Model: {status_info['model']})")
         try:
             logger.debug(f"Sending 'Ping' to provider: {status_info['name']}")
-            response = await asyncio.wait_for(provider.text_chat(prompt="REPLY `PONG` ONLY", timeout=45.0)
+            response = await asyncio.wait_for(provider.text_chat(prompt="REPLY `PONG` ONLY", timeout=45.0))
             logger.debug(f"Received response from {status_info['name']}: {response}")
             # 只要 text_chat 调用成功返回一个 LLMResponse 对象 (即 response 不为 None)，就认为可用
             if response is not None:


### PR DESCRIPTION
### Motivation
在webui切换版本时，重启后一直陷入以下报错(docker log)，至少确实少了个括号
```
Traceback (most recent call last):
  File "/AstrBot/main.py", line 5, in <module>
    from astrbot.core.initial_loader import InitialLoader
  File "/AstrBot/astrbot/core/initial_loader.py", line 15, in <module>
    from astrbot.dashboard.server import AstrBotDashboard
  File "/AstrBot/astrbot/dashboard/server.py", line 11, in <module>
    from .routes import *
  File "/AstrBot/astrbot/dashboard/routes/__init__.py", line 3, in <module>
    from .config import ConfigRoute
  File "/AstrBot/astrbot/dashboard/routes/config.py", line 193
    response = await asyncio.wait_for(provider.text_chat(prompt="REPLY `PONG` ONLY", timeout=45.0)
                                     ^
SyntaxError: '(' was never closed
```
<!--解释为什么要改动-->

### Modifications
补上右括号
<!--简单解释你的改动-->

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 在 `provider.text_chat` 调用中添加缺失的右括号，以修复启动时的 `SyntaxError`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add missing closing parenthesis in the provider.text_chat call to fix the SyntaxError on startup

</details>