### PR TITLE
Refactor: 重构 SharedPreference 类并采用数据库存储替换 json 存储

### DIFF
--- a/astrbot/core/__init__.py
+++ b/astrbot/core/__init__.py
@@ -20,7 +20,7 @@ html_renderer = HtmlRenderer(t2i_base_url)
 logger = LogManager.GetLogger(log_name="astrbot")
 db_helper = SQLiteDatabase(DB_PATH)
 # 简单的偏好设置存储, 这里后续应该存储到数据库中, 一些部分可以存储到配置中
-sp = SharedPreferences()
+sp = SharedPreferences(db_helper=db_helper)
 # 文件令牌服务
 file_token_service = FileTokenService()
 pip_installer = PipInstaller(

--- a/astrbot/core/astrbot_config_mgr.py
+++ b/astrbot/core/astrbot_config_mgr.py
@@ -40,7 +40,9 @@ class AstrBotConfigManager:
 
     def _load_all_configs(self):
         """Load all configurations from the shared preferences."""
-        abconf_data = self.sp.get("abconf_mapping", {})
+        abconf_data = self.sp.get(
+            "abconf_mapping", {}, scope="global", scope_id="global"
+        )
         for uuid_, meta in abconf_data.items():
             filename = meta["path"]
             conf_path = os.path.join(get_astrbot_config_path(), filename)
@@ -55,13 +57,13 @@ class AstrBotConfigManager:
 
     def _is_umo_match(self, p1: str, p2: str) -> bool:
         """判断 p2 umo 是否逻辑包含于 p1 umo"""
-        p1 = p1.split(":")
-        p2 = p2.split(":")
+        p1_ls = p1.split(":")
+        p2_ls = p2.split(":")
 
-        if len(p1) != 3 or len(p2) != 3:
+        if len(p1_ls) != 3 or len(p2_ls) != 3:
             return False  # 非法格式
 
-        return all(p == "" or p == t for p, t in zip(p1, p2))
+        return all(p == "" or p == t for p, t in zip(p1_ls, p2_ls))
 
     def _load_conf_mapping(self, umo: str | MessageSession) -> ConfInfo:
         """获取指定 umo 的配置文件 uuid, 如果不存在则返回默认配置(返回 "default")
@@ -70,7 +72,9 @@ class AstrBotConfigManager:
             ConfInfo: 包含配置文件的 uuid, 路径和名称等信息, 是一个 dict 类型
         """
         # uuid -> { "umop": list, "path": str, "name": str }
-        abconf_data = self.sp.get("abconf_mapping", {})  # default is not included here
+        abconf_data = self.sp.get(
+            "abconf_mapping", {}, scope="global", scope_id="global"
+        )
         if isinstance(umo, MessageSession):
             umo = str(umo)
         else:
@@ -91,7 +95,7 @@ class AstrBotConfigManager:
         abconf_path: str,
         abconf_id: str,
         umo_parts: list[str] | list[MessageSession],
-        abconf_name: str = None,
+        abconf_name: str | None = None,
     ) -> None:
         """保存配置文件的映射关系"""
         for part in umo_parts:
@@ -101,14 +105,16 @@ class AstrBotConfigManager:
                 raise ValueError(
                     "umo_parts must be a list of strings or MessageSession instances"
                 )
-        abconf_data = self.sp.get("abconf_mapping", {})
+        abconf_data = self.sp.get(
+            "abconf_mapping", {}, scope="global", scope_id="global"
+        )
         random_word = abconf_name or uuid.uuid4().hex[:8]
         abconf_data[abconf_id] = {
             "umop": umo_parts,
             "path": abconf_path,
             "name": random_word,
         }
-        self.sp.put("abconf_mapping", abconf_data)
+        self.sp.put("abconf_mapping", abconf_data, scope="global", scope_id="global")
 
     def get_conf(self, umo: str | MessageSession | None) -> AstrBotConfig:
         """获取指定 umo 的配置文件。如果不存在，则 fallback 到默认配置文件。"""
@@ -141,7 +147,10 @@ class AstrBotConfigManager:
         """获取所有配置文件的元数据列表"""
         conf_list = []
         conf_list.append(DEFAULT_CONFIG_CONF_INFO)
-        for uuid_, meta in self.sp.get("abconf_mapping", {}).items():
+        abconf_mapping = self.sp.get(
+            "abconf_mapping", {}, scope="global", scope_id="global"
+        )
+        for uuid_, meta in abconf_mapping.items():
             conf_list.append(ConfInfo(**meta, id=uuid_))
         return conf_list
 
@@ -149,7 +158,7 @@ class AstrBotConfigManager:
         self,
         umo_parts: list[str] | list[MessageSession],
         config: dict = DEFAULT_CONFIG,
