### PR TITLE
feat: 兼容 “命令+参数” 无空格隔开

### DIFF
--- a/astrbot/core/star/filter/command.py
+++ b/astrbot/core/star/filter/command.py
@@ -7,7 +7,6 @@ from astrbot.core.config import AstrBotConfig
 from .custom_filter import CustomFilter
 from ..star_handler import StarHandlerMetadata
 
-
 class GreedyStr(str):
     """标记指令完成其他参数接收后的所有剩余文本。"""
 
@@ -153,10 +152,17 @@ class CommandFilter(HandlerFilter):
                     _full = f"{parent_command_name} {candidate}"
                 else:
                     _full = candidate
-                if message_str.startswith(f"{_full} ") or message_str == _full:
-                    message_str = message_str[len(_full) :].strip()
+                if message_str == _full:
+                    # 完全等于命令名 → 没参数
+                    message_str = ""
                     ok = True
                     break
+                elif message_str.startswith(_full):
+                    # 命令名后面无论是空格还是直接连参数都可以
+                    message_str = message_str[len(_full):].lstrip()
+                    ok = True
+                    break
+
         if not ok:
             return False
 


### PR DESCRIPTION


### Motivation

插件中@filter.command的指令在用户输入“命令+参数” 无空格隔开时无法处理

### Modifications

但只要稍微改动几行CommandFilter中的代码即可兼容

### Check

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码
