### PR TITLE
feat: add extra user content block support

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -81,7 +81,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             "func_tool": self.req.func_tool,
             "model": self.req.model,  # NOTE: in fact, this arg is None in most cases
             "session_id": self.req.session_id,
-            "extra_content_blocks": self.req.extra_content_blocks,
+            "extra_user_content_parts": self.req.extra_user_content_parts,
         }
 
         if self.streaming:

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -81,6 +81,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             "func_tool": self.req.func_tool,
             "model": self.req.model,  # NOTE: in fact, this arg is None in most cases
             "session_id": self.req.session_id,
+            "extra_content_blocks": self.req.extra_content_blocks,
         }
 
         if self.streaming:

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -77,11 +77,11 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
     async def _iter_llm_responses(self) -> T.AsyncGenerator[LLMResponse, None]:
         """Yields chunks *and* a final LLMResponse."""
         payload = {
-            "contexts": self.run_context.messages,
+            "contexts": self.run_context.messages,  # list[Message]
             "func_tool": self.req.func_tool,
             "model": self.req.model,  # NOTE: in fact, this arg is None in most cases
             "session_id": self.req.session_id,
-            "extra_user_content_parts": self.req.extra_user_content_parts,
+            "extra_user_content_parts": self.req.extra_user_content_parts,  # list[ContentPart]
         }
 
         if self.streaming:

--- a/astrbot/core/provider/entities.py
+++ b/astrbot/core/provider/entities.py
@@ -93,9 +93,7 @@ class ProviderRequest:
     """会话 ID"""
     image_urls: list[str] = field(default_factory=list)
     """图片 URL 列表"""
-    extra_user_content_parts: list[dict] | list[ContentPart] = field(
-        default_factory=list
-    )
+    extra_user_content_parts: list[ContentPart] = field(default_factory=list)
     """额外的用户消息内容部分列表，用于在用户消息后添加额外的内容块（如系统提醒、指令等）。支持 dict 或 ContentPart 对象"""
     func_tool: ToolSet | None = None
     """可用的函数工具"""
@@ -184,12 +182,7 @@ class ProviderRequest:
         # 2. 额外的内容块（系统提醒、指令等）
         if self.extra_user_content_parts:
             for part in self.extra_user_content_parts:
-                if hasattr(part, "model_dump"):
-                    # ContentPart 对象，需要 model_dump
-                    content_blocks.append(part.model_dump())
-                else:
-                    # 已经是 dict
-                    content_blocks.append(part)
+                content_blocks.append(part.model_dump())
 
         # 3. 图片内容
         if self.image_urls:

--- a/astrbot/core/provider/entities.py
+++ b/astrbot/core/provider/entities.py
@@ -92,6 +92,8 @@ class ProviderRequest:
     """会话 ID"""
     image_urls: list[str] = field(default_factory=list)
     """图片 URL 列表"""
+    extra_content_blocks: list[dict] = field(default_factory=list)
+    """额外的内容块列表，用于在用户消息后添加额外的文本块（如系统提醒、指令等）"""
     func_tool: ToolSet | None = None
     """可用的函数工具"""
     contexts: list[dict] = field(default_factory=list)
@@ -166,13 +168,21 @@ class ProviderRequest:
 
     async def assemble_context(self) -> dict:
         """将请求(prompt 和 image_urls)包装成 OpenAI 的消息格式。"""
+        # 构建内容块列表
+        content_blocks = []
+
+        # 1. 用户原始发言（OpenAI 建议：用户发言在前）
+        if self.prompt and self.prompt.strip():
+            content_blocks.append({"type": "text", "text": self.prompt})
+        elif self.image_urls:
+            # 如果没有文本但有图片，添加占位文本
+            content_blocks.append({"type": "text", "text": "[图片]"})
+
+        # 2. 额外的内容块（系统提醒、指令等）
+        content_blocks.extend(self.extra_content_blocks)
+
+        # 3. 图片内容
         if self.image_urls:
-            user_content = {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": self.prompt if self.prompt else "[图片]"},
-                ],
-            }
             for image_url in self.image_urls:
                 if image_url.startswith("http"):
                     image_path = await download_image_by_url(image_url)
@@ -185,11 +195,21 @@ class ProviderRequest:
                 if not image_data:
                     logger.warning(f"图片 {image_url} 得到的结果为空，将忽略。")
                     continue
