### PR TITLE
feat: add ModelScope API support

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -823,6 +823,18 @@ CONFIG_METADATA_2 = {
                         "variables": {},
                         "timeout": 60,
                     },
+                    "ModelScope": {
+                        "id": "modelscope",
+                        "type": "openai_chat_completion",
+                        "provider_type": "chat_completion",
+                        "enable": True,
+                        "key": [],
+                        "timeout": 120,
+                        "api_base": "https://api-inference.modelscope.cn/v1",
+                        "model_config": {
+                            "model": "Qwen/Qwen3-32B",
+                        },
+                    },
                     "FastGPT": {
                         "id": "fastgpt",
                         "provider": "fastgpt",

--- a/dashboard/src/views/ProviderPage.vue
+++ b/dashboard/src/views/ProviderPage.vue
@@ -549,6 +549,7 @@ export default {
         'ollama': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/ollama.svg',
         'google': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/gemini-color.svg',
         'deepseek': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/deepseek.svg',
+        'modelscope': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/modelscope.svg',
         'zhipu': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/zhipu.svg',
         'siliconflow': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/siliconcloud.svg',
         'moonshot': 'https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/kimi.svg',


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了 #XYZ

### Motivation
Add ModelScope API support to make it easier for users to use modelscope community resources.
<!--解释为什么要改动-->

### Modifications
ModelScope API has been added to the service provider options in the panel. Users can use the community model by filling in the API-Key of mdoelscope. 
Please note that you need to bind your Alibaba Cloud account before use. For specific methods to obtain the API-Key, please refer to the [link](https://modelscope.cn/docs/model-service/API-Inference/intro).
<!--简单解释你的改动-->

### Check

<!--如果分支被合并
您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 总结

添加 ModelScope API 作为新的聊天完成提供商选项

新功能：
- 在默认设置中引入 ModelScope 配置，支持 API 密钥、自定义基础 URL、超时和默认模型
- 将 ModelScope 图标集成到提供商选择 UI 中

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add ModelScope API as a new chat completion provider option

New Features:
- Introduce ModelScope configuration in the default settings with API key support, custom base URL, timeout, and default model
- Integrate ModelScope icon into the provider selection UI

</details>