### PR TITLE
Feature: i18n for AstrBot

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -31,6 +31,7 @@
     "vee-validate": "4.11.3",
     "vite-plugin-vuetify": "1.0.2",
     "vue": "3.3.4",
+    "vue-i18n": "^11.1.5",
     "vue-router": "4.2.4",
     "vue3-apexcharts": "1.4.4",
     "vue3-print-nb": "0.1.4",

--- a/dashboard/src/App.vue
+++ b/dashboard/src/App.vue
@@ -4,4 +4,24 @@
 
 <script setup lang="ts">
 import { RouterView } from 'vue-router';
+import { useI18n } from 'vue-i18n';
+import { onMounted } from 'vue';
+
+const { locale } = useI18n();
+
+onMounted(() => {
+  const savedLanguage = localStorage.getItem('preferred-language');
+  const supportedLanguages = ['zh-CN', 'en-US'];
+  
+  if (savedLanguage && supportedLanguages.includes(savedLanguage)) {
+    locale.value = savedLanguage;
+  } else {
+    const browserLanguage = navigator.language || navigator.languages?.[0] || 'zh-CN';
+    const matchedLanguage = supportedLanguages.find(lang => 
+      browserLanguage.startsWith(lang) || browserLanguage.startsWith(lang.split('-')[0])
+    );
+    locale.value = matchedLanguage || 'zh-CN';
+    localStorage.setItem('preferred-language', locale.value);
+  }
+});
 </script>

--- a/dashboard/src/components/shared/Logo.vue
+++ b/dashboard/src/components/shared/Logo.vue
@@ -5,10 +5,10 @@
         <img width="110" src="@/assets/images/astrbot_logo_mini.webp" alt="AstrBot Logo">
       </div>
       <div class="logo-text">
-        <h2 :style="{color: useCustomizerStore().uiTheme === 'PurpleTheme' ? '#5e35b1' : '#d7c5fa'}">{{ title }}</h2>
+        <h2 :style="{color: useCustomizerStore().uiTheme === 'PurpleTheme' ? '#5e35b1' : '#d7c5fa'}">{{ props.title || t('component.logo.title') }}</h2>
         <!-- 父子组件传递css变量可能会出错，暂时使用十六进制颜色值 -->
         <h4 :style="{color: useCustomizerStore().uiTheme === 'PurpleTheme' ? '#000000aa' : '#ffffffcc'}"
-            class="hint-text">{{ subtitle }}</h4>
+            class="hint-text">{{  props.subtitle || t('component.logo.subtitle') }}</h4>
       </div>
     </div>
   </div>
@@ -16,13 +16,16 @@
 
 <script setup lang="ts">
 import { useCustomizerStore } from "@/stores/customizer";
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
 
 const props = withDefaults(defineProps<{
   title?: string;
   subtitle?: string;
 }>(), {
-  title: 'AstrBot 仪表盘',
-  subtitle: '欢迎使用'
+  title: '',
+  subtitle: ''
 })
 </script>
 

--- a/dashboard/src/i18n/index.ts
+++ b/dashboard/src/i18n/index.ts
@@ -1,0 +1,15 @@
+import { createI18n } from 'vue-i18n'
+import zh from './locales/zh-CN.json'
+import en from './locales/en-US.json'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'zh-CN',
+  fallbackLocale: 'en-US',
+  messages: {
+    'zh-CN': zh,
+    'en-US': en
+  }
+})
+
+export default i18n

--- a/dashboard/src/i18n/locales/en-US.json
+++ b/dashboard/src/i18n/locales/en-US.json
@@ -1,0 +1,241 @@
+{
+  "auth": {
+    "username": "Username",
+    "password": "Password", 
+    "login": "Login",
+    "loginLoading": "Logging in..."
+  },
+  "theme": {
+    "switchToDark": "Switch to Dark Theme",
+    "switchToLight": "Switch to Light Theme"
+  },
+  "language": {
+    "select": "Select Language",
+    "zh-CN": "简体中文",
+    "en-US": "English"
+  },
+  "component": {
+    "logo": {
+      "title": "AstrBot Dashboard",
+      "subtitle": "Welcome"
+    }
+  },
+  "dashboard": {
+    "title": "Dashboard",
+    "subtitle": "Real-time monitoring and statistics",
+    "lastUpdated": "Last Updated",
+    "loading": "Loading...",
+    "noData": "No platform data available",
+    "stats": {
+      "totalMessages": "Total Messages",
+      "totalMessagesDesc": "Total messages sent from all platforms",
+      "onlinePlatforms": "Message Platforms",
+      "onlinePlatformsDesc": "Number of connected message platforms",
+      "runningTime": "Uptime",
+      "runningTimeDesc": "AstrBot running time",
+      "memoryUsage": "Memory Usage",
+      "cpuLoad": "CPU Load",
+      "online": "Online",
+      "memoryPercentage": "Memory Usage",
+      "status": {
+        "good": "Good",
+        "normal": "Normal",
+        "high": "High"
+      }
+    },
+    "platform": {
+      "title": "Platform Message Statistics",
+      "subtitle": "Message distribution across platforms",
+      "platformCount": "Platforms",
+      "mostActive": "Most Active",
+      "totalPercent": "Total Message %",
+      "messages": "messages"
+    },
+    "messageChart": {
+      "title": "Message Trend Analysis",
+      "subtitle": "Track message volume changes over time",
+      "totalMessages": "Total Messages",
+      "dailyAverage": "Daily Average",
+      "growthRate": "Growth Rate",
+      "timeRanges": {
+        "1day": "Past 1 Day",
+        "3days": "Past 3 Days",
+        "7days": "Past 7 Days",
+        "30days": "Past 30 Days"
+      },
+      "messageCount": "Message Count",
+      "time": "Time"
+    }
+  },
+  "settings": {
+    "sections": {
+      "network": "Network",
+      "system": "System",
+      "internationalization": "Internationalization"
+    },
+    "network": {
+      "githubProxy": "GitHub Proxy",
+      "githubProxyDesc": "Set the GitHub proxy address for downloading plugins or updating AstrBot. This is effective in mainland China's network environment. Can be customized, and changes take effect immediately. All addresses are not guaranteed to be stable. If errors occur when updating plugins/projects, please first check if the proxy address is working properly.",
+      "selectGithubProxy": "Select GitHub Proxy"
+    },
+    "system": {
+      "restart": "Restart",
+      "restartDesc": "Restart AstrBot",
+      "restartButton": "Restart"
+    },
+    "i18n": {
+      "title": "Language Settings",
+      "desc": "Change the interface display language. Settings will take effect immediately and be saved to local storage.",
+      "currentLanguage": "Current Language",
+      "selectLanguage": "Select Language"
+    }
+  },
+  "console": {
+    "title": "Console",
+    "autoScroll": {
+      "enabled": "Auto-scroll enabled",
+      "disabled": "Auto-scroll disabled"
+    },
+    "pip": {
+      "install": "Install pip package",
+      "packageName": "Package name, e.g. llmtuner",
+      "mirror": "Force PyPI repository URL (optional)",
+      "mirrorHint": "Force PyPI repository URL > Configuration item `PyPI repository URL`",
+      "installButton": "Install"
+    }
+  },
+  "about": {
+    "subtitle": "A project born from passion and love ❤️",
+    "starProject": "Star this project! 🌟",
+    "submitIssue": "Submit Issue",
+    "contributors": {
+      "title": "Contributors",
+      "description": "This project is maintained by many open source community members. Thanks to every contributor!",
+      "viewContributors": "View AstrBot Contributors"
+    },
+    "globalDeployment": {
+      "title": "Global Deployment",
+      "license": "AstrBot is open source under AGPL v3 license"
+    }
+  },
+  "alkaid": {
+    "title": "The Alkaid Project.",
+    "subtitle": "AstrBot Alpha Project",
+    "tabs": {
+      "knowledgeBase": "Knowledge Base",
+      "longTermMemory": "Long-term Memory Layer",
+      "other": "..."
+    }
+  },
+  "alkaidSigma": {
+    "title": "The Alkaid Project.",
+    "subtitle": "AstrBot Experimental Project",
+    "tabs": {
+      "longTermMemory": "Long-term Memory Layer",
+      "other": "Other"
+    },
+    "visualization": {
+      "title": "Visualization",
+      "filterUserId": "Filter User ID",
+      "filter": "Filter",
+      "resetFilter": "Reset Filter",
+      "refreshGraph": "Refresh Graph"
+    },
+    "nodeDetails": {
+      "title": "Node Details",
+      "id": "ID",
+      "type": "Type",
+      "name": "Name",
+      "userId": "User ID",
+      "timestamp": "Timestamp"
+    },
+    "graphStats": {
+      "title": "Graph Statistics",
+      "nodeCount": "Node Count",
+      "edgeCount": "Edge Count"
+    },
+    "underDevelopment": "Under Development"
+  },
+  "chat": {
+    "conversationUntitled": "New Conversation",
+    "createConversation": "Create Conversation",
+    "noHistory": "No conversation history",
+    "systemStatus": "System Status",
+    "llmService": "LLM Service",
+    "speechToText": "Speech to Text",
+    "deleteConversation": "Delete this conversation",
+    "fullscreenMode": "Fullscreen Mode",
+    "exitFullscreen": "Exit Fullscreen",
+    "switchToLight": "Switch to Light Mode",
+    "switchToDark": "Switch to Dark Mode",
+    "welcome": {
+      "hello": "Hello, I'm",
+      "help": "Type",
+      "helpCommand": "help",
+      "helpHint": "for help 😊",
+      "voiceRecord": "Hold",
+      "ctrl": "Ctrl",
+      "voiceRecordHint": "to record voice 🎤",
+      "pasteImage": "Press",
+      "pasteImageHint": "to paste image 🏞️"
+    },
+    "input": {
+      "placeholder": "Start typing...",
+      "send": "Send",
+      "voiceInput": "Voice Input",
+      "browserNotSupportAudio": "Your browser does not support audio playback."
+    },
+    "editConversationTitle": "Edit Conversation Title",
+    "editConversationTitleLabel": "Conversation Title",
+    "editConversationTitleCancel": "Cancel",
+    "editConversationTitleSave": "Save"
+  },
+  "provider": {
+    "title": "Service Provider Management",
+    "subtitle": "Manage model service providers",
+    "providers": {
+      "title": "Service Providers",
+      "settings": "Settings",
+      "addProvider": "Add Provider",
+      "tabs": {
+        "all": "All",
+        "chatCompletion": "Basic Chat",
+        "speechToText": "Speech to Text",
+        "textToSpeech": "Text to Speech",
+        "embedding": "Embedding"
+      },
+      "details": {
+        "providerType": "Provider Type",
+        "apiBase": "API Base",
+        "apiKey": "API Key"
+      }
+    },
+    "availability": {
+      "title": "Provider Availability",
+      "refresh": "Refresh Status",
+      "subtitle": "Test model conversation availability, may incur API costs",
+      "noStatus": "Click 'Refresh Status' button to get provider availability",
+      "available": "Available",
+      "unavailable": "Unavailable",
+      "errorMessage": "Error Message"
+    },
+    "logs": {
+      "title": "Service Logs",
+      "expand": "Expand",
+      "collapse": "Collapse"
+    },
+    "dialog": {
+      "add": {
+        "title": "Service Provider",
+        "basic": "Basic",
+        "noTemplates": "No templates available for {type} provider type"
+      },
+      "config": {
+        "edit": "Edit",
+        "add": "Add",
+        "cancel": "Cancel",
+        "save": "Save"
+      }
+    }
+  }
+}

