### PR TITLE
Improve: 引入全新的人格管理模式

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -115,8 +115,7 @@ DEFAULT_CONFIG = {
     "log_level": "INFO",
     "pip_install_arg": "",
     "pypi_index_url": "https://mirrors.aliyun.com/pypi/simple/",
-    "knowledge_db": {},
-    "persona": [],
+    "persona": [], # deprecated
     "timezone": "",
     "callback_api_base": "",
 }
@@ -1698,43 +1697,6 @@ CONFIG_METADATA_2 = {
                         "description": "不支持流式回复的平台分段输出",
                         "type": "bool",
                         "hint": "启用后，若平台不支持流式回复，会分段输出。目前仅支持 aiocqhttp 两个平台，不支持或无需使用流式分段输出的平台会静默忽略此选项",
-                    },
-                },
-            },
-            "persona": {
-                "description": "人格情景设置",
-                "type": "list",
-                "config_template": {
-                    "新人格情景": {
-                        "name": "",
-                        "prompt": "",
-                        "begin_dialogs": [],
-                        "mood_imitation_dialogs": [],
-                    }
-                },
-                "tmpl_display_title": "name",
-                "items": {
-                    "name": {
-                        "description": "人格名称",
-                        "type": "string",
-                        "hint": "人格名称，用于在多个人格中区分。使用 /persona 指令可切换人格。在 大语言模型设置 处可以设置默认人格。",
-                    },
-                    "prompt": {
-                        "description": "设定(系统提示词)",
-                        "type": "text",
-                        "hint": "填写人格的身份背景、性格特征、兴趣爱好、个人经历、口头禅等。",
-                    },
-                    "begin_dialogs": {
-                        "description": "预设对话",
-                        "type": "list",
-                        "items": {"type": "string"},
-                        "hint": "可选。在每个对话前会插入这些预设对话。对话需要成对(用户和助手)，输入完一个角色的内容之后按【回车】。需要偶数个对话",
-                    },
-                    "mood_imitation_dialogs": {
-                        "description": "对话风格模仿",
-                        "type": "list",
-                        "items": {"type": "string"},
-                        "hint": "旨在让模型尽可能模仿学习到所填写的对话的语气风格。格式和 `预设对话` 一致。对话需要成对(用户和助手)，输入完一个角色的内容之后按【回车】。需要偶数个对话",
                     },
                 },
             },

--- a/astrbot/core/core_lifecycle.py
+++ b/astrbot/core/core_lifecycle.py
@@ -22,6 +22,7 @@ from astrbot.core.pipeline.scheduler import PipelineScheduler, PipelineContext
 from astrbot.core.star import PluginManager
 from astrbot.core.platform.manager import PlatformManager
 from astrbot.core.star.context import Context
+from astrbot.core.persona_mgr import PersonaManager
 from astrbot.core.provider.manager import ProviderManager
 from astrbot.core import LogBroker
 from astrbot.core.db import BaseDatabase
@@ -69,13 +70,23 @@ class AstrBotCoreLifecycle:
             logger.setLevel(self.astrbot_config["log_level"])  # 设置日志级别
 
         await self.db.initialize()
-        await do_migration_v4(self.db, {})
+
+        try:
+            await do_migration_v4(self.db, {}, self.astrbot_config)
+        except Exception as e:
+            logger.error(f"迁移到 v4.0.0 新版本数据格式失败: {e}")
 
         # 初始化事件队列
         self.event_queue = Queue()
 
+        # 初始化人格管理器
+        self.persona_mgr = PersonaManager(self.db, self.astrbot_config)
+        await self.persona_mgr.initialize()
+
         # 初始化供应商管理器
-        self.provider_manager = ProviderManager(self.astrbot_config, self.db)
+        self.provider_manager = ProviderManager(
+            self.astrbot_config, self.db, self.persona_mgr
+        )
 
         # 初始化平台管理器
         self.platform_manager = PlatformManager(self.astrbot_config, self.event_queue)
@@ -232,6 +243,9 @@ class AstrBotCoreLifecycle:
         platform_insts = self.platform_manager.get_insts()
         for platform_inst in platform_insts:
             tasks.append(
-                asyncio.create_task(platform_inst.run(), name=f"{platform_inst.meta().id}({platform_inst.meta().name})")
+                asyncio.create_task(
+                    platform_inst.run(),
+                    name=f"{platform_inst.meta().id}({platform_inst.meta().name})",
+                )
             )
         return tasks

--- a/astrbot/core/db/__init__.py
+++ b/astrbot/core/db/__init__.py
@@ -220,6 +220,21 @@ class BaseDatabase(abc.ABC):
         ...
 
     @abc.abstractmethod
+    async def update_persona(
+        self,
+        persona_id: str,
+        system_prompt: str = None,
+        begin_dialogs: list[str] = None,
+    ) -> Persona:
+        """Update a persona's system prompt or begin dialogs."""
+        ...
+
+    @abc.abstractmethod
+    async def delete_persona(self, persona_id: str) -> None:
+        """Delete a persona by its ID."""
+        ...
+
+    @abc.abstractmethod
     async def insert_preference_or_update(self, key: str, value: str) -> Preference:
         """Insert a new preference record."""
         ...

--- a/astrbot/core/db/migration/helper.py
+++ b/astrbot/core/db/migration/helper.py
@@ -1,11 +1,13 @@
 import os
 from astrbot.core.utils.astrbot_path import get_astrbot_data_path
 from astrbot.core.db import BaseDatabase
+from astrbot.core.config import AstrBotConfig
 from astrbot.api import logger
 from .migra_3_to_4 import (
     migration_conversation_table,
     migration_platform_table,
     migration_webchat_data,
+    migration_persona_data,
 )
 
 
