### PR TITLE
fix(wechatpadpro): 修复授权码提取逻辑以兼容新旧接口格式

### DIFF
--- a/astrbot/core/platform/sources/wechatpadpro/wechatpadpro_adapter.py
+++ b/astrbot/core/platform/sources/wechatpadpro/wechatpadpro_adapter.py
@@ -225,21 +225,23 @@ class WeChatPadProAdapter(Platform):
                     # 修正成功判断条件和授权码提取路径
                     if response.status == 200 and response_data.get("Code") == 200:
                         # 授权码在 Data 字段的列表中
-                        if (
-                            response_data.get("Data")
-                            and isinstance(response_data["Data"], list)
-                            and len(response_data["Data"]) > 0
-                        ):
-                            self.auth_key = response_data["Data"][0]
-                            logger.info(f"成功获取授权码 {self.auth_key[:8]}...")
+                        data = response_data.get("Data")
+                        if data:
+                            # 新返回格式
+                            if isinstance(data.get("authKeys"), list) and data["authKeys"]:
+                                self.auth_key = data["authKeys"][0]
+                            # 兼容旧版接口
+                            elif isinstance(data, list) and data:
+                                self.auth_key = data[0]
+                            
+                            if self.auth_key:
+                                logger.info(f"成功获取授权码 {self.auth_key[:8]}...")
+                            else:
+                                logger.error(f"生成授权码成功但未找到授权码: {response_data}")
                         else:
-                            logger.error(
-                                f"生成授权码成功但未找到授权码: {response_data}"
-                            )
+                            logger.error(f"生成授权码成功但未找到授权码: {response_data}")
                     else:
-                        logger.error(
-                            f"生成授权码失败: {response.status}, {response_data}"
-                        )
+                        logger.error(f"生成授权码失败: {response.status}, {response_data}")
             except aiohttp.ClientConnectorError as e:
                 logger.error(f"连接到 WeChatPadPro 服务失败: {e}")
             except Exception as e:

--- a/astrbot/core/platform/sources/wechatpadpro/wechatpadpro_adapter.py
+++ b/astrbot/core/platform/sources/wechatpadpro/wechatpadpro_adapter.py
@@ -210,6 +210,16 @@ class WeChatPadProAdapter(Platform):
                 logger.error(traceback.format_exc())
                 return False
 
+    def _extract_auth_key(self, data):
+        """Helper method to extract auth_key from response data."""
+        if isinstance(data, dict):
+            auth_keys = data.get("authKeys") # 新接口
+            if isinstance(auth_keys, list) and auth_keys:
+                return auth_keys[0]
+        elif isinstance(data, list) and data: # 旧接口
+            return data[0]
+        return None
+
     async def generate_auth_key(self):
         """
         生成授权码。
@@ -218,30 +228,26 @@ class WeChatPadProAdapter(Platform):
         params = {"key": self.admin_key}
         payload = {"Count": 1, "Days": 365}  # 生成一个有效期365天的授权码
 
+        self.auth_key = None  # Reset auth_key before generating a new one
+
         async with aiohttp.ClientSession() as session:
             try:
                 async with session.post(url, params=params, json=payload) as response:
+                    if response.status != 200:
+                        logger.error(f"生成授权码失败: {response.status}, {await response.text()}")
+                        return
+
                     response_data = await response.json()
-                    # 修正成功判断条件和授权码提取路径
-                    if response.status == 200 and response_data.get("Code") == 200:
-                        # 授权码在 Data 字段的列表中
-                        data = response_data.get("Data")
-                        if data:
-                            # 新返回格式
-                            if isinstance(data.get("authKeys"), list) and data["authKeys"]:
-                                self.auth_key = data["authKeys"][0]
-                            # 兼容旧版接口
-                            elif isinstance(data, list) and data:
-                                self.auth_key = data[0]
-                            
-                            if self.auth_key:
-                                logger.info(f"成功获取授权码 {self.auth_key[:8]}...")
-                            else:
-                                logger.error(f"生成授权码成功但未找到授权码: {response_data}")
+                    if response_data.get("Code") == 200:
+                        if data := response_data.get("Data"):
+                            self.auth_key = self._extract_auth_key(data)
+
+                        if self.auth_key:
+                            logger.info("成功获取授权码")
                         else:
                             logger.error(f"生成授权码成功但未找到授权码: {response_data}")
                     else:
-                        logger.error(f"生成授权码失败: {response.status}, {response_data}")
+                        logger.error(f"生成授权码失败: {response_data}")
             except aiohttp.ClientConnectorError as e:
                 logger.error(f"连接到 WeChatPadPro 服务失败: {e}")
             except Exception as e:


### PR DESCRIPTION
新接口返回多了一层authKeys字段，同时兼容二者

<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了 https://github.com/AstrBotDevs/AstrBot/issues/2041

### Motivation

适配WeChatPadPro新接口

### Modifications

修改wechatpadpro_adapter.py，兼容2种格式

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

增强功能：
- 调整 `generate_auth_key` 以检测新 API 格式中的 `authKeys` 列表，并回退到原始的 `Data` 列表以提取授权码。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Adapt generate_auth_key to detect authKeys list in new API format and fall back to the original Data list for extracting authorization codes.

</details>