### PR TITLE
Discord 实现 SlashCommand 的注册、添加对 At 与 Reply 的支持、设置机器人 Activity

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -225,12 +225,15 @@ CONFIG_METADATA_2 = {
                         "telegram_command_auto_refresh": True,
                         "telegram_command_register_interval": 300,
                     },
-                    "discord":{
+                    "discord": {
                         "id": "discord",
                         "type": "discord",
                         "enable": False,
                         "discord_token": "",
                         "discord_proxy": "",
+                        "discord_command_register": True,
+                        "discord_guild_id_for_debug": "",
+                        "discord_activity_name": "",
                     },
                     "slack": {
                         "id": "slack",
@@ -373,6 +376,19 @@ CONFIG_METADATA_2 = {
                         "description": "Discord 代理地址",
                         "type": "string",
                         "hint": "可选的代理地址：http://ip:port"
+                    },
+                    "discord_command_register": {
+                        "description": "是否自动将插件指令注册为 Discord 斜杠指令",
+                        "type": "bool",
+                    },
+                    "discord_activity_name": {
+                        "description": "Discord 活动名称",
+                        "type": "string",
+                        "hint": "可选的 Discord 活动名称。留空则不设置活动。",
+                    },
+                    "discord_guild_id_for_debug": {
+                        "description": "【开发用】指定一个服务器(Guild)ID。在此服务器注册的指令会立刻生效，便于调试。留空则注册为全局指令。",
+                        "type": "string",
                     },
                 },
             },

--- a/astrbot/core/platform/sources/discord/components.py
+++ b/astrbot/core/platform/sources/discord/components.py
@@ -79,6 +79,13 @@ class DiscordButton(BaseMessageComponent):
         self.url = url
         self.disabled = disabled
 
+class DiscordReference(BaseMessageComponent):
+    """Discord引用组件"""
+    type: str = "discord_reference"
+    def __init__(self, message_id: str, channel_id: str):
+        self.message_id = message_id
+        self.channel_id = channel_id
+
 
 class DiscordView(BaseMessageComponent):
     """Discord视图组件，包含按钮和选择菜单"""
@@ -90,6 +97,7 @@ class DiscordView(BaseMessageComponent):
     ):
         self.components = components or []
         self.timeout = timeout
+
 
     def to_discord_view(self) -> discord.ui.View:
         """转换为Discord View对象"""

--- a/astrbot/core/platform/sources/discord/discord_platform_event.py
+++ b/astrbot/core/platform/sources/discord/discord_platform_event.py
@@ -3,14 +3,26 @@ import discord
 import base64
 from io import BytesIO
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List
+import sys
 
 from astrbot.api.event import AstrMessageEvent, MessageChain
-from astrbot.api.platform import AstrBotMessage, PlatformMetadata
-from astrbot.api.message_components import Plain, Image, File, BaseMessageComponent
+from astrbot.api.platform import AstrBotMessage, PlatformMetadata, At
+from astrbot.api.message_components import (
+    Plain,
+    Image,
+    File,
+    BaseMessageComponent,
+    Reply,
+)
 from astrbot import logger
 from .client import DiscordBotClient
 from .components import DiscordEmbed, DiscordView
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 
 # 自定义Discord视图组件（兼容旧版本）
@@ -29,36 +41,52 @@ class DiscordPlatformEvent(AstrMessageEvent):
         platform_meta: PlatformMetadata,
         session_id: str,
         client: DiscordBotClient,
+        interaction_followup_webhook: Optional[discord.Webhook] = None,
     ):
         super().__init__(message_str, message_obj, platform_meta, session_id)
         self.client = client
+        self.interaction_followup_webhook = interaction_followup_webhook
 
+    @override
     async def send(self, message: MessageChain):
         """发送消息到Discord平台"""
+
+        # 解析消息链为 Discord 所需的对象
         try:
-            channel = await self._get_channel()
-            if not channel:
-                logger.error(f"[Discord] 无法获取频道 {self.session_id}")
-                return
+            content, files, view, embeds, reference_message_id = await self._parse_to_discord(message)
+        except Exception as e:
+            logger.error(f"[Discord] 解析消息链时失败: {e}", exc_info=True)
+            return
 
