### PR TITLE
Feature: llm_tool 装饰器返回值支持 mcp 库的 tool 返回值类型 (mcp.type.CallToolResult)

### DIFF
--- a/astrbot/core/pipeline/process_stage/method/llm_request.py
+++ b/astrbot/core/pipeline/process_stage/method/llm_request.py
@@ -171,11 +171,14 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
         )
         async for resp in wrapper:
             if resp is not None:
-                text_content = mcp.types.TextContent(
-                    type="text",
-                    text=str(resp),
-                )
-                yield mcp.types.CallToolResult(content=[text_content])
+                if isinstance(resp, mcp.types.CallToolResult):
+                    yield resp
+                else:
+                    text_content = mcp.types.TextContent(
+                        type="text",
+                        text=str(resp),
+                    )
+                    yield mcp.types.CallToolResult(content=[text_content])
             else:
                 # NOTE: Tool 在这里直接请求发送消息给用户
                 # TODO: 是否需要判断 event.get_result() 是否为空?


### PR DESCRIPTION
### Motivation

统一 Tool 的返回值类型

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 总结

新功能：
- 增加了在 LLM 请求阶段转发 `mcp.types.CallToolResult` 响应的支持，无需额外包装。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Add support for forwarding mcp.types.CallToolResult responses without additional wrapping in the llm request stage.

</details>