### PR TITLE
对#1996的补充

### DIFF
--- a/astrbot/core/config/astrbot_config.py
+++ b/astrbot/core/config/astrbot_config.py
@@ -123,8 +123,13 @@ class AstrBotConfig(dict):
         for key in list(conf.keys()):
             if key not in refer_conf:
                 path_ = path + "." + key if path else key
-                logger.info(f"检查到配置项 {path_} 不存在，将从当前配置中删除")
-                has_new = True
+
+                # 特殊处理 platform_settings.plugin_enable 的子项，不删除
+                if path == "platform_settings.plugin_enable" or path.startswith("platform_settings.plugin_enable."):
+                    new_conf[key] = conf[key]
+                else:
+                    logger.info(f"检查到配置项 {path_} 不存在，将从当前配置中删除")
+                    has_new = True
 
         # 顺序不一致也算作变更
         if list(conf.keys()) != list(new_conf.keys()):


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->

### Motivation

昨天将plugin_enable[]改为plugin_enable{}后，本来可以正常运行，今天再看发现又出问题了，又不会保存配置了😭  


排查后发现，原因是`astrbot_config.py`中`# 检查是否存在参考配置中没有的配置项`部分  
启动时会遍历`cmd_config`中的key，并删除掉默认配置中不存在的部分，导致plugin_enable{}的子项：`platform_settings.plugin_enable.{platform}`被删除

<!--解释为什么要改动-->

### Modifications
为了让配置项不被删除，我有两条路可以走，一个是让plugin_enable以列表形式存储，类似provider[{}{}]，但是这样很多用到plugin_enable的地方都要修改，因为他们是以dict形式来使用这个配置文件的，修改太多怕出问题  

所以我选择另一个方法，在`# 检查是否存在参考配置中没有的配置项`部分加一个判断，如果是plugin_enable的配置则跳过和默认配置比较，直接写入
<!--简单解释你的改动-->

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码