-            # 解析消息链
-            content, files, view, embeds = await self._parse_to_discord(message)
+        kwargs = {}
+        if content:
+            kwargs["content"] = content
+        if files:
+            kwargs["files"] = files
+        if view:
+            kwargs["view"] = view
+        if embeds:
+            kwargs["embeds"] = embeds
+        if reference_message_id and not self.interaction_followup_webhook:
+            kwargs["reference"] = self.client.get_message(int(reference_message_id))
+        if not kwargs:
+            logger.debug("[Discord] 尝试发送空消息，已忽略。")
+            return
 
-            # Discord 不允许发送完全空的消息
-            if not content and not files and not view and not embeds:
-                logger.debug("[Discord] 尝试发送空消息，已忽略。")
-                return
+        # 根据上下文执行发送/回复操作
+        try:
+            # -- 斜杠指令/交互上下文 --
+            if self.interaction_followup_webhook:
+                await self.interaction_followup_webhook.send(**kwargs)
 
-            # 发送消息
-            await channel.send(
-                content=content or None,
-                files=files or None,
-                view=view or None,
-                embeds=embeds or None,
-            )
+            # -- 常规消息上下文 --
+            else:
+                channel = await self._get_channel()
+                if not channel:
+                    return
+                else:
+                    await channel.send(**kwargs)
 
-        except discord.errors.HTTPException as e:
-            logger.error(f"[Discord] 发送消息失败: {e.status} {e.code} - {e.text}")
         except Exception as e:
             logger.error(f"[Discord] 发送消息时发生未知错误: {e}", exc_info=True)
 
@@ -80,14 +108,18 @@ class DiscordPlatformEvent(AstrMessageEvent):
         message: MessageChain,
     ) -> tuple[str, list[discord.File], Optional[discord.ui.View], list[discord.Embed]]:
         """将 MessageChain 解析为 Discord 发送所需的内容"""
-        plain_text_parts = []
+        content = ""
         files = []
         view = None
         embeds = []
-
+        reference_message_id = None
         for i in message.chain:  # 遍历消息链
             if isinstance(i, Plain):  # 如果是文字类型的
-                plain_text_parts.append(i.text)
+                content += i.text
+            elif isinstance(i, Reply):
+                reference_message_id = i.id
+            elif isinstance(i, At):
+                content += f"<@{i.qq}>"
             elif isinstance(i, Image):
                 logger.debug(f"[Discord] 开始处理 Image 组件: {i}")
                 try:
@@ -174,7 +206,8 @@ class DiscordPlatformEvent(AstrMessageEvent):
                         if await asyncio.to_thread(path.exists):
                             file_bytes = await asyncio.to_thread(path.read_bytes)
                             files.append(
-                                discord.File(BytesIO(file_bytes), filename=i.name)
+                                discord.File(BytesIO(file_bytes),
+                                             filename=i.name)
                             )
                         else:
                             logger.warning(
@@ -197,37 +230,10 @@ class DiscordPlatformEvent(AstrMessageEvent):
             else:
                 logger.debug(f"[Discord] 忽略了不支持的消息组件: {i.type}")
 
-        # 合并文本内容
-        content = "\n".join(plain_text_parts)
         if len(content) > 2000:
             logger.warning("[Discord] 消息内容超过2000字符，将被截断。")
             content = content[:2000]
-
-        return content, files, view, embeds
-
-    async def reply(self, message: MessageChain):
-        """回复消息（如果原消息存在）"""
-        try:
-            if hasattr(self.message_obj, "raw_message") and hasattr(
-                self.message_obj.raw_message, "reply"
-            ):
-                # 解析消息链
-                content, files, view, embeds = await self._parse_to_discord(message)
-
-                # 使用Discord的回复功能
-                await self.message_obj.raw_message.reply(
-                    content=content or None,
-                    files=files or None,
-                    view=view or None,
-                    embeds=embeds or None,
-                )
-            else:
-                # 如果无法回复，使用普通发送
-                await self.send(message)
-        except Exception as e:
-            logger.error(f"[Discord] 回复消息失败: {e}")
-            # 回退到普通发送
-            await self.send(message)
+        return content, files, view, embeds, reference_message_id
 
     async def react(self, emoji: str):
         """对原消息添加反应"""


### PR DESCRIPTION
### Motivation

实现 Discord SlashCommand 的注册、实现对 At 与 Reply 的支持、实现设置机器人 Activity

### Modifications

feat: 添加 Discord 斜杠指令注册功能及相关配置项 
feat: 添加 Activity 设置项 
fix: 修复 At、Reply 未处理的问题

### Check

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码
