### PR TITLE
Feature: Add support to sync MCP servers from ModelScope

### DIFF
--- a/dashboard/src/i18n/locales/en-US/features/tool-use.json
+++ b/dashboard/src/i18n/locales/en-US/features/tool-use.json
@@ -17,7 +17,8 @@
       "add": "Add Server",
       "useTemplateStdio": "Stdio Template",
       "useTemplateStreamableHttp": "Streamable HTTP Template",
-      "useTemplateSse": "SSE Template"
+      "useTemplateSse": "SSE Template",
+      "sync": "Sync MCP Servers"
     },
     "empty": "No MCP servers available, click Add Server to add one",
     "status": {
@@ -77,7 +78,8 @@
       "buttons": {
         "cancel": "Cancel",
         "save": "Save",
-        "testConnection": "Test Connection"
+        "testConnection": "Test Connection",
+        "sync": "Sync"
       }
     },
     "serverDetail": {

--- a/dashboard/src/i18n/locales/zh-CN/features/tool-use.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/tool-use.json
@@ -17,7 +17,8 @@
       "add": "新增服务器",
       "useTemplateStdio": "Stdio 模板",
       "useTemplateStreamableHttp": "Streamable HTTP 模板",
-      "useTemplateSse": "SSE 模板"
+      "useTemplateSse": "SSE 模板",
+      "sync": "同步服务器"
     },
     "empty": "暂无 MCP 服务器，点击 新增服务器 添加",
     "status": {
@@ -77,7 +78,8 @@
       "buttons": {
         "cancel": "取消",
         "save": "保存",
-        "testConnection": "测试连接"
+        "testConnection": "测试连接",
+        "sync": "同步"
       }
     },
     "serverDetail": {
@@ -89,7 +91,43 @@
         "importConfig": "导入配置"
       }
     },
-    "confirmDelete": "确定要删除服务器 {name} 吗?"
+    "confirmDelete": "确定要删除服务器 {name} 吗?",
+    "syncProvider": {
+      "title": "同步 MCP 服务器",
+      "subtitle": "从提供商同步 MCP 服务器配置到本地",
+      "steps": {
+        "selectProvider": "步骤 1: 选择提供商",
+        "configureAuth": "步骤 2: 配置认证",
+        "syncServers": "步骤 3: 同步服务器"
+      },
+      "providers": {
+        "modelscope": "ModelScope",
+        "description": "ModelScope 是一个开源的模型社区，提供各种机器学习和AI服务的MCP服务器"
+      },
+      "fields": {
+        "provider": "选择提供商",
+        "accessToken": "访问令牌",
+        "tokenRequired": "访问令牌是必填项",
+        "tokenHint": "请输入您的 ModelScope 访问令牌"
+      },
+      "buttons": {
+        "cancel": "取消",
+        "previous": "上一步",
+        "next": "下一步",
+        "sync": "开始同步",
+        "getToken": "获取令牌"
+      },
+      "status": {
+        "selectProvider": "请选择一个 MCP 服务器提供商",
+        "enterToken": "请输入访问令牌以继续",
+        "readyToSync": "准备同步服务器配置"
+      },
+      "messages": {
+        "syncSuccess": "MCP 服务器同步成功!",
+        "syncError": "同步失败: {error}",
+        "tokenHelp": "如何获取 ModelScope 访问令牌？点击右侧按钮查看说明"
+      }
+    }
   },
   "messages": {
     "getServersError": "获取 MCP 服务器列表失败: {error}",


### PR DESCRIPTION
### Motivation

更加方便、低成本、快捷地创建和使用 MCP 服务器

### Check

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 摘要

启用从外部平台同步 MCP 服务器的功能，首先从 ModelScope 开始。

新功能：
- 在仪表板中添加同步按钮和对话框，用于选择提供商并输入访问令牌
- 暴露新的 POST API /tools/mcp/sync-provider 以触发服务器同步

改进：
- 将 MCP 服务器配置的加载/保存逻辑集中到工具管理器中
- 实现 sync_modelscope_mcp_servers 以从 ModelScope 获取、合并并启用服务器
- 重构现有 MCP 服务器路由，以使用集中化的配置管理方法

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable synchronization of MCP servers from external platforms, starting with ModelScope.

New Features:
- Add Sync button and dialog in the dashboard for selecting provider and entering access token
- Expose new POST API /tools/mcp/sync-provider to trigger server synchronization

Enhancements:
- Centralize MCP server config load/save logic in the Tool Manager
- Implement sync_modelscope_mcp_servers to fetch, merge, and enable servers from ModelScope
- Refactor existing MCP server routes to use the centralized config management methods

</details>