### PR TITLE
fix: 使用增量解码器修复 Dify 流式返回结果偶现的解码错误

### DIFF
--- a/astrbot/core/utils/dify_api_client.py
+++ b/astrbot/core/utils/dify_api_client.py
@@ -1,7 +1,26 @@
+import codecs
 import json
 from astrbot.core import logger
 from aiohttp import ClientSession
 from typing import Dict, List, Any, AsyncGenerator
+
+
+async def _stream_sse(resp) -> AsyncGenerator[dict, None]:
+    decoder = codecs.getincrementaldecoder("utf-8")()
+    buffer = ""
+    async for chunk in resp.content.iter_chunked(8192):
+        buffer += decoder.decode(chunk)
+        while "\n\n" in buffer:
+            block, buffer = buffer.split("\n\n", 1)
+            if block.strip().startswith("data:"):
+                try:
+                    yield json.loads(block[5:])
+                except json.JSONDecodeError:
+                    continue
+    # flush any remaining text
+    buffer += decoder.decode(b"", final=True)
+    if buffer.strip().startswith("data:"):
+        yield json.loads(buffer[5:])
 
 
 class DifyAPIClient:
@@ -33,49 +52,11 @@ class DifyAPIClient:
         ) as resp:
             if resp.status != 200:
                 text = await resp.text()
-                raise Exception(f"chat_messages 请求失败：{resp.status}. {text}")
-
-            buffer = ""
-            byte_buffer = b""
-            while True:
-                # 保持原有的8192字节限制，防止数据过大导致高水位报错
-                chunk = await resp.content.read(8192)
-                if not chunk:
-                    # 处理剩余的字节
-                    if byte_buffer:
-                        buffer += byte_buffer.decode("utf-8", errors='replace')
-                    break
-
-                byte_buffer += chunk
-                try:
-                    # 尝试解码所有字节
-                    decoded_text = byte_buffer.decode("utf-8")
-                    buffer += decoded_text
-                    byte_buffer = b""
-                except UnicodeDecodeError as e:
-                    # 保留不完整的字符字节，解码完整的部分
-                    if e.start > 0:
-                        buffer += byte_buffer[:e.start].decode("utf-8")
-                        byte_buffer = byte_buffer[e.start:]
-                    else:
-                        # 如果错误从开始就发生，保留所有字节等待更多数据
-                        pass
-                
-                blocks = buffer.split("\n\n")
-
-                # 处理完整的数据块
-                for block in blocks[:-1]:
-                    if block.strip() and block.startswith("data:"):
-                        try:
-                            json_str = block[5:]  # 移除 "data:" 前缀
-                            json_obj = json.loads(json_str)
-                            yield json_obj
-                        except json.JSONDecodeError as e:
-                            logger.error(f"JSON解析错误: {str(e)}")
-                            logger.error(f"原始数据块: {json_str}")
-
-                # 保留最后一个可能不完整的块
-                buffer = blocks[-1] if blocks else ""
+                raise Exception(
+                    f"Dify /chat-messages 接口请求失败：{resp.status}. {text}"
+                )
+            async for event in _stream_sse(resp):
+                yield event
 
     async def workflow_run(
         self,
@@ -95,49 +76,11 @@ class DifyAPIClient:
         ) as resp:
             if resp.status != 200:
                 text = await resp.text()
