### PR TITLE
Refactor blacklist to separate stage

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -25,6 +25,9 @@ DEFAULT_CONFIG = {
         "id_whitelist_log": True,
         "wl_ignore_admin_on_group": True,
         "wl_ignore_admin_on_friend": True,
+        "enable_id_black_list": False,
+        "id_blacklist": [],
+        "id_blacklist_log": True,
         "reply_with_mention": False,
         "reply_with_quote": False,
         "path_mapping": [],
@@ -225,7 +228,7 @@ CONFIG_METADATA_2 = {
                         "telegram_command_auto_refresh": True,
                         "telegram_command_register_interval": 300,
                     },
-                    "discord":{
+                    "discord": {
                         "id": "discord",
                         "type": "discord",
                         "enable": False,
@@ -364,15 +367,15 @@ CONFIG_METADATA_2 = {
                         "hint": "请务必填对，否则 @ 机器人将无法唤醒，只能通过前缀唤醒。",
                         "obvious_hint": True,
                     },
-                    "discord_token":{
+                    "discord_token": {
                         "description": "Discord Bot Token",
                         "type": "string",
-                        "hint": "在此处填入你的Discord Bot Token"
+                        "hint": "在此处填入你的Discord Bot Token",
                     },
-                    "discord_proxy":{
+                    "discord_proxy": {
                         "description": "Discord 代理地址",
                         "type": "string",
-                        "hint": "可选的代理地址：http://ip:port"
+                        "hint": "可选的代理地址：http://ip:port",
                     },
                 },
             },
@@ -505,6 +508,22 @@ CONFIG_METADATA_2 = {
                         "description": "打印白名单日志",
                         "type": "bool",
                         "hint": "启用后，当一条消息没通过白名单时，会输出 INFO 级别的日志。",
+                    },
+                    "enable_id_black_list": {
+                        "description": "启用 ID 黑名单",
+                        "type": "bool",
+                    },
+                    "id_blacklist": {
+                        "description": "ID 黑名单",
+                        "type": "list",
+                        "items": {"type": "string"},
+                        "obvious_hint": True,
+                        "hint": "填写的 ID 的消息会被忽略，可使用 /bl 添加黑名单",
+                    },
+                    "id_blacklist_log": {
+                        "description": "打印黑名单日志",
+                        "type": "bool",
+                        "hint": "启用后，当一条消息在黑名单中时，会输出 INFO 级别的日志。",
                     },
                     "wl_ignore_admin_on_group": {
                         "description": "管理员群组消息无视 ID 白名单",

--- a/astrbot/core/pipeline/__init__.py
+++ b/astrbot/core/pipeline/__init__.py
@@ -4,6 +4,7 @@ from astrbot.core.message.message_event_result import (
 )
 
 from .waking_check.stage import WakingCheckStage
+from .blacklist_check.stage import BlacklistCheckStage
 from .whitelist_check.stage import WhitelistCheckStage
 from .rate_limit_check.stage import RateLimitStage
 from .content_safety_check.stage import ContentSafetyCheckStage
@@ -16,6 +17,7 @@ from .respond.stage import RespondStage
 # 管道阶段顺序
 STAGES_ORDER = [
     "WakingCheckStage",  # 检查是否需要唤醒
+    "BlacklistCheckStage",  # 检查黑名单
     "WhitelistCheckStage",  # 检查是否在群聊/私聊白名单
     "RateLimitStage",  # 检查会话是否超过频率限制
     "ContentSafetyCheckStage",  # 检查内容安全
@@ -28,6 +30,7 @@ STAGES_ORDER = [
 
 __all__ = [
     "WakingCheckStage",
+    "BlacklistCheckStage",
     "WhitelistCheckStage",
     "RateLimitStage",
     "ContentSafetyCheckStage",

--- a/astrbot/core/pipeline/blacklist_check/stage.py
+++ b/astrbot/core/pipeline/blacklist_check/stage.py
@@ -1,0 +1,34 @@
+from ..stage import Stage, register_stage
+from ..context import PipelineContext
+from typing import AsyncGenerator, Union
+from astrbot.core.platform.astr_message_event import AstrMessageEvent
+from astrbot.core import logger
+
+
+@register_stage
+class BlacklistCheckStage(Stage):
+    """检查是否在会话或用户黑名单中"""
+
+    async def initialize(self, ctx: PipelineContext) -> None:
+        ps = ctx.astrbot_config["platform_settings"]
+        self.enable_blacklist = ps.get("enable_id_black_list", False)
+        self.blacklist = [str(i).strip() for i in ps.get("id_blacklist", []) if str(i).strip() != ""]
+        self.bl_log = ps.get("id_blacklist_log", True)
+
+    async def process(
+        self, event: AstrMessageEvent
+    ) -> Union[None, AsyncGenerator[None, None]]:
+        if not self.enable_blacklist:
+            return
+        sender = str(event.get_sender_id()).strip()
+        group_id = str(event.get_group_id()).strip()
+        if (
+            event.unified_msg_origin in self.blacklist
+            or sender in self.blacklist
+            or group_id in self.blacklist
+        ):
+            if self.bl_log:
+                logger.info(
+                    f"会话 ID {event.unified_msg_origin} 在会话黑名单中，已终止事件传播。"
+                )
+            event.stop_event()

--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -417,6 +417,47 @@ UID: {user_id} 此 ID 可用于设置管理员。
             event.set_result(MessageEventResult().message("此 SID 不在白名单内。"))
 
     @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("bl")
+    async def bl(self, event: AstrMessageEvent, uid: str = None):
+        """管理黑名单。bl <uid>|list"""
+        config = self.context.get_config()["platform_settings"]
+        if uid is None:
+            event.set_result(
+                MessageEventResult().message(
+                    "使用方法: /bl <id> 添加黑名单；/dbl <id> 删除黑名单；/bl list 查看黑名单。可通过 /sid 获取 ID。"
+                )
+            )
+            return
+
+        if uid == "list":
+            bl = config.get("id_blacklist", [])
+            msg = "黑名单：\n" + "\n".join(bl) if bl else "黑名单为空。"
+            event.set_result(MessageEventResult().message(msg))
+            return
+
+        uid = str(uid)
+        bl = config.setdefault("id_blacklist", [])
+        if uid in bl:
+            event.set_result(MessageEventResult().message("该 ID 已在黑名单中。"))
+            return
+        bl.append(uid)
+        self.context.get_config().save_config()
+        event.set_result(MessageEventResult().message("添加黑名单成功。"))
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("dbl")
+    async def dbl(self, event: AstrMessageEvent, uid: str):
+        """删除黑名单。dbl <uid>"""
+        try:
+            self.context.get_config()["platform_settings"]["id_blacklist"].remove(
+                str(uid)
+            )
+            self.context.get_config().save_config()
+            event.set_result(MessageEventResult().message("删除黑名单成功。"))
+        except ValueError:
+            event.set_result(MessageEventResult().message("此 ID 不在黑名单内。"))
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
     @filter.command("provider")
     async def provider(
         self, event: AstrMessageEvent, idx: Union[str, int] = None, idx2: int = None

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -51,7 +51,7 @@ TEST_COMMANDS = [
     ["bl bl_user", "该 ID 已在黑名单中"],
     ["bl bad_user", "添加黑名单成功。"],
     ["dbl bad_user", "删除黑名单成功。"],
-    ["bl list", "黑名单"],
+    ["bl list", f"黑名单：\n{BLACKLIST_USER}"],
     ["provider", "当前载入的 LLM 提供商"],
     ["reset", "重置成功"],
     # ["model", "查看、切换提供商模型列表"],
@@ -256,6 +256,21 @@ async def test_pipeline_blacklist(
     assert any(
         "不在会话白名单中，已终止事件传播。" in message for message in caplog.messages
     ), "日志中未找到预期的消息"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_blacklist_disabled(
+    pipeline_scheduler: PipelineScheduler, config: AstrBotConfig, caplog
+):
+    caplog.clear()
+    config["platform_settings"]["enable_id_black_list"] = False
+    mock_event = FakeAstrMessageEvent.create_fake_event(
+        "test", SESSION_ID_IN_WHITELIST, sender_id=BLACKLIST_USER
+    )
+    with caplog.at_level(logging.INFO):
+        await pipeline_scheduler.execute(mock_event)
+    assert not any("黑名单" in message for message in caplog.messages)
+    config["platform_settings"]["enable_id_black_list"] = True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了#1293


### Motivation

引入了专门的 `BlacklistCheckStage`，并新增了 `/bl` 和 `/dbl` 聊天命令，用于运行时管理黑名单。同时，配置元数据中新增了启用黑名单、黑名单列表及日志记录等选项；测试套件覆盖了用户 ID、群组 ID 和会话 ID 的黑名单拦截验证。

### Modifications

1. **新增 BlacklistCheckStage**  
   - 在 `initialize()` 中加载黑名单配置：  
2. **新增 `/bl` 和 `/dbl` 命令**  
   - `/bl [list|<ID>]`：查看或添加黑名单  
   - `/dbl <ID>`：删除黑名单  
   - 成功/失败消息反馈用户，避免重复添加。
### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是将 pull request 总结翻译成中文的结果：

## Sourcery 总结

将黑名单处理提取到专用管道阶段，并通过命令启用运行时黑名单管理，相应地更新配置模式，并为黑名单强制执行添加测试。

新功能：
- 添加 `BlacklistCheckStage`，以便在启用黑名单时按用户、群组或会话 ID 阻止消息。
- 引入“/bl”命令，供管理员在运行时列出或将 ID 添加到黑名单。
- 引入“/dbl”命令，供管理员在运行时从黑名单中删除 ID。
- 公开配置选项：`enable_id_black_list`、`id_blacklist` 和 `id_blacklist_log`。

增强功能：
- 在处理管道中的 `WhitelistCheckStage` 之前插入 `BlacklistCheckStage`。
- 启用 `id_blacklist_log` 后，在 INFO 级别记录消息拒绝。

测试：
- 添加测试用例以验证用户 ID、群组 ID 和会话来源的黑名单拦截。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract blacklist handling into a dedicated pipeline stage and enable runtime blacklist management via commands, update configuration schema accordingly, and add tests for blacklist enforcement.

New Features:
- Add BlacklistCheckStage to block messages by user, group, or session ID when blacklisting is enabled.
- Introduce "/bl" command for administrators to list or add IDs to the blacklist at runtime.
- Introduce "/dbl" command for administrators to remove IDs from the blacklist at runtime.
- Expose configuration options: enable_id_black_list, id_blacklist, and id_blacklist_log.

Enhancements:
- Insert BlacklistCheckStage before WhitelistCheckStage in the processing pipeline.
- Log message rejections at INFO level when id_blacklist_log is enabled.

Tests:
- Add test cases to verify blacklist interception for user IDs, group IDs, and session origins.

</details>