### PR TITLE
fix: aiocqhttp 适配器 NapCat 文件名获取为空

### DIFF
--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -246,7 +246,13 @@ class AiocqhttpAdapter(Platform):
                     if m["data"].get("url") and m["data"].get("url").startswith("http"):
                         # Lagrange
                         logger.info("guessing lagrange")
-                        file_name = m["data"].get("file_name", "file")
+                        # 检查多个可能的文件名字段
+                        file_name = (
+                            m["data"].get("file_name", "")
+                            or m["data"].get("name", "")
+                            or m["data"].get("file", "")
+                            or "file"
+                        )
                         abm.message.append(File(name=file_name, url=m["data"]["url"]))
                     else:
                         try:
@@ -265,7 +271,13 @@ class AiocqhttpAdapter(Platform):
                                 )
                             if ret and "url" in ret:
                                 file_url = ret["url"]  # https
-                                file_name = ret.get("file_name", "") or ret.get("name", "") or m["data"].get("file", "") or m["data"].get("file_name", "")
+                                # 优先从 API 返回值获取文件名，其次从原始消息数据获取
+                                file_name = (
+                                    ret.get("file_name", "")
+                                    or ret.get("name", "")
+                                    or m["data"].get("file", "")
+                                    or m["data"].get("file_name", "")
+                                )
                                 a = File(name=file_name, url=file_url)
                                 abm.message.append(a)
                             else:


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
修复使用 NapCat 时，文件消息的 File.name 为空的问题。原代码硬编码 name=""，导致下游插件无法获取文件名和扩展名

  Fixes: 当用户通过 NapCat 发送文件时，aiocqhttp 适配器调用get_group_file_url/get_private_file_url API 获取文件 URL后，未从返回值或原始消息中提取文件名，直接使用空字符串。
### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
- NapCat 分支中，从 API 返回值和原始消息数据中提取文件名
- 优先级：ret["file_name"] > ret["name"] > m["data"]["file"] >m["data"]["file_name"]
- 与 Lagrange 分支保持一致的文件名获取逻辑
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
之前的日志是
```
(本地复制): /AstrBot/data/plugin_data/astrbot_plugin_workspace/user_workspaces/...）/uploads/20251130_063139_uploaded_file [原名: uploaded_file]
```
修改后
<img width="2058" height="160" alt="70f3705ed16c1e5303c8e52e9a676902" src="https://github.com/user-attachments/assets/cd17e365-102b-4d50-bd86-e936fc1db37f" />



<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x]👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

错误修复：
- 确保 NapCat aiocqhttp 适配器中的文件消息，将 `File.name` 设置为基于 API 返回结果或原始消息数据的名称，而不是空字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure file messages in the NapCat aiocqhttp adapter set File.name based on API response or original message data instead of an empty string.

</details>