### PR TITLE
fix: 修复插件指令注解为联合类型时处理异常的问题

### DIFF
--- a/astrbot/core/star/filter/command.py
+++ b/astrbot/core/star/filter/command.py
@@ -1,5 +1,7 @@
 import re
 import inspect
+import types
+import typing
 from typing import List, Any, Type, Dict
 from . import HandlerFilter
 from astrbot.core.platform.astr_message_event import AstrMessageEvent
@@ -12,6 +14,18 @@ class GreedyStr(str):
     """标记指令完成其他参数接收后的所有剩余文本。"""
 
     pass
+
+
+def unwrap_optional(annotation) -> tuple:
+    """去掉 Optional[T] / Union[T, None] / T|None，返回 T"""
+    args = typing.get_args(annotation)
+    non_none_args = [a for a in args if a is not type(None)]
+    if len(non_none_args) == 1:
+        return (non_none_args[0],)
+    elif len(non_none_args) > 1:
+        return tuple(non_none_args)
+    else:
+        return ()
 
 
 # 标准指令受到 wake_prefix 的制约。
@@ -38,8 +52,10 @@ class CommandFilter(HandlerFilter):
     def print_types(self):
         result = ""
         for k, v in self.handler_params.items():
-            if isinstance(v, type):
+            if isinstance(v, Type):
                 result += f"{k}({v.__name__}),"
+            elif isinstance(v, (types.UnionType, typing.Union)):
+                result += f"{k}({v}),"
             else:
                 result += f"{k}({type(v).__name__})={v},"
         result = result.rstrip(",")
@@ -95,7 +111,7 @@ class CommandFilter(HandlerFilter):
             # 没有 GreedyStr 的情况
             if i >= len(params):
                 if (
-                    isinstance(param_type_or_default_val, Type)
+                    isinstance(param_type_or_default_val, (Type, types.UnionType))
                     or param_type_or_default_val is inspect.Parameter.empty
                 ):
                     # 是类型
@@ -132,7 +148,20 @@ class CommandFilter(HandlerFilter):
                     elif isinstance(param_type_or_default_val, float):
                         result[param_name] = float(params[i])
                     else:
-                        result[param_name] = param_type_or_default_val(params[i])
+                        origin = typing.get_origin(param_type_or_default_val)
+                        if origin in (typing.Union, types.UnionType):
+                            # 注解是联合类型
+                            # NOTE: 目前没有处理联合类型嵌套相关的注解写法
+                            nn_types = unwrap_optional(param_type_or_default_val)
+                            if len(nn_types) == 1:
+                                # 只有一个非 NoneType 类型
+                                result[param_name] = nn_types[0](params[i])
+                            else:
+                                # 没有或者有多个非 NoneType 类型，这里我们暂时直接赋值为原始值。
+                                # NOTE: 目前还没有做类型校验
+                                result[param_name] = params[i]
+                        else:
+                            result[param_name] = param_type_or_default_val(params[i])
                 except ValueError:
                     raise ValueError(
                         f"参数 {param_name} 类型错误。完整参数: {self.print_types()}"

--- a/astrbot/core/star/filter/command.py
+++ b/astrbot/core/star/filter/command.py
@@ -54,7 +54,7 @@ class CommandFilter(HandlerFilter):
         for k, v in self.handler_params.items():
             if isinstance(v, type):
                 result += f"{k}({v.__name__}),"
-            elif isinstance(v, (types.UnionType, typing.Union)):
+            elif isinstance(v, types.UnionType) or typing.get_origin(v) is typing.Union:
                 result += f"{k}({v}),"
             else:
                 result += f"{k}({type(v).__name__})={v},"

--- a/astrbot/core/star/filter/command.py
+++ b/astrbot/core/star/filter/command.py
@@ -111,9 +111,8 @@ class CommandFilter(HandlerFilter):
             # 没有 GreedyStr 的情况
             if i >= len(params):
                 if (
-                    isinstance(
-                        param_type_or_default_val, (Type, types.UnionType, typing.Union)
-                    )
+                    isinstance(param_type_or_default_val, (Type, types.UnionType))
+                    or typing.get_origin(param_type_or_default_val) is typing.Union
                     or param_type_or_default_val is inspect.Parameter.empty
                 ):
                     # 是类型

--- a/astrbot/core/star/filter/command.py
+++ b/astrbot/core/star/filter/command.py
@@ -111,7 +111,9 @@ class CommandFilter(HandlerFilter):
             # 没有 GreedyStr 的情况
             if i >= len(params):
                 if (
-                    isinstance(param_type_or_default_val, (Type, types.UnionType))
+                    isinstance(
+                        param_type_or_default_val, (Type, types.UnionType, typing.Union)
+                    )
                     or param_type_or_default_val is inspect.Parameter.empty
                 ):
                     # 是类型

--- a/astrbot/core/star/filter/command.py
+++ b/astrbot/core/star/filter/command.py
@@ -52,7 +52,7 @@ class CommandFilter(HandlerFilter):
     def print_types(self):
         result = ""
         for k, v in self.handler_params.items():
-            if isinstance(v, Type):
+            if isinstance(v, type):
                 result += f"{k}({v.__name__}),"
             elif isinstance(v, (types.UnionType, typing.Union)):
                 result += f"{k}({v}),"


### PR DESCRIPTION
<!-- 如果有的话，请指定此 PR 旨在解决的 ISSUE 编号。 -->
<!-- If applicable, please specify the ISSUE number this PR aims to resolve. -->

---

### Motivation / 动机

当前插件如果使用联合类型来作为指令的参数的注解并且未提供默认值，在调用该插件时，可能会造成报错。表现为: ` 'types.UnionType' object is not callable` 等异常。

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX 错误，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX bug, adds YY feature)-->

