### PR TITLE
Fix: 修复 e.message 为 None 时报错的问题和部分 lint error

### DIFF
--- a/astrbot/core/provider/entities.py
+++ b/astrbot/core/provider/entities.py
@@ -4,9 +4,11 @@ import json
 from astrbot.core.utils.io import download_image_by_url
 from astrbot import logger
 from dataclasses import dataclass, field
-from typing import List, Dict, Type
+from typing import List, Dict, Type, Any
 from astrbot.core.agent.tool import ToolSet
 from openai.types.chat.chat_completion import ChatCompletion
+from google.genai.types import GenerateContentResponse
+from anthropic.types import Message
 from openai.types.chat.chat_completion_message_tool_call import (
     ChatCompletionMessageToolCall,
 )
@@ -30,11 +32,11 @@ class ProviderMetaData:
     desc: str = ""
     """提供商适配器描述."""
     provider_type: ProviderType = ProviderType.CHAT_COMPLETION
-    cls_type: Type = None
+    cls_type: Type | None = None
 
-    default_config_tmpl: dict = None
+    default_config_tmpl: dict | None = None
     """平台的默认配置模板"""
-    provider_display_name: str = None
+    provider_display_name: str | None = None
     """显示在 WebUI 配置页中的提供商名称，如空则是 type"""
 
 
@@ -58,7 +60,7 @@ class ToolCallMessageSegment:
 class AssistantMessageSegment:
     """OpenAI 格式的上下文中 role 为 assistant 的消息段。参考: https://platform.openai.com/docs/guides/function-calling"""
 
-    content: str = None
+    content: str | None = None
     tool_calls: List[ChatCompletionMessageToolCall | Dict] = field(default_factory=list)
     role: str = "assistant"
 
@@ -205,17 +207,17 @@ class ProviderRequest:
 class LLMResponse:
     role: str
     """角色, assistant, tool, err"""
-    result_chain: MessageChain = None
+    result_chain: MessageChain | None = None
     """返回的消息链"""
-    tools_call_args: List[Dict[str, any]] = field(default_factory=list)
+    tools_call_args: List[Dict[str, Any]] = field(default_factory=list)
     """工具调用参数"""
     tools_call_name: List[str] = field(default_factory=list)
     """工具调用名称"""
     tools_call_ids: List[str] = field(default_factory=list)
     """工具调用 ID"""
 
-    raw_completion: ChatCompletion = None
-    _new_record: Dict[str, any] = None
+    raw_completion: ChatCompletion | GenerateContentResponse | Message | None = None
+    _new_record: Dict[str, Any] | None = None
 
     _completion_text: str = ""
 
@@ -226,12 +228,12 @@ class LLMResponse:
         self,
         role: str,
         completion_text: str = "",
-        result_chain: MessageChain = None,
-        tools_call_args: List[Dict[str, any]] = None,
-        tools_call_name: List[str] = None,
-        tools_call_ids: List[str] = None,
-        raw_completion: ChatCompletion = None,
-        _new_record: Dict[str, any] = None,
+        result_chain: MessageChain | None = None,
+        tools_call_args: List[Dict[str, Any]] | None = None,
+        tools_call_name: List[str] | None = None,
+        tools_call_ids: List[str] | None = None,
+        raw_completion: ChatCompletion | None = None,
+        _new_record: Dict[str, Any] | None = None,
         is_chunk: bool = False,
     ):
         """初始化 LLMResponse

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -369,8 +369,8 @@ class ProviderGoogleGenAI(Provider):
                 chain.append(Comp.Plain(part.text))
             elif (
                 part.function_call
-                and part.function_call.name
-                and part.function_call.args
+                and part.function_call.name is not None
+                and part.function_call.args is not None
             ):
                 llm_response.role = "tool"
                 llm_response.tools_call_name.append(part.function_call.name)


### PR DESCRIPTION
### Motivation

修复 e.message 为 None 时报错的问题和一些 lint error

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 总结

通过将 None 消息设为默认值、验证 API 响应中是否存在缺失数据以及清理类型提示和 lint 问题，改进 Gemini 源客户端的错误处理和类型安全。

错误修复：
- 将 `e.message` 默认为空字符串，以避免 `APIError` 处理器中出现 `NoneType` 错误
- 验证并处理查询和流中的空 `candidates` 或 `content`，以防止崩溃
- 检查是否缺少 `candidate.content` 或 `inline_data`，并记录日志或抛出异常，以确保 API 响应的完整性

改进：
- 在 `provider` 和 `entities` 模块中，将可选类型提示切换到 Python 3.10 联合类型语法
- 使用空字符串作为默认的 `chosen_api_key`，并将 `tools` 参数类型从 `FuncCall` 更新为 `ToolSet | None`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve error handling and type safety in Gemini source client by defaulting None messages, validating API responses for missing data, and cleaning up type hints and lint issues

Bug Fixes:
- Default e.message to empty string to avoid NoneType errors in APIError handlers
- Validate and handle empty candidates or content in queries and streams to prevent crashes
- Check for missing candidate.content or inline_data and log or raise exceptions to ensure API response integrity

Enhancements:
- Switch to Python 3.10 union syntax for optional type hints in provider and entities modules
- Use empty string as default chosen_api_key and update tools parameter type from FuncCall to ToolSet | None

</details>