-        name: str = None,
+        name: str | None = None,
     ) -> str:
         """
         umo 由三个部分组成 [platform_id]:[message_type]:[session_id]。
@@ -181,7 +190,9 @@ class AstrBotConfigManager:
             raise ValueError("不能删除默认配置文件")
 
         # 从映射中移除
-        abconf_data = self.sp.get("abconf_mapping", {})
+        abconf_data = self.sp.get(
+            "abconf_mapping", {}, scope="global", scope_id="global"
+        )
         if conf_id not in abconf_data:
             logger.warning(f"配置文件 {conf_id} 不存在于映射中")
             return False
@@ -206,13 +217,13 @@ class AstrBotConfigManager:
 
         # 从映射中移除
         del abconf_data[conf_id]
-        self.sp.put("abconf_mapping", abconf_data)
+        self.sp.put("abconf_mapping", abconf_data, scope="global", scope_id="global")
 
         logger.info(f"成功删除配置文件 {conf_id}")
         return True
 
     def update_conf_info(
-        self, conf_id: str, name: str = None, umo_parts: list[str] = None
+        self, conf_id: str, name: str | None = None, umo_parts: list[str] | None = None
     ) -> bool:
         """更新配置文件信息
 
@@ -227,7 +238,9 @@ class AstrBotConfigManager:
         if conf_id == "default":
             raise ValueError("不能更新默认配置文件的信息")
 
-        abconf_data = self.sp.get("abconf_mapping", {})
+        abconf_data = self.sp.get(
+            "abconf_mapping", {}, scope="global", scope_id="global"
+        )
         if conf_id not in abconf_data:
             logger.warning(f"配置文件 {conf_id} 不存在于映射中")
             return False
@@ -249,11 +262,13 @@ class AstrBotConfigManager:
             abconf_data[conf_id]["umop"] = umo_parts
 
         # 保存更新
-        self.sp.put("abconf_mapping", abconf_data)
+        self.sp.put("abconf_mapping", abconf_data, scope="global", scope_id="global")
         logger.info(f"成功更新配置文件 {conf_id} 的信息")
         return True
 
-    def g(self, umo: str = None, key: str = None, default: _VT = None) -> _VT:
+    def g(
+        self, umo: str | None = None, key: str | None = None, default: _VT = None
+    ) -> _VT:
         """获取配置项。umo 为 None 时使用默认配置"""
         if umo is None:
             return self.confs["default"].get(key, default)

--- a/astrbot/core/db/__init__.py
+++ b/astrbot/core/db/__init__.py
@@ -74,7 +74,7 @@ class BaseDatabase(abc.ABC):
         platform_id: str,
         platform_type: str,
         count: int = 1,
-        timestamp: datetime.datetime = None,
+        timestamp: datetime.datetime | None = None,
     ) -> None:
         """Insert a new platform statistic record."""
         ...
@@ -91,7 +91,7 @@ class BaseDatabase(abc.ABC):
 
     @abc.abstractmethod
     async def get_conversations(
-        self, user_id: str = None, platform_id: str = None
+        self, user_id: str | None = None, platform_id: str | None = None
     ) -> list[ConversationV2]:
         """Get all conversations for a specific user and platform_id(optional).
 
@@ -128,12 +128,12 @@ class BaseDatabase(abc.ABC):
         self,
         user_id: str,
         platform_id: str,
-        content: list[dict] = None,
-        title: str = None,
-        persona_id: str = None,
-        cid: str = None,
-        created_at: datetime.datetime = None,
-        updated_at: datetime.datetime = None,
+        content: list[dict] | None = None,
+        title: str | None = None,
+        persona_id: str | None = None,
+        cid: str | None = None,
+        created_at: datetime.datetime | None = None,
+        updated_at: datetime.datetime | None = None,
     ) -> ConversationV2:
         """Create a new conversation."""
         ...
@@ -142,9 +142,9 @@ class BaseDatabase(abc.ABC):
     async def update_conversation(
         self,
         cid: str,
-        title: str = None,
-        persona_id: str = None,
-        content: list[dict] = None,
+        title: str | None = None,
+        persona_id: str | None = None,
+        content: list[dict] | None = None,
     ) -> None:
         """Update a conversation's history."""
         ...
@@ -160,8 +160,8 @@ class BaseDatabase(abc.ABC):
         platform_id: str,
         user_id: str,
         content: list[dict],
-        sender_id: str = None,
-        sender_name: str = None,
+        sender_id: str | None = None,
+        sender_name: str | None = None,
     ) -> None:
         """Insert a new platform message history record."""
         ...
@@ -204,8 +204,8 @@ class BaseDatabase(abc.ABC):
         self,
         persona_id: str,
         system_prompt: str,
