### PR TITLE
✨ feat: 加入wenturc插件市场镜像站

### DIFF
--- a/astrbot/dashboard/routes/plugin.py
+++ b/astrbot/dashboard/routes/plugin.py
@@ -85,7 +85,7 @@ class PluginRoute(Route):
         if custom:
             urls = [custom]
         else:
-            urls = ["https://api.soulter.top/astrbot/plugins"]
+            urls = ["https://api.soulter.top/astrbot/plugins", "https://api.wenturc.com/astrbot/plugins"]
 
         # 新增：创建 SSL 上下文，使用 certifi 提供的根证书
         ssl_context = ssl.create_default_context(cafile=certifi.where())


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了 #XYZ

### Motivation

<!--解释为什么要改动-->

有时原插件市场不可用，故自行搭建了一个镜像站供大家使用。

此处是简易的[镜像站源码](https://github.com/IGCrystal/astrbot_plugins_market_mirror)

### Modifications

<!--简单解释你的改动-->

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 摘要：

## Sourcery 总结

添加对基于 Wenturc 的插件市场镜像的后备支持，以提高 CLI 和仪表板中的插件列表可用性

新功能：
- 在 CLI 中包含 Wenturc 镜像 URL 以及主插件 API 端点
- 在 CLI 中实现循环后备逻辑，以尝试多个插件 API URL，直到一个成功
- 配置仪表板插件路由，以便在主端点不可用时从 Wenturc 镜像获取

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add fallback support for a Wenturc-based plugin marketplace mirror to improve plugin listing availability in both CLI and dashboard

New Features:
- Include the Wenturc mirror URL alongside the primary plugin API endpoint in the CLI
- Implement looped fallback logic in the CLI to try multiple plugin API URLs until one succeeds
- Configure the dashboard plugin route to fetch from the Wenturc mirror when the primary endpoint is unavailable

</details>