### PR TITLE
fix: 修复无法清空http_proxy代理的问题

### DIFF
--- a/astrbot/core/core_lifecycle.py
+++ b/astrbot/core/core_lifecycle.py
@@ -47,11 +47,18 @@ class AstrBotCoreLifecycle:
         self.db = db  # 初始化数据库
 
         # 设置代理
-        if self.astrbot_config.get("http_proxy", ""):
-            os.environ["https_proxy"] = self.astrbot_config["http_proxy"]
-            os.environ["http_proxy"] = self.astrbot_config["http_proxy"]
-        if proxy := os.environ.get("https_proxy"):
-            logger.debug(f"Using proxy: {proxy}")
+        proxy_config = self.astrbot_config.get("http_proxy", "")
+        if proxy_config != "":
+            os.environ["https_proxy"] = proxy_config
+            os.environ["http_proxy"] = proxy_config
+            logger.debug(f"Using proxy: {proxy_config}")
+        else:
+            # 清空代理环境变量
+            if "https_proxy" in os.environ:
+                del os.environ["https_proxy"]
+            if "http_proxy" in os.environ:
+                del os.environ["http_proxy"]
+            logger.debug("HTTP proxy cleared")
         os.environ["no_proxy"] = "localhost"
 
     async def initialize(self):


### PR DESCRIPTION
修复了无法清空http_proxy代理的问题

### Motivation

这个commit引入了新的问题导致无法清空代理配置：https://github.com/AstrBotDevs/AstrBot/commit/3e715399a1ecaf37276159c567fc8f537128436e
在清空配置文件，软重启后os.environ["http_proxy"]或os.environ["https_proxy"]该环境变量依然作用于Astrbot进程，并没有被删除或清空

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码
