### PR TITLE
Refactor: 重构配置文件管理，以支持更灵活的、会话粒度的（基于 umo part）配置文件隔离

### DIFF
--- a/astrbot/core/astrbot_config_mgr.py
+++ b/astrbot/core/astrbot_config_mgr.py
@@ -3,6 +3,7 @@ import uuid
 from astrbot.core import AstrBotConfig, logger
 from astrbot.core.utils.shared_preferences import SharedPreferences
 from astrbot.core.config.astrbot_config import ASTRBOT_CONFIG_PATH
+from astrbot.core.config.default import DEFAULT_CONFIG
 from astrbot.core.platform.message_session import MessageSession
 from astrbot.core.utils.astrbot_path import get_astrbot_config_path
 from typing import TypeVar, TypedDict
@@ -52,7 +53,7 @@ class AstrBotConfigManager:
                 )
                 continue
 
-    def _is_umo_match(p1: str, p2: str) -> bool:
+    def _is_umo_match(self, p1: str, p2: str) -> bool:
         """判断 p2 umo 是否逻辑包含于 p1 umo"""
         p1 = p1.split(":")
         p2 = p2.split(":")
@@ -69,7 +70,7 @@ class AstrBotConfigManager:
             ConfInfo: 包含配置文件的 uuid, 路径和名称等信息, 是一个 dict 类型
         """
         # uuid -> { "umop": list, "path": str, "name": str }
-        abconf_data = self.sp.get("abconf_mapping", {})
+        abconf_data = self.sp.get("abconf_mapping", {})  # default is not included here
         if isinstance(umo, MessageSession):
             umo = str(umo)
         else:
@@ -142,21 +143,104 @@ class AstrBotConfigManager:
     def create_conf(
         self,
         umo_parts: list[str] | list[MessageSession],
-        config: dict,
+        config: dict = DEFAULT_CONFIG,
         name: str = None,
-    ) -> AstrBotConfig:
+    ) -> str:
         """
         umo 由三个部分组成 [platform_id]:[message_type]:[session_id]。
 
         umo_parts 可以是 "::" (代表所有), 可以是 "[platform_id]::" (代表指定平台下的所有类型消息和会话)。
         """
         conf_uuid = str(uuid.uuid4())
-        conf_file_name = f"{conf_uuid}.json"
-        conf = AstrBotConfig(config_path=conf_file_name, default_config=config)
+        conf_file_name = f"abconf_{conf_uuid}.json"
+        conf_path = os.path.join(get_astrbot_config_path(), conf_file_name)
+        conf = AstrBotConfig(config_path=conf_path, default_config=config)
         conf.save_config()
         self._save_conf_mapping(conf_file_name, conf_uuid, umo_parts, abconf_name=name)
         self.confs[conf_uuid] = conf
-        return conf
+        return conf_uuid
+
+    def delete_conf(self, conf_id: str) -> bool:
+        """删除指定配置文件
+
+        Args:
+            conf_id: 配置文件的 UUID
+
+        Returns:
+            bool: 删除是否成功
+
+        Raises:
+            ValueError: 如果试图删除默认配置文件
+        """
+        if conf_id == "default":
+            raise ValueError("不能删除默认配置文件")
+
+        # 从映射中移除
+        abconf_data = self.sp.get("abconf_mapping", {})
+        if conf_id not in abconf_data:
+            logger.warning(f"配置文件 {conf_id} 不存在于映射中")
+            return False
+
+        # 获取配置文件路径
+        conf_path = os.path.join(get_astrbot_config_path(), abconf_data[conf_id]["path"])
+
+        # 删除配置文件
+        try:
+            if os.path.exists(conf_path):
+                os.remove(conf_path)
+                logger.info(f"已删除配置文件: {conf_path}")
+        except Exception as e:
+            logger.error(f"删除配置文件 {conf_path} 失败: {e}")
+            return False
+
+        # 从内存中移除
+        if conf_id in self.confs:
+            del self.confs[conf_id]
+
+        # 从映射中移除
+        del abconf_data[conf_id]
+        self.sp.put("abconf_mapping", abconf_data)
+
+        logger.info(f"成功删除配置文件 {conf_id}")
+        return True
+
+    def update_conf_info(self, conf_id: str, name: str = None, umo_parts: list[str] = None) -> bool:
+        """更新配置文件信息
+
+        Args:
+            conf_id: 配置文件的 UUID
+            name: 新的配置文件名称 (可选)
+            umo_parts: 新的 UMO 部分列表 (可选)
+
+        Returns:
+            bool: 更新是否成功
+        """
+        if conf_id == "default":
+            raise ValueError("不能更新默认配置文件的信息")
+
+        abconf_data = self.sp.get("abconf_mapping", {})
+        if conf_id not in abconf_data:
+            logger.warning(f"配置文件 {conf_id} 不存在于映射中")
+            return False
+
+        # 更新名称
+        if name is not None:
+            abconf_data[conf_id]["name"] = name
+
+        # 更新 UMO 部分
+        if umo_parts is not None:
+            # 验证 UMO 部分格式
+            for part in umo_parts:
+                if isinstance(part, MessageSession):
+                    part = str(part)
+                elif not isinstance(part, str):
+                    raise ValueError("umo_parts must be a list of strings or MessageSession instances")
+            abconf_data[conf_id]["umop"] = umo_parts
+
+        # 保存更新
+        self.sp.put("abconf_mapping", abconf_data)
+        logger.info(f"成功更新配置文件 {conf_id} 的信息")
+        return True
 
     def g(self, umo: str = None, key: str = None, default: _VT = None) -> _VT:
         """获取配置项。umo 为 None 时使用默认配置"""

--- a/astrbot/core/astrbot_config_mgr.py
+++ b/astrbot/core/astrbot_config_mgr.py
@@ -1,0 +1,166 @@
+import os
+import uuid
+from astrbot.core import AstrBotConfig, logger
+from astrbot.core.utils.shared_preferences import SharedPreferences
+from astrbot.core.config.astrbot_config import ASTRBOT_CONFIG_PATH
+from astrbot.core.platform.message_session import MessageSession
+from astrbot.core.utils.astrbot_path import get_astrbot_config_path
+from typing import TypeVar, TypedDict
+
+_VT = TypeVar("_VT")
+
+
+class ConfInfo(TypedDict):
+    """Configuration information for a specific session or platform."""
+
+    id: str  # UUID of the configuration or "default"
+    umop: list[str]  # Unified Message Origin Pattern
+    name: str
+    path: str  # File name to the configuration file
+
+
+DEFAULT_CONFIG_CONF_INFO = ConfInfo(
+    id="default",
+    umop=["::"],
+    name="default",
+    path=ASTRBOT_CONFIG_PATH,
+)
+
+
+class AstrBotConfigManager:
+    """A class to manage the system configuration of AstrBot, aka ACM"""
+
+    def __init__(self, default_config: AstrBotConfig, sp: SharedPreferences):
+        self.sp = sp
+        self.confs: dict[str, AstrBotConfig] = {}
+        """uuid / "default" -> AstrBotConfig"""
+        self.confs["default"] = default_config
+        self._load_all_configs()
+
+    def _load_all_configs(self):
+        """Load all configurations from the shared preferences."""
+        abconf_data = self.sp.get("abconf_mapping", {})
+        for uuid_, meta in abconf_data.items():
+            filename = meta["path"]
+            conf_path = os.path.join(get_astrbot_config_path(), filename)
+            if os.path.exists(conf_path):
+                conf = AstrBotConfig(config_path=conf_path)
+                self.confs[uuid_] = conf
+            else:
+                logger.warning(
+                    f"Config file {conf_path} for UUID {uuid_} does not exist, skipping."
+                )
+                continue
+
+    def _is_umo_match(p1: str, p2: str) -> bool:
+        """判断 p2 umo 是否逻辑包含于 p1 umo"""
+        p1 = p1.split(":")
+        p2 = p2.split(":")
+
+        if len(p1) != 3 or len(p2) != 3:
+            return False  # 非法格式
+
+        return all(p == "" or p == t for p, t in zip(p1, p2))
+
+    def _load_conf_mapping(self, umo: str | MessageSession) -> ConfInfo:
+        """获取指定 umo 的配置文件 uuid, 如果不存在则返回默认配置(返回 "default")
+
+        Returns:
+            ConfInfo: 包含配置文件的 uuid, 路径和名称等信息, 是一个 dict 类型
+        """
+        # uuid -> { "umop": list, "path": str, "name": str }
+        abconf_data = self.sp.get("abconf_mapping", {})
+        if isinstance(umo, MessageSession):
+            umo = str(umo)
+        else:
+            umo = str(MessageSession.from_str(umo))  # validate
+
+        for uuid_, meta in abconf_data.items():
+            for pattern in meta["umop"]:
+                if self._is_umo_match(pattern, umo):
+                    return ConfInfo(**meta, id=uuid_)
+
+        return DEFAULT_CONFIG_CONF_INFO
+
+    def _save_conf_mapping(
+        self,
+        abconf_path: str,
+        abconf_id: str,
+        umo_parts: list[str] | list[MessageSession],
+        abconf_name: str = None,
+    ) -> None:
+        """保存配置文件的映射关系"""
+        for part in umo_parts:
+            if isinstance(part, MessageSession):
+                part = str(part)
+            elif not isinstance(part, str):
+                raise ValueError(
+                    "umo_parts must be a list of strings or MessageSession instances"
+                )
+        abconf_data = self.sp.get("abconf_mapping", {})
+        random_word = abconf_name or uuid.uuid4().hex[:8]
+        abconf_data[abconf_id] = {
+            "umop": umo_parts,
+            "path": abconf_path,
+            "name": random_word,
+        }
+        self.sp.put("abconf_mapping", abconf_data)
+
+    def get_conf(self, umo: str | MessageSession) -> AstrBotConfig:
+        """获取指定 umo 的配置文件。如果不存在，则 fallback 到默认配置文件。"""
+        if isinstance(umo, MessageSession):
+            umo = f"{umo.platform_id}:{umo.message_type}:{umo.session_id}"
+
+        uuid_ = self._load_conf_mapping(umo)["id"]
+
+        conf = self.confs.get(uuid_)
+        if not conf:
+            conf = self.confs["default"]  # default MUST exists
+
+        return conf
+
+    @property
+    def default_conf(self) -> AstrBotConfig:
+        """获取默认配置文件"""
+        return self.confs["default"]
+
+    def get_conf_info(self, umo: str | MessageSession) -> ConfInfo:
+        """获取指定 umo 的配置文件元数据"""
+        if isinstance(umo, MessageSession):
+            umo = f"{umo.platform_id}:{umo.message_type}:{umo.session_id}"
+
+        return self._load_conf_mapping(umo)
+
+    def get_conf_list(self) -> list[ConfInfo]:
+        """获取所有配置文件的元数据列表"""
+        conf_list = []
+        conf_list.append(DEFAULT_CONFIG_CONF_INFO)
+        for uuid_, meta in self.sp.get("abconf_mapping", {}).items():
+            conf_list.append(ConfInfo(**meta, id=uuid_))
+        return conf_list
+
+    def create_conf(
+        self,
+        umo_parts: list[str] | list[MessageSession],
+        config: dict,
+        name: str = None,
+    ) -> AstrBotConfig:
+        """
+        umo 由三个部分组成 [platform_id]:[message_type]:[session_id]。
+
+        umo_parts 可以是 "::" (代表所有), 可以是 "[platform_id]::" (代表指定平台下的所有类型消息和会话)。
+        """
+        conf_uuid = str(uuid.uuid4())
+        conf_file_name = f"{conf_uuid}.json"
+        conf = AstrBotConfig(config_path=conf_file_name, default_config=config)
+        conf.save_config()
+        self._save_conf_mapping(conf_file_name, conf_uuid, umo_parts, abconf_name=name)
+        self.confs[conf_uuid] = conf
+        return conf
+
+    def g(self, umo: str = None, key: str = None, default: _VT = None) -> _VT:
+        """获取配置项。umo 为 None 时使用默认配置"""
+        if umo is None:
+            return self.confs["default"].get(key, default)
+        conf = self.get_conf(umo)
+        return conf.get(key, default)

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -51,20 +51,25 @@ DEFAULT_CONFIG = {
     "provider_settings": {
         "enable": True,
         "default_provider_id": "",
+        "default_image_caption_provider_id": "",
+        "image_caption_prompt": "Please describe the image using Chinese.",
+        "provider_pool": ["all"],  # "all" 表示使用所有可用的提供者
         "wake_prefix": "",
         "web_search": False,
+        "websearch_provider": "default",
+        "websearch_tavily_key": "",
         "web_search_link": False,
         "display_reasoning_text": False,
         "identifier": False,
         "datetime_system_prompt": True,
         "default_personality": "default",
+        "persona_pool": ["all"],
         "prompt_prefix": "",
         "max_context_length": -1,
         "dequeue_context_length": 1,
         "streaming_response": False,
         "show_tool_use_status": False,
         "streaming_segmented": False,
-        "separate_provider": True,
     },
     "provider_stt_settings": {
         "enable": False,
@@ -80,13 +85,10 @@ DEFAULT_CONFIG = {
         "group_icl_enable": False,
         "group_message_max_cnt": 300,
         "image_caption": False,
-        "image_caption_provider_id": "",
-        "image_caption_prompt": "Please describe the image using Chinese.",
         "active_reply": {
             "enable": False,
             "method": "possibility_reply",
             "possibility_reply": 0.1,
-            "prompt": "",
             "whitelist": [],
         },
     },
@@ -115,8 +117,8 @@ DEFAULT_CONFIG = {
     "log_level": "INFO",
     "pip_install_arg": "",
     "pypi_index_url": "https://mirrors.aliyun.com/pypi/simple/",
-    "persona": [], # deprecated
-    "timezone": "",
+    "persona": [],  # deprecated
+    "timezone": "Asia/Shanghai",
     "callback_api_base": "",
 }
 
@@ -124,7 +126,6 @@ DEFAULT_CONFIG = {
 # 配置项的中文描述、值类型
 CONFIG_METADATA_2 = {
     "platform_group": {
-        "name": "消息平台",
         "metadata": {
             "platform": {
                 "description": "消息平台适配器",
@@ -382,152 +383,120 @@ CONFIG_METADATA_2 = {
                 },
             },
             "platform_settings": {
-                "description": "平台设置",
                 "type": "object",
                 "items": {
                     "plugin_enable": {
                         "invisible": True,  # 隐藏插件启用配置
                     },
                     "unique_session": {
-                        "description": "会话隔离",
                         "type": "bool",
-                        "hint": "启用后，在群组或者频道中，每个人的消息上下文都是独立的。",
                     },
                     "rate_limit": {
-                        "description": "速率限制",
-                        "hint": "每个会话在 `time` 秒内最多只能发送 `count` 条消息。",
                         "type": "object",
                         "items": {
-                            "time": {"description": "消息速率限制时间", "type": "int"},
-                            "count": {"description": "消息速率限制计数", "type": "int"},
+                            "time": {"type": "int"},
+                            "count": {"type": "int"},
                             "strategy": {
-                                "description": "速率限制策略",
                                 "type": "string",
                                 "options": ["stall", "discard"],
-                                "hint": "当消息速率超过限制时的处理策略。stall 为等待，discard 为丢弃。",
                             },
                         },
                     },
                     "no_permission_reply": {
-                        "description": "无权限回复",
                         "type": "bool",
                         "hint": "启用后，当用户没有权限执行某个操作时，机器人会回复一条消息。",
                     },
                     "empty_mention_waiting": {
-                        "description": "只 @ 机器人是否触发等待",
                         "type": "bool",
                         "hint": "启用后，当消息内容只有 @ 机器人时，会触发等待，在 60 秒内的该用户的任意一条消息均会唤醒机器人。这在某些平台不支持 @ 和语音/图片等消息同时发送时特别有用。",
                     },
                     "empty_mention_waiting_need_reply": {
-                        "description": "只 @ 机器人触发等待时是否需要回复提醒",
                         "type": "bool",
                         "hint": "在上面一个配置项中，如果启用了触发等待，启用此项后，机器人会使用 LLM 生成一条回复。否则，将不回复而只是等待。",
                     },
                     "friend_message_needs_wake_prefix": {
-                        "description": "私聊消息是否需要唤醒前缀",
                         "type": "bool",
                         "hint": "启用后，私聊消息需要唤醒前缀才会被处理，同群聊一样。",
                     },
                     "ignore_bot_self_message": {
-                        "description": "是否忽略机器人自身的消息",
                         "type": "bool",
                         "hint": "某些平台会将自身账号在其他 APP 端发送的消息也当做消息事件下发导致给自己发消息时唤醒机器人",
                     },
                     "ignore_at_all": {
-                        "description": "是否忽略 @ 全体成员",
                         "type": "bool",
                         "hint": "启用后，机器人会忽略 @ 全体成员 的消息事件。",
                     },
                     "segmented_reply": {
-                        "description": "分段回复",
                         "type": "object",
                         "items": {
                             "enable": {
-                                "description": "启用分段回复",
                                 "type": "bool",
                             },
                             "only_llm_result": {
-                                "description": "仅对 LLM 结果分段",
                                 "type": "bool",
                             },
                             "interval_method": {
-                                "description": "间隔时间计算方法",
                                 "type": "string",
                                 "options": ["random", "log"],
                                 "hint": "分段回复的间隔时间计算方法。random 为随机时间，log 为根据消息长度计算，$y=log_<log_base>(x)$，x为字数，y的单位为秒。",
                             },
                             "interval": {
-                                "description": "随机间隔时间(秒)",
                                 "type": "string",
                                 "hint": "`random` 方法用。每一段回复的间隔时间，格式为 `最小时间,最大时间`。如 `0.75,2.5`",
                             },
                             "log_base": {
-                                "description": "对数函数底数",
                                 "type": "float",
                                 "hint": "`log` 方法用。对数函数的底数。默认为 2.6",
                             },
                             "words_count_threshold": {
-                                "description": "字数阈值",
                                 "type": "int",
                                 "hint": "超过这个字数的消息不会被分段回复。默认为 150",
                             },
                             "regex": {
-                                "description": "正则表达式",
                                 "type": "string",
                                 "hint": "用于分隔一段消息。默认情况下会根据句号、问号等标点符号分隔。re.findall(r'<regex>', text)",
                             },
                             "content_cleanup_rule": {
-                                "description": "过滤分段后的内容",
                                 "type": "string",
                                 "hint": "移除分段后的内容中的指定的内容。支持正则表达式。如填写 `[。？！]` 将移除所有的句号、问号、感叹号。re.sub(r'<regex>', '', text)",
                             },
                         },
                     },
                     "reply_prefix": {
-                        "description": "回复前缀",
                         "type": "string",
                         "hint": "机器人回复消息时带有的前缀。",
                     },
                     "forward_threshold": {
-                        "description": "转发消息的字数阈值",
                         "type": "int",
                         "hint": "超过一定字数后，机器人会将消息折叠成 QQ 群聊的 “转发消息”，以防止刷屏。目前仅 QQ 平台适配器适用。",
                     },
                     "enable_id_white_list": {
-                        "description": "启用 ID 白名单",
                         "type": "bool",
                     },
                     "id_whitelist": {
-                        "description": "ID 白名单",
                         "type": "list",
                         "items": {"type": "string"},
                         "hint": "只处理填写的 ID 发来的消息事件，为空时不启用。可使用 /sid 指令获取在平台上的会话 ID(类似 abc:GroupMessage:123)。管理员可使用 /wl 添加白名单",
                     },
                     "id_whitelist_log": {
-                        "description": "打印白名单日志",
                         "type": "bool",
                         "hint": "启用后，当一条消息没通过白名单时，会输出 INFO 级别的日志。",
                     },
                     "wl_ignore_admin_on_group": {
-                        "description": "管理员群组消息无视 ID 白名单",
                         "type": "bool",
                     },
                     "wl_ignore_admin_on_friend": {
-                        "description": "管理员私聊消息无视 ID 白名单",
                         "type": "bool",
                     },
                     "reply_with_mention": {
-                        "description": "回复时 @ 发送者",
                         "type": "bool",
                         "hint": "启用后，机器人回复消息时会 @ 发送者。实际效果以具体的平台适配器为准。",
                     },
                     "reply_with_quote": {
-                        "description": "回复时引用消息",
                         "type": "bool",
                         "hint": "启用后，机器人回复消息时会引用原消息。实际效果以具体的平台适配器为准。",
                     },
                     "path_mapping": {
-                        "description": "路径映射",
                         "type": "list",
                         "items": {"type": "string"},
                         "hint": "此功能解决由于文件系统不一致导致路径不存在的问题。格式为 <原路径>:<映射路径>。如 `/app/.config/QQ:/var/lib/docker/volumes/xxxx/_data`。这样，当消息平台下发的事件中图片和语音路径以 `/app/.config/QQ` 开头时，开头被替换为 `/var/lib/docker/volumes/xxxx/_data`。这在 AstrBot 或者平台协议端使用 Docker 部署时特别有用。",
@@ -535,41 +504,33 @@ CONFIG_METADATA_2 = {
                 },
             },
             "content_safety": {
-                "description": "内容安全",
                 "type": "object",
                 "items": {
                     "also_use_in_response": {
-                        "description": "对大模型响应安全审核",
                         "type": "bool",
                         "hint": "启用后，大模型的响应也会通过内容安全审核。",
                     },
                     "baidu_aip": {
-                        "description": "百度内容审核配置",
                         "type": "object",
                         "items": {
                             "enable": {
-                                "description": "启用百度内容审核",
                                 "type": "bool",
                                 "hint": "启用此功能前，您需要手动在设备中安装 baidu-aip 库。一般来说，安装指令如下: `pip3 install baidu-aip`",
                             },
                             "app_id": {"description": "APP ID", "type": "string"},
                             "api_key": {"description": "API Key", "type": "string"},
                             "secret_key": {
-                                "description": "Secret Key",
                                 "type": "string",
                             },
                         },
                     },
                     "internal_keywords": {
-                        "description": "内部关键词过滤",
                         "type": "object",
                         "items": {
                             "enable": {
-                                "description": "启用内部关键词过滤",
                                 "type": "bool",
                             },
                             "extra_keywords": {
-                                "description": "额外关键词",
                                 "type": "list",
                                 "items": {"type": "string"},
                                 "hint": "额外的屏蔽关键词列表，支持正则表达式。",
@@ -584,7 +545,6 @@ CONFIG_METADATA_2 = {
         "name": "服务提供商",
         "metadata": {
             "provider": {
-                "description": "服务提供商配置",
                 "type": "list",
                 "config_template": {
                     "OpenAI": {
@@ -1615,191 +1575,114 @@ CONFIG_METADATA_2 = {
                 },
             },
             "provider_settings": {
-                "description": "大语言模型设置",
                 "type": "object",
                 "items": {
                     "enable": {
-                        "description": "启用大语言模型聊天",
                         "type": "bool",
-                        "hint": "如需切换大语言模型提供商，请使用 /provider 命令。",
-                    },
-                    "separate_provider": {
-                        "description": "提供商会话隔离",
-                        "type": "bool",
-                        "hint": "启用后，每个会话支持独立选择文本生成、STT、TTS 等提供商。如果会话在使用 /provider 指令时提示无权限，可以将会话加入管理员名单或者使用 /alter_cmd provider member 将指令设为非管理员指令。",
                     },
                     "default_provider_id": {
-                        "description": "默认模型提供商 ID",
                         "type": "string",
-                        "hint": "可选。每个聊天会话的默认提供商 ID。",
                     },
                     "wake_prefix": {
-                        "description": "LLM 聊天额外唤醒前缀",
                         "type": "string",
-                        "hint": "使用 LLM 聊天额外的触发条件。如填写 `chat`，则需要消息前缀加上 `/chat` 才能触发 LLM 聊天，是一个防止滥用的手段。",
                     },
                     "web_search": {
-                        "description": "启用网页搜索",
                         "type": "bool",
-                        "hint": "能访问 Google 时效果最佳（国内需要在 `其他配置` 开启 HTTP 代理）。如果 Google 访问失败，程序会依次访问 Bing, Sogo 搜索引擎。",
                     },
                     "web_search_link": {
-                        "description": "网页搜索引用链接",
                         "type": "bool",
-                        "hint": "开启后，将会传入网页搜索结果的链接给模型，并引导模型输出引用链接。",
                     },
                     "display_reasoning_text": {
-                        "description": "显示思考内容",
                         "type": "bool",
-                        "hint": "开启后，将在回复中显示模型的思考过程。",
                     },
                     "identifier": {
-                        "description": "启动识别群员",
                         "type": "bool",
-                        "hint": "在 Prompt 前加上群成员的名字以让模型更好地了解群聊状态。启用将略微增加 token 开销。",
                     },
                     "datetime_system_prompt": {
-                        "description": "启用日期时间系统提示",
                         "type": "bool",
-                        "hint": "启用后，会在系统提示词中加上当前机器的日期时间。",
                     },
                     "default_personality": {
-                        "description": "默认采用的人格情景的名称",
                         "type": "string",
-                        "hint": "",
                     },
                     "prompt_prefix": {
-                        "description": "Prompt 前缀文本",
                         "type": "string",
-                        "hint": "添加之后，会在每次对话的 Prompt 前加上此文本。",
                     },
                     "max_context_length": {
-                        "description": "最多携带对话数量(条)",
                         "type": "int",
-                        "hint": "超出这个数量时将丢弃最旧的部分，用户和AI的一轮聊天记为 1 条。-1 表示不限制，默认为不限制。",
                     },
                     "dequeue_context_length": {
-                        "description": "丢弃对话数量(条)",
                         "type": "int",
-                        "hint": "超出 最多携带对话数量(条) 时，丢弃多少条记录，用户和AI的一轮聊天记为 1 条。适宜的配置，可以提高超长上下文对话 deepseek 命中缓存效果，理想情况下计费将降低到1/3以下",
                     },
                     "streaming_response": {
-                        "description": "启用流式回复",
                         "type": "bool",
-                        "hint": "启用后，将会流式输出 LLM 的响应。目前仅支持 OpenAI API提供商 以及 Telegram、QQ Official 私聊 两个平台",
                     },
                     "show_tool_use_status": {
-                        "description": "函数调用状态输出",
                         "type": "bool",
-                        "hint": "在触发函数调用时输出其函数名和内容。",
                     },
                     "streaming_segmented": {
-                        "description": "不支持流式回复的平台分段输出",
                         "type": "bool",
-                        "hint": "启用后，若平台不支持流式回复，会分段输出。目前仅支持 aiocqhttp 两个平台，不支持或无需使用流式分段输出的平台会静默忽略此选项",
                     },
                 },
             },
             "provider_stt_settings": {
-                "description": "语音转文本(STT)",
                 "type": "object",
                 "items": {
                     "enable": {
-                        "description": "启用语音转文本(STT)",
                         "type": "bool",
-                        "hint": "启用前请在 服务提供商配置 处创建支持 语音转文本任务 的提供商。如 whisper。",
                     },
                     "provider_id": {
-                        "description": "提供商 ID",
                         "type": "string",
-                        "hint": "语音转文本提供商 ID。如果不填写将使用载入的第一个提供商。",
                     },
                 },
             },
             "provider_tts_settings": {
-                "description": "文本转语音(TTS)",
                 "type": "object",
                 "items": {
                     "enable": {
-                        "description": "启用文本转语音(TTS)",
                         "type": "bool",
-                        "hint": "启用前请在 服务提供商配置 处创建支持 语音转文本任务 的提供商。如 openai_tts。",
                     },
                     "provider_id": {
-                        "description": "提供商 ID",
                         "type": "string",
-                        "hint": "文本转语音提供商 ID。如果不填写将使用载入的第一个提供商。",
                     },
                     "dual_output": {
-                        "description": "启用语音和文字双输出",
                         "type": "bool",
-                        "hint": "启用后，Bot 将同时输出语音和文字消息。",
                     },
                     "use_file_service": {
-                        "description": "使用文件服务提供 TTS 语音文件",
                         "type": "bool",
-                        "hint": "启用后，如已配置 callback_api_base ，将会使用文件服务提供TTS语音文件",
                     },
                 },
             },
             "provider_ltm_settings": {
-                "description": "聊天记忆增强(Beta)",
                 "type": "object",
                 "items": {
                     "group_icl_enable": {
-                        "description": "群聊内记录各群员对话",
                         "type": "bool",
-                        "hint": "启用后，会记录群聊内各群员的对话。使用 /reset 命令清除记录。推荐使用 gpt-4o-mini 模型。",
                     },
                     "group_message_max_cnt": {
-                        "description": "群聊消息最大数量",
                         "type": "int",
-                        "hint": "群聊消息最大数量。超过此数量后，会自动清除旧消息。",
                     },
                     "image_caption": {
-                        "description": "群聊图像转述(需模型支持)",
                         "type": "bool",
-                        "hint": "用模型将群聊中的图片消息转述为文字，推荐 gpt-4o-mini 模型。和机器人的唤醒聊天中的图片消息仍然会直接作为上下文输入。",
-                    },
-                    "image_caption_provider_id": {
-                        "description": "图像转述提供商 ID",
-                        "type": "string",
-                        "hint": "可选。图像转述提供商 ID。如为空将选择聊天使用的提供商。",
                     },
                     "image_caption_prompt": {
-                        "description": "图像转述提示词",
                         "type": "string",
                     },
                     "active_reply": {
-                        "description": "主动回复",
                         "type": "object",
                         "items": {
                             "enable": {
-                                "description": "启用主动回复",
                                 "type": "bool",
-                                "hint": "启用后，会根据触发概率主动回复群聊内的对话。QQ官方API(qq_official)不可用",
                             },
                             "whitelist": {
-                                "description": "主动回复白名单",
                                 "type": "list",
                                 "items": {"type": "string"},
-                                "hint": "启用后，只有在白名单内的群聊会被主动回复。为空时不启用白名单过滤。需要通过 /sid 获取 SID 添加到这里。",
                             },
                             "method": {
-                                "description": "回复方法",
                                 "type": "string",
                                 "options": ["possibility_reply"],
-                                "hint": "回复方法。possibility_reply 为根据概率回复",
                             },
                             "possibility_reply": {
-                                "description": "回复概率",
                                 "type": "float",
-                                "hint": "回复概率。当回复方法为 possibility_reply 时有效。当概率 >= 1 时，每条消息都会回复。",
-                            },
-                            "prompt": {
-                                "description": "提示词",
-                                "type": "string",
-                                "hint": "提示词。当提示词为空时，如果触发回复，则向 LLM 请求的是触发的消息的内容；否则是提示词。此项可以和定时回复（暂未实现）配合使用。",
                             },
                         },
                     },
@@ -1808,80 +1691,527 @@ CONFIG_METADATA_2 = {
         },
     },
     "misc_config_group": {
-        "name": "其他配置",
         "metadata": {
             "wake_prefix": {
-                "description": "机器人唤醒前缀",
                 "type": "list",
                 "items": {"type": "string"},
-                "hint": "在不 @ 机器人的情况下，可以通过外加消息前缀来唤醒机器人。更改此配置将影响整个 Bot 的功能唤醒，包括所有指令。如果您不保留 `/`，则内置指令（help等）将需要通过您的唤醒前缀来触发。",
             },
             "t2i": {
-                "description": "文本转图像",
                 "type": "bool",
-                "hint": "启用后，超出一定长度的文本将会通过 AstrBot API 渲染成 Markdown 图片发送。可以缓解审核和消息过长刷屏的问题，并提高 Markdown 文本的可读性。",
             },
             "t2i_word_threshold": {
-                "description": "文本转图像字数阈值",
                 "type": "int",
-                "hint": "超出此字符长度的文本将会被转换成图片。字数不能低于 50。",
             },
             "admins_id": {
-                "description": "管理员 ID",
                 "type": "list",
                 "items": {"type": "string"},
-                "hint": "管理员 ID 列表，管理员可以使用一些特权命令，如 `update`, `plugin` 等。ID 可以通过 `/sid` 指令获得。回车添加，可添加多个。",
             },
             "http_proxy": {
-                "description": "HTTP 代理",
                 "type": "string",
-                "hint": "启用后，会以添加环境变量的方式设置代理。格式为 `http://ip:port`",
             },
             "timezone": {
-                "description": "时区",
                 "type": "string",
-                "hint": "时区设置。请填写 IANA 时区名称, 如 Asia/Shanghai, 为空时使用系统默认时区。所有时区请查看: https://data.iana.org/time-zones/tzdb-2021a/zone1970.tab",
             },
             "callback_api_base": {
-                "description": "对外可达的回调接口地址",
                 "type": "string",
-                "hint": "外部服务可能会通过 AstrBot 生成的回调链接（如文件下载链接）访问 AstrBot 后端。由于 AstrBot 无法自动判断部署环境中对外可达的主机地址（host），因此需要通过此配置项显式指定 “外部服务如何访问 AstrBot” 的地址。如 http://localhost:6185，https://example.com 等。",
             },
             "log_level": {
-                "description": "控制台日志级别",
                 "type": "string",
-                "hint": "控制台输出日志的级别。",
                 "options": ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
             },
             "t2i_strategy": {
-                "description": "文本转图像渲染源",
                 "type": "string",
-                "hint": "文本转图像策略。`remote` 为使用远程基于 HTML 的渲染服务，`local` 为使用 PIL 本地渲染。当使用 local 时，将 ttf 字体命名为 'font.ttf' 放在 data/ 目录下可自定义字体。",
                 "options": ["remote", "local"],
             },
             "t2i_endpoint": {
-                "description": "文本转图像服务接口",
                 "type": "string",
-                "hint": "当 t2i_strategy 为 remote 时生效。为空时使用 AstrBot API 服务",
             },
             "t2i_use_file_service": {
-                "description": "本地文本转图像使用文件服务提供文件",
                 "type": "bool",
-                "hint": "当 t2i_strategy 为 local 并且配置 callback_api_base 时生效。是否使用文件服务提供文件。",
             },
             "pip_install_arg": {
-                "description": "pip 安装参数",
                 "type": "string",
-                "hint": "安装插件依赖时，会使用 Python 的 pip 工具。这里可以填写额外的参数，如 `--break-system-package` 等。",
             },
             "pypi_index_url": {
-                "description": "PyPI 软件仓库地址",
                 "type": "string",
-                "hint": "安装 Python 依赖时请求的 PyPI 软件仓库地址。默认为 https://mirrors.aliyun.com/pypi/simple/",
             },
         },
     },
 }
+
+
+CONFIG_METADATA_3 = {
+    "ai_group": {
+        "name": "AI 配置",
+        "metadata": {
+            "ai": {
+                "description": "模型",
+                "type": "object",
+                "items": {
+                    "provider_settings.enable": {
+                        "description": "启用大语言模型聊天",
+                        "type": "bool",
+                    },
+                    "provider_settings.default_provider_id": {
+                        "description": "默认聊天模型",
+                        "type": "string",
+                        "_special": "select_provider",
+                        "hint": "留空时使用第一个模型。",
+                    },
+                    "provider_settings.default_image_caption_provider_id": {
+                        "description": "默认图片转述模型",
+                        "type": "string",
+                        "_special": "select_provider",
+                        "hint": "留空代表不使用。可用于不支持视觉模态的聊天模型。",
+                    },
+                    "provider_stt_settings.provider_id": {
+                        "description": "语音转文本模型",
+                        "type": "string",
+                        "hint": "留空代表不使用。",
+                        "_special": "select_provider_stt",
+                    },
+                    "provider_tts_settings.provider_id": {
+                        "description": "文本转语音模型",
+                        "type": "string",
+                        "hint": "留空代表不使用。",
+                        "_special": "select_provider_tts",
+                    },
+                    "provider_settings.image_caption_prompt": {
+                        "description": "图片转述提示词",
+                        "type": "text",
+                    },
+                },
+            },
+            "persona": {
+                "description": "人格",
+                "type": "object",
+                "items": {
+                    "provider_settings.default_personality": {
+                        "description": "默认采用的人格",
+                        "type": "string",
+                        "_special": "select_persona",
+                    },
+                },
+            },
+            "websearch": {
+                "description": "网页搜索",
+                "type": "object",
+                "items": {
+                    "provider_settings.web_search": {
+                        "description": "启用网页搜索",
+                        "type": "bool",
+                    },
+                    "provider_settings.websearch_provider": {
+                        "description": "网页搜索提供商",
+                        "type": "string",
+                        "options": ["default", "tavily"],
+                    },
+                    "provider_settings.websearch_tavily_key": {
+                        "description": "Tavily API Key",
+                        "type": "string",
+                        "condition": {
+                            "provider_settings.websearch_provider": "tavily",
+                        },
+                    },
+                    "provider_settings.web_search_link": {
+                        "description": "显示来源引用",
+                        "type": "bool",
+                    },
+                },
+            },
+            "others": {
+                "description": "其他配置",
+                "type": "object",
+                "items": {
+                    "provider_settings.display_reasoning_text": {
+                        "description": "显示思考内容",
+                        "type": "bool",
+                    },
+                    "provider_settings.identifier": {
+                        "description": "用户感知",
+                        "type": "bool",
+                    },
+                    "provider_settings.datetime_system_prompt": {
+                        "description": "现实世界时间感知",
+                        "type": "bool",
+                    },
+                    "provider_settings.show_tool_use_status": {
+                        "description": "输出函数调用状态",
+                        "type": "bool",
+                    },
+                    "provider_settings.streaming_response": {
+                        "description": "流式回复",
+                        "type": "bool",
+                    },
+                    "provider_settings.streaming_segmented": {
+                        "description": "不支持流式回复的平台采取分段输出",
+                        "type": "bool",
+                    },
+                    "provider_settings.max_context_length": {
+                        "description": "最多携带对话轮数",
+                        "type": "int",
+                        "hint": "超出这个数量时丢弃最旧的部分，一轮聊天记为 1 条。-1 为不限制。",
+                    },
+                    "provider_settings.dequeue_context_length": {
+                        "description": "丢弃对话轮数",
+                        "type": "int",
+                        "hint": "超出最多携带对话轮数时, 一次丢弃的聊天轮数。",
+                    },
+                    "provider_settings.wake_prefix": {
+                        "description": "LLM 聊天额外唤醒前缀 ",
+                        "type": "string",
+                    },
+                    "provider_settings.prompt_prefix": {
+                        "description": "额外前缀提示词",
+                        "type": "string",
+                    },
+                    "provider_settings.dual_output": {
+                        "description": "开启 TTS 时同时输出语音和文字内容",
+                        "type": "bool",
+                    },
+                },
+            },
+        },
+    },
+    "platform_group": {
+        "name": "平台配置",
+        "metadata": {
+            "general": {
+                "description": "基本",
+                "type": "object",
+                "items": {
+                    "admins_id": {
+                        "description": "管理员 ID",
+                        "type": "list",
+                        "items": {"type": "string"},
+                    },
+                    "platform_settings.unique_session": {
+                        "description": "隔离会话",
+                        "type": "bool",
+                        "hint": "启用后，群成员的上下文独立。",
+                    },
+                    "wake_prefix": {
+                        "description": "唤醒词",
+                        "type": "list",
+                        "items": {"type": "string"},
+                    },
+                    "platform_settings.friend_message_needs_wake_prefix": {
+                        "description": "私聊消息需要唤醒词",
+                        "type": "bool",
+                    },
+                    "platform_settings.reply_prefix": {
+                        "description": "回复时的文本前缀",
+                        "type": "string",
+                    },
+                    "platform_settings.reply_with_mention": {
+                        "description": "回复时 @ 发送人",
+                        "type": "bool",
+                    },
+                    "platform_settings.reply_with_quote": {
+                        "description": "回复时引用发送人消息",
+                        "type": "bool",
+                    },
+                    "platform_settings.forward_threshold": {
+                        "description": "转发消息的字数阈值",
+                        "type": "int",
+                    },
+                    "platform_settings.empty_mention_waiting": {
+                        "description": "只 @ 机器人是否触发等待",
+                        "type": "bool",
+                    },
+                },
+            },
+            "whitelist": {
+                "description": "白名单",
+                "type": "object",
+                "items": {
+                    "platform_settings.enable_id_white_list": {
+                        "description": "启用白名单",
+                        "type": "bool",
+                        "hint": "启用后，只有在白名单内的会话会被响应。",
+                    },
+                    "platform_settings.id_whitelist": {
+                        "description": "白名单 ID 列表",
+                        "type": "list",
+                        "items": {"type": "string"},
+                        "hint": "使用 /sid 获取 ID。",
+                    },
+                    "platform_settings.id_whitelist_log": {
+                        "description": "输出日志",
+                        "type": "bool",
+                        "hint": "启用后，当一条消息没通过白名单时，会输出 INFO 级别的日志。",
+                    },
+                    "platform_settings.wl_ignore_admin_on_group": {
+                        "description": "管理员群组消息无视 ID 白名单",
+                        "type": "bool",
+                    },
+                    "platform_settings.wl_ignore_admin_on_friend": {
+                        "description": "管理员私聊消息无视 ID 白名单",
+                        "type": "bool",
+                    },
+                },
+            },
+            "rate_limit": {
+                "description": "速率限制",
+                "type": "object",
+                "items": {
+                    "platform_settings.rate_limit.time": {
+                        "description": "消息速率限制时间(秒)",
+                        "type": "int",
+                    },
+                    "platform_settings.rate_limit.count": {
+                        "description": "消息速率限制计数",
+                        "type": "int",
+                    },
+                    "platform_settings.rate_limit.strategy": {
+                        "description": "速率限制策略",
+                        "type": "string",
+                        "options": ["stall", "discard"],
+                    },
+                },
+            },
+            "content_safety": {
+                "description": "内容安全",
+                "type": "object",
+                "items": {
+                    "platform_settings.content_safety.also_use_in_response": {
+                        "description": "同时检查模型的响应内容",
+                        "type": "bool",
+                    },
+                    "platform_settings.content_safety.baidu_aip.enable": {
+                        "description": "使用百度内容安全审核",
+                        "type": "bool",
+                        "hint": "您需要手动安装 baidu-aip 库。",
+                    },
+                    "platform_settings.content_safety.baidu_aip.app_id": {
+                        "description": "App ID",
+                        "type": "string",
+                        "condition": {
+                            "platform_settings.content_safety.baidu_aip.enable": True,
+                        },
+                    },
+                    "platform_settings.content_safety.baidu_aip.api_key": {
+                        "description": "API Key",
+                        "type": "string",
+                        "condition": {
+                            "platform_settings.content_safety.baidu_aip.enable": True,
+                        },
+                    },
+                    "platform_settings.content_safety.baidu_aip.secret_key": {
+                        "description": "Secret Key",
+                        "type": "string",
+                        "condition": {
+                            "platform_settings.content_safety.baidu_aip.enable": True,
+                        },
+                    },
+                    "platform_settings.content_safety.internal_keywords.enable": {
+                        "description": "关键词检查",
+                        "type": "bool",
+                    },
+                    "platform_settings.content_safety.internal_keywords.extra_keywords": {
+                        "description": "额外关键词",
+                        "type": "list",
+                        "items": {"type": "string"},
+                        "hint": "额外的屏蔽关键词列表，支持正则表达式。",
+                    },
+                },
+            },
+            "t2i": {
+                "description": "文本转图像",
+                "type": "object",
+                "items": {
+                    "t2i": {
+                        "description": "文本转图像输出",
+                        "type": "bool",
+                    },
+                    "t2i_word_threshold": {
+                        "description": "文本转图像字数阈值",
+                        "type": "int",
+                    },
+                },
+            },
+            "others": {
+                "description": "其他配置",
+                "type": "object",
+                "items": {
+                    "platform_settings.ignore_bot_self_message": {
+                        "description": "是否忽略机器人自身的消息",
+                        "type": "bool",
+                    },
+                    "platform_settings.ignore_at_all": {
+                        "description": "是否忽略 @ 全体成员事件",
+                        "type": "bool",
+                    },
+                    "platform_settings.no_permission_reply": {
+                        "description": "用户权限不足时是否回复",
+                        "type": "bool",
+                    },
+                },
+            },
+        },
+    },
+    "ext_group": {
+        "name": "扩展配置",
+        "metadata": {
+            "segmented_reply": {
+                "description": "分段回复",
+                "type": "object",
+                "items": {
+                    "platform_settings.segmented_reply.enable": {
+                        "description": "启用分段回复",
+                        "type": "bool",
+                    },
+                    "platform_settings.segmented_reply.only_llm_result": {
+                        "description": "仅对 LLM 结果分段",
+                        "type": "bool",
+                    },
+                    "platform_settings.segmented_reply.interval_method": {
+                        "description": "间隔方法",
+                        "type": "string",
+                        "options": ["random", "log"],
+                    },
+                    "platform_settings.segmented_reply.interval": {
+                        "description": "随机间隔时间",
+                        "type": "string",
+                        "hint": "格式：最小值,最大值（如：1.5,3.5）",
+                        "condition": {
+                            "platform_settings.segmented_reply.interval_method": "random",
+                        },
+                    },
+                    "platform_settings.segmented_reply.log_base": {
+                        "description": "对数底数",
+                        "type": "float",
+                        "hint": "对数间隔的底数，默认为 2.0。取值范围为 1.0-10.0。",
+                        "condition": {
+                            "platform_settings.segmented_reply.interval_method": "log",
+                        },
+                    },
+                    "platform_settings.segmented_reply.words_count_threshold": {
+                        "description": "分段回复字数阈值",
+                        "type": "int",
+                    },
+                    "platform_settings.segmented_reply.regex": {
+                        "description": "分段正则表达式",
+                        "type": "string",
+                    },
+                    "platform_settings.segmented_reply.content_cleanup_rule": {
+                        "description": "内容过滤正则表达式",
+                        "type": "string",
+                        "hint": "移除分段后内容中的指定内容。如填写 `[。？！]` 将移除所有的句号、问号、感叹号。",
+                    },
+                },
+            },
+            "ltm": {
+                "description": "群聊上下文感知（原聊天记忆增强）",
+                "type": "object",
+                "items": {
+                    "provider_ltm_settings.group_icl_enable": {
+                        "description": "启用群聊上下文感知",
+                        "type": "bool",
+                    },
+                    "provider_ltm_settings.group_message_max_cnt": {
+                        "description": "最大消息数量",
+                        "type": "int",
+                    },
+                    "provider_ltm_settings.image_caption": {
+                        "description": "自动理解图片",
+                        "type": "bool",
+                        "hint": "需要设置默认图片转述模型。",
+                    },
+                    "provider_ltm_settings.active_reply.enable": {
+                        "description": "主动回复",
+                        "type": "bool",
+                    },
+                    "provider_ltm_settings.active_reply.method": {
+                        "description": "主动回复方法",
+                        "type": "string",
+                        "options": ["possibility_reply"],
+                        "condition": {
+                            "provider_ltm_settings.active_reply.enable": True,
+                        },
+                    },
+                    "provider_ltm_settings.active_reply.possibility_reply": {
+                        "description": "回复概率",
+                        "type": "float",
+                        "hint": "0.0-1.0 之间的数值",
+                        "condition": {
+                            "provider_ltm_settings.active_reply.enable": True,
+                        },
+                    },
+                    "provider_ltm_settings.active_reply.whitelist": {
+                        "description": "主动回复白名单",
+                        "type": "list",
+                        "items": {"type": "string"},
+                        "hint": "为空时不启用白名单过滤。使用 /sid 获取 ID。",
+                        "condition": {
+                            "provider_ltm_settings.active_reply.enable": True,
+                        },
+                    },
+                },
+            },
+        },
+    },
+}
+
+CONFIG_METADATA_3_SYSTEM = {
+    "system_group": {
+        "name": "系统配置",
+        "metadata": {
+            "system": {
+                "description": "系统配置",
+                "type": "object",
+                "items": {
+                    "t2i_strategy": {
+                        "description": "文本转图像策略",
+                        "type": "string",
+                        "hint": "文本转图像策略。`remote` 为使用远程基于 HTML 的渲染服务，`local` 为使用 PIL 本地渲染。当使用 local 时，将 ttf 字体命名为 'font.ttf' 放在 data/ 目录下可自定义字体。",
+                        "options": ["remote", "local"],
+                    },
+                    "t2i_endpoint": {
+                        "description": "文本转图像服务接口",
+                        "type": "string",
+                        "hint": "为空时使用 AstrBot API 服务",
+                        "condition": {
+                            "t2i_strategy": "remote",
+                        },
+                    },
+                    "log_level": {
+                        "description": "控制台日志级别",
+                        "type": "string",
+                        "hint": "控制台输出日志的级别。",
+                        "options": ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+                    },
+                    "pip_install_arg": {
+                        "description": "pip 安装额外参数",
+                        "type": "string",
+                        "hint": "安装插件依赖时，会使用 Python 的 pip 工具。这里可以填写额外的参数，如 `--break-system-package` 等。",
+                    },
+                    "pypi_index_url": {
+                        "description": "PyPI 软件仓库地址",
+                        "type": "string",
+                        "hint": "安装 Python 依赖时请求的 PyPI 软件仓库地址。默认为 https://mirrors.aliyun.com/pypi/simple/",
+                    },
+                    "callback_api_base": {
+                        "description": "对外可达的回调接口地址",
+                        "type": "string",
+                        "hint": "外部服务可能会通过 AstrBot 生成的回调链接（如文件下载链接）访问 AstrBot 后端。由于 AstrBot 无法自动判断部署环境中对外可达的主机地址（host），因此需要通过此配置项显式指定 “外部服务如何访问 AstrBot” 的地址。如 http://localhost:6185，https://example.com 等。",
+                    },
+                    "timezone": {
+                        "description": "时区",
+                        "type": "string",
+                        "hint": "时区设置。请填写 IANA 时区名称, 如 Asia/Shanghai, 为空时使用系统默认时区。所有时区请查看: https://data.iana.org/time-zones/tzdb-2021a/zone1970.tab",
+                    },
+                    "http_proxy": {
+                        "description": "HTTP 代理",
+                        "type": "string",
+                        "hint": "启用后，会以添加环境变量的方式设置代理。格式为 `http://ip:port`",
+                    },
+                },
+            }
+        },
+    }
+}
+
 
 DEFAULT_VALUE_MAP = {
     "int": 0,

--- a/astrbot/core/core_lifecycle.py
+++ b/astrbot/core/core_lifecycle.py
@@ -27,10 +27,11 @@ from astrbot.core.provider.manager import ProviderManager
 from astrbot.core import LogBroker
 from astrbot.core.db import BaseDatabase
 from astrbot.core.updator import AstrBotUpdator
-from astrbot.core import logger
+from astrbot.core import logger, sp
 from astrbot.core.config.default import VERSION
 from astrbot.core.conversation_mgr import ConversationManager
 from astrbot.core.platform_message_history_mgr import PlatformMessageHistoryManager
+from astrbot.core.astrbot_config_mgr import AstrBotConfigManager
 from astrbot.core.star.star_handler import star_handlers_registry, EventType
 from astrbot.core.star.star_handler import star_map
 from astrbot.core.db.migration.helper import do_migration_v4
@@ -76,11 +77,16 @@ class AstrBotCoreLifecycle:
         except Exception as e:
             logger.error(f"迁移到 v4.0.0 新版本数据格式失败: {e}")
 
+        # 初始化 AstrBot 配置管理器
+        self.astrbot_config_mgr = AstrBotConfigManager(
+            default_config=self.astrbot_config, sp=sp
+        )
+
         # 初始化事件队列
         self.event_queue = Queue()
 
         # 初始化人格管理器
-        self.persona_mgr = PersonaManager(self.db, self.astrbot_config)
+        self.persona_mgr = PersonaManager(self.db, self.astrbot_config_mgr)
         await self.persona_mgr.initialize()
 
         # 初始化供应商管理器
@@ -107,6 +113,7 @@ class AstrBotCoreLifecycle:
             self.conversation_manager,
             self.platform_message_history_manager,
             self.persona_mgr,
+            self.astrbot_config_mgr,
         )
 
         # 初始化插件管理器
@@ -119,17 +126,18 @@ class AstrBotCoreLifecycle:
         await self.provider_manager.initialize()
 
         # 初始化消息事件流水线调度器
-        self.pipeline_scheduler = PipelineScheduler(
-            PipelineContext(self.astrbot_config, self.plugin_manager)
+
+        self.pipeline_scheduler_mapping = await self.load_pipline_scheduler(
+            self.astrbot_config_mgr
         )
-        await self.pipeline_scheduler.initialize()
-        self.star_context.pipeline_ctx = self.pipeline_scheduler.ctx
 
         # 初始化更新器
         self.astrbot_updator = AstrBotUpdator()
 
         # 初始化事件总线
-        self.event_bus = EventBus(self.event_queue, self.pipeline_scheduler)
+        self.event_bus = EventBus(
+            self.event_queue, self.pipeline_scheduler_mapping, self.astrbot_config_mgr
+        )
 
         # 记录启动时间
         self.start_time = int(time.time())
@@ -252,3 +260,20 @@ class AstrBotCoreLifecycle:
                 )
             )
         return tasks
+
+    async def load_pipline_scheduler(
+        self, abconf_mgr: AstrBotConfigManager
+    ) -> dict[str, PipelineScheduler]:
+        """加载消息事件流水线调度器
+
+        Returns:
+            dict[str, PipelineScheduler]: 平台 ID 到流水线调度器的映射
+        """
+        mapping = {}
+        for conf_id, ab_config in abconf_mgr.confs.items():
+            scheduler = PipelineScheduler(
+                PipelineContext(ab_config, self.plugin_manager, conf_id)
+            )
+            await scheduler.initialize()
+            mapping[conf_id] = scheduler
+        return mapping

--- a/astrbot/core/event_bus.py
+++ b/astrbot/core/event_bus.py
@@ -16,30 +16,32 @@ from asyncio import Queue
 from astrbot.core.pipeline.scheduler import PipelineScheduler
 from astrbot.core import logger
 from .platform import AstrMessageEvent
+from astrbot.core.astrbot_config_mgr import AstrBotConfigManager
 
 
 class EventBus:
-    """事件总线: 用于处理事件的分发和处理
+    """用于处理事件的分发和处理"""
 
