### PR TITLE
fix: apply configuration option to enable/disable WebUI in AstrBotDashboard

### DIFF
--- a/astrbot/core/initial_loader.py
+++ b/astrbot/core/initial_loader.py
@@ -41,10 +41,13 @@ class InitialLoader:
         self.dashboard_server = AstrBotDashboard(
             core_lifecycle, self.db, core_lifecycle.dashboard_shutdown_event, webui_dir
         )
-        task = asyncio.gather(
-            core_task, self.dashboard_server.run()
-        )  # 启动核心任务和仪表板服务器
 
+        coro = self.dashboard_server.run()
+        if coro:
+            # 启动核心任务和仪表板服务器
+            task = asyncio.gather(core_task, coro)
+        else:
+            task = core_task
         try:
             await task  # 整个AstrBot在这里运行
         except asyncio.CancelledError:

--- a/astrbot/dashboard/server.py
+++ b/astrbot/dashboard/server.py
@@ -178,6 +178,11 @@ class AstrBotDashboard:
         else:
             port = self.core_lifecycle.astrbot_config["dashboard"].get("port", 6185)
         host = self.core_lifecycle.astrbot_config["dashboard"].get("host", "0.0.0.0")
+        enable = self.core_lifecycle.astrbot_config["dashboard"].get("enable", True)
+
+        if not enable:
+            logger.info("WebUI 已被禁用")
+            return
 
         logger.info(f"正在启动 WebUI, 监听地址: http://{host}:{port}")
 


### PR DESCRIPTION
<!-- 如果有的话，请指定此 PR 旨在解决的 ISSUE 编号。 -->
<!-- If applicable, please specify the ISSUE number this PR aims to resolve. -->

fixes #3149

---

### Motivation / 动机

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX 错误，添加了 YY 功能）-->
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX bug, adds YY feature)-->

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

### Verification Steps / 验证步骤

<!--请为审查者 (Reviewer) 提供清晰、可复现的验证步骤（例如：1. 导航到... 2. 点击...）。-->
<!--Please provide clear and reproducible verification steps for the Reviewer (e.g., 1. Navigate to... 2. Click...).-->

### Screenshots or Test Results / 运行截图或测试结果

<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->

### Compatibility & Breaking Changes / 兼容性与破坏性变更

<!--请说明此变更的兼容性：哪些是破坏性变更？哪些地方做了向后兼容处理？是否提供了数据迁移方法？-->
<!--Please explain the compatibility of this change: What are the breaking changes? What backward-compatible measures were taken? Are data migration paths provided?-->

- [ ] 这是一个破坏性变更 (Breaking Change)。/ This is a breaking change.
- [ ] 这不是一个破坏性变更。/ This is NOT a breaking change.

---

### Checklist / 检查清单

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->
<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [ ] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [ ] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [ ] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Sourcery 摘要

应用 `dashboard.enable` 配置选项，以根据条件启动 WebUI，并在禁用时跳过启动仪表板服务器。

Bug 修复：
- 遵循 `dashboard.enable` 标志以禁用 WebUI 启动。

功能增强：
- 修改初始加载器，使其仅在仪表板服务器任务返回协程时才收集该任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Apply the `dashboard.enable` configuration option to conditionally start the WebUI and skip launching the dashboard server when disabled.

Bug Fixes:
- Respect `dashboard.enable` flag to disable WebUI startup.

Enhancements:
- Modify initial loader to only gather the dashboard server task when it returns a coroutine.

</details>