### PR TITLE
feat: 增加群名称识别到 system prompt, 并提供相应的配置

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -60,6 +60,7 @@ DEFAULT_CONFIG = {
         "web_search_link": False,
         "display_reasoning_text": False,
         "identifier": False,
+        "group_name_display": False,
         "datetime_system_prompt": True,
         "default_personality": "default",
         "persona_pool": ["*"],
@@ -1724,6 +1725,9 @@ CONFIG_METADATA_2 = {
                     "identifier": {
                         "type": "bool",
                     },
+                    "group_name_display": {
+                        "type": "bool",
+                    },
                     "datetime_system_prompt": {
                         "type": "bool",
                     },
@@ -1996,6 +2000,11 @@ CONFIG_METADATA_3 = {
                     "provider_settings.identifier": {
                         "description": "用户识别",
                         "type": "bool",
+                    },
+                    "provider_settings.group_name_display": {
+                        "description": "显示群名称",
+                        "type": "bool",
+                        "hint": "启用后，在支持的平台(aiocqhttp)上会在 prompt 中包含群名称信息。",
                     },
                     "provider_settings.datetime_system_prompt": {
                         "description": "现实世界时间感知",

--- a/astrbot/core/platform/astrbot_message.py
+++ b/astrbot/core/platform/astrbot_message.py
@@ -55,7 +55,7 @@ class AstrBotMessage:
     self_id: str  # 机器人的识别id
     session_id: str  # 会话id。取决于 unique_session 的设置。
     message_id: str  # 消息id
-    group_id: str = ""  # 群组id，如果为私聊，则为空
+    group: Group  # 群组
     sender: MessageMember  # 发送者
     message: List[BaseMessageComponent]  # 消息链使用 Nakuru 的消息链格式
     message_str: str  # 最直观的纯文本消息字符串
@@ -64,6 +64,28 @@ class AstrBotMessage:
 
     def __init__(self) -> None:
         self.timestamp = int(time.time())
+        self.group = None
 
     def __str__(self) -> str:
         return str(self.__dict__)
+
+    @property
+    def group_id(self) -> str:
+        """
+        向后兼容的 group_id 属性
+        群组id，如果为私聊，则为空
+        """
+        if self.group:
+            return self.group.group_id
+        return ""
+
+    @group_id.setter
+    def group_id(self, value: str):
+        """设置 group_id"""
+        if value:
+            if self.group:
+                self.group.group_id = value
+            else:
+                self.group = Group(group_id=value)
+        else:
+            self.group = None

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -167,7 +167,9 @@ class AiocqhttpAdapter(Platform):
 
         if "sub_type" in event:
             if event["sub_type"] == "poke" and "target_id" in event:
-                abm.message.append(Poke(qq=str(event["target_id"]), type="poke"))  # noqa: F405
+                abm.message.append(
+                    Poke(qq=str(event["target_id"]), type="poke")
+                )  # noqa: F405
 
         return abm
 
@@ -187,6 +189,7 @@ class AiocqhttpAdapter(Platform):
         if event["message_type"] == "group":
             abm.type = MessageType.GROUP_MESSAGE
             abm.group_id = str(event.group_id)
+            abm.group.group_name = event.get("group_name", "N/A")
         elif event["message_type"] == "private":
             abm.type = MessageType.FRIEND_MESSAGE
         if self.unique_session and abm.type == MessageType.GROUP_MESSAGE:

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -167,9 +167,7 @@ class AiocqhttpAdapter(Platform):
 
         if "sub_type" in event:
             if event["sub_type"] == "poke" and "target_id" in event:
-                abm.message.append(
-                    Poke(qq=str(event["target_id"]), type="poke")
-                )  # noqa: F405
+                abm.message.append(Poke(qq=str(event["target_id"]), type="poke"))  # noqa: F405
 
         return abm
 

--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -1215,14 +1215,7 @@ UID: {user_id} 此 ID 可用于设置管理员。
             req.prompt = user_info + req.prompt
 
         if cfg.get("group_name_display") and event.message_obj.group_id:
-            group_name = ""
-            if hasattr(event.message_obj.raw_message, "group_name"):
-                group_name = str(event.message_obj.raw_message.group_name)
-            elif (
-                isinstance(event.message_obj.raw_message, dict)
-                and "group_name" in event.message_obj.raw_message
-            ):
-                group_name = str(event.message_obj.raw_message["group_name"])
+            group_name = event.message_obj.group.group_name
 
             if group_name:
                 req.system_prompt += f"\nGroup name: {group_name}\n"

--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -1214,6 +1214,19 @@ UID: {user_id} 此 ID 可用于设置管理员。
             user_info = f"\n[User ID: {user_id}, Nickname: {user_nickname}]\n"
             req.prompt = user_info + req.prompt
 
+        if cfg.get("group_name_display") and event.message_obj.group_id:
+            group_name = ""
+            if hasattr(event.message_obj.raw_message, "group_name"):
+                group_name = str(event.message_obj.raw_message.group_name)
+            elif (
+                isinstance(event.message_obj.raw_message, dict)
+                and "group_name" in event.message_obj.raw_message
+            ):
+                group_name = str(event.message_obj.raw_message["group_name"])
+
+            if group_name:
+                req.system_prompt += f"\nGroup name: {group_name}\n"
+
         # 启用附加时间戳
         if cfg.get("datetime_system_prompt"):
             current_time = None


### PR DESCRIPTION
<!-- 如果有的话，请指定此 PR 旨在解决的 ISSUE 编号。 -->
<!-- If applicable, please specify the ISSUE number this PR aims to resolve. -->


---

### Motivation / 动机

增加群名称感知
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX 错误，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX bug, adds YY feature)-->

### Modifications / 改动点

一处配置内容(在dashboard上配置)
一处注入system prompt

对更多平台的支持:
需要重构一下事件里面的群聊(把id扩展成群聊对象, 保存群聊名称, 但是这样会面临兼容问题)
也可以set_extra不过有点丑陋
现在这样也还行吧, 不过只支持qq
再说了其他平台不一定下发群聊名称

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

### Verification Steps / 验证步骤

如图
<!--请为审查者 (Reviewer) 提供清晰、可复现的验证步骤（例如：1. 导航到... 2. 点击...）。-->
<!--Please provide clear and reproducible verification steps for the Reviewer (e.g., 1. Navigate to... 2. Click...).-->

### Screenshots or Test Results / 运行截图或测试结果

<img width="768" height="114" alt="image" src="https://github.com/user-attachments/assets/4b79266e-508c-42d6-bf34-a743dfa79380" />

<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->

### Compatibility & Breaking Changes / 兼容性与破坏性变更

在AstrBotMessage处通过group_id属性进行向后兼容, 原先位置替换为group以增加事件携带的信息, 也与下方MessageMember保持信息量的一致
<!--请说明此变更的兼容性：哪些是破坏性变更？哪些地方做了向后兼容处理？是否提供了数据迁移方法？-->
<!--Please explain the compatibility of this change: What are the breaking changes? What backward-compatible measures were taken? Are data migration paths provided?-->

- [ ] 这是一个破坏性变更 (Breaking Change)。/ This is a breaking change.
- [x] 这不是一个破坏性变更。/ This is NOT a breaking change.

---

### Checklist / 检查清单

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->
<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Sourcery 总结

引入一个新的配置选项，用于在 LLM 系统提示中包含群组名称，并针对支持的平台实现群组名称提取。

新功能：
- 添加 `group_name_display` 配置标志和仪表盘设置，以启用在提示中包含群组名称的功能
- 当此功能启用时，从收到的 QQ 群消息中提取群组名称并注入到 LLM 系统提示中

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a new configuration option to include group names in LLM system prompts and implement group name extraction for supported platforms.

New Features:
- Add `group_name_display` configuration flag and dashboard setting to enable group name inclusion in prompts
- Extract and inject the group name from incoming QQ group messages into the LLM system prompt when enabled

</details>