-    维护一个异步队列, 来接受各种消息事件
-    """
-
-    def __init__(self, event_queue: Queue, pipeline_scheduler: PipelineScheduler):
+    def __init__(
+        self,
+        event_queue: Queue,
+        pipeline_scheduler_mapping: dict[str, PipelineScheduler],
+        astrbot_config_mgr: AstrBotConfigManager = None,
+    ):
         self.event_queue = event_queue  # 事件队列
-        self.pipeline_scheduler = pipeline_scheduler  # 管道调度器
+        # abconf uuid -> scheduler
+        self.pipeline_scheduler_mapping = pipeline_scheduler_mapping
+        self.astrbot_config_mgr = astrbot_config_mgr
 
     async def dispatch(self):
-        """无限循环的调度函数, 从事件队列中获取新的事件, 打印日志并创建一个新的异步任务来执行管道调度器的处理逻辑"""
         while True:
-            event: AstrMessageEvent = (
-                await self.event_queue.get()
-            )  # 从事件队列中获取新的事件
-            self._print_event(event)  # 打印日志
-            asyncio.create_task(
-                self.pipeline_scheduler.execute(event)
-            )  # 创建新的异步任务来执行管道调度器的处理逻辑
+            event: AstrMessageEvent = await self.event_queue.get()
+            conf_info = self.astrbot_config_mgr.get_conf_info(event.unified_msg_origin)
+            self._print_event(event, conf_info["name"])
+            scheduler = self.pipeline_scheduler_mapping.get(conf_info["id"])
+            asyncio.create_task(scheduler.execute(event))
 
-    def _print_event(self, event: AstrMessageEvent):
+    def _print_event(self, event: AstrMessageEvent, conf_name: str):
         """用于记录事件信息
 
         Args:
@@ -48,10 +50,10 @@ class EventBus:
         # 如果有发送者名称: [平台名] 发送者名称/发送者ID: 消息概要
         if event.get_sender_name():
             logger.info(
-                f"[{event.get_platform_id()}({event.get_platform_name()})] {event.get_sender_name()}/{event.get_sender_id()}: {event.get_message_outline()}"
+                f"[{conf_name}] [{event.get_platform_id()}({event.get_platform_name()})] {event.get_sender_name()}/{event.get_sender_id()}: {event.get_message_outline()}"
             )
         # 没有发送者名称: [平台名] 发送者ID: 消息概要
         else:
             logger.info(
-                f"[{event.get_platform_id()}({event.get_platform_name()})] {event.get_sender_id()}: {event.get_message_outline()}"
+                f"[{conf_name}] [{event.get_platform_id()}({event.get_platform_name()})] {event.get_sender_id()}: {event.get_message_outline()}"
             )

--- a/astrbot/core/persona_mgr.py
+++ b/astrbot/core/persona_mgr.py
@@ -1,15 +1,14 @@
 from astrbot.core.db import BaseDatabase
 from astrbot.core.db.po import Persona, Personality
-from astrbot.core.config import AstrBotConfig
+from astrbot.core.astrbot_config_mgr import AstrBotConfigManager
 from astrbot import logger
 
 
 class PersonaManager:
