### PR TITLE
Fix: active message cannot handle forward type message properly in aiocqhttp adapter

### DIFF
--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
@@ -1,7 +1,7 @@
 import asyncio
 import re
 from typing import AsyncGenerator, Dict, List
-from aiocqhttp import CQHttp
+from aiocqhttp import CQHttp, Event
 from astrbot.api.event import AstrMessageEvent, MessageChain
 from astrbot.api.message_components import (
     Image,
@@ -58,50 +58,79 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
             ret.append(d)
         return ret
 
-    async def send(self, message: MessageChain):
+    @classmethod
+    async def send_message(
+        cls,
+        bot: CQHttp,
+        message_chain: MessageChain,
+        event: Event | None = None,
+        is_group: bool = False,
+        session_id: str = None,
+    ):
+        """发送消息"""
+
+        async def _send(
+            event: Event, is_group: bool, session_id: str, messages: list[dict]
+        ):
+            if event:
+                await bot.send(event=event, message=messages)
+            elif is_group:
+                await bot.send_group_msg(group_id=session_id, message=messages)
+            else:
+                await bot.send_private_msg(user_id=session_id, message=messages)
+
         # 转发消息、文件消息不能和普通消息混在一起发送
         send_one_by_one = any(
-            isinstance(seg, (Node, Nodes, File)) for seg in message.chain
+            isinstance(seg, (Node, Nodes, File)) for seg in message_chain.chain
         )
-        if send_one_by_one:
-            for seg in message.chain:
-                if isinstance(seg, (Node, Nodes)):
-                    # 合并转发消息
-
-                    if isinstance(seg, Node):
-                        nodes = Nodes([seg])
-                        seg = nodes
-
-                    payload = await seg.to_dict()
-
-                    if self.get_group_id():
-                        payload["group_id"] = self.get_group_id()
-                        await self.bot.call_action("send_group_forward_msg", **payload)
-                    else:
-                        payload["user_id"] = self.get_sender_id()
-                        await self.bot.call_action(
-                            "send_private_forward_msg", **payload
-                        )
-                elif isinstance(seg, File):
-                    d = await AiocqhttpMessageEvent._from_segment_to_dict(seg)
-                    await self.bot.send(
-                        self.message_obj.raw_message,
-                        [d],
-                    )
-                else:
-                    await self.bot.send(
-                        self.message_obj.raw_message,
-                        await AiocqhttpMessageEvent._parse_onebot_json(
-                            MessageChain([seg])
-                        ),
-                    )
-                    await asyncio.sleep(0.5)
-        else:
-            ret = await AiocqhttpMessageEvent._parse_onebot_json(message)
+        if not send_one_by_one:
+            ret = await cls._parse_onebot_json(message_chain)
             if not ret:
                 return
-            await self.bot.send(self.message_obj.raw_message, ret)
+            await _send(event, is_group, session_id, ret)
+            return
+        for seg in message_chain.chain:
+            if isinstance(seg, (Node, Nodes)):
+                # 合并转发消息
+                if isinstance(seg, Node):
+                    nodes = Nodes([seg])
+                    seg = nodes
 
+                payload = await seg.to_dict()
+
+                if is_group:
+                    payload["group_id"] = session_id
+                    await bot.call_action("send_group_forward_msg", **payload)
+                else:
+                    payload["user_id"] = session_id
+                    await bot.call_action("send_private_forward_msg", **payload)
+            elif isinstance(seg, File):
+                d = await cls._from_segment_to_dict(seg)
+                await _send(event, is_group, session_id, [d])
+            else:
+                messages = await cls._parse_onebot_json(MessageChain([seg]))
+                if not messages:
+                    continue
+                await _send(event, is_group, session_id, messages)
+                await asyncio.sleep(0.5)
+
+    async def send(self, message: MessageChain):
+        """发送消息"""
+        event = self.message_obj.raw_message
+        assert isinstance(event, Event), "Event must be an instance of aiocqhttp.Event"
+        is_group = False
+        if self.get_group_id():
+            is_group = True
+            session_id = self.get_group_id()
+        else:
+            session_id = self.get_sender_id()
+        await self.send_message(
+            bot=self.bot,
+            message_chain=message,
+            event=event,
+            is_group=is_group,
+            session_id=session_id,
+        )
         await super().send(message)
 
     async def send_streaming(


### PR DESCRIPTION
### Motivation

当前版本 aiocqhttp 适配器下，不能正确处理合并转发消息等消息

### Modifications

重构了消息发送逻辑，对齐了被动消息、主动消息的逻辑，在 aiocqhttp 适配器下。提高了复用性。

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构 aiocqhttp 适配器的消息发送流程，通过将逻辑集中在一个新的 `send_message` 方法中，正确支持事件驱动和会话驱动上下文中合并的转发消息和文件消息。

Bug 修复：
- 修复了 aiocqhttp 适配器下主动发送中转发（Node/Nodes）和文件消息段的处理

增强功能：
- 引入类级别的 `send_message` 方法来统一被动和主动消息发送逻辑
- 重构 `send` 和 `send_by_session` 以委托给新的 `send_message` 方法并简化会话 ID 处理

杂项：
- 调整消息转换中昵称提取的格式

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the aiocqhttp adapter’s message sending flow to correctly support merged forward and file messages in both event-driven and session-driven contexts by centralizing logic in a new send_message method.

Bug Fixes:
- Fix handling of forward (Node/Nodes) and file message segments in active sends under the aiocqhttp adapter

Enhancements:
- Introduce a class-level send_message method to unify passive and active message sending logic
- Refactor send and send_by_session to delegate to the new send_message method and streamline session ID handling

Chores:
- Adjust nickname extraction formatting in message conversion

</details>