### PR TITLE
Update satori_adapter.py - 优化XML解析逻辑，移除正则表达式依赖

### DIFF
--- a/astrbot/core/platform/sources/satori/satori_adapter.py
+++ b/astrbot/core/platform/sources/satori/satori_adapter.py
@@ -633,6 +633,16 @@ class SatoriPlatformAdapter(Platform):
                 else:
                     elements.append(Plain(text="[ARK卡片]"))
 
+            elif tag_name == "json":
+                # JSON标签 视为ARK卡片消息
+                data = attrs.get("data", "")
+                if data:
+                    import html
+                    decoded_data = html.unescape(data)
+                    elements.append(Plain(text=f"[ARK卡片数据: {decoded_data}]"))
+                else:
+                    elements.append(Plain(text="[JSON卡片]"))
+
             else:
                 # 未知标签，递归处理其内容
                 if child.text and child.text.strip():


### PR DESCRIPTION
<!-- 如果有的话，请指定此 PR 旨在解决的 ISSUE 编号。 -->
<!-- If applicable, please specify the ISSUE number this PR aims to resolve. -->

承接自 https://github.com/AstrBotDevs/AstrBot/pull/2686#issuecomment-3298440968

由于上次通过PR之后，我观察到 satori_adapter.py 文件没有得到更新，所以此前的改动内容与本次xml相关优化改动 在此次PR中一并提交


---

### Motivation / 动机

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX 错误，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX bug, adds YY feature)-->

此PR旨在优化Satori平台适配器中的XML解析逻辑，完全移除对正则表达式的依赖。

原先的代码在处理XML命名空间前缀和`<quote>`标签时使用了正则表达式，不够安全和可靠。

混合使用正则表达式和XML解析器导致代码不一致。

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
核心改动文件：
astrbot/core/platform/sources/satori/satori_adapter.py

主要改动：
1. 新增 `_extract_namespace_prefixes` 方法，使用字符串遍历方式替代正则表达式提取XML命名空间前缀
2. 新增 `_extract_quote_element` 方法，使用统一的XML解析器处理quote标签
3. 移除所有正则表达式的使用，确保XML处理逻辑的一致性

### Verification Steps / 验证步骤

<!--请为审查者 (Reviewer) 提供清晰、可复现的验证步骤（例如：1. 导航到... 2. 点击...）。-->
<!--Please provide clear and reproducible verification steps for the Reviewer (e.g., 1. Navigate to... 2. Click...).-->

1. 启动AstrBot并连接到 liteloader onebot 实现的 Satori协议的平台

> 注意：不同Satori协议实现可能有不同的消息格式。
> 
> 在koishi平台使用adapter-satori并开启server-satori实现的Satori协议中，小程序内容会被直接解析为ark消息；
> 
> 而在koishi平台使用adapter-onebot并开启server-satori实现的Satori协议中，小程序内容会被adapter-onebot适配器解析为json内容，进而被上报为json消息。

2. 发送包含XML标签的消息（如包含`<quote>`、`<at>`、`<img>`等标签）

3. 验证消息能被正确解析和处理

4. 特别测试包含命名空间前缀的XML内容是否能正确处理（例如音乐卡片、小程序卡片）

### Screenshots or Test Results / 运行截图或测试结果

<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->

