### PR TITLE
Fix: 移除 _remove_image_from_context中的flag逻辑

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -482,13 +482,8 @@ class ProviderOpenAIOfficial(Provider):
         """
         new_contexts = []
 
-        flag = False
         for context in contexts:
-            if flag:
-                flag = False  # 删除 image 后，下一条（LLM 响应）也要删除
-                continue
             if "content" in context and isinstance(context["content"], list):
-                flag = True
                 # continue
                 new_content = []
                 for item in context["content"]:


### PR DESCRIPTION
解决了 #2048 

### Motivation
修复一种导致'error': {'message': "Messages with role 'tool' must be a response to a preceding message with 'tool_calls'", 'type': 'invalid_request_error', 'param': None, 'code': 'invalid_request_error'}的情况，此情况通常出现在使用图片转述插件时
**bug产生原因：**
flag逻辑会移除带图片消息的下一条消息，如果被移除的是assistant消息，message可能会违反OpenAI API 要求的消息格式（tool 消息前必须有带 tool_calls 的 assistant 消息）导致api返回400 BadRequestError
以使用图像转述插件为例
第一次调用大模型（如 deepseek-chat），因模型不支持图片而触发 _remove_image_from_context 。
模型返回 tool_calls 请求。
插件执行成功后，ToolLoopAgent 将工具结果和历史记录再次发给大模型。
第二次调用大模型（如 deepseek-chat），因为_remove_image_from_context 检测的是self.req，所以仍能检测到图片，_remove_image_from_context 被再次触发。此时，它的 flag 逻辑会错误地将包含 tool_calls 的 assistant 消息删除。而这个assistant消息后面有转述插件的tool消息，这破坏了 OpenAI API 要求的消息格式（tool 消息前必须有带 tool_calls 的 assistant 消息），最终导致 400 BadRequestError，使整个流程失败。

### Modifications
修改位于 astrbot/core/provider/sources/openai_source.py 文件中的 _remove_image_from_context 方法。
移除了方法内部的 flag 判断及其相关逻辑。
**直接移除flag不会引起问题的原因：**
例如
 用户发送了一张“猫弹钢琴”的图片。（视觉模型）AI 回复：“这是一只猫在弹钢琴。”
此时切换到纯文本模型继续对话，历史记录被降级处理。flag 逻辑会删除图片，并且删除 “这是一只猫在弹钢琴”这条回复。
原flag逻辑处理后：[
  {"role": "user", "content": "[图片]"}
]

去除flag逻辑后：[
  {"role": "user", "content": "[图片]"}, 
  {"role": "assistant", "content": "这是一只猫在弹钢琴。"}
]

可见去除flag逻辑并不影响模型理解上下文，反而flag 逻辑会删除图片，并且删除 “这是一只猫在弹钢琴”这条回复，使模型困惑。


### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

移除 `_remove_image_from_context` 中基于标志的消息移除机制，以避免在工具调用之前剥离助手回复，并修复处理基于图像的插件时出现的 `invalid_request_error`。

Bug 修复：
- 修复了当上下文中存在图像时，由于移除了工具调用之前的助手消息而导致的 `invalid_request_error`。

增强功能：
- 通过消除无意中丢弃有效助手响应的过时标志逻辑，简化了 `_remove_image_from_context`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the flag-based removal of messages in _remove_image_from_context to avoid stripping assistant replies before tool calls and fix invalid_request_error when handling image-based plugins.

Bug Fixes:
- Fix invalid_request_error caused by removing the assistant message that precedes a tool call when images are in the context.

Enhancements:
- Simplify _remove_image_from_context by eliminating outdated flag logic that inadvertently dropped valid assistant responses.

</details>