### PR TITLE
🐞 fix: the MCP market only searched the current page

### DIFF
--- a/astrbot/dashboard/routes/tools.py
+++ b/astrbot/dashboard/routes/tools.py
@@ -133,11 +133,13 @@ class ToolsRoute(Route):
 
             if self.save_mcp_config(config):
                 # 动态初始化新MCP客户端
-                await self.tool_mgr.mcp_service_queue.put({
-                    "type": "init",
-                    "name": name,
-                    "cfg": config["mcpServers"][name],
-                })
+                await self.tool_mgr.mcp_service_queue.put(
+                    {
+                        "type": "init",
+                        "name": name,
+                        "cfg": config["mcpServers"][name],
+                    }
+                )
                 return Response().ok(None, f"成功添加 MCP 服务器 {name}").__dict__
             else:
                 return Response().error("保存配置失败").__dict__
@@ -195,29 +197,37 @@ class ToolsRoute(Route):
                 if active:
                     # 如果要激活服务器或者配置已更改
                     if name in self.tool_mgr.mcp_client_dict or not only_update_active:
-                        await self.tool_mgr.mcp_service_queue.put({
-                            "type": "terminate",
-                            "name": name,
-                        })
-                        await self.tool_mgr.mcp_service_queue.put({
-                            "type": "init",
-                            "name": name,
-                            "cfg": config["mcpServers"][name],
-                        })
+                        await self.tool_mgr.mcp_service_queue.put(
+                            {
+                                "type": "terminate",
+                                "name": name,
+                            }
+                        )
+                        await self.tool_mgr.mcp_service_queue.put(
+                            {
+                                "type": "init",
+                                "name": name,
+                                "cfg": config["mcpServers"][name],
+                            }
+                        )
                     else:
                         # 客户端不存在，初始化
-                        await self.tool_mgr.mcp_service_queue.put({
-                            "type": "init",
-                            "name": name,
-                            "cfg": config["mcpServers"][name],
-                        })
+                        await self.tool_mgr.mcp_service_queue.put(
+                            {
+                                "type": "init",
+                                "name": name,
+                                "cfg": config["mcpServers"][name],
+                            }
+                        )
                 else:
                     # 如果要停用服务器
                     if name in self.tool_mgr.mcp_client_dict:
-                        self.tool_mgr.mcp_service_queue.put_nowait({
-                            "type": "terminate",
-                            "name": name,
-                        })
+                        self.tool_mgr.mcp_service_queue.put_nowait(
+                            {
+                                "type": "terminate",
+                                "name": name,
+                            }
+                        )
 
                 return Response().ok(None, f"成功更新 MCP 服务器 {name}").__dict__
             else:
@@ -245,10 +255,12 @@ class ToolsRoute(Route):
             if self.save_mcp_config(config):
                 # 关闭并删除MCP客户端
                 if name in self.tool_mgr.mcp_client_dict:
-                    self.tool_mgr.mcp_service_queue.put_nowait({
-                        "type": "terminate",
-                        "name": name,
-                    })
+                    self.tool_mgr.mcp_service_queue.put_nowait(
+                        {
+                            "type": "terminate",
+                            "name": name,
+                        }
+                    )
 
                 return Response().ok(None, f"成功删除 MCP 服务器 {name}").__dict__
             else:
@@ -267,60 +279,78 @@ class ToolsRoute(Route):
             if search.strip():
                 search_term = search.strip().lower()
                 all_servers = []
-                
+
                 # 首先获取第一页来了解总页数
                 first_page_url = "https://api.soulter.top/astrbot/mcpservers?page=1&page_size=100"  # 使用更大的页面大小
                 async with aiohttp.ClientSession() as session:
                     async with session.get(first_page_url) as response:
                         if response.status == 200:
                             first_data = await response.json()
-                            pagination = first_data.get("data", {}).get("pagination", {})
+                            pagination = first_data.get("data", {}).get(
+                                "pagination", {}
+                            )
                             total_pages = pagination.get("totalPages", 1)
-                            
+
                             # 获取第一页的数据
-                            all_servers.extend(first_data.get("data", {}).get("mcpservers", []))
-                            
+                            all_servers.extend(
+                                first_data.get("data", {}).get("mcpservers", [])
+                            )
+
                             # 获取剩余页面的数据
-                            for current_page in range(2, min(total_pages + 1, 51)):  # 限制最多50页避免请求过多
+                            for current_page in range(
+                                2, min(total_pages + 1, 51)
+                            ):  # 限制最多50页避免请求过多
                                 page_url = f"https://api.soulter.top/astrbot/mcpservers?page={current_page}&page_size=100"
                                 try:
                                     async with session.get(page_url) as page_response:
                                         if page_response.status == 200:
                                             page_data = await page_response.json()