-        begin_dialogs: list[str] = None,
-        tools: list[str] = None,
+        begin_dialogs: list[str] | None = None,
+        tools: list[str] | None = None,
     ) -> Persona:
         """Insert a new persona record."""
         ...
@@ -224,9 +224,9 @@ class BaseDatabase(abc.ABC):
     async def update_persona(
         self,
         persona_id: str,
-        system_prompt: str = None,
-        begin_dialogs: list[str] = None,
-        tools: list[str] = None,
+        system_prompt: str | None = None,
+        begin_dialogs: list[str] | None = None,
+        tools: list[str] | None = None,
     ) -> Persona | None:
         """Update a persona's system prompt or begin dialogs."""
         ...
@@ -237,13 +237,32 @@ class BaseDatabase(abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def insert_preference_or_update(self, key: str, value: str) -> Preference:
+    async def insert_preference_or_update(
+        self, scope: str, scope_id: str, key: str, value: dict
+    ) -> Preference:
         """Insert a new preference record."""
         ...
 
     @abc.abstractmethod
-    async def get_preference(self, key: str) -> Preference:
-        """Get a preference by bot ID and key."""
+    async def get_preference(self, scope: str, scope_id: str, key: str) -> Preference:
+        """Get a preference by scope ID and key."""
+        ...
+
+    @abc.abstractmethod
+    async def get_preferences(
+        self, scope: str, scope_id: str | None = None, key: str | None = None
+    ) -> list[Preference]:
+        """Get all preferences for a specific scope ID or key."""
+        ...
+
+    @abc.abstractmethod
+    async def remove_preference(self, scope: str, scope_id: str, key: str) -> None:
+        """Remove a preference by scope ID and key."""
+        ...
+
+    @abc.abstractmethod
+    async def clear_preferences(self, scope: str, scope_id: str) -> None:
+        """Clear all preferences for a specific scope ID."""
         ...
 
     # @abc.abstractmethod

--- a/astrbot/core/db/migration/shared_preferences_v3.py
+++ b/astrbot/core/db/migration/shared_preferences_v3.py
@@ -1,0 +1,45 @@
+import json
+import os
+from typing import TypeVar
+from astrbot.core.utils.astrbot_path import get_astrbot_data_path
+
+_VT = TypeVar("_VT")
+
+class SharedPreferences:
+    def __init__(self, path=None):
+        if path is None:
+            path = os.path.join(get_astrbot_data_path(), "shared_preferences.json")
+        self.path = path
+        self._data = self._load_preferences()
+
+    def _load_preferences(self):
+        if os.path.exists(self.path):
+            try:
+                with open(self.path, "r") as f:
+                    return json.load(f)
+            except json.JSONDecodeError:
+                os.remove(self.path)
+        return {}
+
+    def _save_preferences(self):
+        with open(self.path, "w") as f:
+            json.dump(self._data, f, indent=4, ensure_ascii=False)
+            f.flush()
+
+    def get(self, key, default: _VT = None) -> _VT:
+        return self._data.get(key, default)
+
+    def put(self, key, value):
+        self._data[key] = value
+        self._save_preferences()
+
+    def remove(self, key):
+        if key in self._data:
+            del self._data[key]
+            self._save_preferences()
+
+    def clear(self):
+        self._data.clear()
+        self._save_preferences()
+
+sp = SharedPreferences()

--- a/astrbot/core/db/po.py
+++ b/astrbot/core/db/po.py
@@ -97,16 +97,32 @@ class Persona(SQLModel, table=True):
 
 
 class Preference(SQLModel, table=True):
-    """This class represents user preferences for bots."""
+    """This class represents preferences for bots."""
 
     __tablename__ = "preferences"
 
-    key: str = Field(primary_key=True, nullable=False)
-    value: str = Field(sa_type=Text, nullable=False)
+    id: int | None = Field(
+        default=None, primary_key=True, sa_column_kwargs={"autoincrement": True}
+    )
+    scope: str = Field(nullable=False)
+    """Scope of the preference, such as 'global', 'umo', 'plugin'."""
+    scope_id: str = Field(nullable=False)
+    """ID of the scope, such as 'global', 'umo', 'plugin_name'."""
+    key: str = Field(nullable=False)
+    value: dict = Field(sa_type=JSON, nullable=False)
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
         sa_column_kwargs={"onupdate": datetime.now(timezone.utc)},
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "scope",
+            "scope_id",
+            "key",
+            name="uix_preference_scope_scope_id_key",
+        ),
     )
 
 
@@ -184,8 +200,8 @@ class Conversation:
     """对话 ID, 是 uuid 格式的字符串"""
     history: str = ""
     """字符串格式的对话列表。"""
