### PR TITLE
Feature: add security warning dialog for onebot token configuration

### DIFF
--- a/dashboard/src/i18n/locales/en-US/features/platform.json
+++ b/dashboard/src/i18n/locales/en-US/features/platform.json
@@ -29,6 +29,11 @@
       "title": "ID Conflict Warning",
       "message": "Detected duplicate ID \"{id}\". Please use a new ID.",
       "confirm": "OK"
+    },
+    "securityWarning": {
+      "title": "Security Warning",
+      "aiocqhttpTokenMissing": "To enhance connection security, it is strongly recommended to set ws_reverse_token. Not setting a token may lead to security risks.",
+      "learnMore": "Learn More"
     }
   },
   "messages": {

--- a/dashboard/src/i18n/locales/zh-CN/features/platform.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/platform.json
@@ -29,6 +29,11 @@
       "title": "ID 冲突警告",
       "message": "检测到 ID \"{id}\" 重复。请使用一个新的 ID。",
       "confirm": "好的"
+    },
+    "securityWarning": {
+      "title": "安全提醒",
+      "aiocqhttpTokenMissing": "为了增强连接安全性，强烈建议您设置 ws_reverse_token。未设置 Token 可能导致安全风险。",
+      "learnMore": "了解更多"
     }
   },
   "messages": {


### PR DESCRIPTION
closes: #2639 

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 总结

引入一个安全警告对话框，当配置 OneBot (aiocqhttp) 且未设置令牌时，提示用户在保存或更新平台之前确认或修改，并重构更新逻辑以便复用

新功能：
- 当创建或更新 OneBot 平台且 ws_reverse_token 为空时，显示一个持久的安全警告对话框
- 允许用户选择继续（即使缺少令牌）或取消以修改配置

改进：
- 将平台更新逻辑提取到一个可复用的 `updatePlatform` 方法中
- 为安全警告对话框添加本地化键（支持英文和中文）

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a security warning dialog when configuring OneBot (aiocqhttp) without a token, prompting users to confirm or revise before saving or updating the platform, and refactor the update logic for reuse

New Features:
- Show a persistent security warning dialog when creating or updating a OneBot platform with an empty ws_reverse_token
- Allow users to either proceed despite missing token or cancel to revise the configuration

Enhancements:
- Extract platform update logic into a reusable updatePlatform method
- Add localization keys for the security warning dialog in English and Chinese

</details>