### PR TITLE
fix: 修复 WebChat 下可能消息错位的问题

### DIFF
--- a/astrbot/core/pipeline/scheduler.py
+++ b/astrbot/core/pipeline/scheduler.py
@@ -73,7 +73,7 @@ class PipelineScheduler:
         await self._process_stages(event)
 
         # 如果没有发送操作, 则发送一个空消息, 以便于后续的处理
-        if not event._has_send_oper and event.get_platform_name() == "webchat":
+        if event.get_platform_name() == "webchat":
             await event.send(None)
 
         logger.debug("pipeline 执行完毕。")

--- a/astrbot/dashboard/routes/chat.py
+++ b/astrbot/dashboard/routes/chat.py
@@ -156,6 +156,7 @@ class ChatRoute(Route):
                 while True:
                     try:
                         result = await asyncio.wait_for(back_queue.get(), timeout=10)
+                        print(f"Received result: {result}")
                     except asyncio.TimeoutError:
                         continue
 
@@ -166,15 +167,12 @@ class ChatRoute(Route):
                     type = result.get("type")
                     cid = result.get("cid")
                     streaming = result.get("streaming", False)
-                    chain_type = result.get("chain_type")
                     yield f"data: {json.dumps(result, ensure_ascii=False)}\n\n"
                     await asyncio.sleep(0.05)
 
-                    if streaming and type != "end":
-                        # If the result is still streaming, we continue to wait for more data
-                        continue
-
-                    if result_text:
+                    if type == "end":
+                        break
+                    elif (streaming and type == "complete") or not streaming:
                         # append bot message
                         conversation = self.db.get_conversation_by_user_id(
                             username, cid
@@ -188,10 +186,6 @@ class ChatRoute(Route):
                         self.db.update_conversation(
                             username, cid, history=json.dumps(history)
                         )
-                        if chain_type not in ["tool_call", "tool_call_result"]:
-                            # If the result is not a tool call or tool call result,
-                            # we can break the loop and end the stream
-                            break
 
             except BaseException as _:
                 logger.debug(f"用户 {username} 断开聊天长连接。")

--- a/astrbot/dashboard/routes/chat.py
+++ b/astrbot/dashboard/routes/chat.py
@@ -156,7 +156,6 @@ class ChatRoute(Route):
                 while True:
                     try:
                         result = await asyncio.wait_for(back_queue.get(), timeout=10)
-                        print(f"Received result: {result}")
                     except asyncio.TimeoutError:
                         continue
 

--- a/dashboard/src/views/ChatPage.vue
+++ b/dashboard/src/views/ChatPage.vue
@@ -981,20 +981,19 @@ export default {
                                 } else {
                                     message_obj.message.value += chunk_json.data;
                                 }
-                            } else if (chunk_json.type === 'end') {
-                                in_streaming = false;
-                                // 在消息流结束后初始化代码复制按钮和图片点击事件
-                                this.initCodeCopyButtons();
-                                this.initImageClickEvents();
-                                continue;
                             } else if (chunk_json.type === 'update_title') {
                                 // 更新对话标题
                                 const conversation = this.conversations.find(c => c.cid === chunk_json.cid);
                                 if (conversation) {
                                     conversation.title = chunk_json.data;
                                 }
-                            } else {
-                                console.warn('未知数据类型:', chunk_json.type);
+                            }
+                            if ((chunk_json.type === 'break' && chunk_json.streaming) || !chunk_json.streaming) {
+                                // break means a segment end
+                                in_streaming = false;
+                                // 在消息流结束后初始化代码复制按钮和图片点击事件
+                                this.initCodeCopyButtons();
+                                this.initImageClickEvents();
                             }
                             this.scrollToBottom();
                         }


### PR DESCRIPTION
### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

修复 WebChat 中的消息错位问题，通过改进后端事件处理、调度器和前端聊天视图中的流结束信号和流分段来实现。

Bug 修复：
- 修正 WebChat 中的消息顺序，确保正确的流结束标记并移除冗余的结束信号

增强功能：
- 引入不同的 "break" 和 "complete" 类型来表示流中的分段结束和最终消息
- 整合 WebChat 事件处理程序和调度器中的请求结束逻辑，以一致地发送终止事件
- 更新 ChatPage.vue 以处理新的分段标记，用于初始化代码复制按钮和图像点击事件
- 在仪表板流式传输路由中添加用于接收到的流结果的调试日志

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix message misalignment in WebChat by refining end-of-stream signaling and stream segmentation across backend event handling, scheduler, and frontend chat view.

Bug Fixes:
- Correct message ordering in WebChat by ensuring proper end-of-stream markers and removing redundant end signals

Enhancements:
- Introduce distinct "break" and "complete" types to signal segment ends and final message in streaming
- Consolidate end-of-request logic in WebChat event handler and scheduler to consistently send termination events
- Update ChatPage.vue to handle new segment markers for initializing code copy buttons and image click events
- Add debug logging for received stream results in dashboard streaming route

</details>