### PR TITLE
Improve: add fallback for missing 'desc' in plugin metadata

### DIFF
--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -211,6 +211,9 @@ class PluginManager:
             metadata = plugin_obj.info()
 
         if isinstance(metadata, dict):
+            if "desc" not in metadata and "description" in metadata:
+                metadata["desc"] = metadata["description"]
+
             if (
                 "name" not in metadata
                 or "desc" not in metadata
@@ -452,8 +455,10 @@ class PluginManager:
                             metadata.desc = metadata_yaml.desc
                             metadata.version = metadata_yaml.version
                             metadata.repo = metadata_yaml.repo
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.error(
+                            f"插件 {root_dir_name} 元数据载入失败: {str(e)}。使用默认元数据。"
+                        )
                     metadata.config = plugin_config
                     if path not in inactivated_plugins:
                         # 只有没有禁用插件时才实例化插件类


### PR DESCRIPTION
and improve error logging

### Motivation

字段优化、提高可读性


### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

改进插件元数据处理，通过为缺失的 ‘desc’ 字段添加回退方案，并在元数据加载失败时记录错误，而不是静默忽略。

增强功能：
- 添加回退方案，当插件元数据中缺少 “desc” 字段时，使用 “description” 字段。
- 当加载插件元数据失败时，记录详细的错误消息，并回退到默认元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve plugin metadata handling by adding a fallback for missing ‘desc’ fields and by logging errors when metadata loading fails instead of silently ignoring them.

Enhancements:
- Add fallback to use “description” field when “desc” is missing in plugin metadata.
- Log detailed error messages when loading plugin metadata fails, and fall back to default metadata.

</details>