### PR TITLE
fix: lark domain and log_level of Lark API client

### DIFF
--- a/astrbot/core/platform/sources/lark/lark_adapter.py
+++ b/astrbot/core/platform/sources/lark/lark_adapter.py
@@ -81,7 +81,12 @@ class LarkPlatformAdapter(Platform):
         )
 
         self.lark_api = (
-            lark.Client.builder().app_id(self.appid).app_secret(self.appsecret).build()
+            lark.Client.builder()
+            .app_id(self.appid)
+            .app_secret(self.appsecret)
+            .log_level(lark.LogLevel.ERROR)
+            .domain(self.domain)
+            .build()
         )
 
         self.webhook_server = None


### PR DESCRIPTION
fixes: #4035

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

为 Lark API 客户端配置正确的域名，并降低消息处理相关的日志级别。

Bug 修复：
- 将 Lark API 客户端设置为使用配置中的域名，而不是默认域名。
- 将 Lark 客户端的日志级别限制为 error，以避免产生过多日志输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Configure the Lark API client with the correct domain and a reduced log level for message handling.

Bug Fixes:
- Set the Lark API client to use the configured domain instead of the default.
- Restrict Lark client logging to error level to avoid excessive log output.

</details>