### PR TITLE
feat(satori): 添加对合并转发消息功能的支持

### DIFF
--- a/astrbot/core/platform/sources/satori/satori_adapter.py
+++ b/astrbot/core/platform/sources/satori/satori_adapter.py
@@ -509,20 +509,21 @@ class SatoriPlatformAdapter(Platform):
     async def _extract_quote_with_regex(self, content: str) -> Optional[dict]:
         """使用正则表达式提取quote标签信息"""
         import re
-        quote_pattern = r'<quote\s+([^>]*)>(.*?)</quote>'
+
+        quote_pattern = r"<quote\s+([^>]*)>(.*?)</quote>"
         match = re.search(quote_pattern, content, re.DOTALL)
-        
+
         if not match:
             return None
-            
+
         attrs_str = match.group(1)
         inner_content = match.group(2)
-        
+
         id_match = re.search(r'id\s*=\s*["\']([^"\']*)["\']', attrs_str)
         quote_id = id_match.group(1) if id_match else ""
         content_without_quote = content.replace(match.group(0), "")
         content_without_quote = content_without_quote.strip()
-        
+
         return {
             "quote": {"id": quote_id, "content": inner_content},
             "content_without_quote": content_without_quote,

--- a/astrbot/core/platform/sources/satori/satori_event.py
+++ b/astrbot/core/platform/sources/satori/satori_event.py
@@ -2,7 +2,18 @@ from typing import TYPE_CHECKING
 from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent, MessageChain
 from astrbot.api.platform import AstrBotMessage, PlatformMetadata
-from astrbot.api.message_components import Plain, Image, At, File, Record, Video, Reply, Forward, Node, Nodes
+from astrbot.api.message_components import (
+    Plain,
+    Image,
+    At,
+    File,
+    Record,
+    Video,
+    Reply,
+    Forward,
+    Node,
+    Nodes,
+)
 
 if TYPE_CHECKING:
     from .satori_adapter import SatoriPlatformAdapter
@@ -48,10 +59,12 @@ class SatoriPlatformEvent(AstrMessageEvent):
             content_parts = []
 
             for component in message.chain:
-                component_content = await cls._convert_component_to_satori_static(component)
+                component_content = await cls._convert_component_to_satori_static(
+                    component
+                )
                 if component_content:
                     content_parts.append(component_content)
-                
+
                 # 特殊处理 Node 和 Nodes 组件
                 if isinstance(component, Node):
                     # 单个转发节点
@@ -108,7 +121,7 @@ class SatoriPlatformEvent(AstrMessageEvent):
                 component_content = await self._convert_component_to_satori(component)
                 if component_content:
                     content_parts.append(component_content)
-                
+
                 # 特殊处理 Node 和 Nodes 组件
                 if isinstance(component, Node):
                     # 单个转发节点
@@ -211,7 +224,9 @@ class SatoriPlatformEvent(AstrMessageEvent):
                     logger.error(f"图片转换为base64失败: {e}")
 
             elif isinstance(component, File):
-                return f'<file src="{component.file}" name="{component.name or "文件"}"/>'
+                return (
+                    f'<file src="{component.file}" name="{component.name or "文件"}"/>'
+                )
 
             elif isinstance(component, Record):
                 try:
@@ -237,7 +252,7 @@ class SatoriPlatformEvent(AstrMessageEvent):
 
             # 对于其他未处理的组件类型，返回空字符串
             return ""
-            
+
         except Exception as e:
             logger.error(f"转换消息组件失败: {e}")
             return ""
@@ -248,27 +263,29 @@ class SatoriPlatformEvent(AstrMessageEvent):
             content_parts = []
             if node.content:
                 for content_component in node.content:
-                    component_content = await self._convert_component_to_satori(content_component)
+                    component_content = await self._convert_component_to_satori(
+                        content_component
+                    )
                     if component_content:
                         content_parts.append(component_content)
 
             content = "".join(content_parts)
-            
+
             # 如果内容为空，添加默认内容
             if not content.strip():
                 content = "[转发消息]"
-            
+
             # 构建 Satori 格式的转发节点
             author_attrs = []
             if node.uin:
                 author_attrs.append(f'id="{node.uin}"')
             if node.name:
                 author_attrs.append(f'name="{node.name}"')
-            
+
             author_attr_str = " ".join(author_attrs)
-            
-            return f'<message><author {author_attr_str}/>{content}</message>'
-            
+
+            return f"<message><author {author_attr_str}/>{content}</message>"
+
         except Exception as e:
             logger.error(f"转换转发节点失败: {e}")
             return ""
@@ -300,7 +317,9 @@ class SatoriPlatformEvent(AstrMessageEvent):
                     logger.error(f"图片转换为base64失败: {e}")
 
             elif isinstance(component, File):
-                return f'<file src="{component.file}" name="{component.name or "文件"}"/>'
+                return (
+                    f'<file src="{component.file}" name="{component.name or "文件"}"/>'
+                )
 
             elif isinstance(component, Record):
                 try:
@@ -326,7 +345,7 @@ class SatoriPlatformEvent(AstrMessageEvent):
 
             # 对于其他未处理的组件类型，返回空字符串
             return ""
-            
+
         except Exception as e:
             logger.error(f"转换消息组件失败: {e}")
             return ""
@@ -338,26 +357,28 @@ class SatoriPlatformEvent(AstrMessageEvent):
             content_parts = []
             if node.content:
                 for content_component in node.content:
-                    component_content = await cls._convert_component_to_satori_static(content_component)
+                    component_content = await cls._convert_component_to_satori_static(
+                        content_component
+                    )
                     if component_content:
                         content_parts.append(component_content)
 
             content = "".join(content_parts)
-            
+
             # 如果内容为空，添加默认内容
             if not content.strip():
                 content = "[转发消息]"
-            
+
             author_attrs = []
             if node.uin:
                 author_attrs.append(f'id="{node.uin}"')
             if node.name:
                 author_attrs.append(f'name="{node.name}"')
-            
+
             author_attr_str = " ".join(author_attrs)
-            
-            return f'<message><author {author_attr_str}/>{content}</message>'
-            
+
+            return f"<message><author {author_attr_str}/>{content}</message>"
+
         except Exception as e:
             logger.error(f"转换转发节点失败: {e}")
             return ""
@@ -366,17 +387,17 @@ class SatoriPlatformEvent(AstrMessageEvent):
         """将多个转发节点转换为 Satori 格式的合并转发"""
         try:
             node_parts = []
-            
+
             for node in nodes.nodes:
                 node_content = await self._convert_node_to_satori(node)
                 if node_content:
                     node_parts.append(node_content)
-            
+
             if node_parts:
-                return f'<message forward>{"".join(node_parts)}</message>'
+                return f"<message forward>{''.join(node_parts)}</message>"
             else:
                 return ""
-                
+
         except Exception as e:
             logger.error(f"转换合并转发消息失败: {e}")
             return ""
@@ -386,17 +407,17 @@ class SatoriPlatformEvent(AstrMessageEvent):
         """将多个转发节点转换为 Satori 格式的合并转发"""
         try:
             node_parts = []
-            
+
             for node in nodes.nodes:
                 node_content = await cls._convert_node_to_satori_static(node)
                 if node_content:
                     node_parts.append(node_content)
-            
+
             if node_parts:
-                return f'<message forward>{"".join(node_parts)}</message>'
+                return f"<message forward>{''.join(node_parts)}</message>"
             else:
                 return ""
-                
+
         except Exception as e:
             logger.error(f"转换合并转发消息失败: {e}")
             return ""


### PR DESCRIPTION
### Motivation / 动机

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX 错误，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX bug, adds YY feature)-->

