### PR TITLE
fix: 修复 /alter_cmd 指令无法控制指令组、子指令组和子指令组下子指令的问题

### DIFF
--- a/astrbot/core/pipeline/waking_check/stage.py
+++ b/astrbot/core/pipeline/waking_check/stage.py
@@ -5,6 +5,7 @@ from astrbot.core.message.components import At, AtAll, Reply
 from astrbot.core.message.message_event_result import MessageChain, MessageEventResult
 from astrbot.core.platform.astr_message_event import AstrMessageEvent
 from astrbot.core.star.filter.permission import PermissionTypeFilter
+from astrbot.core.star.filter.command_group import CommandGroupFilter
 from astrbot.core.star.session_plugin_manager import SessionPluginManager
 from astrbot.core.star.star import star_map
 from astrbot.core.star.star_handler import EventType, star_handlers_registry
@@ -170,11 +171,15 @@ class WakingCheckStage(Stage):
                 is_wake = True
                 event.is_wake = True
 
-                activated_handlers.append(handler)
-                if "parsed_params" in event.get_extra():
-                    handlers_parsed_params[handler.handler_full_name] = event.get_extra(
-                        "parsed_params"
-                    )
+                is_group_cmd_handler = any(
+                    isinstance(f, CommandGroupFilter) for f in handler.event_filters
+                )
+                if not is_group_cmd_handler:
+                    activated_handlers.append(handler)
+                    if "parsed_params" in event.get_extra(default={}):
+                        handlers_parsed_params[handler.handler_full_name] = (
+                            event.get_extra("parsed_params")
+                        )
 
             event._extras.pop("parsed_params", None)
 

--- a/astrbot/core/platform/astr_message_event.py
+++ b/astrbot/core/platform/astr_message_event.py
@@ -4,7 +4,7 @@ import re
 import hashlib
 import uuid
 
-from typing import List, Union, Optional, AsyncGenerator
+from typing import List, Union, Optional, AsyncGenerator, TypeVar, Any
 
 from astrbot import logger
 from astrbot.core.db.po import Conversation
@@ -25,6 +25,8 @@ from astrbot.core.utils.metrics import Metric
 from .astrbot_message import AstrBotMessage, Group
 from .platform_metadata import PlatformMetadata
 from .message_session import MessageSession, MessageSesion  # noqa
+
+_VT = TypeVar("_VT")
 
 
 class AstrMessageEvent(abc.ABC):
@@ -49,7 +51,7 @@ class AstrMessageEvent(abc.ABC):
         """是否唤醒(是否通过 WakingStage)"""
         self.is_at_or_wake_command = False
         """是否是 At 机器人或者带有唤醒词或者是私聊(插件注册的事件监听器会让 is_wake 设为 True, 但是不会让这个属性置为 True)"""
-        self._extras = {}
+        self._extras: dict[str, Any] = {}
         self.session = MessageSesion(
             platform_name=platform_meta.id,
             message_type=message_obj.type,
@@ -57,7 +59,7 @@ class AstrMessageEvent(abc.ABC):
         )
         self.unified_msg_origin = str(self.session)
         """统一的消息来源字符串。格式为 platform_name:message_type:session_id"""
-        self._result: MessageEventResult = None
+        self._result: MessageEventResult | None = None
         """消息事件的结果"""
 
         self._has_send_oper = False
@@ -173,13 +175,15 @@ class AstrMessageEvent(abc.ABC):
         """
         self._extras[key] = value
 
-    def get_extra(self, key=None):
+    def get_extra(
+        self, key: str | None = None, default: _VT = None
+    ) -> dict[str, Any] | _VT:
         """
         获取额外的信息。
         """
         if key is None:
             return self._extras
-        return self._extras.get(key, None)
+        return self._extras.get(key, default)
 
     def clear_extra(self):
         """

--- a/astrbot/core/star/filter/command.py
+++ b/astrbot/core/star/filter/command.py
@@ -32,6 +32,7 @@ class CommandFilter(HandlerFilter):
             self.init_handler_md(handler_md)
         self.custom_filter_list: List[CustomFilter] = []
 
+        # Cache for complete command names list
         self._cmpl_cmd_names: list | None = None
 
     def print_types(self):

--- a/astrbot/core/star/filter/command.py
+++ b/astrbot/core/star/filter/command.py
@@ -32,6 +32,8 @@ class CommandFilter(HandlerFilter):
             self.init_handler_md(handler_md)
         self.custom_filter_list: List[CustomFilter] = []
 
