### PR TITLE
fix: assistant message validation error when tool_call exists but content not exists

### DIFF
--- a/astrbot/core/agent/message.py
+++ b/astrbot/core/agent/message.py
@@ -3,7 +3,7 @@
 
 from typing import Any, ClassVar, Literal, cast
 
-from pydantic import BaseModel, GetCoreSchemaHandler
+from pydantic import BaseModel, GetCoreSchemaHandler, model_validator
 from pydantic_core import core_schema
 
 
@@ -145,7 +145,7 @@ class Message(BaseModel):
         "tool",
     ]
 
-    content: str | list[ContentPart]
+    content: str | list[ContentPart] | None = None
     """The content of the message."""
 
     tool_calls: list[ToolCall] | list[dict] | None = None
@@ -153,6 +153,19 @@ class Message(BaseModel):
 
     tool_call_id: str | None = None
     """The ID of the tool call."""
+
+    @model_validator(mode="after")
+    def check_content_required(self):
+        # assistant + tool_calls is not None: allow content to be None
+        if self.role == "assistant" and self.tool_calls is not None:
+            return self
+
+        # other all cases: content is required
+        if self.content is None:
+            raise ValueError(
+                "content is required unless role='assistant' and tool_calls is not None"
+            )
+        return self
 
 
 class AssistantMessageSegment(Message):


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

统一 assistant 和 tool 消息结构，以在 assistant 消息上正确支持工具调用（tool call）元数据，并在内容缺失时避免验证错误。

Bug Fixes:
- 防止当 assistant 消息包含未显式提供 content 的工具调用（tool calls）时出现验证错误。

Enhancements:
- 将共享的工具调用字段提升到基础消息模型中，使所有消息片段都能一致地携带工具调用元数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify assistant and tool message structures to correctly support tool call metadata on assistant messages and avoid validation errors when content is absent.

Bug Fixes:
- Prevent validation errors when assistant messages include tool calls without explicit content.

Enhancements:
- Lift shared tool call fields to the base message model so all message segments can consistently carry tool call metadata.

</details>