### PR TITLE
Feature: implement log history retrieval and improve log streaming handling

### DIFF
--- a/astrbot/core/log.py
+++ b/astrbot/core/log.py
@@ -96,8 +96,6 @@ class LogBroker:
             Queue: 订阅者的队列, 可用于接收日志消息
         """
         q = Queue(maxsize=CACHED_SIZE + 10)
-        for log in self.log_cache:
-            q.put_nowait(log)
         self.subscribers.append(q)
         return q
 


### PR DESCRIPTION
解决了可能的 WebUI 吞日志的问题。

- 初始日志转变为使用普通 HTTP 请求来获取
- 当 SSE 数据被截断时，一个简单的解决措施

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 总结

提高日志流传输的可靠性并添加日志历史记录检索功能：引入一个专用端点和对过去日志的首次获取，缓冲不完整的 SSE 行以防止数据丢失，并通过跳过空数据、对解析失败发出警告以及移除服务器端队列预加载和节流来平滑流传输行为。

新功能:
- 添加 `/api/log-history` 端点以提供缓存日志
- 在前端通过 HTTP 获取初始日志历史记录，然后再打开实时日志流

错误修复:
- 通过缓冲和重新组装截断的 SSE 片段来修复 WebUI 中潜在的日志丢失问题

改进:
- 跳过空的 SSE 消息并将无效的 JSON 解析错误降级为警告
- 移除 SSE 流传输中的人工休眠延迟，以实现更流畅的日志传输
- 停止在服务器上将日志预加载到新的订阅者队列中

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve log streaming reliability and add log history retrieval: introduce a dedicated endpoint and initial fetch for past logs, buffer incomplete SSE lines to prevent data loss, and smooth out streaming behavior by skipping empty data, warning on parse failures, and removing server-side queue preloading and throttling.

New Features:
- Add /api/log-history endpoint to serve cached logs
- Fetch initial log history via HTTP in the frontend before opening the live log stream

Bug Fixes:
- Fix potential log loss in WebUI by buffering and reassembling truncated SSE fragments

Enhancements:
- Skip empty SSE messages and downgrade invalid JSON parsing errors to warnings
- Remove artificial sleep delay in SSE streaming for smoother log delivery
- Stop preloading logs into new subscriber queues on the server

</details>