-                raise Exception(f"workflow_run 请求失败：{resp.status}. {text}")
-
-            buffer = ""
-            byte_buffer = b""
-            while True:
-                # 保持原有的8192字节限制，防止数据过大导致高水位报错
-                chunk = await resp.content.read(8192)
-                if not chunk:
-                    # 处理剩余的字节
-                    if byte_buffer:
-                        buffer += byte_buffer.decode("utf-8", errors='replace')
-                    break
-
-                byte_buffer += chunk
-                try:
-                    # 尝试解码所有字节
-                    decoded_text = byte_buffer.decode("utf-8")
-                    buffer += decoded_text
-                    byte_buffer = b""
-                except UnicodeDecodeError as e:
-                    # 保留不完整的字符字节，解码完整的部分
-                    if e.start > 0:
-                        buffer += byte_buffer[:e.start].decode("utf-8")
-                        byte_buffer = byte_buffer[e.start:]
-                    else:
-                        # 如果错误从开始就发生，保留所有字节等待更多数据
-                        pass
-                
-                blocks = buffer.split("\n\n")
-
-                # 处理完整的数据块
-                for block in blocks[:-1]:
-                    if block.strip() and block.startswith("data:"):
-                        try:
-                            json_str = block[5:]  # 移除 "data:" 前缀
-                            json_obj = json.loads(json_str)
-                            yield json_obj
-                        except json.JSONDecodeError as e:
-                            logger.error(f"JSON解析错误: {str(e)}")
-                            logger.error(f"原始数据块: {json_str}")
-
-                # 保留最后一个可能不完整的块
-                buffer = blocks[-1] if blocks else ""
+                raise Exception(
+                    f"Dify /workflows/run 接口请求失败：{resp.status}. {text}"
+                )
+            async for event in _stream_sse(resp):
+                yield event
 
     async def file_upload(
         self,

--- a/astrbot/core/utils/dify_api_client.py
+++ b/astrbot/core/utils/dify_api_client.py
@@ -36,13 +36,31 @@ class DifyAPIClient:
                 raise Exception(f"chat_messages 请求失败：{resp.status}. {text}")
 
             buffer = ""
+            byte_buffer = b""
             while True:
                 # 保持原有的8192字节限制，防止数据过大导致高水位报错
                 chunk = await resp.content.read(8192)
                 if not chunk:
+                    # 处理剩余的字节
+                    if byte_buffer:
+                        buffer += byte_buffer.decode("utf-8", errors='replace')
                     break
 
-                buffer += chunk.decode("utf-8")
+                byte_buffer += chunk
+                try:
+                    # 尝试解码所有字节
+                    decoded_text = byte_buffer.decode("utf-8")
+                    buffer += decoded_text
+                    byte_buffer = b""
+                except UnicodeDecodeError as e:
+                    # 保留不完整的字符字节，解码完整的部分
+                    if e.start > 0:
+                        buffer += byte_buffer[:e.start].decode("utf-8")
+                        byte_buffer = byte_buffer[e.start:]
+                    else:
+                        # 如果错误从开始就发生，保留所有字节等待更多数据
+                        pass
+                
                 blocks = buffer.split("\n\n")
 
                 # 处理完整的数据块
@@ -80,13 +98,31 @@ class DifyAPIClient:
                 raise Exception(f"workflow_run 请求失败：{resp.status}. {text}")
 
             buffer = ""
+            byte_buffer = b""
             while True:
                 # 保持原有的8192字节限制，防止数据过大导致高水位报错
                 chunk = await resp.content.read(8192)
                 if not chunk:
+                    # 处理剩余的字节
+                    if byte_buffer:
+                        buffer += byte_buffer.decode("utf-8", errors='replace')
                     break
 
-                buffer += chunk.decode("utf-8")
+                byte_buffer += chunk
+                try:
+                    # 尝试解码所有字节
+                    decoded_text = byte_buffer.decode("utf-8")
+                    buffer += decoded_text
+                    byte_buffer = b""
+                except UnicodeDecodeError as e:
+                    # 保留不完整的字符字节，解码完整的部分
+                    if e.start > 0:
+                        buffer += byte_buffer[:e.start].decode("utf-8")
+                        byte_buffer = byte_buffer[e.start:]
+                    else:
+                        # 如果错误从开始就发生，保留所有字节等待更多数据
+                        pass
+                
                 blocks = buffer.split("\n\n")
 
                 # 处理完整的数据块

--- a/astrbot/core/utils/dify_api_client.py
+++ b/astrbot/core/utils/dify_api_client.py
@@ -1,11 +1,11 @@
 import codecs
 import json
 from astrbot.core import logger
-from aiohttp import ClientSession
+from aiohttp import ClientSession, ClientResponse
 from typing import Dict, List, Any, AsyncGenerator
 
 
-async def _stream_sse(resp) -> AsyncGenerator[dict, None]:
+async def _stream_sse(resp: ClientResponse) -> AsyncGenerator[dict, None]:
     decoder = codecs.getincrementaldecoder("utf-8")()
     buffer = ""
     async for chunk in resp.content.iter_chunked(8192):
@@ -88,12 +88,15 @@ class DifyAPIClient:
         user: str,
     ) -> Dict[str, Any]:
         url = f"{self.api_base}/files/upload"
-        payload = {
-            "user": user,
-            "file": open(file_path, "rb"),
-        }
-        async with self.session.post(url, data=payload, headers=self.headers) as resp:
-            return await resp.json()  # {"id": "xxx", ...}
+        with open(file_path, "rb") as f:
+            payload = {
+                "user": user,
+                "file": f,
+            }
+            async with self.session.post(
+                url, data=payload, headers=self.headers
+            ) as resp:
+                return await resp.json()  # {"id": "xxx", ...}
 
     async def close(self):
         await self.session.close()


### PR DESCRIPTION
---

fixes: #2704 #2761 

### Motivation / 动机

修复linux下dify回复utf-8解码错误的问题

