### PR TITLE
修改openai的嵌入模型默认维度为1024（重新提交，因为做了点别的更改）

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1021,7 +1021,7 @@ CONFIG_METADATA_2 = {
                         "embedding_api_key": "",
                         "embedding_api_base": "",
                         "embedding_model": "",
-                        "embedding_dimensions": 1536,
+                        "embedding_dimensions": 1024,
                         "timeout": 20,
                     },
                     "Gemini Embedding": {

--- a/astrbot/core/provider/sources/openai_embedding_source.py
+++ b/astrbot/core/provider/sources/openai_embedding_source.py
@@ -22,7 +22,7 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
             timeout=int(provider_config.get("timeout", 20)),
         )
         self.model = provider_config.get("embedding_model", "text-embedding-3-small")
-        self.dimension = provider_config.get("embedding_dimensions", 1536)
+        self.dimension = provider_config.get("embedding_dimensions", 1024)
 
     async def get_embedding(self, text: str) -> list[float]:
         """


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->


### Motivation
发现有很多小白使用嵌入模型的时候不会修改维度，导致使用知识库时报错。 

比较常用的 `openai`  `baai/bge-m3`  `qwen`都支持1024维度，所以将默认维度修改为1024。 

本次未修改gemini默认的768维度
<!--解释为什么要改动-->

### Modifications

- 修改了默认配置中的 1536->1024
- 修改了gemini_embedding provider，获取不到配置文件时的默认值 1536->1024

<!--简单解释你的改动-->

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 摘要

更新配置和提供商代码中的默认嵌入维度为 1024，以匹配常见的模型要求并减少用户错误。

改进:
- 更改默认配置中的 default embedding_dimensions 从 1536 到 1024
- 更新 OpenAI 嵌入提供商中的回退嵌入维度从 1536 到 1024

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the default embedding dimension to 1024 across configuration and provider code to match common model requirements and reduce user errors.

Enhancements:
- Change default embedding_dimensions in default config from 1536 to 1024
- Update the fallback embedding dimension in the OpenAI embedding provider from 1536 to 1024

</details>

## Sourcery 总结

改进：
- 将默认嵌入维度从 1536 降低到 1024，在默认配置和 OpenAI 嵌入提供商回退中均生效

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Lower default embedding dimension from 1536 to 1024 in both the default configuration and the OpenAI embedding provider fallback

</details>