### PR TITLE
fix: 多配置文件设置的不同人格无法生效，仍使用设置的第一个人格

### DIFF
--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -1232,11 +1232,13 @@ UID: {user_id} 此 ID 可用于设置管理员。
 
         if req.conversation:
             # persona inject
-            persona_id = req.conversation.persona_id
+            persona_id = req.conversation.persona_id or cfg.get("default_personality")
             if not persona_id and persona_id != "[%None]":  # [%None] 为用户取消人格
-                persona_id = self.context.persona_manager.selected_default_persona_v3[
-                    "name"
-                ]
+                default_persona = (
+                    self.context.persona_manager.selected_default_persona_v3
+                )
+                if default_persona:
+                    persona_id = default_persona["name"]
             persona = next(
                 builtins.filter(
                     lambda persona: persona["name"] == persona_id,


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE --> 
fixes: #2724

### Motivation

fix #2724
<!--解释为什么要改动-->

### Modifications

<!--简单解释你的改动-->

### Check

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容-->

- [ ] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] 👀 我的更改经过良好的测试
- [ ] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [ ] 😮 我的更改没有引入恶意代码

## Sourcery 摘要

当未提供 `persona_id` 时，尊重已配置的默认个性，并且仅在需要时回退到先前选择的默认个性。

错误修复:
- 当 `req.conversation.persona_id` 未设置时，从 `cfg` 应用 `default_personality`
- 避免总是使用第一个个性，仅在没有配置的默认值存在时才回退到 `selected_default_persona_v3`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Respect the configured default personality when no persona_id is provided and fallback to the previously selected default persona only if needed

Bug Fixes:
- Apply default_personality from cfg when req.conversation.persona_id is unset
- Avoid always using the first persona by only falling back to selected_default_persona_v3 if no config default exists

</details>