### PR TITLE
fix: handle None values in _extract_usage to prevent TypeError

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -252,7 +252,9 @@ class ProviderOpenAIOfficial(Provider):
         ptd = usage.prompt_tokens_details
         cached = ptd.cached_tokens if ptd and ptd.cached_tokens else 0
         prompt_tokens = 0 if usage.prompt_tokens is None else usage.prompt_tokens
-        completion_tokens = 0 if usage.completion_tokens is None else usage.completion_tokens
+        completion_tokens = (
+            0 if usage.completion_tokens is None else usage.completion_tokens
+        )
         return TokenUsage(
             input_other=prompt_tokens - cached,
             input_cached=cached,


### PR DESCRIPTION
## Motivation / 动机

使用第三方 API 代理（如中转站）时，部分提供商返回的 `usage` 对象中 `prompt_tokens` 和 `completion_tokens` 可能为 `None`，导致 `_extract_usage` 方法执行算术运算时抛出 `TypeError`:

```
TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'
```

在 Cherry Studio 等客户端中使用相同的 API 代理不会出现此问题，因为它们对 None 值做了兼容处理。

### Modifications / 改动点

修改 `astrbot/core/provider/sources/openai_source.py` 中的 `_extract_usage` 方法：
- 在进行算术运算前，对 `prompt_tokens` 和 `completion_tokens` 添加空值检查
- 若为 None 则回退为 0

### Screenshots or Test Results / 运行截图或测试结果

修复前：
```
File "openai_source.py", line 255, in _extract_usage
    input_other=usage.prompt_tokens - cached,
TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'
```

修复后：正常响应，无报错。

---

### Checklist / 检查清单

- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

Bug Fixes:
- 当 usage 字段为 None 时，将默认的 prompt 和 completion token 计数设为 0，以避免在 token 运算中出现 TypeError。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Default prompt and completion token counts to zero when usage fields are None to avoid TypeError in token arithmetic.

</details>