### PR TITLE
fix: 当在 QQ 官方机器人中启用流式传输时，LLM 不能正常回复

### DIFF
--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -69,6 +69,8 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                 # 结束流式对话，并且传输 buffer 中剩余的消息
                 stream_payload["state"] = 10
                 ret = await self._post_send(stream=stream_payload)
+            else:
+                ret = await self._post_send()
 
         except Exception as e:
             logger.error(f"发送流式消息时出错: {e}", exc_info=True)


### PR DESCRIPTION
- Added a fallback to the `_post_send` method without parameters when the stream payload is not set, ensuring proper message handling in all scenarios.

fixes: #3893

## Summary by Sourcery

Bug Fixes:
- 当缺少流式负载（streaming payload）时，添加备用的消息发送路径，以便在启用流式传输的情况下，QQ 公众号机器人也能正确回复。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add a fallback message send path when streaming payload is missing so QQ official bot replies correctly with streaming enabled.

</details>