### PR TITLE
[Feature] 添加了QQ Offical 发语音的功能（私聊，群发）

### DIFF
--- a/astrbot/core/platform/sources/dingtalk/dingtalk_event.py
+++ b/astrbot/core/platform/sources/dingtalk/dingtalk_event.py
@@ -26,7 +26,7 @@ class DingtalkMessageEvent(AstrMessageEvent):
                 await asyncio.get_event_loop().run_in_executor(
                     None,
                     client.reply_markdown,
-                    "AstrBot",
+                    segment.text,#"AstrBot", -> segment.text, (这里在钉钉的ui呈现为聊天文字,故将"AstrBot",改为segment.text)
                     segment.text,
                     self.message_obj.raw_message,
                 )

--- a/astrbot/core/platform/sources/dingtalk/dingtalk_event.py
+++ b/astrbot/core/platform/sources/dingtalk/dingtalk_event.py
@@ -26,7 +26,7 @@ class DingtalkMessageEvent(AstrMessageEvent):
                 await asyncio.get_event_loop().run_in_executor(
                     None,
                     client.reply_markdown,
-                    segment.text,#"AstrBot", -> segment.text, (这里在钉钉的ui呈现为聊天文字,故将"AstrBot",改为segment.text)
+                    segment.text,
                     segment.text,
                     self.message_obj.raw_message,
                 )

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -118,7 +118,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                     )
                     payload["media"] = media
                     payload["msg_type"] = 7
-                if record_file_path:                # group record msg
+                if record_file_path: # group record msg
                     media = await self.upload_group_and_c2c_record(
                         record_file_path, 3, group_openid=source.group_openid
                     )
@@ -134,7 +134,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                     )
                     payload["media"] = media
                     payload["msg_type"] = 7
-                if record_file_path:                    # c2c record
+                if record_file_path: # c2c record
                     media = await self.upload_group_and_c2c_record(
                         record_file_path, 3, openid = source.author.user_openid
                     )
@@ -210,7 +210,8 @@ class QQOfficialMessageEvent(AstrMessageEvent):
             # 读取本地文件
             async with aiofiles.open(file_source, 'rb') as f:
                 file_content = await f.read()
-                payload["file_data"] = base64.b64encode(file_content).decode('utf-8') # use base64 encode
+                # use base64 encode
+                payload["file_data"] = base64.b64encode(file_content).decode('utf-8')
         else:
             # 使用URL
             payload["url"] = file_source
@@ -283,9 +284,9 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                 else:
                     image_base64 = file_to_base64(i.file)
                 image_base64 = image_base64.removeprefix("base64://")
-            elif isinstance(i, Record):                                             # new: record
+            elif isinstance(i, Record):
                 if i.file:
-                    record_wav_path = await i.convert_to_file_path()                      # wav路径
+                    record_wav_path = await i.convert_to_file_path() # wav 路径
                     temp_dir = os.path.join(get_astrbot_data_path(), "temp")
                     record_tecent_silk_path = os.path.join(temp_dir, f"{uuid.uuid4()}.silk")
                     try:

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -94,10 +94,10 @@ class QQOfficialMessageEvent(AstrMessageEvent):
             plain_text,
             image_base64,
             image_path,
-            Record_file_path
+            record_file_path
         ) = await QQOfficialMessageEvent._parse_to_qqofficial(self.send_buffer)
 
-        if not plain_text and not image_base64 and not image_path and not Record_file_path:
+        if not plain_text and not image_base64 and not image_path and not record_file_path:
             return
 
         payload = {
@@ -118,9 +118,9 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                     )
                     payload["media"] = media
                     payload["msg_type"] = 7
-                if Record_file_path:                #group record msg
+                if record_file_path:                # group record msg
                     media = await self.upload_group_and_c2c_record(
-                        Record_file_path, 3, group_openid=source.group_openid
+                        record_file_path, 3, group_openid=source.group_openid
                     )
                     payload["media"] = media
                     payload["msg_type"] = 7
@@ -134,9 +134,9 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                     )
                     payload["media"] = media
                     payload["msg_type"] = 7
-                if Record_file_path:                    #c2c record
+                if record_file_path:                    # c2c record
                     media = await self.upload_group_and_c2c_record(
-                        Record_file_path, 3, openid = source.author.user_openid
+                        record_file_path, 3, openid = source.author.user_openid
                     )
                     payload["media"] = media
                     payload["msg_type"] = 7
@@ -210,7 +210,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
             # 读取本地文件
             async with aiofiles.open(file_source, 'rb') as f:
                 file_content = await f.read()
-                payload["file_data"] = base64.b64encode(file_content).decode('utf-8')
+                payload["file_data"] = base64.b64encode(file_content).decode('utf-8') # use base64 encode
         else:
             # 使用URL
             payload["url"] = file_source
