### PR TITLE
fix: aiocqhttp优先使用session_id发送消息

### DIFF
--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
@@ -67,12 +67,17 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
         session_id: str,
         messages: list[dict],
     ):
-        if event:
-            await bot.send(event=event, message=messages)
-        elif is_group:
+        # session_id 必须是纯数字字符串
+        session_id = int(session_id) if session_id.isdigit() else None
+    
+        if is_group and isinstance(session_id, int):
             await bot.send_group_msg(group_id=session_id, message=messages)
-        else:
+        elif not is_group and isinstance(session_id, int):
             await bot.send_private_msg(user_id=session_id, message=messages)
+        elif isinstance(event, Event):  # 最后兜底
+            await bot.send(event=event, message=messages)
+        else:
+            raise ValueError("无法发送消息：缺少有效的数字 session_id 和 event")
 
     @classmethod
     async def send_message(
@@ -122,18 +127,15 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
 
     async def send(self, message: MessageChain):
         """发送消息"""
-        event = self.message_obj.raw_message
-        assert isinstance(event, Event), "Event must be an instance of aiocqhttp.Event"
-        is_group = False
-        if self.get_group_id():
-            is_group = True
-            session_id = self.get_group_id()
-        else:
-            session_id = self.get_sender_id()
+        event = getattr(self.message_obj, "raw_message", None)
+
+        is_group = bool(self.get_group_id())
+        session_id = self.get_group_id() if is_group else self.get_sender_id()
+
         await self.send_message(
             bot=self.bot,
             message_chain=message,
-            event=event,
+            event=event, # 不强制要求一定是 Event
             is_group=is_group,
             session_id=session_id,
         )


### PR DESCRIPTION

### Motivation

当前aiocqhttp依赖raw_message来发送消息，raw_message为空时也无法有效回退到用group_id或user_id来发送

### Modifications

调整AiocqhttpMessageEvent中的_dispatch_send和send方法，优先使用session_id（group_id or user_id）发送消息, raw_message兜底，二者皆无则报错


### Check

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码