-                                            all_servers.extend(page_data.get("data", {}).get("mcpservers", []))
+                                            all_servers.extend(
+                                                page_data.get("data", {}).get(
+                                                    "mcpservers", []
+                                                )
+                                            )
                                         else:
-                                            logger.warning(f"获取第{current_page}页失败: HTTP {page_response.status}")
+                                            logger.warning(
+                                                f"获取第{current_page}页失败: HTTP {page_response.status}"
+                                            )
                                 except Exception as e:
                                     logger.warning(f"获取第{current_page}页异常: {e}")
                                     continue
-                
+
                 # 在所有数据中进行搜索
                 filtered_servers = []
                 for server in all_servers:
-                    if (search_term in server.get("name", "").lower() or
-                        search_term in server.get("name_h", "").lower() or
-                        search_term in server.get("description", "").lower()):
+                    if (
+                        search_term in server.get("name", "").lower()
+                        or search_term in server.get("name_h", "").lower()
+                        or search_term in server.get("description", "").lower()
+                    ):
                         filtered_servers.append(server)
-                
+
                 # 分页处理搜索结果
                 start_idx = (page - 1) * page_size
                 end_idx = start_idx + page_size
                 paged_servers = filtered_servers[start_idx:end_idx]
-                
+
                 # 构造响应数据
                 result = {
                     "mcpservers": paged_servers,
                     "pagination": {
                         "total": len(filtered_servers),
-                        "totalPages": max(1, (len(filtered_servers) + page_size - 1) // page_size),
+                        "totalPages": max(
+                            1, (len(filtered_servers) + page_size - 1) // page_size
+                        ),
                         "currentPage": page,
-                        "pageSize": page_size
-                    }
+                        "pageSize": page_size,
+                    },
                 }
-                
-                logger.info(f"MCP市场全局搜索 '{search}': 在{len(all_servers)}个服务器中找到{len(filtered_servers)}个匹配项")
+
+                logger.info(
+                    f"MCP市场全局搜索 '{search}': 在{len(all_servers)}个服务器中找到{len(filtered_servers)}个匹配项"
+                )
                 return Response().ok(result).__dict__
-            
+
             else:
                 # 没有搜索条件，正常分页获取
                 BASE_URL = f"https://api.soulter.top/astrbot/mcpservers?page={page}&page_size={page_size}"
@@ -336,7 +366,7 @@ class ToolsRoute(Route):
                                 .error(f"获取市场数据失败: HTTP {response.status}")
                                 .__dict__
                             )
-                            
+
         except Exception as e:
             logger.error(f"请求MCP市场API异常: {e}")
             logger.error(traceback.format_exc())

--- a/astrbot/dashboard/routes/tools.py
+++ b/astrbot/dashboard/routes/tools.py
@@ -29,7 +29,7 @@ class ToolsRoute(Route):
         }
         self.register_routes()
         self.tool_mgr = self.core_lifecycle.provider_manager.llm_tools
-        
+
         # MCP市场数据缓存
         self._mcp_cache = None
         self._cache_timestamp = None
@@ -38,6 +38,7 @@ class ToolsRoute(Route):
     def _is_cache_valid(self):
         """检查缓存是否有效"""
         import time
+
         if self._mcp_cache is None or self._cache_timestamp is None:
             return False
         return (time.time() - self._cache_timestamp) < self._cache_ttl
@@ -296,7 +297,11 @@ class ToolsRoute(Route):
             return (await response.json())["data"]
 
     async def _fetch_all_mcp_servers(
-        self, session: aiohttp.ClientSession, max_pages: int = 1000, page_size: int = 2000, force_refresh: bool = False
+        self,
+        session: aiohttp.ClientSession,
+        max_pages: int = 1000,
+        page_size: int = 2000,
+        force_refresh: bool = False,
     ) -> list:
         """并发获取所有MCP服务器数据，支持缓存"""
         import asyncio
@@ -308,7 +313,7 @@ class ToolsRoute(Route):
             return self._mcp_cache
 
         logger.info("从API获取MCP市场数据")
-        
+
         # 获取第一页来了解总页数
         first_page = await self._fetch_mcp_page(session, 1, page_size)
         servers = first_page.get("mcpservers", [])
@@ -377,11 +382,17 @@ class ToolsRoute(Route):
             async with aiohttp.ClientSession() as session:
                 if search:
                     # 全局搜索模式