```
 [20:34:34] [Core] [INFO] [satori.satori_adapter:123]: Satori 适配器正在连接到 WebSocket: ws://localhost:5600/v1/events
 [20:34:34] [Core] [INFO] [satori.satori_adapter:124]: Satori 适配器 HTTP API 地址: http://localhost:5600/v1
 [20:34:34] [Core] [INFO] [core.core_lifecycle:201]: AstrBot 启动完成。
[2025-09-16 20:34:34 +0800] [13456] [INFO] Running on http://0.0.0.0:6185 (CTRL + C to quit)
 [20:34:36] [Core] [INFO] [satori.satori_adapter:235]: Satori 连接成功 - Bot 1: platform=llonebot, user_id=1787850032, user_name=猫猫不是喵喵
 [20:34:38] [Core] [INFO] [core.event_bus:52]: [default] [satori(satori)] 上学/1919892171: [ARK卡片数据: {"ver":"1.0.0.19","prompt":"[QQ小程序]千早爱音和丰川祥子暴风骤雨开一局","config":{"type":"normal","width":0,"height":0,"forward":1,"autoSize":0,"ctime":1757412165,"token":"7f1b79e050f9b2975ae956a0f8283924"},"needShareCallBack":false,"app":"com.tencent.miniapp_01","view":"view_8C8E89B49BE609866298ADDFF2DBABA4","meta":{"detail_1":{"appid":"1109937557","appType":0,"title":"哔哩哔哩","desc":"千早爱音和丰川祥子暴风骤雨开一局","icon":"https:\/\/open.gtimg.cn\/open\/app_icon\/00\/95\/17\/76\/100951776_100_m.png?t=1757003233","preview":"https:\/\/qq.ugcimg.cn\/v1\/qa0m914o2lsi0n44b3j7qiv2ocj68196vf72di8k9u5krpsmjftt39m57fnvfko9o81kcnc0g87kbahte9q0928lgoqoapo1f34a838a4up767n43rgh68m2b10p5vvkiejrauk0dv3quku97emc1ids2k\/e9vf2tsqr6j29hl2kodb3vahlc","url":"m.q.qq.com\/a\/s\/b3e7ce16fa80252c94a01a4accc83b5a","scene":1036,"host":{"uin":3075693513,"nick":"薪尽自然凉"},"shareTemplateId":"8C8E89B49BE609866298ADDFF2DBABA4","shareTemplateData":{},"qqdocurl":"https:\/\/b23.tv\/0AsJQoT?share_medium=android&share_source=qq&bbid=XXC0516CA6B10221D0DCE8B753857D333BFE3&ts=1757412165309","showLittleTail":"","gamePoints":"","gamePointsUrl":"","shareOrigin":0}}}]
```

### Compatibility & Breaking Changes / 兼容性与破坏性变更

<!--请说明此变更的兼容性：哪些是破坏性变更？哪些地方做了向后兼容处理？是否提供了数据迁移方法？-->
<!--Please explain the compatibility of this change: What are the breaking changes? What backward-compatible measures were taken? Are data migration paths provided?-->

- 所有正则表达式已被移除
- XML解析逻辑统一且更加安全
- 代码可读性和可维护性得到提升

此变更为内部实现优化，不改变任何对外接口和功能行为，完全向后兼容。

- [ ] 这是一个破坏性变更 (Breaking Change)。/ This is a breaking change.
- [x] 这不是一个破坏性变更。/ This is NOT a breaking change.

---

### Checklist / 检查清单

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->
<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Sourcery 总结

优化 Satori 平台适配器，移除所有基于正则表达式的 XML 解析并统一消息元素处理

新功能：
- 实现命名空间前缀提取，不使用正则表达式
- 添加 `<quote>` 元素的专用提取并转换为 Reply 组件的功能
- 支持将 face、ark 和 JSON 卡片元素结构化解析为纯文本

改进：
- 将混合的正则表达式和 XML 解析替换为一致的 XML 解析器，并在出错时回退到纯文本
- 在 `__init__` 中引入 `PlatformMetadata` 初始化，并在 `meta()` 中返回它
- 通过使用统一的元素构造函数简化图像、文件和音频元素处理

杂项：
- 将默认 Satori 端点更新为 `ws://localhost:5140`
- 从 `satori_adapter` 中移除所有剩余的正则表达式依赖

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize the Satori platform adapter by removing all regex-based XML parsing and unifying message element handling

New Features:
- Implement namespace prefix extraction without using regular expressions
- Add dedicated extraction and conversion of <quote> elements into Reply components
- Support structured parsing of face, ark, and JSON card elements as plain text

Enhancements:
- Replace mixed regex and XML parsing with a consistent XML parser and fallback to plain text on errors
- Introduce PlatformMetadata initialization in __init__ and return it in meta()
- Simplify image, file, and audio element handling by using unified element constructors

Chores:
- Update default Satori endpoint to ws://localhost:5140
- Remove all remaining regular expression dependencies from satori_adapter

</details>