### PR TITLE
fix: 修复工具调用时的 content 内容在重新加载后没有显示在 webchat 的问题

### DIFF
--- a/astrbot/dashboard/routes/chat.py
+++ b/astrbot/dashboard/routes/chat.py
@@ -157,7 +157,11 @@ class ChatRoute(Route):
 
                     if type == "end":
                         break
-                    elif (streaming and type == "complete") or not streaming:
+                    elif (
+                        (streaming and type == "complete")
+                        or not streaming
+                        or type == "break"
+                    ):
                         # append bot message
                         new_his = {"type": "bot", "message": result_text}
                         await self.platform_history_mgr.insert(


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->

### Motivation

多轮工具调用时，带有 tool call 的 message segment 的对应的 content 文本在 webui 重新加载该对话之后没有正常显示出来。

### Modifications


<img width="1636" height="1052" alt="image" src="https://github.com/user-attachments/assets/4bb5c5f9-8959-4da9-a7bd-bcb62f6dc72f" />

<img width="1648" height="586" alt="image" src="https://github.com/user-attachments/assets/b4a9362f-8c13-4747-8dfd-f54c2be59966" />



<!--简单解释你的改动-->

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 
文件相应位置。
- [x] 😮 我的更改没有引入恶意代码
