### PR TITLE
fix: 修复MCP导致的持续占用100% CPU

### DIFF
--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -356,12 +356,14 @@ class FuncCall:
             await self._init_mcp_client(name, cfg)
             await event.wait()
             logger.info(f"收到 MCP 客户端 {name} 终止信号")
-            await self._terminate_mcp_client(name)
         except Exception as e:
             import traceback
 
             traceback.print_exc()
             logger.error(f"初始化 MCP 客户端 {name} 失败: {e}")
+        finally:
+            # 无论如何都能清理
+            await self._terminate_mcp_client(name)
 
     async def _init_mcp_client(self, name: str, config: dict) -> None:
         """初始化单个MCP客户端"""
@@ -629,8 +631,3 @@ class FuncCall:
 
     def __repr__(self):
         return str(self.func_list)
-
-    async def terminate(self):
-        for name in self.mcp_client_dict.keys():
-            await self._terminate_mcp_client(name)
-            logger.debug(f"清理 MCP 客户端 {name} 资源")

--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -130,7 +130,7 @@ class MCPClient:
                     timeout=cfg.get("timeout", 5),
                     sse_read_timeout=cfg.get("sse_read_timeout", 60 * 5),
                 )
-                streams = await self._streams_context.__aenter__()
+                streams = await self.exit_stack.enter_async_context(self._streams_context)
 
                 # Create a new client session
                 self.session = await self.exit_stack.enter_async_context(
@@ -148,7 +148,7 @@ class MCPClient:
                     sse_read_timeout=sse_read_timeout,
                     terminate_on_close=cfg.get("terminate_on_close", True),
                 )
-                read_s, write_s, _ = await self._streams_context.__aenter__()
+                read_s, write_s, _ = await self.exit_stack.enter_async_context(self._streams_context)
 
                 # Create a new client session
                 self.session = await self.exit_stack.enter_async_context(
@@ -414,7 +414,7 @@ class FuncCall:
             try:
                 # 关闭MCP连接
                 await self.mcp_client_dict[name].cleanup()
-                del self.mcp_client_dict[name]
+                self.mcp_client_dict.pop(name)
             except Exception as e:
                 logger.info(f"清空 MCP 客户端资源 {name}: {e}。")
             # 移除关联的FuncTool


### PR DESCRIPTION
fixes #2138

### Motivation

AsyncExitStack必须在同一任务中被创建和退出，否则会导致协程不断自旋，占用CPU

### Modifications

优化MCP相关逻辑

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

好的，这是翻译成中文的pull request总结：

## Sourcery 总结

修复了由于 MCP 连接中不正确的异步上下文处理导致的持续 CPU 占用问题，通过在共享的 AsyncExitStack 中集中上下文入口并改进客户端清理来解决。

Bug 修复：
- 使用 `exit_stack.enter_async_context` 代替直接调用 `__aenter__` 来处理 `_streams_context`，以确保异步上下文在同一任务中创建和退出，从而防止失控的协程。
- 将 `del self.mcp_client_dict[name]` 替换为 `self.mcp_client_dict.pop(name)`，以便在清理期间更安全地删除 MCP 客户端。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix continuous CPU spin caused by improper async context handling in MCP connections by centralizing context entry in a shared AsyncExitStack and refining client cleanup.

Bug Fixes:
- Use `exit_stack.enter_async_context` instead of direct `__aenter__` calls for `_streams_context` to ensure async contexts are created and exited in the same task, preventing runaway coroutines.
- Replace `del self.mcp_client_dict[name]` with `self.mcp_client_dict.pop(name)` for safer MCP client removal during cleanup.

</details>