### PR TITLE
feat: 增加根据qq号/群号主动发送消息的封装, 增加事件构造

### DIFF
--- a/astrbot/core/star/star_tools.py
+++ b/astrbot/core/star/star_tools.py
@@ -1,5 +1,26 @@
+"""
+插件开发工具集
+封装了许多常用的操作，方便插件开发者使用
+
+说明:
+
+主动发送消息: send_message(session, message_chain)
+    根据 session (unified_msg_origin) 主动发送消息, 前提是需要提前获得或构造 session
+
+根据id直接主动发送消息: send_message_by_id(type, id, message_chain, platform="aiocqhttp")
+    根据 id (例如 qq 号, 群号等) 直接, 主动地发送消息
+
+以上两种方式需要构造消息链, 也就是消息组件的列表
+
+构造事件:
+
+首先需要构造一个 AstrBotMessage 对象, 使用 create_message 方法
+然后使用 create_event 方法提交事件到指定平台
+"""
+
 import inspect
 import os
+import uuid
 from pathlib import Path
 from typing import Union, Awaitable, List, Optional, ClassVar
 from astrbot.core.message.components import BaseMessageComponent
@@ -9,7 +30,8 @@ from astrbot.core.platform.astr_message_event import MessageSesion
 from astrbot.core.star.context import Context
 from astrbot.core.star.star import star_map
 from astrbot.core.utils.astrbot_path import get_astrbot_data_path
-
+from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import AiocqhttpMessageEvent
+from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_platform_adapter import AiocqhttpAdapter
 
 class StarTools:
     """
@@ -52,30 +74,56 @@ class StarTools:
         return await cls._context.send_message(session, message_chain)
 
     @classmethod
+    async def send_message_by_id(
+        cls, type: str, id: str, message_chain: MessageChain, platform: str = "aiocqhttp"
+    ):
+        """
+        根据 id(例如qq号, 群号等) 直接, 主动地发送消息
+
+        Args:
+            type (str): 消息类型, 可选: PrivateMessage, GroupMessage
+            id (str): 目标ID, 例如QQ号, 群号等
+            message_chain (MessageChain): 消息链
+            platform (str): 可选的平台名称，默认为空，默认平台(aiocqhttp), 目前只支持 aiocqhttp
+        """
+        platforms = cls._context.platform_manager.get_insts()
+        if platform == "aiocqhttp":
+            adapter = next((p for p in platforms if isinstance(p, AiocqhttpAdapter)), None)
+            if adapter is None:
+                raise ValueError("未找到适配器: AiocqhttpAdapter")
+            AiocqhttpMessageEvent.send_message(
+                bot=adapter.bot,
+                message_chain=message_chain,
+                is_group=(type == "GroupMessage"),
+                session_id=id,
+            )
+
+    @classmethod
     async def create_message(
         cls,
         type: str,
         self_id: str,
         session_id: str,
-        message_id: str,
         sender: MessageMember,
         message: List[BaseMessageComponent],
         message_str: str,
-        raw_message: object,
-        group_id: str = "",
-    ):
+        message_id: str = uuid.uuid4().hex,
+        raw_message: object = None,
+        group_id: str = ""
+    ) -> AstrBotMessage:
         """
         创建一个AstrBot消息对象
 
         Args:
-            type (str): 消息类型
+            type (str): 消息类型, 例如 "GroupMessage" "FriendMessage" "OtherMessage"
             self_id (str): 机器人自身ID
             session_id (str): 会话ID(通常为用户ID)(QQ号, 群号等)
-            message_id (str): 消息ID
-            sender (MessageMember): 发送者信息
-            message (List[BaseMessageComponent]): 消息组件列表
-            message_str (str): 消息字符串
-            raw_message (object): 原始消息对象
+            sender (MessageMember): 发送者信息, 例如 MessageMember(user_id="123456", nickname="昵称")
+            message (List[BaseMessageComponent]): 消息组件列表, 也就是消息链, 这个不会发给 llm, 但是会经过其他处理
+            message_str (str): 消息字符串, 也就是纯文本消息, 也就是发送给 llm 的消息, 与消息链一致
+
+            message_id (str): 消息ID, 构造消息时可以随意填写也可不填
+            raw_message (object): 原始消息对象, 可以随意填写也可不填
             group_id (str, optional): 群组ID, 如果为私聊则为空. Defaults to "".
 
         Returns:
@@ -93,13 +141,34 @@ class StarTools:
         abm.group_id = group_id
         return abm
 
