### PR TITLE
增加 provider 命令的提供商可用性显示

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ astrbot.lock
 chroma
 venv/*
 pytest.ini
+AGENTS.md
+IFLOW.md

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -73,6 +73,7 @@ DEFAULT_CONFIG = {
         "coze_agent_runner_provider_id": "",
         "dashscope_agent_runner_provider_id": "",
         "unsupported_streaming_strategy": "realtime_segmenting",
+        "reachability_check": True,
         "max_agent_step": 30,
         "tool_call_timeout": 60,
     },
@@ -2278,6 +2279,11 @@ CONFIG_METADATA_3 = {
                         "type": "string",
                         "_special": "select_provider",
                         "hint": "留空代表不使用，可用于非多模态模型",
+                    },
+                    "provider_settings.reachability_check": {
+                        "description": "提供商可达性检测",
+                        "type": "bool",
+                        "hint": "/provider 命令列出模型时是否并发检测连通性。开启后会主动调用模型测试连通性，可能产生额外 token 消耗。",
                     },
                     "provider_stt_settings.enable": {
                         "description": "启用语音转文本",

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -36,6 +36,10 @@
           "description": "Default Image Caption Model",
           "hint": "Leave empty to disable; useful for non-multimodal models"
         },
+        "reachability_check": {
+          "description": "Provider Reachability Check",
+          "hint": "When running the /provider command, test provider connectivity in parallel. This actively pings models and may consume extra tokens."
+        },
         "image_caption_prompt": {
           "description": "Image Caption Prompt"
         }

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -36,6 +36,10 @@
           "description": "默认图片转述模型",
           "hint": "留空代表不使用,可用于非多模态模型"
         },
+        "reachability_check": {
+          "description": "提供商可达性检测",
+          "hint": "/provider 命令列出模型时并发检测连通性。开启后会主动调用模型测试连通性,可能产生额外 token 消耗。"
+        },
         "image_caption_prompt": {
           "description": "图片转述提示词"
         }

--- a/packages/astrbot/commands/provider.py
+++ b/packages/astrbot/commands/provider.py
@@ -1,13 +1,168 @@
+import asyncio
+import os
 import re
 
+from astrbot import logger
 from astrbot.api import star
 from astrbot.api.event import AstrMessageEvent, MessageEventResult
 from astrbot.core.provider.entities import ProviderType
+from astrbot.core.provider.provider import RerankProvider
+from astrbot.core.utils.astrbot_path import get_astrbot_path
+
+REACHABILITY_CHECK_TIMEOUT = 30.0
 
 
 class ProviderCommands:
     def __init__(self, context: star.Context):
         self.context = context
+
+    def _log_reachability_failure(
+        self,
+        provider,
+        provider_capability_type: ProviderType | None,
+        err_code: str,
+        err_reason: str,
+    ):
+        """记录不可达原因到日志。"""
+        meta = provider.meta()
+        logger.warning(
+            "Provider reachability check failed: id=%s type=%s code=%s reason=%s",
+            meta.id,
+            provider_capability_type.name if provider_capability_type else "unknown",
+            err_code,
+            err_reason,
+        )
+
+    async def _test_provider_capability(self, provider):
+        """测试单个 provider 的可用性 (复用 Dashboard 的检测逻辑)"""
+        meta = provider.meta()
+        provider_capability_type = meta.provider_type
+
+        try:
+            if provider_capability_type == ProviderType.CHAT_COMPLETION:
+                # 发送 "Ping" 测试对话
+                response = await asyncio.wait_for(
+                    provider.text_chat(prompt="REPLY `PONG` ONLY"),
+                    timeout=REACHABILITY_CHECK_TIMEOUT,
+                )
+                if response is not None:
+                    return True, None, None
+                err_code = "EMPTY_RESPONSE"
+                err_reason = "Provider returned empty response"
+                self._log_reachability_failure(
+                    provider, provider_capability_type, err_code, err_reason
+                )
+                return False, err_code, err_reason
+
+            elif provider_capability_type == ProviderType.EMBEDDING:
+                # 测试 Embedding
+                embedding_result = await asyncio.wait_for(
+                    provider.get_embedding("health_check"),
+                    timeout=REACHABILITY_CHECK_TIMEOUT,
+                )
+                if (
+                    isinstance(embedding_result, list)
+                    and embedding_result
+                    and all(isinstance(x, (int, float)) for x in embedding_result)
+                ):
+                    return True, None, None
+                err_code = "INVALID_EMBEDDING"
+                err_reason = "Provider returned invalid embedding"
+                self._log_reachability_failure(
+                    provider, provider_capability_type, err_code, err_reason
+                )
+                return False, err_code, err_reason
+
+            elif provider_capability_type == ProviderType.TEXT_TO_SPEECH:
+                # 测试 TTS
+                audio_result = await asyncio.wait_for(
+                    provider.get_audio("你好"),
+                    timeout=REACHABILITY_CHECK_TIMEOUT,
+                )
+                if isinstance(audio_result, str) and audio_result:
+                    # 清理检测生成的临时音频文件，避免频繁检测时堆积
+                    if os.path.isfile(audio_result):
+                        try:
+                            os.remove(audio_result)
+                        except OSError as e:
+                            logger.debug(
+                                "Failed to cleanup TTS health check file %s: %s",
+                                audio_result,
+                                e,
+                            )
+                    return True, None, None
+                err_code = "INVALID_AUDIO"
+                err_reason = "Provider returned invalid audio"
+                self._log_reachability_failure(
+                    provider, provider_capability_type, err_code, err_reason
+                )
+                return False, err_code, err_reason
+
+            elif provider_capability_type == ProviderType.SPEECH_TO_TEXT:
+                # 测试 STT
+                sample_audio_path = os.path.join(
+                    get_astrbot_path(),
+                    "samples",
+                    "stt_health_check.wav",
+                )
+                if not os.path.exists(sample_audio_path):
+                    # 如果样本文件不存在，降级为检查是否实现了方法
+                    return hasattr(provider, "get_text"), None, None
+
+                text_result = await asyncio.wait_for(
+                    provider.get_text(sample_audio_path),
+                    timeout=REACHABILITY_CHECK_TIMEOUT,
+                )
+                if isinstance(text_result, str) and text_result:
+                    return True, None, None
+                err_code = "INVALID_TEXT"
+                err_reason = "Provider returned invalid text"
+                self._log_reachability_failure(
+                    provider, provider_capability_type, err_code, err_reason
+                )
+                return False, err_code, err_reason
+
+            elif provider_capability_type == ProviderType.RERANK:
+                # 测试 Rerank
+                if isinstance(provider, RerankProvider):
+                    await asyncio.wait_for(
+                        provider.rerank("Apple", documents=["apple", "banana"]),
+                        timeout=REACHABILITY_CHECK_TIMEOUT,
+                    )
+                    return True, None, None
+                err_code = "NOT_RERANK_PROVIDER"
+                err_reason = "Provider is not RerankProvider"
+                self._log_reachability_failure(
+                    provider, provider_capability_type, err_code, err_reason
+                )
+                return False, err_code, err_reason
+
+            else:
+                # 其他类型暂时视为通过，或者回退到 get_models
+                if hasattr(provider, "get_models"):
+                    await asyncio.wait_for(
+                        provider.get_models(), timeout=REACHABILITY_CHECK_TIMEOUT
+                    )
+                    return True, None, None
+                return True, None, None  # 未知类型默认通过
+
+        except asyncio.TimeoutError:
+            err_code = "TIMEOUT"
+            err_reason = "Reachability check timed out"
+        except Exception as exc:
+            err_code = (
+                getattr(exc, "status_code", None)
+                or getattr(exc, "code", None)
+                or getattr(exc, "error_code", None)
+            )
+            err_reason = str(exc)
+            if not err_code:
+                err_code = exc.__class__.__name__
+
+        self._log_reachability_failure(
+            provider, provider_capability_type, err_code, err_reason
+        )
+        return False, err_code, err_reason
 
     async def provider(
         self,
@@ -17,46 +172,131 @@ class ProviderCommands:
     ):
         """查看或者切换 LLM Provider"""
         umo = event.unified_msg_origin
+        cfg = self.context.get_config(umo).get("provider_settings", {})
+        reachability_check_enabled = cfg.get("reachability_check", True)
 
         if idx is None:
             parts = ["## 载入的 LLM 提供商\n"]
-            for idx, llm in enumerate(self.context.get_all_providers()):
-                id_ = llm.meta().id
-                line = f"{idx + 1}. {id_} ({llm.meta().model})"
+
+            # 获取所有类型的提供商
+            llms = list(self.context.get_all_providers())
+            ttss = self.context.get_all_tts_providers()
+            stts = self.context.get_all_stt_providers()
+
+            # 构造待检测列表: [(provider, type_label), ...]
+            all_providers = []
+            all_providers.extend([(p, "llm") for p in llms])
+            all_providers.extend([(p, "tts") for p in ttss])
+            all_providers.extend([(p, "stt") for p in stts])
+
+            # 并发测试连通性
+            if reachability_check_enabled:
+                if all_providers:
+                    await event.send(
+                        MessageEventResult().message(
+                            "正在进行提供商可达性测试，请稍候..."
+                        )
+                    )
+                check_results = await asyncio.gather(
+                    *[self._test_provider_capability(p) for p, _ in all_providers],
+                    return_exceptions=True,
+                )
+            else:
+                # 用 None 表示未检测
+                check_results = [None for _ in all_providers]
+
+            # 整合结果
+            display_data = []
+            for (p, p_type), reachable in zip(all_providers, check_results):
+                meta = p.meta()
+                id_ = meta.id
+                error_code = None
+
+                if isinstance(reachable, Exception):
+                    # 异常情况下兜底处理，避免单个 provider 导致列表失败
+                    self._log_reachability_failure(
+                        p,
+                        None,
+                        reachable.__class__.__name__,
+                        str(reachable),
+                    )
+                    reachable_flag = False
+                    error_code = reachable.__class__.__name__
+                elif isinstance(reachable, tuple):
+                    reachable_flag, error_code, _ = reachable
+                else:
+                    reachable_flag = reachable
+
+                # 根据类型构建显示名称
+                if p_type == "llm":
+                    info = f"{id_} ({meta.model})"
+                else:
+                    info = f"{id_}"
+
+                # 确定状态标记
+                if reachable_flag is True:
+                    mark = " ✅"
+                elif reachable_flag is False:
+                    if error_code:
+                        mark = f" ❌(错误码: {error_code})"
+                    else:
+                        mark = " ❌"
+                else:
+                    mark = ""  # 不支持检测时不显示标记
+
+                display_data.append(
+                    {
+                        "type": p_type,
+                        "info": info,
+                        "mark": mark,
+                        "provider": p,
+                    }
+                )
+
+            # 分组输出
+            # 1. LLM
+            llm_data = [d for d in display_data if d["type"] == "llm"]
+            for i, d in enumerate(llm_data):
+                line = f"{i + 1}. {d['info']}{d['mark']}"
                 provider_using = self.context.get_using_provider(umo=umo)
-                if provider_using and provider_using.meta().id == id_:
+                if (
+                    provider_using
+                    and provider_using.meta().id == d["provider"].meta().id
+                ):
                     line += " (当前使用)"
                 parts.append(line + "\n")
 
-            tts_providers = self.context.get_all_tts_providers()
-            if tts_providers:
+            # 2. TTS
+            tts_data = [d for d in display_data if d["type"] == "tts"]
+            if tts_data:
                 parts.append("\n## 载入的 TTS 提供商\n")
-                for idx, tts in enumerate(tts_providers):
-                    id_ = tts.meta().id
-                    line = f"{idx + 1}. {id_}"
+                for i, d in enumerate(tts_data):
+                    line = f"{i + 1}. {d['info']}{d['mark']}"
                     tts_using = self.context.get_using_tts_provider(umo=umo)
-                    if tts_using and tts_using.meta().id == id_:
+                    if tts_using and tts_using.meta().id == d["provider"].meta().id:
                         line += " (当前使用)"
                     parts.append(line + "\n")
 
-            stt_providers = self.context.get_all_stt_providers()
-            if stt_providers:
+            # 3. STT
+            stt_data = [d for d in display_data if d["type"] == "stt"]
+            if stt_data:
                 parts.append("\n## 载入的 STT 提供商\n")
-                for idx, stt in enumerate(stt_providers):
-                    id_ = stt.meta().id
-                    line = f"{idx + 1}. {id_}"
+                for i, d in enumerate(stt_data):
+                    line = f"{i + 1}. {d['info']}{d['mark']}"
                     stt_using = self.context.get_using_stt_provider(umo=umo)
-                    if stt_using and stt_using.meta().id == id_:
+                    if stt_using and stt_using.meta().id == d["provider"].meta().id:
                         line += " (当前使用)"
                     parts.append(line + "\n")
 
             parts.append("\n使用 /provider <序号> 切换 LLM 提供商。")
             ret = "".join(parts)
 
-            if tts_providers:
+            if ttss:
                 ret += "\n使用 /provider tts <序号> 切换 TTS 提供商。"
-            if stt_providers:
-                ret += "\n使用 /provider stt <切换> STT 提供商。"
+            if stts:
+                ret += "\n使用 /provider stt <序号> 切换 STT 提供商。"
+            if not reachability_check_enabled:
+                ret += "\n已跳过提供商可达性检测，如需检测请在配置文件中开启。"
 
             event.set_result(MessageEventResult().message(ret))
         elif idx == "tts":


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
增加 provider 命令的提供商可用性显示

### Modifications / 改动点

provider指令不仅仅显示提供商，同时显示提供商可用性
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
provider.py
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<img width="967" height="412" alt="image" src="https://github.com/user-attachments/assets/30768c48-9401-4e88-810e-3de6052ba226" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Sourcery 总结

增强 provider 命令，使其在列出每个 provider 的同时，检查并显示其可达性状态

增强功能：
- 并发测试每个 provider 的连接性，通过获取模型列表并设置 4 秒超时
- 在每个 provider 旁边显示 ✅ 或 ❌ 指示器，以显示其可用性

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在 `/provider` 命令中新增对各类 provider 的可达性检查与状态展示，并使该行为可配置。

新功能：
- 在 `/provider` 命令输出中，为 LLM、TTS 和 STT 的 providers 显示可达性状态指示。
- 新增可配置选项 `reachability_check`，用于控制在列出 providers 时是否检测其连通性。

增强：
- 在列出 providers 时，对不同能力类型的 providers（chat、embedding、TTS、STT、rerank）并发执行健康检查，使用有针对性的测试调用和超时机制。
- 改进 `/provider` 输出中 TTS/STT 部分的格式，并在禁用可达性检查时为用户提供相应指引。

文档：
- 在控制台配置元数据中，为 zh-CN 和 en-US 语言环境记录新的 `provider_settings.reachability_check` 配置选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add reachability checking and status display for providers in the /provider command and make this behavior configurable.

New Features:
- Display reachability status indicators for LLM, TTS, and STT providers in the /provider command output.
- Introduce a configurable reachability_check option to control whether provider connectivity is tested when listing providers.

Enhancements:
- Perform concurrent health checks for different provider capability types (chat, embedding, TTS, STT, rerank) using targeted test calls and timeouts when listing providers.
- Improve /provider output formatting for TTS/STT sections and add user guidance when reachability checks are disabled.

Documentation:
- Document the new provider_settings.reachability_check configuration option in the dashboard configuration metadata for both zh-CN and en-US locales.

</details>

</details>