### PR TITLE
fix: 当返回文本为空并且存在工具调用时错误地被终止事件，导致工具调用结果未被返回

### DIFF
--- a/astrbot/core/pipeline/process_stage/method/llm_request.py
+++ b/astrbot/core/pipeline/process_stage/method/llm_request.py
@@ -335,6 +335,10 @@ class LLMRequestSubStage(Stage):
         ):
             return
 
+        if not llm_response.completion_text and not req.tool_calls_result:
+            logger.debug("LLM 响应为空，不保存记录。")
+            return
+
         # 历史上下文
         messages = copy.deepcopy(req.contexts)
         # 这一轮对话请求的用户输入

--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -144,8 +144,6 @@ class RespondStage(Stage):
             try:
                 if await self._is_empty_message_chain(result.chain):
                     logger.info("消息为空，跳过发送阶段")
-                    event.clear_result()
-                    event.stop_event()
                     return
             except Exception as e:
                 logger.warning(f"空内容检查异常: {e}")


### PR DESCRIPTION
fixes: #2448 #2379

### Motivation

当返回文本为空并且存在工具调用时错误地被终止事件，导致工具调用结果未被返回

### Modifications

1. 返回空文本时，在 ResponseStage 阶段不终止事件；
2. 不持久化空文本且没有工具调用的 LLM 响应，防止后续请求 API 错误。


### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## 由 Sourcery 提供的总结

修复空 LLM 响应处理，以确保工具调用结果被返回并避免持久化无效的空响应

Bug 修复：
- 停止在空消息链上过早终止响应阶段，以避免工具调用结果丢失
- 跳过将没有工具调用的空 LLM 响应保存到历史记录中，以防止后续 API 错误

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix empty LLM response handling to ensure tool call results are returned and avoid persisting invalid empty responses

Bug Fixes:
- Stop prematurely terminating the response stage on empty message chains so tool call results are not lost
- Skip saving empty LLM responses without tool calls to history to prevent subsequent API errors

</details>