### PR TITLE
feat:发送消息前的At和Reply改用概率添加，同时过滤掉不支持的组件

### DIFF
--- a/astrbot/core/config/astrbot_config.py
+++ b/astrbot/core/config/astrbot_config.py
@@ -89,6 +89,15 @@ class AstrBotConfig(dict):
         # 创建一个新的有序字典以保持参考配置的顺序
         new_conf = {}
 
+        # 向后兼容性处理
+        if path == "platform_settings":
+            for key in ["reply_with_mention", "reply_with_quote"]:
+                if key in conf and isinstance(conf[key], bool):
+                    # 将布尔值转换为概率值
+                    conf[key] = 1.0 if conf[key] else 0.0
+                    has_new = True
+                    logger.info(f"配置项 {key} 已从布尔值转换为概率值: {conf[key]}")
+
         # 先按照参考配置的顺序添加配置项
         for key, value in refer_conf.items():
             if key not in conf:

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -25,8 +25,8 @@ DEFAULT_CONFIG = {
         "id_whitelist_log": True,
         "wl_ignore_admin_on_group": True,
         "wl_ignore_admin_on_friend": True,
-        "reply_with_mention": False,
-        "reply_with_quote": False,
+        "reply_with_mention": 0.0,
+        "reply_with_quote": 0.0,
         "path_mapping": [],
         "segmented_reply": {
             "enable": False,
@@ -466,13 +466,13 @@ CONFIG_METADATA_2 = {
                     },
                     "reply_with_mention": {
                         "description": "回复时 @ 发送者",
-                        "type": "bool",
-                        "hint": "启用后，机器人回复消息时会 @ 发送者。实际效果以具体的平台适配器为准。",
+                        "type": "float",
+                        "hint": "启用后，机器人回复消息时会 @ 发送者。0.0-1.0 之间的概率值，0.0 表示从不，1.0 表示总是。实际效果以具体的平台适配器为准。",
                     },
                     "reply_with_quote": {
                         "description": "回复时引用消息",
-                        "type": "bool",
-                        "hint": "启用后，机器人回复消息时会引用原消息。实际效果以具体的平台适配器为准。",
+                        "type": "float",
+                        "hint": "启用后，机器人回复消息时会引用原消息。0.0-1.0 之间的概率值，0.0 表示从不，1.0 表示总是。实际效果以具体的平台适配器为准。",
                     },
                     "path_mapping": {
                         "description": "路径映射",

--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -5,7 +5,7 @@ import traceback
 from typing import AsyncGenerator, Union
 
 from astrbot.core import html_renderer, logger, file_token_service
-from astrbot.core.message.components import At, Face, File, Image, Node, Plain, Record, Reply
+from astrbot.core.message.components import At, Face, Image, Node, Plain, Record, Reply
 from astrbot.core.message.message_event_result import ResultContentType
 from astrbot.core.platform.astr_message_event import AstrMessageEvent
 from astrbot.core.platform.message_type import MessageType
@@ -294,5 +294,4 @@ class ResultDecorateStage(Stage):
 
                 # 引用回复
                 if random.random() < self.reply_with_quote:
-                    if not any(isinstance(item, File) for item in result.chain):
                         result.chain.insert(0, Reply(id=event.message_obj.message_id))


### PR DESCRIPTION
### Motivation

- 目前在发送消息前给消息附加的At组件或Reply组件只能设置为True/False，一些用户希望改成按概率附加，从而达到更拟人的效果
- At、Reply组件不能和Record、Video、File等组件放在一个消息链里，否则会导致语音、视频、文件等组件发不出来，要增加一个过滤机制

### Modifications

- 概率控制：将 reply_with_mention 和 reply_with_quote 从布尔值改为支持 0.0~1.0 的概率值，允许控制回复行为触发概率。
- 兼容处理：若旧配置仍为布尔值，将自动转换为对应的概率值（True → 1.0，False → 0.0）。
- 优化触发条件：避免私聊触发 @，防止重复 @bot，仅在消息链存在Plain、Face、Image、At时考虑插入At、Reply组件。

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 总结

启用概率性插入提及（At）和引用回复组件，并针对不支持的消息链进行过滤，以及向后兼容布尔配置。

新特性：
- 支持基于概率的提及和引用回复触发器，而不是布尔标志

增强功能：
- 自动将旧的布尔回复设置转换为等效的浮点概率
- 过滤 At/Reply 注入到仅包含受支持组件的消息，并防止重复或私聊提及

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

启用概率性插入提及和引用回复组件，过滤不支持的消息链，并保持与布尔配置的向后兼容性

新特性：
- 支持基于概率的 'reply_with_mention' 和 'reply_with_quote' 触发器

Bug 修复：
- 阻止提及/引用注入阻止语音、视频和文件组件，并避免私有或重复的机器人提及

增强功能：
- 自动将旧的布尔回复配置转换为等效的概率值
- 限制提及/引用插入到包含支持的组件类型的消息链

文档：
- 更新默认配置模式和提示，以使用浮点概率进行提及和引用设置

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable probabilistic insertion of mention and quote reply components, filter unsupported message chains, and maintain backward compatibility with boolean configs

New Features:
- Support probability-based 'reply_with_mention' and 'reply_with_quote' triggers

Bug Fixes:
- Prevent mention/quote injections from blocking voice, video, and file components and avoid private or duplicate bot mentions

Enhancements:
- Auto-convert legacy boolean reply configs to equivalent probability values
- Restrict mention/quote insertion to message chains containing supported component types

Documentation:
- Update default config schema and hints to use float probabilities for mention and quote settings

</details>

</details>