### PR TITLE
Fix/command permission management

### DIFF
--- a/astrbot/dashboard/routes/__init__.py
+++ b/astrbot/dashboard/routes/__init__.py
@@ -10,6 +10,7 @@ from .tools import ToolsRoute  # 导入新的ToolsRoute
 from .conversation import ConversationRoute
 from .file import FileRoute
 from .session_management import SessionManagementRoute
+from .command_permission import CommandPermissionRoute
 
 
 __all__ = [
@@ -25,4 +26,5 @@ __all__ = [
     "ConversationRoute",
     "FileRoute",
     "SessionManagementRoute",
+    "CommandPermissionRoute",
 ]

--- a/astrbot/dashboard/routes/command_permission.py
+++ b/astrbot/dashboard/routes/command_permission.py
@@ -1,0 +1,202 @@
+import traceback
+from typing import List, Dict, Any
+
+from .route import Route, Response, RouteContext
+from astrbot.core import logger
+from quart import request
+from astrbot.core.core_lifecycle import AstrBotCoreLifecycle
+from astrbot.core.star.star_handler import star_handlers_registry, StarHandlerMetadata
+from astrbot.core.star.filter.command import CommandFilter
+from astrbot.core.star.filter.command_group import CommandGroupFilter
+from astrbot.core.star.filter.permission import PermissionTypeFilter
+from astrbot.core.star.star import star_map
+from astrbot.core import DEMO_MODE
+from astrbot.core.utils.shared_preferences import SharedPreferences
+
+
+class CommandPermissionRoute(Route):
+    def __init__(
+        self,
+        context: RouteContext,
+        core_lifecycle: AstrBotCoreLifecycle,
+    ) -> None:
+        super().__init__(context)
+        self.routes = {
+            "/command_permission/get": ("GET", self.get_command_permissions),
+            "/command_permission/set": ("POST", self.set_command_permission),
+            "/command_permission/get_commands": ("GET", self.get_all_commands),
+        }
+        self.core_lifecycle = core_lifecycle
+        self.register_routes()
+
+    async def get_command_permissions(self) -> Response:
+        """获取所有指令的权限配置"""
+        try:
+            sp = SharedPreferences()
+            alter_cmd_cfg = sp.get("alter_cmd", {})
+            
+            # 构建权限配置列表
+            permissions = []
+            
+            # 遍历所有插件的权限配置
+            for plugin_name, plugin_config in alter_cmd_cfg.items():
+                for command_name, config in plugin_config.items():
+                    permission_type = config.get("permission", "member")
+                    permissions.append({
+                        "plugin_name": plugin_name,
+                        "command_name": command_name,
+                        "permission": permission_type,
+                        "id": f"{plugin_name}.{command_name}"
+                    })
+            
+            return Response().ok({"permissions": permissions}).__dict__
+        except Exception:
+            logger.error(f"/api/command_permission/get: {traceback.format_exc()}")
+            return Response().error("获取指令权限配置失败").__dict__
+
+    async def get_all_commands(self) -> Response:
+        """获取所有可用的指令列表"""
+        try:
+            commands = []
+            
+            # 遍历所有注册的处理器
+            for handler in star_handlers_registry:
+                assert isinstance(handler, StarHandlerMetadata)
+                plugin = star_map.get(handler.handler_module_path)
+                
+                if not plugin:
+                    continue
+                
+                # 查找指令过滤器
+                for filter_ in handler.event_filters:
+                    if isinstance(filter_, CommandFilter):
+                        # 检查当前权限配置
+                        sp = SharedPreferences()
+                        alter_cmd_cfg = sp.get("alter_cmd", {})
+                        current_permission = "member"  # 默认权限
+                        
+                        if (plugin.name in alter_cmd_cfg and 
+                            handler.handler_name in alter_cmd_cfg[plugin.name]):
+                            current_permission = alter_cmd_cfg[plugin.name][handler.handler_name].get("permission", "member")
+                        
+                        # 检查是否有默认的权限过滤器
+                        has_default_admin = False
+                        for f in handler.event_filters:
+                            if isinstance(f, PermissionTypeFilter):
+                                if f.permission_type.name == "ADMIN":
+                                    has_default_admin = True
+                                    if current_permission == "member":
+                                        current_permission = "admin"
+                                break
+                        
+                        commands.append({
+                            "command_name": filter_.command_name,
+                            "plugin_name": plugin.name,
+                            "handler_name": handler.handler_name,
+                            "description": getattr(handler, 'description', ''),
+                            "current_permission": current_permission,
+                            "has_default_admin": has_default_admin,
+                            "id": f"{plugin.name}.{handler.handler_name}"
+                        })
+                    elif isinstance(filter_, CommandGroupFilter):
+                        # 处理指令组
+                        sp = SharedPreferences()
+                        alter_cmd_cfg = sp.get("alter_cmd", {})
+                        current_permission = "member"
+                        
+                        if (plugin.name in alter_cmd_cfg and 
+                            handler.handler_name in alter_cmd_cfg[plugin.name]):
+                            current_permission = alter_cmd_cfg[plugin.name][handler.handler_name].get("permission", "member")
+                        
+                        has_default_admin = False
+                        for f in handler.event_filters:
+                            if isinstance(f, PermissionTypeFilter):
+                                if f.permission_type.name == "ADMIN":
+                                    has_default_admin = True
+                                    if current_permission == "member":
+                                        current_permission = "admin"
+                                break
+                        
+                        commands.append({
+                            "command_name": filter_.group_name,
+                            "plugin_name": plugin.name,
+                            "handler_name": handler.handler_name,
+                            "description": getattr(handler, 'description', ''),
+                            "current_permission": current_permission,
+                            "has_default_admin": has_default_admin,
+                            "is_group": True,
+                            "id": f"{plugin.name}.{handler.handler_name}"
+                        })
+            
+            return Response().ok({"commands": commands}).__dict__
+        except Exception:
+            logger.error(f"/api/command_permission/get_commands: {traceback.format_exc()}")
+            return Response().error("获取指令列表失败").__dict__
+
+    async def set_command_permission(self) -> Response:
+        """设置指令权限"""
+        if DEMO_MODE:
+            return Response().error("演示模式下不允许修改配置").__dict__
+        
+        try:
+            data = await request.get_json()
+            plugin_name = data.get("plugin_name")
+            handler_name = data.get("handler_name")
+            permission = data.get("permission")
+            
+            if not all([plugin_name, handler_name, permission]):
+                return Response().error("参数不完整").__dict__
+            
+            if permission not in ["admin", "member"]:
+                return Response().error("权限类型错误，只能是 admin 或 member").__dict__
+            
+            # 查找对应的处理器
+            found_handler = None
+            for handler in star_handlers_registry:
+                if (handler.handler_module_path in star_map and
+                    star_map[handler.handler_module_path].name == plugin_name and
+                    handler.handler_name == handler_name):
+                    found_handler = handler
+                    break
+            
+            if not found_handler:
+                return Response().error("未找到指定的指令处理器").__dict__
+            
+            # 更新配置
+            sp = SharedPreferences()
+            alter_cmd_cfg = sp.get("alter_cmd", {})
+            
+            if plugin_name not in alter_cmd_cfg:
+                alter_cmd_cfg[plugin_name] = {}
+            
+            if handler_name not in alter_cmd_cfg[plugin_name]:
+                alter_cmd_cfg[plugin_name][handler_name] = {}
+            
+            alter_cmd_cfg[plugin_name][handler_name]["permission"] = permission
+            sp.put("alter_cmd", alter_cmd_cfg)
+            
+            # 动态更新权限过滤器
+            found_permission_filter = False
+            for filter_ in found_handler.event_filters:
+                if isinstance(filter_, PermissionTypeFilter):
+                    from astrbot.core.star.filter.permission import PermissionType
+                    if permission == "admin":
+                        filter_.permission_type = PermissionType.ADMIN
+                    else:
+                        filter_.permission_type = PermissionType.MEMBER
+                    found_permission_filter = True
+                    break
+            
+            if not found_permission_filter:
+                # 如果没有权限过滤器，则添加一个
+                from astrbot.core.star.filter.permission import PermissionType
+                new_filter = PermissionTypeFilter(
+                    PermissionType.ADMIN if permission == "admin" else PermissionType.MEMBER
+                )
+                found_handler.event_filters.insert(0, new_filter)
+            
+            return Response().ok({"message": f"已将 {handler_name} 权限设置为 {permission}"}).__dict__
+            
+        except Exception:
+            logger.error(f"/api/command_permission/set: {traceback.format_exc()}")
+            return Response().error("设置指令权限失败").__dict__

--- a/astrbot/dashboard/server.py
+++ b/astrbot/dashboard/server.py
@@ -60,6 +60,9 @@ class AstrBotDashboard:
         self.session_management_route = SessionManagementRoute(
             self.context, db, core_lifecycle
         )
+        self.command_permission_route = CommandPermissionRoute(
+            self.context, core_lifecycle
+        )
 
         self.app.add_url_rule(
             "/api/plug/<path:subpath>",

--- a/dashboard/src/i18n/locales/en-US/core/navigation.json
+++ b/dashboard/src/i18n/locales/en-US/core/navigation.json
@@ -4,6 +4,7 @@
   "providers": "Providers",
   "toolUse": "MCP Tools",
   "config": "Config",
+  "commandPermission": "Command Permission",
   "extension": "Extensions",
   "extensionMarketplace": "Extension Market",
   "chat": "Chat",

--- a/dashboard/src/i18n/locales/zh-CN/core/navigation.json
+++ b/dashboard/src/i18n/locales/zh-CN/core/navigation.json
@@ -4,6 +4,7 @@
   "providers": "服务提供商",
   "toolUse": "MCP",
   "config": "配置文件",
+  "commandPermission": "指令权限管理",
   "extension": "插件管理",
   "extensionMarketplace": "插件市场",
   "chat": "聊天",

--- a/dashboard/src/layouts/full/vertical-sidebar/sidebarItem.ts
+++ b/dashboard/src/layouts/full/vertical-sidebar/sidebarItem.ts
@@ -44,6 +44,11 @@ const sidebarItem: menu[] = [
     to: '/config',
   },
   {
+    title: 'core.navigation.commandPermission',
+    icon: 'mdi-shield-key',
+    to: '/command-permission',
+  },
+  {
     title: 'core.navigation.extension',
     icon: 'mdi-puzzle',
     to: '/extension'

--- a/dashboard/src/router/MainRoutes.ts
+++ b/dashboard/src/router/MainRoutes.ts
@@ -105,6 +105,11 @@ const MainRoutes = {
       name: 'About',
       path: '/about',
       component: () => import('@/views/AboutPage.vue')
+    },
+    {
+      name: 'CommandPermission',
+      path: '/command-permission',
+      component: () => import('@/views/CommandPermissionPage.vue')
     }
   ]
 };

--- a/dashboard/src/views/CommandPermissionPage.vue
+++ b/dashboard/src/views/CommandPermissionPage.vue
@@ -1,0 +1,327 @@
+<template>
+  <div class="pa-4">
+    <v-row>
+      <v-col cols="12">
+        <v-card>
+          <v-card-title class="d-flex align-center">
+            <v-icon start>mdi-shield-key</v-icon>
+            指令权限管理
+          </v-card-title>
+          <v-card-subtitle>
+            管理所有指令的访问权限，控制哪些指令需要管理员权限
+          </v-card-subtitle>
+        </v-card>
+      </v-col>
+    </v-row>
+
+    <v-row class="mt-4">
+      <v-col cols="12">
+        <v-card>
+          <v-card-title>
+            <v-row class="align-center">
+              <v-col cols="6">
+                <span>指令列表</span>
+              </v-col>
+              <v-col cols="6" class="text-right">
+                <v-btn 
+                  color="primary" 
+                  @click="loadCommands"
+                  :loading="loading"
+                  variant="outlined"
+                >
+                  <v-icon start>mdi-refresh</v-icon>
+                  刷新列表
+                </v-btn>
+              </v-col>
+            </v-row>
+          </v-card-title>
+
+          <v-card-text>
+            <!-- 搜索和过滤 -->
+            <v-row class="mb-4">
+              <v-col cols="12" md="6">
+                <v-text-field
+                  v-model="searchText"
+                  label="搜索指令或插件"
+                  prepend-inner-icon="mdi-magnify"
+                  clearable
+                  variant="outlined"
+                  density="compact"
+                ></v-text-field>
+              </v-col>
+              <v-col cols="12" md="3">
+                <v-select
+                  v-model="filterPlugin"
+                  :items="pluginOptions"
+                  label="筛选插件"
+                  clearable
+                  variant="outlined"
+                  density="compact"
+                ></v-select>
+              </v-col>
+              <v-col cols="12" md="3">
+                <v-select
+                  v-model="filterPermission"
+                  :items="permissionOptions"
+                  label="筛选权限"
+                  clearable
+                  variant="outlined"
+                  density="compact"
+                ></v-select>
+              </v-col>
+            </v-row>
+
+            <!-- 数据表格 -->
+            <v-data-table
+              :headers="headers"
+              :items="filteredCommands"
+              :loading="loading"
+              :search="searchText"
+              class="elevation-1"
+            >
+              <template v-slot:item.command_name="{ item }">
+                <v-chip 
+                  :color="item.is_group ? 'purple' : 'blue'"
+                  variant="outlined"
+                  size="small"
+                >
+                  <v-icon start>{{ item.is_group ? 'mdi-folder' : 'mdi-console' }}</v-icon>
+                  {{ item.command_name }}
+                </v-chip>
+              </template>
+
+              <template v-slot:item.plugin_name="{ item }">
+                <v-chip 
+                  color="green"
+                  variant="tonal"
+                  size="small"
+                >
+                  {{ item.plugin_name }}
+                </v-chip>
+              </template>
+
+              <template v-slot:item.current_permission="{ item }">
+                <v-chip 
+                  :color="item.current_permission === 'admin' ? 'red' : 'blue'"
+                  :variant="item.current_permission === 'admin' ? 'flat' : 'tonal'"
+                  size="small"
+                >
+                  <v-icon start>
+                    {{ item.current_permission === 'admin' ? 'mdi-shield-crown' : 'mdi-account-group' }}
+                  </v-icon>
+                  {{ item.current_permission === 'admin' ? '管理员' : '所有用户' }}
+                </v-chip>
+              </template>
+
+              <template v-slot:item.actions="{ item }">
+                <v-btn-toggle
+                  :model-value="item.current_permission"
+                  @update:model-value="changePermission(item, $event)"
+                  mandatory
+                  variant="outlined"
+                  size="small"
+                  divided
+                >
+                  <v-btn value="member" size="small">
+                    <v-icon>mdi-account-group</v-icon>
+                    所有用户
+                  </v-btn>
+                  <v-btn value="admin" size="small">
+                    <v-icon>mdi-shield-crown</v-icon>
+                    管理员
+                  </v-btn>
+                </v-btn-toggle>
+              </template>
+
+              <template v-slot:item.description="{ item }">
+                <span class="text-body-2">{{ item.description || '无描述' }}</span>
+              </template>
+            </v-data-table>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+
+    <!-- 成功/错误提示 -->
+    <v-snackbar
+      v-model="snackbar.show"
+      :color="snackbar.color"
+      :timeout="3000"
+    >
+      {{ snackbar.message }}
+      <template v-slot:actions>
+        <v-btn
+          color="white"
+          variant="text"
+          @click="snackbar.show = false"
+        >
+          关闭
+        </v-btn>
+      </template>
+    </v-snackbar>
+
+    <!-- 确认对话框 -->
+    <v-dialog v-model="confirmDialog.show" max-width="400">
+      <v-card>
+        <v-card-title class="headline">确认修改</v-card-title>
+        <v-card-text>
+          确定要将指令 <strong>{{ confirmDialog.command }}</strong> 的权限修改为 
+          <strong>{{ confirmDialog.permission === 'admin' ? '管理员' : '所有用户' }}</strong> 吗？
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn
+            color="grey"
+            text
+            @click="confirmDialog.show = false"
+          >
+            取消
+          </v-btn>
+          <v-btn
+            color="primary"
+            @click="confirmPermissionChange"
+            :loading="confirmDialog.loading"
+          >
+            确认
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, reactive } from 'vue'
+import axios from 'axios'
+
+// 响应式数据
+const loading = ref(false)
+const commands = ref([])
+const searchText = ref('')
+const filterPlugin = ref('')
+const filterPermission = ref('')
+
+const snackbar = reactive({
+  show: false,
+  message: '',
+  color: 'success'
+})
+
+const confirmDialog = reactive({
+  show: false,
+  command: '',
+  permission: '',
+  item: null,
+  loading: false
+})
+
+// 表格头部定义
+const headers = [
+  { title: '指令名称', key: 'command_name', align: 'start' },
+  { title: '所属插件', key: 'plugin_name', align: 'start' },
+  { title: '当前权限', key: 'current_permission', align: 'center' },
+  { title: '描述', key: 'description', align: 'start' },
+  { title: '操作', key: 'actions', align: 'center', sortable: false, width: '200px' }
+]
+
+// 权限选项
+const permissionOptions = [
+  { title: '管理员', value: 'admin' },
+  { title: '所有用户', value: 'member' }
+]
+
+// 计算属性
+const pluginOptions = computed(() => {
+  const plugins = [...new Set(commands.value.map(cmd => cmd.plugin_name))]
+  return plugins.map(plugin => ({ title: plugin, value: plugin }))
+})
+
+const filteredCommands = computed(() => {
+  let filtered = commands.value
+
+  if (filterPlugin.value) {
+    filtered = filtered.filter(cmd => cmd.plugin_name === filterPlugin.value)
+  }
+
+  if (filterPermission.value) {
+    filtered = filtered.filter(cmd => cmd.current_permission === filterPermission.value)
+  }
+
+  return filtered
+})
+
+// 方法
+const showSnackbar = (message, color = 'success') => {
+  snackbar.message = message
+  snackbar.color = color
+  snackbar.show = true
+}
+
+const loadCommands = async () => {
+  loading.value = true
+  try {
+    const response = await axios.get('/api/command_permission/get_commands')
+    if (response.data.status === 'ok') {
+      commands.value = response.data.data.commands
+    } else {
+      showSnackbar('加载指令列表失败: ' + response.data.message, 'error')
+    }
+  } catch (error) {
+    console.error('加载指令列表失败:', error)
+    showSnackbar('加载指令列表失败', 'error')
+  } finally {
+    loading.value = false
+  }
+}
+
+const changePermission = (item, newPermission) => {
+  confirmDialog.command = item.command_name
+  confirmDialog.permission = newPermission
+  confirmDialog.item = item
+  confirmDialog.show = true
+}
+
+const confirmPermissionChange = async () => {
+  confirmDialog.loading = true
+  try {
+    const response = await axios.post('/api/command_permission/set', {
+      plugin_name: confirmDialog.item.plugin_name,
+      handler_name: confirmDialog.item.handler_name,
+      permission: confirmDialog.permission
+    })
+
+    if (response.data.status === 'ok') {
+      // 更新本地数据
+      confirmDialog.item.current_permission = confirmDialog.permission
+      showSnackbar(response.data.data.message, 'success')
+      confirmDialog.show = false
+    } else {
+      showSnackbar('修改权限失败: ' + response.data.message, 'error')
+    }
+  } catch (error) {
+    console.error('修改权限失败:', error)
+    showSnackbar('修改权限失败', 'error')
+  } finally {
+    confirmDialog.loading = false
+  }
+}
+
+// 生命周期
+onMounted(() => {
+  loadCommands()
+})
+</script>
+
+<style scoped>
+.v-card {
+  transition: all 0.3s ease;
+}
+
+.v-data-table {
+  border-radius: 8px;
+}
+
+.v-chip {
+  font-weight: 500;
+}
+</style>


