### PR TITLE
Feature: 为 WebChat 页面添加文件上传按钮

### DIFF
--- a/dashboard/src/views/ChatPage.vue
+++ b/dashboard/src/views/ChatPage.vue
@@ -720,6 +720,8 @@ export default {
             if (file) {
                 this.processAndUploadImage(file);
             }
+            // Reset the input value to allow selecting the same file again
+            event.target.value = null;
         },
         getConversations() {
             axios.get('/api/chat/conversations').then(response => {

--- a/dashboard/src/views/ChatPage.vue
+++ b/dashboard/src/views/ChatPage.vue
@@ -895,15 +895,13 @@ export default {
 
             // Convert image filenames to blob URLs for display
             if (imageNamesToSend.length > 0) {
-                for (let i = 0; i < imageNamesToSend.length; i++) {
-                    // If it's just a filename, get the blob URL
-                    if (!imageNamesToSend[i].startsWith('blob:')) {
-                        const imgUrl = await this.getMediaFile(imageNamesToSend[i]);
-                        userMessage.image_url.push(imgUrl);
-                    } else {
-                        userMessage.image_url.push(imageNamesToSend[i]);
+                const imagePromises = imageNamesToSend.map(name => {
+                    if (!name.startsWith('blob:')) {
+                        return this.getMediaFile(name);
                     }
-                }
+                    return Promise.resolve(name);
+                });
+                userMessage.image_url = await Promise.all(imagePromises);
             }
 
             // Convert audio filename to blob URL for display

--- a/dashboard/src/views/ChatPage.vue
+++ b/dashboard/src/views/ChatPage.vue
@@ -226,7 +226,7 @@
                                     <ProviderModelSelector ref="providerModelSelector" />
                                 </div>
                                 <div style="display: flex; justify-content: flex-end; margin-top: 8px;">
-                                    <input type="file" ref="imageInput" @change="handleFileSelect" accept="image/*" style="display: none" />
+                                    <input type="file" ref="imageInput" @change="handleFileSelect" accept="image/*" style="display: none" multiple />
                                     <v-btn @click="triggerImageInput" icon="mdi-plus" variant="text" color="deep-purple"
                                         class="add-btn" size="small" />
                                     <v-btn @click="sendMessage" icon="mdi-send" variant="text" color="deep-purple"
@@ -716,9 +716,11 @@ export default {
         },
 
         handleFileSelect(event) {
-            const file = event.target.files[0];
-            if (file) {
-                this.processAndUploadImage(file);
+            const files = event.target.files;
+            if (files) {
+                for (const file of files) {
+                    this.processAndUploadImage(file);
+                }
             }
             // Reset the input value to allow selecting the same file again
             event.target.value = '';

--- a/dashboard/src/views/ChatPage.vue
+++ b/dashboard/src/views/ChatPage.vue
@@ -703,6 +703,12 @@ export default {
         },
 
         removeImage(index) {
+            // Revoke the blob URL to prevent memory leaks
+            const urlToRevoke = this.stagedImagesUrl[index];
+            if (urlToRevoke && urlToRevoke.startsWith('blob:')) {
+                URL.revokeObjectURL(urlToRevoke);
+            }
+
             this.stagedImagesName.splice(index, 1);
             this.stagedImagesUrl.splice(index, 1);
         },

--- a/dashboard/src/views/ChatPage.vue
+++ b/dashboard/src/views/ChatPage.vue
@@ -721,7 +721,7 @@ export default {
                 this.processAndUploadImage(file);
             }
             // Reset the input value to allow selecting the same file again
-            event.target.value = null;
+            event.target.value = '';
         },
         getConversations() {
             axios.get('/api/chat/conversations').then(response => {


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了 #2052 #2119 

### Motivation

目前在webchat页面添加图片需要打开资源管理器复制到剪贴板再粘贴上传，某些时候有所不便

### Modifications

添加了一个文件上传按钮，抽离了处理上传图片的逻辑，在点击后调用并以和复制粘贴一样的行为添加到待发预览区域

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

在聊天 UI 中添加图片上传按钮，并重构粘贴和文件选择工作流程的图片暂存和发送逻辑

新功能：
- 在 webchat 页面添加一个隐藏的文件输入和上传按钮，以允许选择图片
- 支持将选定的图片上传到服务器并暂存以进行预览

增强功能：
- 将粘贴和上传逻辑提取到统一的 `processAndUploadImage` 方法中
- 重构 `sendMessage` 以在局部变量中捕获暂存的数据，并提前清除输入

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an image upload button to the chat UI and refactor the image staging and sending logic for both paste and file selection workflows

New Features:
- Add a hidden file input and upload button to the webchat page to allow image selection
- Support uploading selected images to the server and staging them for preview

Enhancements:
- Extract paste and upload logic into a unified processAndUploadImage method
- Refactor sendMessage to capture staged data in local variables and clear inputs early

</details>