-                    all_servers = await self._fetch_all_mcp_servers(session, force_refresh=force_refresh)
+                    all_servers = await self._fetch_all_mcp_servers(
+                        session, force_refresh=force_refresh
+                    )
                     filtered_servers = self._filter_servers(all_servers, search)
                     result = self._paginate_list(filtered_servers, page, page_size)
 
-                    cache_status = "缓存" if not force_refresh and self._is_cache_valid() else "API"
+                    cache_status = (
+                        "缓存"
+                        if not force_refresh and self._is_cache_valid()
+                        else "API"
+                    )
                     logger.info(
                         f"MCP市场全局搜索 '{search}' ({cache_status}): 在{len(all_servers)}个服务器中找到{len(filtered_servers)}个匹配项"
                     )

--- a/dashboard/src/views/ToolUsePage.vue
+++ b/dashboard/src/views/ToolUsePage.vue
@@ -49,11 +49,11 @@
               <v-icon color="primary" class="me-2">mdi-server</v-icon>
               <span class="text-h6">{{ tm('mcpServers.title') }}</span>
               <v-spacer></v-spacer>
-              <v-btn color="primary" prepend-icon="mdi-refresh" variant="tonal" @click="getServers" :loading="loading">
+              <v-btn color="primary" prepend-icon="mdi-refresh" variant="tonal" @click="getServers" :loading="loading" rounded="lg">
                 {{ tm('mcpServers.buttons.refresh') }}
               </v-btn>
               <v-btn color="primary" style="margin-left: 8px;" prepend-icon="mdi-plus" variant="tonal"
-                @click="showMcpServerDialog = true">
+                @click="showMcpServerDialog = true" rounded="lg">
                 {{ tm('mcpServers.buttons.add') }}
               </v-btn>
             </v-card-title>
@@ -69,7 +69,7 @@
               <v-row v-else>
                 <v-col v-for="(server, index) in mcpServers || []" :key="index" cols="12" md="6" lg="4" xl="3">
                   <item-card
-                    style="background-color: #f7f2f9;"
+                    class="server-card"
                     :item="server" 
                     title-field="name" 
                     enabled-field="active"
