### PR TITLE
fix: 修复了CosyVoice V2，Qwen TTS生成报错的问题。Fixed compatability problems with CosyVoice V2, Qwen TTS.

### DIFF
--- a/astrbot/core/provider/sources/dashscope_tts.py
+++ b/astrbot/core/provider/sources/dashscope_tts.py
@@ -1,10 +1,21 @@
-import os
-import dashscope
-import uuid
 import asyncio
-from dashscope.audio.tts_v2 import *
-from ..provider import TTSProvider
+import base64
+import os
+import uuid
+from typing import Optional, Tuple
+from urllib.error import URLError
+from urllib.request import urlopen
+
+import dashscope
+from dashscope.audio.tts_v2 import AudioFormat, SpeechSynthesizer
+
+try:
+    from dashscope.aigc.multimodal_conversation import MultiModalConversation
+except ImportError:  # pragma: no cover - older dashscope versions without Qwen TTS support
+    MultiModalConversation = None
+
 from ..entities import ProviderType
+from ..provider import TTSProvider
 from ..register import register_provider_adapter
 from astrbot.core.utils.astrbot_path import get_astrbot_data_path
 
@@ -26,16 +37,120 @@ class ProviderDashscopeTTSAPI(TTSProvider):
         dashscope.api_key = self.chosen_api_key
 
     async def get_audio(self, text: str) -> str:
+        model = self.get_model()
+        if not model:
+            raise RuntimeError("Dashscope TTS model is not configured.")
+
         temp_dir = os.path.join(get_astrbot_data_path(), "temp")