@@ -283,9 +283,9 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                 else:
                     image_base64 = file_to_base64(i.file)
                 image_base64 = image_base64.removeprefix("base64://")
-            elif isinstance(i, Record):                                             #new: record
+            elif isinstance(i, Record):                                             # new: record
                 if i.file:
-                    record_wav_path = await i.convert_to_file_path()                      #wav路径
+                    record_wav_path = await i.convert_to_file_path()                      # wav路径
                     temp_dir = os.path.join(get_astrbot_data_path(), "temp")
                     record_tecent_silk_path = os.path.join(temp_dir, f"{uuid.uuid4()}.silk")
                     try:
@@ -293,11 +293,11 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                         if duration > 0:
                             record_file_path = record_tecent_silk_path
                         else:
-                            record_file_path = None                                 #这么处理（？）
+                            record_file_path = None                                 
                             logger.error("转换音频格式时出错：音频时长不大于0")
                     except Exception as e:
                         logger.error(f"处理语音时出错: {e}")
-                        record_file_path = None                                     #这么处理（？）
+                        record_file_path = None                                     
             else:
                 logger.debug(f"qq_official 忽略 {i.type}")
         return plain_text, image_base64, image_file_path, record_file_path

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -237,7 +237,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                     file_id=result.get("id", "")
                 )
         except Exception as e:
-            print(f"上传请求错误: {e}")
+            logger.error(f"上传请求错误: {e}")
         
         return None
     

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -3,15 +3,23 @@ import botpy.message
 import botpy.types
 import botpy.types.message
 import asyncio
+import base64
+import aiofiles
 from astrbot.core.utils.io import file_to_base64, download_image_by_url
+from astrbot.core.utils.tencent_record_helper import wav_to_tencent_silk
+from astrbot.core.utils.astrbot_path import get_astrbot_data_path
 from astrbot.api.event import AstrMessageEvent, MessageChain
 from astrbot.api.platform import AstrBotMessage, PlatformMetadata
-from astrbot.api.message_components import Plain, Image
+from astrbot.api.message_components import Plain, Image, Record
 from botpy import Client
 from botpy.http import Route
 from astrbot.api import logger
+from botpy.types.message import Media
 from botpy.types import message
+from typing import Optional
 import random
+import uuid
+import os
 
 
 class QQOfficialMessageEvent(AstrMessageEvent):
@@ -36,6 +44,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
         stream_payload = {"state": 1, "id": None, "index": 0, "reset": False}
         last_edit_time = 0  # 上次编辑消息的时间
         throttle_interval = 1  # 编辑消息的间隔时间 (秒)
+        ret = None
         try:
             async for chain in generator:
                 source = self.message_obj.raw_message
@@ -85,9 +94,10 @@ class QQOfficialMessageEvent(AstrMessageEvent):
             plain_text,
             image_base64,
             image_path,
+            Record_file_path
         ) = await QQOfficialMessageEvent._parse_to_qqofficial(self.send_buffer)
 
-        if not plain_text and not image_base64 and not image_path:
+        if not plain_text and not image_base64 and not image_path and not Record_file_path:
             return
 
         payload = {
@@ -98,11 +108,19 @@ class QQOfficialMessageEvent(AstrMessageEvent):
         if not isinstance(source, (botpy.message.Message, botpy.message.DirectMessage)):
             payload["msg_seq"] = random.randint(1, 10000)
 
+        ret = None
+
         match type(source):
             case botpy.message.GroupMessage:
                 if image_base64:
                     media = await self.upload_group_and_c2c_image(
                         image_base64, 1, group_openid=source.group_openid
+                    )
+                    payload["media"] = media
+                    payload["msg_type"] = 7
+                if Record_file_path:                #group record msg
+                    media = await self.upload_group_and_c2c_record(
+                        Record_file_path, 3, group_openid=source.group_openid
                     )
                     payload["media"] = media
                     payload["msg_type"] = 7
@@ -113,6 +131,12 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                 if image_base64:
                     media = await self.upload_group_and_c2c_image(
                         image_base64, 1, openid=source.author.user_openid
+                    )
+                    payload["media"] = media
+                    payload["msg_type"] = 7
+                if Record_file_path:                    #c2c record
+                    media = await self.upload_group_and_c2c_record(
+                        Record_file_path, 3, openid = source.author.user_openid
                     )
                     payload["media"] = media
                     payload["msg_type"] = 7
@@ -165,6 +189,58 @@ class QQOfficialMessageEvent(AstrMessageEvent):
             )
             return await self.bot.api._http.request(route, json=payload)
 
