### PR TITLE
fix: 代办提醒发送错误

### DIFF
--- a/astrbot/core/platform/sources/telegram/tg_adapter.py
+++ b/astrbot/core/platform/sources/telegram/tg_adapter.py
@@ -85,10 +85,23 @@ class TelegramPlatformAdapter(Platform):
 
     @override
     async def send_by_session(
-        self, session: MessageSesion, message_chain: MessageChain
+            self, session: MessageSesion, message_chain: MessageChain
     ):
         from_username = session.session_id
-        await TelegramPlatformEvent.send_with_client(
+
+        message_obj = AstrBotMessage()
+        message_obj.type = session.message_type
+        message_obj.message = message_chain.get_plain_text()
+
+        telegram_event = TelegramPlatformEvent(
+            message_str=message_chain.get_plain_text(),
+            message_obj=message_obj,
+            platform_meta=self.meta(),
+            session_id=session.session_id,
+            client=self.client,
+        )
+
+        await telegram_event.send_with_client(
             self.client, message_chain, from_username
         )
         await super().send_by_session(session, message_chain)


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了 #XYZ

### Motivation

<!--解释为什么要改动-->

### Modifications

<!--简单解释你的改动-->

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [ ] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] 👀 我的更改经过良好的测试
- [ ] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [ ] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

修复了 Telegram 待办事项提醒发送不正确的错误，通过在发送前构造一个包含所需消息对象和元数据的事件实例来解决。

Bug 修复：
- 修正 Telegram 待办事项提醒发送，确保消息内容和会话元数据被正确提供给事件。

增强功能：
- 重构 `send_by_session` 以构建 `AstrBotMessage` 并使用 `message_str`、`message_obj`、`platform_meta`、`session_id` 和 `client` 初始化 `TelegramPlatformEvent`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix incorrect Telegram to-do reminder sending by constructing an event instance with the required message object and metadata before dispatch.

Bug Fixes:
- Correct Telegram to-do reminder dispatch by ensuring message content and session metadata are properly provided to the event.

Enhancements:
- Refactor send_by_session to build an AstrBotMessage and initialize TelegramPlatformEvent with message_str, message_obj, platform_meta, session_id, and client.

</details>