### PR TITLE
feat: 添加一键升级所有插件功能

### DIFF
--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -829,7 +829,8 @@ class PluginManager:
                 
                 results["success"].append({
                     "name": plugin_name,
-                    "message": f"更新成功: {current_version} -> {online_version}"
+                    "from_version": current_version,
+                    "to_version": online_version
                 })
                 logger.info(f"插件 {plugin_name} 更新成功")
             except Exception as e:

--- a/astrbot/dashboard/routes/plugin.py
+++ b/astrbot/dashboard/routes/plugin.py
@@ -440,10 +440,18 @@ class PluginRoute(Route):
             failed_count = len(results["failed"])
             skipped_count = len(results["skipped"])
             
-            message = f"批量更新完成: 成功 {success_count} 个, 失败 {failed_count} 个, 跳过 {skipped_count} 个"
-            logger.info(message)
+            # 返回结构化消息
+            message_data = {
+                "success_count": success_count,
+                "failed_count": failed_count, 
+                "skipped_count": skipped_count
+            }
             
-            return Response().ok(results, message).__dict__
+            # 日志仍使用中文
+            log_message = f"批量更新完成: 成功 {success_count} 个, 失败 {failed_count} 个, 跳过 {skipped_count} 个"
+            logger.info(log_message)
+            
+            return Response().ok(results, message_data).__dict__
         except Exception as e:
             logger.error(f"/api/plugin/update-all: {traceback.format_exc()}")
             return Response().error(str(e)).__dict__

--- a/dashboard/src/i18n/locales/en-US/features/extension.json
+++ b/dashboard/src/i18n/locales/en-US/features/extension.json
@@ -18,6 +18,7 @@
     "hideSystemPlugins": "Hide System Extensions",
     "platformConfig": "Platform Command Config",
     "install": "Install",
+    "updateAll": "Update All Extensions",
     "uninstall": "Uninstall",
     "update": "Update",
     "reload": "Reload",
@@ -40,6 +41,7 @@
     "disabled": "Disabled",
     "system": "System",
     "loading": "Loading...",
+    "updatingAllPlugins": "Updating all extensions...",
     "installed": "Installed",
     "unknown": "Unknown"
   },

--- a/dashboard/src/i18n/locales/en-US/features/extension.json
+++ b/dashboard/src/i18n/locales/en-US/features/extension.json
@@ -146,7 +146,14 @@
     "confirmDelete": "Are you sure you want to delete this extension?",
     "fillUrlOrFile": "Please fill in extension URL or upload extension file",
     "dontFillBoth": "Please don't fill in both extension URL and upload file",
-    "supportedFormats": "Supports .zip extension files"
+    "supportedFormats": "Supports .zip extension files",
+    "updateSuccessTitle": "Successfully Updated",
+    "updateFailedTitle": "Update Failed",
+    "updateSkippedTitle": "Skipped",
+    "batchUpdateFailed": "Batch update failed",
+    "pluginsHaveUpdates": " extensions have updates available",
+    "batchUpdateCompleted": "Batch update completed: {success} succeeded, {failed} failed, {skipped} skipped",
+    "updateSuccessWithVersion": "Update successful: {from} -> {to}"
   },
   "upload": {
     "fromFile": "Install from File",

--- a/dashboard/src/i18n/locales/zh-CN/features/extension.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/extension.json
@@ -18,6 +18,7 @@
     "hideSystemPlugins": "隐藏系统插件",
     "platformConfig": "平台命令配置",
     "install": "安装",
+    "updateAll": "升级所有插件",
     "uninstall": "卸载",
     "update": "更新",
     "reload": "重载",
@@ -40,6 +41,7 @@
     "disabled": "禁用",
     "system": "系统",
     "loading": "加载中...",
+    "updatingAllPlugins": "正在批量升级插件...",
     "installed": "已安装",
     "unknown": "未知"
   },

--- a/dashboard/src/i18n/locales/zh-CN/features/extension.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/extension.json
@@ -146,7 +146,14 @@
     "confirmDelete": "确定要删除插件吗？",
     "fillUrlOrFile": "请填写插件链接或上传插件文件",
     "dontFillBoth": "请不要同时填写插件链接和上传文件",
