### PR TITLE
Fix: hot reload state synchronization issue in ProviderManager

### DIFF
--- a/astrbot/core/provider/manager.py
+++ b/astrbot/core/provider/manager.py
@@ -389,6 +389,10 @@ class ProviderManager:
         if provider_config["enable"]:
             await self.load_provider(provider_config)
 
+        # 重新获取最新的配置
+        latest_config = self.acm.get_conf("default")
+        self.providers_config = latest_config["provider"]
+
         # 和配置文件保持同步
         config_ids = [provider["id"] for provider in self.providers_config]
         logger.debug(f"providers in user's config: {config_ids}")

--- a/astrbot/core/provider/manager.py
+++ b/astrbot/core/provider/manager.py
@@ -400,29 +400,50 @@ class ProviderManager:
             if key not in config_ids:
                 await self.terminate_provider(key)
 
-        if len(self.provider_insts) == 0:
+        # 确保当前 Provider 实例仍然有效
+        if (
+            self.curr_provider_inst
+            and self.curr_provider_inst.meta().id not in self.inst_map
+        ):
             self.curr_provider_inst = None
-        elif self.curr_provider_inst is None and len(self.provider_insts) > 0:
+        # 自动选择第一个可用的 Provider
+        if self.curr_provider_inst is None and len(self.provider_insts) > 0:
             self.curr_provider_inst = self.provider_insts[0]
             logger.info(
                 f"自动选择 {self.curr_provider_inst.meta().id} 作为当前提供商适配器。"
             )
+        elif len(self.provider_insts) == 0:
+            self.curr_provider_inst = None
 
-        if len(self.stt_provider_insts) == 0:
+        # 确保当前 STT Provider 实例仍然有效
+        if (
+            self.curr_stt_provider_inst
+            and self.curr_stt_provider_inst.meta().id not in self.inst_map
+        ):
             self.curr_stt_provider_inst = None
-        elif self.curr_stt_provider_inst is None and len(self.stt_provider_insts) > 0:
+        # 自动选择第一个可用的 STT Provider
+        if self.curr_stt_provider_inst is None and len(self.stt_provider_insts) > 0:
             self.curr_stt_provider_inst = self.stt_provider_insts[0]
             logger.info(
                 f"自动选择 {self.curr_stt_provider_inst.meta().id} 作为当前语音转文本提供商适配器。"
             )
+        elif len(self.stt_provider_insts) == 0:
+            self.curr_stt_provider_inst = None
 
-        if len(self.tts_provider_insts) == 0:
+        # 确保当前 TTS Provider 实例仍然有效
+        if (
+            self.curr_tts_provider_inst
+            and self.curr_tts_provider_inst.meta().id not in self.inst_map
+        ):
             self.curr_tts_provider_inst = None
-        elif self.curr_tts_provider_inst is None and len(self.tts_provider_insts) > 0:
+        # 自动选择第一个可用的 TTS Provider
+        if self.curr_tts_provider_inst is None and len(self.tts_provider_insts) > 0:
             self.curr_tts_provider_inst = self.tts_provider_insts[0]
             logger.info(
                 f"自动选择 {self.curr_tts_provider_inst.meta().id} 作为当前文本转语音提供商适配器。"
             )
+        elif len(self.tts_provider_insts) == 0:
+            self.curr_tts_provider_inst = None
 
     def get_insts(self):
         return self.provider_insts


### PR DESCRIPTION
---

### Motivation / 动机

reload不会更新服务提供商列表，只会在已有的里面更新

### Modifications / 改动点

reload的时候重新加载服务提供商

### Verification Steps / 验证步骤

就是更新一下

### Screenshots or Test Results / 运行截图或测试结果

没

### Compatibility & Breaking Changes / 兼容性与破坏性变更

无变化

- [x] 这不是一个破坏性变更。/ This is NOT a breaking change.

---

### Checklist / 检查清单

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->
<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Sourcery 总结

错误修复：
- 在 `ProviderManager.reload` 中重新加载完整的提供者列表，以保持内存状态与最新配置同步。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在重新加载时获取并应用最新的提供商配置，并协调内存中的提供商实例以反映这些更改。

错误修复：
- 在热重载时重新加载完整的提供商列表，以使内存状态与最新配置同步
- 如果当前提供商、STT 和 TTS 实例失效，则对其进行验证和重置，并自动选择第一个可用的实例

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fetch and apply the latest provider configuration on reload and reconcile in-memory provider instances to reflect those changes.

Bug Fixes:
- Reload the full provider list on hot reload to synchronize in-memory state with the latest configuration
- Validate and reset current provider, STT, and TTS instances if they become invalid and auto-select the first available instance

</details>

</details>