### PR TITLE
feat:支持通过引用bot消息来唤醒bot

### DIFF
--- a/astrbot/core/platform/sources/dingtalk/dingtalk_event.py
+++ b/astrbot/core/platform/sources/dingtalk/dingtalk_event.py
@@ -32,20 +32,25 @@ class DingtalkMessageEvent(AstrMessageEvent):
                 )
             elif isinstance(segment, Comp.Image):
                 markdown_str = ""
-                if segment.file and segment.file.startswith("file:///"):
-                    logger.warning(
-                        "dingtalk only support url image, not: " + segment.file
-                    )
-                    continue
-                elif segment.file and segment.file.startswith("http"):
-                    markdown_str += f"![image]({segment.file})\n\n"
-                elif segment.file and segment.file.startswith("base64://"):
-                    logger.warning("dingtalk only support url image, not base64")
-                    continue
-                else:
-                    logger.warning(
-                        "dingtalk only support url image, not: " + segment.file
-                    )
+                try:
+                    if segment.file and segment.file.startswith("file:///"):
+                        # 本地文件，注册到文件服务
+                        url = await segment.register_to_file_service()
+                        markdown_str += f"![image]({url})\n\n"
+                    elif segment.file and segment.file.startswith("http"):
+                        # HTTP URL，直接使用
+                        markdown_str += f"![image]({segment.file})\n\n"
+                    elif segment.file and segment.file.startswith("base64://"):
+                        # base64图片，注册到文件服务
+                        url = await segment.register_to_file_service()
+                        markdown_str += f"![image]({url})\n\n"
+                    else:
+                        # 其他本地路径，尝试注册到文件服务
+                        url = await segment.register_to_file_service()
+                        markdown_str += f"![image]({url})\n\n"
+                except Exception as e:
+                    logger.error(f"钉钉图片处理失败: {e}")
+                    logger.warning(f"跳过图片发送: {segment.file}")
                     continue
 
                 ret = await asyncio.get_event_loop().run_in_executor(


### PR DESCRIPTION

解决了 #1602 

### Motivation

当前判断唤醒（wake）的逻辑未能覆盖引用消息唤醒（如用户回复了 bot 的消息）的场景。在某些对话上下文中，用户通过回复 bot 的消息与其交互，这种情况应当被识别为唤醒。

### Modifications

- 增加了一段逻辑：当收到的消息中包含 Reply 且其 sender_id 为 bot 自身时，将视为被唤醒。

### Check

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码
