### PR TITLE
pytest recommendation: `pip install --editable .`

### DIFF
--- a/.github/workflows/coverage_test.yml
+++ b/.github/workflows/coverage_test.yml
@@ -26,18 +26,17 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pytest pytest-cov pytest-asyncio
+          pip install pytest pytest-asyncio pytest-cov
+          pip install --editable .
 
       - name: Run tests
         run: |
-          mkdir data
-          mkdir data/plugins
-          mkdir data/config
-          mkdir data/temp
+          mkdir -p data/plugins
+          mkdir -p data/config
+          mkdir -p data/temp
           export TESTING=true
           export ZHIPU_API_KEY=${{ secrets.OPENAI_API_KEY }}
-          PYTHONPATH=./ pytest --cov=. tests/ -v -o log_cli=true -o log_level=DEBUG
+          pytest --cov=. tests/ -v -o log_cli=true -o log_level=DEBUG
 
       - name: Upload results to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/coverage_test.yml
+++ b/.github/workflows/coverage_test.yml
@@ -1,6 +1,6 @@
 name: Run tests and upload coverage
 
-on: 
+on:
   push:
     branches:
       - master
@@ -8,6 +8,7 @@ on:
       - 'README.md'
       - 'changelogs/**'
       - 'dashboard/**'
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -36,7 +37,7 @@ jobs:
           mkdir -p data/temp
           export TESTING=true
           export ZHIPU_API_KEY=${{ secrets.OPENAI_API_KEY }}
-          pytest --cov=. tests/ -v -o log_cli=true -o log_level=DEBUG
+          pytest --cov=. -v -o log_cli=true -o log_level=DEBUG
 
       - name: Upload results to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
https://docs.pytest.org/en/stable/how-to/existingtestsuite.html

This makes setting `PYTHONPATH` unnecessary and will pull requirements from `pyproject.toml` instead of `requirements.txt`, so it is similar to end-user installations.

`makedir -p data/plugins` will do both `mkdir data` and `mkdir data/plugins`.

The `$CI` environment variable might be better to use than `$TESTING` because it is preset to `true` in GitHub Actions.
* https://docs.github.com/en/actions/reference/variables-reference#default-environment-variables
* https://docs.pytest.org/en/stable/explanation/ci.html

Instead of doing `pytest tests/`, just do `pytest` so that [pytest discovery](https://docs.pytest.org/en/stable/explanation/goodpractices.html#conventions-for-python-test-discovery) can find tests anywhere in the codebase.

<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了 #XYZ

### Motivation

<!--解释为什么要改动-->

### Modifications

<!--简单解释你的改动-->

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [ ] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] 👀 我的更改经过良好的测试
- [ ] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [ ] 😮 我的更改没有引入恶意代码

## Sourcery 总结

更新 GitHub Actions 工作流程，以可编辑模式安装项目，简化测试设置，并简化 pytest 调用

CI：
- 使用 `pip install --editable .` 安装项目及其依赖项，而不是使用 requirements.txt
- 使用 `mkdir -p` 来整合测试数据目录的创建
- 移除运行 pytest 时的手动 PYTHONPATH 导出

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update GitHub Actions workflow to install the project in editable mode, streamline test setup, and simplify pytest invocation

CI:
- Install project and its dependencies with `pip install --editable .` instead of using requirements.txt
- Use `mkdir -p` to consolidate creation of test data directories
- Remove manual PYTHONPATH export when running pytest

</details>