### PR TITLE
Fix: 防止错误恢复机制_remove_image_from_context发生KeyError

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -487,7 +487,7 @@ class ProviderOpenAIOfficial(Provider):
             if flag:
                 flag = False  # 删除 image 后，下一条（LLM 响应）也要删除
                 continue
-            if isinstance(context["content"], list):
+            if "content" in context and isinstance(context["content"], list):
                 flag = True
                 # continue
                 new_content = []


### PR DESCRIPTION
无对应issue

### Motivation
错误恢复机制 `_remove_image_from_context` 在处理包含工具调用（Tool Calls）的对话历史时，会因为 `KeyError: 'content'` 而崩溃。

### Modifications
本次修改只涉及一行代码，位于 `astrbot/core/provider/sources/openai_source.py` 文件中的 `_remove_image_from_context` 函数。

修改前:
  if isinstance(context["content"], list):
修改后:
  if "content" in context and isinstance(context["content"], list):

通过在访问 `context["content"]` 之前，增加一个 `"content" in context 的安全检查，确保了在处理没有content键的工具调用消息时（比如助手消息role: "assistant"用于发出工具调用指令时并不包含 `content` 键），函数也能够安全地跳过，而不会再引发 KeyError。

### Check

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 添加保护机制，确保在 `_remove_image_from_context` 函数中检查 `content` 键的值的类型之前，`content` 键确实存在。这可以防止在处理没有 `content` 的工具调用消息时出现 KeyError。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add guard to ensure `content` key exists before type-checking its value in `_remove_image_from_context`, preventing a KeyError when handling tool call messages without `content`.

</details>