### PR TITLE
feat:支持通过引用bot消息来唤醒bot

### DIFF
--- a/astrbot/core/pipeline/waking_check/stage.py
+++ b/astrbot/core/pipeline/waking_check/stage.py
@@ -4,7 +4,7 @@ from astrbot import logger
 from typing import Union, AsyncGenerator
 from astrbot.core.platform.astr_message_event import AstrMessageEvent
 from astrbot.core.message.message_event_result import MessageEventResult, MessageChain
-from astrbot.core.message.components import At, AtAll
+from astrbot.core.message.components import At, AtAll, Reply
 from astrbot.core.star.star_handler import star_handlers_registry, EventType
 from astrbot.core.star.star import star_map
 from astrbot.core.star.filter.permission import PermissionTypeFilter
@@ -88,6 +88,12 @@ class WakingCheckStage(Stage):
                     is_wake = True
                     event.is_wake = True
                     wake_prefix = ""
+                    event.is_at_or_wake_command = True
+                    break
+            for message in messages:
+                if isinstance(message, Reply) and str(message.sender_id) == str(event.get_self_id()):
+                    is_wake = True
+                    event.is_wake = True
                     event.is_at_or_wake_command = True
                     break
             # 检查是否是私聊

--- a/astrbot/core/pipeline/waking_check/stage.py
+++ b/astrbot/core/pipeline/waking_check/stage.py
@@ -90,6 +90,7 @@ class WakingCheckStage(Stage):
                     wake_prefix = ""
                     event.is_at_or_wake_command = True
                     break
+            # 检查是否引用了bot的消息
             for message in messages:
                 if isinstance(message, Reply) and str(message.sender_id) == str(event.get_self_id()):
                     is_wake = True


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了 #1602

### Motivation

当前判断唤醒（wake）的逻辑未能覆盖引用消息唤醒（如用户回复了 bot 的消息）的场景。在某些对话上下文中，用户通过回复 bot 的消息与其交互，这种情况应当被识别为唤醒。

### Modifications

- 增加了一段逻辑：当收到的消息中包含 Reply 且其 sender_id 为 bot 自身时，将视为被唤醒。

### Check

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 总结

新功能：
- 支持在用户回复机器人消息时唤醒机器人

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Support waking the bot when a user replies to one of its messages

</details>