2025-09-26 19:45:35 +0800] [1] [INFO] 172.19.0.1:49796 GET /api/update/check 1.1 200 203 4449829

   [19:45:47] [Core] [ERRO] [sources.dify_source:183]: Dify 请求失败：'utf-8' codec can't decode bytes in position 1683-1684: 
  unexpected end of data 

   [19:45:47] [Core] [INFO] [respond.stage:161]: Prepare to send - xxxx: LLM 响应错误: Dify 请求失败：'utf-8' 
  codec can't decode bytes in position 1683-1684: unexpected end of data  

   [19:45:47] [Plug] [INFO] [astrbot_proactive_reply.main:86]: ✅ 插件数据目录: /AstrBot/data/plugins/astrbot_proactive_reply 

   [19:45:47] [Core] [INFO] [respond.stage:161]: Prepare to send - xxxx: Dify 请求失败：'utf-8' codec can't 
  decode bytes in position 1683-1684: unexpected end of data  

   [19:45:47] [Plug] [INFO] [astrbot_proactive_reply.main:86]: ✅ 插件数据目录: /AstrBot/data/plugins/astrbot_proactive_reply



### Modifications / 改动点

修改了 astrbot/core/utils/dify_api_client.py 

  改进点：
  1. 字节缓冲区：使用 byte_buffer 来保存原始字节数据
  2. 异常处理：正确处理 UnicodeDecodeError，保留不完整的字符字节
  3. 数据完整性：只有当字符完整时才进行解码，避免丢失数据
  4. 兜底机制：最后使用 errors='replace' 处理剩余的字节

  工作原理：
  - 收到字节数据时先存入 byte_buffer
  - 尝试解码所有字节，成功则清空缓冲区
  - 如果解码失败，保留不完整的字符字节，解码完整的部分
  - 这样确保多字节UTF-8字符不会被错误分割

### Verification Steps / 验证步骤

linux docker  astrbot v4.1.7  使用dify创建chatflow，并在webchat对其发送信息，便报错

### Screenshots or Test Results / 运行截图或测试结果
 [19:59:54] [Plug] [WARN] [core.llm_enhancer:85]: 用户默认知识库 'general' 不存在，跳过 LLM 请求增强。 

 [19:59:54] [Core] [INFO] [utils.dify_api_client:30]: chat_messages payload: {'inputs': {'system_prompt': '[对话信息] 用户：dingjiatong，时间：2025-09-26 19:59:54You are a helpful and friendly assistant.'}, 'query': 'hi', 'user': 'webchat:FriendMessage:webchat!xxxx!a06e038c-6eef-4dbe-8ba0-9c399a091245', 'response_mode': 'streaming', 'conversation_id': '', 'files': [], 'url': 'https://api.dify.ai/v1/chat-messages'} 

 [20:00:07] [Core] [INFO] [respond.stage:161]: Prepare to send - dingjiatong/dingjiatong: 

❗ 需要先绑定账户。请提供：

• 永久绑定：

  - 登录名：如13800138000

  - 密码：yourpassword

• 临时绑定：

  - SSO令牌ID

  - 以下之一：

    - 建设云UID（精确绑定）

    - 手机号（自动匹配）

    - 姓名（模糊匹配）

请根据以上信息提供相关数据，以便为您完成绑定。  

 [20:00:07] [Plug] [INFO] [astrbot_proactive_reply.main:86]: ✅ 插件数据目录: /AstrBot/data/plugins/astrbot_proactive_reply 

[2025-09-26 20:00:08 +0800] [1] [INFO] 172.19.0.1:51016 POST /api/chat/send 1.1 200 - 14358592

### Compatibility & Breaking Changes / 兼容性与破坏性变更

- [ ] 这是一个破坏性变更 (Breaking Change)。/ This is a breaking change.
- [x] 这不是一个破坏性变更。/ This is NOT a breaking change.

---

### Checklist / 检查清单

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->
<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Sourcery 总结

通过缓冲原始字节并仅解码完整的 UTF-8 序列，改进 `dify_api_client` 中的流式响应处理，以防止 `UnicodeDecodeError`，同时保留不完整的多字节字符，并对任何剩余字节使用替换回退机制。

错误修复：
- 修复在 Linux 上处理 Dify 流式响应时因处理不完整的多字节 UTF-8 序列而导致的 `UnicodeDecodeError`。

功能增强：
- 引入一个字节缓冲区，用于累积原始数据块并仅解码完整的 UTF-8 字符，保留部分字节直到它们完整。
- 将带有 `errors='replace'` 回退机制的增强解码逻辑应用于 `chat_messages` 和 `workflow_run` 函数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the streaming response handling in dify_api_client by buffering raw bytes and decoding only complete UTF-8 sequences to prevent UnicodeDecodeError while preserving incomplete multibyte characters and using a replace fallback for any remaining bytes.

Bug Fixes:
- Fix UnicodeDecodeError when processing streaming Dify responses on Linux by handling incomplete multibyte UTF-8 sequences.

Enhancements:
- Introduce a byte buffer to accumulate raw chunks and decode only complete UTF-8 characters, preserving partial bytes until complete.
- Apply the enhanced decoding logic with errors='replace' fallback in both chat_messages and workflow_run functions.

</details>