### Modifications / 改动点

增加对联合类型的处理支持。

需要注意的是，由于目前 handler_params 的值可能是 Type 也可能是 types.UnionType 也可能是 typing.Union 也可能是具体基本类型的值，因此在动态处理时，可能会多次调用 `origin = typing.get_origin(param_type_or_default_val)`，这个可以通过重构 handler_params 来避免，在初次加载的时候附上 `is_union_type` 的 flag。

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

### Verification Steps / 验证步骤

```py

    @filter.command("t00")
    async def test00(self, event: AstrMessageEvent, p1=None):
        yield event.plain_result(f"test {p1}")

    @filter.command("t01")
    async def test01(self, event: AstrMessageEvent, p1="1"):
        yield event.plain_result(f"test {p1}")

    @filter.command("t02")
    async def yest11(self, event: AstrMessageEvent, p1=1):
        yield event.plain_result(f"test {p1}")

    @filter.command("t03")
    async def t03(self, event: AstrMessageEvent, p1=True):
        yield event.plain_result(f"test {p1}")

    @filter.command("t0")
    async def test0(self, event: AstrMessageEvent, p1: str = None):
        yield event.plain_result(f"test {p1}")

    @filter.command("t")
    async def test1(self, event: AstrMessageEvent, p1: str):
        yield event.plain_result(f"test {p1}")

    @filter.command("t2") # 有问题
    async def test2(self, event: AstrMessageEvent, p2: str | None):
        yield event.plain_result(f"test {p2}")

    @filter.command("t3")
    async def test3(self, event: AstrMessageEvent, p3: str = "1"):
        yield event.plain_result(f"test {p3}")

    @filter.command("test")
    async def test4(self, event: AstrMessageEvent, p4: str | None = "1"):
        yield event.plain_result(f"test {p4}")

    @filter.command("test5")
    async def test5(self, event: AstrMessageEvent, p5: str | None = None):
        yield event.plain_result(f"test {p5}")

    @filter.command("test51")
    async def test51(self, event: AstrMessageEvent, p6: Union[str, None]):
        yield event.plain_result(f"test {p6}")

    @filter.command("test6")
    async def test6(self, event: AstrMessageEvent, p6: Union[str, None] = "1"):
        yield event.plain_result(f"test {p6}")

    @filter.command("test7")
    async def test7(self, event: AstrMessageEvent, p7: Union[str, None] = None):
        yield event.plain_result(f"test {p7}")

    @filter.command("test8") # 有问题
    async def test71(self, event: AstrMessageEvent, p8: Optional[str]):
        yield event.plain_result(f"test {p8}")

    @filter.command("test8")
    async def test8(self, event: AstrMessageEvent, p8: Optional[str] = "1"):
        yield event.plain_result(f"test {p8}")

    @filter.command("test9")
    async def test9(self, event: AstrMessageEvent, p9: Optional[str] = None):
        yield event.plain_result(f"test {p9}")

    @filter.command("test10")
    async def test10(self, event: AstrMessageEvent, p10: int):
        yield event.plain_result(f"test {p10}")

    @filter.command("test10")
    async def test10(self, event: AstrMessageEvent, p10: int):
        yield event.plain_result(f"test {p10}")

    @filter.command("test11")
    async def test11(self, event: AstrMessageEvent, p11: int | None = None):
        yield event.plain_result(f"test {p11}")

    @filter.command("test13")
    async def test13(self, event: AstrMessageEvent, p11: int | None):
        yield event.plain_result(f"test {p11}")

    @filter.command("test12")
    async def test12(self, event: AstrMessageEvent, p12: int = None):
        yield event.plain_result(f"test {p12}")

    @filter.command("test121")
    async def test121(self, event: AstrMessageEvent, p12: int = "abc"):
        yield event.plain_result(f"test {p12}")

```

<!--请为审查者 (Reviewer) 提供清晰、可复现的验证步骤（例如：1. 导航到... 2. 点击...）。-->
<!--Please provide clear and reproducible verification steps for the Reviewer (e.g., 1. Navigate to... 2. Click...).-->

### Screenshots or Test Results / 运行截图或测试结果

<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->

### Compatibility & Breaking Changes / 兼容性与破坏性变更

<!--请说明此变更的兼容性：哪些是破坏性变更？哪些地方做了向后兼容处理？是否提供了数据迁移方法？-->
<!--Please explain the compatibility of this change: What are the breaking changes? What backward-compatible measures were taken? Are data migration paths provided?-->

- [ ] 这是一个破坏性变更 (Breaking Change)。/ This is a breaking change.
- [x] 这不是一个破坏性变更。/ This is NOT a breaking change.

---

### Checklist / 检查清单

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->
<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Sourcery 总结

修复命令过滤器，使其能正确处理参数的 `Union` 和 `Optional` 类型注解，防止联合类型导致的调用错误。

错误修复：
- 修复参数转换逻辑，以避免当注解使用 `Union` 或 `Optional` 时出现的“types.UnionType object is not callable”错误

功能增强：
- 添加 `unwrap_optional` 辅助函数，用于从 `Optional/Union` 注解中提取底层类型
- 扩展 `print_types` 和验证逻辑，以在命令处理器中支持 `typing.Union` 和 PEP 604 联合类型

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix command filter to correctly handle Union and Optional type annotations for parameters, preventing callable errors with union types

Bug Fixes:
- Fix parameter conversion logic to avoid 'types.UnionType object is not callable' errors when annotations use Union or Optional

Enhancements:
- Add unwrap_optional helper to extract underlying types from Optional/Union annotations
- Extend print_types and validation logic to support typing.Union and PEP 604 union types in command handlers

</details>