+        self._cmpl_cmd_names: list | None = None
+
     def print_types(self):
         result = ""
         for k, v in self.handler_params.items():
@@ -136,6 +138,28 @@ class CommandFilter(HandlerFilter):
                     )
         return result
 
+    def get_complete_command_names(self):
+        if self._cmpl_cmd_names is not None:
+            return self._cmpl_cmd_names
+        self._cmpl_cmd_names = [
+            f"{parent} {cmd}" if parent else cmd
+            for cmd in [self.command_name] + list(self.alias)
+            for parent in self.parent_command_names or [""]
+        ]
+        return self._cmpl_cmd_names
+
+    def startswith(self, message_str: str) -> bool:
+        for full_cmd in self.get_complete_command_names():
+            if message_str.startswith(f"{full_cmd} ") or message_str == full_cmd:
+                return True
+        return False
+
+    def equals(self, message_str: str) -> bool:
+        for full_cmd in self.get_complete_command_names():
+            if message_str == full_cmd:
+                return True
+        return False
+
     def filter(self, event: AstrMessageEvent, cfg: AstrBotConfig) -> bool:
         if not event.is_at_or_wake_command:
             return False
@@ -145,19 +169,7 @@ class CommandFilter(HandlerFilter):
 
         # 检查是否以指令开头
         message_str = re.sub(r"\s+", " ", event.get_message_str().strip())
-        candidates = [self.command_name] + list(self.alias)
-        ok = False
-        for candidate in candidates:
-            for parent_command_name in self.parent_command_names:
-                if parent_command_name:
-                    _full = f"{parent_command_name} {candidate}"
-                else:
-                    _full = candidate
-                if message_str.startswith(f"{_full} ") or message_str == _full:
-                    message_str = message_str[len(_full) :].strip()
-                    ok = True
-                    break
-        if not ok:
+        if not self.startswith(message_str):
             return False
 
         # 分割为列表

--- a/astrbot/core/star/filter/command_group.py
+++ b/astrbot/core/star/filter/command_group.py
@@ -22,6 +22,8 @@ class CommandGroupFilter(HandlerFilter):
         self.custom_filter_list: List[CustomFilter] = []
         self.parent_group = parent_group
 
+        self._cmpl_cmd_names: list | None = None  # 缓存完整指令名列表
+
     def add_sub_command_filter(
         self, sub_command_filter: Union[CommandFilter, CommandGroupFilter]
     ):
@@ -34,6 +36,9 @@ class CommandGroupFilter(HandlerFilter):
         """遍历父节点获取完整的指令名。
 
         新版本 v3.4.29 采用预编译指令，不再从指令组递归遍历子指令，因此这个方法是返回包括别名在内的整个指令名列表。"""
+        if self._cmpl_cmd_names is not None:
+            return self._cmpl_cmd_names
+
         parent_cmd_names = (
             self.parent_group.get_complete_command_names() if self.parent_group else []
         )
@@ -47,6 +52,7 @@ class CommandGroupFilter(HandlerFilter):
         for parent_cmd_name in parent_cmd_names:
             for candidate in candidates:
                 result.append(parent_cmd_name + " " + candidate)
+        self._cmpl_cmd_names = result
         return result
 
     # 以树的形式打印出来
@@ -97,6 +103,12 @@ class CommandGroupFilter(HandlerFilter):
                 return False
         return True
 
+    def startswith(self, message_str: str) -> bool:
+        return message_str.startswith(tuple(self.get_complete_command_names()))
+
+    def equals(self, message_str: str) -> bool:
+        return message_str in self.get_complete_command_names()
+
     def filter(self, event: AstrMessageEvent, cfg: AstrBotConfig) -> bool:
         if not event.is_at_or_wake_command:
             return False
@@ -105,8 +117,7 @@ class CommandGroupFilter(HandlerFilter):
         if not self.custom_filter_ok(event, cfg):
             return False
 
-        complete_command_names = self.get_complete_command_names()
-        if event.message_str.strip() in complete_command_names:
+        if self.equals(event.message_str.strip()):
             tree = (
                 self.group_name
                 + "\n"
@@ -116,5 +127,4 @@ class CommandGroupFilter(HandlerFilter):
                 f"参数不足。{self.group_name} 指令组下有如下指令，请参考：\n" + tree
             )
 
-        complete_command_names = [name + " " for name in complete_command_names]
-        return event.message_str.startswith(tuple(complete_command_names))
+        return self.startswith(event.message_str)

