### PR TITLE
fix: TypeError 'NoneType' object is not iterable

### DIFF
--- a/astrbot/core/platform/astr_message_event.py
+++ b/astrbot/core/platform/astr_message_event.py
@@ -92,8 +92,10 @@ class AstrMessageEvent(abc.ABC):
         """
         return self.message_str
 
-    def _outline_chain(self, chain: List[BaseMessageComponent]) -> str:
+    def _outline_chain(self, chain: Optional[List[BaseMessageComponent]]) -> str:
         outline = ""
+        if not chain:
+            return outline
         for i in chain:
             if isinstance(i, Plain):
                 outline += i.text
@@ -265,6 +267,9 @@ class AstrMessageEvent(abc.ABC):
         """
         if isinstance(result, str):
             result = MessageEventResult().message(result)
+        # 兼容外部插件或调用方传入的 chain=None 的情况，确保为可迭代列表
+        if isinstance(result, MessageEventResult) and result.chain is None:
+            result.chain = []
         self._result = result
 
     def stop_event(self):


### PR DESCRIPTION
<!-- 如果有的话，请指定此 PR 旨在解决的 ISSUE 编号。 -->
<!-- If applicable, please specify the ISSUE number this PR aims to resolve. -->

fixes #XYZ

---

### Motivation / 动机

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX 错误，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX bug, adds YY feature)-->

```
Task exception was never retrieved
future: <Task finished name='Task-404' coro=<PipelineScheduler.execute() done, defined at /AstrBot/astrbot/core/pipeline/scheduler.py:68> exception=TypeError("'NoneType' object is not iterable")>
Traceback (most recent call last):
  File "/AstrBot/astrbot/core/pipeline/scheduler.py", line 74, in execute
    await self._process_stages(event)
  File "/AstrBot/astrbot/core/pipeline/scheduler.py", line 51, in _process_stages
    await self._process_stages(event, i + 1)
  File "/AstrBot/astrbot/core/pipeline/scheduler.py", line 62, in _process_stages
    await coroutine
  File "/AstrBot/astrbot/core/pipeline/respond/stage.py", line 162, in process
    f"Prepare to send - {event.get_sender_name()}/{event.get_sender_id()}: {event._outline_chain(result.chain)}"
                                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/AstrBot/astrbot/core/platform/astr_message_event.py", line 97, in _outline_chain
    for i in chain:
TypeError: 'NoneType' object is not iterable

```

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

### Verification Steps / 验证步骤

<!--请为审查者 (Reviewer) 提供清晰、可复现的验证步骤（例如：1. 导航到... 2. 点击...）。-->
<!--Please provide clear and reproducible verification steps for the Reviewer (e.g., 1. Navigate to... 2. Click...).-->

### Screenshots or Test Results / 运行截图或测试结果

<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->

### Compatibility & Breaking Changes / 兼容性与破坏性变更

<!--请说明此变更的兼容性：哪些是破坏性变更？哪些地方做了向后兼容处理？是否提供了数据迁移方法？-->
<!--Please explain the compatibility of this change: What are the breaking changes? What backward-compatible measures were taken? Are data migration paths provided?-->

- [ ] 这是一个破坏性变更 (Breaking Change)。/ This is a breaking change.
- [ ] 这不是一个破坏性变更。/ This is NOT a breaking change.

---

### Checklist / 检查清单

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->
<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [ ] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [ ] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [ ] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Sourcery 总结

防止消息事件中出现 None 链以避免迭代错误

Bug 修复:
- 在 _outline_chain 中处理 None 或空消息链，通过返回一个空字符串
- 确保当 result.chain 为 None 时，其默认为一个空列表，以防止 TypeError

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard against None chains in message events to avoid iteration errors

Bug Fixes:
- Handle None or empty message chains in _outline_chain by returning an empty string
- Ensure result.chain defaults to an empty list when None to prevent TypeError

</details>