### PR TITLE
refactor(tts): 将FishAudio TTS角色名称查询改为直接使用参考模型ID

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -970,7 +970,7 @@ CONFIG_METADATA_2 = {
                         "enable": False,
                         "api_key": "",
                         "api_base": "https://api.fish.audio/v1",
-                        "fishaudio-tts-character": "可莉",
+                        "fishaudio-tts-reference-id": "626bb6d3f3364c9cbc3aa6a67300a664",
                         "timeout": "20",
                     },
                     "阿里云百炼 TTS(API)": {
@@ -1559,10 +1559,10 @@ CONFIG_METADATA_2 = {
                         "type": "string",
                         "hint": "OpenAI TTS 的声音。OpenAI 默认支持：'alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer'",
                     },
-                    "fishaudio-tts-character": {
-                        "description": "character",
+                    "fishaudio-tts-reference-id": {
+                        "description": "reference_id",
                         "type": "string",
-                        "hint": "fishaudio TTS 的角色。默认为可莉。更多角色请访问：https://fish.audio/zh-CN/discovery",
+                        "hint": "fishaudio TTS 的参考模型ID。默认为：626bb6d3f3364c9cbc3aa6a67300a664（可莉）。更多模型请访问：https://fish.audio/zh-CN/discovery，进入模型详情界面后可复制模型ID",
                     },
                     "whisper_hint": {
                         "description": "本地部署 Whisper 模型须知",


### PR DESCRIPTION
<!--解释为什么要改动-->

避免同名冲突：不同模型可能使用相同的角色名称，导致获取错误的模型，无法使用用户期望的模型
提高性能：移除了额外的API查询步骤，减少延迟
增强可靠性：用户直接指定准确的模型ID，避免搜索失败的情况
简化维护：减少了代码复杂度，降低维护成本

这个修改使得FishAudio TTS的配置更加直观、可靠且易于使用，同时提升了系统的整体性能。

<!--简单解释你的改动-->

- 移除复杂的角色查询逻辑 删除了 get_reference_id_by_character 方法
移除了通过角色名称搜索模型ID的API调用逻辑
- 简化配置字段 将 fishaudio-tts-character 字段替换为 fishaudio-tts-reference-id 设置默认值为可莉的模型ID：626bb6d3f3364c9cbc3aa6a67300a664
- 优化代码结构 直接在初始化时获取reference_id
简化请求生成逻辑，直接使用配置的模型ID

- 新的使用方式
用户需要从 FishAudio 模型的详情页面/URL 中获取具体的模型ID（如 626bb6d3f3364c9cbc3aa6a67300a664），并在配置中直接填入 fishaudio-tts-reference-id 字段。

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [√] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [√] 👀 我的更改经过良好的测试
- [√] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [√] 😮 我的更改没有引入恶意代码