-    def __init__(self, db_helper: BaseDatabase, astrbot_config: AstrBotConfig):
+    def __init__(self, db_helper: BaseDatabase, acm: AstrBotConfigManager):
         self.db = db_helper
-        self.config = astrbot_config
-        _ps: dict = astrbot_config["provider_settings"]
-        self.default_persona: str = _ps.get("default_personality", "default")
+        default_ps = acm.default_conf.get("provider_settings", {})
+        self.default_persona: str = default_ps.get("default_personality", "default")
         self.personas: list[Persona] = []
         self.selected_default_persona: Persona | None = None
 

--- a/astrbot/core/pipeline/context.py
+++ b/astrbot/core/pipeline/context.py
@@ -2,7 +2,7 @@ import inspect
 import traceback
 import typing as T
 from dataclasses import dataclass
-from astrbot.core.config.astrbot_config import AstrBotConfig
+from astrbot.core.config import AstrBotConfig
 from astrbot.core.platform.astr_message_event import AstrMessageEvent
 from astrbot.core.star import PluginManager
 from astrbot.api import logger
@@ -17,6 +17,7 @@ class PipelineContext:
 
     astrbot_config: AstrBotConfig  # AstrBot 配置对象
     plugin_manager: PluginManager  # 插件管理器对象
+    astrbot_config_id: str
 
     async def call_event_hook(
         self,

--- a/astrbot/core/pipeline/process_stage/agent_runner/tool_loop_agent.py
+++ b/astrbot/core/pipeline/process_stage/agent_runner/tool_loop_agent.py
@@ -197,7 +197,7 @@ class ToolLoopAgent(BaseAgentRunner):
                 logger.info(f"使用工具：{func_tool_name}，参数：{func_tool_args}")
                 executor = func_tool.execute(
                     event=self.event,
-                    pipeline_context=self.pipeline_ctx,
+                    call_handler_func=self.pipeline_ctx.call_handler,
                     **func_tool_args,
                 )
                 async for resp in executor:

--- a/astrbot/core/platform/astr_message_event.py
+++ b/astrbot/core/platform/astr_message_event.py
@@ -3,7 +3,7 @@ import asyncio
 import re
 import hashlib
 import uuid
-from dataclasses import dataclass
+
 from typing import List, Union, Optional, AsyncGenerator
 
 from astrbot.core.db.po import Conversation
@@ -23,32 +23,7 @@ from astrbot.core.provider.entities import ProviderRequest
 from astrbot.core.utils.metrics import Metric
 from .astrbot_message import AstrBotMessage, Group
 from .platform_metadata import PlatformMetadata
-
-
-@dataclass
-class MessageSession:
-    """描述一条消息在 AstrBot 中对应的会话的唯一标识。
-    如果您需要实例化 MessageSession，请不要给 platform_id 赋值（或者同时给 platform_name 和 platform_id 赋值相同值）。它会在 __post_init__ 中自动设置为 platform_name 的值。"""
-
-    platform_name: str
-    """平台适配器实例的唯一标识符。自 AstrBot v4.0.0 起，该字段实际为 platform_id。"""
-    message_type: MessageType
-    session_id: str
-    platform_id: str = None
-
-    def __str__(self):
-        return f"{self.platform_id}:{self.message_type.value}:{self.session_id}"
-
-    def __post_init__(self):
-        self.platform_id = self.platform_name
-
-    @staticmethod
-    def from_str(session_str: str):
-        platform_id, message_type, session_id = session_str.split(":")
-        return MessageSession(platform_id, MessageType(message_type), session_id)
-
-
-MessageSesion = MessageSession  # back compatibility
+from .message_session import MessageSession, MessageSesion # noqa
 
 
 class AstrMessageEvent(abc.ABC):

--- a/astrbot/core/platform/manager.py
+++ b/astrbot/core/platform/manager.py
@@ -18,6 +18,9 @@ class PlatformManager:
 
         self.platforms_config = config["platform"]
         self.settings = config["platform_settings"]
+        """NOTE: 这里是 default 的配置文件，以保证最大的兼容性；
+        这个配置中的 unique_session 需要特殊处理，
+        约定整个项目中对 unique_session 的引用都从 default 的配置中获取"""
         self.event_queue = event_queue
 
     async def initialize(self):

--- a/astrbot/core/platform/message_session.py
+++ b/astrbot/core/platform/message_session.py
@@ -1,0 +1,28 @@
+from astrbot.core.platform.message_type import MessageType
+from dataclasses import dataclass
+
+
+@dataclass
+class MessageSession:
+    """描述一条消息在 AstrBot 中对应的会话的唯一标识。
+    如果您需要实例化 MessageSession，请不要给 platform_id 赋值（或者同时给 platform_name 和 platform_id 赋值相同值）。它会在 __post_init__ 中自动设置为 platform_name 的值。"""
+
+    platform_name: str
+    """平台适配器实例的唯一标识符。自 AstrBot v4.0.0 起，该字段实际为 platform_id。"""
+    message_type: MessageType
+    session_id: str
+    platform_id: str = None
+
+    def __str__(self):
+        return f"{self.platform_id}:{self.message_type.value}:{self.session_id}"
+
+    def __post_init__(self):
+        self.platform_id = self.platform_name
+
+    @staticmethod
+    def from_str(session_str: str):
+        platform_id, message_type, session_id = session_str.split(":")
+        return MessageSession(platform_id, MessageType(message_type), session_id)
+
+
+MessageSesion = MessageSession  # back compatibility

--- a/astrbot/core/platform/platform.py
+++ b/astrbot/core/platform/platform.py
@@ -5,7 +5,7 @@ from asyncio import Queue
 from .platform_metadata import PlatformMetadata
 from .astr_message_event import AstrMessageEvent
 from astrbot.core.message.message_event_result import MessageChain
-from .astr_message_event import MessageSesion
+from .message_session import MessageSesion
 from astrbot.core.utils.metrics import Metric
 
 

--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -206,7 +206,7 @@ class ToolSet:
         """Get all function tools."""
         return self.get_tool(name)
 
-    def openai_schema(self, omit_empty_parameters: bool = False) -> List[Dict]:
+    def openai_schema(self, omit_empty_parameter_field: bool = False) -> List[Dict]:
         """Convert tools to OpenAI API function calling schema format."""
         result = []
         for tool in self.tools:
@@ -218,7 +218,7 @@ class ToolSet:
                 },
             }
 
-            if tool.parameters.get("properties") or not omit_empty_parameters:
+            if tool.parameters.get("properties") or not omit_empty_parameter_field:
                 func_def["function"]["parameters"] = tool.parameters
 
             result.append(func_def)
@@ -318,8 +318,8 @@ class ToolSet:
         return declarations
 
     @deprecated(reason="Use openai_schema() instead", version="4.0.0")
-    def get_func_desc_openai_style(self, omit_empty_parameters: bool = False):
-        return self.openai_schema(omit_empty_parameters)
+    def get_func_desc_openai_style(self, omit_empty_parameter_field: bool = False):
+        return self.openai_schema(omit_empty_parameter_field)
 
     @deprecated(reason="Use anthropic_schema() instead", version="4.0.0")
     def get_func_desc_anthropic_style(self):
@@ -816,7 +816,7 @@ class FunctionToolManager:
         """
         tools = [f for f in self.func_list if f.active]
         toolset = ToolSet(tools)
-        return toolset.openai_schema(omit_empty_parameters=omit_empty_parameter_field)
+        return toolset.openai_schema(omit_empty_parameter_field=omit_empty_parameter_field)
 
     def get_func_desc_anthropic_style(self) -> list:
         """

--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -34,7 +34,6 @@ from typing_extensions import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from astrbot.core.platform.astr_message_event import AstrMessageEvent
-    from astrbot.core.pipeline.context import PipelineContext
 
 
 DEFAULT_MCP_CONFIG = {"mcpServers": {}}
@@ -80,14 +79,14 @@ class FunctionTool:
     async def execute(
         self,
         event: AstrMessageEvent = None,
-        pipeline_context: "PipelineContext" = None,
+        call_handler_func: Awaitable = None,
         **tool_args,
     ) -> AsyncGenerator[Any | mcp.types.CallToolResult, None]:
         """执行函数调用。
 
         Args:
             event (AstrMessageEvent): 事件对象, 当 origin 为 local 时必须提供。
-            pipeline_context (PipelineContext): 流水线调度器上下文, 当 origin 为 local 时必须提供。
+            call_handler_func (AsyncGenerator): 用于调用处理函数的异步生成器, 当 origin 为 mcp 时必须提供。
             **kwargs: 函数调用的参数。
 
         Returns:
@@ -96,7 +95,7 @@ class FunctionTool:
         if self.origin == "local":
             if not event:
                 raise ValueError("Event must be provided for local function tools.")
-            wrapper = pipeline_context.call_handler(
+            wrapper = call_handler_func(
                 event=event,
                 handler=self.handler,
                 **tool_args,

--- a/astrbot/core/provider/manager.py
+++ b/astrbot/core/provider/manager.py
@@ -82,7 +82,7 @@ class ProviderManager:
         """
         if provider_id not in self.inst_map:
             raise ValueError(f"提供商 {provider_id} 不存在，无法设置。")
-        if umo and self.provider_settings["separate_provider"]:
+        if umo:
             perf = sp.get("session_provider_perf", {})
             session_perf = perf.get(umo, {})
             session_perf[provider_type.value] = provider_id

--- a/astrbot/dashboard/routes/plugin.py
+++ b/astrbot/dashboard/routes/plugin.py
@@ -286,14 +286,6 @@ class PluginRoute(Route):
                             f"{filter.parent_command_names[0]} {filter.command_name}"
                         )
                         info["cmd"] = info["cmd"].strip()
-                        if (
-                            self.core_lifecycle.astrbot_config["wake_prefix"]
-                            and len(self.core_lifecycle.astrbot_config["wake_prefix"])
-                            > 0
-                        ):
-                            info["cmd"] = (
-                                f"{self.core_lifecycle.astrbot_config['wake_prefix'][0]}{info['cmd']}"
-                            )
                     elif isinstance(filter, CommandGroupFilter):
                         info["type"] = "指令组"
                         info["cmd"] = filter.get_complete_command_names()[0]
@@ -301,14 +293,6 @@ class PluginRoute(Route):
                         info["sub_command"] = filter.print_cmd_tree(
                             filter.sub_command_filters
                         )
-                        if (
-                            self.core_lifecycle.astrbot_config["wake_prefix"]
-                            and len(self.core_lifecycle.astrbot_config["wake_prefix"])
-                            > 0
-                        ):
-                            info["cmd"] = (
-                                f"{self.core_lifecycle.astrbot_config['wake_prefix'][0]}{info['cmd']}"
-                            )
                     elif isinstance(filter, RegexFilter):
                         info["type"] = "正则匹配"
                         info["cmd"] = filter.regex_str