-                user_content["content"].append(
+                content_blocks.append(
                     {"type": "image_url", "image_url": {"url": image_data}},
                 )
-            return user_content
-        return {"role": "user", "content": self.prompt}
+
+        # 只有当只有一个来自 prompt 的文本块且没有额外内容块时，才降级为简单格式以保持向后兼容
+        if (
+            len(content_blocks) == 1
+            and content_blocks[0]["type"] == "text"
+            and not self.extra_content_blocks
+            and not self.image_urls
+        ):
+            return {"role": "user", "content": content_blocks[0]["text"]}
+
+        # 否则返回多模态格式
+        return {"role": "user", "content": content_blocks}
 
     async def _encode_image_bs64(self, image_url: str) -> str:
         """将图片转换为 base64"""

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -4,7 +4,7 @@ import os
 from collections.abc import AsyncGenerator
 from typing import TypeAlias, Union
 
-from astrbot.core.agent.message import Message
+from astrbot.core.agent.message import ContentPart, Message
 from astrbot.core.agent.tool import ToolSet
 from astrbot.core.provider.entities import (
     LLMResponse,
@@ -103,7 +103,7 @@ class Provider(AbstractProvider):
         system_prompt: str | None = None,
         tool_calls_result: ToolCallsResult | list[ToolCallsResult] | None = None,
         model: str | None = None,
-        extra_user_content_parts: list[dict] | None = None,
+        extra_user_content_parts: list[ContentPart] | None = None,
         **kwargs,
     ) -> LLMResponse:
         """获得 LLM 的文本对话结果。会使用当前的模型进行对话。

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -103,7 +103,7 @@ class Provider(AbstractProvider):
         system_prompt: str | None = None,
         tool_calls_result: ToolCallsResult | list[ToolCallsResult] | None = None,
         model: str | None = None,
-        extra_content_blocks: list[dict] | None = None,
+        extra_user_content_parts: list[dict] | None = None,
         **kwargs,
     ) -> LLMResponse:
         """获得 LLM 的文本对话结果。会使用当前的模型进行对话。
@@ -115,7 +115,7 @@ class Provider(AbstractProvider):
             tools: tool set
             contexts: 上下文，和 prompt 二选一使用
             tool_calls_result: 回传给 LLM 的工具调用结果。参考: https://platform.openai.com/docs/guides/function-calling
-            extra_content_blocks: 额外的内容块列表，用于在用户消息后添加额外的文本块（如系统提醒、指令等）
+            extra_user_content_parts: 额外的内容块列表，用于在用户消息后添加额外的文本块（如系统提醒、指令等）
             kwargs: 其他参数
 
         Notes:

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -103,6 +103,7 @@ class Provider(AbstractProvider):
         system_prompt: str | None = None,
         tool_calls_result: ToolCallsResult | list[ToolCallsResult] | None = None,
         model: str | None = None,
+        extra_content_blocks: list[dict] | None = None,
         **kwargs,
     ) -> LLMResponse:
         """获得 LLM 的文本对话结果。会使用当前的模型进行对话。
@@ -114,6 +115,7 @@ class Provider(AbstractProvider):
             tools: tool set
             contexts: 上下文，和 prompt 二选一使用
             tool_calls_result: 回传给 LLM 的工具调用结果。参考: https://platform.openai.com/docs/guides/function-calling
+            extra_content_blocks: 额外的内容块列表，用于在用户消息后添加额外的文本块（如系统提醒、指令等）
             kwargs: 其他参数
 
         Notes:

--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -448,8 +448,14 @@ class ProviderAnthropic(Provider):
                     },
                 )
 
-        # 如果只有一个文本块且没有图片，返回简单格式以保持向后兼容
-        if len(content) == 1 and content[0]["type"] == "text":
+        # 如果只有主文本且没有额外内容块和图片，返回简单格式以保持向后兼容
+        if (
+            text
+            and not extra_content_blocks
+            and not image_urls
+            and len(content) == 1
+            and content[0]["type"] == "text"
+        ):
             return {"role": "user", "content": content[0]["text"]}
 
         # 否则返回多模态格式

--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -11,6 +11,7 @@ from anthropic.types.usage import Usage
 
 from astrbot import logger
 from astrbot.api.provider import Provider
+from astrbot.core.agent.message import ContentPart
 from astrbot.core.provider.entities import LLMResponse, TokenUsage
 from astrbot.core.provider.func_tool_manager import ToolSet
 from astrbot.core.utils.io import download_image_by_url
@@ -398,7 +399,7 @@ class ProviderAnthropic(Provider):
         self,
         text: str,
         image_urls: list[str] | None = None,
-        extra_user_content_parts: list[dict] | None = None,
+        extra_user_content_parts: list[ContentPart] | None = None,
     ):
         """组装上下文，支持文本和图片"""
         content = []
@@ -417,9 +418,7 @@ class ProviderAnthropic(Provider):
         if extra_user_content_parts:
             # 过滤出文本块，因为 Anthropic 主要支持文本和图片
             text_blocks = [
-                block
-                for block in extra_user_content_parts
-                if block.get("type") == "text"
+                block for block in extra_user_content_parts if block.type == "text"
             ]
             content.extend(text_blocks)
 

--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -296,13 +296,16 @@ class ProviderAnthropic(Provider):
         system_prompt=None,
         tool_calls_result=None,
         model=None,
+        extra_content_blocks=None,
         **kwargs,
     ) -> LLMResponse:
         if contexts is None:
             contexts = []
         new_record = None
         if prompt is not None:
-            new_record = await self.assemble_context(prompt, image_urls)
+            new_record = await self.assemble_context(
+                prompt, image_urls, extra_content_blocks
+            )
         context_query = self._ensure_message_to_dicts(contexts)
         if new_record:
             context_query.append(new_record)
@@ -350,13 +353,16 @@ class ProviderAnthropic(Provider):
         system_prompt=None,
         tool_calls_result=None,
         model=None,
+        extra_content_blocks=None,
         **kwargs,
     ):
         if contexts is None:
             contexts = []
         new_record = None
         if prompt is not None:
-            new_record = await self.assemble_context(prompt, image_urls)
+            new_record = await self.assemble_context(
+                prompt, image_urls, extra_content_blocks
+            )
         context_query = self._ensure_message_to_dicts(contexts)
         if new_record:
             context_query.append(new_record)
@@ -403,6 +409,9 @@ class ProviderAnthropic(Provider):
         elif image_urls:
             # 如果没有文本但有图片，添加占位文本
             content.append({"type": "text", "text": "[图片]"})
+        elif extra_content_blocks:
+            # 如果只有额外内容块，也需要添加占位文本
+            content.append({"type": "text", "text": " "})
 
         # 2. 额外的内容块（系统提醒、指令等）
         if extra_content_blocks:

--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -296,7 +296,7 @@ class ProviderAnthropic(Provider):
         system_prompt=None,
         tool_calls_result=None,
         model=None,
-        extra_content_blocks=None,
+        extra_user_content_parts=None,
         **kwargs,
     ) -> LLMResponse:
         if contexts is None:
@@ -304,7 +304,7 @@ class ProviderAnthropic(Provider):
         new_record = None
         if prompt is not None:
             new_record = await self.assemble_context(
-                prompt, image_urls, extra_content_blocks
+                prompt, image_urls, extra_user_content_parts
             )
         context_query = self._ensure_message_to_dicts(contexts)
         if new_record:
@@ -353,7 +353,7 @@ class ProviderAnthropic(Provider):
         system_prompt=None,
         tool_calls_result=None,
         model=None,
-        extra_content_blocks=None,
+        extra_user_content_parts=None,
         **kwargs,
     ):
         if contexts is None:
@@ -361,7 +361,7 @@ class ProviderAnthropic(Provider):
         new_record = None
         if prompt is not None:
             new_record = await self.assemble_context(
-                prompt, image_urls, extra_content_blocks
+                prompt, image_urls, extra_user_content_parts
             )
         context_query = self._ensure_message_to_dicts(contexts)
         if new_record:
@@ -398,7 +398,7 @@ class ProviderAnthropic(Provider):
         self,
         text: str,
         image_urls: list[str] | None = None,
-        extra_content_blocks: list[dict] | None = None,
+        extra_user_content_parts: list[dict] | None = None,
     ):
         """组装上下文，支持文本和图片"""
         content = []
@@ -409,15 +409,17 @@ class ProviderAnthropic(Provider):
         elif image_urls:
             # 如果没有文本但有图片，添加占位文本
             content.append({"type": "text", "text": "[图片]"})
-        elif extra_content_blocks:
+        elif extra_user_content_parts:
             # 如果只有额外内容块，也需要添加占位文本
             content.append({"type": "text", "text": " "})
 
         # 2. 额外的内容块（系统提醒、指令等）
-        if extra_content_blocks:
+        if extra_user_content_parts:
             # 过滤出文本块，因为 Anthropic 主要支持文本和图片
             text_blocks = [
-                block for block in extra_content_blocks if block.get("type") == "text"
+                block
+                for block in extra_user_content_parts
+                if block.get("type") == "text"
             ]
             content.extend(text_blocks)
 
@@ -460,7 +462,7 @@ class ProviderAnthropic(Provider):
         # 如果只有主文本且没有额外内容块和图片，返回简单格式以保持向后兼容
         if (
             text
-            and not extra_content_blocks
+            and not extra_user_content_parts
             and not image_urls
             and len(content) == 1
             and content[0]["type"] == "text"

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -680,13 +680,16 @@ class ProviderGoogleGenAI(Provider):
         system_prompt=None,
         tool_calls_result=None,
         model=None,
+        extra_content_blocks=None,
         **kwargs,
     ) -> LLMResponse:
         if contexts is None:
             contexts = []
         new_record = None
         if prompt is not None:
-            new_record = await self.assemble_context(prompt, image_urls)
+            new_record = await self.assemble_context(
+                prompt, image_urls, extra_content_blocks
+            )
         context_query = self._ensure_message_to_dicts(contexts)
         if new_record:
             context_query.append(new_record)
@@ -732,13 +735,16 @@ class ProviderGoogleGenAI(Provider):
         system_prompt=None,
         tool_calls_result=None,
         model=None,
+        extra_content_blocks=None,
         **kwargs,
     ) -> AsyncGenerator[LLMResponse, None]:
         if contexts is None:
             contexts = []
         new_record = None
         if prompt is not None:
-            new_record = await self.assemble_context(prompt, image_urls)
+            new_record = await self.assemble_context(
+                prompt, image_urls, extra_content_blocks
+            )
         context_query = self._ensure_message_to_dicts(contexts)
         if new_record:
             context_query.append(new_record)
@@ -813,6 +819,9 @@ class ProviderGoogleGenAI(Provider):
         elif image_urls:
             # 如果没有文本但有图片，添加占位文本
             content_blocks.append({"type": "text", "text": "[图片]"})
+        elif extra_content_blocks:
+            # 如果只有额外内容块，也需要添加占位文本
+            content_blocks.append({"type": "text", "text": " "})
 
         # 2. 额外的内容块（系统提醒、指令等）
         if extra_content_blocks:

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -839,8 +839,14 @@ class ProviderGoogleGenAI(Provider):
                     },
                 )
 
-        # 如果只有文本且没有额外内容块，返回简单格式以保持向后兼容
-        if len(content_blocks) == 1 and content_blocks[0]["type"] == "text":
+        # 如果只有主文本且没有额外内容块和图片，返回简单格式以保持向后兼容
+        if (
+            text
+            and not extra_content_blocks
+            and not image_urls
+            and len(content_blocks) == 1
+            and content_blocks[0]["type"] == "text"
+        ):
             return {"role": "user", "content": content_blocks[0]["text"]}
 
         # 否则返回多模态格式

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -13,6 +13,7 @@ from google.genai.errors import APIError
 import astrbot.core.message.components as Comp
 from astrbot import logger
 from astrbot.api.provider import Provider
+from astrbot.core.agent.message import ContentPart
 from astrbot.core.message.message_event_result import MessageChain
 from astrbot.core.provider.entities import LLMResponse, TokenUsage
 from astrbot.core.provider.func_tool_manager import ToolSet
@@ -807,7 +808,7 @@ class ProviderGoogleGenAI(Provider):
         self,
         text: str,
         image_urls: list[str] | None = None,
-        extra_user_content_parts: list[dict] | None = None,
+        extra_user_content_parts: list[ContentPart] | None = None,
     ):
         """组装上下文。"""
         # 构建内容块列表
@@ -825,7 +826,8 @@ class ProviderGoogleGenAI(Provider):
 
         # 2. 额外的内容块（系统提醒、指令等）
         if extra_user_content_parts:
-            content_blocks.extend(extra_user_content_parts)
+            for part in extra_user_content_parts:
+                content_blocks.append(part.model_dump())
 
         # 3. 图片内容
         if image_urls:

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -680,7 +680,7 @@ class ProviderGoogleGenAI(Provider):
         system_prompt=None,
         tool_calls_result=None,
         model=None,
-        extra_content_blocks=None,
+        extra_user_content_parts=None,
         **kwargs,
     ) -> LLMResponse:
         if contexts is None:
@@ -688,7 +688,7 @@ class ProviderGoogleGenAI(Provider):
         new_record = None
         if prompt is not None:
             new_record = await self.assemble_context(
-                prompt, image_urls, extra_content_blocks
+                prompt, image_urls, extra_user_content_parts
             )
         context_query = self._ensure_message_to_dicts(contexts)
         if new_record:
@@ -735,7 +735,7 @@ class ProviderGoogleGenAI(Provider):
         system_prompt=None,
         tool_calls_result=None,
         model=None,
-        extra_content_blocks=None,
+        extra_user_content_parts=None,
         **kwargs,
     ) -> AsyncGenerator[LLMResponse, None]:
         if contexts is None:
@@ -743,7 +743,7 @@ class ProviderGoogleGenAI(Provider):
         new_record = None
         if prompt is not None:
             new_record = await self.assemble_context(
-                prompt, image_urls, extra_content_blocks
+                prompt, image_urls, extra_user_content_parts
             )
         context_query = self._ensure_message_to_dicts(contexts)
         if new_record:
@@ -807,7 +807,7 @@ class ProviderGoogleGenAI(Provider):
         self,
         text: str,
         image_urls: list[str] | None = None,
-        extra_content_blocks: list[dict] | None = None,
+        extra_user_content_parts: list[dict] | None = None,
     ):
         """组装上下文。"""
         # 构建内容块列表
@@ -819,13 +819,13 @@ class ProviderGoogleGenAI(Provider):
         elif image_urls:
             # 如果没有文本但有图片，添加占位文本
             content_blocks.append({"type": "text", "text": "[图片]"})
-        elif extra_content_blocks:
+        elif extra_user_content_parts:
             # 如果只有额外内容块，也需要添加占位文本
             content_blocks.append({"type": "text", "text": " "})
 
         # 2. 额外的内容块（系统提醒、指令等）
-        if extra_content_blocks:
-            content_blocks.extend(extra_content_blocks)
+        if extra_user_content_parts:
+            content_blocks.extend(extra_user_content_parts)
 
         # 3. 图片内容
         if image_urls:
@@ -851,7 +851,7 @@ class ProviderGoogleGenAI(Provider):
         # 如果只有主文本且没有额外内容块和图片，返回简单格式以保持向后兼容
         if (
             text
-            and not extra_content_blocks
+            and not extra_user_content_parts
             and not image_urls
             and len(content_blocks) == 1
             and content_blocks[0]["type"] == "text"

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -348,6 +348,7 @@ class ProviderOpenAIOfficial(Provider):
         system_prompt: str | None = None,
         tool_calls_result: ToolCallsResult | list[ToolCallsResult] | None = None,
         model: str | None = None,
+        extra_content_blocks: list[dict] | None = None,
         **kwargs,
     ) -> tuple:
         """准备聊天所需的有效载荷和上下文"""
@@ -355,7 +356,9 @@ class ProviderOpenAIOfficial(Provider):
             contexts = []
         new_record = None
         if prompt is not None:
-            new_record = await self.assemble_context(prompt, image_urls)
+            new_record = await self.assemble_context(
+                prompt, image_urls, extra_content_blocks
+            )
         context_query = self._ensure_message_to_dicts(contexts)
         if new_record:
             context_query.append(new_record)
@@ -476,6 +479,7 @@ class ProviderOpenAIOfficial(Provider):
         system_prompt=None,
         tool_calls_result=None,
         model=None,
+        extra_content_blocks=None,
         **kwargs,
     ) -> LLMResponse:
         payloads, context_query = await self._prepare_chat_payload(
@@ -485,6 +489,7 @@ class ProviderOpenAIOfficial(Provider):
             system_prompt,
             tool_calls_result,
             model=model,
+            extra_content_blocks=extra_content_blocks,
             **kwargs,
         )
 
@@ -636,6 +641,9 @@ class ProviderOpenAIOfficial(Provider):
         elif image_urls:
             # 如果没有文本但有图片，添加占位文本
             content_blocks.append({"type": "text", "text": "[图片]"})
+        elif extra_content_blocks:
+            # 如果只有额外内容块，也需要添加占位文本
+            content_blocks.append({"type": "text", "text": " "})
 
         # 2. 额外的内容块（系统提醒、指令等）
         if extra_content_blocks:

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -17,7 +17,7 @@ from openai.types.completion_usage import CompletionUsage
 import astrbot.core.message.components as Comp
 from astrbot import logger
 from astrbot.api.provider import Provider
-from astrbot.core.agent.message import Message
+from astrbot.core.agent.message import ContentPart, Message
 from astrbot.core.agent.tool import ToolSet
 from astrbot.core.message.message_event_result import MessageChain
 from astrbot.core.provider.entities import LLMResponse, TokenUsage, ToolCallsResult
@@ -348,7 +348,7 @@ class ProviderOpenAIOfficial(Provider):
         system_prompt: str | None = None,
         tool_calls_result: ToolCallsResult | list[ToolCallsResult] | None = None,
         model: str | None = None,
-        extra_user_content_parts: list[dict] | None = None,
+        extra_user_content_parts: list[ContentPart] | None = None,
         **kwargs,
     ) -> tuple:
         """准备聊天所需的有效载荷和上下文"""
@@ -629,7 +629,7 @@ class ProviderOpenAIOfficial(Provider):
         self,
         text: str,
         image_urls: list[str] | None = None,
-        extra_user_content_parts: list[dict] | None = None,
+        extra_user_content_parts: list[ContentPart] | None = None,
     ) -> dict:
         """组装成符合 OpenAI 格式的 role 为 user 的消息段"""
         # 构建内容块列表
@@ -647,7 +647,8 @@ class ProviderOpenAIOfficial(Provider):
 
         # 2. 额外的内容块（系统提醒、指令等）
         if extra_user_content_parts:
-            content_blocks.extend(extra_user_content_parts)
+            for part in extra_user_content_parts:
+                content_blocks.append(part.model_dump())
 
         # 3. 图片内容
         if image_urls:

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -348,7 +348,7 @@ class ProviderOpenAIOfficial(Provider):
         system_prompt: str | None = None,
         tool_calls_result: ToolCallsResult | list[ToolCallsResult] | None = None,
         model: str | None = None,
-        extra_content_blocks: list[dict] | None = None,
+        extra_user_content_parts: list[dict] | None = None,
         **kwargs,
     ) -> tuple:
         """准备聊天所需的有效载荷和上下文"""
@@ -357,7 +357,7 @@ class ProviderOpenAIOfficial(Provider):
         new_record = None
         if prompt is not None:
             new_record = await self.assemble_context(
-                prompt, image_urls, extra_content_blocks
+                prompt, image_urls, extra_user_content_parts
             )
         context_query = self._ensure_message_to_dicts(contexts)
         if new_record:
@@ -479,7 +479,7 @@ class ProviderOpenAIOfficial(Provider):
         system_prompt=None,
         tool_calls_result=None,
         model=None,
-        extra_content_blocks=None,
+        extra_user_content_parts=None,
         **kwargs,
     ) -> LLMResponse:
         payloads, context_query = await self._prepare_chat_payload(
@@ -489,7 +489,7 @@ class ProviderOpenAIOfficial(Provider):
             system_prompt,
             tool_calls_result,
             model=model,
-            extra_content_blocks=extra_content_blocks,
+            extra_user_content_parts=extra_user_content_parts,
             **kwargs,
         )
 
@@ -629,7 +629,7 @@ class ProviderOpenAIOfficial(Provider):
         self,
         text: str,
         image_urls: list[str] | None = None,
-        extra_content_blocks: list[dict] | None = None,
+        extra_user_content_parts: list[dict] | None = None,
     ) -> dict:
         """组装成符合 OpenAI 格式的 role 为 user 的消息段"""
         # 构建内容块列表
@@ -641,13 +641,13 @@ class ProviderOpenAIOfficial(Provider):
         elif image_urls:
             # 如果没有文本但有图片，添加占位文本
             content_blocks.append({"type": "text", "text": "[图片]"})
-        elif extra_content_blocks:
+        elif extra_user_content_parts:
             # 如果只有额外内容块，也需要添加占位文本
             content_blocks.append({"type": "text", "text": " "})
 
         # 2. 额外的内容块（系统提醒、指令等）
-        if extra_content_blocks:
-            content_blocks.extend(extra_content_blocks)
+        if extra_user_content_parts:
+            content_blocks.extend(extra_user_content_parts)
 
         # 3. 图片内容
         if image_urls:
@@ -673,7 +673,7 @@ class ProviderOpenAIOfficial(Provider):
         # 如果只有主文本且没有额外内容块和图片，返回简单格式以保持向后兼容
         if (
             text
-            and not extra_content_blocks
+            and not extra_user_content_parts
             and not image_urls
             and len(content_blocks) == 1
             and content_blocks[0]["type"] == "text"

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -662,8 +662,14 @@ class ProviderOpenAIOfficial(Provider):
                     },
                 )
 
-        # 如果只有文本且没有额外内容块，返回简单格式以保持向后兼容
-        if len(content_blocks) == 1 and content_blocks[0]["type"] == "text":
+        # 如果只有主文本且没有额外内容块和图片，返回简单格式以保持向后兼容
+        if (
+            text
+            and not extra_content_blocks
+            and not image_urls
+            and len(content_blocks) == 1
+            and content_blocks[0]["type"] == "text"
+        ):
             return {"role": "user", "content": content_blocks[0]["text"]}
 
         # 否则返回多模态格式

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -624,13 +624,25 @@ class ProviderOpenAIOfficial(Provider):
         self,
         text: str,
         image_urls: list[str] | None = None,
+        extra_content_blocks: list[dict] | None = None,
     ) -> dict:
         """组装成符合 OpenAI 格式的 role 为 user 的消息段"""
+        # 构建内容块列表
+        content_blocks = []
+
+        # 1. 用户原始发言（OpenAI 建议：用户发言在前）
+        if text:
+            content_blocks.append({"type": "text", "text": text})
+        elif image_urls:
+            # 如果没有文本但有图片，添加占位文本
+            content_blocks.append({"type": "text", "text": "[图片]"})
+
+        # 2. 额外的内容块（系统提醒、指令等）
+        if extra_content_blocks:
+            content_blocks.extend(extra_content_blocks)
+
+        # 3. 图片内容
         if image_urls:
-            user_content = {
-                "role": "user",
-                "content": [{"type": "text", "text": text if text else "[图片]"}],
-            }
             for image_url in image_urls:
                 if image_url.startswith("http"):
                     image_path = await download_image_by_url(image_url)
@@ -643,14 +655,19 @@ class ProviderOpenAIOfficial(Provider):
                 if not image_data:
                     logger.warning(f"图片 {image_url} 得到的结果为空，将忽略。")
                     continue
-                user_content["content"].append(
+                content_blocks.append(
                     {
                         "type": "image_url",
                         "image_url": {"url": image_data},
                     },
                 )
-            return user_content
-        return {"role": "user", "content": text}
+
+        # 如果只有文本且没有额外内容块，返回简单格式以保持向后兼容
+        if len(content_blocks) == 1 and content_blocks[0]["type"] == "text":
+            return {"role": "user", "content": content_blocks[0]["text"]}
+
+        # 否则返回多模态格式
+        return {"role": "user", "content": content_blocks}
 
     async def encode_image_bs64(self, image_url: str) -> str:
         """将图片转换为 base64"""

--- a/packages/astrbot/process_llm_request.py
+++ b/packages/astrbot/process_llm_request.py
@@ -242,6 +242,6 @@ class ProcessLLMRequest:
         # 统一包裹所有系统提醒
         if system_parts:
             system_content = (
-                "<system_reminder>" + "".join(system_parts) + "</system_reminder>"
+                "<system_reminder>" + "\n".join(system_parts) + "</system_reminder>"
             )
             req.extra_content_blocks.append({"type": "text", "text": system_content})

--- a/packages/astrbot/process_llm_request.py
+++ b/packages/astrbot/process_llm_request.py
@@ -85,7 +85,12 @@ class ProcessLLMRequest:
                 req.image_urls,
             )
             if caption:
-                req.prompt = f"(Image Caption: {caption})\n\n{req.prompt}"
+                req.extra_content_blocks.append(
+                    {
+                        "type": "text",
+                        "text": f"<image_caption>{caption}</image_caption>",
+                    }
+                )
                 req.image_urls = []
         except Exception as e:
             logger.error(f"处理图片描述失败: {e}")
@@ -129,13 +134,14 @@ class ProcessLLMRequest:
             else:
                 req.prompt = prefix + req.prompt
 
+        # 收集系统提醒信息
+        system_parts = []
+
         # user identifier
         if cfg.get("identifier"):
             user_id = event.message_obj.sender.user_id
             user_nickname = event.message_obj.sender.nickname
-            req.prompt = (
-                f"\n[User ID: {user_id}, Nickname: {user_nickname}]\n{req.prompt}"
-            )
+            system_parts.append(f"User ID: {user_id}, Nickname: {user_nickname}")
 
         # group name identifier
         if cfg.get("group_name_display") and event.message_obj.group_id:
@@ -146,7 +152,7 @@ class ProcessLLMRequest:
                 return
             group_name = event.message_obj.group.group_name
             if group_name:
-                req.system_prompt += f"\nGroup name: {group_name}\n"
+                system_parts.append(f"Group name: {group_name}")
 
         # time info
         if cfg.get("datetime_system_prompt"):
@@ -162,7 +168,7 @@ class ProcessLLMRequest:
                 current_time = (
                     datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M (%Z)")
                 )
-            req.system_prompt += f"\nCurrent datetime: {current_time}\n"
+            system_parts.append(f"Current datetime: {current_time}")
 
         img_cap_prov_id: str = cfg.get("default_image_caption_provider_id") or ""
         if req.conversation:
@@ -225,10 +231,17 @@ class ProcessLLMRequest:
                 except BaseException as e:
                     logger.error(f"处理引用图片失败: {e}")
 
-            # 3. 将所有部分组合成文本并直接注入到当前消息中
+            # 3. 将所有部分组合成文本并添加到 extra_content_blocks 中
             # 确保引用内容被正确的标签包裹
             quoted_content = "\n".join(content_parts)
             # 确保所有内容都在<Quoted Message>标签内
             quoted_text = f"<Quoted Message>\n{quoted_content}\n</Quoted Message>"
 
-            req.prompt = f"{quoted_text}\n\n{req.prompt}"
+            req.extra_content_blocks.append({"type": "text", "text": quoted_text})
+
+        # 统一包裹所有系统提醒
+        if system_parts:
+            system_content = (
+                "<system_reminder>" + "".join(system_parts) + "</system_reminder>"
+            )
+            req.extra_content_blocks.append({"type": "text", "text": system_content})

--- a/packages/astrbot/process_llm_request.py
+++ b/packages/astrbot/process_llm_request.py
@@ -7,6 +7,7 @@ from astrbot.api import logger, sp, star
 from astrbot.api.event import AstrMessageEvent
 from astrbot.api.message_components import Image, Reply
 from astrbot.api.provider import Provider, ProviderRequest
+from astrbot.core.agent.message import TextPart
 from astrbot.core.provider.func_tool_manager import ToolSet
 
 
@@ -85,11 +86,8 @@ class ProcessLLMRequest:
                 req.image_urls,
             )
             if caption:
-                req.extra_content_blocks.append(
-                    {
-                        "type": "text",
-                        "text": f"<image_caption>{caption}</image_caption>",
-                    }
+                req.extra_user_content_parts.append(
+                    TextPart(text=f"<image_caption>{caption}</image_caption>")
                 )
                 req.image_urls = []
         except Exception as e:
@@ -231,17 +229,17 @@ class ProcessLLMRequest:
                 except BaseException as e:
                     logger.error(f"处理引用图片失败: {e}")
 
-            # 3. 将所有部分组合成文本并添加到 extra_content_blocks 中
+            # 3. 将所有部分组合成文本并添加到 extra_user_content_parts 中
             # 确保引用内容被正确的标签包裹
             quoted_content = "\n".join(content_parts)
             # 确保所有内容都在<Quoted Message>标签内
             quoted_text = f"<Quoted Message>\n{quoted_content}\n</Quoted Message>"
 
-            req.extra_content_blocks.append({"type": "text", "text": quoted_text})
+            req.extra_user_content_parts.append(TextPart(text=quoted_text))
 
         # 统一包裹所有系统提醒
         if system_parts:
             system_content = (
                 "<system_reminder>" + "\n".join(system_parts) + "</system_reminder>"
             )
-            req.extra_content_blocks.append({"type": "text", "text": system_content})
+            req.extra_user_content_parts.append(TextPart(text=system_content))


### PR DESCRIPTION
🎯 动机 / Motivation

  解决的问题：
   - 多文本块支持缺失：当前 AstrBot 只支持单条用户消息，无法在一个请求中包含多个文本块
   - 系统信息污染用户输入：用户标识、时间、群组信息等系统提醒直接插入到用户输入中，违反了 OpenAI 最佳实践
   - 格式不够优雅：系统提醒分散在多个文本块中，浪费 token 且不易解析

  添加的功能：
   - 多文本块消息支持：通过 extra_content_blocks 属性支持多个文本块
   - 优化系统提醒格式：统一用 <system_reminder> 包裹，遵循 OpenAI 最佳实践
   - 语义化标签：区分系统提醒、图片描述、引用消息

  ---

  📝 改动点 / Modifications

  核心文件修改：

   1. `core/provider/entities.py`
      - 新增 extra_content_blocks 属性（默认空列表）
      - 重构 assemble_context() 方法支持多文本块
      - 智能降级：单文本块时保持向后兼容

   2. `core/provider/sources/openai_source.py`
      - 更新 assemble_context() 支持多文本块和额外内容

   3. `core/provider/sources/gemini_source.py`
      - 更新 assemble_context() 支持多文本块和额外内容

   4. `core/provider/sources/anthropic_source.py`
      - 更新 assemble_context() 支持多文本块和额外内容

   5. `packages/astrbot/process_llm_request.py`
      - 重构系统提醒收集机制：先收集，后统一包裹
      - 图片描述改为 <image_caption> 标签
      - 系统提醒统一为 <system_reminder> 格式

  实现的功能：
   - ✅ 多文本块支持：一个用户消息可包含多个文本块
   - ✅ OpenAI 最佳实践：用户发言在前，系统提醒在后
   - ✅ Token 优化：去除冗余换行，统一系统提醒格式
   - ✅ 向后兼容：现有代码无需修改
   - ✅ 语义清晰：明确区分不同类型的内容

  ---

  🖼️ 测试结果 / Test Results

  测试场景：
   1. 向后兼容性测试：只有 prompt 时正确降级为简单格式
   2. 多文本块测试：prompt + extra_content_blocks 正确生成数组格式
   3. 系统提醒格式测试：验证 <system_reminder> 包裹格式
   4. 图片描述测试：验证 <image_caption> 标签格式

  测试输出示例：
```
   1 {
   2   "role": "user",
   3   "content": [
   4     {"type": "text", "text": "你好世界"},
   5     {"type": "text", "text": "<system_reminder>User ID: 123, Nickname: TestUserGroup name:
     测试群Current datetime: 2025-12-25 10:30</system_reminder>"},
   6     {"type": "text", "text": "<image_caption>一张美丽的风景图</image_caption>"}
   7   ]
   8 }
```

  ---

  ✅ 检查清单 / Checklist

   - [x] 😊 功能讨论：多文本块功能是架构优化，无需额外讨论
   - [x] 👀 测试充分：已通过完整的功能测试，验证了向后兼容性和新功能
   - [x] 🤓 无新依赖：未引入任何新的依赖库
   - [x] 😮 代码安全：代码仅涉及消息格式优化，无安全风险

  ---

  🚀 使用示例

```
   1 # 插件中使用新功能
   2 req = event.request_llm(prompt="你好")
   3 req.extra_content_blocks.extend([
   4     {"type": "text", "text": "<system_reminder>请用友好的语气回答</system_reminder>"}
   5 ])
   6 yield req
```
   
 需要注意的是，本次PR并未对所以 本人从未使用的功能进行优化。
 比如知识库。
   

✦ 这个 PR 为 AstrBot 的多模态消息处理奠定了基础，同时保持了完全的向后兼容性！🎯

## Summary by Sourcery

在保持现有单文本行为向后兼容的前提下，为用户消息添加对多个内容块的结构化支持。

新功能：
- 在 `ProviderRequest` 上引入 `extra_content_blocks` 字段，用于携带额外的用户消息片段，例如系统提醒、图像描述和引用消息。
- 在 OpenAI、Gemini 和 Anthropic 提供方中支持多块用户内容，将主要文本、额外内容块和图片组合成统一的消息载荷。

增强点：
- 优化各提供方的上下文组装逻辑，以主要用户发言为优先；在仅有图片时添加文本占位符；在适用时回退到旧的单文本格式。
- 通过收集元数据（用户、群组、时间），将系统提醒标准化为一个统一的 `<system_reminder>` 文本块，而不是直接注入到提示词中。
- 修改图像描述和引用消息的处理方式，将其作为带语义标签的文本块（例如 `<image_caption>`、`<Quoted Message>`）追加在用户消息之后，而非前置到提示词前面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add structured support for multiple content blocks in user messages while keeping existing single-text behavior backward compatible.

New Features:
- Introduce an extra_content_blocks field on ProviderRequest to carry additional user message segments such as system reminders, image captions, and quoted messages.
- Support multi-block user content in OpenAI, Gemini, and Anthropic providers, combining primary text, extra content blocks, and images into a unified message payload.

Enhancements:
- Refine context assembly across providers to prioritize the main user utterance, add a text placeholder when only images are present, and fall back to the legacy single-text format when applicable.
- Standardize system reminder formatting by collecting metadata (user, group, time) and wrapping it in a single <system_reminder> text block instead of injecting it directly into the prompt.
- Change image captions and quoted message handling to emit semantically tagged text blocks (e.g., <image_caption>, <Quoted Message>) appended after the user message instead of prefixing the prompt.

</details>