### PR TITLE
feat: 优化 WebUI 面板启动逻辑，优先使用本地构建的 dashboard/dist 目录

### DIFF
--- a/astrbot/dashboard/server.py
+++ b/astrbot/dashboard/server.py
@@ -32,7 +32,13 @@ class AstrBotDashboard:
     ) -> None:
         self.core_lifecycle = core_lifecycle
         self.config = core_lifecycle.astrbot_config
-        self.data_path = os.path.abspath(os.path.join(get_astrbot_data_path(), "dist"))
+
+        local_dashboard_dist = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../dashboard/dist"))
+        if os.path.exists(local_dashboard_dist):
+            self.data_path = local_dashboard_dist
+        else:
+            self.data_path = os.path.abspath(os.path.join(get_astrbot_data_path(), "dist"))
+            
         self.app = Quart("dashboard", static_folder=self.data_path, static_url_path="/")
         APP = self.app  # noqa
         self.app.config["MAX_CONTENT_LENGTH"] = (

--- a/main.py
+++ b/main.py
@@ -40,6 +40,11 @@ def check_env():
 async def check_dashboard_files():
     """下载管理面板文件"""
 
+    dashboard_dist_path = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "dashboard", "dist"))
+    if os.path.exists(dashboard_dist_path):
+        logger.info("检测到本地构建的 dashboard/dist 目录，将直接使用该目录作为前端面板")
+        return
+     
     v = await get_dashboard_version()
     if v is not None:
         # has file

--- a/main.py
+++ b/main.py
@@ -42,8 +42,18 @@ async def check_dashboard_files():
 
     dashboard_dist_path = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "dashboard", "dist"))
     if os.path.exists(dashboard_dist_path):
-        logger.info("检测到本地构建的 dashboard/dist 目录，将直接使用该目录作为前端面板")
-        return
+        logger.info("检测到本地构建的 dashboard/dist 目录")
+        # 等待用户输入
+        while True:
+            user_input = input("是否使用本地构建的 dashboard/dist 目录？(Y/N): ").strip().lower()
+            if user_input in ['y', 'yes', 'a', '是', '']:
+                logger.info("将直接使用本地构建的 dashboard/dist 目录作为前端面板")
+                return
+            elif user_input in ['n', 'no', '否']:
+                logger.info("忽略本地构建的 dashboard/dist 目录，使用默认逻辑。如果你希望一直使用 data/dist 目录，请将 dashboard/dist 目录删除。")
+                break
+            else:
+                logger.info("请输入 Y(是) 或 N(否)")
      
     v = await get_dashboard_version()
     if v is not None:

--- a/main.py
+++ b/main.py
@@ -47,10 +47,10 @@ async def check_dashboard_files():
         while True:
             user_input = input("是否使用本地构建的 dashboard/dist 目录？(Y/N): ").strip().lower()
             if user_input in ['y', 'yes', 'a', '是', '']:
-                logger.info("将直接使用本地构建的 dashboard/dist 目录作为前端面板")
+                logger.info("将直接使用本地构建的 dashboard/dist 目录作为前端面板。如果你希望使用 data/dist 目录，请将 dashboard/dist 目录删除。")
                 return
             elif user_input in ['n', 'no', '否']:
-                logger.info("忽略本地构建的 dashboard/dist 目录，使用默认逻辑。如果你希望一直使用 data/dist 目录，请将 dashboard/dist 目录删除。")
+                logger.info("忽略本地构建的 dashboard/dist 目录，使用默认逻辑。如果你希望不再进行此交互，请将 dashboard/dist 目录删除，以使用 data/dist。")
                 break
             else:
                 logger.info("请输入 Y(是) 或 N(否)")


### PR DESCRIPTION



### Motivation

<!--解释为什么要改动-->
在本地开发 WebUI 面板时，开发者会在 dashboard 目录下进行前端开发 并构建生成文件到 dashboard/dist 目录。

为了能够立即查看本地构建的效果 而不使用前端 dev 模式启动，需要优化 WebUI 面板的启动逻辑。

当前的逻辑是先检测 data/dist 下的 version 文件是否存在，如果不存在就直接拉取远端的 dist。

但这导致了在本地开发时 无法方便地使用本地构建的文件进行测试。

### Modifications

优先检测是否存在 dashboard/dist 的本地构建目录

如果存在 dashboard/dist，则直接使用该目录作为前端面板资源

如果不存在 dashboard/dist，才进入原有的检测版本、拉取等判断逻辑，之后才使用 data/dist

---

同时，为了避免用户混淆（例如更新了远程面板但因为本地构建存在而看不到变化），

在检测到本地构建时增加了用户交互确认步骤：

检测到本地构建的 dashboard/dist 目录时，会提示用户："是否使用本地构建的 dashboard/dist 目录？(Y/N)"

用户可以选择使用本地构建（Y/y/yes/是/A/a 或直接回车）或忽略本地构建（N/n/no/否）

只有当用户明确选择使用本地构建时，才会使用 dashboard/dist 文件

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码