-    # todo: 添加构造事件的方法
-    # async def create_event(
-    #     self, platform: str, umo: str, sender_id: str, session_id: str
-    # ):
-    #     platform = self._context.get_platform(platform)
+    @classmethod
+    async def create_event(
+        cls, abm: AstrBotMessage, platform: str = "aiocqhttp", is_wake: bool = True
 
-    # todo: 添加找到对应平台并提交对应事件的方法
+    ) -> None:
+        """
+        创建并提交事件到指定平台
+        当有需要创建一个事件, 触发某些处理流程时, 使用该方法
+
+        Args:
+            abm (AstrBotMessage): 要提交的消息对象, 请先使用 create_message 创建
+            platform (str): 可选的平台名称，默认为空，默认平台(aiocqhttp), 目前只支持 aiocqhttp
+            is_wake (bool): 是否标记为唤醒事件, 默认为 True, 只有唤醒事件才会被 llm 响应
+        """
+        platforms = cls._context.platform_manager.get_insts()
+        if platform == "aiocqhttp":
+            adapter = next((p for p in platforms if isinstance(p, AiocqhttpAdapter)), None)
+            if adapter is None:
+                raise ValueError("未找到适配器: AiocqhttpAdapter")
+            event = AiocqhttpMessageEvent(
+                message_str=abm.message_str,
+                message_obj=abm,
+                platform_meta=adapter.metadata,
+                session_id=abm.session_id,
+                bot=adapter.bot,
+            )
+            event.is_wake = is_wake
+            adapter.commit_event(event)
 
     @classmethod
     def activate_llm_tool(cls, name: str) -> bool:

--- a/astrbot/core/star/star_tools.py
+++ b/astrbot/core/star/star_tools.py
@@ -84,7 +84,7 @@ class StarTools:
             type (str): 消息类型, 可选: PrivateMessage, GroupMessage
             id (str): 目标ID, 例如QQ号, 群号等
             message_chain (MessageChain): 消息链
-            platform (str): 可选的平台名称，默认为空，默认平台(aiocqhttp), 目前只支持 aiocqhttp
+            platform (str): 可选的平台名称，默认平台(aiocqhttp), 目前只支持 aiocqhttp
         """
         platforms = cls._context.platform_manager.get_insts()
         if platform == "aiocqhttp":
@@ -97,6 +97,8 @@ class StarTools:
                 is_group=(type == "GroupMessage"),
                 session_id=id,
             )
+        else:
+            raise ValueError(f"不支持的平台: {platform}")
 
     @classmethod
     async def create_message(
@@ -107,7 +109,7 @@ class StarTools:
         sender: MessageMember,
         message: List[BaseMessageComponent],
         message_str: str,
-        message_id: str = uuid.uuid4().hex,
+        message_id: str = "",
         raw_message: object = None,
         group_id: str = ""
     ) -> AstrBotMessage:
@@ -133,6 +135,8 @@ class StarTools:
         abm.type = type
         abm.self_id = self_id
         abm.session_id = session_id
+        if message_id == "":
+            message_id = uuid.uuid4().hex
         abm.message_id = message_id
         abm.sender = sender
         abm.message = message
@@ -152,7 +156,7 @@ class StarTools:
 
         Args:
             abm (AstrBotMessage): 要提交的消息对象, 请先使用 create_message 创建
-            platform (str): 可选的平台名称，默认为空，默认平台(aiocqhttp), 目前只支持 aiocqhttp
+            platform (str): 可选的平台名称，默认平台(aiocqhttp), 目前只支持 aiocqhttp
             is_wake (bool): 是否标记为唤醒事件, 默认为 True, 只有唤醒事件才会被 llm 响应
         """
         platforms = cls._context.platform_manager.get_insts()
@@ -169,6 +173,8 @@ class StarTools:
             )
             event.is_wake = is_wake
             adapter.commit_event(event)
+        else:
+            raise ValueError(f"不支持的平台: {platform}")
 
     @classmethod
     def activate_llm_tool(cls, name: str) -> bool:


### PR DESCRIPTION
解决了 #2595 #2596 

### Motivation

为插件开发提供根据群id/用户id主动发送消息的封装接口, 提供事件构造的封装接口

### Modifications

增加两个接口和部分说明

### Check

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 总结

添加用于主动消息发送和事件构建的接口

新功能:
- 添加 `send_message_by_id` 方法，用于通过用户或群组 ID 主动发送消息
- 添加 `create_event` 方法，用于构建消息事件并将其提交到平台

增强功能:
- 更新 `create_message` 签名，使用默认参数和显式返回类型以简化消息构建

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add interfaces for proactive messaging and event construction

New Features:
- Add send_message_by_id method to proactively send messages by user or group ID
- Add create_event method to construct and submit message events to the platform

Enhancements:
- Update create_message signature with default parameters and explicit return type to simplify message construction

</details>