--- a/dashboard/src/components/shared/AstrBotConfig.vue
+++ b/dashboard/src/components/shared/AstrBotConfig.vue
@@ -176,7 +176,7 @@ function saveEditedContent() {
                 <!-- List item -->
                 <ListConfigItem
                   v-else-if="metadata[metadataKey].items[key]?.type === 'list' && !metadata[metadataKey].items[key]?.invisible"
-                  :value="iterable[key]"
+                  v-model="iterable[key]"
                   class="config-field"
                 />
               </div>
@@ -287,9 +287,9 @@ function saveEditedContent() {
             ></v-switch>
             
             <!-- List item -->
-            <ListConfigItem
+            <ListConfigItem 
               v-else-if="metadata[metadataKey]?.type === 'list' && !metadata[metadataKey]?.invisible"
-              :value="iterable[metadataKey]"
+              v-model="iterable[metadataKey]"
               class="config-field"
             />
           </div>

--- a/dashboard/src/components/shared/AstrBotConfigV4.vue
+++ b/dashboard/src/components/shared/AstrBotConfigV4.vue
@@ -1,0 +1,396 @@
+<script setup>
+import { VueMonacoEditor } from '@guolao/vue-monaco-editor'
+import { ref, computed } from 'vue'
+import ListConfigItem from './ListConfigItem.vue'
+import ProviderSelector from './ProviderSelector.vue'
+import PersonaSelector from './PersonaSelector.vue'
+import { useI18n } from '@/i18n/composables'
+
+
+const props = defineProps({
+  metadata: {
+    type: Object,
+    required: true
+  },
+  iterable: {
+    type: Object,
+    required: true
+  },
+  metadataKey: {
+    type: String,
+    required: true
+  }
+})
+
+const { t } = useI18n()
+
+const dialog = ref(false)
+const currentEditingKey = ref('')
+const currentEditingLanguage = ref('json')
+const currentEditingTheme = ref('vs-light')
+let currentEditingKeyIterable = null
+
+function getValueBySelector(obj, selector) {
+  const keys = selector.split('.')
+  let current = obj
+  for (const key of keys) {
+    if (current && typeof current === 'object' && key in current) {
+      current = current[key]
+    } else {
+      return undefined
+    }
+  }
+  return current
+}
+
+function setValueBySelector(obj, selector, value) {
+  const keys = selector.split('.')
+  let current = obj
+
+  // 创建嵌套对象路径
+  for (let i = 0; i < keys.length - 1; i++) {
+    const key = keys[i]
+    if (!current[key] || typeof current[key] !== 'object') {
+      current[key] = {}
+    }
+    current = current[key]
+  }
+
+  // 设置最终值
+  current[keys[keys.length - 1]] = value
+}
+
+// 创建一个计算属性来处理 JSON selector 的获取和设置
+function createSelectorModel(selector) {
+  return computed({
+    get() {
+      return getValueBySelector(props.iterable, selector)
+    },
+    set(value) {
+      setValueBySelector(props.iterable, selector, value)
+    }
+  })
+}
+
+function openEditorDialog(key, value, theme, language) {
+  currentEditingKey.value = key
+  currentEditingLanguage.value = language || 'json'
+  currentEditingTheme.value = theme || 'vs-light'
+  currentEditingKeyIterable = value
+  dialog.value = true
+}
+
+function saveEditedContent() {
+  dialog.value = false
+}
+
+function shouldShowItem(itemMeta, itemKey) {
+  if (!itemMeta?.condition) {
+    return true
+  }
+  for (const [conditionKey, expectedValue] of Object.entries(itemMeta.condition)) {
+    const actualValue = getValueBySelector(props.iterable, conditionKey)
+    if (actualValue !== expectedValue) {
+      return false
+    }
+  }
+  return true
+}
+
+function hasVisibleItemsAfter(items, currentIndex) {
+  const itemEntries = Object.entries(items)
+  
+  // 检查当前索引之后是否还有可见的配置项
+  for (let i = currentIndex + 1; i < itemEntries.length; i++) {
+    const [itemKey, itemMeta] = itemEntries[i]
+    if (shouldShowItem(itemMeta, itemKey)) {
+      return true
+    }
+  }
+  
+  return false
+}
+</script>
+
+<template>
+
+
+  <v-card style="margin-bottom: 16px; padding-bottom: 8px; background-color: rgb(var(--v-theme-background));" rounded="md" variant="outlined">
+    <v-card-text class="config-section" v-if="metadata[metadataKey]?.type === 'object'">
+      <v-list-item-title class="config-title">
+        {{ metadata[metadataKey]?.description }}
+      </v-list-item-title>
+      <v-list-item-subtitle class="config-hint">
+        <span v-if="metadata[metadataKey]?.obvious_hint && metadata[metadataKey]?.hint" class="important-hint">‼️</span>
+        {{ metadata[metadataKey]?.hint }}
+      </v-list-item-subtitle>
+    </v-card-text>
+
+    <!-- Object Type Configuration with JSON Selector Support -->
+    <div v-if="metadata[metadataKey]?.type === 'object'" class="object-config">
+      <div v-for="(itemMeta, itemKey, index) in metadata[metadataKey].items" :key="itemKey" class="config-item">
+        <!-- Check if itemKey is a JSON selector -->
+        <template v-if="shouldShowItem(itemMeta, itemKey)">
+          <!-- JSON Selector Property -->
+          <v-row v-if="!itemMeta?.invisible" class="config-row">
+            <v-col cols="12" sm="6" class="property-info">
+              <v-list-item density="compact">
+                <v-list-item-title class="property-name">
+                  {{ itemMeta?.description || itemKey }}
+                  <span class="property-key">({{ itemKey }})</span>
+                </v-list-item-title>
+
+                <v-list-item-subtitle class="property-hint">
+                  <span v-if="itemMeta?.obvious_hint && itemMeta?.hint" class="important-hint">‼️</span>
+                  {{ itemMeta?.hint }}
+                </v-list-item-subtitle>
+              </v-list-item>
+            </v-col>
+            <v-col cols="12" sm="6" class="config-input">
+              <div class="w-100" v-if="!itemMeta?._special">
+                <!-- Select input for JSON selector -->
+                <v-select v-if="itemMeta?.options" v-model="createSelectorModel(itemKey).value"
+                  :items="itemMeta?.options" :disabled="itemMeta?.readonly" density="compact" variant="outlined"
+                  class="config-field" hide-details></v-select>
+
+                <!-- Code Editor for JSON selector -->
+                <div v-else-if="itemMeta?.editor_mode" class="editor-container">
+                  <VueMonacoEditor :theme="itemMeta?.editor_theme || 'vs-light'"
+                    :language="itemMeta?.editor_language || 'json'"
+                    style="min-height: 100px; flex-grow: 1; border: 1px solid rgba(0, 0, 0, 0.1);"
+                    v-model:value="createSelectorModel(itemKey).value">
+                  </VueMonacoEditor>
+                  <v-btn icon size="small" variant="text" color="primary" class="editor-fullscreen-btn"
+                    @click="openEditorDialog(itemKey, iterable, itemMeta?.editor_theme, itemMeta?.editor_language)"
+                    :title="t('core.common.editor.fullscreen')">
+                    <v-icon>mdi-fullscreen</v-icon>
+                  </v-btn>
+                </div>
+
+                <!-- String input for JSON selector -->
+                <v-text-field v-else-if="itemMeta?.type === 'string'" v-model="createSelectorModel(itemKey).value"
+                  density="compact" variant="outlined" class="config-field" hide-details></v-text-field>
+
+                <!-- Numeric input for JSON selector -->
+                <v-text-field v-else-if="itemMeta?.type === 'int' || itemMeta?.type === 'float'"
+                  v-model="createSelectorModel(itemKey).value" density="compact" variant="outlined" class="config-field"
+                  type="number" hide-details></v-text-field>
+
+                <!-- Text area for JSON selector -->
+                <v-textarea v-else-if="itemMeta?.type === 'text'" v-model="createSelectorModel(itemKey).value"
+                  variant="outlined" rows="3" class="config-field" hide-details></v-textarea>
+
+                <!-- Boolean switch for JSON selector -->
+                <v-switch v-else-if="itemMeta?.type === 'bool'" v-model="createSelectorModel(itemKey).value"
+                  color="primary" inset density="compact" hide-details style="display: flex; justify-content: end;"></v-switch>
+
+                <!-- List item for JSON selector -->
+                <ListConfigItem 
+                  v-else-if="itemMeta?.type === 'list'"
+                  v-model="createSelectorModel(itemKey).value"
+                  button-text="修改"
+                  class="config-field"
+                />
+
+                <!-- Fallback for JSON selector -->
+                <v-text-field v-else v-model="createSelectorModel(itemKey).value" density="compact" variant="outlined"
+                  class="config-field" hide-details></v-text-field>
+              </div>
+              <div v-else-if="itemMeta?._special === 'select_provider'">
+                <ProviderSelector 
+                  v-model="createSelectorModel(itemKey).value"
+                  :provider-type="'chat_completion'"
+                />
+              </div>
+              <div v-else-if="itemMeta?._special === 'select_provider_stt'">
+                <ProviderSelector 
+                  v-model="createSelectorModel(itemKey).value"
+                  :provider-type="'speech_to_text'"
+                />
+              </div>
+              <div v-else-if="itemMeta?._special === 'select_provider_tts'">
+                <ProviderSelector 
+                  v-model="createSelectorModel(itemKey).value"
+                  :provider-type="'text_to_speech'"
+                />
+              </div>
+              <div v-else-if="itemMeta?._special === 'provider_pool'">
+                <ProviderSelector 
+                  v-model="createSelectorModel(itemKey).value"
+                  :provider-type="'chat_completion'"
+                  button-text="选择提供商池..."
+                />
+              </div>
+              <div v-else-if="itemMeta?._special === 'select_persona'">
+                <PersonaSelector 
+                  v-model="createSelectorModel(itemKey).value"
+                />
+              </div>
+              <div v-else-if="itemMeta?._special === 'persona_pool'">
+                <PersonaSelector 
+                  v-model="createSelectorModel(itemKey).value"
+                  button-text="选择人格池..."
+                />
+              </div>
+
+            </v-col>
+          </v-row>
+        </template>
+        <v-divider class="config-divider" v-if="shouldShowItem(itemMeta, itemKey) && hasVisibleItemsAfter(metadata[metadataKey].items, index)"></v-divider>
+      </div>
+
+    </div>
+  </v-card>
+
+  <!-- Full Screen Editor Dialog -->
+  <v-dialog v-model="dialog" fullscreen transition="dialog-bottom-transition" scrollable>
+    <v-card>
+      <v-toolbar color="primary" dark>
+        <v-btn icon @click="dialog = false">
+          <v-icon>mdi-close</v-icon>
+        </v-btn>
+        <v-toolbar-title>{{ t('core.common.editor.editingTitle') }} - {{ currentEditingKey }}</v-toolbar-title>
+        <v-spacer></v-spacer>
+        <v-toolbar-items>
+          <v-btn variant="text" @click="saveEditedContent">{{ t('core.common.save') }}</v-btn>
+        </v-toolbar-items>
+      </v-toolbar>
+      <v-card-text class="pa-0">
+        <VueMonacoEditor :theme="currentEditingTheme" :language="currentEditingLanguage"
+          style="height: calc(100vh - 64px);" v-model:value="currentEditingKeyIterable[currentEditingKey]">
+        </VueMonacoEditor>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+
+
+<style scoped>
+.config-section {
+  margin-bottom: 4px;
+}
+
+.config-title {
+  /* font-weight: 600; */
+  font-size: 1.3rem;
+  color: var(--v-theme-primaryText);
+}
+
+.config-hint {
+  font-size: 0.75rem;
+  color: var(--v-theme-secondaryText);
+  margin-top: 2px;
+}
+
+.metadata-key,
+.property-key {
+  font-size: 0.85em;
+  opacity: 0.7;
+  font-weight: normal;
+  display: none;
+}
+
+.important-hint {
+  opacity: 1;
+  margin-right: 4px;
+}
+
+.object-config,
+.simple-config {
+  width: 100%;
+}
+
+.nested-object {
+  padding-left: 16px;
+}
+
+.nested-container {
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  padding: 12px;
+  margin: 12px 0;
+  background-color: rgba(0, 0, 0, 0.02);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.config-row {
+  margin: 0;
+  align-items: center;
+  padding: 10px 8px;
+  border-radius: 4px;
+}
+
+.config-row:hover {
+  background-color: rgba(0, 0, 0, 0.03);
+}
+
+.property-info {
+  padding: 0;
+}
+
+.property-name {
+  font-size: 0.875rem;
+  /* font-weight: 600; */
+  color: var(--v-theme-primaryText);
+}
+
+.property-hint {
+  font-size: 0.75rem;
+  color: var(--v-theme-secondaryText);
+  margin-top: 2px;
+}
+
+.type-indicator {
+  display: flex;
+  justify-content: center;
+}
+
+.config-input {
+  padding: 4px 8px;
+}
+
+.config-field {
+  margin-bottom: 0;
+}
+
+.config-divider {
+  border-color: rgba(0, 0, 0, 0.1);
+  margin-left: 24px;
+}
+
+.editor-container {
+  position: relative;
+  display: flex;
+  width: 100%;
+}
+
+.editor-fullscreen-btn {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 10;
+  background-color: rgba(0, 0, 0, 0.3);
+  border-radius: 4px;
+}
+
+.editor-fullscreen-btn:hover {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+@media (max-width: 600px) {
+  .nested-object {
+    padding-left: 8px;
+  }
+
+  .config-row {
+    padding: 8px 0;
+  }
+
+  .property-info,
+  .type-indicator,
+  .config-input {
+    padding: 4px;
+  }
+}
+</style>

--- a/dashboard/src/components/shared/ListConfigItem.vue
+++ b/dashboard/src/components/shared/ListConfigItem.vue
@@ -1,135 +1,216 @@
 <template>
-  <div class="list-config-item">
-    <v-list dense style="background-color: transparent;max-height: 300px; overflow-y: auto;">
-      <v-list-item v-for="(item, index) in items" :key="index">
-        <v-list-item-content style="display: flex; justify-content: space-between;">
-          <v-list-item-title v-if="editIndex !== index">
-            <v-chip size="small" label color="primary">{{ item }}</v-chip>
-          </v-list-item-title>
+  <div class="d-flex align-center justify-space-between">
+    <div>
+      <span v-if="!modelValue || modelValue.length === 0" style="color: rgb(var(--v-theme-primaryText));">
+        暂无项目
+      </span>
+      <div v-else class="d-flex flex-wrap ga-2">
+        <v-chip v-for="item in displayItems" :key="item" size="x-small" label color="primary">
+          {{ item.length > 20 ? item.slice(0, 20) + '...' : item }}
+        </v-chip>
+        <v-chip v-if="modelValue.length > maxDisplayItems" size="x-small" label color="grey-lighten-1">
+          +{{ modelValue.length - maxDisplayItems }}
+        </v-chip>
+      </div>
+    </div>
+    <v-btn size="small" color="primary" variant="tonal" @click="openDialog">
+      {{ buttonText }}
+    </v-btn>
+  </div>
+
+  <!-- List Management Dialog -->
+  <v-dialog v-model="dialog" max-width="600px">
+    <v-card>
+      <v-card-title class="text-h3 py-4" style="font-weight: normal;">
+        {{ dialogTitle }}
+      </v-card-title>
+      
+      <v-card-text class="pa-0" style="max-height: 400px; overflow-y: auto;">
+        <v-list v-if="localItems.length > 0" density="compact">
+          <v-list-item
+            v-for="(item, index) in localItems"
+            :key="index"
+            rounded="md"
+            class="ma-1">
+            <v-list-item-title v-if="editIndex !== index">
+              {{ item }}
+            </v-list-item-title>
+            <v-text-field 
+              v-else
+              v-model="editItem" 
+              hide-details 
+              variant="outlined" 
+              density="compact"
+              @keyup.enter="saveEdit" 
+              @keyup.esc="cancelEdit"
+              autofocus
+            ></v-text-field>
+            
+            <template v-slot:append>
+              <div v-if="editIndex !== index" class="d-flex">
+                <v-btn @click="startEdit(index, item)" variant="plain" icon size="small">
+                  <v-icon>mdi-pencil</v-icon>
+                </v-btn>
+                <v-btn @click="removeItem(index)" variant="plain" icon size="small">
+                  <v-icon>mdi-close</v-icon>
+                </v-btn>
+              </div>
+              <div v-else class="d-flex">
+                <v-btn @click="saveEdit" variant="plain" color="success" icon size="small">
+                  <v-icon>mdi-check</v-icon>
+                </v-btn>
+                <v-btn @click="cancelEdit" variant="plain" color="error" icon size="small">
+                  <v-icon>mdi-close</v-icon>
+                </v-btn>
+              </div>
+            </template>
+          </v-list-item>
+        </v-list>
+        
+        <div v-else class="text-center py-8">
+          <v-icon size="64" color="grey-lighten-1">mdi-format-list-bulleted</v-icon>
+          <p class="text-grey mt-4">暂无项目</p>
+        </div>
+      </v-card-text>
+
+      <!-- Add new item section -->
+      <v-card-text class="pa-4">
+        <div class="d-flex align-center ga-2">
           <v-text-field 
-            v-else
-            v-model="editItem" 
-            dense 
-            hide-details 
+            v-model="newItem" 
+            :label="t('core.common.list.addItemPlaceholder')" 
+            @keyup.enter="addItem" 
+            clearable 
+            hide-details
             variant="outlined" 
             density="compact"
-            @keyup.enter="saveEdit" 
-            @keyup.esc="cancelEdit"
-            autofocus
-          ></v-text-field>
-          <div v-if="editIndex !== index">
-            <v-btn @click="startEdit(index, item)" variant="plain" class="edit-btn" icon size="small">
-              <v-icon>mdi-pencil</v-icon>
-            </v-btn>
-            <v-btn @click="removeItem(index)" variant="plain" icon size="small">
-              <v-icon>mdi-close</v-icon>
-            </v-btn>
-          </div>
-          <div v-else>
-            <v-btn @click="saveEdit" variant="plain" color="success" icon size="small">
-              <v-icon>mdi-check</v-icon>
-            </v-btn>
-            <v-btn @click="cancelEdit" variant="plain" color="error" icon size="small">
-              <v-icon>mdi-close</v-icon>
-            </v-btn>
-          </div>
-        </v-list-item-content>
-      </v-list-item>
-    </v-list>
-    <div style="display: flex; align-items: center;">
-      <v-text-field v-model="newItem" :label="t('core.common.list.addItemPlaceholder')" @keyup.enter="addItem" clearable dense hide-details
-        variant="outlined" density="compact"></v-text-field>
-      <v-btn @click="addItem" text variant="tonal">
-        <v-icon>mdi-plus</v-icon>
-        {{ t('core.common.list.addButton') }}
-      </v-btn>
-    </div>
+            class="flex-grow-1">
+          </v-text-field>
+          <v-btn @click="addItem" variant="tonal" color="primary">
+            <v-icon>mdi-plus</v-icon>
+            {{ t('core.common.list.addButton') }}
+          </v-btn>
+        </div>
+      </v-card-text>
 
-  </div>
+      <v-card-actions class="pa-4">
+        <v-spacer></v-spacer>
+        <v-btn variant="text" @click="cancelDialog">取消</v-btn>
+        <v-btn color="primary" @click="confirmDialog">确认</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
 </template>
 
-<script>
-import { useI18n } from '@/i18n/composables';
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { useI18n } from '@/i18n/composables'
 
-export default {
-  name: 'ListConfigItem',
-  setup() {
-    const { t } = useI18n();
-    return { t };
+const { t } = useI18n()
+
+const props = defineProps({
+  modelValue: {
+    type: Array,
+    default: () => []
   },
-  props: {
-    value: {
-      type: Array,
-      default: () => [],
-    },
-    label: {
-      type: String,
-      default: '',
-    },
+  label: {
+    type: String,
+    default: ''
   },
-  data() {
-    return {
-      newItem: '',
-      items: this.value,
-      editIndex: -1,
-      editItem: '',
-    };
+  buttonText: {
+    type: String,
+    default: '修改'
   },
-  watch: {
-    items(newVal) {
-      this.$emit('input', newVal);
-    },
+  dialogTitle: {
+    type: String,
+    default: '修改列表项'
   },
-  methods: {
-    addItem() {
-      if (this.newItem.trim() !== '') {
-        this.items.push(this.newItem.trim());
-        this.newItem = '';
-      }
-    },
-    removeItem(index) {
-      this.items.splice(index, 1);
-    },
-    startEdit(index, item) {
-      this.editIndex = index;
-      this.editItem = item;
-    },
-    saveEdit() {
-      if (this.editItem.trim() !== '') {
-        this.items[this.editIndex] = this.editItem.trim();
-        this.cancelEdit();
-      }
-    },
-    cancelEdit() {
-      this.editIndex = -1;
-      this.editItem = '';
-    },
-  },
-};
+  maxDisplayItems: {
+    type: Number,
+    default: 1
+  }
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const dialog = ref(false)
+const localItems = ref([])
+const originalItems = ref([])
+const newItem = ref('')
+const editIndex = ref(-1)
+const editItem = ref('')
+
+// 计算要显示的项目
+const displayItems = computed(() => {
+  return props.modelValue.slice(0, props.maxDisplayItems)
+})
+
+// 监听 modelValue 变化，同步到 localItems
+watch(() => props.modelValue, (newValue) => {
+  localItems.value = [...(newValue || [])]
+}, { immediate: true })
+
+function openDialog() {
+  localItems.value = [...(props.modelValue || [])]
+  originalItems.value = [...(props.modelValue || [])]
+  dialog.value = true
+  editIndex.value = -1
+  editItem.value = ''
+  newItem.value = ''
+}
+
+function addItem() {
+  if (newItem.value.trim() !== '') {
+    localItems.value.push(newItem.value.trim())
+    newItem.value = ''
+  }
+}
+
+function removeItem(index) {
+  localItems.value.splice(index, 1)
+}
+
+function startEdit(index, item) {
+  editIndex.value = index
+  editItem.value = item
+}
+
+function saveEdit() {
+  if (editItem.value.trim() !== '') {
+    localItems.value[editIndex.value] = editItem.value.trim()
+    cancelEdit()
+  }
+}
+
+function cancelEdit() {
+  editIndex.value = -1
+  editItem.value = ''
+}
+
+function confirmDialog() {
+  emit('update:modelValue', [...localItems.value])
+  dialog.value = false
+}
+
+function cancelDialog() {
+  localItems.value = [...originalItems.value]
+  editIndex.value = -1
+  editItem.value = ''
+  newItem.value = ''
+  dialog.value = false
+}
 </script>
 
 <style scoped>
-.list-config-item {
-  border: 1px solid var(--v-theme-border);
-  padding: 16px;
-  margin-bottom: 8px;
-  border-radius: 10px;
-  background-color: var(--v-theme-background);
-}
-
 .v-list-item {
-  padding: 0;
+  transition: all 0.2s ease;
 }
 
-.v-list-item-title {
-  font-size: 14px;
+.v-list-item:hover {
+  background-color: rgba(var(--v-theme-primary), 0.04);
 }
 
-.v-btn {
-  margin-left: 8px;
-}
-
-.edit-btn {
-  margin-right: -8px;
+.v-chip {
+  margin: 2px;
 }
 </style>

--- a/dashboard/src/components/shared/PersonaSelector.vue
+++ b/dashboard/src/components/shared/PersonaSelector.vue
@@ -1,0 +1,141 @@
+<template>
+  <div class="d-flex align-center justify-space-between">
+    <span v-if="!modelValue" style="color: rgb(var(--v-theme-primaryText));">
+      未选择
+    </span>
+    <span v-else>
+      {{ modelValue }}
+    </span>
+    <v-btn size="small" color="primary" variant="tonal" @click="openDialog">
+      {{ buttonText }}
+    </v-btn>
+  </div>
+
+  <!-- Persona Selection Dialog -->
+  <v-dialog v-model="dialog" max-width="600px">
+    <v-card>
+      <v-card-title class="text-h3 py-4" style="font-weight: normal;">
+        选择人格
+      </v-card-title>
+      
+      <v-card-text class="pa-0" style="max-height: 400px; overflow-y: auto;">
+        <v-progress-linear v-if="loading" indeterminate color="primary"></v-progress-linear>
+        
+        <v-list v-if="!loading && personaList.length > 0" density="compact">
+          <v-list-item
+            v-for="persona in personaList"
+            :key="persona.persona_id"
+            :value="persona.persona_id"
+            @click="selectPersona(persona)"
+            :active="selectedPersona === persona.persona_id"
+            rounded="md"
+            class="ma-1">
+            <v-list-item-title>{{ persona.persona_id }}</v-list-item-title>
+            <v-list-item-subtitle>
+              {{ persona.system_prompt ? persona.system_prompt.substring(0, 50) + '...' : '无描述' }}
+            </v-list-item-subtitle>
+            
+            <template v-slot:append>
+              <v-icon v-if="selectedPersona === persona.persona_id" color="primary">mdi-check-circle</v-icon>
+            </template>
+          </v-list-item>
+        </v-list>
+        
+        <div v-else-if="!loading && personaList.length === 0" class="text-center py-8">
+          <v-icon size="64" color="grey-lighten-1">mdi-account-off</v-icon>
+          <p class="text-grey mt-4">暂无可用的人格</p>
+        </div>
+      </v-card-text>
+      
+      <v-divider></v-divider>
+      
+      <v-card-actions class="pa-4">
+        <v-spacer></v-spacer>
+        <v-btn variant="text" @click="cancelSelection">取消</v-btn>
+        <v-btn 
+          color="primary" 
+          @click="confirmSelection"
+          :disabled="!selectedPersona">
+          确认选择
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+import axios from 'axios'
+
+const props = defineProps({
+  modelValue: {
+    type: String,
+    default: ''
+  },
+  buttonText: {
+    type: String,
+    default: '选择人格...'
+  }
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const dialog = ref(false)
+const personaList = ref([])
+const loading = ref(false)
+const selectedPersona = ref('')
+
+// 监听 modelValue 变化，同步到 selectedPersona
+watch(() => props.modelValue, (newValue) => {
+  selectedPersona.value = newValue || ''
+}, { immediate: true })
+
+async function openDialog() {
+  selectedPersona.value = props.modelValue || ''
+  dialog.value = true
+  await loadPersonas()
+}
+
+async function loadPersonas() {
+  loading.value = true
+  try {
+    const response = await axios.get('/api/persona/list')
+    if (response.data.status === 'ok') {
+      personaList.value = response.data.data || []
+    }
+  } catch (error) {
+    console.error('加载人格列表失败:', error)
+    personaList.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+function selectPersona(persona) {
+  selectedPersona.value = persona.persona_id
+}
+
+function confirmSelection() {
+  emit('update:modelValue', selectedPersona.value)
+  dialog.value = false
+}
+
+function cancelSelection() {
+  selectedPersona.value = props.modelValue || ''
+  dialog.value = false
+}
+</script>
+
+<style scoped>
+.v-list-item {
+  transition: all 0.2s ease;
+}
+
+.v-list-item:hover {
+  background-color: rgba(var(--v-theme-primary), 0.04);
+}
+
+.v-list-item.v-list-item--active {
+  background-color: rgba(var(--v-theme-primary), 0.08);
+}
+</style>

--- a/dashboard/src/components/shared/ProviderSelector.vue
+++ b/dashboard/src/components/shared/ProviderSelector.vue
@@ -1,0 +1,150 @@
+<template>
+  <div class="d-flex align-center justify-space-between">
+    <span v-if="!modelValue" style="color: rgb(var(--v-theme-primaryText));">
+      未选择
+    </span>
+    <span v-else>
+      {{ modelValue }}
+    </span>
+    <v-btn size="small" color="primary" variant="tonal" @click="openDialog">
+      {{ buttonText }}
+    </v-btn>
+  </div>
+
+  <!-- Provider Selection Dialog -->
+  <v-dialog v-model="dialog" max-width="600px">
+    <v-card>
+      <v-card-title class="text-h3 py-4" style="font-weight: normal;">
+        选择提供商
+      </v-card-title>
+      
+      <v-card-text class="pa-0" style="max-height: 400px; overflow-y: auto;">
+        <v-progress-linear v-if="loading" indeterminate color="primary"></v-progress-linear>
+        
+        <v-list v-if="!loading && providerList.length > 0" density="compact">
+          <v-list-item
+            v-for="provider in providerList"
+            :key="provider.id"
+            :value="provider.id"
+            @click="selectProvider(provider)"
+            :active="selectedProvider === provider.id"
+            rounded="md"
+            class="ma-1">
+            <v-list-item-title>{{ provider.id }}</v-list-item-title>
+            <v-list-item-subtitle>
+              {{ provider.type || provider.provider_type || '未知类型' }}
+              <span v-if="provider.model_config?.model">- {{ provider.model_config.model }}</span>
+            </v-list-item-subtitle>
+            
+            <template v-slot:append>
+              <v-icon v-if="selectedProvider === provider.id" color="primary">mdi-check-circle</v-icon>
+            </template>
+          </v-list-item>
+        </v-list>
+        
+        <div v-else-if="!loading && providerList.length === 0" class="text-center py-8">
+          <v-icon size="64" color="grey-lighten-1">mdi-api-off</v-icon>
+          <p class="text-grey mt-4">暂无可用的提供商</p>
+        </div>
+      </v-card-text>
+      
+      <v-divider></v-divider>
+      
+      <v-card-actions class="pa-4">
+        <v-spacer></v-spacer>
+        <v-btn variant="text" @click="cancelSelection">取消</v-btn>
+        <v-btn 
+          color="primary" 
+          @click="confirmSelection"
+          :disabled="!selectedProvider">
+          确认选择
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+import axios from 'axios'
+
+const props = defineProps({
+  modelValue: {
+    type: String,
+    default: ''
+  },
+  providerType: {
+    type: String,
+    default: 'chat_completion'
+  },
+  buttonText: {
+    type: String,
+    default: '选择提供商...'
+  }
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const dialog = ref(false)
+const providerList = ref([])
+const loading = ref(false)
+const selectedProvider = ref('')
+
+// 监听 modelValue 变化，同步到 selectedProvider
+watch(() => props.modelValue, (newValue) => {
+  selectedProvider.value = newValue || ''
+}, { immediate: true })
+
+async function openDialog() {
+  selectedProvider.value = props.modelValue || ''
+  dialog.value = true
+  await loadProviders()
+}
+
+async function loadProviders() {
+  loading.value = true
+  try {
+    const response = await axios.get('/api/config/provider/list', {
+      params: {
+        provider_type: props.providerType
+      }
+    })
+    if (response.data.status === 'ok') {
+      providerList.value = response.data.data || []
+    }
+  } catch (error) {
+    console.error('加载提供商列表失败:', error)
+    providerList.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+function selectProvider(provider) {
+  selectedProvider.value = provider.id
+}
+
+function confirmSelection() {
+  emit('update:modelValue', selectedProvider.value)
+  dialog.value = false
+}
+
+function cancelSelection() {
+  selectedProvider.value = props.modelValue || ''
+  dialog.value = false
+}
+</script>
+
+<style scoped>
+.v-list-item {
+  transition: all 0.2s ease;
+}
+
+.v-list-item:hover {
+  background-color: rgba(var(--v-theme-primary), 0.04);
+}
+
+.v-list-item.v-list-item--active {
+  background-color: rgba(var(--v-theme-primary), 0.08);
+}
+</style>

--- a/dashboard/src/i18n/locales/zh-CN/features/config.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config.json
@@ -30,7 +30,11 @@
     "configApplyError": "配置未应用，Json 格式错误。",
     "saveSuccess": "配置保存成功",
     "saveError": "配置保存失败",
-    "loadError": "配置加载失败"
+    "loadError": "配置加载失败",
+    "deleteSuccess": "删除成功",
+    "deleteError": "删除失败",
+    "updateSuccess": "更新成功",
+    "updateError": "更新失败"
   },
   "sections": {
     "general": "常规设置",

--- a/dashboard/src/layouts/full/vertical-sidebar/VerticalSidebar.vue
+++ b/dashboard/src/layouts/full/vertical-sidebar/VerticalSidebar.vue
@@ -1,6 +1,5 @@
 <script setup>
-import { ref, shallowRef, onMounted } from 'vue';
-import axios from 'axios';
+import { ref, shallowRef } from 'vue';
 import { useCustomizerStore } from '../../../stores/customizer';
 import { useI18n } from '@/i18n/composables';
 import sidebarItems from './sidebarItem';

--- a/dashboard/src/views/ConfigPage.vue
+++ b/dashboard/src/views/ConfigPage.vue
@@ -1,124 +1,175 @@
-
-
 <template>
-  <v-card style="margin-bottom: 16px;">
-    <v-card-text style="padding: 0;">
-      <div>
-        <v-btn-group variant="outlined" divided>
-          <v-btn icon="mdi-text-box-edit-outline" style="width: 80px;" :color="editorTab === 0 ? 'primary' : ''"
-            @click="editorTab = 0">
+
+  <div style="display: flex; flex-direction: column; align-items: center;">
+    <div v-if="selectedConfigID || isSystemConfig" class="mt-4 config-panel"
+      style="display: flex; flex-direction: column; align-items: start;">
+
+      <!-- 普通配置选择区域 -->
+      <div class="d-flex flex-row pr-4"
+        style="margin-bottom: 16px; align-items: center; gap: 12px; justify-content: space-between; width: 100%;">
+        <div class="d-flex flex-row align-center" style="gap: 12px;" >
+          <v-select style="min-width: 130px;" v-model="selectedConfigID" :items="configSelectItems" item-title="name" v-if="!isSystemConfig"
+            item-value="id" label="选择配置文件" hide-details density="compact" rounded="md" variant="outlined"
+            @update:model-value="onConfigSelect">
+            <template v-slot:item="{ props: itemProps, item }">
+              <v-list-item v-bind="itemProps"
+                :subtitle="item.raw.id === '_%manage%_' ? '管理所有配置文件' : formatUmop(item.raw.umop)"
+                :class="item.raw.id === '_%manage%_' ? 'text-primary' : ''">
+              </v-list-item>
+            </template>
+          </v-select>
+        </div>
+
+        <v-btn-toggle v-model="configType" mandatory color="primary" variant="outlined" density="comfortable"
+          rounded="md" @update:model-value="onConfigTypeToggle">
+          <v-btn value="normal" prepend-icon="mdi-cog" size="large" >
+            普通
           </v-btn>
-          <v-btn icon="mdi-code-json" style="width: 80px;" :color="editorTab === 1 ? 'primary' : ''"
-            @click="configToString(); editorTab = 1;"></v-btn>
-        </v-btn-group>
-        <v-btn v-if="editorTab === 1" style="margin-left: 16px;" size="small" @click="configToString()">{{ tm('editor.revertCode') }}</v-btn>
-        <v-btn v-if="editorTab === 1 && config_data_has_changed" style="margin-left: 16px;" size="small"
-          @click="applyStrConfig()">{{ tm('editor.applyConfig') }}</v-btn>
-        <small v-if="editorTab === 1" style="margin-left: 16px;">💡 {{ tm('editor.applyTip') }}</small>
+          <v-btn value="system" prepend-icon="mdi-cog-outline" size="large">
+            系统
+          </v-btn>
+        </v-btn-toggle>
       </div>
 
-    </v-card-text>
-  </v-card>
+      <v-progress-linear v-if="!fetched" indeterminate color="primary"></v-progress-linear>
 
-  <!-- 可视化编辑 -->
-  <v-card v-if="editorTab === 0">
-    <v-tabs v-model="tab" align-tabs="left" color="deep-purple-accent-4">
-      <v-tab v-for="(val, key, index) in metadata" :key="index" :value="index"
-        style="font-weight: 1000; font-size: 15px">
-        {{ metadata[key]['name'] }}
-      </v-tab>
-    </v-tabs>
-    <v-tabs-window v-model="tab">
-      <v-tabs-window-item v-for="(val, key, index) in metadata" v-show="index == tab" :key="index">
-        <v-container fluid>
+      <div v-if="(selectedConfigID || isSystemConfig) && fetched" style="width: 100%;">
+        <!-- 可视化编辑 -->
+        <div :class="$vuetify.display.mobile ? '' : 'd-flex'">
+          <v-tabs v-model="tab" :direction="$vuetify.display.mobile ? 'horizontal' : 'vertical'"
+            :align-tabs="$vuetify.display.mobile ? 'left' : 'start'" color="deep-purple-accent-4" class="config-tabs">
+            <v-tab v-for="(val, key, index) in metadata" :key="index" :value="index"
+              style="font-weight: 1000; font-size: 15px">
+              {{ metadata[key]['name'] }}
+            </v-tab>
+          </v-tabs>
+          <v-tabs-window v-model="tab" class="config-tabs-window">
+            <v-tabs-window-item v-for="(val, key, index) in metadata" v-show="index == tab" :key="index">
+              <v-container fluid>
+                <div v-for="(val2, key2, index2) in metadata[key]['metadata']" :key="key2">
+                  <!-- Support both traditional and JSON selector metadata -->
+                  <AstrBotConfigV4 :metadata="{ [key2]: metadata[key]['metadata'][key2] }" :iterable="config_data"
+                    :metadataKey="key2">
+                  </AstrBotConfigV4>
+                </div>
+              </v-container>
+            </v-tabs-window-item>
 
-          <div v-for="(val2, key2, index2) in metadata[key]['metadata']">
-            <!-- <h3>{{ metadata[key]['metadata'][key2]['description'] }}</h3> -->
-            <div v-if="metadata[key]['metadata'][key2]?.config_template"
-              v-show="key2 !== 'platform' && key2 !== 'provider'" style="border: 1px solid var(--v-theme-border); padding: 8px; margin-bottom: 16px; border-radius: 10px">
-              <!-- 带有 config_template 的配置项 -->
-              <v-list-item-title style="font-weight: bold;">
-                {{ metadata[key]['metadata'][key2]['description'] }} ({{ key2 }})
-              </v-list-item-title>
-              <v-tabs style="margin-top: 16px;" align-tabs="left" color="deep-purple-accent-4"
-              
-                v-model="config_template_tab">
-                <v-tab v-if="metadata[key]['metadata'][key2]?.tmpl_display_title"
-                  v-for="(item, index) in config_data[key2]" :key="index" :value="index">
-                  {{ item[metadata[key]['metadata'][key2]?.tmpl_display_title] }}
-                </v-tab>
-                <v-tab v-else v-for="(item, index) in config_data[key2]" :key="index + '_'" :value="index">
-                  {{ item.id }}({{ item.type }})
-                </v-tab>
-                <v-menu>
-                  <template v-slot:activator="{ props }">
-                    <v-btn variant="plain" size="large" v-bind="props">
-                      <v-icon>mdi-plus</v-icon>
-                    </v-btn>
-                  </template>
-                  <v-list @update:selected="addFromDefaultConfigTmpl($event, key, key2)">
-                    <v-list-item v-for="(item, index) in metadata[key]['metadata'][key2]?.config_template" :key="index"
-                      :value="index">
-                      <v-list-item-title>{{ index }}</v-list-item-title>
-                    </v-list-item>
-                  </v-list>
-                </v-menu>
-              </v-tabs>
-              <v-tabs-window v-model="config_template_tab">
-                <v-tabs-window-item v-for="(config_item, index) in config_data[key2]"
-                  v-show="config_template_tab === index" :key="index" :value="index">
-                  <div style="padding: 16px;">
-                    <v-btn variant="tonal" rounded="xl" color="error" @click="deleteItem(key2, index)">
-                      {{ tm('actions.delete') }}
-                    </v-btn>
 
-                    <AstrBotConfig :metadata="metadata[key]['metadata']" :iterable="config_item" :metadataKey="key2">
-                    </AstrBotConfig>
-                  </div>
-                </v-tabs-window-item>
-              </v-tabs-window>
+            <div style="margin-left: 16px; padding-bottom: 16px">
+              <small>{{ tm('help.helpPrefix') }}
+                <a href="https://astrbot.app/" target="_blank">{{ tm('help.documentation') }}</a>
+                {{ tm('help.helpMiddle') }}
+                <a href="https://qm.qq.com/cgi-bin/qm/qr?k=EYGsuUTfe00_iOu9JTXS7_TEpMkXOvwv&jump_from=webapi&authKey=uUEMKCROfsseS+8IzqPjzV3y1tzy4AkykwTib2jNkOFdzezF9s9XknqnIaf3CDft"
+                  target="_blank">{{ tm('help.support') }}</a>{{ tm('help.helpSuffix') }}
+              </small>
             </div>
 
-            <div v-else>
-              <!-- 如果配置项是一个 object，那么 iterable 需要取到这个 object 的值，否则取到整个 config_data -->
-              <div v-if="metadata[key]['metadata'][key2]['type'] == 'object'" style="border: 1px solid var(--v-theme-border); padding: 8px; margin-bottom: 16px; border-radius: 10px">
-                <AstrBotConfig
-                  :metadata="metadata[key]['metadata']" :iterable="config_data[key2]" :metadataKey="key2">
-                </AstrBotConfig>
+          </v-tabs-window>
+        </div>
+
+        <v-btn icon="mdi-content-save" size="x-large" style="position: fixed; right: 52px; bottom: 52px;"
+          color="darkprimary" @click="updateConfig">
+        </v-btn>
+
+        <v-btn icon="mdi-code-json" size="x-large" style="position: fixed; right: 52px; bottom: 124px;" color="primary"
+          @click="configToString(); codeEditorDialog = true">
+        </v-btn>
+
+      </div>
+
+    </div>
+  </div>
+
+
+  <!-- Full Screen Editor Dialog -->
+  <v-dialog v-model="codeEditorDialog" fullscreen transition="dialog-bottom-transition" scrollable>
+    <v-card>
+      <v-toolbar color="primary" dark>
+        <v-btn icon @click="codeEditorDialog = false">
+          <v-icon>mdi-close</v-icon>
+        </v-btn>
+        <v-toolbar-title>编辑配置文件</v-toolbar-title>
+        <v-spacer></v-spacer>
+        <v-toolbar-items style="display: flex; align-items: center;">
+          <v-btn style="margin-left: 16px;" size="small" @click="configToString()">{{
+            tm('editor.revertCode') }}</v-btn>
+          <v-btn v-if="config_data_has_changed" style="margin-left: 16px;" size="small" @click="applyStrConfig()">{{
+            tm('editor.applyConfig') }}</v-btn>
+          <small style="margin-left: 16px;">💡 {{ tm('editor.applyTip') }}</small>
+        </v-toolbar-items>
+      </v-toolbar>
+      <v-card-text class="pa-0">
+        <VueMonacoEditor language="json" theme="vs-dark" style="height: calc(100vh - 64px);"
+          v-model:value="config_data_str">
+        </VueMonacoEditor>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+
+  <!-- Config Management Dialog -->
+  <v-dialog v-model="configManageDialog" max-width="800px">
+    <v-card>
+      <v-card-title class="d-flex align-center justify-space-between">
+        <span class="text-h4">配置文件管理</span>
+        <v-btn icon="mdi-close" variant="text" @click="configManageDialog = false"></v-btn>
+      </v-card-title>
+
+      <v-card-text>
+        <small>AstrBot 支持针对不同消息平台实例分别设置配置文件。默认会使用 `default` 配置。</small>
+        <div class="mt-6 mb-4">
+          <v-btn prepend-icon="mdi-plus" @click="startCreateConfig" variant="tonal" color="primary">
+            新建配置文件
+          </v-btn>
+        </div>
+
+        <!-- Config List -->
+        <v-list lines="two">
+          <v-list-item v-for="config in configInfoList" :key="config.id" :title="config.name">
+            <v-list-item-subtitle>当前应用于: {{ formatUmop(config.umop) }} </v-list-item-subtitle>
+
+            <template v-slot:append v-if="config.id !== 'default'">
+              <div class="d-flex align-center" style="gap: 8px;">
+                <v-btn icon="mdi-pencil" size="small" variant="text" color="warning"
+                  @click="startEditConfig(config)"></v-btn>
+                <v-btn icon="mdi-delete" size="small" variant="text" color="error"
+                  @click="confirmDeleteConfig(config)"></v-btn>
               </div>
-              <AstrBotConfig v-else :metadata="metadata[key]['metadata']" :iterable="config_data" :metadataKey="key2">
-              </AstrBotConfig>
-            </div>
+            </template>
+          </v-list-item>
+        </v-list>
 
+        <!-- Create/Edit Form -->
+        <v-divider v-if="showConfigForm" class="my-6"></v-divider>
+
+        <div v-if="showConfigForm">
+          <h3 class="mb-4">{{ isEditingConfig ? '编辑配置文件' : '新建配置文件' }}</h3>
+
+          <div class="mb-4">
+            <small v-if="conflictMessage">⚠ {{ conflictMessage }}</small>
           </div>
 
+          <v-text-field v-model="configFormData.name" label="配置文件名称" variant="outlined" class="mb-4"
+            hide-details></v-text-field>
 
+          <v-select v-model="configFormData.umop" :items="platformList" item-title="id" item-value="id" label="应用于平台"
+            variant="outlined" hide-details multiple @update:model-value="checkPlatformConflictOnForm">
+            <template v-slot:item="{ props: itemProps, item }">
+              <v-list-item v-bind="itemProps" :subtitle="item.raw.type"></v-list-item>
+            </template>
+          </v-select>
 
-        </v-container>
-      </v-tabs-window-item>
-
-
-      <div style="margin-left: 16px; padding-bottom: 16px">
-        <small>{{ tm('help.helpPrefix') }} 
-          <a href="https://astrbot.app/" target="_blank">{{ tm('help.documentation') }}</a>
-          {{ tm('help.helpMiddle') }} 
-          <a href="https://qm.qq.com/cgi-bin/qm/qr?k=EYGsuUTfe00_iOu9JTXS7_TEpMkXOvwv&jump_from=webapi&authKey=uUEMKCROfsseS+8IzqPjzV3y1tzy4AkykwTib2jNkOFdzezF9s9XknqnIaf3CDft" target="_blank">{{ tm('help.support') }}</a>{{ tm('help.helpSuffix') }}
-        </small>
-      </div>
-
-    </v-tabs-window>
-  </v-card>
-
-  <!-- 代码编辑 -->
-  <v-card v-else style="background-color: #1e1e1e;">
-    <VueMonacoEditor theme="vs-dark" language="json" height="80vh" style="padding-top: 16px; padding-bottom: 16px;"
-      v-model:value="config_data_str">
-    </VueMonacoEditor>
-  </v-card>
-
-  <v-btn icon="mdi-content-save" size="x-large" style="position: fixed; right: 52px; bottom: 52px;" color="darkprimary"
-    @click="updateConfig">
-  </v-btn>
+          <div class="d-flex justify-end mt-4" style="gap: 8px;">
+            <v-btn variant="text" @click="cancelConfigForm">取消</v-btn>
+            <v-btn color="primary" @click="saveConfigForm"
+              :disabled="!configFormData.name || !configFormData.umop.length || !!conflictMessage">
+              {{ isEditingConfig ? '更新' : '创建' }}
+            </v-btn>
+          </div>
+        </div>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
 
   <v-snackbar :timeout="3000" elevation="24" :color="save_message_success" v-model="save_message_snack">
     {{ save_message }}
@@ -130,23 +181,22 @@
 
 <script>
 import axios from 'axios';
-import AstrBotConfig from '@/components/shared/AstrBotConfig.vue';
+import AstrBotConfigV4 from '@/components/shared/AstrBotConfigV4.vue';
 import WaitingForRestart from '@/components/shared/WaitingForRestart.vue';
 import { VueMonacoEditor } from '@guolao/vue-monaco-editor'
-import config from '@/config';
 import { useI18n, useModuleI18n } from '@/i18n/composables';
 
 export default {
   name: 'ConfigPage',
   components: {
-    AstrBotConfig,
+    AstrBotConfigV4,
     VueMonacoEditor,
     WaitingForRestart
   },
   setup() {
     const { t } = useI18n();
     const { tm } = useModuleI18n('features/config');
-    
+
     return {
       t,
       tm
@@ -154,7 +204,6 @@ export default {
   },
 
   computed: {
-    // 安全访问翻译的计算属性
     messages() {
       return {
         loadError: this.tm('messages.loadError'),
@@ -163,7 +212,22 @@ export default {
         configApplied: this.tm('messages.configApplied'),
         configApplyError: this.tm('messages.configApplyError')
       };
-    }
+    },
+    configInfoNameList() {
+      return this.configInfoList.map(info => info.name);
+    },
+    selectedConfigInfo() {
+      return this.configInfoList.find(info => info.id === this.selectedConfigID) || {};
+    },
+    configSelectItems() {
+      const items = [...this.configInfoList];
+      items.push({
+        id: '_%manage%_',
+        name: '管理配置文件...',
+        umop: []
+      });
+      return items;
+    },
   },
   watch: {
     config_data_str: function (val) {
@@ -172,6 +236,10 @@ export default {
   },
   data() {
     return {
+      codeEditorDialog: false,
+      configManageDialog: false,
+      showConfigForm: false,
+      isEditingConfig: false,
       config_data_has_changed: false,
       config_data_str: "",
       config_data: {
@@ -179,30 +247,79 @@ export default {
       },
       fetched: false,
       metadata: {},
-      provider_config_tmpl: {},
-      adapter_config_tmpl: {}, // 平台适配器
       save_message_snack: false,
       save_message: "",
       save_message_success: "",
-      namespace: "",
-      tab: 0,
-      editorTab: 0, // 0: visual, 1: code
 
-      config_template_tab: 0,
+      tab: 0, // 用于切换配置标签页
+
+      // 配置类型切换
+      configType: 'normal', // 'normal' 或 'system'
+
+      // 系统配置开关
+      isSystemConfig: false,
+
+      // 多配置文件管理
+      selectedConfigID: null, // 用于存储当前选中的配置项信息
+      configInfoList: [],
+      platformList: [],
+      configFormData: {
+        name: '',
+        umop: [],
+      },
+      editingConfigId: null,
+      conflictMessage: '', // 冲突提示信息
     }
   },
   mounted() {
-    this.getConfig();
+    this.getConfigInfoList("default");
+    // 初始化配置类型状态
+    this.configType = this.isSystemConfig ? 'system' : 'normal';
   },
   methods: {
-    getConfig() {
-      // 获取配置
-      axios.get('/api/config/get').then((res) => {
+    getConfigInfoList(abconf_id) {
+      // 获取配置列表
+      axios.get('/api/config/abconfs').then((res) => {
+        this.configInfoList = res.data.data.info_list;
+
+        if (abconf_id) {
+          for (let i = 0; i < this.configInfoList.length; i++) {
+            if (this.configInfoList[i].id === abconf_id) {
+              this.selectedConfigID = this.configInfoList[i].id
+              this.getConfig(abconf_id);
+              break;
+            }
+          }
+        }
+      }).catch((err) => {
+        this.save_message = this.messages.loadError;
+        this.save_message_snack = true;
+        this.save_message_success = "error";
+      });
+    },
+    getPlatformList() {
+      axios.get('/api/config/platform/list').then((res) => {
+        this.platformList = res.data.data.platforms;
+      }).catch((err) => {
+        console.error(this.t('status.dataError'), err);
+      });
+    },
+    getConfig(abconf_id) {
+      this.fetched = false
+      const params = {};
+
+      if (this.isSystemConfig) {
+        params.system_config = '1';
+      } else {
+        params.id = abconf_id || this.selectedConfigID;
+      }
+
+      axios.get('/api/config/abconf', {
+        params: params
+      }).then((res) => {
         this.config_data = res.data.data.config;
         this.fetched = true
         this.metadata = res.data.data.metadata;
-        this.provider_config_tmpl = res.data.data.provider_config_tmpl;
-        this.adapter_config_tmpl = res.data.data.adapter_config_tmpl;
       }).catch((err) => {
         this.save_message = this.messages.loadError;
         this.save_message_snack = true;
@@ -211,12 +328,28 @@ export default {
     },
     updateConfig() {
       if (!this.fetched) return;
-      axios.post('/api/config/astrbot/update', this.config_data).then((res) => {
+
+      const postData = {
+        config: this.config_data
+      };
+
+      if (this.isSystemConfig) {
+        postData.conf_id = 'default';
+      } else {
+        postData.conf_id = this.selectedConfigID;
+      }
+
+      axios.post('/api/config/astrbot/update', postData).then((res) => {
         if (res.data.status === "ok") {
           this.save_message = res.data.message || this.messages.saveSuccess;
           this.save_message_snack = true;
           this.save_message_success = "success";
-          this.$refs.wfr.check();
+
+          if (this.isSystemConfig) {
+            axios.post('/api/stat/restart-core').then(() => {
+              this.$refs.wfr.check();
+            })
+          }
         } else {
           this.save_message = res.data.message || this.messages.saveError;
           this.save_message_snack = true;
@@ -245,27 +378,248 @@ export default {
         this.save_message_snack = true;
       }
     },
-    addFromDefaultConfigTmpl(val, group_name, config_item_name) {
-      console.log(val);
+    createNewConfig() {
+      // 修正为 umo part 形式
+      // 暂时只支持 platform:: 形式
+      const umo_parts = this.configFormData.umop.map(platform => platform + "::");
 
-      let tmpl = this.metadata[group_name]['metadata'][config_item_name]['config_template'][val];
-      let new_tmpl_cfg = JSON.parse(JSON.stringify(tmpl));
-      // new_tmpl_cfg.id = "new_" + val + "_" + this.config_data[config_item_name].length;
-      this.config_data[config_item_name].push(new_tmpl_cfg);
-      this.config_template_tab = this.config_data[config_item_name].length - 1;
+      axios.post('/api/config/abconf/new', {
+        umo_parts: umo_parts,
+        name: this.configFormData.name
+      }).then((res) => {
+        if (res.data.status === "ok") {
+          this.save_message = res.data.message;
+          this.save_message_snack = true;
+          this.save_message_success = "success";
+          this.getConfigInfoList(res.data.data.conf_id);
+          this.cancelConfigForm();
+        } else {
+          this.save_message = res.data.message;
+          this.save_message_snack = true;
+          this.save_message_success = "error";
+        }
+      }).catch((err) => {
+        console.error(err);
+        this.save_message = "新配置文件创建失败";
+        this.save_message_snack = true;
+        this.save_message_success = "error";
+      });
     },
-    deleteItem(config_item_name, index) {
-      console.log(config_item_name, index);
-      let new_list = [];
-      for (let i = 0; i < this.config_data[config_item_name].length; i++) {
-        if (i !== index) {
-          new_list.push(this.config_data[config_item_name][i]);
+    checkPlatformConflict(newPlatforms) {
+      const conflictConfigs = [];
+
+      // 遍历现有的配置文件，排除名为 "default" 的配置
+      for (const config of this.configInfoList) {
+        if (config.name === 'default') {
+          continue; // 跳过 default 配置
+        }
+
+        if (config.umop && config.umop.length > 0) {
+          // 获取现有配置的平台列表
+          const existingPlatforms = config.umop.map(umop => {
+            const platformPart = umop.split(":")[0];
+            return platformPart === "" ? "*" : platformPart; // 空字符串表示所有平台
+          });
+
+          // 检查是否有重复的平台
+          const hasConflict = newPlatforms.some(newPlatform => {
+            return existingPlatforms.includes(newPlatform) || existingPlatforms.includes("*");
+          }) || (newPlatforms.includes("*") && existingPlatforms.length > 0);
+
+          if (hasConflict) {
+            conflictConfigs.push(config);
+          }
         }
       }
-      this.config_data[config_item_name] = new_list;
 
-      if (this.config_template_tab > 0) {
-        this.config_template_tab -= 1;
+      return conflictConfigs;
+    },
+    onConfigSelect(value) {
+      if (value === '_%manage%_') {
+        this.configManageDialog = true;
+        this.getPlatformList();
+        // 重置选择到之前的值
+        this.$nextTick(() => {
+          this.selectedConfigID = this.selectedConfigInfo.id || 'default';
+        });
+      } else {
+        this.getConfig(value);
+      }
+    },
+    startCreateConfig() {
+      this.showConfigForm = true;
+      this.isEditingConfig = false;
+      this.configFormData = {
+        name: '',
+        umop: [],
+      };
+      this.editingConfigId = null;
+      this.conflictMessage = '';
+    },
+    startEditConfig(config) {
+      this.showConfigForm = true;
+      this.isEditingConfig = true;
+      this.editingConfigId = config.id;
+      this.configFormData = {
+        name: config.name || '',
+        umop: config.umop ? config.umop.map(part => part.split("::")[0]).filter(p => p) : [],
+      };
+      this.conflictMessage = '';
+    },
+    cancelConfigForm() {
+      this.showConfigForm = false;
+      this.isEditingConfig = false;
+      this.editingConfigId = null;
+      this.configFormData = {
+        name: '',
+        umop: [],
+      };
+      this.conflictMessage = '';
+    },
+    saveConfigForm() {
+      if (!this.configFormData.name || !this.configFormData.umop.length) {
+        this.save_message = "请填写配置名称和选择应用平台";
+        this.save_message_snack = true;
+        this.save_message_success = "error";
+        return;
+      }
+
+      if (this.conflictMessage) {
+        return;
+      }
+
+      if (this.isEditingConfig) {
+        this.updateConfigInfo();
+      } else {
+        this.createNewConfig();
+      }
+    },
+    confirmDeleteConfig(config) {
+      if (confirm(`确定要删除配置文件 "${config.name}" 吗？此操作不可恢复。`)) {
+        this.deleteConfig(config.id);
+      }
+    },
+    deleteConfig(configId) {
+      axios.post('/api/config/abconf/delete', {
+        id: configId
+      }).then((res) => {
+        if (res.data.status === "ok") {
+          this.save_message = res.data.message;
+          this.save_message_snack = true;
+          this.save_message_success = "success";
+          // 删除成功后，更新配置列表
+          this.getConfigInfoList("default");
+        } else {
+          this.save_message = res.data.message;
+          this.save_message_snack = true;
+          this.save_message_success = "error";
+        }
+      }).catch((err) => {
+        console.error(err);
+        this.save_message = "删除配置文件失败";
+        this.save_message_snack = true;
+        this.save_message_success = "error";
+      });
+    },
+    checkPlatformConflictOnForm() {
+      if (!this.configFormData.umop || this.configFormData.umop.length === 0) {
+        this.conflictMessage = '';
+        return;
+      }
+
+      // 检查与其他配置文件的冲突
+      let conflictConfigs = this.checkPlatformConflict(this.configFormData.umop);
+
+      // 如果是编辑模式，排除当前编辑的配置文件
+      if (this.isEditingConfig && this.editingConfigId) {
+        conflictConfigs = conflictConfigs.filter(config => config.id !== this.editingConfigId);
+      }
+
+      if (conflictConfigs.length > 0) {
+        const conflictNames = conflictConfigs.map(config => config.name).join(', ');
+        this.conflictMessage = `提示：选择的平台与现有配置文件重复：${conflictNames}。AstrBot 将只会应用首个匹配的配置文件。`;
+      } else {
+        this.conflictMessage = '';
+      }
+    },
+    updateConfigInfo() {
+      // 修正为 umo part 形式
+      // 暂时只支持 platform:: 形式
+      const umo_parts = this.configFormData.umop.map(platform => platform + "::");
+
+      axios.post('/api/config/abconf/update', {
+        id: this.editingConfigId,
+        name: this.configFormData.name,
+        umo_parts: umo_parts
+      }).then((res) => {
+        if (res.data.status === "ok") {
+          this.save_message = res.data.message;
+          this.save_message_snack = true;
+          this.save_message_success = "success";
+          this.getConfigInfoList(this.editingConfigId);
+          this.cancelConfigForm();
+        } else {
+          this.save_message = res.data.message;
+          this.save_message_snack = true;
+          this.save_message_success = "error";
+        }
+      }).catch((err) => {
+        console.error(err);
+        this.save_message = "更新配置文件失败";
+        this.save_message_snack = true;
+        this.save_message_success = "error";
+      });
+    },
+    formatUmop(umop) {
+      if (!umop) {
+        return
+      }
+      let ret = ""
+      for (let i = 0; i < umop.length; i++) {
+        let platformPart = umop[i].split(":")[0];
+        if (platformPart === "") {
+          return "所有平台";
+        } else {
+          ret += platformPart + ",";
+        }
+      }
+      ret = ret.slice(0, -1);
+      return ret;
+    },
+    onConfigTypeToggle() {
+      this.isSystemConfig = this.configType === 'system';
+      this.tab = 0; // 重置标签页
+      this.fetched = false; // 重置加载状态
+
+      if (this.isSystemConfig) {
+        // 切换到系统配置
+        this.getConfig();
+      } else {
+        // 切换回普通配置，如果有选中的配置文件则加载，否则加载default
+        if (this.selectedConfigID) {
+          this.getConfig(this.selectedConfigID);
+        } else {
+          this.getConfigInfoList("default");
+        }
+      }
+    },
+    onSystemConfigToggle() {
+      // 保持向后兼容性，更新 configType
+      this.configType = this.isSystemConfig ? 'system' : 'normal';
+
+      this.tab = 0; // 重置标签页
+      this.fetched = false; // 重置加载状态
+
+      if (this.isSystemConfig) {
+        // 切换到系统配置
+        this.getConfig();
+      } else {
+        // 切换回普通配置，如果有选中的配置文件则加载，否则加载default
+        if (this.selectedConfigID) {
+          this.getConfig(this.selectedConfigID);
+        } else {
+          this.getConfigInfoList("default");
+        }
       }
     }
   },
@@ -276,5 +630,58 @@ export default {
 <style>
 .v-tab {
   text-transform: none !important;
+}
+
+/* 按钮切换样式优化 */
+.v-btn-toggle .v-btn {
+  transition: all 0.3s ease !important;
+}
+
+.v-btn-toggle .v-btn:not(.v-btn--active) {
+  opacity: 0.7;
+}
+
+.v-btn-toggle .v-btn.v-btn--active {
+  opacity: 1;
+  font-weight: 600;
+}
+
+@media (min-width: 768px) {
+  .config-tabs {
+    display: flex;
+    margin: 16px 16px 0 0;
+  }
+
+  .config-panel {
+    width: 750px;
+  }
+
+  .config-tabs-window {
+    flex: 1;
+  }
+
+  .config-tabs .v-tab {
+    justify-content: flex-start !important;
+    text-align: left;
+    min-height: 48px;
+  }
+}
+
+@media (max-width: 767px) {
+  .config-tabs {
+    width: 100%;
+  }
+
+  .v-container {
+    padding: 4px;
+  }
+
+  .config-panel {
+    width: 100%;
+  }
+
+  .config-tabs-window {
+    margin-top: 16px;
+  }
 }
 </style>

--- a/dashboard/src/views/PlatformPage.vue
+++ b/dashboard/src/views/PlatformPage.vue
@@ -151,8 +151,6 @@
       {{ save_message }}
     </v-snackbar>
 
-    <WaitingForRestart ref="wfr"></WaitingForRestart>
-
     <!-- ID冲突确认对话框 -->
     <v-dialog v-model="showIdConflictDialog" max-width="450" persistent>
       <v-card>
@@ -359,7 +357,6 @@ export default {
           this.loading = false;
           this.showPlatformCfg = false;
           this.getConfig();
-          this.$refs.wfr.check();
           this.showSuccess(res.data.message || this.messages.updateSuccess);
         }).catch((err) => {
           this.loading = false;
@@ -413,7 +410,6 @@ export default {
       if (confirm(`${this.messages.deleteConfirm} ${platform.id}?`)) {
         axios.post('/api/config/platform/delete', { id: platform.id }).then((res) => {
           this.getConfig();
-          this.$refs.wfr.check();
           this.showSuccess(res.data.message || this.messages.deleteSuccess);
         }).catch((err) => {
           this.showError(err.response?.data?.message || err.message);
@@ -429,7 +425,6 @@ export default {
         config: platform
       }).then((res) => {
         this.getConfig();
-        this.$refs.wfr.check();
         this.showSuccess(res.data.message || this.messages.statusUpdateSuccess);
       }).catch((err) => {
         platform.enable = !platform.enable; // 发生错误时回滚状态

--- a/dashboard/src/views/ProviderPage.vue
+++ b/dashboard/src/views/ProviderPage.vue
@@ -12,9 +12,6 @@
           </p>
         </div>
         <div>
-          <v-btn color="success" prepend-icon="mdi-cog" variant="tonal" class="me-2" @click="showSettingsDialog = true" rounded="xl" size="x-large">
-            {{ tm('providers.settings') }}
-          </v-btn>
           <v-btn color="primary" prepend-icon="mdi-plus" variant="tonal" @click="showAddProviderDialog = true" rounded="xl" size="x-large">
             {{ tm('providers.addProvider') }}
           </v-btn>
@@ -250,49 +247,6 @@
       </v-card>
     </v-dialog>
 
-    <!-- 设置对话框 -->
-    <v-dialog v-model="showSettingsDialog" max-width="600px">
-      <v-card>
-        <v-card-title class="bg-primary text-white py-3 px-4" style="display: flex; align-items: center;">
-          <v-icon color="white" class="me-2">mdi-cog</v-icon>
-          <span>{{ tm('dialogs.settings.title') }}</span>
-          <v-spacer></v-spacer>
-          <v-btn icon variant="text" color="white" @click="showSettingsDialog = false">
-            <v-icon>mdi-close</v-icon>
-          </v-btn>
-        </v-card-title>
-
-        <v-card-text class="pa-4">
-          <v-list>
-            <v-list-item>
-              <v-switch
-                style="padding: 12px;"
-                v-model="sessionSeparationEnabled"
-                color="primary"
-                :loading="sessionSettingLoading"
-                @change="updateSessionSeparation"
-                hide-details
-              >
-                <template v-slot:label>
-                  <div>
-                    <div class="text-subtitle-1">{{ tm('dialogs.settings.sessionSeparation.title') }}</div>
-                    <div class="text-caption text-medium-emphasis">{{ tm('dialogs.settings.sessionSeparation.description') }}</div>
-                  </div>
-                </template>
-              </v-switch>
-            </v-list-item>
-          </v-list>
-        </v-card-text>
-
-        <v-card-actions class="pa-4">
-          <v-spacer></v-spacer>
-          <v-btn variant="text" @click="showSettingsDialog = false">
-            {{ tm('dialogs.settings.close') }}
-          </v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
-
     <!-- 消息提示 -->
     <v-snackbar :timeout="3000" elevation="24" :color="save_message_success" v-model="save_message_snack"
       location="top">
@@ -364,11 +318,6 @@ export default {
       fetched: false,
       metadata: {},
       showProviderCfg: false,
-
-      // 设置对话框相关
-      showSettingsDialog: false,
-      sessionSeparationEnabled: false,
-      sessionSettingLoading: false,
 
       // ID冲突确认对话框
       showIdConflictDialog: false,
@@ -464,10 +413,8 @@ export default {
           add: this.tm('messages.success.add'),
           delete: this.tm('messages.success.delete'),
           statusUpdate: this.tm('messages.success.statusUpdate'),
-          sessionSeparation: this.tm('messages.success.sessionSeparation')
         },
         error: {
-          sessionSeparation: this.tm('messages.error.sessionSeparation'),
           fetchStatus: this.tm('messages.error.fetchStatus')
         },
         confirm: {
@@ -502,7 +449,6 @@ export default {
 
   mounted() {
     this.getConfig();
-    this.getSessionSeparationStatus();
   },
 
   methods: {
@@ -719,32 +665,6 @@ export default {
       }).catch((err) => {
         provider.enable = !provider.enable; // 发生错误时回滚状态
         this.showError(err.response?.data?.message || err.message);
-      });
-    },
-
-    // 获取会话隔离配置状态
-    getSessionSeparationStatus() {
-      axios.get('/api/config/provider/get_session_seperate').then((res) => {
-        if (res.data && res.data.status === 'ok') {
-          this.sessionSeparationEnabled = res.data.data.enable;
-        }
-      }).catch((err) => {
-        this.showError(err.response?.data?.message || this.messages.error.sessionSeparation);
-      });
-    },
-
-    // 更新会话隔离配置
-    updateSessionSeparation() {
-      this.sessionSettingLoading = true;
-      axios.post('/api/config/provider/set_session_seperate', {
-        enable: this.sessionSeparationEnabled
-      }).then((res) => {
-        this.showSuccess(res.data.message || this.messages.success.sessionSeparation);
-        this.sessionSettingLoading = false;
-      }).catch((err) => {
-        this.sessionSeparationEnabled = !this.sessionSeparationEnabled; // 发生错误时回滚状态
-        this.showError(err.response?.data?.message || err.message);
-        this.sessionSettingLoading = false;
       });
     },
 

--- a/packages/astrbot/long_term_memory.py
+++ b/packages/astrbot/long_term_memory.py
@@ -8,6 +8,7 @@ from astrbot.api.provider import ProviderRequest
 from astrbot.api.message_components import Plain, Image
 from astrbot import logger
 from collections import defaultdict
+from astrbot.core.astrbot_config_mgr import AstrBotConfigManager
 
 """
 聊天记忆增强
@@ -15,28 +16,40 @@ from collections import defaultdict
 
 
 class LongTermMemory:
-    def __init__(self, config: dict, context: star.Context):
-        self.config = config
+    def __init__(self, acm: AstrBotConfigManager, context: star.Context):
+        self.acm = acm
         self.context = context
         self.session_chats = defaultdict(list)
         """记录群成员的群聊记录"""
+
+    def cfg(self, event: AstrMessageEvent):
+        cfg = self.context.get_config(umo=event.unified_msg_origin)
         try:
-            self.max_cnt = int(self.config["group_message_max_cnt"])
+            max_cnt = int(cfg["group_message_max_cnt"])
         except BaseException as e:
             logger.error(e)
-            self.max_cnt = 300
-        self.image_caption = self.config["image_caption"]
-        self.image_caption_prompt = self.config["image_caption_prompt"]
-        self.image_caption_provider_id = self.config["image_caption_provider_id"]
-
-        self.active_reply = self.config["active_reply"]
-        self.enable_active_reply = self.active_reply.get("enable", False)
-        self.ar_method = self.active_reply["method"]
-        self.ar_possibility = self.active_reply["possibility_reply"]
-        self.ar_prompt = self.active_reply.get("prompt", "")
-        self.ar_whitelist = self.active_reply.get("whitelist", [])
-
-        # self.put_history_to_prompt = self.config["put_history_to_prompt"]
+            max_cnt = 300
+        image_caption = cfg["image_caption"]
+        image_caption_prompt = cfg["image_caption_prompt"]
+        image_caption_provider_id = cfg["image_caption_provider_id"]
+        active_reply = cfg["active_reply"]
+        enable_active_reply = active_reply.get("enable", False)
+        ar_method = active_reply["method"]
+        ar_possibility = active_reply["possibility_reply"]
+        ar_prompt = active_reply.get("prompt", "")
+        ar_whitelist = active_reply.get("whitelist", [])
+        ret = {
+            "max_cnt": max_cnt,
+            "image_caption": image_caption,
+            "image_caption_prompt": image_caption_prompt,
+            "image_caption_provider_id": image_caption_provider_id,
+            "enable_active_reply": enable_active_reply,
+            "ar_method": ar_method,
+            "ar_possibility": ar_possibility,
+            "ar_prompt": ar_prompt,
+            "ar_whitelist": ar_whitelist,
+        }
+        return ret
 
     async def remove_session(self, event: AstrMessageEvent) -> int:
         cnt = 0
@@ -45,17 +58,17 @@ class LongTermMemory:
             del self.session_chats[event.unified_msg_origin]
         return cnt
 
-    async def get_image_caption(self, image_url: str) -> str:
-        if not self.image_caption_provider_id:
+    async def get_image_caption(
+        self, image_url: str, image_caption_provider_id: str, image_caption_prompt: str
+    ) -> str:
+        if not image_caption_provider_id:
             provider = self.context.get_using_provider()
         else:
-            provider = self.context.get_provider_by_id(self.image_caption_provider_id)
+            provider = self.context.get_provider_by_id(image_caption_provider_id)
             if not provider:
-                raise Exception(
-                    f"没有找到 ID 为 {self.image_caption_provider_id} 的提供商"
-                )
+                raise Exception(f"没有找到 ID 为 {image_caption_provider_id} 的提供商")
         response = await provider.text_chat(
-            prompt=self.image_caption_prompt,
+            prompt=image_caption_prompt,
             session_id=uuid.uuid4().hex,
             image_urls=[image_url],
             persist=False,
@@ -63,7 +76,8 @@ class LongTermMemory:
         return response.completion_text
 
     async def need_active_reply(self, event: AstrMessageEvent) -> bool:
-        if not self.enable_active_reply:
+        cfg = self.cfg(event)
+        if not cfg["enable_active_reply"]:
             return False
         if event.get_message_type() != MessageType.GROUP_MESSAGE:
             return False
@@ -72,15 +86,15 @@ class LongTermMemory:
             # if the message is a command, let it pass
             return False
 
-        if self.ar_whitelist and (
-            event.unified_msg_origin not in self.ar_whitelist
-            and (event.get_group_id() and event.get_group_id() not in self.ar_whitelist)
+        if cfg["ar_whitelist"] and (
+            event.unified_msg_origin not in cfg["ar_whitelist"]
+            and (event.get_group_id() and event.get_group_id() not in cfg["ar_whitelist"])
         ):
             return False
 
-        match self.ar_method:
+        match cfg["ar_method"]:
             case "possibility_reply":
-                trig = random.random() < self.ar_possibility
+                trig = random.random() < cfg["ar_possibility"]
                 return trig
 
         return False
@@ -92,15 +106,19 @@ class LongTermMemory:
 
             final_message = f"[{event.message_obj.sender.nickname}/{datetime_str}]: "
 
+            cfg = self.cfg(event)
+
             for comp in event.get_messages():
                 if isinstance(comp, Plain):
                     final_message += f" {comp.text}"
                 elif isinstance(comp, Image):
-                    # image_urls.append(comp.url if comp.url else comp.file)
-                    if self.image_caption:
+                    cfg = self.cfg(event)
+                    if cfg["image_caption"]:
                         try:
                             caption = await self.get_image_caption(
-                                comp.url if comp.url else comp.file
+                                comp.url if comp.url else comp.file,
+                                cfg["image_caption_provider_id"],
+                                cfg["image_caption_prompt"],
                             )
                             final_message += f" [Image: {caption}]"
                         except Exception as e:
@@ -109,7 +127,7 @@ class LongTermMemory:
                         final_message += " [Image]"
             logger.debug(f"ltm | {event.unified_msg_origin} | {final_message}")
             self.session_chats[event.unified_msg_origin].append(final_message)
-            if len(self.session_chats[event.unified_msg_origin]) > self.max_cnt:
+            if len(self.session_chats[event.unified_msg_origin]) > cfg["max_cnt"]:
                 self.session_chats[event.unified_msg_origin].pop(0)
 
     async def on_req_llm(self, event: AstrMessageEvent, req: ProviderRequest):
@@ -119,7 +137,8 @@ class LongTermMemory:
 
         chats_str = "\n---\n".join(self.session_chats[event.unified_msg_origin])
 
-        if self.enable_active_reply:
+        cfg = self.cfg(event)
+        if cfg["enable_active_reply"]:
             prompt = req.prompt
             req.prompt = f"You are now in a chatroom. The chat history is as follows:\n{chats_str}"
             req.prompt += f"\nNow, a new message is coming: `{prompt}`. Please react to it. Only output your response and do not output any other information."
@@ -138,5 +157,6 @@ class LongTermMemory:
             final_message = f"[You/{datetime.datetime.now().strftime('%H:%M:%S')}]: {event.get_result().get_plain_text()}"
             logger.debug(f"ltm | {event.unified_msg_origin} | {final_message}")
             self.session_chats[event.unified_msg_origin].append(final_message)
-            if len(self.session_chats[event.unified_msg_origin]) > self.max_cnt:
+            cfg = self.cfg(event)
+            if len(self.session_chats[event.unified_msg_origin]) > cfg["max_cnt"]:
                 self.session_chats[event.unified_msg_origin].pop(0)

--- a/packages/astrbot/long_term_memory.py
+++ b/packages/astrbot/long_term_memory.py
@@ -30,8 +30,8 @@ class LongTermMemory:
             logger.error(e)
             max_cnt = 300
         image_caption = cfg["image_caption"]
-        image_caption_prompt = cfg["image_caption_prompt"]
-        image_caption_provider_id = cfg["image_caption_provider_id"]
+        image_caption_prompt = cfg["image_caption_prompt"] # TODO: 去掉这个配置项
+        image_caption_provider_id = cfg["image_caption_provider_id"] # TODO: 去掉这个配置项
         active_reply = cfg["active_reply"]
         enable_active_reply = active_reply.get("enable", False)
         ar_method = active_reply["method"]

--- a/packages/thinking_filter/main.py
+++ b/packages/thinking_filter/main.py
@@ -8,15 +8,13 @@ from openai.types.chat.chat_completion import ChatCompletion
 class R1Filter(Star):
     def __init__(self, context: Context):
         super().__init__(context)
-        self.display_reasoning_text = (
-            self.context.get_config()
-            .get("provider_settings", {})
-            .get("display_reasoning_text", False)
-        )
 
     @filter.on_llm_response()
     async def resp(self, event: AstrMessageEvent, response: LLMResponse):
-        if self.display_reasoning_text:
+        cfg = self.context.get_config(umo=event.unified_msg_origin).get(
+            "provider_settings", {}
+        )
+        if cfg.get("display_reasoning_text", False):
             # 显示推理内容的处理逻辑
             if (
                 response


### PR DESCRIPTION
### Motivation

更灵活的、会话粒度的（基于 umo part）配置文件隔离。

使用场景

*待补充*

### Modifications

#### UMO Part

AstrBot 内部的 UMO 用于表示一个会话的来源，其结构异常简单，由三个部分组成 [platform_id]:[message_type]:[session_id]。

UMO Part 可以用来指定 UMO 的范围，即类似于正则表达式。可以是 "::" (代表所有), 也可以是 "[platform_id]::" (代表指定平台下的所有类型消息和会话)，也可以是 "[platform_id]:FriendMessage:" (代表指定平台下的所有私聊消息)。

#### AstrBotConfigManager

本次更改中，对配置文件的管理进行了大批量重构，以支持用户自行通过 UMO Part 列表来选择某个配置文件的应用范围。

PipelineScheduler 是 AstrBot 的 Pipeline 调度器实现。在过去，一个 AstrBot 实例只会启动一个调度器。本实现为每个配置文件分配了独立的调度器实例，以从高层来将来自不同会话的消息事件通过 Event Bus 打到指定的 Pipeline 当中。

为统一管理配置文件，特创建了一个 AstrBotConfigManager。每个新增的配置文件由 UUID（或者 default） 来标识，持久化在 `data/config/abconf_<UUID>.json` 下。映射关系目前存储在 SharedPreference 中。配置文件列表中，至少会存在一个 ID 为 `"default"` 的配置文件，其为默认配置文件，其 UMO Parts 为 `["::"]`。一个会话的事件只会打入一个 Pipeline 中，至少会打入 `default` Pipeline。**服务提供商、消息平台适配器的配置文件仍然并且只存储在 `default` 配置文件中。**

> 后期 SharedPreference 会重构为持久化在数据库中。

#### 前向兼容

本更改对前向兼容量力而为，尽可能实现了对旧版本的兼容性，正常情况下用户可以无缝升级。

需要注意的是，直接调用了 AstrBot 的配置文件的插件需要在 event.get_config() 中加入 `umo` 参数，否则会使用 `default` 配置文件。

#### 移除的组件

本更改移除了 `websearch` 指令。


#### TODO

- [ ] 更新前端文件
- [ ] 完善的回归测试

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 总结

通过引入 UMO Part 模式并管理多个配置文件，实现会话粒度配置隔离，并重构核心组件以实现按会话分派事件和检索设置。

新功能：
- 支持 UMO Part 模式，以会话粒度匹配和隔离配置
- 添加 AstrBotConfigManager 以加载、创建和管理由 UUID 和 UMO 模式映射的多个配置文件
- 为每个配置文件初始化独立的 PipelineScheduler，并根据会话来源路由事件

改进：
- 重构 Context.get_config、EventBus、核心生命周期和 PipelineContext，以获取和应用会话特定的配置
- 更新 LongTermMemory、命令 (llm, t2i, wl/dwl)、session_controller 和 thinking_filter 以使用按会话设置
- 将 MessageSession 移至其独立模块，并调整整个代码库中的引用
- 废弃并移除代码中的 websearch 命令，将控制权委派给 WebUI

杂项：
- 移除过时的 websearch 插件初始化和处理程序

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable session-granular configuration isolation by introducing UMO Part patterns and managing multiple config files, and refactor core components to dispatch events and retrieve settings per-session.

New Features:
- Support UMO Part patterns to match and isolate configurations at session granularity
- Add AstrBotConfigManager to load, create and manage multiple configuration files mapped by UUID and UMO patterns
- Initialize a separate PipelineScheduler for each configuration file and route events based on session origin

Enhancements:
- Refactor Context.get_config, EventBus, core lifecycle and PipelineContext to fetch and apply session-specific configs
- Update LongTermMemory, commands (llm, t2i, wl/dwl), session_controller and thinking_filter to use per-session settings
- Move MessageSession into its own module and adjust references across the codebase
- Deprecate and remove the in-code websearch command, delegating control to the WebUI

Chores:
- Remove obsolete websearch plugin initialization and handlers

</details>