### PR TITLE
fix:修复commandfilter对布尔类型的解析

### DIFF
--- a/astrbot/core/star/filter/command.py
+++ b/astrbot/core/star/filter/command.py
@@ -7,9 +7,12 @@ from astrbot.core.config import AstrBotConfig
 from .custom_filter import CustomFilter
 from ..star_handler import StarHandlerMetadata
 
+
 class GreedyStr(str):
     """标记指令完成其他参数接收后的所有剩余文本。"""
+
     pass
+
 
 # 标准指令受到 wake_prefix 的制约。
 class CommandFilter(HandlerFilter):
@@ -18,8 +21,8 @@ class CommandFilter(HandlerFilter):
     def __init__(
         self,
         command_name: str,
-        alias: set = None,
-        handler_md: StarHandlerMetadata = None,
+        alias: set | None = None,
+        handler_md: StarHandlerMetadata | None = None,
         parent_command_names: List[str] = [""],
     ):
         self.command_name = command_name
@@ -113,9 +116,9 @@ class CommandFilter(HandlerFilter):
                     elif isinstance(param_type_or_default_val, bool):
                         # 处理布尔类型
                         lower_param = params[i].lower()
-                        if lower_param in ['true', 'yes', '1']:
+                        if lower_param in ["true", "yes", "1"]:
                             result[param_name] = True
-                        elif lower_param in ['false', 'no', '0']:
+                        elif lower_param in ["false", "no", "0"]:
                             result[param_name] = False
                         else:
                             raise ValueError(

--- a/astrbot/core/star/filter/command.py
+++ b/astrbot/core/star/filter/command.py
@@ -115,7 +115,7 @@ class CommandFilter(HandlerFilter):
                         result[param_name] = params[i]
                     elif isinstance(param_type_or_default_val, bool):
                         # 处理布尔类型
-                        lower_param = params[i].lower()
+                        lower_param = str(params[i]).lower()
                         if lower_param in ["true", "yes", "1"]:
                             result[param_name] = True
                         elif lower_param in ["false", "no", "0"]:

--- a/astrbot/core/star/filter/command.py
+++ b/astrbot/core/star/filter/command.py
@@ -110,6 +110,17 @@ class CommandFilter(HandlerFilter):
                     elif isinstance(param_type_or_default_val, str):
                         # 如果 param_type_or_default_val 是字符串，直接赋值
                         result[param_name] = params[i]
+                    elif isinstance(param_type_or_default_val, bool):
+                        # 处理布尔类型
+                        lower_param = params[i].lower()
+                        if lower_param in ['true', 'yes', '1']:
+                            result[param_name] = True
+                        elif lower_param in ['false', 'no', '0']:
+                            result[param_name] = False
+                        else:
+                            raise ValueError(
+                                f"参数 {param_name} 必须是布尔值（true/false, yes/no, 1/0）。"
+                            )
                     elif isinstance(param_type_or_default_val, int):
                         result[param_name] = int(params[i])
                     elif isinstance(param_type_or_default_val, float):


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->


### Motivation
使用@filter.command注册指令时,无法正常解析布尔类型的参数
(会被当做int类型解析,为0时返回false,非零返回true,其他情况如true,false会抛出ValueError异常)
<!--解释为什么要改动-->

### Modifications
在CommandFilter类中修改了validate_and_convert_params方法,加入了解析参数类型为布尔时的解析策略
<!--简单解释你的改动-->

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [ y] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ y] 👀 我的更改经过良好的测试
- [ y] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [ y] 😮 我的更改没有引入恶意代码

好的，这是将给定的 pull request 总结翻译成中文的结果：

## Sourcery 总结

Bug 修复:
- 修复了 `CommandFilter` 中的布尔参数解析，使其能够接受 true/false、yes/no 和 1/0 表示，而不会因为有效的输入引发错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix boolean argument parsing in CommandFilter to accept true/false, yes/no, and 1/0 representations without raising errors for valid inputs

</details>