### PR TITLE
fix: 修复插件的 terminate 方法无法被正常调用的问题（v3.5.23 及以上版本可见）

### DIFF
--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -809,11 +809,11 @@ class PluginManager:
         if star_metadata.star_cls is None:
             return
 
-        if hasattr(star_metadata.star_cls, "__del__"):
+        if '__del__' in star_metadata.star_cls_type.__dict__:
             asyncio.get_event_loop().run_in_executor(
                 None, star_metadata.star_cls.__del__
             )
-        elif hasattr(star_metadata.star_cls, "terminate"):
+        elif 'terminate' in star_metadata.star_cls_type.__dict__:
             await star_metadata.star_cls.terminate()
 
     async def turn_on_plugin(self, plugin_name: str):


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->

### Motivation

原代码是这么写的：
```
if hasattr(star_metadata.star_cls, "__del__"):
    asyncio.get_event_loop().run_in_executor(
        None, star_metadata.star_cls.__del__
    )
elif hasattr(star_metadata.star_cls, "terminate"):
    await star_metadata.star_cls.terminate()
```
原意：终止插件时，先判断插件类是否存在`__del__`方法，如果有则执行`__del__`方法，否则判断是否存在`terminate`方法，如果存在则执行`terminate`方法。

问题：文件`astrbot/core/star/__init__.py`中`Star`类定义了`__del__`方法，插件类会继承这个方法，而`hasattr(star_metadata.star_cls, "__del__")`这条语句无法判断这个方法是插件类自身定义的，还是从父类继承的。这使得对于所有插件，`hasattr(star_metadata.star_cls, "__del__")`始终为`True`，进而导致无法调用`terminate`方法。

### Modifications

将判断是否存在`__del__`方法的语句改为`'__del__' in star_metadata.star_cls_type.__dict__`，这样可以判断插件类自身是否定义了`__del__`方法。（`terminate`仿此）

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 总结

错误修复：
- 将 `hasattr` 检查替换为类 `__dict__` 中的 `'__del__'` / `'terminate'`，以避免总是检测到继承的 `__del__` 并确保 `terminate` 被调用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Replace hasattr checks with '__del__'/'terminate' in class __dict__ to avoid always detecting inherited __del__ and ensure terminate is called.

</details>