-    "supportedFormats": "支持 .zip 格式的插件文件"
+    "supportedFormats": "支持 .zip 格式的插件文件",
+    "updateSuccessTitle": "成功更新",
+    "updateFailedTitle": "更新失败",
+    "updateSkippedTitle": "已跳过",
+    "batchUpdateFailed": "批量更新失败",
+    "pluginsHaveUpdates": "个插件有更新可用",
+    "batchUpdateCompleted": "批量更新完成: 成功 {success} 个, 失败 {failed} 个, 跳过 {skipped} 个",
+    "updateSuccessWithVersion": "更新成功: {from} -> {to}"
   },
   "upload": {
     "fromFile": "从文件安装",

--- a/dashboard/src/views/ExtensionPage.vue
+++ b/dashboard/src/views/ExtensionPage.vue
@@ -7,18 +7,7 @@ import ProxySelector from '@/components/shared/ProxySelector.vue';
 import axios from 'axios';
 import { useCommonStore } from '@/stores/common';
 import { useI18n, useModuleI18n } from '@/i18n/composables';
-import MarkdownIt from 'markdown-it';
-
 import { ref, computed, onMounted, reactive } from 'vue';
-
-// 配置markdown-it，安全设置
-const md = new MarkdownIt({
-    html: false,        // 禁用HTML标签，防XSS
-    breaks: true,       // 换行转<br>
-    linkify: true,      // 自动转链接
-    typographer: false  // 禁用智能引号
-});
-
 
 const commonStore = useCommonStore();
 const { t } = useI18n();
@@ -279,7 +268,7 @@ const updateAllPlugins = async () => {
       online_version: plugin.online_version
     }));
 
-    const res = await axios.post('/api/plugin/update-all', {
+    const res = await axios.post('/api/plugin/update', {
       proxy: localStorage.getItem('selectedGitHubProxy') || "",
       plugins_to_update: pluginsToUpdate
     });


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了 #2548 

### Motivation

添加了一键升级所有可更新插件的功能。

### Modifications

- 后端在 star_manager.py 增加 update_plugins_by_list 方法，根据前端传递的插件列表进行批量更新。
- 在 plugin.py 增加了 /plugin/update-all API路由，接受前端发送的批量更新请求，返回格式化结果。
- 前端增加了 “升级所有插件” 按钮，仅在检查到有插件可更新时显示。
- 前端修复了标签页组件从 v-tab-item 到 v-window-item 的更新，更新为vuetify 3.x的新组件。
- 国际化支持。


### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 总结

实现覆盖后端和前端的一键批量插件升级功能。

新功能：
- 暴露新的 POST /plugin/update-all API，用于执行指定插件的批量更新。
- 添加 star_manager.update_plugins_by_list，用于处理批量更新逻辑，并报告成功、失败和跳过情况。
- 在“扩展”页面引入一个“全部更新”按钮，该按钮在有可用更新时出现，并触发带有详细结果的批量更新流程。

改进：
- 在扩展标签页中，为了 Vuetify 3 兼容性，从 v-tab-item 迁移到 v-window-item。
- 增强加载对话框，以渲染格式化的 HTML 来显示批量更新结果。

文档：
- 为新的批量更新按钮和相关的 UI 字符串添加 i18n 条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement a one-click bulk plugin upgrade feature across backend and frontend.

New Features:
- Expose a new POST /plugin/update-all API to perform batch updates of specified plugins.
- Add star_manager.update_plugins_by_list to handle bulk update logic with success, failure, and skip reporting.
- Introduce an “Update All” button in the extensions page that appears when updates are available and triggers the batch update flow with detailed results.

Enhancements:
- Migrate from v-tab-item to v-window-item for Vuetify 3 compatibility in the extension tabs.
- Enhance the loading dialog to render formatted HTML for bulk update results.

Documentation:
- Add i18n entries for the new bulk update button and related UI strings.

</details>