+    async def upload_group_and_c2c_record(
+        self, 
+        file_source: str, 
+        file_type: int, 
+        srv_send_msg: bool = False,
+        **kwargs
+    ) -> Optional[Media]:
+        """
+        上传媒体文件
+        """
+        # 构建基础payload
+        payload = {
+            "file_type": file_type,
+            "srv_send_msg": srv_send_msg
+        }
+        
+        # 处理文件数据
+        if os.path.exists(file_source):
+            # 读取本地文件
+            async with aiofiles.open(file_source, 'rb') as f:
+                file_content = await f.read()
+                payload["file_data"] = base64.b64encode(file_content).decode('utf-8')
+        else:
+            # 使用URL
+            payload["url"] = file_source
+        
+        # 添加接收者信息和确定路由
+        if "openid" in kwargs:
+            payload["openid"] = kwargs["openid"]
+            route = Route("POST", "/v2/users/{openid}/files", openid=kwargs["openid"])
+        elif "group_openid" in kwargs:
+            payload["group_openid"] =kwargs["group_openid"]
+            route = Route("POST", "/v2/groups/{group_openid}/files", group_openid=kwargs["group_openid"])
+        else:
+            return None
+        
+        try:
+            # 使用底层HTTP请求
+            result = await self.bot.api._http.request(route, json=payload)
+            
+            if result:
+                return Media(
+                    file_uuid=result.get("file_uuid"),
+                    file_info=result.get("file_info"),
+                    ttl=result.get("ttl", 0),
+                    file_id=result.get("id", "")
+                )
+        except Exception as e:
+            print(f"上传请求错误: {e}")
+        
+        return None
+    
     async def post_c2c_message(
         self,
         openid: str,
@@ -191,6 +267,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
         plain_text = ""
         image_base64 = None  # only one img supported
         image_file_path = None
+        record_file_path = None
         for i in message.chain:
             if isinstance(i, Plain):
                 plain_text += i.text
@@ -206,6 +283,21 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                 else:
                     image_base64 = file_to_base64(i.file)
                 image_base64 = image_base64.removeprefix("base64://")
+            elif isinstance(i, Record):                                             #new: record
+                if i.file:
+                    record_wav_path = await i.convert_to_file_path()                      #wav路径
+                    temp_dir = os.path.join(get_astrbot_data_path(), "temp")
+                    record_tecent_silk_path = os.path.join(temp_dir, f"{uuid.uuid4()}.silk")
+                    try:
+                        duration = await wav_to_tencent_silk(record_wav_path, record_tecent_silk_path)
+                        if duration > 0:
+                            record_file_path = record_tecent_silk_path
+                        else:
+                            record_file_path = None                                 #这么处理（？）
+                            logger.error("转换音频格式时出错：音频时长不大于0")
+                    except Exception as e:
+                        logger.error(f"处理语音时出错: {e}")
+                        record_file_path = None                                     #这么处理（？）
             else:
                 logger.debug(f"qq_official 忽略 {i.type}")
-        return plain_text, image_base64, image_file_path
+        return plain_text, image_base64, image_file_path, record_file_path

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
@@ -156,6 +156,7 @@ class QQOfficialPlatformAdapter(Platform):
             abm.self_id = "unknown_selfid"
             msg.append(At(qq="qq_official"))
             msg.append(Plain(abm.message_str))
+            logger.warning(f"QQ offical adapter message: {message.attachments}")#use to debug
             if message.attachments:
                 for i in message.attachments:
                     if i.content_type.startswith("image"):

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
@@ -156,7 +156,6 @@ class QQOfficialPlatformAdapter(Platform):
             abm.self_id = "unknown_selfid"
             msg.append(At(qq="qq_official"))
             msg.append(Plain(abm.message_str))
-            logger.warning(f"QQ offical adapter message: {message.attachments}")#use to debug
             if message.attachments:
                 for i in message.attachments:
                     if i.content_type.startswith("image"):


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了 #XYZ

### Motivation

<!--解释为什么要改动-->

算是群友的req吧，就是添加了对发语音的支持

### Modifications

<!--简单解释你的改动-->

在_parse_to_qqofficial中添加了elif isinstance(i, Record):

还新写了：upload_group_and_c2c_record

稍对之前的ret处理进行更改

btw，我也没怎么写注释

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 总结

在 QQ 官方平台增加发送语音消息的支持，包括解析、格式转换和上传

新功能：
- 支持在 QQ 官方平台发送语音消息（群聊和私聊）

改进：
- 解析 Record 组件并将 WAV 文件转换为腾讯 Silk 格式
- 实现 `upload_group_and_c2c_record` 以处理语音媒体上传
- 调整钉钉回复以使用实际消息文本进行 UI 显示
- 在 QQ 官方适配器中增加附件的调试日志

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for sending voice messages on the QQ Official platform, including parsing, format conversion, and upload

New Features:
- Support sending voice messages (group and private) on QQ Official

Enhancements:
- Parse Record components and convert WAV files to Tencent Silk format
- Implement upload_group_and_c2c_record to handle voice media uploads
- Adjust DingTalk reply to use the actual message text for UI display
- Add debug logging for attachments in the QQ Official adapter

</details>