### PR TITLE
perf: 优化日志框底部 padding

### DIFF
--- a/dashboard/src/views/PlatformPage.vue
+++ b/dashboard/src/views/PlatformPage.vue
@@ -35,7 +35,7 @@
       </div>
 
       <!-- 日志部分 -->
-      <v-card elevation="0" class="mt-4">
+      <v-card elevation="0" class="mt-4 mb-10">
         <v-card-title class="d-flex align-center py-3 px-4">
           <v-icon class="me-2">mdi-console-line</v-icon>
           <span class="text-h4">{{ tm('logs.title') }}</span>
@@ -233,5 +233,6 @@ export default {
 .platform-page {
   padding: 20px;
   padding-top: 8px;
+  padding-bottom: 40px;
 }
 </style>

--- a/dashboard/src/views/ProviderPage.vue
+++ b/dashboard/src/views/ProviderPage.vue
@@ -148,7 +148,7 @@
       </div>
 
       <!-- 日志部分 -->
-      <v-card elevation="0" class="mt-4">
+      <v-card elevation="0" class="mt-4 mb-10">
         <v-card-title class="d-flex align-center py-3 px-4">
           <v-icon class="me-2">mdi-console-line</v-icon>
           <span class="text-h4">{{ tm('logs.title') }}</span>
@@ -849,6 +849,7 @@ export default {
 .provider-page {
   padding: 20px;
   padding-top: 8px;
+  padding-bottom: 40px;
 }
 
 .status-card {


### PR DESCRIPTION
## 修复日志框底部留白问题

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

修复 Provider 页面和 Platform 页面屏幕高度不足 需要滚动时，**滚动到底部，日志框下方没有留白的视觉体验问题**。

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- 为 `ProviderPage.vue` 和 `PlatformPage.vue` 的日志卡片添加 `mb-10` 底部边距类

- 为两个页面的容器添加 `padding-bottom: 40px` 样式

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->

<!--请粘贴截图、GIF 或测试日志，作为执行"验证步骤"的证据，证明此改动有效。-->

修复前：页面滚动到底部时，日志框紧贴页面底部，视觉上容易误以为日志框没有完全显示。
<img width="1178" height="566" alt="image" src="https://github.com/user-attachments/assets/6e0f5ede-6cc4-4b04-ad4e-e9e7dbfdb587" />

修复后：日志框下方有适当留白，与页面其他区域的 padding 保持一致。
<img width="1364" height="605" alt="image" src="https://github.com/user-attachments/assets/54bec2ba-7264-4486-8eba-e168a88bb0f7" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.

- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.

- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.

- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

调整 Provider 和 Platform 页面中日志部分的布局间距，以提升底部留白和滚动体验。

改进内容：
- 为 Provider 和 Platform 页面上的日志卡片添加底部外边距，在滚动至页面底部时提供视觉留白。
- 增加 Provider 和 Platform 页面容器的底部内边距，以确保页面间距的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust layout spacing for log sections on Provider and Platform pages to improve bottom padding and scrolling experience.

Enhancements:
- Add bottom margin to log cards on Provider and Platform pages to provide visual whitespace when scrolled to the bottom.
- Increase bottom padding of Provider and Platform page containers for consistent page spacing.

</details>