--- a/astrbot/core/star/filter/command_group.py
+++ b/astrbot/core/star/filter/command_group.py
@@ -116,6 +116,5 @@ class CommandGroupFilter(HandlerFilter):
                 f"参数不足。{self.group_name} 指令组下有如下指令，请参考：\n" + tree
             )
 
-        # complete_command_names = [name + " " for name in complete_command_names]
-        # return event.message_str.startswith(tuple(complete_command_names))
-        return False
+        complete_command_names = [name + " " for name in complete_command_names]
+        return event.message_str.startswith(tuple(complete_command_names))

--- a/astrbot/core/star/filter/command_group.py
+++ b/astrbot/core/star/filter/command_group.py
@@ -22,7 +22,8 @@ class CommandGroupFilter(HandlerFilter):
         self.custom_filter_list: List[CustomFilter] = []
         self.parent_group = parent_group
 
-        self._cmpl_cmd_names: list | None = None  # 缓存完整指令名列表
+        # Cache for complete command names list
+        self._cmpl_cmd_names: list | None = None
 
     def add_sub_command_filter(
         self, sub_command_filter: Union[CommandFilter, CommandGroupFilter]

--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -1485,24 +1485,3 @@ UID: {user_id} 此 ID 可用于设置管理员。
     def test_group(self):
         """测试指令组"""
         pass
-
-    @test_group.command("cmd1")
-    async def test_cmd1(self, event: AstrMessageEvent):
-        yield event.plain_result("这是测试指令组的cmd1指令")
-
-    @test_group.command("cmd2")
-    async def test_cmd2(self, event: AstrMessageEvent):
-        yield event.plain_result("这是测试指令组的cmd2指令")
-
-    @test_group.group("subgroup")
-    def test_subgroup(self):
-        """测试子指令组"""
-        pass
-
-    @test_subgroup.command("subcmd1")
-    async def test_subcmd1(self, event: AstrMessageEvent):
-        yield event.plain_result("这是测试子指令组的subcmd1指令")
-
-    @test_subgroup.command("subcmd2")
-    async def test_subcmd2(self, event: AstrMessageEvent):
-        yield event.plain_result("这是测试子指令组的subcmd2指令")

--- a/packages/astrbot/main.py
+++ b/packages/astrbot/main.py
@@ -1348,22 +1348,22 @@ UID: {user_id} 此 ID 可用于设置管理员。
                 logger.error(f"ltm: {e}")
 
     @filter.permission_type(filter.PermissionType.ADMIN)
-    @filter.command("alter_cmd")
+    @filter.command("alter_cmd", alias={"alter"})
     async def alter_cmd(self, event: AstrMessageEvent):
-        # token = event.message_str.split(" ")
         token = self.parse_commands(event.message_str)
-        if token.len < 2:
+        if token.len < 3:
             yield event.plain_result(
-                "可设置所有其他指令是否需要管理员权限。\n格式: /alter_cmd <cmd_name> <admin/member>\n 例如: /alter_cmd provider admin 将 provider 设置为管理员指令\n /alter_cmd reset config 打开reset权限配置"
+                "该指令用于设置指令或指令组的权限。\n"
+                "格式: /alter_cmd <cmd_name> <admin/member>\n"
+                "例1: /alter_cmd c1 admin 将 c1 设为管理员指令\n"
+                "例2: /alter_cmd g1 c1 admin 将 g1 指令组的 c1 子指令设为管理员指令\n"
+                "/alter_cmd reset config 打开 reset 权限配置"
             )
             return
 
-        cmd_name = token.get(1)
-        cmd_type = token.get(2)
+        cmd_name = " ".join(token.tokens[1:-1])
+        cmd_type = token.get(-1)
 
-        # ============================
-        #    对reset权限进行特殊处理
-        # ============================
         if cmd_name == "reset" and cmd_type == "config":
             alter_cmd_cfg = await sp.global_get("alter_cmd", {})
             plugin_ = alter_cmd_cfg.get("astrbot", {})
@@ -1413,16 +1413,18 @@ UID: {user_id} 此 ID 可用于设置管理员。
 
         # 查找指令
         found_command = None
+        cmd_group = False
         for handler in star_handlers_registry:
             assert isinstance(handler, StarHandlerMetadata)
             for filter_ in handler.event_filters:
                 if isinstance(filter_, CommandFilter):
-                    if filter_.command_name == cmd_name:
+                    if filter_.equals(cmd_name):
                         found_command = handler
                         break
                 elif isinstance(filter_, CommandGroupFilter):
-                    if cmd_name == filter_.group_name:
+                    if filter_.equals(cmd_name):
                         found_command = handler
+                        cmd_group = True
                         break
 
         if not found_command:
@@ -1459,8 +1461,10 @@ UID: {user_id} 此 ID 可用于设置管理员。
                     else filter.PermissionType.MEMBER
                 ),
             )