@@ -24,7 +26,9 @@ async def check_migration_needed_v4(db_helper: BaseDatabase) -> bool:
 
 
 async def do_migration_v4(
-    db_helper: BaseDatabase, platform_id_map: dict[str, dict[str, str]]
+    db_helper: BaseDatabase,
+    platform_id_map: dict[str, dict[str, str]],
+    astrbot_config: AstrBotConfig,
 ):
     """
     执行数据库迁移
@@ -44,6 +48,9 @@ async def do_migration_v4(
 
     # 执行 WebChat 数据迁移
     await migration_webchat_data(db_helper, platform_id_map)
+
+    # 执行人格数据迁移
+    await migration_persona_data(db_helper, astrbot_config)
 
     # 标记迁移完成
     await db_helper.insert_preference_or_update("migration_done_v4", "true")

--- a/astrbot/core/db/po.py
+++ b/astrbot/core/db/po.py
@@ -9,7 +9,7 @@ from sqlmodel import (
     UniqueConstraint,
     Field,
 )
-from typing import Optional
+from typing import Optional, TypedDict
 
 
 class PlatformStat(SQLModel, table=True):
@@ -39,12 +39,14 @@ class PlatformStat(SQLModel, table=True):
 class ConversationV2(SQLModel, table=True):
     __tablename__ = "conversations"
 
-    inner_conversation_id: int = Field(primary_key=True, sa_column_kwargs={"autoincrement": True})
+    inner_conversation_id: int = Field(
+        primary_key=True, sa_column_kwargs={"autoincrement": True}
+    )
     conversation_id: str = Field(
         max_length=36,
         nullable=False,
         unique=True,
-        default_factory=lambda: str(uuid.uuid4())
+        default_factory=lambda: str(uuid.uuid4()),
     )
     platform_id: str = Field(nullable=False)
     user_id: str = Field(nullable=False)
@@ -119,7 +121,9 @@ class PlatformMessageHistory(SQLModel, table=True):
     platform_id: str = Field(nullable=False)
     user_id: str = Field(nullable=False)  # An id of group, user in platform
     sender_id: Optional[str] = Field(default=None)  # ID of the sender in the platform
-    sender_name: Optional[str] = Field(default=None)  # Name of the sender in the platform
+    sender_name: Optional[str] = Field(
+        default=None
+    )  # Name of the sender in the platform
     content: dict = Field(sa_type=JSON, nullable=False)  # a message chain list
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = Field(
@@ -136,12 +140,14 @@ class Attachment(SQLModel, table=True):
 
     __tablename__ = "attachments"
 
-    inner_attachment_id: int = Field(primary_key=True, sa_column_kwargs={"autoincrement": True})
+    inner_attachment_id: int = Field(
+        primary_key=True, sa_column_kwargs={"autoincrement": True}
+    )
     attachment_id: str = Field(
         max_length=36,
         nullable=False,
         unique=True,
-        default_factory=lambda: str(uuid.uuid4())
+        default_factory=lambda: str(uuid.uuid4()),
     )
     path: str = Field(nullable=False)  # Path to the file on disk
     type: str = Field(nullable=False)  # Type of the file (e.g., 'image', 'file')
@@ -180,6 +186,22 @@ class Conversation:
     persona_id: str = ""
     created_at: int = 0
     updated_at: int = 0
+
+
+class Personality(TypedDict):
+    """LLM 人格类。
+
+    在 v4.0.0 版本及之后，推荐使用上面的 Persona 类。并且， mood_imitation_dialogs 字段已被废弃。
+    """
+    prompt: str = ""
+    name: str = ""
+    begin_dialogs: list[str] = []
+    mood_imitation_dialogs: list[str] = []
+    """情感模拟对话预设。在 v4.0.0 版本及之后，已被废弃。"""
+
+    # cache
+    _begin_dialogs_processed: list[dict] = []
+    _mood_imitation_dialogs_processed: str = ""
 
 
 # ====

--- a/astrbot/core/persona_mgr.py
+++ b/astrbot/core/persona_mgr.py
@@ -1,0 +1,134 @@
+from astrbot.core.db import BaseDatabase
+from astrbot.core.db.po import Persona, Personality
+from astrbot.core.config import AstrBotConfig
+from astrbot import logger
+
+
+class PersonaManager:
+    def __init__(self, db_helper: BaseDatabase, astrbot_config: AstrBotConfig):
+        self.db = db_helper
+        self.config = astrbot_config
+        _ps: dict = astrbot_config["provider_settings"]
+        self.default_persona: str = _ps.get("default_personality", "default")
+        self.personas: list[Persona] = []
+
+    async def initialize(self):
+        self.personas = await self.get_all_personas()
+        logger.info(f"已加载 {len(self.personas)} 个人格。")
+
+    async def get_persona(self, persona_id: str):
+        """获取指定 persona 的信息"""
+        persona = await self.db.get_persona_by_id(persona_id)
+        if not persona:
+            raise ValueError(f"Persona with ID {persona_id} does not exist.")
+        return persona
+
+    async def delete_persona(self, persona_id: str):
+        """删除指定 persona"""
+        if not await self.db.get_persona_by_id(persona_id):
+            raise ValueError(f"Persona with ID {persona_id} does not exist.")
+        await self.db.delete_persona(persona_id)
+        self.personas = [p for p in self.personas if p.persona_id != persona_id]
+
+    async def update_persona(
+        self,
+        persona_id: str,
+        system_prompt: str = None,
+        begin_dialogs: list[str] = None,
+    ):
+        """更新指定 persona 的信息"""
+        existing_persona = await self.db.get_persona_by_id(persona_id)
+        if not existing_persona:
+            raise ValueError(f"Persona with ID {persona_id} does not exist.")
+        persona = self.db.update_persona(persona_id, system_prompt, begin_dialogs)
+        if persona:
+            for i, p in enumerate(self.personas):
+                if p.persona_id == persona_id:
+                    self.personas[i] = persona
+                    break
+        return persona
+
+    async def get_all_personas(self) -> list[Persona]:
+        """获取所有 personas"""
+        return await self.db.get_personas()
+
+    async def create_persona(
+        self, persona_id: str, system_prompt: str, begin_dialogs: list[str] = None
+    ) -> Persona:
+        """创建新的 persona"""
+        if await self.db.get_persona_by_id(persona_id):
+            raise ValueError(f"Persona with ID {persona_id} already exists.")
+        new_persona = await self.db.insert_persona(
+            persona_id, system_prompt, begin_dialogs
+        )
+        self.personas.append(new_persona)
+        return new_persona
+
+    def get_v3_persona_data(
+        self,
+    ) -> tuple[list[dict], list[Personality], Personality]:
+        """获取 AstrBot <4.0.0 版本的 persona 数据。
+
+        Returns:
+            - list[dict]: 包含 persona 配置的字典列表。
+            - list[Personality]: 包含 Personality 对象的列表。
+            - Personality: 默认选择的 Personality 对象。
+        """
+        v3_persona_config = [
+            {
+                "prompt": persona.system_prompt,
+                "name": persona.persona_id,
+                "begin_dialogs": persona.begin_dialogs or [],
+                "mood_imitation_dialogs": [],  # deprecated
+            }
+            for persona in self.personas
+        ]
+
+        v3_personas: list[Personality] = []
+        selected_default_persona: Personality | None = None
+
+        for persona in v3_persona_config:
+            begin_dialogs = persona.get("begin_dialogs", [])
+            bd_processed = []
+            if begin_dialogs:
+                if len(begin_dialogs) % 2 != 0:
+                    logger.error(
+                        f"{persona['name']} 人格情景预设对话格式不对，条数应该为偶数。"
+                    )
+                    begin_dialogs = []
+                user_turn = True
+                for dialog in begin_dialogs:
+                    bd_processed.append(
+                        {
+                            "role": "user" if user_turn else "assistant",
+                            "content": dialog,
+                            "_no_save": None,  # 不持久化到 db
+                        }
+                    )
+                    user_turn = not user_turn
+
+            try:
+                persona = Personality(
+                    **persona,
+                    _begin_dialogs_processed=bd_processed,
+                    _mood_imitation_dialogs_processed="",  # deprecated
+                )
+                if persona["name"] == self.default_persona:
+                    selected_default_persona = persona
+                v3_personas.append(persona)
+            except Exception as e:
+                logger.error(f"解析 Persona 配置失败：{e}")
+
+        if not selected_default_persona and len(v3_personas) > 0:
+            # 默认选择第一个
+            selected_default_persona = v3_personas[0]
+
+        if not selected_default_persona:
+            selected_default_persona = Personality(
+                prompt="You are a helpful and friendly assistant.",
+                name="default",
+                _begin_dialogs_processed=[],
+            )
+            v3_personas.append(selected_default_persona)
+
+        return v3_persona_config, v3_personas, selected_default_persona

--- a/astrbot/core/provider/manager.py
+++ b/astrbot/core/provider/manager.py
@@ -7,85 +7,27 @@ from astrbot.core.config.astrbot_config import AstrBotConfig
 from astrbot.core.db import BaseDatabase
 
 from .entities import ProviderType
-from .provider import Personality, Provider, STTProvider, TTSProvider, EmbeddingProvider
+from .provider import Provider, STTProvider, TTSProvider, EmbeddingProvider
 from .register import llm_tools, provider_cls_map
+from ..persona_mgr import PersonaManager
 
 
 class ProviderManager:
-    def __init__(self, config: AstrBotConfig, db_helper: BaseDatabase):
+    def __init__(
+        self,
+        config: AstrBotConfig,
+        db_helper: BaseDatabase,
+        persona_mgr: PersonaManager,
+    ):
+        self.persona_mgr = persona_mgr
+        self.astrbot_config = config
         self.providers_config: List = config["provider"]
         self.provider_settings: dict = config["provider_settings"]
         self.provider_stt_settings: dict = config.get("provider_stt_settings", {})
         self.provider_tts_settings: dict = config.get("provider_tts_settings", {})
-        self.persona_configs: list = config.get("persona", [])
-        self.astrbot_config = config
 
-        # 人格情景管理
-        # 目前没有拆成独立的模块
-        self.default_persona_name = self.provider_settings.get(
-            "default_personality", "default"
-        )
-        self.personas: List[Personality] = []
-        self.selected_default_persona = None
-        for persona in self.persona_configs:
-            begin_dialogs = persona.get("begin_dialogs", [])
-            mood_imitation_dialogs = persona.get("mood_imitation_dialogs", [])
-            bd_processed = []
-            mid_processed = ""
-            if begin_dialogs:
-                if len(begin_dialogs) % 2 != 0:
-                    logger.error(
-                        f"{persona['name']} 人格情景预设对话格式不对，条数应该为偶数。"
-                    )
-                    begin_dialogs = []
-                user_turn = True
-                for dialog in begin_dialogs:
-                    bd_processed.append(
-                        {
-                            "role": "user" if user_turn else "assistant",
-                            "content": dialog,
-                            "_no_save": None,  # 不持久化到 db
-                        }
-                    )
-                    user_turn = not user_turn
-            if mood_imitation_dialogs:
-                if len(mood_imitation_dialogs) % 2 != 0:
-                    logger.error(
-                        f"{persona['name']} 对话风格对话格式不对，条数应该为偶数。"
-                    )
-                    mood_imitation_dialogs = []
-                user_turn = True
-                for dialog in mood_imitation_dialogs:
-                    role = "A" if user_turn else "B"
-                    mid_processed += f"{role}: {dialog}\n"
-                    if not user_turn:
-                        mid_processed += "\n"
-                    user_turn = not user_turn
-
-            try:
-                persona = Personality(
-                    **persona,
-                    _begin_dialogs_processed=bd_processed,
-                    _mood_imitation_dialogs_processed=mid_processed,
-                )
-                if persona["name"] == self.default_persona_name:
-                    self.selected_default_persona = persona
-                self.personas.append(persona)
-            except Exception as e:
-                logger.error(f"解析 Persona 配置失败：{e}")
-
-        if not self.selected_default_persona and len(self.personas) > 0:
-            # 默认选择第一个
-            self.selected_default_persona = self.personas[0]
-
-        if not self.selected_default_persona:
-            self.selected_default_persona = Personality(
-                prompt="You are a helpful and friendly assistant.",
-                name="default",
-                _begin_dialogs_processed=[],
-                _mood_imitation_dialogs_processed="",
-            )
-            self.personas.append(self.selected_default_persona)
+        # 人格相关属性，v4.0.0 版本后被废弃，推荐使用 PersonaManager
+        self.default_persona_name = persona_mgr.default_persona
 
         self.provider_insts: List[Provider] = []
         """加载的 Provider 的实例"""
@@ -112,6 +54,24 @@ class ProviderManager:
         kdb_cfg = config.get("knowledge_db", {})
         if kdb_cfg and len(kdb_cfg):
             self.curr_kdb_name = list(kdb_cfg.keys())[0]
+
+    @property
+    def persona_configs(self) -> list:
+        """动态获取最新的 persona 配置"""
+        persona_configs, _, _ = self.persona_mgr.get_v3_persona_data()
+        return persona_configs
+
+    @property
+    def personas(self) -> list:
+        """动态获取最新的 personas 列表"""
+        _, personas, _ = self.persona_mgr.get_v3_persona_data()
+        return personas
+
+    @property
+    def selected_default_persona(self):
+        """动态获取最新的默认选中 persona"""
+        _, _, selected_default_persona = self.persona_mgr.get_v3_persona_data()
+        return selected_default_persona
 
     async def set_provider(
         self, provider_id: str, provider_type: ProviderType, umo: str = None

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -1,21 +1,11 @@
 import abc
 from typing import List
-from typing import TypedDict, AsyncGenerator
+from typing import AsyncGenerator
 from astrbot.core.provider.func_tool_manager import FuncCall
 from astrbot.core.provider.entities import LLMResponse, ToolCallsResult, ProviderType
 from astrbot.core.provider.register import provider_cls_map
+from astrbot.core.db.po import Personality
 from dataclasses import dataclass
-
-
-class Personality(TypedDict):
-    prompt: str = ""
-    name: str = ""
-    begin_dialogs: List[str] = []
-    mood_imitation_dialogs: List[str] = []
-
-    # cache
-    _begin_dialogs_processed: List[dict] = []
-    _mood_imitation_dialogs_processed: str = ""
 
 
 @dataclass

--- a/astrbot/core/star/context.py
+++ b/astrbot/core/star/context.py
@@ -17,6 +17,8 @@ from astrbot.core.message.message_event_result import MessageChain
 from astrbot.core.provider.manager import ProviderManager
 from astrbot.core.platform import Platform
 from astrbot.core.platform.manager import PlatformManager
+from astrbot.core.platform_message_history_mgr import PlatformMessageHistoryManager
+from astrbot.core.persona_mgr import PersonaManager
 from .star import star_registry, StarMetadata, star_map
 from .star_handler import star_handlers_registry, StarHandlerMetadata, EventType
 from .filter.command import CommandFilter
@@ -62,6 +64,8 @@ class Context:
         provider_manager: ProviderManager = None,
         platform_manager: PlatformManager = None,
         conversation_manager: ConversationManager = None,
+        message_history_manager: PlatformMessageHistoryManager = None,
+        persona_manager: PersonaManager = None,
     ):
         self._event_queue = event_queue
         self._config = config
@@ -69,6 +73,8 @@ class Context:
         self.provider_manager = provider_manager
         self.platform_manager = platform_manager
         self.conversation_manager = conversation_manager
+        self.message_history_manager = message_history_manager
+        self.persona_manager = persona_manager
 
     def get_registered_star(self, star_name: str) -> StarMetadata:
         """根据插件名获取插件的 Metadata"""
@@ -208,7 +214,9 @@ class Context:
         return self._event_queue
 
     @deprecated(version="4.0.0", reason="Use get_platform_inst instead")
-    def get_platform(self, platform_type: Union[PlatformAdapterType, str]) -> Platform | None:
+    def get_platform(
+        self, platform_type: Union[PlatformAdapterType, str]
+    ) -> Platform | None:
         """
         获取指定类型的平台适配器。
 

