### PR TITLE
fix: 将Dingtalk Adapter的Graceful shutdown 的异常改为 KeyboardInterrupt

### DIFF
--- a/astrbot/core/platform/sources/dingtalk/dingtalk_adapter.py
+++ b/astrbot/core/platform/sources/dingtalk/dingtalk_adapter.py
@@ -250,7 +250,7 @@ class DingtalkPlatformAdapter(Platform):
 
     async def terminate(self):
         def monkey_patch_close():
-            raise Exception("Graceful shutdown")
+            raise KeyboardInterrupt("Graceful shutdown")
 
         self.client_.open_connection = monkey_patch_close
         await self.client_.websocket.close(code=1000, reason="Graceful shutdown")


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
By Gemini:
```
根据提供的 dingtalk_stream SDK 源码分析，目前的实现存在一个逻辑缺陷，且确实有更好的实现方式。

# 问题分析

在 SDK 的 DingTalkStreamClient.start 方法中（stream.py 第 63-92 行）：                                                                                                                
         while True:
             try:
                 connection = self.open_connection()
                 # ... 省略 ...
             except KeyboardInterrupt as e:
                 break  # <--- 唯一能真正跳出循环的地方
             except (asyncio.exceptions.CancelledError,
                     websockets.exceptions.ConnectionClosedError) as e:
                 # ... 省略 ...
                 continue # 只是重试
             except Exception as e:
                 # ... 省略 ...
                 continue # 现在的实现会落入这里，导致无限重试
                                                                                                                                                              
你当前的实现使用了 raise Exception("Graceful shutdown")。这不会停止 SDK，因为 SDK 会捕获通用的 Exception，打印日志，休眠 3秒，然后再次尝试连接。这会导致后台一直报错重连，而不是优雅退出。

# 更好的实现方案

根据 SDK 源码，唯一能让 start() 方法执行 break 跳出循环的捕获异常是 KeyboardInterrupt。

因此，应该修改 monkey_patch_close 抛出 KeyboardInterrupt。这样 SDK 会捕获它并执行 break，从而让 start() 方法自然结束返回。
```
### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
astrbot\core\platform\sources\dingtalk\dingtalk_adapter.py
- 修改了抛出异常的类型


- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [ ] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

Bug Fixes:
- 将 Dingtalk 适配器的优雅关闭逻辑修改为抛出 `KeyboardInterrupt`，以便 SDK 循环可以干净退出，而不是无限重试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Change the Dingtalk adapter’s graceful shutdown logic to raise KeyboardInterrupt so the SDK loop can exit cleanly instead of retrying indefinitely.

</details>