-
-        yield event.plain_result(f"已将 {cmd_name} 设置为 {cmd_type} 指令")
+        cmd_group_str = "指令组" if cmd_group else "指令"
+        yield event.plain_result(
+            f"已将「{cmd_name}」{cmd_group_str} 的权限级别调整为 {cmd_type}。"
+        )
 
     async def update_reset_permission(self, scene_key: str, perm_type: str):
         """更新reset命令在特定场景下的权限设置
@@ -1476,3 +1480,29 @@ UID: {user_id} 此 ID 可用于设置管理员。
         plugin_cfg["reset"] = reset_cfg
         alter_cmd_cfg["astrbot"] = plugin_cfg
         await sp.global_put("alter_cmd", alter_cmd_cfg)
+
+    @filter.command_group("test")
+    def test_group(self):
+        """测试指令组"""
+        pass
+
+    @test_group.command("cmd1")
+    async def test_cmd1(self, event: AstrMessageEvent):
+        yield event.plain_result("这是测试指令组的cmd1指令")
+
+    @test_group.command("cmd2")
+    async def test_cmd2(self, event: AstrMessageEvent):
+        yield event.plain_result("这是测试指令组的cmd2指令")
+
+    @test_group.group("subgroup")
+    def test_subgroup(self):
+        """测试子指令组"""
+        pass
+
+    @test_subgroup.command("subcmd1")
+    async def test_subcmd1(self, event: AstrMessageEvent):
+        yield event.plain_result("这是测试子指令组的subcmd1指令")
+
+    @test_subgroup.command("subcmd2")
+    async def test_subcmd2(self, event: AstrMessageEvent):
+        yield event.plain_result("这是测试子指令组的subcmd2指令")


### PR DESCRIPTION
…up permission check

<!-- 如果有的话，请指定此 PR 旨在解决的 ISSUE 编号。 -->
<!-- If applicable, please specify the ISSUE number this PR aims to resolve. -->

fixes #2212 #1077

Edit:
刚发现和 #2199 撞车了…
但是……修改思路不一样。

---

### Motivation / 动机

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX 错误，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX bug, adds YY feature)-->
修复了指令组中指令未能正确判断ADMIN权限的问题

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
修改了command_group filter通过后的返回值
（回滚了某人的更改，没能理解这个更改为什么是这样）

### Verification Steps / 验证步骤

<!--请为审查者 (Reviewer) 提供清晰、可复现的验证步骤（例如：1. 导航到... 2. 点击...）。-->
<!--Please provide clear and reproducible verification steps for the Reviewer (e.g., 1. Navigate to... 2. Click...).-->
ADMIN: /alter_cmd [Command Group] ADMIN
MEMBER: /[Command Group] [Command]
如果修改无误，应当无返回（关闭无权限回显）或报权限不足

### Screenshots or Test Results / 运行截图或测试结果

<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<img width="932" height="567" alt="image" src="https://github.com/user-attachments/assets/f15bb5f5-7a41-4340-a190-f5c375f6776d" />
`/memory`为某个插件提供的指令组
第一次回复后，在配置文件中删除了用户的ADMIN权限
第二次拒绝回复。

### Compatibility & Breaking Changes / 兼容性与破坏性变更

<!--请说明此变更的兼容性：哪些是破坏性变更？哪些地方做了向后兼容处理？是否提供了数据迁移方法？-->
<!--Please explain the compatibility of this change: What are the breaking changes? What backward-compatible measures were taken? Are data migration paths provided?-->

- [ ] 这是一个破坏性变更 (Breaking Change)。/ This is a breaking change.
- [x] 这不是一个破坏性变更。/ This is NOT a breaking change.

---

### Checklist / 检查清单

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->
<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Sourcery 总结

错误修复：
- 恢复 `command_group` 过滤器中的消息前缀检查，并移除总是返回 `false` 的代码，以修复 ADMIN 权限判断问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Restore the message prefix check in the command_group filter and remove the always-false return to fix ADMIN permission judging.

</details>