### PR TITLE
Fix: 修正 QQ 群成员昵称获取

### DIFF
--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -308,13 +308,13 @@ class AiocqhttpAdapter(Platform):
                             continue
 
                         at_info = await self.bot.call_action(
-                            action="get_stranger_info",
+                            action="get_group_member_info",
+                            group_id=event.group_id,
                             user_id=int(m["data"]["qq"]),
+                            no_cache=False,
                         )
                         if at_info:
-                            nickname = at_info.get("nick", "") or at_info.get(
-                                "nickname", ""
-                            )
+                            nickname = at_info.get("card", "")
                             is_at_self = str(m["data"]["qq"]) in {abm.self_id, "all"}
 
                             abm.message.append(

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -315,6 +315,13 @@ class AiocqhttpAdapter(Platform):
                         )
                         if at_info:
                             nickname = at_info.get("card", "")
+                            if nickname == "":
+                                at_info = await self.bot.call_action(
+                                    action="get_stranger_info",
+                                    user_id=int(m["data"]["qq"]),
+                                    no_cache=False,
+                                )
+                                nickname = at_info.get("nick", "") or at_info.get("nickname", "")
                             is_at_self = str(m["data"]["qq"]) in {abm.self_id, "all"}
 
                             abm.message.append(


### PR DESCRIPTION
### Motivation

之前的逻辑获取的不是群昵称

### Modifications

修改了一处api改为获取群昵称

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 总结

错误修复:
- 从 get_stranger_info API 切换到 get_group_member_info API，并提取 "card" 字段作为群成员昵称

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Switch from get_stranger_info to get_group_member_info API and extract the "card" field for group member nickname

</details>