@@ -918,6 +918,10 @@ export default {
 .tools-page {
   padding: 20px;
   padding-top: 8px;
+}
+
+.server-card {
+  background-color: rgba(var(--v-theme-primary), 0.05) !important;
 }
 
 .tool-chips {

--- a/dashboard/src/views/ToolUsePage.vue
+++ b/dashboard/src/views/ToolUsePage.vue
@@ -219,7 +219,7 @@
               <v-text-field v-model="marketplaceSearch" prepend-inner-icon="mdi-magnify" :label="tm('marketplace.search')"
                 variant="outlined" density="compact" hide-details class="mx-2" style="max-width: 300px" clearable
                 @update:model-value="searchMarketplaceServers"></v-text-field>
-              <v-btn color="primary" prepend-icon="mdi-refresh" variant="text" @click="fetchMarketplaceServers(1)"
+              <v-btn color="primary" prepend-icon="mdi-refresh" variant="text" @click="fetchMarketplaceServers(1, true)"
                 :loading="marketplaceLoading">
                 {{ tm('marketplace.buttons.refresh') }}
               </v-btn>
@@ -802,7 +802,7 @@ export default {
     // MCP 市场相关方法
 
     // 获取市场服务器列表
-    fetchMarketplaceServers(page = 1) {
+    fetchMarketplaceServers(page = 1, forceRefresh = false) {
       this.marketplaceLoading = true;
 
       // 构建请求参数
@@ -814,6 +814,11 @@ export default {
       // 如果有搜索关键词，添加到请求参数
       if (this.safeMarketplaceSearch.trim()) {
         params.search = this.safeMarketplaceSearch.trim();
+      }
+
+      // 如果强制刷新，添加参数
+      if (forceRefresh) {
+        params.force_refresh = true;
       }
 
       axios.get('/api/tools/mcp/market', { params })

--- a/dashboard/src/views/ToolUsePage.vue
+++ b/dashboard/src/views/ToolUsePage.vue
@@ -536,6 +536,11 @@ export default {
   },
 
   computed: {
+    // 安全的搜索字符串
+    safeMarketplaceSearch() {
+      return this.marketplaceSearch || '';
+    },
+
     filteredTools() {
       if (!this.toolSearch) return this.tools;
 
@@ -570,19 +575,19 @@ export default {
       }
     },
 
-    // 过滤后的市场服务器
+    // 过滤后的市场服务器（服务端已处理搜索）
     filteredMarketplaceServers() {
-      if (!this.marketplaceSearch.trim()) {
-        return this.marketplaceServers;
-      }
-      
-      const searchTerm = this.marketplaceSearch.toLowerCase();
-      return this.marketplaceServers.filter(server => 
-        server.name.toLowerCase().includes(searchTerm) || 
-        (server.name_h && server.name_h.toLowerCase().includes(searchTerm)) ||
-        (server.description && server.description.toLowerCase().includes(searchTerm))
-      );
+      return this.marketplaceServers;
     },
+  },
+
+  watch: {
+    // 确保marketplaceSearch始终是字符串
+    marketplaceSearch(newVal) {
+      if (newVal === null || newVal === undefined) {
+        this.marketplaceSearch = '';
+      }
+    }
   },
 
   mounted() {
@@ -807,8 +812,8 @@ export default {
       };
 
       // 如果有搜索关键词，添加到请求参数
-      if (this.marketplaceSearch.trim()) {
-        params.search = this.marketplaceSearch.trim();
+      if (this.safeMarketplaceSearch.trim()) {
+        params.search = this.safeMarketplaceSearch.trim();
       }
 
       axios.get('/api/tools/mcp/market', { params })
@@ -842,6 +847,7 @@ export default {
 
     // 切换分页
     changePage(page) {
+      this.currentMarketPage = page;
       this.fetchMarketplaceServers(page);
     },
 


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了 #1932

### 修改MCP市场使用逻辑如下图所示

```mermaid
graph TD
    A[用户操作] --> B{操作类型}
    
    %% 正常浏览模式
    B -->|正常浏览| C[前端请求<br>/api/tools/mcp/market<br>?page=1&page_size=9]
    C --> D[后端直接调用API<br>api.soulter.top/astrbot/mcpservers<br>?page=1&page_size=9]
    D --> E[返回当前页数据<br>高效，只获取当前页]
    
    %% 搜索模式
    B -->|搜索模式| F[前端请求<br>/api/tools/mcp/market<br>?search=keyword&page=1000&page_size=2000]
    F --> G{检查缓存是否有效<br>5分钟内}
    G -->|有效缓存| H[使用缓存数据]
    G -->|无缓存/过期| I[获取所有数据并缓存]
    I --> J[本地过滤 keyword]
    H --> J
    J --> K[本地分页]
    K --> L[返回搜索结果]
    
    %% 刷新按钮
    B -->|点击刷新| M[前端请求<br>/api/tools/mcp/market<br>?force_refresh=true&page=1000&page_size=2000]
    M --> N[后端清除缓存]
    N --> O[强制从API获取最新数据]
    O --> P[更新缓存]
    P --> Q[返回最新结果]
    
    %% 样式定义
    classDef userAction fill:#e1f5fe,stroke:#01579b,stroke-width:2px
    classDef frontend fill:#f3e5f5,stroke:#4a148c,stroke-width:2px
    classDef backend fill:#e8f5e8,stroke:#1b5e20,stroke-width:2px
    classDef cache fill:#fff3e0,stroke:#e65100,stroke-width:2px
    classDef api fill:#fce4ec,stroke:#880e4f,stroke-width:2px
    
    class A,B userAction
    class C,F,M frontend
    class D,G,N,O backend
    class H,I,P cache
    class E,L,Q api
```

### Motivation

<!--解释为什么要改动-->

### Modifications

<!--简单解释你的改动-->

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

启用 MCP 市场端点的整页搜索，并更新前端以使用服务器端过滤、安全地处理搜索输入以及维护分页状态。

新功能：
- 为 MCP 市场添加跨所有页面的服务器端全局搜索

Bug 修复：
- 修复 MCP 市场搜索仅限于当前页面的问题

增强功能：
- 添加 `safeMarketplaceSearch` 计算属性和输入监听器，以强制执行字符串搜索词
- 限制后端页面获取在全局搜索中最多为 50，以避免过多的请求
- 删除冗余的客户端过滤，并在分页更改时同步当前页面

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable full-page search on the MCP market endpoint and update the frontend to use server-side filtering, handle search input safely, and maintain pagination state.

New Features:
- Add server-side global search for MCP market across all pages

Bug Fixes:
- Fix MCP market search being limited to the current page

Enhancements:
- Add safeMarketplaceSearch computed property and input watcher to enforce string search terms
- Limit backend page fetches to a maximum of 50 in global search to avoid excessive requests
- Remove redundant client-side filtering and sync current page on pagination changes

</details>