### PR TITLE
docs: clarify segmented_reply words_count_threshold hint

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -638,7 +638,7 @@ CONFIG_METADATA_2 = {
                             },
                             "words_count_threshold": {
                                 "type": "int",
-                                "hint": "超过这个字数的消息不会被分段回复。默认为 150",
+                                "hint": "分段回复的字数上限。只有字数小于此值的消息才会被分段，超过此值的长消息将直接发送（不分段）。默认为 150",
                             },
                             "regex": {
                                 "type": "string",


### PR DESCRIPTION
Update the configuration hint for `words_count_threshold` to explicitly state that it acts as a maximum limit for segmentation, preventing user confusion about it being a minimum trigger.

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
The previous hint ("超过这个字数的消息不会被分段回复") was ambiguous and led to confusion. Users (including myself) misinterpreted `words_count_threshold` as a "minimum trigger threshold" (i.e., messages must be *longer* than this to segment), whereas it is actually a "maximum limit" (messages must be *shorter* than this to segment). This change clarifies the behavior in the configuration UI.

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
- Modified [astrbot/core/config/default.py](cci:7://file:///d:/codeToGit/AstrBot/astrbot/core/config/default.py:0:0-0:0): Updated the `hint` text for `segmented_reply.words_count_threshold` to clearly explain that it is an upper limit for segmentation.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
N/A (Documentation/Hint text update only. Verified by reading the code logic in [astrbot/core/pipeline/result_decorate/stage.py](cci:7://file:///d:/codeToGit/AstrBot/astrbot/core/pipeline/result_decorate/stage.py:0:0-0:0) line 160).

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

文档：
- 更新 `segmented_reply.words_count_threshold` 的提示文本，将其清晰地描述为用于分段的上限，而不是触发分段的最小值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update the segmented_reply.words_count_threshold hint text to clearly describe it as an upper limit for segmentation rather than a minimum trigger.

</details>