### PR TITLE
feat(core): 优化分段回复，移除首次发送延迟

### DIFF
--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -206,9 +206,11 @@ class RespondStage(Stage):
                     )
                     return
                 async with session_lock_manager.acquire_lock(event.unified_msg_origin):
-                    for comp in result.chain:
-                        i = await self._calc_comp_interval(comp)
-                        await asyncio.sleep(i)
+                    for index, comp in enumerate(result.chain):
+                        if index > 0:
+                            i = await self._calc_comp_interval(comp)
+                            await asyncio.sleep(i)
+
                         try:
                             if comp.type in need_separately:
                                 await event.send(MessageChain([comp]))


### PR DESCRIPTION
### 动机
当前分段回复的第一条消息存在不必要的延迟，影响用户体验。

### 改动点
- 修改 strbot/core/pipeline/respond/stage.py。
- 在发送循环中增加 if index > 0 判断，使第一条消息被立即发送。

### 兼容性
- [x] 这不是一个破坏性变更。