--- a/dashboard/src/i18n/locales/zh-CN.json
+++ b/dashboard/src/i18n/locales/zh-CN.json
@@ -1,0 +1,241 @@
+{
+  "auth": {
+    "username": "用户名",
+    "password": "密码",
+    "login": "登录",
+    "loginLoading": "登录中..."
+  },
+  "theme": {
+    "switchToDark": "切换到深色主题",
+    "switchToLight": "切换到浅色主题"
+  },
+  "language": {
+    "select": "选择语言",
+    "zh-CN": "简体中文",
+    "en-US": "English"
+  },
+  "component": {
+    "logo": {
+      "title": "AstrBot 仪表盘",
+      "subtitle": "欢迎使用"
+    }
+  },
+  "dashboard": {
+    "title": "控制台",
+    "subtitle": "实时监控和统计数据",
+    "lastUpdated": "最后更新",
+    "loading": "加载中...",
+    "noData": "暂无平台数据",
+    "stats": {
+      "totalMessages": "消息总数",
+      "totalMessagesDesc": "所有平台发送的消息总计",
+      "onlinePlatforms": "消息平台",
+      "onlinePlatformsDesc": "已连接的消息平台数量",
+      "runningTime": "运行时间",
+      "runningTimeDesc": "AstrBot 运行时间",
+      "memoryUsage": "内存占用",
+      "cpuLoad": "CPU 负载",
+      "online": "在线",
+      "memoryPercentage": "内存使用率",
+      "status": {
+        "good": "良好",
+        "normal": "正常",
+        "high": "偏高"
+      }
+    },
+    "platform": {
+      "title": "平台消息统计",
+      "subtitle": "各平台消息数量分布",
+      "platformCount": "平台数",
+      "mostActive": "最活跃",
+      "totalPercent": "总消息占比",
+      "messages": "条"
+    },
+    "messageChart": {
+      "title": "消息趋势分析",
+      "subtitle": "跟踪消息数量随时间的变化",
+      "totalMessages": "总消息数",
+      "dailyAverage": "平均每天",
+      "growthRate": "增长率",
+      "timeRanges": {
+        "1day": "过去 1 天",
+        "3days": "过去 3 天",
+        "7days": "过去 7 天",
+        "30days": "过去 30 天"
+      },
+      "messageCount": "消息条数",
+      "time": "时间"
+    }
+  },
+  "settings": {
+    "sections": {
+      "network": "网络",
+      "system": "系统",
+      "internationalization": "国际化"
+    },
+    "network": {
+      "githubProxy": "GitHub 加速地址",
+      "githubProxyDesc": "设置下载插件或者更新 AstrBot 时所用的 GitHub 加速地址。这在中国大陆的网络环境有效。可以自定义，输入结果实时生效。所有地址均不保证稳定性，如果在更新插件/项目时出现报错，请首先检查加速地址是否能正常使用。",
+      "selectGithubProxy": "选择 GitHub 加速地址"
+    },
+    "system": {
+      "restart": "重启",
+      "restartDesc": "重启 AstrBot",
+      "restartButton": "重启"
+    },
+    "i18n": {
+      "title": "语言设置",
+      "desc": "更改界面显示语言。设置将立即生效并保存到本地存储。",
+      "currentLanguage": "当前语言",
+      "selectLanguage": "选择语言"
+    }
+  },
+  "console": {
+    "title": "控制台",
+    "autoScroll": {
+      "enabled": "自动滚动已开启",
+      "disabled": "自动滚动已关闭"
+    },
+    "pip": {
+      "install": "安装 pip 库",
+      "packageName": "库名，如 llmtuner",
+      "mirror": "强制 PyPI 软件仓库链接（可选）",
+      "mirrorHint": "强制 PyPI 软件仓库链接 > 配置项 `PyPI 软件仓库地址`",
+      "installButton": "安装"
+    }
+  },
+  "about": {
+    "subtitle": "一个源于兴趣和热爱的项目 ❤️",
+    "starProject": "Star 这个项目! 🌟",
+    "submitIssue": "提交 Issue",
+    "contributors": {
+      "title": "贡献者",
+      "description": "本项目由众多开源社区成员共同维护。感谢每一位贡献者的付出！",
+      "viewContributors": "查看 AstrBot 贡献者"
+    },
+    "globalDeployment": {
+      "title": "全球部署",
+      "license": "AstrBot 采用 AGPL v3 协议开源"
+    }
+  },
+  "alkaid": {
+    "title": "The Alkaid Project.",
+    "subtitle": "AstrBot Alpha 项目",
+    "tabs": {
+      "knowledgeBase": "知识库",
+      "longTermMemory": "长期记忆层",
+      "other": "..."
+    }
+  },
+  "alkaidSigma": {
+    "title": "The Alkaid Project.",
+    "subtitle": "AstrBot 实验性项目",
+    "tabs": {
+      "longTermMemory": "长期记忆层",
+      "other": "其他"
+    },
+    "visualization": {
+      "title": "可视化",
+      "filterUserId": "筛选用户 ID",
+      "filter": "筛选",
+      "resetFilter": "重置筛选",
+      "refreshGraph": "刷新图形"
+    },
+    "nodeDetails": {
+      "title": "节点详情",
+      "id": "ID",
+      "type": "类型",
+      "name": "名称",
+      "userId": "用户ID",
+      "timestamp": "时间戳"
+    },
+    "graphStats": {
+      "title": "图形统计",
+      "nodeCount": "节点数",
+      "edgeCount": "边数"
+    },
+    "underDevelopment": "功能开发中"
+  },
+  "chat": {
+    "conversationUntitled": "新对话",
+    "createConversation": "创建对话",
+    "noHistory": "暂无对话历史",
+    "systemStatus": "系统状态",
+    "llmService": "LLM 服务",
+    "speechToText": "语音转文本",
+    "deleteConversation": "删除此对话",
+    "fullscreenMode": "全屏模式",
+    "exitFullscreen": "退出全屏",
+    "switchToLight": "切换到日间模式",
+    "switchToDark": "切换到夜间模式",
+    "welcome": {
+      "hello": "Hello, I'm",
+      "help": "输入",
+      "helpCommand": "help",
+      "helpHint": "获取帮助 😊",
+      "voiceRecord": "长按",
+      "ctrl": "Ctrl",
+      "voiceRecordHint": "录制语音 🎤",
+      "pasteImage": "按",
+      "pasteImageHint": "粘贴图片 🏞️"
+    },
+    "input": {
+      "placeholder": "开始输入...",
+      "send": "发送",
+      "voiceInput": "语音输入",
+      "browserNotSupportAudio": "您的浏览器不支持音频播放。"
+    },
+    "editConversationTitle": "编辑对话标题",
+    "editConversationTitleLabel": "对话标题",
+    "editConversationTitleCancel": "取消",
+    "editConversationTitleSave": "保存"
+  },
+  "provider": {
+    "title": "服务提供商管理",
+    "subtitle": "管理模型服务提供商",
+    "providers": {
+      "title": "服务提供商",
+      "settings": "设置",
+      "addProvider": "新增服务提供商",
+      "tabs": {
+        "all": "全部",
+        "chatCompletion": "基本对话",
+        "speechToText": "语音转文字",
+        "textToSpeech": "文字转语音",
+        "embedding": "Embedding"
+      },
+      "details": {
+        "providerType": "提供商类型",
+        "apiBase": "API Base",
+        "apiKey": "API Key"
+      }
+    },
+    "availability": {
+      "title": "供应商可用性",
+      "refresh": "刷新状态",
+      "subtitle": "通过测试模型对话可用性判断，可能产生API费用",
+      "noStatus": "点击\"刷新状态\"按钮获取供应商可用性",
+      "available": "可用",
+      "unavailable": "不可用",
+      "errorMessage": "错误信息"
+    },
+    "logs": {
+      "title": "服务日志",
+      "expand": "展开",
+      "collapse": "收起"
+    },
+    "dialog": {
+      "add": {
+        "title": "服务提供商",
+        "basic": "基本",
+        "noTemplates": "暂无{type}类型的提供商模板"
+      },
+      "config": {
+        "edit": "编辑",
+        "add": "新增",
+        "cancel": "取消",
+        "save": "保存"
+      }
+    }
+  }
+}

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -6,6 +6,7 @@ import vuetify from './plugins/vuetify';
 import confirmPlugin from './plugins/confirmPlugin';
 import '@/scss/style.scss';
 import VueApexCharts from 'vue3-apexcharts';
+import i18n from './i18n';
 
 import print from 'vue3-print-nb';
 import { loader } from '@guolao/vue-monaco-editor'
@@ -18,6 +19,7 @@ app.use(print);
 app.use(VueApexCharts);
 app.use(vuetify);
 app.use(confirmPlugin);
+app.use(i18n);
 app.mount('#app');
 
 

--- a/dashboard/src/views/AboutPage.vue
+++ b/dashboard/src/views/AboutPage.vue
@@ -11,15 +11,15 @@
                         </div>
                         <div class="title-container">
                             <h1 class="text-h2 font-weight-bold">AstrBot</h1>
-                            <p class="text-subtitle-1" style="color: var(--v-theme-secondaryText);">A project out of interests and loves ❤️</p>
+                            <p class="text-subtitle-1" style="color: var(--v-theme-secondaryText);">{{ t('about.subtitle') }}</p>
                             <div class="action-buttons">
                                 <v-btn @click="open('https://github.com/Soulter/AstrBot')"
                                     color="primary" variant="elevated" prepend-icon="mdi-star">
-                                    Star 这个项目! 🌟
+                                    {{ t('about.starProject') }}
                                 </v-btn>
                                 <v-btn class="ml-4" @click="open('https://github.com/Soulter/AstrBot/issues')"
                                     color="secondary" variant="elevated" prepend-icon="mdi-comment-question">
-                                    提交 Issue
+                                    {{ t('about.submitIssue') }}
                                 </v-btn>
                             </div>
                         </div>
@@ -31,12 +31,12 @@
                     <v-container>
                         <v-row justify="center" align="center">
                             <v-col cols="12" md="6" class="pr-md-8 contributors-info">
-                                <h2 class="text-h4 font-weight-medium">贡献者</h2>
+                                <h2 class="text-h4 font-weight-medium">{{ t('about.contributors.title') }}</h2>
                                 <p class="mb-4 text-body-1" style="color: var(--v-theme-secondaryText);">
-                                    本项目由众多开源社区成员共同维护。感谢每一位贡献者的付出！
+                                    {{ t('about.contributors.description') }}
                                 </p>
                                 <p class="text-body-1" style="color: var(--v-theme-secondaryText);">
-                                    <a href="https://github.com/Soulter/AstrBot/graphs/contributors" class="text-decoration-none custom-link">查看 AstrBot 贡献者</a>
+                                    <a href="https://github.com/Soulter/AstrBot/graphs/contributors" class="text-decoration-none custom-link">{{ t('about.contributors.viewContributors') }}</a>
                                 </p>
                             </v-col>
                             <v-col cols="12" md="6">
@@ -60,11 +60,11 @@
                     <v-container>
                         <v-row justify="center" align="center" class="flex-md-row-reverse">
                             <v-col cols="12" md="6" class="pl-md-8 stats-info">
-                                <h2 class="text-h4 font-weight-medium">全球部署</h2>
+                                <h2 class="text-h4 font-weight-medium">{{ t('about.globalDeployment.title') }}</h2>
                                 
                                 <div class="license-container mt-8">
                                     <img v-bind="props" src="https://www.gnu.org/graphics/agplv3-with-text-100x42.png" style="cursor: pointer;"/>
-                                    <p class="text-caption mt-2" style="color: var(--v-theme-secondaryText);">AstrBot 采用 AGPL v3 协议开源</p>
+                                    <p class="text-caption mt-2" style="color: var(--v-theme-secondaryText);">{{ t('about.globalDeployment.license') }}</p>
                                 </div>
                             </v-col>
                             <v-col cols="12" md="6">
@@ -89,9 +89,14 @@
 
 <script>
 import {useCustomizerStore} from "@/stores/customizer";
