### PR TITLE
Refactor: mcp server reload mechanism

### DIFF
--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -464,11 +464,11 @@ class FuncCall:
                 self.func_list = [
                     f
                     for f in self.func_list
-                    if not (f.origin == "mcp" and f.mcp_server_name == name)
+                    if f.origin != "mcp" or f.mcp_server_name != name
                 ]
         else:
             running_events = [
-                client.running_event for client in self.mcp_client_dict.values()
+                client.running_event.wait() for client in self.mcp_client_dict.values()
             ]
             for key, event in self.mcp_client_event.items():
                 event.set()

--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -193,7 +193,7 @@ class MCPClient:
                         logger=logger,
                         identifier=f"MCPServer-{name}",
                         callback=callback,
-                    ),
+                    ), # type: ignore
                 ),
             )
 
@@ -412,8 +412,8 @@ class FuncCall:
         self,
         name: str,
         config: dict,
-        event: asyncio.Event = None,
-        ready_future: asyncio.Future = None,
+        event: asyncio.Event | None = None,
+        ready_future: asyncio.Future | None = None,
         timeout: int = 30,
     ) -> None:
         """Enable_mcp_server a new MCP server to the manager and initialize it.
@@ -443,9 +443,11 @@ class FuncCall:
             self.mcp_client_event[name] = event
 
         if ready_future.done() and ready_future.exception():
-            raise ready_future.exception()
+            exc = ready_future.exception()
+            if exc is not None:
+                raise exc
 
-    async def disable_mcp_server(self, name: str = None, timeout: float = 10) -> None:
+    async def disable_mcp_server(self, name: str | None = None, timeout: float = 10) -> None:
         """Disable an MCP server by its name.
 
         Args:

--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -125,7 +125,7 @@ class MCPClient:
         if "url" in cfg:
             success, error_msg = await _quick_test_mcp_connection(cfg)
             if not success:
-                raise Exception(f"远程服务器不可达或配置错误: {error_msg}")
+                raise Exception(error_msg)
 
             if cfg.get("transport") != "streamable_http":
                 # SSE transport method
@@ -268,12 +268,10 @@ async def _quick_test_mcp_connection(config: dict) -> tuple[bool, str]:
                     else:
                         return False, f"HTTP {response.status}: {response.reason}"
 
-    except aiohttp.ClientError as e:
-        return False, f"客户端错误: {str(e)}"
     except asyncio.TimeoutError:
         return False, f"连接超时: {timeout}秒"
     except Exception as e:
-        return False, f"未知错误: {str(e)}"
+        return False, f"{e!s}"
 
 
 class FuncCall:
@@ -462,7 +460,7 @@ class FuncCall:
         if "url" in config:
             success, error_msg = await _quick_test_mcp_connection(config)
             if not success:
-                raise Exception(f"远程服务器不可达或配置错误: {error_msg}")
+                raise Exception(error_msg)
 
         mcp_client = MCPClient()
         try:

--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -56,7 +56,7 @@ async def _quick_test_mcp_connection(config: dict) -> tuple[bool, str]:
 
     url = cfg["url"]
     headers = cfg.get("headers", {})
-    timeout = cfg.get("timeout", 5)
+    timeout = cfg.get("timeout", 10)
 
     try:
         async with aiohttp.ClientSession() as session:

--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -451,7 +451,9 @@ class FuncCall:
         Args:
             name (str): The name of the MCP server to disable. If None, ALL MCP servers will be disabled.
         """
-        if name and name in self.mcp_client_event:
+        if name:
+            if name not in self.mcp_client_event:
+                return
             client = self.mcp_client_dict.get(name)
             self.mcp_client_event[name].set()
             if not client:

--- a/dashboard/src/components/shared/ItemCard.vue
+++ b/dashboard/src/components/shared/ItemCard.vue
@@ -9,6 +9,8 @@
             hide-details 
             density="compact" 
             :model-value="getItemEnabled()"
+            :loading="loading"
+            :disabled="loading"
             v-bind="props" 
             @update:model-value="toggleEnabled"
           ></v-switch>
@@ -77,6 +79,10 @@ export default {
     bglogo: {
       type: String,
       default: null
+    },
+    loading: {
+      type: Boolean,
+      default: false
     }
   },
   emits: ['toggle-enabled', 'delete', 'edit'],

--- a/dashboard/src/i18n/locales/en-US/features/tool-use.json
+++ b/dashboard/src/i18n/locales/en-US/features/tool-use.json
@@ -15,7 +15,9 @@
     "buttons": {
       "refresh": "Refresh",
       "add": "Add Server",
-      "useTemplate": "Use Template"
+      "useTemplateStdio": "Stdio Template",
+      "useTemplateStreamableHttp": "Streamable HTTP Template",
+      "useTemplateSse": "SSE Template"
     },
     "empty": "No MCP servers available, click Add Server to add one",
     "status": {
@@ -68,10 +70,6 @@
         "enable": "Enable Server",
         "config": "Server Configuration"
       },
-      "configNotes": {
-        "note1": "1. Some MCP servers may require filling in `API_KEY` or `TOKEN` information in env according to their requirements, please check if filled.",
-        "note2": "2. When url parameter is specified in configuration: if `transport` parameter is also specified as `streamable_http`, Streamable HTTP is used, otherwise SSE connection is used."
-      },
       "errors": {
         "configEmpty": "Configuration cannot be empty",
         "jsonFormat": "JSON format error: {error}",
@@ -79,7 +77,8 @@
       },
       "buttons": {
         "cancel": "Cancel",
-        "save": "Save"
+        "save": "Save",
+        "testConnection": "Test Connection"
       }
     },
     "serverDetail": {

--- a/dashboard/src/i18n/locales/zh-CN/features/tool-use.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/tool-use.json
@@ -15,7 +15,9 @@
     "buttons": {
       "refresh": "刷新",
       "add": "新增服务器",
-      "useTemplate": "使用模板"
+      "useTemplateStdio": "Stdio 模板",
+      "useTemplateStreamableHttp": "Streamable HTTP 模板",
+      "useTemplateSse": "SSE 模板"
     },
     "empty": "暂无 MCP 服务器，点击 新增服务器 添加",
     "status": {
@@ -68,10 +70,6 @@
         "enable": "启用服务器",
         "config": "服务器配置"
       },
-      "configNotes": {
-        "note1": "1. 某些 MCP 服务器可能需要按照其要求在 env 中填充 `API_KEY` 或 `TOKEN` 等信息，请注意检查是否填写。",
-        "note2": "2. 当配置中指定 url 参数时：如果还同时指定 `transport` 参数的值为 `streamable_http`，则使用 Steamable HTTP，否则使用 SSE 连接。"
-      },
       "errors": {
         "configEmpty": "配置不能为空",
         "jsonFormat": "JSON 格式错误: {error}",
@@ -79,7 +77,8 @@
       },
       "buttons": {
         "cancel": "取消",
-        "save": "保存"
+        "save": "保存",
+        "testConnection": "测试连接"
       }
     },
     "serverDetail": {

--- a/dashboard/src/views/ToolUsePage.vue
+++ b/dashboard/src/views/ToolUsePage.vue
@@ -20,7 +20,8 @@
             </v-tooltip>
           </p>
         </div>
-        <v-btn color="primary" prepend-icon="mdi-plus" variant="tonal" @click="showMcpServerDialog = true" rounded="xl" size="x-large">
+        <v-btn color="primary" prepend-icon="mdi-plus" variant="tonal" @click="showMcpServerDialog = true" rounded="xl"
+          size="x-large">
           {{ tm('mcpServers.buttons.add') }}
         </v-btn>
       </v-row>
@@ -49,7 +50,8 @@
               <v-icon color="primary" class="me-2">mdi-server</v-icon>
               <span class="text-h6">{{ tm('mcpServers.title') }}</span>
               <v-spacer></v-spacer>
-              <v-btn color="primary" prepend-icon="mdi-refresh" variant="tonal" @click="getServers" :loading="loadingGettingServers">
+              <v-btn color="primary" prepend-icon="mdi-refresh" variant="tonal" @click="getServers"
+                :loading="loadingGettingServers">
                 {{ tm('mcpServers.buttons.refresh') }}
               </v-btn>
               <v-btn color="primary" style="margin-left: 8px;" prepend-icon="mdi-plus" variant="tonal"
@@ -68,49 +70,67 @@
 
               <v-row v-else>
                 <v-col v-for="(server, index) in mcpServers || []" :key="index" cols="12" md="6" lg="4" xl="3">
-                  <item-card
-                    style="background-color: #f7f2f9;"
-                    :item="server" 
-                    :loading="loadingUpdatingServer"
-                    title-field="name" 
-                    enabled-field="active"
-                    @toggle-enabled="updateServerStatus"
-                    @delete="deleteServer" 
-                    @edit="editServer">
+                  <item-card style="background-color: #f7f2f9;" :item="server" title-field="name" enabled-field="active"
+                    @toggle-enabled="updateServerStatus" @delete="deleteServer" @edit="editServer">
                     <template v-slot:item-details="{ item }">
                       <div class="d-flex align-center mb-2">
                         <v-icon size="small" color="grey" class="me-2">mdi-file-code</v-icon>
-                        <span class="text-caption text-medium-emphasis text-truncate" :title="getServerConfigSummary(item)">
+                        <span class="text-caption text-medium-emphasis text-truncate"
+                          :title="getServerConfigSummary(item)">
                           {{ getServerConfigSummary(item) }}
                         </span>
                       </div>
 
-                      <div v-if="item.tools && item.tools.length > 0">
-                        <div class="d-flex align-center mb-1">
-                          <v-icon size="small" color="grey" class="me-2">mdi-tools</v-icon>
-                          <v-dialog max-width="600px">
-                            <template v-slot:activator="{ props: listToolsProps }">
-                              <span class="text-caption text-medium-emphasis cursor-pointer" v-bind="listToolsProps" style="text-decoration: underline;">
-                                {{ tm('mcpServers.status.availableTools', { count: item.tools.length }) }} ({{ item.tools.length }})
-                              </span>
-                            </template>
-                            <v-card style="padding: 16px;">
-                              <v-card-title class="d-flex align-center">
-                                <span>{{ tm('mcpServers.status.availableTools') }}</span>
-                              </v-card-title>
-                              <v-card-text>
-                                <ul>
-                                  <li v-for="(tool, idx) in item.tools" :key="idx" style="margin: 8px 0px;">{{ tool }}</li>
-                                </ul>
-                              </v-card-text>
-                            </v-card>
-                          </v-dialog>
+
+                      <div class="d-flex" style="gap: 8px;">
+                        <div>
+                          <div v-if="item.tools && item.tools.length > 0">
+                            <div class="d-flex align-center mb-1">
+                              <v-icon size="small" color="grey" class="me-2">mdi-tools</v-icon>
+                              <v-dialog max-width="600px">
+                                <template v-slot:activator="{ props: listToolsProps }">
+                                  <span class="text-caption text-medium-emphasis cursor-pointer" v-bind="listToolsProps"
+                                    style="text-decoration: underline;">
+                                    {{ tm('mcpServers.status.availableTools', { count: item.tools.length }) }} ({{
+                                      item.tools.length }})
+                                  </span>
+                                </template>
+                                <template v-slot:default="{ isActive }">
+                                  <v-card style="padding: 16px;">
+                                    <v-card-title class="d-flex align-center">
+                                      <span>{{ tm('mcpServers.status.availableTools') }}</span>
+                                    </v-card-title>
+                                    <v-card-text>
+                                      <ul>
+                                        <li v-for="(tool, idx) in item.tools" :key="idx" style="margin: 8px 0px;">{{
+                                          tool
+                                          }}
+                                        </li>
+                                      </ul>
+                                    </v-card-text>
+                                    <v-card-actions class="d-flex justify-end">
+                                      <v-btn variant="text" color="primary" @click="isActive.value = false">
+                                        Close
+                                      </v-btn>
+                                    </v-card-actions>
+                                  </v-card>
+                                </template>
+
+
+                              </v-dialog>
+                            </div>
+                          </div>
+                          <div v-else class="text-caption text-medium-emphasis">
+                            <v-icon size="small" color="warning" class="me-1">mdi-alert-circle</v-icon>
+                            {{ tm('mcpServers.status.noTools') }}
+                          </div>
+                        </div>
+                        <div v-if="mcpServerUpdateLoaders[item.name]" class="text-caption text-medium-emphasis">
+                          <v-progress-circular indeterminate color="primary" size="16"></v-progress-circular>
                         </div>
                       </div>
-                      <div v-else class="text-caption text-medium-emphasis mt-2">
-                        <v-icon size="small" color="warning" class="me-1">mdi-alert-circle</v-icon>
-                        {{ tm('mcpServers.status.noTools') }}
-                      </div>
+
+
                     </template>
                   </item-card>
                 </v-col>
@@ -142,8 +162,9 @@
                   </div>
 
                   <div v-else>
-                    <v-text-field v-model="toolSearch" prepend-inner-icon="mdi-magnify" :label="tm('functionTools.search')" variant="outlined"
-                      density="compact" class="mb-4" hide-details clearable></v-text-field>
+                    <v-text-field v-model="toolSearch" prepend-inner-icon="mdi-magnify"
+                      :label="tm('functionTools.search')" variant="outlined" density="compact" class="mb-4" hide-details
+                      clearable></v-text-field>
 
                     <v-expansion-panels v-model="openedPanel" multiple>
                       <v-expansion-panel v-for="(tool, index) in filteredTools" :key="index" :value="index"
@@ -227,9 +248,9 @@
               <v-icon color="primary" class="me-2">mdi-store</v-icon>
               <span class="text-h6">{{ tm('marketplace.title') }}</span>
               <v-spacer></v-spacer>
-              <v-text-field v-model="marketplaceSearch" prepend-inner-icon="mdi-magnify" :label="tm('marketplace.search')"
-                variant="outlined" density="compact" hide-details class="mx-2" style="max-width: 300px" clearable
-                @update:model-value="searchMarketplaceServers"></v-text-field>
+              <v-text-field v-model="marketplaceSearch" prepend-inner-icon="mdi-magnify"
+                :label="tm('marketplace.search')" variant="outlined" density="compact" hide-details class="mx-2"
+                style="max-width: 300px" clearable @update:model-value="searchMarketplaceServers"></v-text-field>
               <v-btn color="primary" prepend-icon="mdi-refresh" variant="text" @click="fetchMarketplaceServers(1)"
                 :loading="marketplaceLoading">
                 {{ tm('marketplace.buttons.refresh') }}
@@ -267,7 +288,8 @@
                       <div class="d-flex align-center mb-2">
                         <v-icon size="small" color="grey" class="me-2">mdi-tools</v-icon>
                         <span class="text-caption text-medium-emphasis">
-                          {{ tm('marketplace.status.availableTools', { count: server.tools ? server.tools.length : 0 }) }}
+                          {{ tm('marketplace.status.availableTools', { count: server.tools ? server.tools.length : 0 })
+                          }}
                         </span>
                       </div>
 
@@ -321,8 +343,8 @@
 
         <v-card-text class="py-4">
           <v-form @submit.prevent="saveServer" ref="form">
-            <v-text-field v-model="currentServer.name" :label="tm('dialogs.addServer.fields.name')" variant="outlined" :rules="[v => !!v || tm('dialogs.addServer.fields.nameRequired')]"
-              required class="mb-3"></v-text-field>
+            <v-text-field v-model="currentServer.name" :label="tm('dialogs.addServer.fields.name')" variant="outlined"
+              :rules="[v => !!v || tm('dialogs.addServer.fields.nameRequired')]" required class="mb-3"></v-text-field>
 
             <div class="mb-2 d-flex align-center">
               <span class="text-subtitle-1">{{ tm('dialogs.addServer.fields.config') }}</span>
@@ -330,7 +352,8 @@
               <v-btn size="small" color="primary" variant="tonal" @click="setConfigTemplate('stdio')" class="me-1">
                 {{ tm('mcpServers.buttons.useTemplateStdio') }}
               </v-btn>
-              <v-btn size="small" color="primary" variant="tonal" @click="setConfigTemplate('streamable_http')" class="me-1">
+              <v-btn size="small" color="primary" variant="tonal" @click="setConfigTemplate('streamable_http')"
+                class="me-1">
                 {{ tm('mcpServers.buttons.useTemplateStreamableHttp') }}
               </v-btn>
               <v-btn size="small" color="primary" variant="tonal" @click="setConfigTemplate('sse')" class="me-1">
@@ -360,7 +383,7 @@
           <div style="margin-top: 8px;">
             <small>{{ addServerDialogMessage }}</small>
           </div>
-          
+
         </v-card-text>
 
         <v-card-actions class="pa-4">
@@ -517,7 +540,7 @@ export default {
       showTools: true,
       loading: false,
       loadingGettingServers: false,
-      loadingUpdatingServer: false,
+      mcpServerUpdateLoaders: {}, // record loading state for each server update
       isEditMode: false,
       serverConfigJson: '',
       jsonError: null,
@@ -587,10 +610,10 @@ export default {
       if (!this.marketplaceSearch.trim()) {
         return this.marketplaceServers;
       }
-      
+
       const searchTerm = this.marketplaceSearch.toLowerCase();
-      return this.marketplaceServers.filter(server => 
-        server.name.toLowerCase().includes(searchTerm) || 
+      return this.marketplaceServers.filter(server =>
+        server.name.toLowerCase().includes(searchTerm) ||
         (server.name_h && server.name_h.toLowerCase().includes(searchTerm)) ||
         (server.description && server.description.toLowerCase().includes(searchTerm))
       );
@@ -634,6 +657,12 @@ export default {
       axios.get('/api/tools/mcp/servers')
         .then(response => {
           this.mcpServers = response.data.data || [];
+          this.mcpServers.forEach(server => {
+            // Ensure each server has a loader state
+            if (!this.mcpServerUpdateLoaders[server.name]) {
+              this.mcpServerUpdateLoaders[server.name] = false;
+            }
+          });
         })
         .catch(error => {
           this.showError(this.tm('messages.getServersError', { error: error.message }));
@@ -777,7 +806,7 @@ export default {
 
     updateServerStatus(server) {
       // 切换服务器状态
-      this.loadingUpdatingServer = true;
+      this.mcpServerUpdateLoaders[server.name] = true;
       server.active = !server.active;
       axios.post('/api/tools/mcp/update', server)
         .then(response => {
@@ -789,7 +818,7 @@ export default {
           server.active = !server.active;
         })
         .finally(() => {
-          this.loadingUpdatingServer = false;
+          this.mcpServerUpdateLoaders[server.name] = false;
         });
     },
 

--- a/dashboard/src/views/ToolUsePage.vue
+++ b/dashboard/src/views/ToolUsePage.vue
@@ -746,6 +746,7 @@ export default {
           .then(response => {
             this.loading = false;
             this.showMcpServerDialog = false;
+            this.addServerDialogMessage = "";
             this.getServers();
             this.getTools();
             this.showSuccess(response.data.message || this.tm('messages.saveSuccess'));
@@ -824,6 +825,7 @@ export default {
 
     closeServerDialog() {
       this.showMcpServerDialog = false;
+      this.addServerDialogMessage = '';
       this.resetForm();
     },
 


### PR DESCRIPTION
### Motivation

目前 WebUI 上添加 / 关闭 MCP Server 时是立即返回的，导致没办法关注其添加时返回的结果，带来困惑

### Modification

大量使用 asyncio 的 Event 和 Future 特性来重构了 MCP Server 的载入和终止机制，这样的效果是前端将会有一个 loading 来等待逻辑执行完毕。

然而，在我的测试当中发现，在尝试加载 MCP Server 提供商（如 Smithery）的错误配置的 MCP Server 时，报错没有被抛出，导致一直会卡在  `await self.session.initialize()` 当中。我给的暂时的处理办法时加一个 timeout（默认是 20s），当超时时，会抛出异常，然而这种方式没办法捕获并且记录被错误配置的 MCP Server 的异常信息，并且由于 astrbot 的 logger 没有捕获到，也会导致 WebUI 的控制台观察不到错误，需要通过终端查看。这是一个值得优化的点。

---

附：

当错误配置 MCP Server 的 Streamable HTTP URL 时，Smithery 的报错如下：

```bash
Error in post_writer: Client error '422 Unprocessable Entity' for url 'https://server.smithery.ai/@smithery-ai/github/mcp?api_key=9d3xxxxx-8xxxxxxxd-a840-23xxxxxb0d66&profile=revolutionary-eagle-dxxxxxxxX1'
```


### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码
