### PR TITLE
fix: qq_official_webhook is_sandbox field error

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -165,7 +165,7 @@ CONFIG_METADATA_2 = {
                         "enable": False,
                         "appid": "",
                         "secret": "",
-                        "is_sandbox": "false",
+                        "is_sandbox": False,
                         "callback_server_host": "0.0.0.0",
                         "port": 6196,
                     },
@@ -324,6 +324,10 @@ CONFIG_METADATA_2 = {
                     #     "type": "string",
                     #     "options": ["fullscreen", "embedded"],
                     # },
+                    "is_sandbox": {
+                        "description": "沙箱模式",
+                        "type": "bool",
+                    },
                     "satori_api_base_url": {
                         "description": "Satori API 终结点",
                         "type": "string",

--- a/astrbot/core/platform/sources/qqofficial_webhook/qo_webhook_server.py
+++ b/astrbot/core/platform/sources/qqofficial_webhook/qo_webhook_server.py
@@ -15,7 +15,7 @@ class QQOfficialWebhook:
         self.appid = config["appid"]
         self.secret = config["secret"]
         self.port = config.get("port", 6196)
-        self.is_sandbox = config.get("is_sandbox", "false").lower() == "true"
+        self.is_sandbox = config.get("is_sandbox", False)
         self.callback_server_host = config.get("callback_server_host", "0.0.0.0")
 
         if isinstance(self.port, str):


### PR DESCRIPTION
由于配置类型为字符串, 修复为字符串判断

## Sourcery 摘要

将 `is_sandbox` 配置值解析为布尔类型并传递给 `BotHttp` 客户端，在配置中添加其默认值，并清理相关代码格式。

新功能：
- 通过从配置中读取 `is_sandbox` 设置并将其转发到 HTTP 客户端，支持 QQ 官方 webhook 的沙盒模式

改进：
- 在默认配置中添加 `is_sandbox` 默认条目
- 将 URL 规则注册、消息连接和日志记录的多行语句简化为单行表达式

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Parse the is_sandbox config value as a boolean and propagate it to the BotHttp client, add its default to the configuration, and clean up related code formatting.

New Features:
- Support sandbox mode for QQ official webhook by reading the is_sandbox setting from config and forwarding it to the HTTP client

Enhancements:
- Add default is_sandbox entry in default config
- Simplify multi-line statements for URL rule registration, message concatenation, and logging into single-line expressions

</details>