### PR TITLE
fix: 修复编辑会话名称窗口的圆角和左右边距问题

### DIFF
--- a/dashboard/src/views/SessionManagementPage.vue
+++ b/dashboard/src/views/SessionManagementPage.vue
@@ -480,7 +480,7 @@
 
     <!-- 会话命名编辑对话框 -->
     <v-dialog v-model="nameEditDialog" max-width="500" min-height="60%">
-      <v-card v-if="selectedSessionForName" rounded="12">
+      <v-card v-if="selectedSessionForName">
         <v-card-title class="bg-primary text-white py-3 px-4" style="display: flex; align-items: center;">
           <v-icon color="white" class="me-2">mdi-rename-box</v-icon>
           <span>{{ tm('nameEditor.title') }}</span>
@@ -490,8 +490,9 @@
           </v-btn>
         </v-card-title>
 
-        <v-card-text class="pa-4">
-          <v-text-field
+        <v-card-text>
+          <div style="padding-left: 16px; padding-right: 16px;">
+            <v-text-field
             v-model="newSessionName"
             :label="tm('nameEditor.customName')"
             :placeholder="tm('nameEditor.placeholder')"
@@ -518,6 +519,7 @@
           >
             {{ tm('nameEditor.hint') }}
           </v-alert>
+          </div>
         </v-card-text>
 
         <v-card-actions class="px-4 pb-4">


### PR DESCRIPTION
### Motivation

- 修复了 `会话管理` -> `编辑会话名称` 窗口的圆角和边距显示异常问题。

### Modifications

- 编辑会话名称对话框的 `v-card` 组件上有一个 `rounded="12"` 属性，这个属性与当前的 Vuetify 版本或
  CSS 样式产生了冲突，导致圆角边框显示异常问题，移除该属性。

```
.v-card-text {
    padding: 16px 0 !important;
  }
```
- 该样式的 `!important` 规则覆盖了 pa-4 类的效果，导致只引用了上下边距，没有引用左右边距，解决方法：在 `v-card-text` 标签内添加 `<div style="padding-left: 16px; padding-right: 16px;">` ，与 `插件管理` 窗口效果保持一致。

- 修复前效果：
<img width="671" height="815" alt="97a0d8fe-3546-4d2e-b925-32f70d4d0c22" src="https://github.com/user-attachments/assets/eef04359-f52d-439a-9fbb-211ec0230605" />

- 修复后效果：
<img width="687" height="810" alt="7ed1e6a2-1973-4524-8728-c8beac345e49" src="https://github.com/user-attachments/assets/7cce3dad-57ea-4c72-9fa1-f1050d81965d" />

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 总结

Bug 修复：
- 移除冲突的 `rounded` 属性并手动添加水平内边距，以修复编辑会话名称对话框的圆角和边距显示问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Remove conflicting rounded prop and manually add horizontal padding to fix the edit session name dialog's corner and margin display issues.

</details>