### PR TITLE
feat: wechatpadpro 触发tts时 添加对mp3格式音频支持

### DIFF
--- a/astrbot/core/platform/sources/wechatpadpro/wechatpadpro_message_event.py
+++ b/astrbot/core/platform/sources/wechatpadpro/wechatpadpro_message_event.py
@@ -17,7 +17,7 @@ from astrbot.core.message.message_event_result import MessageChain
 from astrbot.core.platform.astr_message_event import AstrMessageEvent
 from astrbot.core.platform.astrbot_message import AstrBotMessage, MessageType
 from astrbot.core.platform.platform_metadata import PlatformMetadata
-from astrbot.core.utils.tencent_record_helper import wav_to_tencent_silk_base64
+from astrbot.core.utils.tencent_record_helper import audio_to_tencent_silk_base64
 
 if TYPE_CHECKING:
     from .wechatpadpro_adapter import WeChatPadProAdapter
@@ -109,7 +109,7 @@ class WeChatPadProMessageEvent(AstrMessageEvent):
     async def _send_voice(self, session: aiohttp.ClientSession, comp: Record):
         record_path = await comp.convert_to_file_path()
         # 默认已经存在 data/temp 中
-        b64, duration = await wav_to_tencent_silk_base64(record_path)
+        b64, duration = await audio_to_tencent_silk_base64(record_path)
         payload = {
             "ToUserName": self.session_id,
             "VoiceData": b64,


### PR DESCRIPTION
解决了 #1616

### Motivation
多个tts服务商 提供的音频除了wav 还有mp3,  wechatpadpro 添加发送语音的mp3适配

### Modifications
如果文件不是wav 默认走mp3转wav逻辑

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [ ] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] 👀 我的更改经过良好的测试
- [ ] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [ ] 😮 我的更改没有引入恶意代码