+import { useI18n } from 'vue-i18n';
 
 export default {
     name: 'AboutPage',
+    setup() {
+        const { t } = useI18n();
+        return { t };
+    },
     data() {
         return {
             selectedLogo: 0
@@ -99,7 +104,7 @@ export default {
     },
 
     methods: {
-      useCustomizerStore,
+        useCustomizerStore,
         open(url) {
             window.open(url, '_blank');
         }

--- a/dashboard/src/views/AlkaidPage.vue
+++ b/dashboard/src/views/AlkaidPage.vue
@@ -3,8 +3,8 @@
     <v-card-text class="pa-4" style="height: 100%;">
       <v-container fluid class="d-flex flex-column" style="height: 100%;">
         <div style="margin-bottom: 32px;">
-          <h1 class="gradient-text">The Alkaid Project.</h1>
-          <small style="color: #a3a3a3;">AstrBot Alpha 项目</small>
+          <h1 class="gradient-text">{{ t('alkaid.title') }}</h1>
+          <small style="color: #a3a3a3;">{{ t('alkaid.subtitle') }}</small>
         </div>
 
         <div style="display: flex; gap: 8px; margin-bottom: 16px;">
@@ -12,19 +12,19 @@
             :color="isActive('knowledge-base') ? '#9b72cb' : ''" rounded="lg" 
             @click="navigateTo('knowledge-base')">
             <v-icon start>mdi-text-box-search</v-icon>
-            知识库
+            {{ t('alkaid.tabs.knowledgeBase') }}
           </v-btn>
           <v-btn size="large" :variant="isActive('long-term-memory') ? 'flat' : 'tonal'"
             :color="isActive('long-term-memory') ? '#9b72cb' : ''" rounded="lg"
             @click="navigateTo('long-term-memory')">
             <v-icon start>mdi-dots-hexagon</v-icon>
-            长期记忆层
+            {{ t('alkaid.tabs.longTermMemory') }}
           </v-btn>
           <v-btn size="large" :variant="isActive('other') ? 'flat' : 'tonal'"
             :color="isActive('other') ? '#9b72cb' : ''" rounded="lg" 
             @click="navigateTo('other')">
             <v-icon start>mdi-tools</v-icon>
-            ...
+            {{ t('alkaid.tabs.other') }}
           </v-btn>
         </div>
 
@@ -37,9 +37,15 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
   name: 'AlkaidPage',
   components: {},
+  setup() {
+    const { t } = useI18n();
+    return { t };
+  },
   data() {
     return {}
   },

--- a/dashboard/src/views/AlkaidPage_sigma.vue
+++ b/dashboard/src/views/AlkaidPage_sigma.vue
@@ -2,6 +2,9 @@
 import Graph from "graphology";
 import Sigma from "sigma";
 import ForceSupervisor from "graphology-layout-force/worker";
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
 </script>
 
 
@@ -10,8 +13,8 @@ import ForceSupervisor from "graphology-layout-force/worker";
     <v-card-text class="pa-4" style="height: 100%;">
       <v-container fluid class="d-flex flex-column" style="height: 100%;">
         <div style="margin-bottom: 32px;">
-          <h1 class="gradient-text">The Alkaid Project.</h1>
-          <small style="color: #a3a3a3;">AstrBot 实验性项目</small>
+          <h1 class="gradient-text">{{ t('alkaidSigma.title') }}</h1>
+          <small style="color: #a3a3a3;">{{ t('alkaidSigma.subtitle') }}</small>
         </div>
 
         <div style="display: flex; gap: 8px; margin-bottom: 16px;">
@@ -19,12 +22,12 @@ import ForceSupervisor from "graphology-layout-force/worker";
             :color="activeTab === 'long-term-memory' ? '#9b72cb' : ''" rounded="lg"
             @click="activeTab = 'long-term-memory'">
             <v-icon start>mdi-dots-hexagon</v-icon>
-            长期记忆层
+            {{ t('alkaidSigma.tabs.longTermMemory') }}
           </v-btn>
           <v-btn size="large" :variant="activeTab === 'other' ? 'flat' : 'tonal'"
             :color="activeTab === 'other' ? '#9b72cb' : ''" rounded="lg" @click="activeTab = 'other'">
             <v-icon start>mdi-dots-horizontal</v-icon>
-            其他
+            {{ t('alkaidSigma.tabs.other') }}
           </v-btn>
         </div>
 
@@ -35,24 +38,24 @@ import ForceSupervisor from "graphology-layout-force/worker";
           <div id="graph-control-panel"
             style="min-width: 450px; border: 1px solid #eee; border-radius: 8px; padding: 16px; margin-left: 16px;">
             <div>
-              <span style="color: #333333;">可视化</span>
+              <span style="color: #333333;">{{ t('alkaidSigma.visualization.title') }}</span>
               <div style="margin-top: 8px;">
                 <v-autocomplete v-model="searchUserId" :items="userIdList" variant="outlined"
-                  label="筛选用户 ID"></v-autocomplete>
+                  :label="t('alkaidSigma.visualization.filterUserId')"></v-autocomplete>
                 <v-btn color="primary" @click="onNodeSelect" variant="tonal" style="margin-top: 8px;">
                   <v-icon start>mdi-magnify</v-icon>
-                  筛选
+                  {{ t('alkaidSigma.visualization.filter') }}
                 </v-btn>
                 <v-btn color="secondary" @click="resetFilter" variant="tonal"
                   style="margin-top: 8px; margin-left: 8px;">
                   <v-icon start>mdi-filter-remove</v-icon>
-                  重置筛选
+                  {{ t('alkaidSigma.visualization.resetFilter') }}
                 </v-btn>
               </div>
               <div style="margin-top: 16px;">
                 <v-btn color="primary" @click="refreshGraph" variant="tonal">
                   <v-icon start>mdi-refresh</v-icon>
-                  刷新图形
+                  {{ t('alkaidSigma.visualization.refreshGraph') }}
                 </v-btn>
               </div>
             </div>
@@ -60,41 +63,41 @@ import ForceSupervisor from "graphology-layout-force/worker";
             <v-divider class="my-4"></v-divider>
 
             <div v-if="selectedNode" class="mt-4">
-              <h3>节点详情</h3>
+              <h3>{{ t('alkaidSigma.nodeDetails.title') }}</h3>
               <v-card variant="outlined" class="mt-2 pa-3">
                 <div v-if="selectedNode.id">
                   <div class="d-flex justify-space-between">
-                    <span class="text-subtitle-2">ID:</span>
+                    <span class="text-subtitle-2">{{ t('alkaidSigma.nodeDetails.id') }}:</span>
                     <span>{{ selectedNode.id }}</span>
                   </div>
                 </div>
                 <div v-if="selectedNode._label">
                   <div class="d-flex justify-space-between">
-                    <span class="text-subtitle-2">类型:</span>
+                    <span class="text-subtitle-2">{{ t('alkaidSigma.nodeDetails.type') }}:</span>
                     <span>{{ selectedNode._label }}</span>
                   </div>
                 </div>
                 <div v-if="selectedNode.name">
                   <div class="d-flex justify-space-between">
-                    <span class="text-subtitle-2">名称:</span>
+                    <span class="text-subtitle-2">{{ t('alkaidSigma.nodeDetails.name') }}:</span>
                     <span>{{ selectedNode.name }}</span>
                   </div>
                 </div>
                 <div v-if="selectedNode.user_id">
                   <div class="d-flex justify-space-between">
-                    <span class="text-subtitle-2">用户ID:</span>
+                    <span class="text-subtitle-2">{{ t('alkaidSigma.nodeDetails.userId') }}:</span>
                     <span>{{ selectedNode.user_id }}</span>
                   </div>
                 </div>
                 <div v-if="selectedNode.ts">
                   <div class="d-flex justify-space-between">
-                    <span class="text-subtitle-2">时间戳:</span>
+                    <span class="text-subtitle-2">{{ t('alkaidSigma.nodeDetails.timestamp') }}:</span>
                     <span>{{ selectedNode.ts }}</span>
                   </div>
                 </div>
                 <div v-if="selectedNode.type">
                   <div class="d-flex justify-space-between">
-                    <span class="text-subtitle-2">类型:</span>
+                    <span class="text-subtitle-2">{{ t('alkaidSigma.nodeDetails.type') }}:</span>
                     <span>{{ selectedNode.type }}</span>
                   </div>
                 </div>
@@ -102,14 +105,14 @@ import ForceSupervisor from "graphology-layout-force/worker";
             </div>
 
             <div v-if="graphStats" class="mt-4">
-              <h3>图形统计</h3>
+              <h3>{{ t('alkaidSigma.graphStats.title') }}</h3>
               <v-card variant="outlined" class="mt-2 pa-3">
                 <div class="d-flex justify-space-between">
-                  <span class="text-subtitle-2">节点数:</span>
+                  <span class="text-subtitle-2">{{ t('alkaidSigma.graphStats.nodeCount') }}:</span>
                   <span>{{ graphStats.nodeCount }}</span>
                 </div>
                 <div class="d-flex justify-space-between">
-                  <span class="text-subtitle-2">边数:</span>
+                  <span class="text-subtitle-2">{{ t('alkaidSigma.graphStats.edgeCount') }}:</span>
                   <span>{{ graphStats.edgeCount }}</span>
                 </div>
               </v-card>
@@ -121,7 +124,7 @@ import ForceSupervisor from "graphology-layout-force/worker";
           <div class="d-flex align-center justify-center"
             style="flex-grow: 1; width: 100%; border: 1px solid #eee; border-radius: 8px;">
             <v-icon size="64" color="grey-lighten-1">mdi-tools</v-icon>
-            <p class="text-h6 text-grey ml-4">功能开发中</p>
+            <p class="text-h6 text-grey ml-4">{{ t('alkaidSigma.underDevelopment') }}</p>
           </div>
         </div>
 

--- a/dashboard/src/views/ChatPage.vue
+++ b/dashboard/src/views/ChatPage.vue
@@ -5,6 +5,9 @@ import { marked } from 'marked';
 import { ref } from 'vue';
 import { defineProps } from 'vue';
 import { useCustomizerStore } from '@/stores/customizer';
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
 
 marked.setOptions({
     breaks: true
@@ -41,7 +44,7 @@ const props = defineProps({
 
                     <div style="padding: 16px; padding-top: 8px;">
                         <v-btn block variant="text" class="new-chat-btn" @click="newC" :disabled="!currCid"
-                            v-if="!sidebarCollapsed" prepend-icon="mdi-plus" style="box-shadow: 0 1px 2px rgba(0,0,0,0.1); background-color: transparent !important; border-radius: 4px;">创建对话</v-btn>
+                            v-if="!sidebarCollapsed" prepend-icon="mdi-plus" style="box-shadow: 0 1px 2px rgba(0,0,0,0.1); background-color: transparent !important; border-radius: 4px;">{{ t('chat.createConversation') }}</v-btn>
                         <v-btn icon="mdi-plus" rounded="lg" @click="newC" :disabled="!currCid" v-if="sidebarCollapsed"
                             elevation="0"></v-btn>
                     </div>
@@ -57,7 +60,7 @@ const props = defineProps({
                                 <v-list-item v-for="(item, i) in conversations" :key="item.cid" :value="item.cid"
                                     rounded="lg" class="conversation-item" active-color="secondary">
                                     <v-list-item-title v-if="!sidebarCollapsed" class="conversation-title">{{ item.title
-                                        || '新对话' }}</v-list-item-title>
+                                        || t('chat.conversationUntitled') }}</v-list-item-title>
                                     <!-- <v-list-item-subtitle v-if="!sidebarCollapsed" class="timestamp">{{
                                         formatDate(item.updated_at)
                                         }}</v-list-item-subtitle> -->
@@ -74,7 +77,7 @@ const props = defineProps({
                             <div class="no-conversations" v-if="conversations.length === 0">
                                 <v-icon icon="mdi-message-text-outline" size="large" color="grey-lighten-1"></v-icon>
                                 <div class="no-conversations-text" v-if="!sidebarCollapsed || sidebarHoverExpanded">
-                                    暂无对话历史</div>
+                                    {{ t('chat.noHistory') }}</div>
                             </div>
                         </v-fade-transition>
                     </div>
@@ -85,7 +88,7 @@ const props = defineProps({
                     <div style="padding: 16px;" :class="{ 'fade-in': sidebarHoverExpanded }"
                         v-if="!sidebarCollapsed">
                         <div class="sidebar-section-title">
-                            系统状态
+                            {{ t('chat.systemStatus') }}
                         </div>
                         <div class="status-chips">
                             <v-chip class="status-chip" :color="status?.llm_enabled ? 'primary' : 'grey-lighten-2'"
@@ -94,7 +97,7 @@ const props = defineProps({
                                     <v-icon :icon="status?.llm_enabled ? 'mdi-check-circle' : 'mdi-alert-circle'"
                                         size="x-small"></v-icon>
                                 </template>
-                                <span>LLM 服务</span>
+                                <span>{{ t('chat.llmService') }}</span>
                             </v-chip>
 
                             <v-chip class="status-chip" :color="status?.stt_enabled ? 'success' : 'grey-lighten-2'"
@@ -103,7 +106,7 @@ const props = defineProps({
                                     <v-icon :icon="status?.stt_enabled ? 'mdi-check-circle' : 'mdi-alert-circle'"
                                         size="x-small"></v-icon>
                                 </template>
-                                <span>语音转文本</span>
+                                <span>{{ t('chat.speechToText') }}</span>
                             </v-chip>
                         </div>
 
@@ -119,7 +122,7 @@ const props = defineProps({
                                 <v-btn variant="outlined" rounded="sm" class="delete-chat-btn"
                                     @click="deleteConversation(currCid)" color="error" density="comfortable" size="small">
                                     <v-icon start size="small">mdi-delete</v-icon>
-                                    删除此对话
+                                    {{ t('chat.deleteConversation') }}
                                 </v-btn>
                             </div>
                         </transition>
@@ -131,19 +134,19 @@ const props = defineProps({
 
                     <div class="conversation-header fade-in">
                         <div class="conversation-header-content" v-if="currCid && getCurrentConversation">
-                            <h2 class="conversation-header-title">{{ getCurrentConversation.title || '新对话' }}</h2>
+                            <h2 class="conversation-header-title">{{ getCurrentConversation.title || t('chat.conversationUntitled') }}</h2>
                             <div class="conversation-header-time">{{ formatDate(getCurrentConversation.updated_at) }}</div>
                         </div>
                         <div class="conversation-header-actions">
                             <!-- router 推送到 /chatbox -->
-                            <v-tooltip text="全屏模式" v-if="!props.chatboxMode">
+                            <v-tooltip :text="t('chat.fullscreenMode')" v-if="!props.chatboxMode">
                                 <template v-slot:activator="{ props }">
                                     <v-icon v-bind="props" @click="router.push(currCid ? `/chatbox/${currCid}` : '/chatbox')"
                                         class="fullscreen-icon">mdi-fullscreen</v-icon>
                                 </template>
                             </v-tooltip>
                             <!-- 主题切换按钮 -->
-                            <v-tooltip :text="isDark ? '切换到日间模式' : '切换到夜间模式'" v-if="props.chatboxMode">
+                            <v-tooltip :text="isDark ? t('chat.switchToLight') : t('chat.switchToDark')" v-if="props.chatboxMode">
                                 <template v-slot:activator="{ props }">
                                     <v-btn v-bind="props" icon @click="toggleTheme" class="theme-toggle-icon" variant="text">
                                         <v-icon>{{ isDark ? 'mdi-weather-night' : 'mdi-white-balance-sunny' }}</v-icon>
@@ -151,7 +154,7 @@ const props = defineProps({
                                 </template>
                             </v-tooltip>
                             <!-- router 推送到 /chat -->
-                            <v-tooltip text="退出全屏" v-if="props.chatboxMode">
+                            <v-tooltip :text="t('chat.exitFullscreen')" v-if="props.chatboxMode">
                                 <template v-slot:activator="{ props }">
                                     <v-icon v-bind="props" @click="router.push(currCid ? `/chat/${currCid}` : '/chat')"
                                         class="fullscreen-icon">mdi-fullscreen-exit</v-icon>
@@ -165,23 +168,23 @@ const props = defineProps({
                         <!-- 空聊天欢迎页 -->
                         <div class="welcome-container fade-in" v-if="messages.length == 0">
                             <div class="welcome-title">
-                                <span>Hello, I'm</span>
+                                <span>{{ t('chat.welcome.hello') }}</span>
                                 <span class="bot-name">AstrBot ⭐</span>
                             </div>
                             <div class="welcome-hint">
-                                <span>输入</span>
-                                <code>help</code>
-                                <span>获取帮助 😊</span>
+                                <span>{{ t('chat.welcome.help') }}</span>
+                                <code>{{ t('chat.welcome.helpCommand') }}</code>
+                                <span>{{ t('chat.welcome.helpHint') }}</span>
                             </div>
                             <div class="welcome-hint">
-                                <span>长按</span>
-                                <code>Ctrl</code>
-                                <span>录制语音 🎤</span>
+                                <span>{{ t('chat.welcome.voiceRecord') }}</span>
+                                <code>{{ t('chat.welcome.ctrl') }}</code>
+                                <span>{{ t('chat.welcome.voiceRecordHint') }}</span>
                             </div>
                             <div class="welcome-hint">
-                                <span>按</span>
-                                <code>Ctrl + V</code>
-                                <span>粘贴图片 🏞️</span>
+                                <span>{{ t('chat.welcome.pasteImage') }}</span>
+                                <code>{{ t('chat.welcome.ctrl') }}</code>
+                                <span>{{ t('chat.welcome.pasteImageHint') }}</span>
                             </div>
                         </div>
 
@@ -205,7 +208,7 @@ const props = defineProps({
                                         <div class="audio-attachment" v-if="msg.audio_url && msg.audio_url.length > 0">
                                             <audio controls class="audio-player">
                                                 <source :src="msg.audio_url" type="audio/wav">
-                                                您的浏览器不支持音频播放。
+                                                {{ t('chat.input.browserNotSupportAudio') }}
                                             </audio>
                                         </div>
                                     </div>
@@ -230,7 +233,7 @@ const props = defineProps({
                     <!-- 输入区域 -->
                     <div class="input-area fade-in">
                         <v-text-field autocomplete="off" id="input-field" variant="outlined" v-model="prompt"
-                            :label="inputFieldLabel" placeholder="开始输入..." :loading="loadingChat"
+                            :label="inputFieldLabel" :placeholder="t('chat.input.placeholder')" :loading="loadingChat"
                             clear-icon="mdi-close-circle" clearable @click:clear="clearMessage" class="message-input"
                             @keydown="handleInputKeyDown" hide-details>
                             <template v-slot:loader>
@@ -239,7 +242,7 @@ const props = defineProps({
                             </template>
 
                             <template v-slot:append>
-                                <v-tooltip text="发送">
+                                <v-tooltip :text="t('chat.input.send')">
                                     <template v-slot:activator="{ props }">
                                         <v-btn v-bind="props" @click="sendMessage" class="send-btn" icon="mdi-send"
                                             variant="text" color="deep-purple"
@@ -247,12 +250,10 @@ const props = defineProps({
                                     </template>
                                 </v-tooltip>
 
-                                <v-tooltip text="语音输入">
+                                <v-tooltip :text="t('chat.input.voiceInput')">
                                     <template v-slot:activator="{ props }">
-                                        <v-btn v-bind="props" @click="isRecording ? stopRecording() : startRecording()"
-                                            class="record-btn"
-                                            :icon="isRecording ? 'mdi-stop-circle' : 'mdi-microphone'" variant="text"
-                                            :color="isRecording ? 'error' : 'deep-purple'" />
+                                        <v-btn v-bind="props" @click="startRecording" class="voice-btn" icon="mdi-microphone"
+                                            variant="text" color="deep-purple" />
                                     </template>
                                 </v-tooltip>
                             </template>
@@ -284,15 +285,15 @@ const props = defineProps({
     <!-- 编辑对话标题对话框 -->
     <v-dialog v-model="editTitleDialog" max-width="400">
         <v-card>
-            <v-card-title class="dialog-title">编辑对话标题</v-card-title>
+            <v-card-title class="dialog-title">{{ t('chat.editConversationTitle') }}</v-card-title>
             <v-card-text>
-                <v-text-field v-model="editingTitle" label="对话标题" variant="outlined" hide-details class="mt-2"
+                <v-text-field v-model="editingTitle" :label="t('chat.editConversationTitleLabel')" variant="outlined" hide-details class="mt-2"
                     @keyup.enter="saveTitle" autofocus />
             </v-card-text>
             <v-card-actions>
                 <v-spacer></v-spacer>
-                <v-btn text @click="editTitleDialog = false" color="grey-darken-1">取消</v-btn>
-                <v-btn text @click="saveTitle" color="primary">保存</v-btn>
+                <v-btn text @click="editTitleDialog = false" color="grey-darken-1">{{ t('chat.editConversationTitleCancel') }}</v-btn>
+                <v-btn text @click="saveTitle" color="primary">{{ t('chat.editConversationTitleSave') }}</v-btn>
             </v-card-actions>
         </v-card>
     </v-dialog>

--- a/dashboard/src/views/ConsolePage.vue
+++ b/dashboard/src/views/ConsolePage.vue
@@ -1,34 +1,36 @@
 <script setup>
 import ConsoleDisplayer from '@/components/shared/ConsoleDisplayer.vue';
 import axios from 'axios';
+import { useI18n } from 'vue-i18n';
 
+const { t } = useI18n();
 </script>
 
 <template>
   <div style="height: 100%;">
     <div
       style="background-color: var(--v-theme-surface); padding: 8px; padding-left: 16px; border-radius: 8px; margin-bottom: 16px; display: flex; flex-direction: row; align-items: center; justify-content: space-between;">
-      <h4>控制台</h4>
+      <h4>{{ t('console.title') }}</h4>
       <div class="d-flex align-center">
         <v-switch
           v-model="autoScrollDisabled"
-          :label="autoScrollDisabled ? '自动滚动已关闭' : '自动滚动已开启'"
+          :label="autoScrollDisabled ? t('console.autoScroll.disabled') : t('console.autoScroll.enabled')"
           hide-details
           density="compact"
           style="margin-right: 16px;"
         ></v-switch>
         <v-dialog v-model="pipDialog" width="400">
           <template v-slot:activator="{ props }">
-            <v-btn variant="plain" v-bind="props">安装 pip 库</v-btn>
+            <v-btn variant="plain" v-bind="props">{{ t('console.pip.install') }}</v-btn>
           </template>
           <v-card>
             <v-card-title>
-              <span class="text-h5">安装 Pip 库</span>
+              <span class="text-h5">{{ t('console.pip.install') }}</span>
             </v-card-title>
             <v-card-text>
-              <v-text-field v-model="pipInstallPayload.package" label="*库名，如 llmtuner" variant="outlined"></v-text-field>
-              <v-text-field v-model="pipInstallPayload.mirror" label="强制 PyPI 软件仓库链接（可选）" variant="outlined"></v-text-field>
-              <small>强制 PyPI 软件仓库链接 > 配置项 `PyPI 软件仓库地址`</small>
+              <v-text-field v-model="pipInstallPayload.package" :label="t('console.pip.packageName')" variant="outlined"></v-text-field>
+              <v-text-field v-model="pipInstallPayload.mirror" :label="t('console.pip.mirror')" variant="outlined"></v-text-field>
+              <small>{{ t('console.pip.mirrorHint') }}</small>
               <div>
                 <small>{{ status }}</small>
               </div>
@@ -37,7 +39,7 @@ import axios from 'axios';
             <v-card-actions>
               <v-spacer></v-spacer>
               <v-btn color="blue-darken-1" variant="text" @click="pipInstall" :loading="loading">
-                安装
+                {{ t('console.pip.installButton') }}
               </v-btn>
             </v-card-actions>
           </v-card>

--- a/dashboard/src/views/ProviderPage.vue
+++ b/dashboard/src/views/ProviderPage.vue
@@ -5,10 +5,10 @@
       <v-row>
         <v-col cols="12">
           <h1 class="text-h4 font-weight-bold mb-2">
-            <v-icon size="x-large" color="primary" class="me-2">mdi-creation</v-icon>服务提供商管理
+            <v-icon size="x-large" color="primary" class="me-2">mdi-creation</v-icon>{{ t('provider.title') }}
           </h1>
           <p class="text-subtitle-1 text-medium-emphasis mb-4">
-            管理模型服务提供商
+            {{ t('provider.subtitle') }}
           </p>
         </v-col>
       </v-row>
@@ -17,14 +17,14 @@
       <v-card class="mb-6" elevation="2">
         <v-card-title class="d-flex align-center py-3 px-4">
           <v-icon color="primary" class="me-2">mdi-api</v-icon>
-          <span class="text-h6">服务提供商</span>
+          <span class="text-h6">{{ t('provider.providers.title') }}</span>
           <v-chip color="info" size="small" class="ml-2">{{ config_data.provider?.length || 0 }}</v-chip>
           <v-spacer></v-spacer>
           <v-btn color="success" prepend-icon="mdi-cog" variant="tonal" class="me-2" @click="showSettingsDialog = true">
-            设置
+            {{ t('provider.providers.settings') }}
           </v-btn>
           <v-btn color="primary" prepend-icon="mdi-plus" variant="tonal" @click="showAddProviderDialog = true">
-            新增服务提供商
+            {{ t('provider.providers.addProvider') }}
           </v-btn>
         </v-card-title>
 
@@ -35,23 +35,23 @@
           <v-tabs v-model="activeProviderTypeTab" bg-color="transparent">
             <v-tab value="all" class="font-weight-medium px-3">
               <v-icon start>mdi-filter-variant</v-icon>
-              全部
+              {{ t('provider.providers.tabs.all') }}
             </v-tab>
             <v-tab value="chat_completion" class="font-weight-medium px-3">
               <v-icon start>mdi-message-text</v-icon>
-              基本对话
+              {{ t('provider.providers.tabs.chatCompletion') }}
             </v-tab>
             <v-tab value="speech_to_text" class="font-weight-medium px-3">
               <v-icon start>mdi-microphone-message</v-icon>
-              语音转文字
+              {{ t('provider.providers.tabs.speechToText') }}
             </v-tab>
             <v-tab value="text_to_speech" class="font-weight-medium px-3">
               <v-icon start>mdi-volume-high</v-icon>
-              文字转语音
+              {{ t('provider.providers.tabs.textToSpeech') }}
             </v-tab>
             <v-tab value="embedding" class="font-weight-medium px-3">
               <v-icon start>mdi-code-json</v-icon>
-              Embedding
+              {{ t('provider.providers.tabs.embedding') }}
             </v-tab>
           </v-tabs>
         </v-card-text>
@@ -71,19 +71,19 @@
               <div class="d-flex align-center mb-2">
                 <v-icon size="small" color="grey" class="me-2">mdi-tag</v-icon>
                 <span class="text-caption text-medium-emphasis">
-                  提供商类型:
+                  {{ t('provider.providers.details.providerType') }}:
                   <v-chip size="x-small" color="primary" class="ml-1">{{ item.type }}</v-chip>
                 </span>
               </div>
               <div v-if="item.api_base" class="d-flex align-center mb-2">
                 <v-icon size="small" color="grey" class="me-2">mdi-web</v-icon>
                 <span class="text-caption text-medium-emphasis text-truncate" :title="item.api_base">
-                  API Base: {{ item.api_base }}
+                  {{ t('provider.providers.details.apiBase') }}: {{ item.api_base }}
                 </span>
               </div>
               <div v-if="item.api_key" class="d-flex align-center">
                 <v-icon size="small" color="grey" class="me-2">mdi-key</v-icon>
-                <span class="text-caption text-medium-emphasis">API Key: ••••••••</span>
+                <span class="text-caption text-medium-emphasis">{{ t('provider.providers.details.apiKey') }}: ••••••••</span>
               </div>
             </template>
           </item-card-grid>
@@ -94,22 +94,22 @@
       <v-card class="mb-6" elevation="2">
         <v-card-title class="d-flex align-center py-3 px-4">
           <v-icon color="primary" class="me-2">mdi-heart-pulse</v-icon>
-          <span class="text-h6">供应商可用性</span>
+          <span class="text-h6">{{ t('provider.availability.title') }}</span>
           <v-spacer></v-spacer>
           <v-btn color="primary" variant="tonal" :loading="loadingStatus" @click="fetchProviderStatus">
             <v-icon left>mdi-refresh</v-icon>
-            刷新状态
+            {{ t('provider.availability.refresh') }}
           </v-btn>
         </v-card-title>
         <v-card-subtitle class="px-4 py-1 text-caption text-medium-emphasis">
-          通过测试模型对话可用性判断，可能产生API费用
+          {{ t('provider.availability.subtitle') }}
         </v-card-subtitle>
 
         <v-divider></v-divider>
 
         <v-card-text class="px-4 py-3">
           <v-alert v-if="providerStatuses.length === 0" type="info" variant="tonal">
-            点击"刷新状态"按钮获取供应商可用性
+            {{ t('provider.availability.noStatus') }}
           </v-alert>
           
           <v-container v-else class="pa-0">
@@ -122,11 +122,11 @@
                     </v-icon>
                     <span class="font-weight-bold">{{ status.id }}</span>
                     <v-chip :color="status.status === 'available' ? 'success' : 'error'" size="small" class="ml-2">
-                      {{ status.status === 'available' ? '可用' : '不可用' }}
+                      {{ status.status === 'available' ? t('provider.availability.available') : t('provider.availability.unavailable') }}
                     </v-chip>
                   </v-card-item>
                   <v-card-text v-if="status.status === 'unavailable'" class="text-caption text-medium-emphasis">
-                    <span class="font-weight-bold">错误信息:</span> {{ status.error }}
+                    <span class="font-weight-bold">{{ t('provider.availability.errorMessage') }}:</span> {{ status.error }}
                   </v-card-text>
                 </v-card>
               </v-col>
@@ -139,10 +139,10 @@
       <v-card elevation="2">
         <v-card-title class="d-flex align-center py-3 px-4">
           <v-icon color="primary" class="me-2">mdi-console-line</v-icon>
-          <span class="text-h6">服务日志</span>
+          <span class="text-h6">{{ t('provider.logs.title') }}</span>
           <v-spacer></v-spacer>
           <v-btn variant="text" color="primary" @click="showConsole = !showConsole">
-            {{ showConsole ? '收起' : '展开' }}
+            {{ showConsole ? t('provider.logs.collapse') : t('provider.logs.expand') }}
             <v-icon>{{ showConsole ? 'mdi-chevron-up' : 'mdi-chevron-down' }}</v-icon>
           </v-btn>
         </v-card-title>
@@ -162,7 +162,7 @@
       <v-card class="provider-selection-dialog">
         <v-card-title class="bg-primary text-white py-3 px-4" style="display: flex; align-items: center;">
           <v-icon color="white" class="me-2">mdi-plus-circle</v-icon>
-          <span>服务提供商</span>
+          <span>{{ t('provider.dialog.add.title') }}</span>
           <v-spacer></v-spacer>
           <v-btn icon variant="text" color="white" @click="showAddProviderDialog = false">
             <v-icon>mdi-close</v-icon>
@@ -173,19 +173,19 @@
           <v-tabs v-model="activeProviderTab" grow slider-color="primary" bg-color="background">
             <v-tab value="chat_completion" class="font-weight-medium px-3">
               <v-icon start>mdi-message-text</v-icon>
-              基本
+              {{ t('provider.dialog.add.basic') }}
             </v-tab>
             <v-tab value="speech_to_text" class="font-weight-medium px-3">
               <v-icon start>mdi-microphone-message</v-icon>
-              语音转文字
+              {{ t('provider.providers.tabs.speechToText') }}
             </v-tab>
             <v-tab value="text_to_speech" class="font-weight-medium px-3">
               <v-icon start>mdi-volume-high</v-icon>
-              文字转语音
+              {{ t('provider.providers.tabs.textToSpeech') }}
             </v-tab>
             <v-tab value="embedding" class="font-weight-medium px-3">
               <v-icon start>mdi-code-json</v-icon>
-              Embedding
+              {{ t('provider.providers.tabs.embedding') }}
             </v-tab>
           </v-tabs>
 
@@ -216,7 +216,7 @@
                 </v-col>
                 <v-col v-if="Object.keys(getTemplatesByType(tabType)).length === 0" cols="12">
                   <v-alert type="info" variant="tonal">
-                    暂无{{ getTabTypeName(tabType) }}类型的提供商模板
+                    {{ t('provider.dialog.add.noTemplates', { type: getTabTypeName(tabType) }) }}
                   </v-alert>
                 </v-col>
               </v-row>
@@ -231,7 +231,7 @@
       <v-card>
         <v-card-title class="bg-primary text-white py-3">
           <v-icon color="white" class="me-2">{{ updatingMode ? 'mdi-pencil' : 'mdi-plus' }}</v-icon>
-          <span>{{ updatingMode ? '编辑' : '新增' }} {{ newSelectedProviderName }} 服务提供商</span>
+          <span>{{ updatingMode ? t('provider.dialog.config.edit') : t('provider.dialog.config.add') }} {{ newSelectedProviderName }} {{ t('provider.providers.title') }}</span>
         </v-card-title>
 
         <v-card-text class="py-4">
@@ -247,10 +247,10 @@
         <v-card-actions class="pa-4">
           <v-spacer></v-spacer>
           <v-btn variant="text" @click="showProviderCfg = false" :disabled="loading">
-            取消
+            {{ t('provider.dialog.config.cancel') }}
           </v-btn>
           <v-btn color="primary" @click="newProvider" :loading="loading">
-            保存
+            {{ t('provider.dialog.config.save') }}
           </v-btn>
         </v-card-actions>
       </v-card>
@@ -309,370 +309,346 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import { computed, onMounted, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 import axios from 'axios';
 import AstrBotConfig from '@/components/shared/AstrBotConfig.vue';
 import WaitingForRestart from '@/components/shared/WaitingForRestart.vue';
 import ConsoleDisplayer from '@/components/shared/ConsoleDisplayer.vue';
 import ItemCardGrid from '@/components/shared/ItemCardGrid.vue';
 
-export default {
-  name: 'ProviderPage',
-  components: {
-    AstrBotConfig,
-    WaitingForRestart,
-    ConsoleDisplayer,
-    ItemCardGrid
-  },
-  data() {
-    return {
-      config_data: {},
-      fetched: false,
-      metadata: {},
-      showProviderCfg: false,
+const { t } = useI18n();
 
-      // 设置对话框相关
-      showSettingsDialog: false,
-      sessionSeparationEnabled: false,
-      sessionSettingLoading: false,
+const config_data = ref({});
+const fetched = ref(false);
+const metadata = ref({});
+const showProviderCfg = ref(false);
 
-      newSelectedProviderName: '',
-      newSelectedProviderConfig: {},
-      updatingMode: false,
+// 设置对话框相关
+const showSettingsDialog = ref(false);
+const sessionSeparationEnabled = ref(false);
+const sessionSettingLoading = ref(false);
 
-      loading: false,
+const newSelectedProviderName = ref('');
+const newSelectedProviderConfig = ref({});
+const updatingMode = ref(false);
 
-      save_message_snack: false,
-      save_message: "",
-      save_message_success: "success",
+const loading = ref(false);
 
-      showConsole: false,
-      
-      // 供应商状态相关
-      providerStatuses: [],
-      loadingStatus: false,
+const save_message_snack = ref(false);
+const save_message = ref("");
+const save_message_success = ref("success");
 
-      // 新增提供商对话框相关
-      showAddProviderDialog: false,
-      activeProviderTab: 'chat_completion',
+const showConsole = ref(false);
 
-      // 添加提供商类型分类
-      activeProviderTypeTab: 'all',
+// 供应商状态相关
+const providerStatuses = ref([]);
+const loadingStatus = ref(false);
 
-      // 兼容旧版本（< v3.5.11）的 mapping，用于映射到对应的提供商能力类型
-      oldVersionProviderTypeMapping: {
-        "openai_chat_completion": "chat_completion",
-        "anthropic_chat_completion": "chat_completion",
-        "googlegenai_chat_completion": "chat_completion",
-        "zhipu_chat_completion": "chat_completion",
-        "llm_tuner": "chat_completion",
-        "dify": "chat_completion",
-        "dashscope": "chat_completion",
-        "openai_whisper_api": "speech_to_text",
-        "openai_whisper_selfhost": "speech_to_text",
-        "sensevoice_stt_selfhost": "speech_to_text",
-        "openai_tts_api": "text_to_speech",
-        "edge_tts": "text_to_speech",
-        "gsvi_tts_api": "text_to_speech",
-        "fishaudio_tts_api": "text_to_speech",
-        "dashscope_tts": "text_to_speech",
-        "azure_tts": "text_to_speech",
-        "minimax_tts_api": "text_to_speech",
-        "volcengine_tts": "text_to_speech",
-      }
+// 新增提供商对话框相关
+const showAddProviderDialog = ref(false);
+const activeProviderTab = ref('chat_completion');
+
+// 添加提供商类型分类
+const activeProviderTypeTab = ref('all');
+
+// 兼容旧版本（< v3.5.11）的 mapping，用于映射到对应的提供商能力类型
+const oldVersionProviderTypeMapping = {
+  "openai_chat_completion": "chat_completion",
+  "anthropic_chat_completion": "chat_completion",
+  "googlegenai_chat_completion": "chat_completion",
+  "zhipu_chat_completion": "chat_completion",
+  "llm_tuner": "chat_completion",
+  "dify": "chat_completion",
+  "dashscope": "chat_completion",
+  "openai_whisper_api": "speech_to_text",
+  "openai_whisper_selfhost": "speech_to_text",
+  "sensevoice_stt_selfhost": "speech_to_text",
+  "openai_tts_api": "text_to_speech",
+  "edge_tts": "text_to_speech",
+  "gsvi_tts_api": "text_to_speech",
+  "fishaudio_tts_api": "text_to_speech",
+  "dashscope_tts": "text_to_speech",
+  "azure_tts": "text_to_speech",
+  "minimax_tts_api": "text_to_speech",
+  "volcengine_tts": "text_to_speech",
+};
+
+const filteredProviders = computed(() => {
+  if (!config_data.value.provider || activeProviderTypeTab.value === 'all') {
+    return config_data.value.provider || [];
+  }
+
+  return config_data.value.provider.filter(provider => {
+    // 如果provider.provider_type已经存在，直接使用它
+    if (provider.provider_type) {
+      return provider.provider_type === activeProviderTypeTab.value;
     }
-  },
-
-  computed: {
-    // 根据选择的标签过滤提供商列表
-    filteredProviders() {
-      if (!this.config_data.provider || this.activeProviderTypeTab === 'all') {
-        return this.config_data.provider || [];
-      }
-
-      return this.config_data.provider.filter(provider => {
-        // 如果provider.provider_type已经存在，直接使用它
-        if (provider.provider_type) {
-          return provider.provider_type === this.activeProviderTypeTab;
-        }
-        
-        // 否则使用映射关系
-        const mappedType = this.oldVersionProviderTypeMapping[provider.type];
-        return mappedType === this.activeProviderTypeTab;
-      });
-    }
-  },
-
-  mounted() {
-    this.getConfig();
-    this.getSessionSeparationStatus();
-  },
-
-  methods: {
-    getConfig() {
-      axios.get('/api/config/get').then((res) => {
-        this.config_data = res.data.data.config;
-        this.fetched = true
-        this.metadata = res.data.data.metadata;
-      }).catch((err) => {
-        this.showError(err.response?.data?.message || err.message);
-      });
-    },
-
-    // 获取空列表文本
-    getEmptyText() {
-      if (this.activeProviderTypeTab === 'all') {
-        return "暂无服务提供商，点击 新增服务提供商 添加";
-      } else {
-        return `暂无${this.getTabTypeName(this.activeProviderTypeTab)}类型的服务提供商，点击 新增服务提供商 添加`;
-      }
-    },
-
-    // 按提供商类型获取模板列表
-    getTemplatesByType(type) {
-      const templates = this.metadata['provider_group']?.metadata?.provider?.config_template || {};
-      const filtered = {};
-
-      for (const [name, template] of Object.entries(templates)) {
-        if (template.provider_type === type) {
-          filtered[name] = template;
-        }
-      }
-
-      return filtered;
-    },
-
-    // 获取提供商类型对应的图标
-    getProviderIcon(type) {
-      const icons = {
-        'OpenAI': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/openai.svg',
-        'Azure OpenAI': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/openai.svg',
-        'Whisper': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/openai.svg',
-        'xAI': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/xai.svg',
-        'Anthropic': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/anthropic.svg',
-        'Ollama': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/anthropic.svg',
-        'Gemini': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/gemini-color.svg',
-        'Gemini(OpenAI兼容)': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/gemini-color.svg',
-        'DeepSeek': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/deepseek.svg',
-        '智谱 AI': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/zhipu.svg',
-        '硅基流动': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/siliconcloud.svg',
-        'Kimi': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/kimi.svg',
-        'PPIO派欧云': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/ppio.svg',
-        'Dify': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/dify-color.svg',
-        '阿里云百炼': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/alibabacloud-color.svg',
-        'FastGPT': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/fastgpt-color.svg',
-        'LM Studio': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/lmstudio.svg',
-        'FishAudio': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/fishaudio.svg',
-        'Azure': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/azure.svg',
-        'MiniMax': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/minimax.svg',
-      };
-      for (const key in icons) {
-        if (type.startsWith(key)) {
-          return icons[key];
-        }
-      }
-      return ''
-    },
-
-    // 获取Tab类型的中文名称
-    getTabTypeName(tabType) {
-      const names = {
-        'chat_completion': '基本对话',
-        'speech_to_text': '语音转文本',
-        'text_to_speech': '文本转语音',
-        'embedding': 'Embedding'
-      };
-      return names[tabType] || tabType;
-    },
-
-    // 获取提供商简介
-    getProviderDescription(template, name) {
-      if (name == 'OpenAI') {
-        return `${template.type} 服务提供商。同时也支持所有兼容 OpenAI API 的模型提供商。`;
-      }
-      return `${template.type} 服务提供商`;
-    },
-
-    // 选择提供商模板
-    selectProviderTemplate(name) {
-      this.newSelectedProviderName = name;
-      this.showProviderCfg = true;
-      this.updatingMode = false;
-      this.newSelectedProviderConfig = JSON.parse(JSON.stringify(
-        this.metadata['provider_group']?.metadata?.provider?.config_template[name] || {}
-      ));
-      this.showAddProviderDialog = false;
-    },
-
-    // 废弃旧方法，保留为兼容
-    addFromDefaultConfigTmpl(index) {
-      this.selectProviderTemplate(index[0]);
-    },
-
-    configExistingProvider(provider) {
-      this.newSelectedProviderName = provider.id;
-      this.newSelectedProviderConfig = {};
-
-      // 比对默认配置模版，看看是否有更新
-      let templates = this.metadata['provider_group']?.metadata?.provider?.config_template || {};
-      let defaultConfig = {};
-      for (let key in templates) {
-        if (templates[key]?.type === provider.type) {
-          defaultConfig = templates[key];
-          break;
-        }
-      }
-
-      const mergeConfigWithOrder = (target, source, reference) => {
-        // 首先复制所有source中的属性到target
-        if (source && typeof source === 'object' && !Array.isArray(source)) {
-          for (let key in source) {
-            if (source.hasOwnProperty(key)) {
-              if (typeof source[key] === 'object' && source[key] !== null) {
-                target[key] = Array.isArray(source[key]) ? [...source[key]] : {...source[key]};
-              } else {
-                target[key] = source[key];
-              }
-            }
-          }
-        }
-
-        // 然后根据reference的结构添加或覆盖属性
-        for (let key in reference) {
-          if (typeof reference[key] === 'object' && reference[key] !== null) {
-            if (!(key in target)) {
-              target[key] = Array.isArray(reference[key]) ? [] : {};
-            }
-            mergeConfigWithOrder(
-              target[key],
-              source && source[key] ? source[key] : {},
-              reference[key]
-            );
-          } else if (!(key in target)) {
-            // 只有当target中不存在该键时才从reference复制
-            target[key] = reference[key];
-          }
-        }
-      };
-
-      if (defaultConfig) {
-        mergeConfigWithOrder(this.newSelectedProviderConfig, provider, defaultConfig);
-      }
-
-      this.showProviderCfg = true;
-      this.updatingMode = true;
-    },
-
-    newProvider() {
-      this.loading = true;
-      if (this.updatingMode) {
-        axios.post('/api/config/provider/update', {
-          id: this.newSelectedProviderName,
-          config: this.newSelectedProviderConfig
-        }).then((res) => {
-          this.loading = false;
-          this.showProviderCfg = false;
-          this.getConfig();
-          this.showSuccess(res.data.message || "更新成功!");
-        }).catch((err) => {
-          this.loading = false;
-          this.showError(err.response?.data?.message || err.message);
-        });
-        this.updatingMode = false;
-      } else {
-        axios.post('/api/config/provider/new', this.newSelectedProviderConfig).then((res) => {
-          this.loading = false;
-          this.showProviderCfg = false;
-          this.getConfig();
-          this.showSuccess(res.data.message || "添加成功!");
-        }).catch((err) => {
-          this.loading = false;
-          this.showError(err.response?.data?.message || err.message);
-        });
-      }
-    },
-
-    deleteProvider(provider) {
-      if (confirm(`确定要删除服务提供商 ${provider.id} 吗?`)) {
-        axios.post('/api/config/provider/delete', { id: provider.id }).then((res) => {
-          this.getConfig();
-          this.showSuccess(res.data.message || "删除成功!");
-        }).catch((err) => {
-          this.showError(err.response?.data?.message || err.message);
-        });
-      }
-    },
-
-    providerStatusChange(provider) {
-      provider.enable = !provider.enable; // 切换状态
-
-      axios.post('/api/config/provider/update', {
-        id: provider.id,
-        config: provider
-      }).then((res) => {
-        this.getConfig();
-        this.showSuccess(res.data.message || "状态更新成功!");
-      }).catch((err) => {
-        provider.enable = !provider.enable; // 发生错误时回滚状态
-        this.showError(err.response?.data?.message || err.message);
-      });
-    },
-
-    // 获取会话隔离配置状态
-    getSessionSeparationStatus() {
-      axios.get('/api/config/provider/get_session_seperate').then((res) => {
-        if (res.data && res.data.status === 'ok') {
-          this.sessionSeparationEnabled = res.data.data.enable;
-        }
-      }).catch((err) => {
-        this.showError(err.response?.data?.message || "获取会话隔离配置失败");
-      });
-    },
-
-    // 更新会话隔离配置
-    updateSessionSeparation() {
-      this.sessionSettingLoading = true;
-      axios.post('/api/config/provider/set_session_seperate', {
-        enable: this.sessionSeparationEnabled
-      }).then((res) => {
-        this.showSuccess(res.data.message || "会话隔离设置已更新");
-        this.sessionSettingLoading = false;
-      }).catch((err) => {
-        this.sessionSeparationEnabled = !this.sessionSeparationEnabled; // 发生错误时回滚状态
-        this.showError(err.response?.data?.message || err.message);
-        this.sessionSettingLoading = false;
-      });
-    },
-
-    showSuccess(message) {
-      this.save_message = message;
-      this.save_message_success = "success";
-      this.save_message_snack = true;
-    },
-
-    showError(message) {
-      this.save_message = message;
-      this.save_message_success = "error";
-      this.save_message_snack = true;
-    },
     
-    // 获取供应商状态
-    fetchProviderStatus() {
-      this.loadingStatus = true;
-      axios.get('/api/config/provider/check_status').then((res) => {
-        if (res.data && res.data.status === 'ok') {
-          this.providerStatuses = res.data.data || [];
-        } else {
-          this.showError(res.data?.message || "获取供应商状态失败");
-        }
-        this.loadingStatus = false;
-      }).catch((err) => {
-        this.loadingStatus = false;
-        this.showError(err.response?.data?.message || err.message);
-      });
+    // 否则使用映射关系
+    const mappedType = oldVersionProviderTypeMapping[provider.type];
+    return mappedType === activeProviderTypeTab.value;
+  });
+});
+
+const getEmptyText = () => {
+  if (activeProviderTypeTab.value === 'all') {
+    return "暂无服务提供商，点击 新增服务提供商 添加";
+  } else {
+    return `暂无${getTabTypeName(activeProviderTypeTab.value)}类型的服务提供商，点击 新增服务提供商 添加`;
+  }
+};
+
+const getTemplatesByType = (type) => {
+  const templates = metadata.value['provider_group']?.metadata?.provider?.config_template || {};
+  const filtered = {};
+
+  for (const [name, template] of Object.entries(templates)) {
+    if (template.provider_type === type) {
+      filtered[name] = template;
     }
   }
-}
+
+  return filtered;
+};
+
+const getProviderIcon = (type) => {
+  const icons = {
+    'OpenAI': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/openai.svg',
+    'Azure OpenAI': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/openai.svg',
+    'Whisper': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/openai.svg',
+    'xAI': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/xai.svg',
+    'Anthropic': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/anthropic.svg',
+    'Ollama': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/anthropic.svg',
+    'Gemini': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/gemini-color.svg',
+    'Gemini(OpenAI兼容)': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/gemini-color.svg',
+    'DeepSeek': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/deepseek.svg',
+    '智谱 AI': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/zhipu.svg',
+    '硅基流动': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/siliconcloud.svg',
+    'Kimi': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/kimi.svg',
+    'PPIO派欧云': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/ppio.svg',
+    'Dify': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/dify-color.svg',
+    '阿里云百炼': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/alibabacloud-color.svg',
+    'FastGPT': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/fastgpt-color.svg',
+    'LM Studio': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/lmstudio.svg',
+    'FishAudio': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/fishaudio.svg',
+    'Azure': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/azure.svg',
+    'MiniMax': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/minimax.svg',
+  };
+  for (const key in icons) {
+    if (type.startsWith(key)) {
+      return icons[key];
+    }
+  }
+  return ''
+};
+
+const getTabTypeName = (tabType) => {
+  const names = {
+    'chat_completion': '基本对话',
+    'speech_to_text': '语音转文本',
+    'text_to_speech': '文本转语音',
+    'embedding': 'Embedding'
+  };
+  return names[tabType] || tabType;
+};
+
+const getProviderDescription = (template, name) => {
+  if (name == 'OpenAI') {
+    return `${template.type} 服务提供商。同时也支持所有兼容 OpenAI API 的模型提供商。`;
+  }
+  return `${template.type} 服务提供商`;
+};
+
+const selectProviderTemplate = (name) => {
+  newSelectedProviderName.value = name;
+  showProviderCfg.value = true;
+  updatingMode.value = false;
+  newSelectedProviderConfig.value = JSON.parse(JSON.stringify(
+    metadata.value['provider_group']?.metadata?.provider?.config_template[name] || {}
+  ));
+  showAddProviderDialog.value = false;
+};
+
+const addFromDefaultConfigTmpl = (index) => {
+  selectProviderTemplate(index[0]);
+};
+
+const configExistingProvider = (provider) => {
+  newSelectedProviderName.value = provider.id;
+  newSelectedProviderConfig.value = {};
+
+  // 比对默认配置模版，看看是否有更新
+  let templates = metadata.value['provider_group']?.metadata?.provider?.config_template || {};
+  let defaultConfig = {};
+  for (let key in templates) {
+    if (templates[key]?.type === provider.type) {
+      defaultConfig = templates[key];
+      break;
+    }
+  }
+
+  const mergeConfigWithOrder = (target, source, reference) => {
+    // 首先复制所有source中的属性到target
+    if (source && typeof source === 'object' && !Array.isArray(source)) {
+      for (let key in source) {
+        if (source.hasOwnProperty(key)) {
+          if (typeof source[key] === 'object' && source[key] !== null) {
+            target[key] = Array.isArray(source[key]) ? [...source[key]] : {...source[key]};
+          } else {
+            target[key] = source[key];
+          }
+        }
+      }
+    }
+
+    // 然后根据reference的结构添加或覆盖属性
+    for (let key in reference) {
+      if (typeof reference[key] === 'object' && reference[key] !== null) {
+        if (!(key in target)) {
+          target[key] = Array.isArray(reference[key]) ? [] : {};
+        }
+        mergeConfigWithOrder(
+          target[key],
+          source && source[key] ? source[key] : {},
+          reference[key]
+        );
+      } else if (!(key in target)) {
+        // 只有当target中不存在该键时才从reference复制
+        target[key] = reference[key];
+      }
+    }
+  };
+
+  if (defaultConfig) {
+    mergeConfigWithOrder(newSelectedProviderConfig.value, provider, defaultConfig);
+  }
+
+  showProviderCfg.value = true;
+  updatingMode.value = true;
+};
+
+const newProvider = () => {
+  loading.value = true;
+  if (updatingMode.value) {
+    axios.post('/api/config/provider/update', {
+      id: newSelectedProviderName.value,
+      config: newSelectedProviderConfig.value
+    }).then((res) => {
+      loading.value = false;
+      showProviderCfg.value = false;
+      getConfig();
+      showSuccess(res.data.message || "更新成功!");
+    }).catch((err) => {
+      loading.value = false;
+      showError(err.response?.data?.message || err.message);
+    });
+    updatingMode.value = false;
+  } else {
+    axios.post('/api/config/provider/new', newSelectedProviderConfig.value).then((res) => {
+      loading.value = false;
+      showProviderCfg.value = false;
+      getConfig();
+      showSuccess(res.data.message || "添加成功!");
+    }).catch((err) => {
+      loading.value = false;
+      showError(err.response?.data?.message || err.message);
+    });
+  }
+};
+
+const deleteProvider = (provider) => {
+  if (confirm(`确定要删除服务提供商 ${provider.id} 吗?`)) {
+    axios.post('/api/config/provider/delete', { id: provider.id }).then((res) => {
+      getConfig();
+      showSuccess(res.data.message || "删除成功!");
+    }).catch((err) => {
+      showError(err.response?.data?.message || err.message);
+    });
+  }
+};
+
+const providerStatusChange = (provider) => {
+  provider.enable = !provider.enable; // 切换状态
+
+  axios.post('/api/config/provider/update', {
+    id: provider.id,
+    config: provider
+  }).then((res) => {
+    getConfig();
+    showSuccess(res.data.message || "状态更新成功!");
+  }).catch((err) => {
+    provider.enable = !provider.enable; // 发生错误时回滚状态
+    showError(err.response?.data?.message || err.message);
+  });
+};
+
+const getSessionSeparationStatus = () => {
+  axios.get('/api/config/provider/get_session_seperate').then((res) => {
+    if (res.data && res.data.status === 'ok') {
+      sessionSeparationEnabled.value = res.data.data.enable;
+    }
+  }).catch((err) => {
+    showError(err.response?.data?.message || "获取会话隔离配置失败");
+  });
+};
+
+const updateSessionSeparation = () => {
+  sessionSettingLoading.value = true;
+  axios.post('/api/config/provider/set_session_seperate', {
+    enable: sessionSeparationEnabled.value
+  }).then((res) => {
+    showSuccess(res.data.message || "会话隔离设置已更新");
+    sessionSettingLoading.value = false;
+  }).catch((err) => {
+    sessionSeparationEnabled.value = !sessionSeparationEnabled.value; // 发生错误时回滚状态
+    showError(err.response?.data?.message || err.message);
+    sessionSettingLoading.value = false;
+  });
+};
+
+const showSuccess = (message) => {
+  save_message.value = message;
+  save_message_success.value = "success";
+  save_message_snack.value = true;
+};
+
+const showError = (message) => {
+  save_message.value = message;
+  save_message_success.value = "error";
+  save_message_snack.value = true;
+};
+
+const fetchProviderStatus = () => {
+  loadingStatus.value = true;
+  axios.get('/api/config/provider/check_status').then((res) => {
+    if (res.data && res.data.status === 'ok') {
+      providerStatuses.value = res.data.data || [];
+    } else {
+      showError(res.data?.message || "获取供应商状态失败");
+    }
+    loadingStatus.value = false;
+  }).catch((err) => {
+    loadingStatus.value = false;
+    showError(err.response?.data?.message || err.message);
+  });
+};
+
+const getConfig = () => {
+  axios.get('/api/config/get').then((res) => {
+    config_data.value = res.data.data.config;
+    fetched.value = true;
+    metadata.value = res.data.data.metadata;
+  }).catch((err) => {
+    showError(err.response?.data?.message || err.message);
+  });
+};
+
+onMounted(() => {
+  getConfig();
+  getSessionSeparationStatus();
+});
 </script>
 
 <style scoped>

--- a/dashboard/src/views/Settings.vue
+++ b/dashboard/src/views/Settings.vue
@@ -1,69 +1,123 @@
 <template>
+  <div style="background-color: var(--v-theme-surface, #fff); padding: 8px; padding-left: 16px; border-radius: 8px; margin-bottom: 16px;">
+    <v-list lines="two">
+      <v-list-subheader>{{ t('settings.sections.network') }}</v-list-subheader>
 
-    <div style="background-color: var(--v-theme-surface, #fff); padding: 8px; padding-left: 16px; border-radius: 8px; margin-bottom: 16px;">
+      <v-list-item :subtitle="t('settings.network.githubProxyDesc')" :title="t('settings.network.githubProxy')">
+        <v-combobox 
+          variant="outlined" 
+          style="width: 100%; margin-top: 16px;" 
+          v-model="selectedGitHubProxy" 
+          :items="githubProxies"
+          :label="t('settings.network.selectGithubProxy')"
+        />
+      </v-list-item>
 
-        <v-list lines="two">
-            <v-list-subheader>网络</v-list-subheader>
+      <v-list-subheader>{{ t('settings.sections.system') }}</v-list-subheader>
 
-            <v-list-item subtitle="设置下载插件或者更新 AstrBot 时所用的 GitHub 加速地址。这在中国大陆的网络环境有效。可以自定义，输入结果实时生效。所有地址均不保证稳定性，如果在更新插件/项目时出现报错，请首先检查加速地址是否能正常使用。" title="GitHub 加速地址">
+      <v-list-item :subtitle="t('settings.system.restartDesc')" :title="t('settings.system.restart')">
+        <v-btn style="margin-top: 16px;" color="error" @click="restartAstrBot">
+          {{ t('settings.system.restartButton') }}
+        </v-btn>
+      </v-list-item>
 
-                <v-combobox variant="outlined" style="width: 100%; margin-top: 16px;" v-model="selectedGitHubProxy" :items="githubProxies"
-                    label="选择 GitHub 加速地址">
-                </v-combobox>
-            </v-list-item>
+      <v-list-subheader>{{ t('settings.sections.internationalization') }}</v-list-subheader>
 
-            <v-list-subheader>系统</v-list-subheader>
+      <v-list-item :subtitle="t('settings.i18n.desc')" :title="t('settings.i18n.title')">
+        <div style="margin-top: 16px; width: 100%;">
+          <div class="mb-3">
+            <span class="text-body-2 text-medium-emphasis">{{ t('settings.i18n.currentLanguage') }}: </span>
+            <v-chip size="small" color="primary" variant="flat">
+              {{ t(`language.${locale}`) }}
+            </v-chip>
+          </div>
+          
+          <v-select
+            v-model="locale"
+            :items="languages"
+            item-title="label"
+            item-value="value"
+            variant="outlined"
+            density="comfortable"
+            :label="t('settings.i18n.selectLanguage')"
+            @update:model-value="changeLanguage"
+            style="max-width: 300px;"
+          >
+            <template #selection="{ item }">
+              <div class="d-flex align-center">
+                <v-icon class="me-2">mdi-translate</v-icon>
+                {{ item.raw.label }}
+              </div>
+            </template>
+            <template #item="{ props, item }">
+              <v-list-item v-bind="props" :title="item.raw.label">
+                <template #prepend>
+                  <v-icon>mdi-translate</v-icon>
+                </template>
+              </v-list-item>
+            </template>
+          </v-select>
+        </div>
+      </v-list-item>
+    </v-list>
+  </div>
 
-            <v-list-item subtitle="重启 AstrBot" title="重启">
-                <v-btn style="margin-top: 16px;" color="error" @click="restartAstrBot">重启</v-btn>
-            </v-list-item>
-
-            
-
-
-        </v-list>
-
-    </div>
-
-    <WaitingForRestart ref="wfr"></WaitingForRestart>
-
-
+  <WaitingForRestart ref="wfr"></WaitingForRestart>
 </template>
 
 <script>
 import axios from 'axios';
 import WaitingForRestart from '@/components/shared/WaitingForRestart.vue';
+import { useI18n } from 'vue-i18n';
 
 export default {
-    components: {
-        WaitingForRestart,
-    },
-    data() {
-        return {
-            githubProxies: [
-                "https://gh.llkk.cc",
-                "https://gitproxy.click",
-            ],
-            selectedGitHubProxy: "",
-        }
-    },
-    methods: {
-        restartAstrBot() {
-            axios.post('/api/stat/restart-core').then(() => {
-                this.$refs.wfr.check();
-            })
-        }
-    },
-    mounted() {
-        this.selectedGitHubProxy = localStorage.getItem('selectedGitHubProxy') || "";
-    },
-    watch: {
-        selectedGitHubProxy: function (newVal, oldVal) {
-            if (!newVal) {
-                newVal = ""
-            }
-            localStorage.setItem('selectedGitHubProxy', newVal);
-        }
+  components: {
+    WaitingForRestart,
+  },
+  setup() {
+    const { t, locale } = useI18n();
+    return { t, locale };
+  },
+  data() {
+    return {
+      githubProxies: [
+        "https://gh.llkk.cc",
+        "https://gitproxy.click",
+      ],
+      selectedGitHubProxy: "",
+      languages: [
+        { value: 'zh-CN', label: '简体中文' },
+        { value: 'en-US', label: 'English' }
+      ]
     }
+  },
+  methods: {
+    restartAstrBot() {
+      axios.post('/api/stat/restart-core').then(() => {
+        this.$refs.wfr.check();
+      })
+    },
+    changeLanguage(lang) {
+      this.locale = lang;
+      localStorage.setItem('preferred-language', lang);
+    }
+  },
+  mounted() {
+    this.selectedGitHubProxy = localStorage.getItem('selectedGitHubProxy') || "";
+    
+    // 从本地存储恢复语言设置
+    const savedLang = localStorage.getItem('preferred-language');
+    if (savedLang && this.languages.some(lang => lang.value === savedLang)) {
+      this.locale = savedLang;
+    }
+  },
+  watch: {
+    selectedGitHubProxy: function (newVal, oldVal) {
+      if (!newVal) {
+        newVal = ""
+      }
+      localStorage.setItem('selectedGitHubProxy', newVal);
+    }
+  }
 }
 </script>

--- a/dashboard/src/views/authentication/auth/LoginPage.vue
+++ b/dashboard/src/views/authentication/auth/LoginPage.vue
@@ -5,11 +5,18 @@ import { onMounted, ref } from 'vue';
 import { useAuthStore } from '@/stores/auth';
 import { useRouter } from 'vue-router';
 import {useCustomizerStore} from "@/stores/customizer";
+import { useI18n } from 'vue-i18n';
 
+const { t, locale } = useI18n();
 const cardVisible = ref(false);
 const router = useRouter();
 const authStore = useAuthStore();
 const customizer = useCustomizerStore();
+
+const languages = [
+  { value: 'zh-CN', title: 'zh-CN' },
+  { value: 'en-US', title: 'en-US' }
+];
 
 // 主题切换函数
 function toggleTheme() {
@@ -18,7 +25,19 @@ function toggleTheme() {
   );
 }
 
+// 语言切换函数
+function changeLanguage(lang: string) {
+  locale.value = lang;
+  localStorage.setItem('preferred-language', lang);
+}
+
 onMounted(() => {
+  // 从本地存储恢复语言设置
+  const savedLang = localStorage.getItem('preferred-language');
+  if (savedLang && languages.some(lang => lang.value === savedLang)) {
+    locale.value = savedLang;
+  }
+  
   // 检查用户是否已登录，如果已登录则重定向
   if (authStore.has_token()) {
     router.push(authStore.returnUrl || '/');
@@ -36,8 +55,30 @@ onMounted(() => {
   <div v-if="useCustomizerStore().uiTheme==='PurpleTheme'" class="login-page-container">
     <div class="login-background"></div>
     
-    <!-- 主题切换按钮 -->
-    <div class="theme-toggle-container">
+    <!-- 控制按钮组 -->
+    <div class="controls-container">
+      <!-- 语言选择 -->
+      <v-select
+        v-model="locale"
+        :items="languages"
+        item-title="title"
+        item-value="value"
+        variant="outlined"
+        density="compact"
+        class="language-select"
+        hide-details
+        @update:model-value="changeLanguage"
+      >
+        <template #selection="{ item }">
+          <v-icon class="me-2">mdi-translate</v-icon>
+          {{ t(`language.${item.value}`) }}
+        </template>
+        <template #item="{ props, item }">
+          <v-list-item v-bind="props" :title="t(`language.${item.value}`)"></v-list-item>
+        </template>
+      </v-select>
+      
+      <!-- 主题切换按钮 -->
       <v-btn
         @click="toggleTheme"
         class="theme-toggle-btn"
@@ -49,7 +90,7 @@ onMounted(() => {
       >
         <v-icon size="20">mdi-weather-night</v-icon>
         <v-tooltip activator="parent" location="left">
-          切换到深色主题
+          {{ t('theme.switchToDark') }}
         </v-tooltip>
       </v-btn>
     </div>
@@ -73,8 +114,30 @@ onMounted(() => {
   <div v-else class="login-page-container-dark">
     <div class="login-background-dark"></div>
     
-    <!-- 主题切换按钮 -->
-    <div class="theme-toggle-container">
+    <!-- 控制按钮组 -->
+    <div class="controls-container">
+      <!-- 语言选择 -->
+      <v-select
+        v-model="locale"
+        :items="languages"
+        item-title="title"
+        item-value="value"
+        variant="outlined"
+        density="compact"
+        class="language-select language-select-dark"
+        hide-details
+        @update:model-value="changeLanguage"
+      >
+        <template #selection="{ item }">
+          <v-icon class="me-2">mdi-translate</v-icon>
+          {{ t(`language.${item.value}`) }}
+        </template>
+        <template #item="{ props, item }">
+          <v-list-item v-bind="props" :title="t(`language.${item.value}`)"></v-list-item>
+        </template>
+      </v-select>
+      
+      <!-- 主题切换按钮 -->
       <v-btn
         @click="toggleTheme"
         class="theme-toggle-btn"
@@ -86,7 +149,7 @@ onMounted(() => {
       >
         <v-icon size="20">mdi-white-balance-sunny</v-icon>
         <v-tooltip activator="parent" location="left">
-          切换到浅色主题
+          {{ t('theme.switchToLight') }}
         </v-tooltip>
       </v-btn>
     </div>
@@ -190,6 +253,50 @@ onMounted(() => {
   }
   100% {
     transform: rotate(360deg);
+  }
+}
+
+.controls-container {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.language-select {
+  min-width: 160px;
+  max-width: 200px;
+  
+  .v-field {
+    background: rgba(255, 255, 255, 0.9) !important;
+    border-radius: 8px !important;
+    
+    &:hover {
+      background: rgba(255, 255, 255, 0.95) !important;
+    }
+  }
+  
+  .v-field__input {
+    font-size: 0.875rem;
+    padding: 8px 12px;
+  }
+}
+
+.language-select-dark {
+  .v-field {
+    background: rgba(42, 39, 51, 0.9) !important;
+    color: #ffffff !important;
+    
+    &:hover {
+      background: rgba(42, 39, 51, 0.95) !important;
+    }
+  }
+  
+  .v-icon {
+    color: #ffffff !important;
   }
 }
 

--- a/dashboard/src/views/authentication/authForms/AuthLogin.vue
+++ b/dashboard/src/views/authentication/authForms/AuthLogin.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
-import {ref, useCssModule} from 'vue';
+import { ref } from 'vue';
 import { useAuthStore } from '@/stores/auth';
 import { Form } from 'vee-validate';
 import md5 from 'js-md5';
-import {useCustomizerStore} from "@/stores/customizer";
+import { useCustomizerStore } from "@/stores/customizer";
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
 
 const valid = ref(false);
 const show1 = ref(false);
@@ -14,7 +17,7 @@ const loading = ref(false);
 /* eslint-disable @typescript-eslint/no-explicit-any */
 async function validate(values: any, { setErrors }: any) {
   loading.value = true;
-  
+
   // md5加密
   let password_ = password.value;
   if (password.value != '') {
@@ -38,58 +41,23 @@ async function validate(values: any, { setErrors }: any) {
 
 <template>
   <Form @submit="validate" class="mt-4 login-form" v-slot="{ errors, isSubmitting }">
-    <v-text-field 
-      v-model="username" 
-      label="用户名" 
-      class="mb-6 input-field" 
-      required 
-      density="comfortable"
-      hide-details="auto" 
-      variant="outlined"
-      :style="{color: useCustomizerStore().uiTheme === 'PurpleTheme' ? '#000000dd' : '#ffffff'}"
-      prepend-inner-icon="mdi-account"
-      :disabled="loading"
-    ></v-text-field>
-    
-    <v-text-field 
-      v-model="password" 
-      label="密码" 
-      required 
-      density="comfortable" 
-      variant="outlined"
-      :style="{color: useCustomizerStore().uiTheme === 'PurpleTheme' ? '#000000dd' : '#ffffff'}"
-      hide-details="auto" 
-      :append-icon="show1 ? 'mdi-eye' : 'mdi-eye-off'"
-      :type="show1 ? 'text' : 'password'" 
-      @click:append="show1 = !show1" 
-      class="pwd-input"
-      prepend-inner-icon="mdi-lock"
-      :disabled="loading"
-    ></v-text-field>
-    
-    <v-btn 
-      color="secondary" 
-      :loading="isSubmitting || loading" 
-      block 
-      class="login-btn mt-8" 
-      variant="flat" 
-      size="large" 
-      :disabled="valid"
-      type="submit"
-      elevation="2"
+    <v-text-field v-model="username" :label="t('auth.username')" class="mb-6 input-field" required density="comfortable"
+      hide-details="auto" variant="outlined"
+      :style="{ color: useCustomizerStore().uiTheme === 'PurpleTheme' ? '#000000dd' : '#ffffff' }"
+      prepend-inner-icon="mdi-account" :disabled="loading"></v-text-field>
 
-    >
-      <span class="login-btn-text">登录</span>
+    <v-text-field v-model="password" :label="t('auth.password')" required density="comfortable" variant="outlined"
+      :style="{ color: useCustomizerStore().uiTheme === 'PurpleTheme' ? '#000000dd' : '#ffffff' }" hide-details="auto"
+      :append-icon="show1 ? 'mdi-eye' : 'mdi-eye-off'" :type="show1 ? 'text' : 'password'"
+      @click:append="show1 = !show1" class="pwd-input" prepend-inner-icon="mdi-lock" :disabled="loading"></v-text-field>
+
+    <v-btn color="secondary" :loading="isSubmitting || loading" block class="login-btn mt-8" variant="flat" size="large"
+      :disabled="valid" type="submit" elevation="2">
+      <span class="login-btn-text">{{ t('auth.login') }}</span>
     </v-btn>
-    
+
     <div v-if="errors.apiError" class="mt-4 error-container">
-      <v-alert 
-        color="error" 
-        variant="tonal" 
-        density="comfortable"
-        icon="mdi-alert-circle"
-        border="start"
-      >
+      <v-alert color="error" variant="tonal" density="comfortable" icon="mdi-alert-circle" border="start">
         {{ errors.apiError }}
       </v-alert>
     </div>
@@ -102,24 +70,25 @@ async function validate(values: any, { setErrors }: any) {
     font-weight: 500;
   }
 
-  .input-field, .pwd-input {
+  .input-field,
+  .pwd-input {
     .v-field__field {
       padding-top: 5px;
       padding-bottom: 5px;
     }
-    
+
     .v-field__outline {
       opacity: 0.7;
     }
-    
+
     &:hover .v-field__outline {
       opacity: 0.9;
     }
-    
+
     .v-field--focused .v-field__outline {
       opacity: 1;
     }
-    
+
     .v-field__prepend-inner {
       padding-right: 8px;
       opacity: 0.7;
@@ -135,36 +104,36 @@ async function validate(values: any, { setErrors }: any) {
       top: 50%;
       transform: translateY(-50%);
       opacity: 0.7;
-      
+
       &:hover {
         opacity: 1;
       }
     }
   }
-  
+
   .login-btn {
     margin-top: 12px;
     height: 48px;
     transition: all 0.3s ease;
     letter-spacing: 0.5px;
     border-radius: 8px !important;
-    
+
     &:hover {
       transform: translateY(-2px);
       box-shadow: 0 5px 15px rgba(94, 53, 177, 0.2) !important;
     }
-    
+
     .login-btn-text {
       font-size: 1.05rem;
       font-weight: 500;
     }
   }
-  
+
   .hint-text {
     color: var(--v-theme-secondaryText);
     padding-left: 5px;
   }
-  
+
   .error-container {
     .v-alert {
       border-left-width: 4px !important;

--- a/dashboard/src/views/dashboards/default/DefaultDashboard.vue
+++ b/dashboard/src/views/dashboards/default/DefaultDashboard.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="dashboard-container">
     <div class="dashboard-header">
-      <h1 class="dashboard-title">控制台</h1>
-      <div class="dashboard-subtitle">实时监控和统计数据</div>
+      <h1 class="dashboard-title">{{ t('dashboard.title') }}</h1>
+      <div class="dashboard-subtitle">{{ t('dashboard.subtitle') }}</div>
     </div>
     
     <v-slide-y-transition>
@@ -58,7 +58,7 @@
     </v-row>
     <div class="dashboard-footer">
       <v-chip size="small" color="primary" variant="flat" prepend-icon="mdi-refresh">
-        最后更新: {{ lastUpdated }}
+        {{ t('dashboard.lastUpdated') }}: {{ lastUpdated }}
       </v-chip>
       <v-btn 
         icon="mdi-refresh" 
@@ -82,6 +82,7 @@ import MemoryUsage from './components/MemoryUsage.vue';
 import MessageStat from './components/MessageStat.vue';
 import PlatformStat from './components/PlatformStat.vue';
 import axios from 'axios';
+import { useI18n } from 'vue-i18n';
 
 export default {
   name: 'DefaultDashboard',
@@ -93,17 +94,22 @@ export default {
     MessageStat,
     PlatformStat,
   },
+  setup() {
+    const { t } = useI18n();
+    return { t };
+  },
   data: () => ({
     stat: {},
     noticeTitle: '',
     noticeContent: '',
     noticeType: '',
-    lastUpdated: '加载中...',
+    lastUpdated: '',
     refreshInterval: null,
     isRefreshing: false
   }),
 
   mounted() {
+    this.lastUpdated = this.t('dashboard.loading');
     this.fetchData();
     this.fetchNotice();
     

--- a/dashboard/src/views/dashboards/default/components/MemoryUsage.vue
+++ b/dashboard/src/views/dashboards/default/components/MemoryUsage.vue
@@ -7,7 +7,7 @@
         </div>
         
         <div class="stat-content">
-          <div class="stat-title">内存占用</div>
+          <div class="stat-title">{{ t('dashboard.stats.memoryUsage') }}</div>
           <div class="stat-value-wrapper">
             <h2 class="stat-value">{{ stat.memory?.process || 0 }} <span class="memory-unit">MiB / {{ stat.memory?.system || 0 }} MiB</span></h2>
             <v-chip :color="memoryStatus.color" size="x-small" class="status-chip">
@@ -19,7 +19,7 @@
       
       <div class="metrics-container">
         <div class="metric-item">
-          <div class="metric-label">CPU 负载</div>
+          <div class="metric-label">{{ t('dashboard.stats.cpuLoad') }}</div>
           <div class="metric-value">{{ stat.cpu_percent || '0' }}%</div>
         </div>
       </div>
@@ -28,9 +28,15 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
   name: 'MemoryUsage',
   props: ['stat'],
+  setup() {
+    const { t } = useI18n();
+    return { t };
+  },
   computed: {
     memoryPercentage() {
       if (!this.stat.memory || !this.stat.memory.process || !this.stat.memory.system) return 0;
@@ -39,11 +45,11 @@ export default {
     memoryStatus() {
       const percentage = this.memoryPercentage;
       if (percentage < 30) {
-        return { color: 'success', label: '良好' };
+        return { color: 'success', label: this.t('dashboard.stats.status.good') };
       } else if (percentage < 70) {
-        return { color: 'warning', label: '正常' };
+        return { color: 'warning', label: this.t('dashboard.stats.status.normal') };
       } else {
-        return { color: 'error', label: '偏高' };
+        return { color: 'error', label: this.t('dashboard.stats.status.high') };
       }
     }
   }

--- a/dashboard/src/views/dashboards/default/components/MessageStat.vue
+++ b/dashboard/src/views/dashboards/default/components/MessageStat.vue
@@ -3,8 +3,8 @@
     <v-card-text>
       <div class="chart-header">
         <div>
-          <div class="chart-title">消息趋势分析</div>
-          <div class="chart-subtitle">跟踪消息数量随时间的变化</div>
+          <div class="chart-title">{{ t('dashboard.messageChart.title') }}</div>
+          <div class="chart-subtitle">{{ t('dashboard.messageChart.subtitle') }}</div>
         </div>
         
         <v-select 
@@ -32,17 +32,17 @@
       
       <div class="chart-stats">
         <div class="stat-box">
-          <div class="stat-label">总消息数</div>
+          <div class="stat-label">{{ t('dashboard.messageChart.totalMessages') }}</div>
           <div class="stat-number">{{ totalMessages }}</div>
         </div>
         
         <div class="stat-box">
-          <div class="stat-label">平均每天</div>
+          <div class="stat-label">{{ t('dashboard.messageChart.dailyAverage') }}</div>
           <div class="stat-number">{{ dailyAverage }}</div>
         </div>
         
         <div class="stat-box" :class="{'trend-up': growthRate > 0, 'trend-down': growthRate < 0}">
-          <div class="stat-label">增长率</div>
+          <div class="stat-label">{{ t('dashboard.messageChart.growthRate') }}</div>
           <div class="stat-number">
             <v-icon size="small" :icon="growthRate > 0 ? 'mdi-arrow-up' : 'mdi-arrow-down'"></v-icon>
             {{ Math.abs(growthRate) }}%
@@ -53,7 +53,7 @@
       <div class="chart-container">
         <div v-if="loading" class="loading-overlay">
           <v-progress-circular indeterminate color="primary"></v-progress-circular>
-          <div class="loading-text">加载中...</div>
+          <div class="loading-text">{{ t('dashboard.loading') }}</div>
         </div>
         <apexchart 
           type="area" 
@@ -70,135 +70,151 @@
 <script>
 import axios from 'axios';
 import {useCustomizerStore} from "@/stores/customizer";
+import { useI18n } from 'vue-i18n';
 
 export default {
   name: 'MessageStat',
   props: ['stat'],
-  data: () => ({
-    totalMessages: '0',
-    dailyAverage: '0',
-    growthRate: 0,
-    loading: false,
-    selectedTimeRange: { label: '过去 1 天', value: 86400 },
-    timeRanges: [
-      { label: '过去 1 天', value: 86400 },
-      { label: '过去 3 天', value: 259200 },
-      { label: '过去 7 天', value: 604800 },
-      { label: '过去 30 天', value: 2592000 },
-    ],
-    
-    chartOptions: {
-      chart: {
-        type: 'area',
-        height: 400,
-        fontFamily: `inherit`,
-        foreColor: '#a1aab2',
-        toolbar: {
-          show: true,
-          tools: {
-            download: true,
-            selection: false,
-            zoom: true,
-            zoomin: true,
-            zoomout: true,
-            pan: true,
+  setup() {
+    const { t } = useI18n();
+    return { t };
+  },
+  data() {
+    return {
+      totalMessages: '0',
+      dailyAverage: '0',
+      growthRate: 0,
+      loading: false,
+      selectedTimeRange: { label: '', value: 86400 },
+      timeRanges: [],
+      
+      chartOptions: {
+        chart: {
+          type: 'area',
+          height: 400,
+          fontFamily: `inherit`,
+          foreColor: '#a1aab2',
+          toolbar: {
+            show: true,
+            tools: {
+              download: true,
+              selection: false,
+              zoom: true,
+              zoomin: true,
+              zoomout: true,
+              pan: true,
+            },
+          },
+          animations: {
+            enabled: true,
+            easing: 'easeinout',
+            speed: 800,
           },
         },
-        animations: {
-          enabled: true,
-          easing: 'easeinout',
-          speed: 800,
+        colors: ['#5e35b1'],
+        fill: {
+          type: 'solid',
+          opacity: 0.3,
         },
-      },
-      colors: ['#5e35b1'],
-      fill: {
-        type: 'solid',
-        opacity: 0.3,
-      },
-      dataLabels: {
-        enabled: false
-      },
-      stroke: {
-        curve: 'smooth',
-        width: 2
-      },
-      markers: {
-        size: 3,
-        strokeWidth: 2,
-        hover: {
-          size: 5,
-        }
-      },
-      tooltip: {
-        theme: useCustomizerStore().uiTheme==='PurpleTheme' ? 'light' : 'dark',
-        x: {
-          format: 'yyyy-MM-dd HH:mm'
+        dataLabels: {
+          enabled: false
         },
-        y: {
-          title: {
-            formatter: () => '消息条数 '
-          }
+        stroke: {
+          curve: 'smooth',
+          width: 2
         },
-      },
-      xaxis: {
-        type: 'datetime',
-        title: {
-          text: '时间'
-        },
-        labels: {
-          formatter: function (value) {
-            return new Date(value).toLocaleString('zh-CN', {
-              month: 'short',
-              day: 'numeric',
-              hour: '2-digit',
-              minute: '2-digit'
-            });
+        markers: {
+          size: 3,
+          strokeWidth: 2,
+          hover: {
+            size: 5,
           }
         },
         tooltip: {
-          enabled: false
+          theme: useCustomizerStore().uiTheme==='PurpleTheme' ? 'light' : 'dark',
+          x: {
+            format: 'yyyy-MM-dd HH:mm'
+          },
+          y: {
+            title: {
+              formatter: () => this.t('dashboard.messageChart.messageCount') + ' '
+            }
+          },
+        },
+        xaxis: {
+          type: 'datetime',
+          title: {
+            text: this.t('dashboard.messageChart.time')
+          },
+          labels: {
+            formatter: function (value) {
+              return new Date(value).toLocaleString('zh-CN', {
+                month: 'short',
+                day: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit'
+              });
+            }
+          },
+          tooltip: {
+            enabled: false
+          }
+        },
+        yaxis: {
+          title: {
+            text: this.t('dashboard.messageChart.messageCount')
+          },
+          min: function(min) {
+            return min < 10 ? 0 : Math.floor(min * 0.8);
+          },
+        },
+        grid: {
+          borderColor: "gray100",
+          row: {
+            colors: ['transparent', 'transparent'],
+            opacity: 0.2
+          },
+          column: {
+            colors: ['transparent', 'transparent'],
+          },
+          padding: {
+            left: 0,
+            right: 0
+          }
         }
       },
-      yaxis: {
-        title: {
-          text: '消息条数'
-        },
-        min: function(min) {
-          return min < 10 ? 0 : Math.floor(min * 0.8);
-        },
-      },
-      grid: {
-        borderColor: "gray100",
-        row: {
-          colors: ['transparent', 'transparent'],
-          opacity: 0.2
-        },
-        column: {
-          colors: ['transparent', 'transparent'],
-        },
-        padding: {
-          left: 0,
-          right: 0
+      
+      chartSeries: [
+        {
+          name: '',
+          data: []
         }
-      }
-    },
-    
-    chartSeries: [
-      {
-        name: '消息条数',
-        data: []
-      }
-    ],
-    
-    messageTimeSeries: []
-  }),
-
+      ],
+      
+      messageTimeSeries: []
+    }
+  },
+  
   mounted() {
-    // 初始加载
+    this.initializeI18n();
     this.fetchMessageSeries();
   },
-
+  
   methods: {
+    initializeI18n() {
+      this.selectedTimeRange = { 
+        label: this.t('dashboard.messageChart.timeRanges.1day'), 
+        value: 86400 
+      };
+      this.timeRanges = [
+        { label: this.t('dashboard.messageChart.timeRanges.1day'), value: 86400 },
+        { label: this.t('dashboard.messageChart.timeRanges.3days'), value: 259200 },
+        { label: this.t('dashboard.messageChart.timeRanges.7days'), value: 604800 },
+        { label: this.t('dashboard.messageChart.timeRanges.30days'), value: 2592000 },
+      ];
+      this.chartSeries[0].name = this.t('dashboard.messageChart.messageCount');
+    },
+    
     formatNumber(num) {
       return new Intl.NumberFormat('zh-CN').format(num);
     },

--- a/dashboard/src/views/dashboards/default/components/OnlinePlatform.vue
+++ b/dashboard/src/views/dashboards/default/components/OnlinePlatform.vue
@@ -7,11 +7,11 @@
         </div>
         
         <div class="stat-content">
-          <div class="stat-title">消息平台</div>
+          <div class="stat-title">{{ t('dashboard.stats.onlinePlatforms') }}</div>
           <div class="stat-value-wrapper">
             <h2 class="stat-value">{{ stat.platform_count || 0 }}</h2>
           </div>
-          <div class="stat-subtitle">已连接的消息平台数量</div>
+          <div class="stat-subtitle">{{ t('dashboard.stats.onlinePlatformsDesc') }}</div>
         </div>
       </div>
     </v-card-text>
@@ -19,9 +19,15 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
   name: 'OnlinePlatform',
-  props: ['stat']
+  props: ['stat'],
+  setup() {
+    const { t } = useI18n();
+    return { t };
+  }
 };
 </script>
 

--- a/dashboard/src/views/dashboards/default/components/OnlineTime.vue
+++ b/dashboard/src/views/dashboards/default/components/OnlineTime.vue
@@ -8,15 +8,15 @@
           </div>
           
           <div class="stat-content">
-            <div class="stat-title">运行时间</div>
-            <h3 class="uptime-value">{{ stat.running || '加载中...' }}</h3>
+            <div class="stat-title">{{ t('dashboard.stats.runningTime') }}</div>
+            <h3 class="uptime-value">{{ stat.running || t('dashboard.loading') }}</h3>
           </div>
           
           <v-spacer></v-spacer>
           
           <div class="uptime-status">
             <v-icon icon="mdi-circle" size="10" color="success" class="blink-animation"></v-icon>
-            <span class="status-text">在线</span>
+            <span class="status-text">{{ t('dashboard.stats.online') }}</span>
           </div>
         </div>
       </v-card-text>
@@ -30,7 +30,7 @@
           </div>
           
           <div class="stat-content">
-            <div class="stat-title">内存占用</div>
+            <div class="stat-title">{{ t('dashboard.stats.memoryUsage') }}</div>
             <div class="memory-values">
               <h3 class="memory-value">{{ stat.memory?.process || 0 }} <span class="memory-unit">MiB</span></h3>
               <span class="memory-separator">/</span>
@@ -53,13 +53,19 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
   name: 'OnlineTime',
   props: ['stat'],
+  setup() {
+    const { t } = useI18n();
+    return { t };
+  },
   data: () => ({
     stat: {
       memory: { process: 0, system: 0 },
-      running: "加载中...",
+      running: "",
     },
   }),
   computed: {

--- a/dashboard/src/views/dashboards/default/components/PlatformStat.vue
+++ b/dashboard/src/views/dashboards/default/components/PlatformStat.vue
@@ -3,8 +3,8 @@
     <v-card-text>
       <div class="platform-header">
         <div>
-          <div class="platform-title">平台消息统计</div>
-          <div class="platform-subtitle">各平台消息数量分布</div>
+          <div class="platform-title">{{ t('dashboard.platform.title') }}</div>
+          <div class="platform-subtitle">{{ t('dashboard.platform.subtitle') }}</div>
         </div>
       </div>
       
@@ -27,7 +27,7 @@
             <template v-slot:append>
               <div class="platform-count">
                 <span class="count-value">{{ platform.count }}</span>
-                <span class="count-label">条</span>
+                <span class="count-label">{{ t('dashboard.platform.messages') }}</span>
               </div>
             </template>
           </v-list-item>
@@ -35,17 +35,17 @@
         
         <div class="platform-stats-summary">
           <div class="platform-stat-item">
-            <div class="stat-label">平台数</div>
+            <div class="stat-label">{{ t('dashboard.platform.platformCount') }}</div>
             <div class="stat-value">{{ platforms.length }}</div>
           </div>
           <v-divider vertical></v-divider>
           <div class="platform-stat-item">
-            <div class="stat-label">最活跃</div>
+            <div class="stat-label">{{ t('dashboard.platform.mostActive') }}</div>
             <div class="stat-value">{{ mostActivePlatform }}</div>
           </div>
           <v-divider vertical></v-divider>
           <div class="platform-stat-item">
-            <div class="stat-label">总消息占比</div>
+            <div class="stat-label">{{ t('dashboard.platform.totalPercent') }}</div>
             <div class="stat-value">{{ topPlatformPercentage }}%</div>
           </div>
         </div>
@@ -65,16 +65,22 @@
       
       <div v-else class="no-data">
         <v-icon icon="mdi-information-outline" size="40" color="grey-lighten-1"></v-icon>
-        <div class="no-data-text">暂无平台数据</div>
+        <div class="no-data-text">{{ t('dashboard.noData') }}</div>
       </div>
     </v-card-text>
   </v-card>
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
   name: 'PlatformStat',
   props: ['stat'],
+  setup() {
+    const { t } = useI18n();
+    return { t };
+  },
   data: () => ({
     platforms: []
   }),

--- a/dashboard/src/views/dashboards/default/components/RunningTime.vue
+++ b/dashboard/src/views/dashboards/default/components/RunningTime.vue
@@ -7,11 +7,11 @@
         </div>
         
         <div class="stat-content">
-          <div class="stat-title">运行时间</div>
+          <div class="stat-title">{{ t('dashboard.stats.runningTime') }}</div>
           <div class="stat-value-wrapper">
             <h2 class="stat-value">{{ formattedTime }}</h2>
           </div>
-          <div class="stat-subtitle">AstrBot 运行时间</div>
+          <div class="stat-subtitle">{{ t('dashboard.stats.runningTimeDesc') }}</div>
         </div>
       </div>
     </v-card-text>
@@ -19,12 +19,18 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
   name: 'RunningTime',
   props: ['stat'],
+  setup() {
+    const { t } = useI18n();
+    return { t };
+  },
   computed: {
     formattedTime() {
-      return this.stat?.running || '加载中...';
+      return this.stat?.running || this.t('dashboard.loading');
     }
   }
 };

--- a/dashboard/src/views/dashboards/default/components/TotalMessage.vue
+++ b/dashboard/src/views/dashboards/default/components/TotalMessage.vue
@@ -7,14 +7,14 @@
         </div>
         
         <div class="stat-content">
-          <div class="stat-title">消息总数</div>
+          <div class="stat-title">{{ t('dashboard.stats.totalMessages') }}</div>
           <div class="stat-value-wrapper">
             <h2 class="stat-value">{{ formattedCount }}</h2>
             <v-chip v-if="stat.daily_increase" class="trend-chip" size="x-small" color="success">
               +{{ stat.daily_increase }}
             </v-chip>
           </div>
-          <div class="stat-subtitle">所有平台发送的消息总计</div>
+          <div class="stat-subtitle">{{ t('dashboard.stats.totalMessagesDesc') }}</div>
         </div>
       </div>
     </v-card-text>
@@ -22,9 +22,15 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
   name: 'TotalMessage',
   props: ['stat'],
+  setup() {
+    const { t } = useI18n();
+    return { t };
+  },
   computed: {
     formattedCount() {
       const count = this.stat?.message_count;


### PR DESCRIPTION
### Motivation

This PR aims to make AstrBot more international.

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是将 pull request 总结翻译成中文的结果：

## Sourcery 总结

通过添加 vue-i18n 支持、将硬编码文本替换为翻译键以及提供运行时语言切换和持久性，在 AstrBot 仪表板中集成国际化。

新特性：
- 添加 vue-i18n 插件，其中包含中文和英文的语言环境资源文件
- 将所有视图和组件中的静态 UI 标签和消息替换为 t(…) 翻译调用
- 在“设置”和“登录”页面以及应用程序初始化时公开语言选择器
- 在 localStorage 中持久保存首选语言，并在启动时自动检测浏览器语言环境

增强功能：
- 重构组件和脚本以使用 Composition API 的 useI18n hook
- 将语言环境回退配置为英语，以处理缺失的翻译

构建：
- 添加 "vue-i18n" 依赖项并在 main.ts 中初始化它

<details>
<summary>Original summary in English</summary>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

将国际化集成到 AstrBot 仪表板中，通过添加 vue-i18n 支持、翻译所有 UI 文本，并启用具有持久性和回退处理的运行时语言选择。

新特性：
- 添加包含中文 (zh-CN) 和英文 (en-US) 区域设置资源文件的 vue-i18n 插件
- 在“设置”和“登录”页面中公开语言选择器，并在启动时检测语言
- 在 localStorage 中持久保存用户的首选语言并自动检测浏览器区域设置

增强功能：
- 将所有硬编码的 UI 字符串替换为跨视图和组件的 t() 翻译调用
- 重构组件以使用 Composition API 的 useI18n hook 进行翻译
- 为缺少的翻译配置英语回退区域设置

构建：
- 添加 vue-i18n 依赖项并在 main.ts 中初始化 i18n 插件

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate internationalization into the AstrBot dashboard by adding vue-i18n support, translating all UI text, and enabling runtime language selection with persistence and fallback handling

New Features:
- Add vue-i18n plugin with Chinese (zh-CN) and English (en-US) locale resource files
- Expose language selector in Settings and Login pages and detect language on startup
- Persist user’s preferred language in localStorage and auto-detect browser locale

Enhancements:
- Replace all hard-coded UI strings across views and components with t() translation calls
- Refactor components to use the Composition API’s useI18n hook for translations
- Configure English fallback locale for missing translations

Build:
- Add vue-i18n dependency and initialize the i18n plugin in main.ts

</details>

</details>