### PR TITLE
revert: "fix: omit empty content field for the LLM request after tool calls are completed"

### DIFF
--- a/astrbot/core/agent/message.py
+++ b/astrbot/core/agent/message.py
@@ -1,10 +1,10 @@
 # Inspired by MoonshotAI/kosong, credits to MoonshotAI/kosong authors for the original implementation.
 # License: Apache License 2.0
+
 from typing import Any, ClassVar, Literal, cast
 
 from pydantic import BaseModel, GetCoreSchemaHandler, model_validator
 from pydantic_core import core_schema
-from typing_extensions import override
 
 
 class ContentPart(BaseModel):
@@ -166,12 +166,6 @@ class Message(BaseModel):
                 "content is required unless role='assistant' and tool_calls is not None"
             )
         return self
-
-    @override
-    def model_dump(self, **kwargs: Any) -> dict[str, Any]:
-        if self.tool_calls is not None and not self.content:
-            kwargs.setdefault("exclude", set()).add("content")
-        return super().model_dump(**kwargs)
 
 
 class AssistantMessageSegment(Message):


### PR DESCRIPTION
Reverts AstrBotDevs/AstrBot#4008

## Summary by Sourcery

Bug Fixes:
- 通过移除自定义的 `model_dump` 覆盖，实现工具调用后在助手消息序列化中重新包含 `content` 字段，即使该字段为空。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Restore inclusion of the content field in assistant message serialization after tool calls, even when the content is empty, by removing the custom model_dump override.

</details>