### PR TITLE
为插件市场添加本地缓存

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1021,7 +1021,7 @@ CONFIG_METADATA_2 = {
                         "embedding_api_key": "",
                         "embedding_api_base": "",
                         "embedding_model": "",
-                        "embedding_dimensions": 1536,
+                        "embedding_dimensions": 1024,
                         "timeout": 20,
                     },
                     "Gemini Embedding": {

--- a/astrbot/core/provider/sources/openai_embedding_source.py
+++ b/astrbot/core/provider/sources/openai_embedding_source.py
@@ -22,7 +22,7 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
             timeout=int(provider_config.get("timeout", 20)),
         )
         self.model = provider_config.get("embedding_model", "text-embedding-3-small")
-        self.dimension = provider_config.get("embedding_dimensions", 1536)
+        self.dimension = provider_config.get("embedding_dimensions", 1024)
 
     async def get_embedding(self, text: str) -> list[float]:
         """

--- a/dashboard/src/i18n/locales/en-US/features/extension.json
+++ b/dashboard/src/i18n/locales/en-US/features/extension.json
@@ -32,7 +32,8 @@
     "cancel": "Cancel",
     "actions": "Actions",
     "back": "Back",
-    "selectFile": "Select File"
+    "selectFile": "Select File",
+    "refresh": "Refresh"
   },
   "status": {
     "enabled": "Enabled",

--- a/dashboard/src/i18n/locales/zh-CN/features/extension.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/extension.json
@@ -32,7 +32,8 @@
     "cancel": "取消",
     "actions": "操作",
     "back": "返回",
-    "selectFile": "选择文件"
+    "selectFile": "选择文件",
+    "refresh": "刷新"
   },
   "status": {
     "enabled": "启用",

--- a/dashboard/src/stores/common.js
+++ b/dashboard/src/stores/common.js
@@ -116,7 +116,11 @@ export const useCommonStore = defineStore({
       if (!force && this.pluginMarketData.length > 0) {
         return Promise.resolve(this.pluginMarketData);
       }
-      return axios.get('/api/plugin/market_list')
+      
+      // 如果是强制刷新，添加 force_refresh 参数
+      const url = force ? '/api/plugin/market_list?force_refresh=true' : '/api/plugin/market_list';
+      
+      return axios.get(url)
         .then((res) => {
           let data = []
           for (let key in res.data.data) {

--- a/dashboard/src/views/ExtensionPage.vue
+++ b/dashboard/src/views/ExtensionPage.vue
@@ -71,6 +71,7 @@ const uploadTab = ref('file');
 const showPluginFullName = ref(false);
 const marketSearch = ref("");
 const filterKeys = ['name', 'desc', 'author'];
+const refreshingMarket = ref(false);
 
 const plugin_handler_info_headers = computed(() => [
   { title: tm('table.headers.eventType'), key: 'event_type_h' },
@@ -560,6 +561,25 @@ const newExtension = async () => {
   }
 };
 
+// 刷新插件市场数据
+const refreshPluginMarket = async () => {
+  refreshingMarket.value = true;
+  try {
+    // 强制刷新插件市场数据
+    const data = await commonStore.getPluginCollections(true);
+    pluginMarketData.value = data;
+    trimExtensionName();
+    checkAlreadyInstalled();
+    checkUpdate();
+    
+    toast(tm('messages.refreshSuccess'), "success");
+  } catch (err) {
+    toast(tm('messages.refreshFailed') + " " + err, "error");
+  } finally {
+    refreshingMarket.value = false;
+  }
+};
+
 // 生命周期
 onMounted(async () => {
   await getExtensions();
@@ -851,8 +871,20 @@ onMounted(async () => {
             <div class="mt-4">
               <div class="d-flex align-center mb-2" style="justify-content: space-between;">
                 <h2>{{ tm('market.allPlugins') }}</h2>
-                <v-switch v-model="showPluginFullName" :label="tm('market.showFullName')" hide-details density="compact"
-                  style="margin-left: 12px" />
+                <div class="d-flex align-center">
+                  <v-btn 
+                    variant="tonal" 
+                    size="small" 
+                    @click="refreshPluginMarket" 
+                    :loading="refreshingMarket"
+                    class="mr-2"
+                  >
+                    <v-icon>mdi-refresh</v-icon>
+                    {{ tm('buttons.refresh') }}
+                  </v-btn>
+                  <v-switch v-model="showPluginFullName" :label="tm('market.showFullName')" hide-details density="compact"
+                    style="margin-left: 12px" />
+                </div>
               </div>
 
               <v-col cols="12" md="12" style="padding: 0px;">


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->


### Motivation
将插件市场的数据进行本地缓存，防止soulter的api失效导致插件市场无法使用
<!--解释为什么要改动-->

### Modifications
- 依然会优先使用api获取的数据，确保实时同步
- 每次获取api时，会更新本地缓存
- 如果获取失败则使用本地缓存
- 获取结果为{}或者空时，也视为获取失败
- 在前端页面添加刷新按键，用于手动刷新本地缓存

#### 小建议
希望可以单独提供插件市场数据的哈希值，这样就可以通过哈希值来判断是否需要进行更新，不需要每次都从api获取完整数据，可以大大节省服务器资源

<!--简单解释你的改动-->

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 总结

在后端为插件市场数据实现本地缓存，支持自动保存和加载，在 API 调用失败或响应为空时回退到缓存，并支持强制刷新；在前端添加刷新按钮以手动触发缓存更新；将默认嵌入维度调整为 1024。

新功能:
- 实现后端插件市场数据的本地缓存，支持回退到缓存文件和强制刷新
- 在前端添加手动刷新按钮，并在 store 中添加 force-refresh 参数以更新插件市场数据

改进:
- 将默认嵌入维度从 1536 减少到 1024

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement local caching for plugin marketplace data on the backend with automatic saving and loading, fallback to cache on API failures or empty responses, and support force-refresh; add a refresh button in the frontend to manually trigger cache update; adjust default embedding dimensions to 1024.

New Features:
- Implement backend local caching for plugin marketplace data with fallback to cached file and force-refresh support
- Add frontend manual refresh button and force-refresh parameter in store to update plugin market data

Enhancements:
- Reduce default embedding dimensions from 1536 to 1024

</details>