--- a/astrbot/dashboard/routes/__init__.py
+++ b/astrbot/dashboard/routes/__init__.py
@@ -6,11 +6,11 @@ from .stat import StatRoute
 from .log import LogRoute
 from .static_file import StaticFileRoute
 from .chat import ChatRoute
-from .tools import ToolsRoute  # 导入新的ToolsRoute
+from .tools import ToolsRoute
 from .conversation import ConversationRoute
 from .file import FileRoute
 from .session_management import SessionManagementRoute
-
+from .persona import PersonaRoute
 
 __all__ = [
     "AuthRoute",
@@ -25,4 +25,5 @@ __all__ = [
     "ConversationRoute",
     "FileRoute",
     "SessionManagementRoute",
+    "PersonaRoute",
 ]

--- a/astrbot/dashboard/routes/persona.py
+++ b/astrbot/dashboard/routes/persona.py
@@ -1,0 +1,193 @@
+import traceback
+import json
+from .route import Route, Response, RouteContext
+from astrbot.core import logger
+from quart import request
+from astrbot.core.db import BaseDatabase
+from astrbot.core.core_lifecycle import AstrBotCoreLifecycle
+
+
+class PersonaRoute(Route):
+    def __init__(
+        self,
+        context: RouteContext,
+        db_helper: BaseDatabase,
+        core_lifecycle: AstrBotCoreLifecycle,
+    ) -> None:
+        super().__init__(context)
+        self.routes = {
+            "/persona/list": ("GET", self.list_personas),
+            "/persona/detail": ("POST", self.get_persona_detail),
+            "/persona/create": ("POST", self.create_persona),
+            "/persona/update": ("POST", self.update_persona),
+            "/persona/delete": ("POST", self.delete_persona),
+        }
+        self.db_helper = db_helper
+        self.persona_mgr = core_lifecycle.persona_mgr
+        self.register_routes()
+
+    async def list_personas(self):
+        """获取所有人格列表"""
+        try:
+            personas = await self.persona_mgr.get_all_personas()
+            return (
+                Response()
+                .ok(
+                    [
+                        {
+                            "persona_id": persona.persona_id,
+                            "system_prompt": persona.system_prompt,
+                            "begin_dialogs": persona.begin_dialogs or [],
+                            "created_at": persona.created_at.isoformat()
+                            if persona.created_at
+                            else None,
+                            "updated_at": persona.updated_at.isoformat()
+                            if persona.updated_at
+                            else None,
+                        }
+                        for persona in personas
+                    ]
+                )
+                .__dict__
+            )
+        except Exception as e:
+            logger.error(f"获取人格列表失败: {str(e)}\n{traceback.format_exc()}")
+            return Response().error(f"获取人格列表失败: {str(e)}").__dict__
+
+    async def get_persona_detail(self):
+        """获取指定人格的详细信息"""
+        try:
+            data = await request.get_json()
+            persona_id = data.get("persona_id")
+
+            if not persona_id:
+                return Response().error("缺少必要参数: persona_id").__dict__
+
+            persona = await self.persona_mgr.get_persona(persona_id)
+            if not persona:
+                return Response().error("人格不存在").__dict__
+
+            return (
+                Response()
+                .ok(
+                    {
+                        "persona_id": persona.persona_id,
+                        "system_prompt": persona.system_prompt,
+                        "begin_dialogs": persona.begin_dialogs or [],
+                        "created_at": persona.created_at.isoformat()
+                        if persona.created_at
+                        else None,
+                        "updated_at": persona.updated_at.isoformat()
+                        if persona.updated_at
+                        else None,
+                    }
+                )
+                .__dict__
+            )
+        except Exception as e:
+            logger.error(f"获取人格详情失败: {str(e)}\n{traceback.format_exc()}")
+            return Response().error(f"获取人格详情失败: {str(e)}").__dict__
+
+    async def create_persona(self):
+        """创建新人格"""
+        try:
+            data = await request.get_json()
+            persona_id = data.get("persona_id", "").strip()
+            system_prompt = data.get("system_prompt", "").strip()
+            begin_dialogs = data.get("begin_dialogs", [])
+
+            if not persona_id:
+                return Response().error("人格ID不能为空").__dict__
+
+            if not system_prompt:
+                return Response().error("系统提示词不能为空").__dict__
+
+            # 验证 begin_dialogs 格式
+            if begin_dialogs and len(begin_dialogs) % 2 != 0:
+                return (
+                    Response()
+                    .error("预设对话数量必须为偶数（用户和助手轮流对话）")
+                    .__dict__
+                )
+
+            persona = await self.persona_mgr.create_persona(
+                persona_id=persona_id,
+                system_prompt=system_prompt,
+                begin_dialogs=begin_dialogs if begin_dialogs else None,
+            )
+
+            return (
+                Response()
+                .ok(
+                    {
+                        "message": "人格创建成功",
+                        "persona": {
+                            "persona_id": persona.persona_id,
+                            "system_prompt": persona.system_prompt,
+                            "begin_dialogs": persona.begin_dialogs or [],
+                            "created_at": persona.created_at.isoformat()
+                            if persona.created_at
+                            else None,
+                            "updated_at": persona.updated_at.isoformat()
+                            if persona.updated_at
+                            else None,
+                        },
+                    }
+                )
+                .__dict__
+            )
+        except ValueError as e:
+            return Response().error(str(e)).__dict__
+        except Exception as e:
+            logger.error(f"创建人格失败: {str(e)}\n{traceback.format_exc()}")
+            return Response().error(f"创建人格失败: {str(e)}").__dict__
+
+    async def update_persona(self):
+        """更新人格信息"""
+        try:
+            data = await request.get_json()
+            persona_id = data.get("persona_id")
+            system_prompt = data.get("system_prompt")
+            begin_dialogs = data.get("begin_dialogs")
+
+            if not persona_id:
+                return Response().error("缺少必要参数: persona_id").__dict__
+
+            # 验证 begin_dialogs 格式
+            if begin_dialogs is not None and len(begin_dialogs) % 2 != 0:
+                return (
+                    Response()
+                    .error("预设对话数量必须为偶数（用户和助手轮流对话）")
+                    .__dict__
+                )
+
+            await self.persona_mgr.update_persona(
+                persona_id=persona_id,
+                system_prompt=system_prompt,
+                begin_dialogs=begin_dialogs,
+            )
+
+            return Response().ok({"message": "人格更新成功"}).__dict__
+        except ValueError as e:
+            return Response().error(str(e)).__dict__
+        except Exception as e:
+            logger.error(f"更新人格失败: {str(e)}\n{traceback.format_exc()}")
+            return Response().error(f"更新人格失败: {str(e)}").__dict__
+
+    async def delete_persona(self):
+        """删除人格"""
+        try:
+            data = await request.get_json()
+            persona_id = data.get("persona_id")
+
+            if not persona_id:
+                return Response().error("缺少必要参数: persona_id").__dict__
+
+            await self.persona_mgr.delete_persona(persona_id)
+
+            return Response().ok({"message": "人格删除成功"}).__dict__
+        except ValueError as e:
+            return Response().error(str(e)).__dict__
+        except Exception as e:
+            logger.error(f"删除人格失败: {str(e)}\n{traceback.format_exc()}")
+            return Response().error(f"删除人格失败: {str(e)}").__dict__

--- a/astrbot/dashboard/server.py
+++ b/astrbot/dashboard/server.py
@@ -60,6 +60,9 @@ class AstrBotDashboard:
         self.session_management_route = SessionManagementRoute(
             self.context, db, core_lifecycle
         )
+        self.persona_route = PersonaRoute(
+            self.context, db, core_lifecycle
+        )
 
         self.app.add_url_rule(
             "/api/plug/<path:subpath>",

--- a/dashboard/src/i18n/loader.ts
+++ b/dashboard/src/i18n/loader.ts
@@ -52,6 +52,7 @@ export class I18nLoader {
       { name: 'features/alkaid/index', path: 'features/alkaid/index.json' },
       { name: 'features/alkaid/knowledge-base', path: 'features/alkaid/knowledge-base.json' },
       { name: 'features/alkaid/memory', path: 'features/alkaid/memory.json' },
+      { name: 'features/persona', path: 'features/persona.json' },
       
       // 消息模块
       { name: 'messages/errors', path: 'messages/errors.json' },

--- a/dashboard/src/i18n/locales/en-US/core/navigation.json
+++ b/dashboard/src/i18n/locales/en-US/core/navigation.json
@@ -2,6 +2,7 @@
   "dashboard": "Dashboard", 
   "platforms": "Platforms",
   "providers": "Providers",
+  "persona": "Persona",
   "toolUse": "MCP Tools",
   "config": "Config",
   "extension": "Extensions",

--- a/dashboard/src/i18n/locales/en-US/features/persona.json
+++ b/dashboard/src/i18n/locales/en-US/features/persona.json
@@ -1,0 +1,53 @@
+{
+  "page": {
+    "description": "Manage and configure chat bot personality settings"
+  },
+  "buttons": {
+    "create": "Create Persona",
+    "createFirst": "Create First Persona",
+    "edit": "Edit",
+    "delete": "Delete",
+    "cancel": "Cancel",
+    "save": "Save",
+    "addDialogPair": "Add Dialog Pair"
+  },
+  "labels": {
+    "presetDialogs": "Preset Dialogs ({count} pairs)",
+    "createdAt": "Created At",
+    "updatedAt": "Updated At"
+  },
+  "form": {
+    "personaId": "Persona ID",
+    "systemPrompt": "System Prompt",
+    "presetDialogs": "Preset Dialogs",
+    "presetDialogsHelp": "Add some preset dialogs to help the bot better understand the role settings. The number of dialogs must be even (users and assistants take turns).",
+    "userMessage": "User Message",
+    "assistantMessage": "Assistant Message"
+  },
+  "dialog": {
+    "create": {
+      "title": "Create New Persona"
+    },
+    "edit": {
+      "title": "Edit Persona"
+    }
+  },
+  "empty": {
+    "title": "No Persona Configured",
+    "description": "Create your first persona to start using personalized chatbots"
+  },
+  "validation": {
+    "required": "This field is required",
+    "minLength": "Minimum {min} characters required",
+    "alphanumeric": "Only letters, numbers, underscores and hyphens are allowed",
+    "dialogRequired": "{type} cannot be empty"
+  },
+  "messages": {
+    "loadError": "Failed to load persona list",
+    "saveSuccess": "Saved successfully",
+    "saveError": "Save failed",
+    "deleteConfirm": "Are you sure you want to delete persona \"{id}\"? This action cannot be undone.",
+    "deleteSuccess": "Deleted successfully",
+    "deleteError": "Delete failed"
+  }
+}

--- a/dashboard/src/i18n/locales/zh-CN/core/navigation.json
+++ b/dashboard/src/i18n/locales/zh-CN/core/navigation.json
@@ -2,6 +2,7 @@
   "dashboard": "统计",
   "platforms": "消息平台",
   "providers": "服务提供商",
+  "persona": "人格管理",
   "toolUse": "MCP",
   "config": "配置文件",
   "extension": "插件管理",

--- a/dashboard/src/i18n/locales/zh-CN/features/persona.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/persona.json
@@ -1,0 +1,53 @@
+{
+  "page": {
+    "description": "管理和配置聊天机器人的人格角色设定"
+  },
+  "buttons": {
+    "create": "创建人格",
+    "createFirst": "创建第一个人格",
+    "edit": "编辑",
+    "delete": "删除",
+    "cancel": "取消",
+    "save": "保存",
+    "addDialogPair": "添加对话对"
+  },
+  "labels": {
+    "presetDialogs": "预设对话 ({count} 对)",
+    "createdAt": "创建时间",
+    "updatedAt": "更新时间"
+  },
+  "form": {
+    "personaId": "人格 ID",
+    "systemPrompt": "系统提示词",
+    "presetDialogs": "预设对话",
+    "presetDialogsHelp": "添加一些预设的对话来帮助机器人更好地理解角色设定。对话数量必须为偶数（用户和助手轮流对话）。",
+    "userMessage": "用户消息",
+    "assistantMessage": "助手消息"
+  },
+  "dialog": {
+    "create": {
+      "title": "创建新人格"
+    },
+    "edit": {
+      "title": "编辑人格"
+    }
+  },
+  "empty": {
+    "title": "暂无人格配置",
+    "description": "创建您的第一个人格来开始使用个性化的聊天机器人"
+  },
+  "validation": {
+    "required": "此字段为必填项",
+    "minLength": "最少需要 {min} 个字符",
+    "alphanumeric": "只能包含字母、数字、下划线和连字符",
+    "dialogRequired": "{type}不能为空"
+  },
+  "messages": {
+    "loadError": "加载人格列表失败",
+    "saveSuccess": "保存成功",
+    "saveError": "保存失败",
+    "deleteConfirm": "确定要删除人格 \"{id}\" 吗？此操作不可撤销。",
+    "deleteSuccess": "删除成功",
+    "deleteError": "删除失败"
+  }
+}

--- a/dashboard/src/i18n/translations.ts
+++ b/dashboard/src/i18n/translations.ts
@@ -25,6 +25,7 @@ import zhCNDashboard from './locales/zh-CN/features/dashboard.json';
 import zhCNAlkaidIndex from './locales/zh-CN/features/alkaid/index.json';
 import zhCNAlkaidKnowledgeBase from './locales/zh-CN/features/alkaid/knowledge-base.json';
 import zhCNAlkaidMemory from './locales/zh-CN/features/alkaid/memory.json';
+import zhCNPersona from './locales/zh-CN/features/persona.json';
 
 import zhCNErrors from './locales/zh-CN/messages/errors.json';
 import zhCNSuccess from './locales/zh-CN/messages/success.json';
@@ -54,6 +55,7 @@ import enUSDashboard from './locales/en-US/features/dashboard.json';
 import enUSAlkaidIndex from './locales/en-US/features/alkaid/index.json';
 import enUSAlkaidKnowledgeBase from './locales/en-US/features/alkaid/knowledge-base.json';
 import enUSAlkaidMemory from './locales/en-US/features/alkaid/memory.json';
+import enUSPersona from './locales/en-US/features/persona.json';
 
 import enUSErrors from './locales/en-US/messages/errors.json';
 import enUSSuccess from './locales/en-US/messages/success.json';
@@ -88,7 +90,8 @@ export const translations = {
         index: zhCNAlkaidIndex,
         'knowledge-base': zhCNAlkaidKnowledgeBase,
         memory: zhCNAlkaidMemory
-      }
+      },
+      persona: zhCNPersona
     },
     messages: {
       errors: zhCNErrors,
@@ -123,7 +126,8 @@ export const translations = {
         index: enUSAlkaidIndex,
         'knowledge-base': enUSAlkaidKnowledgeBase,
         memory: enUSAlkaidMemory
-      }
+      },
+      persona: enUSPersona
     },
     messages: {
       errors: enUSErrors,

--- a/dashboard/src/layouts/full/vertical-sidebar/sidebarItem.ts
+++ b/dashboard/src/layouts/full/vertical-sidebar/sidebarItem.ts
@@ -64,8 +64,12 @@ const sidebarItem: menu[] = [
     to: '/session-management'
   },
   {
+    title: 'core.navigation.persona',
+    icon: 'mdi-heart',
+    to: '/persona'
+  },
+  {
     title: 'core.navigation.console',
-
     icon: 'mdi-console',
     to: '/console'
   },

--- a/dashboard/src/router/MainRoutes.ts
+++ b/dashboard/src/router/MainRoutes.ts
@@ -57,6 +57,11 @@ const MainRoutes = {
       component: () => import('@/views/SessionManagementPage.vue')
     },
     {
+      name: 'Persona',
+      path: '/persona',
+      component: () => import('@/views/PersonaPage.vue')
+    },
+    {
       name: 'Console',
       path: '/console',
       component: () => import('@/views/ConsolePage.vue')

--- a/dashboard/src/views/PersonaPage.vue
+++ b/dashboard/src/views/PersonaPage.vue
@@ -1,0 +1,456 @@
+<template>
+    <div class="persona-page">
+        <v-container fluid class="pa-0">
+            <!-- 页面标题 -->
+            <v-row class="d-flex justify-space-between align-center px-4 py-3 pb-8">
+                <div>
+                    <h1 class="text-h1 font-weight-bold mb-2">
+                        <v-icon color="black" class="me-2">mdi-heart</v-icon>{{ t('core.navigation.persona') }}
+                    </h1>
+                    <p class="text-subtitle-1 text-medium-emphasis mb-4">
+                        {{ tm('page.description') }}
+                    </p>
+                </div>
+                <div>
+                    <v-btn color="primary" variant="tonal" prepend-icon="mdi-plus" @click="openCreateDialog"
+                        rounded="xl" size="x-large">
+                        {{ tm('buttons.create') }}
+                    </v-btn>
+                </div>
+            </v-row>
+
+
+            <!-- 人格卡片网格 -->
+            <v-row>
+                <v-col v-for="persona in personas" :key="persona.persona_id" cols="12" md="6" lg="4" xl="3">
+                    <v-card class="persona-card" elevation="2" rounded="lg" @click="viewPersona(persona)">
+                        <v-card-title class="d-flex justify-space-between align-center">
+                            <div class="text-truncate ml-2">
+                                {{ persona.persona_id }}
+                            </div>
+                            <v-menu offset-y>
+                                <template v-slot:activator="{ props }">
+                                    <v-btn icon="mdi-dots-vertical" variant="text" size="small" v-bind="props"
+                                        @click.stop />
+                                </template>
+                                <v-list density="compact">
+                                    <v-list-item @click="editPersona(persona)">
+                                        <v-list-item-title>
+                                            <v-icon class="mr-2" size="small">mdi-pencil</v-icon>
+                                            {{ tm('buttons.edit') }}
+                                        </v-list-item-title>
+                                    </v-list-item>
+                                    <v-list-item @click="deletePersona(persona)" class="text-error">
+                                        <v-list-item-title>
+                                            <v-icon class="mr-2" size="small">mdi-delete</v-icon>
+                                            {{ tm('buttons.delete') }}
+                                        </v-list-item-title>
+                                    </v-list-item>
+                                </v-list>
+                            </v-menu>
+                        </v-card-title>
+
+                        <v-card-text>
+                            <div class="system-prompt-preview">
+                                {{ truncateText(persona.system_prompt, 100) }}
+                            </div>
+
+                            <div class="mt-3" v-if="persona.begin_dialogs && persona.begin_dialogs.length > 0">
+                                <v-chip size="small" color="secondary" variant="tonal" prepend-icon="mdi-chat">
+                                    {{ tm('labels.presetDialogs', { count: persona.begin_dialogs.length / 2 }) }}
+                                </v-chip>
+                            </div>
+
+                            <div class="mt-3 text-caption text-medium-emphasis">
+                                {{ tm('labels.createdAt') }}: {{ formatDate(persona.created_at) }}
+                            </div>
+                        </v-card-text>
+                    </v-card>
+                </v-col>
+
+                <!-- 空状态 -->
+                <v-col v-if="personas.length === 0 && !loading" cols="12">
+                    <v-card class="text-center pa-8" elevation="0">
+                        <v-icon size="64" color="grey-lighten-1" class="mb-4">mdi-account-group</v-icon>
+                        <h3 class="text-h5 mb-2">{{ tm('empty.title') }}</h3>
+                        <p class="text-body-1 text-medium-emphasis mb-4">{{ tm('empty.description') }}</p>
+                        <v-btn color="primary" variant="flat" prepend-icon="mdi-plus" @click="openCreateDialog">
+                            {{ tm('buttons.createFirst') }}
+                        </v-btn>
+                    </v-card>
+                </v-col>
+            </v-row>
+
+            <!-- 加载状态 -->
+            <v-row v-if="loading">
+                <v-col v-for="n in 6" :key="n" cols="12" md="6" lg="4" xl="3">
+                    <v-skeleton-loader type="card" rounded="lg"></v-skeleton-loader>
+                </v-col>
+            </v-row>
+        </v-container>
+
+        <!-- 创建/编辑人格对话框 -->
+        <v-dialog v-model="showPersonaDialog" max-width="800px" persistent>
+            <v-card>
+                <v-card-title class="text-h5">
+                    {{ editingPersona ? tm('dialog.edit.title') : tm('dialog.create.title') }}
+                </v-card-title>
+
+                <v-card-text>
+                    <v-form ref="personaForm" v-model="formValid">
+                        <v-text-field v-model="personaForm.persona_id" :label="tm('form.personaId')"
+                            :rules="personaIdRules" :disabled="editingPersona" variant="outlined" density="comfortable"
+                            class="mb-4" />
+
+                        <v-textarea v-model="personaForm.system_prompt" :label="tm('form.systemPrompt')"
+                            :rules="systemPromptRules" variant="outlined" rows="6" class="mb-4" />
+
+                        <v-expansion-panels v-model="expandedPanels" multiple>
+                            <v-expansion-panel value="dialogs">
+                                <v-expansion-panel-title>
+                                    <v-icon class="mr-2">mdi-chat</v-icon>
+                                    {{ tm('form.presetDialogs') }}
+                                    <v-chip v-if="personaForm.begin_dialogs.length > 0" size="small" color="primary"
+                                        variant="tonal" class="ml-2">
+                                        {{ personaForm.begin_dialogs.length / 2 }}
+                                    </v-chip>
+                                </v-expansion-panel-title>
+
+                                <v-expansion-panel-text>
+                                    <div class="mb-3">
+                                        <p class="text-body-2 text-medium-emphasis">
+                                            {{ tm('form.presetDialogsHelp') }}
+                                        </p>
+                                    </div>
+
+                                    <div v-for="(dialog, index) in personaForm.begin_dialogs" :key="index" class="mb-3">
+                                        <v-textarea v-model="personaForm.begin_dialogs[index]"
+                                            :label="index % 2 === 0 ? tm('form.userMessage') : tm('form.assistantMessage')"
+                                            :rules="getDialogRules(index)"
+                                            variant="outlined" rows="2" density="comfortable">
+                                            <template v-slot:append>
+                                                <v-btn icon="mdi-delete" variant="text" size="small" color="error"
+                                                    @click="removeDialog(index)" />
+                                            </template>
+                                        </v-textarea>
+                                    </div>
+
+                                    <v-btn variant="outlined" prepend-icon="mdi-plus" @click="addDialogPair" block>
+                                        {{ tm('buttons.addDialogPair') }}
+                                    </v-btn>
+                                </v-expansion-panel-text>
+                            </v-expansion-panel>
+                        </v-expansion-panels>
+                    </v-form>
+                </v-card-text>
+
+                <v-card-actions>
+                    <v-spacer />
+                    <v-btn color="grey" variant="text" @click="closePersonaDialog">
+                        {{ tm('buttons.cancel') }}
+                    </v-btn>
+                    <v-btn color="primary" variant="flat" @click="savePersona" :loading="saving" :disabled="!formValid">
+                        {{ tm('buttons.save') }}
+                    </v-btn>
+                </v-card-actions>
+            </v-card>
+        </v-dialog>
+
+        <!-- 查看人格详情对话框 -->
+        <v-dialog v-model="showViewDialog" max-width="700px">
+            <v-card v-if="viewingPersona">
+                <v-card-title class="d-flex justify-space-between align-center">
+                    <span class="text-h5">{{ viewingPersona.persona_id }}</span>
+                    <v-btn icon="mdi-close" variant="text" @click="showViewDialog = false" />
+                </v-card-title>
+
+                <v-card-text>
+                    <div class="mb-4">
+                        <h4 class="text-h6 mb-2">{{ tm('form.systemPrompt') }}</h4>
+                        <div class="system-prompt-content">
+                            {{ viewingPersona.system_prompt }}
+                        </div>
+                    </div>
+
+                    <div v-if="viewingPersona.begin_dialogs && viewingPersona.begin_dialogs.length > 0" class="mb-4">
+                        <h4 class="text-h6 mb-2">{{ tm('form.presetDialogs') }}</h4>
+                        <div v-for="(dialog, index) in viewingPersona.begin_dialogs" :key="index" class="mb-2">
+                            <v-chip :color="index % 2 === 0 ? 'primary' : 'secondary'" variant="tonal" size="small"
+                                class="mb-1">
+                                {{ index % 2 === 0 ? tm('form.userMessage') : tm('form.assistantMessage') }}
+                            </v-chip>
+                            <div class="dialog-content ml-2">
+                                {{ dialog }}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="text-caption text-medium-emphasis">
+                        <div>{{ tm('labels.createdAt') }}: {{ formatDate(viewingPersona.created_at) }}</div>
+                        <div v-if="viewingPersona.updated_at">{{ tm('labels.updatedAt') }}: {{
+                            formatDate(viewingPersona.updated_at) }}</div>
+                    </div>
+                </v-card-text>
+            </v-card>
+        </v-dialog>
+
+        <!-- 消息提示 -->
+        <v-snackbar :timeout="3000" elevation="24" :color="messageType" v-model="showMessage" location="top">
+            {{ message }}
+        </v-snackbar>
+    </div>
+</template>
+
+<script>
+import axios from 'axios';
+import { useI18n, useModuleI18n } from '@/i18n/composables';
+
+export default {
+    name: 'PersonaPage',
+    setup() {
+        const { t } = useI18n();
+        const { tm } = useModuleI18n('features/persona');
+        return { t, tm };
+    },
+    data() {
+        return {
+            personas: [],
+            loading: false,
+            saving: false,
+            showPersonaDialog: false,
+            showViewDialog: false,
+            editingPersona: null,
+            viewingPersona: null,
+            expandedPanels: [],
+            formValid: false,
+            personaForm: {
+                persona_id: '',
+                system_prompt: '',
+                begin_dialogs: []
+            },
+            showMessage: false,
+            message: '',
+            messageType: 'success',
+            personaIdRules: [
+                v => !!v || this.tm('validation.required'),
+                v => (v && v.length >= 2) || this.tm('validation.minLength', { min: 2 }),
+                v => /^[a-zA-Z0-9_-]+$/.test(v) || this.tm('validation.alphanumeric')
+            ],
+            systemPromptRules: [
+                v => !!v || this.tm('validation.required'),
+                v => (v && v.length >= 10) || this.tm('validation.minLength', { min: 10 })
+            ]
+        }
+    },
+
+    mounted() {
+        this.loadPersonas();
+    },
+
+    methods: {
+        async loadPersonas() {
+            this.loading = true;
+            try {
+                const response = await axios.get('/api/persona/list');
+                if (response.data.status === 'ok') {
+                    this.personas = response.data.data;
+                } else {
+                    this.showError(response.data.message || this.tm('messages.loadError'));
+                }
+            } catch (error) {
+                this.showError(error.response?.data?.message || this.tm('messages.loadError'));
+            }
+            this.loading = false;
+        },
+
+        openCreateDialog() {
+            this.editingPersona = null;
+            this.personaForm = {
+                persona_id: '',
+                system_prompt: '',
+                begin_dialogs: []
+            };
+            this.expandedPanels = [];
+            this.showPersonaDialog = true;
+        },
+
+        editPersona(persona) {
+            this.editingPersona = persona;
+            this.personaForm = {
+                persona_id: persona.persona_id,
+                system_prompt: persona.system_prompt,
+                begin_dialogs: [...(persona.begin_dialogs || [])]
+            };
+            this.expandedPanels = [];
+            this.showPersonaDialog = true;
+        },
+
+        viewPersona(persona) {
+            this.viewingPersona = persona;
+            this.showViewDialog = true;
+        },
+
+        closePersonaDialog() {
+            this.showPersonaDialog = false;
+            this.editingPersona = null;
+            this.personaForm = {
+                persona_id: '',
+                system_prompt: '',
+                begin_dialogs: []
+            };
+        },
+
+        async savePersona() {
+            if (!this.formValid) return;
+
+            // 验证预设对话不能为空
+            if (this.personaForm.begin_dialogs.length > 0) {
+                for (let i = 0; i < this.personaForm.begin_dialogs.length; i++) {
+                    if (!this.personaForm.begin_dialogs[i] || this.personaForm.begin_dialogs[i].trim() === '') {
+                        const dialogType = i % 2 === 0 ? this.tm('form.userMessage') : this.tm('form.assistantMessage');
+                        this.showError(this.tm('validation.dialogRequired', { type: dialogType }));
+                        return;
+                    }
+                }
+            }
+
+            this.saving = true;
+            try {
+                const url = this.editingPersona ? '/api/persona/update' : '/api/persona/create';
+                const response = await axios.post(url, this.personaForm);
+
+                if (response.data.status === 'ok') {
+                    this.showSuccess(response.data.message || this.tm('messages.saveSuccess'));
+                    this.closePersonaDialog();
+                    await this.loadPersonas();
+                } else {
+                    this.showError(response.data.message || this.tm('messages.saveError'));
+                }
+            } catch (error) {
+                this.showError(error.response?.data?.message || this.tm('messages.saveError'));
+            }
+            this.saving = false;
+        },
+
+        async deletePersona(persona) {
+            if (!confirm(this.tm('messages.deleteConfirm', { id: persona.persona_id }))) {
+                return;
+            }
+
+            try {
+                const response = await axios.post('/api/persona/delete', {
+                    persona_id: persona.persona_id
+                });
+
+                if (response.data.status === 'ok') {
+                    this.showSuccess(response.data.message || this.tm('messages.deleteSuccess'));
+                    await this.loadPersonas();
+                } else {
+                    this.showError(response.data.message || this.tm('messages.deleteError'));
+                }
+            } catch (error) {
+                this.showError(error.response?.data?.message || this.tm('messages.deleteError'));
+            }
+        },
+
+        addDialogPair() {
+            this.personaForm.begin_dialogs.push('', '');
+            // 自动展开预设对话面板
+            if (!this.expandedPanels.includes('dialogs')) {
+                this.expandedPanels.push('dialogs');
+            }
+        },
+
+        removeDialog(index) {
+            // 如果是偶数索引（用户消息），删除用户消息和对应的助手消息
+            if (index % 2 === 0 && index + 1 < this.personaForm.begin_dialogs.length) {
+                this.personaForm.begin_dialogs.splice(index, 2);
+            }
+            // 如果是奇数索引（助手消息），删除助手消息和对应的用户消息
+            else if (index % 2 === 1 && index - 1 >= 0) {
+                this.personaForm.begin_dialogs.splice(index - 1, 2);
+            }
+        },
+
+        truncateText(text, maxLength) {
+            if (!text) return '';
+            return text.length > maxLength ? text.substring(0, maxLength) + '...' : text;
+        },
+
+        formatDate(dateString) {
+            if (!dateString) return '';
+            return new Date(dateString).toLocaleString();
+        },
+
+        showSuccess(message) {
+            this.message = message;
+            this.messageType = 'success';
+            this.showMessage = true;
+        },
+
+        showError(message) {
+            this.message = message;
+            this.messageType = 'error';
+            this.showMessage = true;
+        },
+
+        getDialogRules(index) {
+            const dialogType = index % 2 === 0 ? this.tm('form.userMessage') : this.tm('form.assistantMessage');
+            return [
+                v => !!v || this.tm('validation.dialogRequired', { type: dialogType }),
+                v => (v && v.trim().length > 0) || this.tm('validation.dialogRequired', { type: dialogType })
+            ];
+        }
+    }
+}
+</script>
+
+<style scoped>
+.persona-page {
+    padding: 20px;
+    padding-top: 8px;
+}
+
+.persona-card {
+    transition: all 0.3s ease;
+    height: 100%;
+    cursor: pointer;
+}
+
+.persona-card:hover {
+    box-shadow: 0 8px 25px 0 rgba(0, 0, 0, 0.15);
+}
+
+.system-prompt-preview {
+    font-size: 14px;
+    line-height: 1.4;
+    color: rgba(var(--v-theme-on-surface), 0.7);
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    line-clamp: 3;
+    -webkit-box-orient: vertical;
+}
+
+.system-prompt-content {
+    background-color: rgba(var(--v-theme-surface-variant), 0.3);
+    padding: 12px;
+    border-radius: 8px;
+    font-family: 'Roboto Mono', monospace;
+    font-size: 14px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.dialog-content {
+    background-color: rgba(var(--v-theme-surface-variant), 0.3);
+    padding: 8px 12px;
+    border-radius: 8px;
+    font-size: 14px;
+    line-height: 1.4;
+    margin-bottom: 8px;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+</style>


### PR DESCRIPTION
### Motivation

动态修改人格，而不需要重启。

并且将人格管理从 Provider 中独立出来。

Note: 

1. 配置文件中的 persona 会被迁移到数据库的 personas 表中，配置文件中的 persona 数据不会被删除，但也不会被同步，鉴于一些插件直接引用了配置文件中的 persona 数据，因此不直接删除（但已过时，建议使用 `self.context.persona_mgr`）。
2. 前端设计只是暂时的。会将 Persona、Tool-Use 与 MCP Server 结合起来，形成自主定义的 Agent。

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码
