### PR TITLE
Fix: 调整Gemini原生工具启用行为

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -620,6 +620,7 @@ CONFIG_METADATA_2 = {
                         "gm_resp_image_modal": False,
                         "gm_native_search": False,
                         "gm_native_coderunner": False,
+                        "gm_url_context": False,
                         "gm_safety_settings": {
                             "harassment": "BLOCK_MEDIUM_AND_ABOVE",
                             "hate_speech": "BLOCK_MEDIUM_AND_ABOVE",

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1024,6 +1024,12 @@ CONFIG_METADATA_2 = {
                         "hint": "启用后所有函数工具将全部失效",
                         "obvious_hint": True,
                     },
+                    "gm_url_context": {
+                        "description": "启用URL上下文功能",
+                        "type": "bool",
+                        "hint": "启用后所有函数工具将全部失效",
+                        "obvious_hint": True,
+                    },
                     "gm_safety_settings": {
                         "description": "安全过滤器",
                         "type": "object",

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -162,7 +162,7 @@ class ProviderGoogleGenAI(Provider):
 
                 if url_context:
                     if hasattr(types, "UrlContext"):
-                        tool_list.append(types.Tool(web_context=types.UrlContext()))
+                        tool_list.append(types.Tool(url_context=types.UrlContext()))
                     else:
                         logger.warning(
                             "当前 SDK 版本不支持 URL 上下文工具，已忽略该设置，请升级 google-genai 包"
@@ -185,7 +185,7 @@ class ProviderGoogleGenAI(Provider):
 
             if url_context and not native_coderunner:
                 if hasattr(types, "UrlContext"):
-                    tool_list.append(types.Tool(web_context=types.UrlContext()))
+                    tool_list.append(types.Tool(url_context=types.UrlContext()))
                 else:
                     logger.warning(
                         "当前 SDK 版本不支持 URL 上下文工具，已忽略该设置，请升级 google-genai 包"

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -141,30 +141,58 @@ class ProviderGoogleGenAI(Provider):
             logger.warning("流式输出不支持图片模态，已自动降级为文本模态")
             modalities = ["Text"]
 
-        tool_list = None
+        tool_list = []
         model_name = self.get_model()
         native_coderunner = self.provider_config.get("gm_native_coderunner", False)
         native_search = self.provider_config.get("gm_native_search", False)
+        url_context = self.provider_config.get("gm_url_context", False)
 
         if "gemini-2.5" in model_name:
             if native_coderunner:
-                tool_list = [types.Tool(code_execution=types.ToolCodeExecution())]
-            if native_search:
-                if tool_list:
+                tool_list.append(types.Tool(code_execution=types.ToolCodeExecution()))
+                if native_search:
+                    logger.warning("代码执行工具与搜索工具互斥，已忽略搜索工具")
+                if url_context:
+                    logger.warning(
+                        "代码执行工具与URL上下文工具互斥，已忽略URL上下文工具"
+                    )
+            else:
+                if native_search:
                     tool_list.append(types.Tool(google_search=types.GoogleSearch()))
-                else:
-                    tool_list = [types.Tool(google_search=types.GoogleSearch())]
+
+                if url_context:
+                    if hasattr(types, "UrlContext"):
+                        tool_list.append(types.Tool(web_context=types.UrlContext()))
+                    else:
+                        logger.warning(
+                            "当前 SDK 版本不支持 URL 上下文工具，已忽略该设置，请升级 google-genai 包"
+                        )
+
         elif "gemini-2.0-lite" in model_name:
-            if native_coderunner or native_search:
-                logger.warning("gemini-2.0-lite 不支持代码执行和搜索工具，将忽略这些设置")
-                tool_list = None
+            if native_coderunner or native_search or url_context:
+                logger.warning(
+                    "gemini-2.0-lite 不支持代码执行、搜索工具和URL上下文，将忽略这些设置"
+                )
+            tool_list = None
+
         else:
             if native_coderunner:
-                tool_list = [types.Tool(code_execution=types.ToolCodeExecution())]
+                tool_list.append(types.Tool(code_execution=types.ToolCodeExecution()))
                 if native_search:
-                    logger.warning("已启用代码执行工具，搜索工具将被忽略")
+                    logger.warning("代码执行工具与搜索工具互斥，已忽略搜索工具")
             elif native_search:
-                tool_list = [types.Tool(google_search=types.GoogleSearch())]
+                tool_list.append(types.Tool(google_search=types.GoogleSearch()))
+
+            if url_context and not native_coderunner:
+                if hasattr(types, "UrlContext"):
+                    tool_list.append(types.Tool(web_context=types.UrlContext()))
+                else:
+                    logger.warning(
+                        "当前 SDK 版本不支持 URL 上下文工具，已忽略该设置，请升级 google-genai 包"
+                    )
+
+        if not tool_list:
+            tool_list = None
 
         if tools and tool_list:
             logger.warning("已启用原生工具，函数工具将被忽略")
@@ -172,6 +200,7 @@ class ProviderGoogleGenAI(Provider):
             tool_list = [
                 types.Tool(function_declarations=func_desc["function_declarations"])
             ]
+
         return types.GenerateContentConfig(
             system_instruction=system_instruction,
             temperature=temperature,


### PR DESCRIPTION
fixes #1678

### Motivation

在Google近期对Gemini的更新中，Grounding可以和Code execution同时启用了(仅限2.5系列)

官方新增了"URL Context"功能，AI Studio描述为Browse the url context，可以和Grounding同时启用

### Modifications

修正逻辑，新增支持

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

添加对 Gemini 新的 URL Context 工具的支持，并改进不同 Gemini 模型变体的原生工具选择逻辑

新特性：
- 支持为 Gemini 2.5 模型启用 URL Context 工具

增强功能：
- 重构工具选择，以强制代码执行、搜索和 URL Context 工具之间的互斥
- 当使用不支持的 gemini-2.0-lite 模型时，发出警告并禁用原生工具
- 引入 gm_url_context 配置选项，以在默认设置中切换 URL Context 支持

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for Gemini’s new URL Context tool and refine the native tool selection logic for different Gemini model variants

New Features:
- Support enabling the URL Context tool for Gemini 2.5 models

Enhancements:
- Refactor tool selection to enforce mutual exclusion between code execution, search, and URL Context tools
- Warn and disable native tools when using the unsupported gemini-2.0-lite model
- Introduce a gm_url_context configuration option to toggle URL Context support in the default settings

</details>