### PR TITLE
🐞 fix: 显示运行时长国际化

### DIFF
--- a/dashboard/src/i18n/locales/en-US/features/dashboard.json
+++ b/dashboard/src/i18n/locales/en-US/features/dashboard.json
@@ -21,7 +21,8 @@
     },
     "runningTime": {
       "title": "Uptime",
-      "subtitle": "System uptime duration"
+      "subtitle": "System uptime duration",
+      "format": "{hours}h {minutes}m {seconds}s"
     },
     "memoryUsage": {
       "title": "Memory Usage",

--- a/dashboard/src/i18n/locales/zh-CN/features/dashboard.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/dashboard.json
@@ -21,7 +21,8 @@
     },
     "runningTime": {
       "title": "运行时间",
-      "subtitle": "系统已运行时长"
+      "subtitle": "系统已运行时长",
+      "format": "{hours}小时{minutes}分{seconds}秒"
     },
     "memoryUsage": {
       "title": "内存占用",

--- a/dashboard/src/views/dashboards/default/components/RunningTime.vue
+++ b/dashboard/src/views/dashboards/default/components/RunningTime.vue
@@ -30,7 +30,16 @@ export default {
   },
   computed: {
     formattedTime() {
-      return this.stat?.running || this.t('status.loading');
+      if (!this.stat?.running) {
+        return this.t('status.loading');
+      }
+
+      const { hours, minutes, seconds } = this.stat.running;
+      return this.t('stats.runningTime.format', {
+        hours,
+        minutes,
+        seconds
+      });
     }
   }
 };


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了 #XYZ

### Motivation

<!--解释为什么要改动-->
目前在WebUI中，显示的运行时长没有国际化，故有此修改

### Modifications

<!--简单解释你的改动-->

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

修复了运行时间国际化的问题，通过从后端返回结构化的时间组件，并在 UI 中使用 i18n 对其进行格式化

Bug 修复：
- 本地化 WebUI 中的运行时间显示

增强功能：
- 将运行时间作为小时/分钟/秒组件返回，而不是静态字符串
- 使用翻译键在仪表盘组件中格式化运行时间

文档：
- 将 runningTime.format 条目添加到英语和中文区域设置文件中

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix running time internationalization by returning structured time components from the backend and formatting them in the UI using i18n

Bug Fixes:
- Localize running time display in the WebUI

Enhancements:
- Return running time as hours/minutes/seconds components instead of a static string
- Format running time in the dashboard component using translation keys

Documentation:
- Add runningTime.format entries to English and Chinese locale files

</details>