-        path = os.path.join(temp_dir, f"dashscope_tts_{uuid.uuid4()}.wav")
-        self.synthesizer = SpeechSynthesizer(
-            model=self.get_model(),
+        os.makedirs(temp_dir, exist_ok=True)
+
+        if self._is_qwen_tts_model(model):
+            audio_bytes, ext = await self._synthesize_with_qwen_tts(model, text)
+        else:
+            audio_bytes, ext = await self._synthesize_with_cosyvoice(model, text)
+
+        if not audio_bytes:
+            raise RuntimeError(
+                "Audio synthesis failed, returned empty content. The model may not be supported or the service is unavailable."
+            )
+
+        path = os.path.join(temp_dir, f"dashscope_tts_{uuid.uuid4()}{ext}")
+        with open(path, "wb") as f:
+            f.write(audio_bytes)
+        return path
+
+    def _call_qwen_tts(self, model: str, text: str):
+        if MultiModalConversation is None:
+            raise RuntimeError(
+                "dashscope SDK missing MultiModalConversation. Please upgrade the dashscope package to use Qwen TTS models."
+            )
+
+        kwargs = {
+            "model": model,
+            "text": text,
+            "api_key": self.chosen_api_key,
+        }
+        if self.voice:
+            kwargs["voice"] = self.voice
+        return MultiModalConversation.call(**kwargs)
+
+    async def _synthesize_with_qwen_tts(self, model: str, text: str) -> Tuple[Optional[bytes], str]:
+        loop = asyncio.get_event_loop()
+        response = await loop.run_in_executor(None, self._call_qwen_tts, model, text)
+
+        audio_bytes = self._extract_audio_from_response(response)
+        if not audio_bytes:
+            error_details = self._format_dashscope_error(response)
+            raise RuntimeError(
+                f"Audio synthesis failed for model '{model}'. {error_details}"
+            )
+        ext = ".wav"
+        return audio_bytes, ext
+
+    def _extract_audio_from_response(self, response) -> Optional[bytes]:
+        output = getattr(response, "output", None)
+        audio_obj = getattr(output, "audio", None) if output is not None else None
+        if not audio_obj:
+            return None
+
+        data_b64 = getattr(audio_obj, "data", None)
+        if data_b64:
+            try:
+                return base64.b64decode(data_b64)
+            except (ValueError, TypeError):
+                return None
+
+        url = getattr(audio_obj, "url", None)
+        if url:
+            return self._download_audio_from_url(url)
+        return None
+
+    def _download_audio_from_url(self, url: str) -> Optional[bytes]:
+        if not url:
+            return None
+        timeout = max(self.timeout_ms / 1000, 1) if self.timeout_ms else 20
+        try:
+            with urlopen(url, timeout=timeout) as response:
+                return response.read()
+        except (URLError, TimeoutError, OSError):
+            return None
+
+    async def _synthesize_with_cosyvoice(self, model: str, text: str) -> Tuple[Optional[bytes], str]:
+        synthesizer = SpeechSynthesizer(
+            model=model,
             voice=self.voice,
             format=AudioFormat.WAV_24000HZ_MONO_16BIT,
         )
-        audio = await asyncio.get_event_loop().run_in_executor(
-            None, self.synthesizer.call, text, self.timeout_ms
+        loop = asyncio.get_event_loop()
+        audio_bytes = await loop.run_in_executor(
+            None, synthesizer.call, text, self.timeout_ms
         )
-        with open(path, "wb") as f:
-            f.write(audio)
-        return path
+        if not audio_bytes:
+            response = getattr(synthesizer, "get_response", None)
+            detail = ""
+            if callable(response):
+                resp = response()
+                detail = self._format_dashscope_error(resp)
+            raise RuntimeError(
+                f"Audio synthesis failed for model '{model}'. {detail}".strip()
+            )
+        return audio_bytes, ".wav"
+
+    def _is_qwen_tts_model(self, model: str) -> bool:
+        model_lower = model.lower()
+        return "tts" in model_lower and model_lower.startswith("qwen")
+
+    def _format_dashscope_error(self, response) -> str:
+        status_code = getattr(response, "status_code", None)
+        code = getattr(response, "code", None)
+        message = getattr(response, "message", None)
+        parts = []
+        if status_code is not None:
+            parts.append(f"status_code={status_code}")
+        if code:
+            parts.append(f"code={code}")
+        if message:
+            parts.append(f"message={message}")
+        if not parts:
+            return ""
+        return " ".join(parts)


### PR DESCRIPTION
[2553](https://github.com/AstrBotDevs/AstrBot/issues/2553)

fixes #2553

---

### Motivation / 动机

修复了CosyVoice V2，Qwen TTS生成报错的问题。Fixed compatability problems with CosyVoice V2, Qwen TTS.

### Modifications / 改动点

只更改了`dashscope_tts.py`这一个文件。更新了API调用方式，CosyVoice与Qwen TTS使用不同格式调用。

### Verification Steps / 验证步骤

添加CosyVoice V2，Qwen TTS模型，先测试服务提供商可用性。然后在聊天中开启TTS语音生成功能，实际验证。
为了方便测试，可以使用下面的配置。**注意替换API Key**。
```JSON
{
      "id": "Qwen TTS",
      "provider": "dashscope",
      "type": "dashscope_tts",
      "provider_type": "text_to_speech",
      "enable": true,
      "api_key": "sk-YOUR API KEY",
      "model": "qwen-tts",
      "dashscope_tts_voice": "Cherry",
      "timeout": 20
},
{
      "id": "CozyVoice V2",
      "provider": "dashscope",
      "type": "dashscope_tts",
      "provider_type": "text_to_speech",
      "enable": true,
      "api_key": "sk-YOUR API KEY",
      "model": "cosyvoice-v2",
      "dashscope_tts_voice": "longnan_v2",
      "timeout": 20
}
```

### Screenshots or Test Results / 运行截图或测试结果

<img width="2307" height="1285" alt="image" src="https://github.com/user-attachments/assets/6e5dc16a-36a1-476d-a473-c3a3e37171cd" />
<img width="1080" height="2400" alt="Screenshot_20251005-144812" src="https://github.com/user-attachments/assets/a7ea635a-5090-4199-90fa-f19e3f095d3f" />

### Compatibility & Breaking Changes / 兼容性与破坏性变更

- [ ] 这是一个破坏性变更 (Breaking Change)。/ This is a breaking change.
- [x] 这不是一个破坏性变更。/ This is NOT a breaking change.

---

### Checklist / 检查清单

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->
<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.
