### PR TITLE
fix: 修复分段回复时，引用消息单独发送导致第一条消息内容为空的问题

### DIFF
--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -1,17 +1,15 @@
 import random
 import asyncio
 import math
-import traceback
 import astrbot.core.message.components as Comp
 from typing import Union, AsyncGenerator
 from ..stage import register_stage, Stage
-from ..context import PipelineContext
+from ..context import PipelineContext, call_event_hook
 from astrbot.core.platform.astr_message_event import AstrMessageEvent
 from astrbot.core.message.message_event_result import MessageChain, ResultContentType
 from astrbot.core import logger
-from astrbot.core.message.message_event_result import BaseMessageComponent
-from astrbot.core.star.star_handler import star_handlers_registry, EventType
-from astrbot.core.star.star import star_map
+from astrbot.core.message.components import BaseMessageComponent, ComponentType
+from astrbot.core.star.star_handler import EventType
 from astrbot.core.utils.path_util import path_Mapping
 from astrbot.core.utils.session_lock import session_lock_manager
 
@@ -114,6 +112,43 @@ class RespondStage(Stage):
         # 如果所有组件都为空
         return True
 
+    def is_seg_reply_required(self, event: AstrMessageEvent) -> bool:
+        """检查是否需要分段回复"""
+        if not self.enable_seg:
+            return False
+
+        if self.only_llm_result and not event.get_result().is_llm_result():
+            return False
+
+        if event.get_platform_name() in [
+            "qq_official",
+            "weixin_official_account",
+            "dingtalk",
+        ]:
+            return False
+
+        return True
+
+    def _extract_comp(
+        self,
+        raw_chain: list[BaseMessageComponent],
+        extract_types: set[ComponentType],
+        modify_raw_chain: bool = True,
+    ):
+        extracted = []
+        if modify_raw_chain:
+            remaining = []
+            for comp in raw_chain:
+                if comp.type in extract_types:
+                    extracted.append(comp)
+                else:
+                    remaining.append(comp)
+            raw_chain[:] = remaining
+        else:
+            extracted = [comp for comp in raw_chain if comp.type in extract_types]
+
+        return extracted
+
     async def process(
         self, event: AstrMessageEvent
     ) -> Union[None, AsyncGenerator[None, None]]:
@@ -123,7 +158,14 @@ class RespondStage(Stage):
         if result.result_content_type == ResultContentType.STREAMING_FINISH:
             return
 
+        logger.info(
+            f"Prepare to send - {event.get_sender_name()}/{event.get_sender_id()}: {event._outline_chain(result.chain)}"
+        )
+
         if result.result_content_type == ResultContentType.STREAMING_RESULT:
