### PR TITLE
fixed：解决插件页表格视图中，点击状态字段表头排序不起作用的问题 issue##2585，并且增加列宽

### DIFF
--- a/dashboard/src/views/ExtensionPage.vue
+++ b/dashboard/src/views/ExtensionPage.vue
@@ -78,7 +78,7 @@ const pluginHeaders = computed(() => [
   { title: tm('table.headers.description'), key: 'desc', maxWidth: '250px' },
   { title: tm('table.headers.version'), key: 'version', width: '100px' },
   { title: tm('table.headers.author'), key: 'author', width: '100px' },
-  { title: tm('table.headers.status'), key: 'status', width: '80px' },
+  { title: tm('table.headers.status'), key: 'activated', width: '100px' },
   { title: tm('table.headers.actions'), key: 'actions', sortable: false, width: '220px' }
 ]);
 
@@ -660,7 +660,7 @@ onMounted(async () => {
                       <div class="text-body-2">{{ item.author }}</div>
                     </template>
 
-                    <template v-slot:item.status="{ item }">
+                    <template v-slot:item.activated="{ item }">
                       <v-chip :color="item.activated ? 'success' : 'error'" size="small" class="font-weight-medium"
                         :variant="item.activated ? 'flat' : 'outlined'">
                         {{ item.activated ? tm('status.enabled') : tm('status.disabled') }}


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了 #XYZ

### Motivation

<!--解释为什么要改动-->

### Modifications

<!--简单解释你的改动-->

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [ ] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] 👀 我的更改经过良好的测试
- [ ] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [ ] 😮 我的更改没有引入恶意代码

## Sourcery 总结

修复插件页面状态列的排序功能，通过将其键更新为 'activated' 以匹配数据属性并调整其宽度

Bug 修复:
- 恢复插件状态列的排序功能，通过将其标题键与实际数据字段 'activated' 对齐

改进:
- 将状态列的宽度从 80px 增加到 100px，以提高可读性

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix sorting on the plugin page status column by updating its key to 'activated' to match the data property and adjust its width

Bug Fixes:
- Restore sorting functionality for the plugin status column by aligning its header key with the actual data field 'activated'

Enhancements:
- Increase the status column width from 80px to 100px for better readability

</details>