### PR TITLE
fix: 修复了 OpenAI 类型的 LLM 空内容响应导致的无法解析 completion 的错误。

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -176,7 +176,7 @@ class ProviderOpenAIOfficial(Provider):
             raise Exception("API 返回的 completion 为空。")
         choice = completion.choices[0]
 
-        if choice.message.content:
+        if choice.message.content is not None:
             # text completion
             completion_text = str(choice.message.content).strip()
             llm_response.result_chain = MessageChain().message(completion_text)
@@ -210,7 +210,7 @@ class ProviderOpenAIOfficial(Provider):
                 "API 返回的 completion 由于内容安全过滤被拒绝(非 AstrBot)。"
             )
 
-        if not llm_response.completion_text and not llm_response.tools_call_args:
+        if llm_response.completion_text is None and not llm_response.tools_call_args:
             logger.error(f"API 返回的 completion 无法解析：{completion}。")
             raise Exception(f"API 返回的 completion 无法解析：{completion}。")
 


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了 #2273

### Motivation

<!--解释为什么要改动-->
解决当 OpenAI 类型的 LLM 返回空内容（`content` 为空字符串）时，因解析逻辑对空内容处理不当导致的“无法解析 completion”错误，确保空字符串响应能被正常处理。

### Modifications

<!--简单解释你的改动-->
- 将判断条件`if choice.message.content:`修改为`if choice.message.content is not None:`，避免因空字符串被视为 False 而跳过 result_chain 初始化；
- 将判断条件`if not llm_response.completion_text and not llm_response.tools_call_args:`修改为`if llm_response.completion_text is None and not llm_response.tools_call_args:`，避免误判为“无法解析”。


### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码