+            if result.async_stream is None:
+                logger.warning("async_stream 为空，跳过发送。")
+                return
             # 流式结果直接交付平台适配器处理
             use_fallback = self.config.get("provider_settings", {}).get(
                 "streaming_segmented", False
@@ -148,87 +190,62 @@ class RespondStage(Stage):
             except Exception as e:
                 logger.warning(f"空内容检查异常: {e}")
 
-            record_comps = [c for c in result.chain if isinstance(c, Comp.Record)]
-            non_record_comps = [
-                c for c in result.chain if not isinstance(c, Comp.Record)
-            ]
-
-            if (
-                self.enable_seg
-                and (
-                    (self.only_llm_result and result.is_llm_result())
-                    or not self.only_llm_result
+            # 发送消息链
+            # Record 需要强制单独发送
+            need_separately = {ComponentType.Record}
+            if self.is_seg_reply_required(event):
+                header_comps = self._extract_comp(
+                    result.chain,
+                    {ComponentType.Reply, ComponentType.At},
+                    modify_raw_chain=True,
                 )
-                and event.get_platform_name()
-                not in ["qq_official", "weixin_official_account", "dingtalk"]
-            ):
-                decorated_comps = []
-                if self.reply_with_mention:
-                    for comp in result.chain:
-                        if isinstance(comp, Comp.At):
-                            decorated_comps.append(comp)
-                            result.chain.remove(comp)
-                            break
-                if self.reply_with_quote:
-                    for comp in result.chain:
-                        if isinstance(comp, Comp.Reply):
-                            decorated_comps.append(comp)
-                            result.chain.remove(comp)
-                            break
-
-                # leverage lock to guarentee the order of message sending among different events
+                if not result.chain or len(result.chain) == 0:
+                    # may fix #2670
+                    logger.warning(
+                        f"实际消息链为空, 跳过发送阶段。header_chain: {header_comps}, actual_chain: {result.chain}"
+                    )
+                    return
                 async with session_lock_manager.acquire_lock(event.unified_msg_origin):
-                    for rcomp in record_comps:
-                        i = await self._calc_comp_interval(rcomp)
-                        await asyncio.sleep(i)
-                        try:
-                            await event.send(MessageChain([rcomp]))
-                        except Exception as e:
-                            logger.error(f"发送消息失败: {e} chain: {result.chain}")
-                            break
-                    # 分段回复
-                    for comp in non_record_comps:
+                    for comp in result.chain:
                         i = await self._calc_comp_interval(comp)
                         await asyncio.sleep(i)
                         try:
-                            await event.send(MessageChain([*decorated_comps, comp]))
-                            decorated_comps = []  # 清空已发送的装饰组件
+                            if comp.type in need_separately:
+                                await event.send(MessageChain([comp]))
+                            else:
+                                await event.send(MessageChain([*header_comps, comp]))
+                                header_comps.clear()
                         except Exception as e:
-                            logger.error(f"发送消息失败: {e} chain: {result.chain}")
-                            break
+                            logger.error(
+                                f"发送消息链失败: chain = {MessageChain([comp])}, error = {e}",
+                                exc_info=True,
+                            )
             else:
-                for rcomp in record_comps:
+                sep_comps = self._extract_comp(
+                    result.chain,
+                    need_separately,
+                    modify_raw_chain=True,
+                )
+                for comp in sep_comps:
+                    chain = MessageChain([comp])
                     try:
-                        await event.send(MessageChain([rcomp]))
+                        await event.send(chain)
                     except Exception as e:
-                        logger.error(f"发送消息失败: {e} chain: {result.chain}")
+                        logger.error(
+                            f"发送消息链失败: chain = {chain}, error = {e}",
+                            exc_info=True,
+                        )
+                chain = MessageChain(result.chain)
+                if result.chain and len(result.chain) > 0:
+                    try:
+                        await event.send(chain)
+                    except Exception as e:
+                        logger.error(
+                            f"发送消息链失败: chain = {chain}, error = {e}",
+                            exc_info=True,
+                        )
 
-                try:
-                    await event.send(MessageChain(non_record_comps))
-                except Exception as e:
-                    logger.error(traceback.format_exc())
-                    logger.error(f"发送消息失败: {e} chain: {result.chain}")
-
-            logger.info(
-                f"AstrBot -> {event.get_sender_name()}/{event.get_sender_id()}: {event._outline_chain(result.chain)}"
-            )
-
-        handlers = star_handlers_registry.get_handlers_by_event_type(
-            EventType.OnAfterMessageSentEvent, plugins_name=event.plugins_name
-        )
-        for handler in handlers:
-            try:
-                logger.debug(
-                    f"hook(on_after_message_sent) -> {star_map[handler.handler_module_path].name} - {handler.handler_name}"
-                )
-                await handler.handler(event)
-            except BaseException:
-                logger.error(traceback.format_exc())
-
-            if event.is_stopped():
-                logger.info(
-                    f"{star_map[handler.handler_module_path].name} - {handler.handler_name} 终止了事件传播。"
-                )
-                return
+        if await call_event_hook(event, EventType.OnAfterMessageSentEvent):
+            return
 
         event.clear_result()


### PR DESCRIPTION
fixes: #2132 #2670

<!-- 如果有的话，请指定此 PR 旨在解决的 ISSUE 编号。 -->
<!-- If applicable, please specify the ISSUE number this PR aims to resolve. -->

---

### Motivation / 动机

修复分段回复时，引用消息单独发送导致第一条消息内容为空的问题

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX 错误，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX bug, adds YY feature)-->

### Modifications / 改动点

重构了 respond_stage 的发送消息链的逻辑，让整体代码变得更加易读。

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

### Verification Steps / 验证步骤

1. 开启分段回复和回复时引用消息，目前的代码逻辑会首先发送一条空的带有引用内容的消息，而这个更改解决了这个问题。
2. 开启 TTS 和分段回复和回复时引用消息，可以看到所有消息正常发送。


<!--请为审查者 (Reviewer) 提供清晰、可复现的验证步骤（例如：1. 导航到... 2. 点击...）。-->
<!--Please provide clear and reproducible verification steps for the Reviewer (e.g., 1. Navigate to... 2. Click...).-->

### Screenshots or Test Results / 运行截图或测试结果

<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->

### Compatibility & Breaking Changes / 兼容性与破坏性变更

<!--请说明此变更的兼容性：哪些是破坏性变更？哪些地方做了向后兼容处理？是否提供了数据迁移方法？-->
<!--Please explain the compatibility of this change: What are the breaking changes? What backward-compatible measures were taken? Are data migration paths provided?-->

- [ ] 这是一个破坏性变更 (Breaking Change)。/ This is a breaking change.
- [x] 这不是一个破坏性变更。/ This is NOT a breaking change.

---

### Checklist / 检查清单

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->
<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.
