### PR TITLE
fix: 指令组的权限过滤器无法生效问题

### DIFF
--- a/astrbot/core/pipeline/waking_check/stage.py
+++ b/astrbot/core/pipeline/waking_check/stage.py
@@ -128,6 +128,7 @@ class WakingCheckStage(Stage):
                         if not filter.filter(event, self.ctx.astrbot_config):
                             permission_not_pass = True
                             permission_filter_raise_error = filter.raise_error
+                            break
                     else:
                         if not filter.filter(event, self.ctx.astrbot_config):
                             passed = False


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了 #2198 

### Motivation

<!--解释为什么要改动-->
详细见issue吧

### Modifications

<!--简单解释你的改动-->
详细见issue吧

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 总结

Bug 修复:
- 添加 `break` 以便在首次权限检查失败时退出过滤循环

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add break to exit the filter loop on the first failed permission check

</details>