### PR TITLE
使用定义的Plain类型代替原始基础类型str，保持代码统一性

### DIFF
--- a/astrbot/core/message/components.py
+++ b/astrbot/core/message/components.py
@@ -125,6 +125,8 @@ class Plain(BaseMessageComponent):
     def toDict(self):
         return {"type": "text", "data": {"text": self.text.strip()}}
 
+    async def to_dict(self):
+        return {"type": "text", "data": {"text": self.text}}
 
 class Face(BaseMessageComponent):
     type: ComponentType = "Face"
@@ -610,13 +612,10 @@ class Node(BaseMessageComponent):
                         "data": {"file": f"base64://{bs64}"},
                     }
                 )
-            elif isinstance(comp, str):
-                data_content.append(
-                    {
-                    "type": "text",
-                    "data": {"text": comp.strip()}
-                    }
-                )
+            elif isinstance(comp, Plain):
+                # For Plain segments, we need to handle the plain differently
+                d = await comp.to_dict()
+                data_content.append(d)
             elif isinstance(comp, File):
                 # For File segments, we need to handle the file differently
                 d = await comp.to_dict()


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了 #XYZ

### Motivation

修改str为Plain类型，保持代码一致性，另外去掉strip，防止删除换行等造成打印格式问题

### Modifications

<!--简单解释你的改动-->

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [ ] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] 👀 我的更改经过良好的测试
- [ ] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [ ] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 摘要：

## Sourcery 总结

将原始字符串段替换为定义的 Plain 类型，用于文本组件，并通过删除自动剥离来保留格式

增强功能：
- 在文本组件上添加异步 to_dict 方法，以返回未修改的文本
- 更新消息序列化以检测 Plain 段而不是 str 并删除 strip 调用

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace raw string segments with a defined Plain type for text components and preserve formatting by removing automatic stripping

Enhancements:
- Add async to_dict method on text component to return unmodified text
- Update message serialization to detect Plain segments instead of str and drop strip calls

</details>