### PR TITLE
fix: 忽略 Gemini “返回内容为空”的错误消息，将 OpenAI 和 Gemini 的此类消息以 info 级别输出在控制台上。

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -214,6 +214,9 @@ class ProviderOpenAIOfficial(Provider):
             logger.error(f"API 返回的 completion 无法解析：{completion}。")
             raise Exception(f"API 返回的 completion 无法解析：{completion}。")
 
+        if llm_response.completion_text == "":
+            logger.info("API 可能返回了空消息。")
+
         llm_response.raw_completion = completion
 
         return llm_response


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
此 PR 与 #2279 同类

### Motivation

#2279 仅解决了 OpenAI 提供商的此类问题，此 PR 解决 Gemini 的空消息返回问题。
未对其他供应商做出相应更改是因为尚未测试其他供应商的模型。

### Modifications

- `raise Exception("API 返回的内容为空。")`改为`logger.info("API 可能返回了空消息。")`，避免输出到消息平台；
- 遍历`result_parts`前添加`if result_parts:`条件，避免遍历 None 导致报错；
- `openai_source.py`添加了`logger.info`作为控制台提示。

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码