支持合并转发功能，在 Satori 适配器中添加对 `Forward`、`Node`、`Nodes` 消息组件的支持。

当前适配器缺少对这些组件的处理，导致发送合并转发消息时失败。

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- **修改文件**: [`astrbot/core/platform/sources/satori/satori_event.py`](astrbot/core/platform/sources/satori/satori_event.py)
- **主要改动**:
  1. 导入新增的 `Forward`、`Node`、`Nodes` 组件类
  2. 重构消息组件处理逻辑，提取公共方法 `_convert_component_to_satori()` 和 `_convert_component_to_satori_static()`
  3. 实现转发节点转换方法 `_convert_node_to_satori()` 和 `_convert_node_to_satori_static()`
  4. 实现合并转发转换方法 `_convert_nodes_to_satori()` 和 `_convert_nodes_to_satori_static()`
  5. 更新 `send_with_adapter()` 和 `send()` 方法以支持转发组件

- **支持的功能**:
  - ✅ 单条消息转发: `<message id="123456789" forward/>`
  - ✅ 合并转发: `<message forward><message><author id="123" name="用户"/>{内容}</message>...</message>`
  - ✅ 模拟用户消息: `<message><author id="123" name="Alice"/>{内容}</message>`

### Compatibility & Breaking Changes / 兼容性与破坏性变更

<!--请说明此变更的兼容性：哪些是破坏性变更？哪些地方做了向后兼容处理？是否提供了数据迁移方法？-->
<!--Please explain the compatibility of this change: What are the breaking changes? What backward-compatible measures were taken? Are data migration paths provided?-->

- [x] 这是一个破坏性变更 (Breaking Change)。/ This is a breaking change.
- [ ] 这不是一个破坏性变更。/ This is NOT a breaking change.

**兼容性说明**: 此变更完全向后兼容，只是新增功能，不会影响现有代码的正常运行。

---

### Checklist / 检查清单

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->
<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

在 Satori 适配器中启用合并转发消息，通过引入 Forward、Node 和 Nodes 转换，并整合组件到 Satori 的格式化逻辑

New Features:
- 支持 Forward、Node 和 Nodes 组件，以在 Satori 中启用单个转发、合并转发和用户原创消息

Enhancements:
- 将消息组件转换重构为共享的辅助方法，用于实例和静态上下文

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable merged forwarding messages in the Satori adapter by introducing Forward, Node, and Nodes conversions and consolidating component-to-Satori formatting logic

New Features:
- Support Forward, Node, and Nodes components to enable single forward, merged forward, and authored user messages in Satori

Enhancements:
- Refactor message component conversion into shared helper methods for instance and static contexts

</details>