### PR TITLE
perf(satori): increase websocket max message size to 10MB

### DIFF
--- a/astrbot/core/platform/sources/satori/satori_adapter.py
+++ b/astrbot/core/platform/sources/satori/satori_adapter.py
@@ -143,9 +143,9 @@ class SatoriPlatformAdapter(Platform):
 
         try:
             websocket = await connect(
-                self.endpoint, 
+                self.endpoint,
                 additional_headers={},
-                max_size=10 * 1024 * 1024  # 10MB
+                max_size=10 * 1024 * 1024,  # 10MB
             )
 
             self.ws = websocket


### PR DESCRIPTION
## Fix Satori WebSocket connection drops due to large message size

Add max_size parameter to websocket connection to handle larger messages and prevent connection drops when receiving large payloads from Satori platform.

修复 Satori WebSocket 因消息过大而断开连接的问题，通过增加 max_size 参数来支持接收更大的消息负载。

### Motivation / 动机

修复了 Satori 适配器在接收大消息时出现的连接断开和无限重连问题。

**问题描述：**
当 Satori 服务器发送超过 1MB（默认限制）的 WebSocket 消息时，连接会因为 `message too big` 错误而关闭，导致适配器陷入无限重连循环。

**错误日志：**
```
[16:37:10] [Core] [WARN] [satori.satori_adapter:161]: Satori WebSocket 连接关闭: sent 1009 (message too big) frame with 2541903 bytes exceeds limit of 1048576 bytes; no close frame received
```

### Modifications / 改动点

**修改文件：**
- `astrbot/core/platform/sources/satori/satori_adapter.py`

**具体改动：**
在 `connect_websocket()` 方法中的 WebSocket 连接调用处（第 145-149 行），为 `connect()` 函数添加了 `max_size` 参数：

```python
websocket = await connect(
    self.endpoint, 
    additional_headers={},
    max_size=10 * 1024 * 1024  # 10MB
)
```

**功能说明：**
- 将 WebSocket 消息大小限制从默认的 1MB 提升到 10MB
- 允许 Satori 适配器接收更大的消息负载
- 防止因消息过大导致的连接断开和重连循环

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

**修复前：**
```log
[16:37:08] [Core] [INFO] [satori.satori_adapter:137]: Satori 适配器正在连接到 WebSocket: ws://localhost:5140/satori/v1/events

[16:37:10] [Core] [WARN] [satori.satori_adapter:161]: Satori WebSocket 连接关闭: sent 1009 (message too big) frame with 2541903 bytes exceeds limit of 1048576 bytes

[16:37:15] [Core] [INFO] [satori.satori_adapter:137]: Satori 适配器正在连接到 WebSocket: ws://localhost:5140/satori/v1/events

[16:37:17] [Core] [WARN] [satori.satori_adapter:161]: Satori WebSocket 连接关闭: sent 1009 (message too big) frame with 2541903 bytes exceeds limit of 1048576 bytes
```

**修复后：**
连接稳定，不再出现 `message too big` 错误和无限重连问题。
```log
 [16:46:34] [Core] [INFO] [satori.satori_adapter:137]: Satori 适配器正在连接到 WebSocket: ws://localhost:5140/satori/v1/events

 [16:46:34] [Core] [INFO] [satori.satori_adapter:138]: Satori 适配器 HTTP API 地址: http://localhost:5140/satori/v1

[2025-12-28 16:46:36 +0800] [11780] [INFO] 127.0.0.1:59442 GET /api/tools/mcp/servers 1.1 200 41 999

 [16:46:36] [Core] [INFO] [satori.satori_adapter:254]: Satori 连接成功 - Bot 1: platform=onebot, user_id=1787850032, user_name=猫猫不是喵喵

 [16:46:36] [Core] [INFO] [satori.satori_adapter:254]: Satori 连接成功 - Bot 2: platform=yunhu, user_id=37090343, user_name=小学云bot

 [16:46:36] [Core] [INFO] [satori.satori_adapter:254]: Satori 连接成功 - Bot 3: platform=yunhu, user_id=86297657, user_name=yunhu test bot

 [16:46:36] [Core] [INFO] [satori.satori_adapter:254]: Satori 连接成功 - Bot 4: platform=bilibili, user_id=312276085, user_name=叫我小学就好了

 [16:46:36] [Core] [INFO] [satori.satori_adapter:254]: Satori 连接成功 - Bot 5: platform=nextchat, user_id=nextchat, user_name=nextchat
```


---

### Checklist / 检查清单

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

Bug Fixes:
- 防止 Satori WebSocket 连接在接收大于默认 1MB 限制的消息时被关闭并不断重新连接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent Satori WebSocket connections from closing and endlessly reconnecting when receiving messages larger than the default 1MB limit.

</details>