### PR TITLE
fix: 优化统计页内存占用和消息数据趋势的样式

### DIFF
--- a/dashboard/src/views/dashboards/default/components/MemoryUsage.vue
+++ b/dashboard/src/views/dashboards/default/components/MemoryUsage.vue
@@ -98,6 +98,7 @@ export default {
 
 .stat-value-wrapper {
   display: flex;
+  flex-wrap: wrap;
   align-items: baseline;
   justify-content: space-between;
   margin-bottom: 4px;

--- a/dashboard/src/views/dashboards/default/components/MessageStat.vue
+++ b/dashboard/src/views/dashboards/default/components/MessageStat.vue
@@ -44,7 +44,7 @@
         <div class="stat-box" :class="{'trend-up': growthRate > 0, 'trend-down': growthRate < 0}">
           <div class="stat-label">{{ t('charts.messageTrend.growthRate') }}</div>
           <div class="stat-number">
-            <v-icon size="small" :icon="growthRate > 0 ? 'mdi-arrow-up' : 'mdi-arrow-down'"></v-icon>
+            <v-icon v-show="growthRate !== 0" size="small" :icon="growthRate > 0 ? 'mdi-arrow-up' : 'mdi-arrow-down'"></v-icon>
             {{ Math.abs(growthRate) }}%
           </div>
         </div>

--- a/dashboard/src/views/dashboards/default/components/MessageStat.vue
+++ b/dashboard/src/views/dashboards/default/components/MessageStat.vue
@@ -303,8 +303,10 @@ export default {
 
 .chart-header {
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   align-items: flex-start;
+  gap: 10px;
   margin-bottom: 20px;
 }
 
@@ -321,7 +323,7 @@ export default {
 }
 
 .time-select {
-  max-width: 150px;
+  max-width: fit-content;
   font-size: 14px;
 }
 
@@ -349,6 +351,7 @@ export default {
   font-weight: 600;
   color: var(--v-theme-primaryText);
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
 }
 


### PR DESCRIPTION
### Modifications / 改动点

1.隐藏增长率为零时的趋势图标
2.调整统计页内存占用和消息趋势分析的布局，优化响应式显示

### Screenshots or Test Results / 运行截图或测试结果

改动前：
<img width="1260" height="974" alt="image" src="https://github.com/user-attachments/assets/e2cafafc-2284-43c2-bd79-aa050f939348" />
<img width="1260" height="974" alt="image" src="https://github.com/user-attachments/assets/ae873080-204b-48ae-9d21-bbe9a16c9441" />

改动后：
<img width="1260" height="974" alt="image" src="https://github.com/user-attachments/assets/a9f3ec86-2473-480f-9f57-e8df927601d6" />
<img width="1260" height="974" alt="image" src="https://github.com/user-attachments/assets/ce471ae5-a887-4729-a07e-2fb840d25c7e" />

### Compatibility & Breaking Changes / 兼容性与破坏性变更

- [ ] 这是一个破坏性变更 (Breaking Change)。/ This is a breaking change.
- [x] 这不是一个破坏性变更。/ This is NOT a breaking change.

## Sourcery 总结

优化统计页面，通过隐藏零增长趋势图标并优化图表、时间选择器和内存使用组件的基于 flex 的布局，以增强响应性和视觉清晰度。

增强功能：
- 当增长率为零时隐藏趋势图标，以避免显示中性指示器。
- 在图表头部和统计信息包装器中引入 flex-wrap 和间距，以改进响应式布局。
- 更新时间选择器的 max-width 为 fit-content，以实现在不同视口下的动态尺寸调整。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize the statistics page by hiding zero-growth trend icons and refining flex-based layouts for charts, time selectors, and memory usage components to enhance responsiveness and visual clarity.

Enhancements:
- Hide trend icons when growth rate is zero to avoid displaying neutral indicators.
- Introduce flex-wrap and gap spacing in chart headers and statistic wrappers for improved responsive layout.
- Update time selector max-width to fit-content for dynamic sizing across viewports.

</details>