### PR TITLE
fix: omit empty content field for the LLM request after tool calls are completed

### DIFF
--- a/astrbot/core/agent/message.py
+++ b/astrbot/core/agent/message.py
@@ -173,6 +173,7 @@ class Message(BaseModel):
             kwargs.setdefault("exclude", set()).add("content")
         return super().model_dump(**kwargs)
 
+
 class AssistantMessageSegment(Message):
     """A message segment from the assistant."""
 


### PR DESCRIPTION
原标题：feat: 支持 tool_call 后进行的 LLM 请求中 content 为自定义内容 (#4003)

*由于忘记按照 Contributing.md 的要求进行 branch 重命名，因而已重新提交一份 PR 请求，向维护者致歉！*

----

此 Pull Request 是一个针对 Issue #4003 的解决方案，通过修改 **本地(local) agent** 等的相关代码，使得在 tool_call 结束后的二次 LLM 请求的 `content` 字段不为空，以规避 Issue 中的问题。

此 Pull Request 作为一个 feature 进行提交是因为：我使用了配置文件来确保用户可以 **选择性** 地启用相关代码，并默认设置为不启用，因此此 PR 对既有用户来说无影响；对于的确需要此自定义 `content` 内容的用户，其则可作为一个单独的小功能启用并加以配置。

### Modifications / 改动点

涉及 AstrBot core 的功能性代码：

- `astrbot/core/agent/runners/tool_loop_agent_runner.py` ：
  - 可能负责 **本地(local) agent** 相关的 **函数调用** 逻辑（有错请指正）
  - **所做修改**：我在发送请求之前的代码里新增了针对 `content` 字段值的检测，如果为空字符串，则替代为对应内容
- `astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py`
  - **本地(local) agent** 相关
  - **所做修改**：我在 `_save_to_history` 函数中引入了对 `messages` 列表中的各 `message` 的 `content` 的检测，如果为相关字符串，则将其置空，确保之后（从对话数据历史角度来看）行为与先前一致
- `packages/astrbot/main.py`
  - 官方 AstrBot 系统插件，用于提供人设注入等功能
  - **所做修改**：新增了一个 `priority=1` 的 `on_llm_request` 钩子，遍历整个 `context` (role=assistant) 并将空的 `content` 替换为对应值
  - **为什么在这引入**：首先是我实在看不懂 pipeline 怎么跑的了，我个人目前用的话这样足矣；其次是有鉴于这个官方插件也负责一些比较重要的功能，因此在这里引入也算符合代码职责的划分

剩下的为网页 i18n 本地化相关配置，此处省略。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

**由于我个人仅使用【本地(local) agent】，因而无法对其他 agent 配置进行测试；但根据修改的具体文件来看，这不应该对第三方 agent 的现有集成代码造成影响。**

以下是一次完整的测试log（注意 WARN 等级（黄色）的日志）：

首先是 `/reset` 重置对话：

<img width="1934" height="291" alt="image" src="https://github.com/user-attachments/assets/853360d2-ba45-48dc-aacb-13cd589c88c7" />

然后是第一次对话，其自然触发了工具调用：

<img width="2534" height="569" alt="image" src="https://github.com/user-attachments/assets/fefec5db-d72a-49fb-a723-3b6ef3814fdf" />

<img width="2556" height="846" alt="image" src="https://github.com/user-attachments/assets/e06ef7a7-ac60-43c9-82aa-892070a9ba1a" />

强行调用一次知识库时：

<img width="2551" height="550" alt="image" src="https://github.com/user-attachments/assets/2ada736f-f9ee-4873-927c-4a6be63f3801" />

<img width="2560" height="914" alt="image" src="https://github.com/user-attachments/assets/93fd31ca-8b05-4597-891f-8384eeda9fb9" />

通过 AstrBot 面板查看：

<img width="1181" height="706" alt="image" src="https://github.com/user-attachments/assets/9ec521d9-4e07-4ce2-87cf-c3f0af4c022e" />

通过 `/history` 命令查看：

<img width="788" height="343" alt="image" src="https://github.com/user-attachments/assets/9d3e32ca-57c9-4631-b784-b82c86d3ed00" />

对比实际执行结果（注：我打开了输出函数调用过程）：

<img width="627" height="569" alt="image" src="https://github.com/user-attachments/assets/d37af56a-7b5a-4a6c-821f-50ee763a57f0" />

配置文件页的设置：

<img width="921" height="265" alt="image" src="https://github.com/user-attachments/assets/69450503-f0c8-4d42-bf91-6078dcb68ba3" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [ ] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

为工具调用（tool call）后的 LLM 请求新增可配置的“空助手内容”处理方式，在避免空内容问题的同时保持已存对话历史的语义不变。

New Features:
- 新增 provider 配置，用于在工具调用之后、向后续 LLM 发送请求之前，将助手的空内容替换为可配置的占位字符串。
- 在官方 AstrBot 插件中新增 `on_llm_request` 钩子，当该功能启用时，在各类助手上下文中统一应用上述空内容替换逻辑。

Enhancements:
- 更新本地 agent 运行器和内部流水线的历史记录阶段，使其遵从新的 provider 设置，在保存对话历史时将占位内容还原为空内容。
- 扩展默认配置和控制台（dashboard）配置元数据（包括 i18n 条目），以便在 UI 中暴露新的 provider 选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable handling of blank assistant content in post-tool-call LLM requests to avoid empty-content issues while preserving stored conversation history semantics.

New Features:
- Introduce provider settings to replace blank assistant content after tool calls with a configurable placeholder string before sending follow-up LLM requests.
- Add an on_llm_request hook in the official AstrBot plugin to apply the blank-content replacement across assistant contexts when enabled.

Enhancements:
- Update the local agent runner and internal pipeline history stage to respect the new provider settings and revert placeholder content back to blank when saving conversation history.
- Extend default configuration and dashboard config metadata, including i18n entries, to expose the new provider options in the UI.

</details>