### PR TITLE
fix: 解决插件页表格视图中，点击状态字段表头排序不起作用的问题 issue##2585，并且增加列宽

### DIFF
--- a/dashboard/src/views/ExtensionPage.vue
+++ b/dashboard/src/views/ExtensionPage.vue
@@ -78,7 +78,7 @@ const pluginHeaders = computed(() => [
   { title: tm('table.headers.description'), key: 'desc', maxWidth: '250px' },
   { title: tm('table.headers.version'), key: 'version', width: '100px' },
   { title: tm('table.headers.author'), key: 'author', width: '100px' },
-  { title: tm('table.headers.status'), key: 'status', width: '80px' },
+  { title: tm('table.headers.status'), key: 'activated', width: '100px' },
   { title: tm('table.headers.actions'), key: 'actions', sortable: false, width: '220px' }
 ]);
 
@@ -660,7 +660,7 @@ onMounted(async () => {
                       <div class="text-body-2">{{ item.author }}</div>
                     </template>
 
-                    <template v-slot:item.status="{ item }">
+                    <template v-slot:item.activated="{ item }">
                       <v-chip :color="item.activated ? 'success' : 'error'" size="small" class="font-weight-medium"
                         :variant="item.activated ? 'flat' : 'outlined'">
                         {{ item.activated ? tm('status.enabled') : tm('status.disabled') }}


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
fixes: #2585 

### Motivation

<!--解释为什么要改动-->
功能修复：解决插件页表格视图中，点击状态字段表头排序不起作用的问题 issue #2585，并且增加列宽

### Modifications

<!--简单解释你的改动-->
在插件表格视图中，状态表头的key写的是`status`，但数据中实际为`activated`，本次改动主要更改为后者
### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [勾 ] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ 勾] 👀 我的更改经过良好的测试
- [勾 ] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [勾 ] 😮 我的更改没有引入恶意代码

## Sourcery 摘要

修复插件表状态列排序问题，方法是更新表头键以匹配数据字段并增加其宽度

Bug 修复：
- 修复插件表中状态列的排序问题，方法是修正表头键以匹配 'activated' 数据属性

增强功能：
- 将状态列宽度从 80px 增加到 100px

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix plugin table status column sorting by updating the header key to match the data field and increase its width

Bug Fixes:
- Fix sorting on the status column in the plugin table by correcting the header key to match the 'activated' data property

Enhancements:
- Increase status column width from 80px to 100px

</details>