-    title: str = ""
-    persona_id: str = ""
+    title: str | None = ""
+    persona_id: str | None = ""
     created_at: int = 0
     updated_at: int = 0
 

--- a/astrbot/core/platform/sources/webchat/webchat_adapter.py
+++ b/astrbot/core/platform/sources/webchat/webchat_adapter.py
@@ -77,7 +77,7 @@ class WebChatAdapter(Platform):
         os.makedirs(self.imgs_dir, exist_ok=True)
 
         self.metadata = PlatformMetadata(
-            name="webchat", description="webchat", id=self.config.get("id", "")
+            name="webchat", description="webchat", id="webchat"
         )
 
     async def send_by_session(

--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -425,10 +425,17 @@ class FunctionToolManager:
         if func_tool is not None:
             func_tool.active = False
 
-            inactivated_llm_tools: list = sp.get("inactivated_llm_tools", [])
+            inactivated_llm_tools: list = sp.get(
+                "inactivated_llm_tools", [], scope="global", scope_id="global"
+            )
             if name not in inactivated_llm_tools:
                 inactivated_llm_tools.append(name)
-                sp.put("inactivated_llm_tools", inactivated_llm_tools)
+                sp.put(
+                    "inactivated_llm_tools",
+                    inactivated_llm_tools,
+                    scope="global",
+                    scope_id="global",
+                )
 
             return True
         return False
@@ -445,10 +452,17 @@ class FunctionToolManager:
 
             func_tool.active = True
 
-            inactivated_llm_tools: list = sp.get("inactivated_llm_tools", [])
+            inactivated_llm_tools: list = sp.get(
+                "inactivated_llm_tools", [], scope="global", scope_id="global"
+            )
             if name in inactivated_llm_tools:
                 inactivated_llm_tools.remove(name)
-                sp.put("inactivated_llm_tools", inactivated_llm_tools)
+                sp.put(
+                    "inactivated_llm_tools",
+                    inactivated_llm_tools,
+                    scope="global",
+                    scope_id="global",
+                )
 
             return True
         return False

--- a/astrbot/core/provider/sources/dashscope_source.py
+++ b/astrbot/core/provider/sources/dashscope_source.py
@@ -75,8 +75,7 @@ class ProviderDashscope(ProviderOpenAIOfficial):
         # 获得会话变量
         payload_vars = self.variables.copy()
         # 动态变量
-        session_vars = sp.get("session_variables", {})
-        session_var = session_vars.get(session_id, {})
+        session_var = await sp.session_get(session_id, "session_variables", default={})
         payload_vars.update(session_var)
 
         if (

--- a/astrbot/core/provider/sources/dify_source.py
+++ b/astrbot/core/provider/sources/dify_source.py
@@ -97,8 +97,7 @@ class ProviderDify(Provider):
         # 获得会话变量
         payload_vars = self.variables.copy()
         # 动态变量
-        session_vars = sp.get("session_variables", {})
-        session_var = session_vars.get(session_id, {})
+        session_var = await sp.session_get(session_id, "session_variables", default={})
         payload_vars.update(session_var)
         payload_vars["system_prompt"] = system_prompt
 

--- a/astrbot/core/star/session_llm_manager.py
+++ b/astrbot/core/star/session_llm_manager.py
@@ -2,8 +2,6 @@
 会话服务管理器 - 负责管理每个会话的LLM、TTS等服务的启停状态
 """
 
-from typing import Dict
-
 from astrbot.core import logger, sp
 from astrbot.core.platform.astr_message_event import AstrMessageEvent
 
@@ -26,8 +24,9 @@ class SessionServiceManager:
             bool: True表示启用，False表示禁用
         """
         # 获取会话服务配置
-        session_config = sp.get("session_service_config", {}) or {}
-        session_services = session_config.get(session_id, {})
+        session_services = sp.get(
+            "session_service_config", {}, scope="umo", scope_id=session_id
+        )
 
         # 如果配置了该会话的LLM状态，返回该状态
         llm_enabled = session_services.get("llm_enabled")
@@ -45,16 +44,13 @@ class SessionServiceManager:
             session_id: 会话ID (unified_msg_origin)
             enabled: True表示启用，False表示禁用
         """
-        # 获取当前配置
-        session_config = sp.get("session_service_config", {}) or {}
-        if session_id not in session_config:
-            session_config[session_id] = {}
-
-        # 设置LLM状态
-        session_config[session_id]["llm_enabled"] = enabled
-
-        # 保存配置
-        sp.put("session_service_config", session_config)
+        session_config = (
+            sp.get("session_service_config", {}, scope="umo", scope_id=session_id) or {}
+        )
+        session_config["llm_enabled"] = enabled
+        sp.put(
+            "session_service_config", session_config, scope="umo", scope_id=session_id
+        )
 
         logger.info(
             f"会话 {session_id} 的LLM状态已更新为: {'启用' if enabled else '禁用'}"
@@ -88,8 +84,9 @@ class SessionServiceManager:
             bool: True表示启用，False表示禁用
         """
         # 获取会话服务配置
-        session_config = sp.get("session_service_config", {}) or {}
-        session_services = session_config.get(session_id, {})
+        session_services = sp.get(
+            "session_service_config", {}, scope="umo", scope_id=session_id
+        )
 
         # 如果配置了该会话的TTS状态，返回该状态
         tts_enabled = session_services.get("tts_enabled")
@@ -107,16 +104,13 @@ class SessionServiceManager:
             session_id: 会话ID (unified_msg_origin)
             enabled: True表示启用，False表示禁用
         """
-        # 获取当前配置
-        session_config = sp.get("session_service_config", {}) or {}
-        if session_id not in session_config:
-            session_config[session_id] = {}
-
-        # 设置TTS状态
-        session_config[session_id]["tts_enabled"] = enabled
-
-        # 保存配置
-        sp.put("session_service_config", session_config)
+        session_config = (
+            sp.get("session_service_config", {}, scope="umo", scope_id=session_id) or {}
+        )
+        session_config["tts_enabled"] = enabled
+        sp.put(
+            "session_service_config", session_config, scope="umo", scope_id=session_id
+        )
 
         logger.info(
             f"会话 {session_id} 的TTS状态已更新为: {'启用' if enabled else '禁用'}"
@@ -150,8 +144,9 @@ class SessionServiceManager:
             bool: True表示启用，False表示禁用
         """
         # 获取会话服务配置
-        session_config = sp.get("session_service_config", {}) or {}
-        session_services = session_config.get(session_id, {})
+        session_services = sp.get(
+            "session_service_config", {}, scope="umo", scope_id=session_id
+        )
 
         # 如果配置了该会话的整体状态，返回该状态
         session_enabled = session_services.get("session_enabled")
@@ -169,16 +164,13 @@ class SessionServiceManager:
             session_id: 会话ID (unified_msg_origin)
             enabled: True表示启用，False表示禁用
         """
-        # 获取当前配置
-        session_config = sp.get("session_service_config", {}) or {}
-        if session_id not in session_config:
-            session_config[session_id] = {}
-
-        # 设置会话整体状态
-        session_config[session_id]["session_enabled"] = enabled
-
-        # 保存配置
-        sp.put("session_service_config", session_config)
+        session_config = (
+            sp.get("session_service_config", {}, scope="umo", scope_id=session_id) or {}
+        )
+        session_config["session_enabled"] = enabled
+        sp.put(
+            "session_service_config", session_config, scope="umo", scope_id=session_id
+        )
 
         logger.info(
             f"会话 {session_id} 的整体状态已更新为: {'启用' if enabled else '禁用'}"
@@ -202,7 +194,7 @@ class SessionServiceManager:
     # =============================================================================
 
     @staticmethod
-    def get_session_custom_name(session_id: str) -> str:
+    def get_session_custom_name(session_id: str) -> str | None:
         """获取会话的自定义名称
 
         Args:
@@ -211,8 +203,9 @@ class SessionServiceManager:
         Returns:
             str: 自定义名称，如果没有设置则返回None
         """
-        session_config = sp.get("session_service_config", {}) or {}
-        session_services = session_config.get(session_id, {})
+        session_services = sp.get(
+            "session_service_config", {}, scope="umo", scope_id=session_id
+        )
         return session_services.get("custom_name")
 
     @staticmethod
@@ -223,20 +216,17 @@ class SessionServiceManager:
             session_id: 会话ID (unified_msg_origin)
             custom_name: 自定义名称，可以为空字符串来清除名称
         """
-        # 获取当前配置
-        session_config = sp.get("session_service_config", {}) or {}
-        if session_id not in session_config:
-            session_config[session_id] = {}
-
-        # 设置自定义名称
+        session_config = (
+            sp.get("session_service_config", {}, scope="umo", scope_id=session_id) or {}
+        )
         if custom_name and custom_name.strip():
-            session_config[session_id]["custom_name"] = custom_name.strip()
+            session_config["custom_name"] = custom_name.strip()
         else:
             # 如果传入空名称，则删除自定义名称
-            session_config[session_id].pop("custom_name", None)
-
-        # 保存配置
-        sp.put("session_service_config", session_config)
+            session_config.pop("custom_name", None)
+        sp.put(
+            "session_service_config", session_config, scope="umo", scope_id=session_id
+        )
 
         logger.info(
             f"会话 {session_id} 的自定义名称已更新为: {custom_name.strip() if custom_name and custom_name.strip() else '已清除'}"
@@ -258,36 +248,3 @@ class SessionServiceManager:
 
         # 如果没有自定义名称，返回session_id的最后一段
         return session_id.split(":")[2] if session_id.count(":") >= 2 else session_id
-
-    # =============================================================================
-    # 通用配置方法
-    # =============================================================================
-
-    @staticmethod
-    def get_session_service_config(session_id: str) -> Dict[str, bool]:
-        """获取指定会话的服务配置
-
-        Args:
-            session_id: 会话ID (unified_msg_origin)
-
-        Returns:
-            Dict[str, bool]: 包含session_enabled、llm_enabled、tts_enabled的字典
-        """
-        session_config = sp.get("session_service_config", {}) or {}
-        return session_config.get(
-            session_id,
-            {
-                "session_enabled": True,  # 默认启用
-                "llm_enabled": True,  # 默认启用
-                "tts_enabled": True,  # 默认启用
-            },
-        )
-
-    @staticmethod
-    def get_all_session_configs() -> Dict[str, Dict[str, bool]]:
-        """获取所有会话的服务配置
-
-        Returns:
-            Dict[str, Dict[str, bool]]: 所有会话的服务配置
-        """
-        return sp.get("session_service_config", {}) or {}

--- a/astrbot/core/star/session_plugin_manager.py
+++ b/astrbot/core/star/session_plugin_manager.py
@@ -22,7 +22,9 @@ class SessionPluginManager:
             bool: True表示启用，False表示禁用
         """
         # 获取会话插件配置
-        session_plugin_config = sp.get("session_plugin_config", {}) or {}
+        session_plugin_config = sp.get(
+            "session_plugin_config", {}, scope="umo", scope_id=session_id
+        )
         session_config = session_plugin_config.get(session_id, {})
 
         enabled_plugins = session_config.get("enabled_plugins", [])
@@ -51,7 +53,9 @@ class SessionPluginManager:
             enabled: True表示启用，False表示禁用
         """
         # 获取当前配置
-        session_plugin_config = sp.get("session_plugin_config", {}) or {}
+        session_plugin_config = sp.get(
+            "session_plugin_config", {}, scope="umo", scope_id=session_id
+        )
         if session_id not in session_plugin_config:
             session_plugin_config[session_id] = {
                 "enabled_plugins": [],
@@ -79,7 +83,9 @@ class SessionPluginManager:
         session_config["enabled_plugins"] = enabled_plugins
         session_config["disabled_plugins"] = disabled_plugins
         session_plugin_config[session_id] = session_config
-        sp.put("session_plugin_config", session_plugin_config)
+        sp.put(
+            "session_plugin_config", session_plugin_config, scope="umo", scope_id=session_id
+        )
 
         logger.info(
             f"会话 {session_id} 的插件 {plugin_name} 状态已更新为: {'启用' if enabled else '禁用'}"
@@ -95,7 +101,9 @@ class SessionPluginManager:
         Returns:
             Dict[str, List[str]]: 包含enabled_plugins和disabled_plugins的字典
         """
-        session_plugin_config = sp.get("session_plugin_config", {}) or {}
+        session_plugin_config = sp.get(
+            "session_plugin_config", {}, scope="umo", scope_id=session_id
+        )
         return session_plugin_config.get(
             session_id, {"enabled_plugins": [], "disabled_plugins": []}
         )

--- a/astrbot/core/utils/shared_preferences.py
+++ b/astrbot/core/utils/shared_preferences.py
@@ -1,43 +1,214 @@
-import json
+from astrbot.core.db import BaseDatabase
+from astrbot.core.db.po import Preference
+import threading
+import asyncio
 import os
-from typing import TypeVar
+from typing import TypeVar, Any, overload
 from .astrbot_path import get_astrbot_data_path
+
 
 _VT = TypeVar("_VT")
 
+
 class SharedPreferences:
-    def __init__(self, path=None):
-        if path is None:
-            path = os.path.join(get_astrbot_data_path(), "shared_preferences.json")
-        self.path = path
-        self._data = self._load_preferences()
+    def __init__(self, db_helper: BaseDatabase, json_storage_path=None):
+        if json_storage_path is None:
+            json_storage_path = os.path.join(
+                get_astrbot_data_path(), "shared_preferences.json"
+            )
+        self.path = json_storage_path
+        self.db_helper = db_helper
 
-    def _load_preferences(self):
-        if os.path.exists(self.path):
-            try:
-                with open(self.path, "r") as f:
-                    return json.load(f)
-            except json.JSONDecodeError:
-                os.remove(self.path)
-        return {}
+    async def get_async(
+        self,
+        scope: str,
+        scope_id: str,
+        key: str,
+        default: _VT = None,
+    ) -> _VT:
+        """获取指定范围和键的偏好设置"""
+        if scope_id is not None and key is not None:
+            result = await self.db_helper.get_preference(scope, scope_id, key)
+            if result:
+                ret = result.value["val"]
+            else:
+                ret = default
+            return ret
+        else:
+            raise ValueError(
+                "scope_id and key cannot be None when getting a specific preference."
+            )
 
-    def _save_preferences(self):
-        with open(self.path, "w") as f:
-            json.dump(self._data, f, indent=4, ensure_ascii=False)
-            f.flush()
+    async def range_get_async(
+        self, scope: str, scope_id: str | None = None, key: str | None = None
+    ) -> list[Preference]:
+        """获取指定范围的偏好设置
+        Note: 返回 Preference 列表，其中的 value 属性是一个 dict，value["val"] 为值。scope_id 和 key 可以为 None，这时返回该范围下所有的偏好设置。
+        """
+        ret = await self.db_helper.get_preferences(scope, scope_id, key)
+        return ret
 
-    def get(self, key, default: _VT = None) -> _VT:
-        return self._data.get(key, default)
+    @overload
+    async def session_get(
+        self, umo: None, key: str, default: Any = None
+    ) -> list[Preference]: ...
 
-    def put(self, key, value):
-        self._data[key] = value
-        self._save_preferences()
+    @overload
+    async def session_get(
+        self, umo: str, key: None, default: Any = None
+    ) -> list[Preference]: ...
 
-    def remove(self, key):
-        if key in self._data:
-            del self._data[key]
-            self._save_preferences()
+    @overload
+    async def session_get(
+        self, umo: None, key: None, default: Any = None
+    ) -> list[Preference]: ...
 
-    def clear(self):
-        self._data.clear()
-        self._save_preferences()
+    async def session_get(
+        self, umo: str | None, key: str | None = None, default: _VT = None
+    ) -> _VT | list[Preference]:
+        """获取会话范围的偏好设置
+
+        Note: 当 scope_id 或者 key 为 None，时，返回 Preference 列表，其中的 value 属性是一个 dict，value["val"] 为值。
+        """
+        if umo is None or key is None:
+            return await self.range_get_async("umo", umo, key)
+        return await self.get_async("umo", umo, key, default)
+
+    @overload
+    async def global_get(
+        self, key: None, default: Any = None
+    ) -> list[Preference]: ...
+
+    @overload
+    async def global_get(
+        self, key: str, default: _VT = None
+    ) -> _VT: ...
+
+    async def global_get(
+        self, key: str | None, default: _VT = None
+    ) -> _VT | list[Preference]:
+        """获取全局范围的偏好设置
+
+        Note: 当 scope_id 或者 key 为 None，时，返回 Preference 列表，其中的 value 属性是一个 dict，value["val"] 为值。
+        """
+        if key is None:
+            return await self.range_get_async("global", "global", key)
+        return await self.get_async("global", "global", key, default)
+
+    async def put_async(self, scope: str, scope_id: str, key: str, value: Any):
+        """设置指定范围和键的偏好设置"""
+        await self.db_helper.insert_preference_or_update(
+            scope, scope_id, key, {"val": value}
+        )
+
+    async def session_put(self, umo: str, key: str, value: Any):
+        await self.put_async("umo", umo, key, value)
+
+    async def global_put(self, key: str, value: Any):
+        await self.put_async("global", "global", key, value)
+
+    async def remove_async(self, scope: str, scope_id: str, key: str):
+        """删除指定范围和键的偏好设置"""
+        await self.db_helper.remove_preference(scope, scope_id, key)
+
+    async def session_remove(self, umo: str, key: str):
+        await self.remove_async("umo", umo, key)
+
+    async def global_remove(self, key: str):
+        """删除全局偏好设置"""
+        await self.remove_async("global", "global", key)
+
+    async def clear_async(self, scope: str, scope_id: str):
+        """清空指定范围的所有偏好设置"""
+        await self.db_helper.clear_preferences(scope, scope_id)
+
+    # ====
+    # DEPRECATED METHODS
+    # ====
+
+    def get(
+        self,
+        key: str,
+        default: _VT = None,
+        scope: str | None = None,
+        scope_id: str | None = "",
+    ) -> _VT:
+        """获取偏好设置（已弃用）"""
+        result: _VT | None = None
+
+        def runner():
+            nonlocal result, scope, scope_id
+            scope = scope or "unknown"
+            if scope_id == "":
+                scope_id = "unknown"
+            if scope_id is None or key is None:
+                # result = asyncio.run(self.range_get_async(scope, scope_id, key))
+                raise ValueError(
+                    "scope_id and key cannot be None when getting a specific preference."
+                )
+            else:
+                result = asyncio.run(self.get_async(scope, scope_id, key, default))
+
+        t = threading.Thread(target=runner)
+        t.start()
+        t.join()
+
+        if result is None:
+            return default
+
+        return result
+
+    def range_get(
+        self, scope: str, scope_id: str | None = None, key: str | None = None
+    ) -> list[Preference]:
+        """获取指定范围的偏好设置（已弃用）"""
+        result: list[Preference] = []
+
+        def runner():
+            nonlocal result, scope, scope_id, key
+            result = asyncio.run(self.range_get_async(scope, scope_id, key))
+
+        t = threading.Thread(target=runner)
+        t.start()
+        t.join()
+
+        return result
+
+    def put(self, key, value, scope: str | None = None, scope_id: str | None = None):
+        """设置偏好设置（已弃用）"""
+
+        def runner():
+            nonlocal scope, scope_id
+            scope = scope or "unknown"
+            scope_id = scope_id or "unknown"
+            asyncio.run(self.put_async(scope, scope_id, key, value))
+
+        t = threading.Thread(target=runner)
+        t.start()
+        t.join()
+
+    def remove(self, key, scope: str | None = None, scope_id: str | None = None):
+        """删除偏好设置（已弃用）"""
+
+        def runner():
+            nonlocal scope, scope_id
+            scope = scope or "unknown"
+            scope_id = scope_id or "unknown"
+            asyncio.run(self.remove_async(scope, scope_id, key))
+
+        t = threading.Thread(target=runner)
+        t.start()
+        t.join()
+
+    def clear(self, scope: str | None = None, scope_id: str | None = None):
+        """清空偏好设置（已弃用）"""
+
+        def runner():
+            nonlocal scope, scope_id
+            scope = scope or "unknown"
+            scope_id = scope_id or "unknown"
+            asyncio.run(self.clear_async(scope, scope_id))
+
+        t = threading.Thread(target=runner)
+        t.start()
+        t.join()


### PR DESCRIPTION
Closes: #2435

### Motivation

1. 统一管理会话的偏好
2. 更安全的偏好存储方式

### Modifications

给 preferences 表加了 `scope` 和 `scope_id` 两列。`scope` 可以为 `global`, `umo`, `plugin` 等。umo 时代表存储会话偏好数据，此时约定 `scope_id` 为 umo。`plugin` 时存储插件自定义的 KV 数据，此时约定 `scope_id` 为 `plugin_name`。

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 总结

重构 SharedPreferences，使用数据库支持的存储和带作用域的偏好设置，替代 JSON 文件；更新 Preference 模型和数据库接口；将现有基于 JSON 的偏好设置迁移到新模式；并使所有依赖模块适应新的异步带作用域的偏好设置 API，同时弃用旧的基于文件的方法。

改进：
- 将 SharedPreferences 中的 JSON 文件存储替换为支持带作用域偏好设置的异步数据库支持的存储
- 扩展 Preference 模型，增加 `scope` 和 `scope_id` 字段，并更新 BaseDatabase 和 SQLiteDatabase 以处理带作用域的 CRUD 操作
- 引入 `session_get`/`put`、`global_get`/`put` 和其他异步方法用于带作用域的偏好设置访问，并弃用遗留的同步方法
- 增加一个迁移步骤，将现有基于 JSON 的偏好设置转移到新的数据库模式中
- 更新代码库中的模块（`session_llm_manager`、`conversation_mgr`、`config_mgr`、`provider` 和 `star managers`、`dashboard routes` 等），以使用新的异步带作用域的偏好设置 API
- 移除周期性 JSON 写入，并清理已弃用的基于文件的偏好设置方法

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor SharedPreferences to use database-backed storage with scoped preferences instead of JSON file, update the Preference model and database interfaces, migrate existing JSON-based preferences to the new schema, and adapt all dependent modules to the new async scoped preference API while deprecating the old file-based methods.

Enhancements:
- Replace JSON file storage in SharedPreferences with async database-backed storage supporting scoped preferences
- Extend the Preference model with `scope` and `scope_id` fields and update BaseDatabase and SQLiteDatabase to handle scoped CRUD operations
- Introduce session_get/put, global_get/put and other async methods for scoped preference access and deprecate legacy synchronous methods
- Add a migration step to transfer existing JSON-based preferences into the new database schema
- Update modules across the codebase (session_llm_manager, conversation_mgr, config_mgr, provider and star managers, dashboard routes, etc.) to use the new async scoped preference API
- Remove periodic JSON writes and cleanup deprecated file-based preference methods

</details>