### PR TITLE
在WebUI界面添加 隐藏/显示 已禁用插件功能

### DIFF
--- a/astrbot/dashboard/routes/session_management.py
+++ b/astrbot/dashboard/routes/session_management.py
@@ -8,7 +8,6 @@ from astrbot.core.db import BaseDatabase
 from astrbot.core.provider.entities import ProviderType
 from astrbot.core.star.session_llm_manager import SessionServiceManager
 from astrbot.core.star.session_plugin_manager import SessionPluginManager
-
 from .route import Response, Route, RouteContext
 
 
@@ -371,6 +370,7 @@ class SessionManagementRoute(Route):
         """获取指定会话的插件配置信息"""
         try:
             session_id = request.args.get("session_id")
+            hide_disabled = request.args.get("hide_disabled", "false").lower() == "true"
 
             if not session_id:
                 return Response().error("缺少必要参数: session_id").__dict__
@@ -386,6 +386,10 @@ class SessionManagementRoute(Route):
                     plugin_enabled = SessionPluginManager.is_plugin_enabled_for_session(
                         session_id, plugin_name
                     )
+
+                    # 如果启用了隐藏已禁用插件选项，则跳过已禁用的插件
+                    if hide_disabled and not plugin_enabled:
+                        continue
 
                     all_plugins.append(
                         {

--- a/dashboard/src/i18n/locales/zh-CN/features/extension.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/extension.json
@@ -16,6 +16,8 @@
   "buttons": {
     "showSystemPlugins": "显示系统插件",
     "hideSystemPlugins": "隐藏系统插件",
+    "hideDisabledPlugins": "隐藏已禁用插件",
+    "showDisabledPlugins": "显示已禁用插件",
     "install": "安装",
     "uninstall": "卸载",
     "update": "更新",

--- a/dashboard/src/views/ExtensionPage.vue
+++ b/dashboard/src/views/ExtensionPage.vue
@@ -5,11 +5,11 @@ import ConsoleDisplayer from '@/components/shared/ConsoleDisplayer.vue';
 import ReadmeDialog from '@/components/shared/ReadmeDialog.vue';
 import ProxySelector from '@/components/shared/ProxySelector.vue';
 import axios from 'axios';
-import { pinyin } from 'pinyin-pro';
-import { useCommonStore } from '@/stores/common';
-import { useI18n, useModuleI18n } from '@/i18n/composables';
+import {pinyin} from 'pinyin-pro';
+import {useCommonStore} from '@/stores/common';
+import {useI18n, useModuleI18n} from '@/i18n/composables';
 
-import { ref, computed, onMounted, reactive } from 'vue';
+import {computed, onMounted, reactive, ref} from 'vue';
 
 
 const commonStore = useCommonStore();
@@ -22,6 +22,7 @@ const extension_data = reactive({
   message: ""
 });
 const showReserved = ref(false);
+const hideDisabled = ref(false);
 const snack_message = ref("");
 const snack_show = ref(false);
 const snack_success = ref("success");
@@ -124,10 +125,17 @@ const pluginMarketHeaders = computed(() => [
 
 // 过滤要显示的插件
 const filteredExtensions = computed(() => {
+  let result = extension_data?.data || [];
+
   if (!showReserved.value) {
-    return extension_data?.data?.filter(ext => !ext.reserved) || [];
+    result = result.filter(ext => !ext.reserved);
   }
-  return extension_data.data || [];
+
+  if (!hideDisabled.value) {
+    result = result.filter(ext => ext.activated);
+  }
+
+  return result;
 });
 
 // 通过搜索过滤插件
@@ -153,6 +161,10 @@ const toggleShowReserved = () => {
   showReserved.value = !showReserved.value;
 };
 
+const toggleHideDisabled = () => {
+  hideDisabled.value = !hideDisabled.value;
+};
+
 const toast = (message, success) => {
   snack_message.value = message;
   snack_show.value = true;
@@ -176,7 +188,11 @@ const onLoadingDialogResult = (statusCode, result, timeToClose = 2000) => {
 const getExtensions = async () => {
   loading_.value = true;
   try {
-    const res = await axios.get('/api/plugin/get');
+    const res = await axios.get('/api/plugin/get', {
+      params: {
+        hide_disabled: false // 强制获取所有插件，在前端过滤
+      }
+    });
     Object.assign(extension_data, res.data);
     checkUpdate();
   } catch (err) {
@@ -593,6 +609,11 @@ onMounted(async () => {
                 <v-btn class="ml-2" variant="tonal" @click="toggleShowReserved">
                   <v-icon>{{ showReserved ? 'mdi-eye-off' : 'mdi-eye' }}</v-icon>
                   {{ showReserved ? tm('buttons.hideSystemPlugins') : tm('buttons.showSystemPlugins') }}
+                </v-btn>
+
+                <v-btn class="ml-2" variant="tonal" @click="toggleHideDisabled">
+                  <v-icon>{{ hideDisabled ? 'mdi-eye-off' : 'mdi-eye' }}</v-icon>
+                  {{ hideDisabled ? tm('buttons.hideDisabledPlugins') : tm('buttons.showDisabledPlugins') }}
                 </v-btn>
 
                 <v-btn class="ml-2" color="primary" variant="tonal" @click="dialog = true">


### PR DESCRIPTION
<!-- 如果有的话，请指定此 PR 旨在解决的 ISSUE 编号。 -->
<!-- If applicable, please specify the ISSUE number this PR aims to resolve. -->

fixes #3117

---

### Motivation / 动机

在WebUI界面添加 隐藏/显示 已禁用插件功能

### Modifications / 改动点

<img width="768" height="371" alt="image" src="https://github.com/user-attachments/assets/f25b97dc-8304-4a9d-a64f-3aa82f050ab4" />

## Sourcery 总结

通过添加一个专门的切换控件、调整客户端过滤逻辑并扩展后端 API 以支持 `hide_disabled` 参数，实现在 WebUI 中隐藏禁用插件的功能。

新功能：
- 在 WebUI 中添加一个切换按钮，用于隐藏或显示禁用插件
- 在 ExtensionPage.vue 中基于 `hideDisabled` 状态引入前端过滤
- 扩展插件检索 API，使其接受 `hide_disabled` 参数，并在请求时跳过禁用插件

改进：
- 始终从后端获取所有插件，并在客户端应用过滤
- 更新插件列表过滤逻辑，以结合保留插件和禁用插件的可见性设置

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable hiding of disabled plugins in the WebUI by adding a dedicated toggle control, adjusting the client-side filtering logic, and extending the backend API to support the hide_disabled parameter.

New Features:
- Add a toggle button in the WebUI to hide or show disabled plugins
- Introduce front-end filtering based on the hideDisabled state in ExtensionPage.vue
- Extend the plugin retrieval API to accept a hide_disabled parameter and skip disabled plugins when requested

Enhancements:
- Always fetch all plugins from the backend and apply filtering on the client side
- Update the plugin list filtering logic to combine reserved and disabled plugin visibility settings

</details>