### PR TITLE
fix(AiocqhttpAdapter): 修复at_info.get("nick", "")的错误

### DIFF
--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -168,9 +168,7 @@ class AiocqhttpAdapter(Platform):
 
         if "sub_type" in event:
             if event["sub_type"] == "poke" and "target_id" in event:
-                abm.message.append(
-                    Poke(qq=str(event["target_id"]), type="poke")
-                )  # noqa: F405
+                abm.message.append(Poke(qq=str(event["target_id"]), type="poke"))  # noqa: F405
 
         return abm
 
@@ -183,7 +181,6 @@ class AiocqhttpAdapter(Platform):
         @param get_reply: 是否获取回复消息。这个参数是为了防止多个回复嵌套。
         """
         abm = AstrBotMessage()
-        logger.info(f"event: {event}")
         abm.self_id = str(event.self_id)
         abm.sender = MessageMember(
             str(event.sender["user_id"]), event.sender["nickname"]

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -183,6 +183,7 @@ class AiocqhttpAdapter(Platform):
         @param get_reply: 是否获取回复消息。这个参数是为了防止多个回复嵌套。
         """
         abm = AstrBotMessage()
+        logger.info(f"event: {event}")
         abm.self_id = str(event.self_id)
         abm.sender = MessageMember(
             str(event.sender["user_id"]), event.sender["nickname"]
@@ -273,6 +274,8 @@ class AiocqhttpAdapter(Platform):
                                 action="get_msg",
                                 message_id=int(m["data"]["id"]),
                             )
+                            # 添加必要的 post_type 字段，防止 Event.from_payload 报错
+                            reply_event_data["post_type"] = "message"
                             abm_reply = await self._convert_handle_message_event(
                                 Event.from_payload(reply_event_data), get_reply=False
                             )

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -307,7 +307,7 @@ class AiocqhttpAdapter(Platform):
                             user_id=int(m["data"]["qq"]),
                         )
                         if at_info:
-                            nickname = at_info.get("nickname", "")
+                            nickname = at_info.get("nick", "") or at_info.get("nickname", "")
                             is_at_self = str(m["data"]["qq"]) in {abm.self_id, "all"}
 
                             abm.message.append(

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -307,7 +307,7 @@ class AiocqhttpAdapter(Platform):
                             user_id=int(m["data"]["qq"]),
                         )
                         if at_info:
-                            nickname = at_info.get("nick", "")
+                            nickname = at_info.get("nickname", "")
                             is_at_self = str(m["data"]["qq"]) in {abm.self_id, "all"}
 
                             abm.message.append(
@@ -322,7 +322,7 @@ class AiocqhttpAdapter(Platform):
                                 first_at_self_processed = True
                             else:
                                 # 非第一个@机器人或@其他用户，添加到message_str
-                                message_str += f" @{nickname} "
+                                message_str += f" @{nickname}({m['data']['qq']}) "
                         else:
                             abm.message.append(At(qq=str(m["data"]["qq"]), name=""))
                     except ActionFailed as e:


### PR DESCRIPTION
### Motivation

aiocqhttp_platform_adapter.py:310

at_info.get("nick", "") 应为 at_info.get("nickname", "")

这个问题导致message_str内的At参数都丢失，从而导致大模型无法读取到@的人

[aiocqhttp.aiocqhttp_platform_adapter:295]: 获取引用消息失败: 'NoneType' object has no attribute 'self_id'。

### Modifications

at_info.get("nick", "") -> at_info.get("nickname", "")

同时在aiocqhttp_platform_adapter.py:325

为at类型的message_str添加了qq 便于大模型识别at内容

aiocqhttp_platform_adapter.py:278
添加必要的 post_type 字段，防止 Event.from_payload 报错
reply_event_data["post_type"] = "message"

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 提供的总结

修复 aiocqhttp 适配器中的 @ 提及处理，通过检索正确的昵称字段并在渲染的提及中包含 QQ 标识符

Bug 修复：
- 使用 `at_info.get("nickname", "")` 而不是 `at_info.get("nick", "")` 来正确获取用户昵称

增强功能：
- 将 QQ 标识符附加到 @mention 字符串，以提高大型模型的识别能力

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix at mention handling in aiocqhttp adapter by retrieving the correct nickname field and including the QQ identifier in rendered mentions

Bug Fixes:
- Use at_info.get("nickname", "") instead of at_info.get("nick", "") to correctly fetch user nicknames

Enhancements:
- Append the QQ identifier to @mention strings to improve recognition by large models

</details>