### PR TITLE
feat:钉钉发图时自动将非HTTP图片注册成URL

### DIFF
--- a/astrbot/core/platform/sources/dingtalk/dingtalk_event.py
+++ b/astrbot/core/platform/sources/dingtalk/dingtalk_event.py
@@ -31,34 +31,32 @@ class DingtalkMessageEvent(AstrMessageEvent):
                     self.message_obj.raw_message,
                 )
             elif isinstance(segment, Comp.Image):
-                file_ = segment.file
                 markdown_str = ""
 
                 try:
-                    if not file_:
+                    if not segment.file:
                         logger.warning("钉钉图片 segment 缺少 file 字段，跳过")
                         continue
-
-                    if file_.startswith("http://", "https://"):
-                        markdown_str += f"![image]({file_})\n\n"
+                    if segment.file.startswith(("http://", "https://")):
+                        image_url = segment.file
                     else:
-                        url = await segment.register_to_file_service()
-                        markdown_str += f"![image]({url})\n\n"
+                        image_url = await segment.register_to_file_service()
+
+                    markdown_str = f"![image]({image_url})\n\n"
+
+                    ret = await asyncio.get_event_loop().run_in_executor(
+                        None,
+                        client.reply_markdown,
+                        "😄",
+                        markdown_str,
+                        self.message_obj.raw_message,
+                    )
+                    logger.debug(f"send image: {ret}")
 
                 except Exception as e:
                     logger.error(f"钉钉图片处理失败: {e}")
-                    logger.warning(f"跳过图片发送: {file_}")
+                    logger.warning(f"跳过图片发送: {image_path}")
                     continue
-
-                ret = await asyncio.get_event_loop().run_in_executor(
-                    None,
-                    client.reply_markdown,
-                    "😄",
-                    markdown_str,
-                    self.message_obj.raw_message,
-                )
-                logger.debug(f"send image: {ret}")
-
     async def send(self, message: MessageChain):
         await self.send_with_client(self.client, message)
         await super().send(message)

--- a/astrbot/core/platform/sources/dingtalk/dingtalk_event.py
+++ b/astrbot/core/platform/sources/dingtalk/dingtalk_event.py
@@ -31,23 +31,23 @@ class DingtalkMessageEvent(AstrMessageEvent):
                     self.message_obj.raw_message,
                 )
             elif isinstance(segment, Comp.Image):
-                file = segment.file
+                file_ = segment.file
                 markdown_str = ""
 
                 try:
-                    if not file:
+                    if not file_:
                         logger.warning("钉钉图片 segment 缺少 file 字段，跳过")
                         continue
 
-                    if file.startswith("http"):
-                        markdown_str += f"![image]({file})\n\n"
+                    if file_.startswith("http://", "https://"):
+                        markdown_str += f"![image]({file_})\n\n"
                     else:
                         url = await segment.register_to_file_service()
                         markdown_str += f"![image]({url})\n\n"
 
                 except Exception as e:
                     logger.error(f"钉钉图片处理失败: {e}")
-                    logger.warning(f"跳过图片发送: {file}")
+                    logger.warning(f"跳过图片发送: {file_}")
                     continue
 
                 ret = await asyncio.get_event_loop().run_in_executor(


### PR DESCRIPTION
### Motivation

钉钉发图时仅支持URL，框架虽然提供了文件注册URL的功能，却没有自动根据传入的图片参数类型来处理

### Modifications

改进钉钉消息发送器，通过将非 HTTP 图片注册到文件服务并添加强大的错误处理，从而统一处理图片片段

- 将本地文件路径和 base64 图片数据注册到文件服务，并在 markdown 中使用生成的 URL
- 保留对 HTTP URL 的直接支持，并将所有图片处理分支合并到一个 try 代码块中
- 记录错误并在文件服务注册或处理失败时跳过图片片段


### Check

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 总结

改进了钉钉消息发送器，通过将非 HTTP 图像注册到文件服务、嵌入生成的 URL 并通过增强的错误管理来整合图像处理，从而自动处理这些图像。

新功能：
- 自动将本地文件和 base64 图像注册到文件服务并嵌入其 URL
- 保留直接 HTTP 图像 URL，无需额外注册

Bug 修复：
- 当钉钉图像片段缺少 file 字段时，跳过图像处理

增强功能：
- 在单个 try-catch 块中统一处理 HTTP 和非 HTTP 图像，具有强大的错误日志记录和跳过功能

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the DingTalk message sender to automatically handle non-HTTP images by registering them to the file service, embed their generated URLs, and consolidate image processing with enhanced error management.

New Features:
- Automatically register local file and base64 images to the file service and embed their URLs
- Preserve direct HTTP image URLs without additional registration

Bug Fixes:
- Skip image processing when a DingTalk image segment lacks the file field

Enhancements:
- Unify HTTP and non-HTTP image handling in a single try-catch block with robust error logging and skipping

</details>