### PR TITLE
perf: 优化WebChat对话标题生成

### DIFF
--- a/astrbot/core/pipeline/process_stage/method/llm_request.py
+++ b/astrbot/core/pipeline/process_stage/method/llm_request.py
@@ -259,7 +259,7 @@ class LLMRequestSubStage(Stage):
                     f"{cleaned_text}\n"
                     "Only output the summary within 10 words, DO NOT INCLUDE any other text."
                     "You must use the same language as the user."
-                    "If you think the dialog is too short to summarize, only output a special mark: `None`"
+                    "If you think the dialog is too short to summarize, only output a special mark: `<None>`"
                 ),
             )
             if llm_resp and llm_resp.completion_text:
@@ -267,7 +267,7 @@ class LLMRequestSubStage(Stage):
                     f"WebChat 对话标题生成响应: {llm_resp.completion_text.strip()}"
                 )
                 title = llm_resp.completion_text.strip()
-                if not title or "None" == title:
+                if not title or "<None>" in title:
                     return
                 await self.conv_manager.update_conversation_title(
                     event.unified_msg_origin, title=title


### PR DESCRIPTION
### Motivation

![62f9f7b2fe376f2c6110267ffdc10e66](https://github.com/user-attachments/assets/c9dc360d-03e1-415b-858e-eabbe41ecfd4)

### Modifications

<!--简单解释你的改动-->

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 总结

优化 WebChat 对话标题生成，更新空对话标记并调整其处理逻辑。

增强功能：
- 当对话太短而无法总结时，使用 `<None>` 而不是 `None` 作为特殊标记
- 更新标题检查条件以检测 `<None>` 标记并跳过更新会话标题

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize WebChat dialog title generation by updating the empty-dialog marker and adjusting its handling logic.

Enhancements:
- Use `<None>` instead of `None` as the special marker when a dialog is too short to summarize
- Update title-check condition to detect `<None>` marker and skip updating the conversation title

</details>