### PR DESCRIPTION

新增指令管理面板

以下为ai的总结：

### Motivation

目前 AstrBot 的指令权限需要在配置文件中手动修改，操作不便且对不熟悉代码的用户不友好。为了方便管理员在图形化界面中直观地管理各个指令的访问权限，决定新增一个指令权限管理面板。该面板允许管理员查看所有指令，并动态修改其权限（例如，设置为“仅管理员可用”或“所有用户可用”）。

### Modifications

1.  **后端 (Backend):**
    * 新增了 `astrabot/dashboard/routes/command_permission.py` 文件，创建了全新的指令权限管理 API 路由。
    * 实现了三个主要 API 端点：
        * `GET /api/command_permission/get_commands`: 动态扫描并返回所有已注册的指令（包括指令组），及其所属插件、描述和当前的权限设置。
        * `POST /api/command_permission/set`: 接收前端请求，用于修改指定指令的权限。配置会保存到 `SharedPreferences` 中，并实时动态更新应用中的权限过滤器，无需重启即可生效。
        * `GET /api/command_permission/get`: 获取当前所有已修改的权限配置。
    * 在 `server.py` 中注册并挂载了新的 `CommandPermissionRoute`。

2.  **前端 (Frontend):**
    * 创建了全新的 Vue 页面组件 `dashboard/src/views/CommandPermissionPage.vue` 作为指令权限管理的主界面。
    * 该页面包含一个功能完备的 `v-data-table`，用于展示所有指令的列表。
    * UI 功能包括：
        * **搜索与筛选**: 支持按指令名称/插件名称进行文本搜索，并提供了按所属插件和权限类型进行筛选的下拉菜单。
        * **权限展示**: 直观地使用标签（Chip）和图标展示指令是普通指令还是指令组，以及其当前权限是“管理员”还是“所有用户”。
        * **在线修改**: 在每条指令的操作列中，提供了一个开关按钮组，管理员点击即可修改权限。修改前会弹出确认对话框，防止误操作。
    * 添加了相应的路由（`MainRoutes.ts`）和侧边栏导航链接（`sidebarItem.ts`），并配置了中英文国际化（i18n）文本。

3.  **代码质量改进 (Refactoring):**
    * 将 `dashboard/src/stores/common.js` 文件重构为 TypeScript (`common.ts`)，增加了类型定义（Interface），增强了代码的健壮性和可维护性。

### Check

- [x] 😊 我的 Commit Message 符合良好的[[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码
<img width="1038" height="581" alt="20250803133850" src="https://github.com/user-attachments/assets/e3c9688d-7273-4214-83a3-5d0b0dad9f6b" />
<img width="1272" height="584" alt="20250803134116" src="https://github.com/user-attachments/assets/57618768-c111-4abc-a976-e409c828f072" />
<img width="1267" height="572" alt="20250803134145" src="https://github.com/user-attachments/assets/fd722ce9-063e-45b0-8a16-52a5be51fb68" />
