### PR TITLE
fix: 修复LLM调用已禁用的工具

### DIFF
--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -1255,15 +1255,15 @@ UID: {user_id} 此 ID 可用于设置管理员。
             if (persona and persona.get("tools") is None) or not persona:
                 # select all
                 toolset = tmgr.get_full_tool_set()
+                for tool in toolset:
+                    if not tool.active:
+                        toolset.remove_tool(tool.name)
             else:
                 toolset = ToolSet()
                 for tool_name in persona["tools"]:
                     tool = tmgr.get_func(tool_name)
-                    if tool:
+                    if tool and tool.active:
                         toolset.add_tool(tool)
-            for tool in toolset:
-                if not tool.active:
-                    toolset.remove_tool(tool.name)
             req.func_tool = toolset
             logger.debug(f"Tool set for persona {persona_id}: {toolset.names()}")
 


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
fixes #2712 #2707 #2667 #2655

### Motivation

<!--解释为什么要改动-->
原有方法在获取每个人格可用的工具后，并没有剔除已禁用的工具。导致所有可用的工具（包括已经禁用的工具）放入请求中，导致LLM概率调用禁用的工具，引发非预期的情况。

### Modifications

在获取人格可用工具后循环判断工具是否启用，移除禁用的工具
<!--简单解释你的改动-->

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

## Sourcery 总结

错误修复:
- 在为角色收集可用工具后，过滤掉已禁用的工具，以阻止 LLM 调用它们。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Filter out disabled tools after collecting available tools for a persona to stop the LLM from invoking them.

</details>