### PR TITLE
Add blacklist support (#2)

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -25,6 +25,9 @@ DEFAULT_CONFIG = {
         "id_whitelist_log": True,
         "wl_ignore_admin_on_group": True,
         "wl_ignore_admin_on_friend": True,
+        "enable_id_black_list": False,
+        "id_blacklist": [],
+        "id_blacklist_log": True,
         "reply_with_mention": False,
         "reply_with_quote": False,
         "path_mapping": [],
@@ -225,7 +228,7 @@ CONFIG_METADATA_2 = {
                         "telegram_command_auto_refresh": True,
                         "telegram_command_register_interval": 300,
                     },
-                    "discord":{
+                    "discord": {
                         "id": "discord",
                         "type": "discord",
                         "enable": False,
@@ -364,15 +367,15 @@ CONFIG_METADATA_2 = {
                         "hint": "请务必填对，否则 @ 机器人将无法唤醒，只能通过前缀唤醒。",
                         "obvious_hint": True,
                     },
-                    "discord_token":{
+                    "discord_token": {
                         "description": "Discord Bot Token",
                         "type": "string",
-                        "hint": "在此处填入你的Discord Bot Token"
+                        "hint": "在此处填入你的Discord Bot Token",
                     },
-                    "discord_proxy":{
+                    "discord_proxy": {
                         "description": "Discord 代理地址",
                         "type": "string",
-                        "hint": "可选的代理地址：http://ip:port"
+                        "hint": "可选的代理地址：http://ip:port",
                     },
                 },
             },
@@ -505,6 +508,22 @@ CONFIG_METADATA_2 = {
                         "description": "打印白名单日志",
                         "type": "bool",
                         "hint": "启用后，当一条消息没通过白名单时，会输出 INFO 级别的日志。",
+                    },
+                    "enable_id_black_list": {
+                        "description": "启用 ID 黑名单",
+                        "type": "bool",
+                    },
+                    "id_blacklist": {
+                        "description": "ID 黑名单",
+                        "type": "list",
+                        "items": {"type": "string"},
+                        "obvious_hint": True,
+                        "hint": "填写的 ID 的消息会被忽略，可使用 /bl 添加黑名单",
+                    },
+                    "id_blacklist_log": {
+                        "description": "打印黑名单日志",
+                        "type": "bool",
+                        "hint": "启用后，当一条消息在黑名单中时，会输出 INFO 级别的日志。",
                     },
                     "wl_ignore_admin_on_group": {
                         "description": "管理员群组消息无视 ID 白名单",

--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -417,6 +417,34 @@ UID: {user_id} 此 ID 可用于设置管理员。
             event.set_result(MessageEventResult().message("此 SID 不在白名单内。"))
 
     @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("bl")
+    async def bl(self, event: AstrMessageEvent, uid: str = None):
+        """添加黑名单。bl <uid>"""
+        if uid is None:
+            event.set_result(
+                MessageEventResult().message(
+                    "使用方法: /bl <id> 添加黑名单；/dbl <id> 删除黑名单。可通过 /sid 获取 ID。"
+                )
+            )
+            return
+        self.context.get_config()["platform_settings"]["id_blacklist"].append(str(uid))
+        self.context.get_config().save_config()
+        event.set_result(MessageEventResult().message("添加黑名单成功。"))
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("dbl")
+    async def dbl(self, event: AstrMessageEvent, uid: str):
+        """删除黑名单。dbl <uid>"""
+        try:
+            self.context.get_config()["platform_settings"]["id_blacklist"].remove(
+                str(uid)
+            )
+            self.context.get_config().save_config()
+            event.set_result(MessageEventResult().message("删除黑名单成功。"))
+        except ValueError:
+            event.set_result(MessageEventResult().message("此 ID 不在黑名单内。"))
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
     @filter.command("provider")
     async def provider(
         self, event: AstrMessageEvent, idx: Union[str, int] = None, idx2: int = None

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -22,6 +22,7 @@ from asyncio import Queue
 
 SESSION_ID_IN_WHITELIST = "test_sid_wl"
 SESSION_ID_NOT_IN_WHITELIST = "test_sid"
+BLACKLIST_USER = "bl_user"
 TEST_LLM_PROVIDER = {
     "id": "zhipu_default",
     "type": "openai_chat_completion",
@@ -45,6 +46,8 @@ TEST_COMMANDS = [
     ["deop test_op", "取消授权成功。"],
     ["wl test_platform:FriendMessage:test_sid_wl2", "添加白名单成功。"],
     ["dwl test_platform:FriendMessage:test_sid_wl2", "删除白名单成功。"],
+    ["bl bad_user", "添加黑名单成功。"],
+    ["dbl bad_user", "删除黑名单成功。"],
     ["provider", "当前载入的 LLM 提供商"],
     ["reset", "重置成功"],
     # ["model", "查看、切换提供商模型列表"],
@@ -105,6 +108,8 @@ def config():
         "test_platform:FriendMessage:test_sid_wl",
         "test_platform:GroupMessage:test_sid_wl",
     ]
+    cfg["platform_settings"]["id_blacklist"] = [BLACKLIST_USER]
+    cfg["platform_settings"]["enable_id_black_list"] = True
     cfg["admins_id"] = ["123456"]
     cfg["content_safety"]["internal_keywords"]["extra_keywords"] = ["^TEST_NEGATIVE"]
     cfg["provider"] = [TEST_LLM_PROVIDER]
@@ -205,6 +210,21 @@ async def test_pipeline_wl(
         "不在会话白名单中，已终止事件传播。" not in message
         for message in caplog.messages
     ), "日志中未找到预期的消息"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_blacklist(
+    pipeline_scheduler: PipelineScheduler, config: AstrBotConfig, caplog
+):
+    caplog.clear()
+    mock_event = FakeAstrMessageEvent.create_fake_event(
+        "test", SESSION_ID_IN_WHITELIST, sender_id=BLACKLIST_USER
+    )
+    with caplog.at_level(logging.INFO):
+        await pipeline_scheduler.execute(mock_event)
+    assert any("黑名单" in message for message in caplog.messages), (
+        "日志中未找到预期的消息"
+    )
 
     mock_event = FakeAstrMessageEvent.create_fake_event("test", sender_id="123")
     with caplog.at_level(logging.INFO):


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了 


### Motivation
为 astrbot 增加黑名单功能，以便能够屏蔽指定的发送者或会话，增强对恶意或不受欢迎消息的控制。

### Modifications
- 在默认配置中新增黑名单相关选项，包括开启/关闭开关、阻止 ID 列表以及操作日志记录  
- 扩展 `WhitelistCheckStage`，将黑名单检查逻辑集成进去，阻止黑名单中的发送者或会话触发事件  
- 引入新的 `/bl` 和 `/dbl` 聊天命令，用于在运行时管理黑名单（添加/删除列表项并查看当前黑名单）  
- 更新测试用例，覆盖黑名单配置和命令操作，并新增测试验证黑名单拦截效果  

### Check
<!-- 如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容 -->
- [ ] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)  
- [ ] 🧪 我的更改经过良好的测试  
- [ ] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置  
- [ ] 😲 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

添加 ID 黑名单功能，以阻止来自指定发送者或会话的不必要消息。

新功能：
- 引入运行时聊天命令 `/bl` 和 `/dbl`，用于从黑名单添加和删除 ID。

增强功能：
- 扩展消息过滤管道，以根据黑名单进行检查，并在匹配时停止事件传播。

测试：
- 添加了涵盖黑名单配置、命令操作和过滤行为的测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add ID blacklist functionality to block unwanted messages from specified senders or sessions.

New Features:
- Introduce runtime chat commands `/bl` and `/dbl` for adding and removing IDs from the blacklist.

Enhancements:
- Extend the message filter pipeline to check against the blacklist and halt event propagation when matched.

Tests:
- Add tests covering blacklist configuration, command operations, and filtering behavior.

</details>