### PR TITLE
feat: add JSON value for custom_extra_body

### DIFF
--- a/dashboard/src/components/shared/ObjectEditor.vue
+++ b/dashboard/src/components/shared/ObjectEditor.vue
@@ -69,8 +69,10 @@
                   v-model="pair.value"
                   density="compact"
                   variant="outlined"
-                  hide-details
+                  hide-details="auto"
                   placeholder="JSON"
+                  @blur="updateJSON(index, pair.value)"
+                  :error-messages="pair.jsonError"
                 ></v-text-field>
               </v-col>
               <v-col cols="1" class="pl-2">
@@ -228,6 +230,15 @@ function addKeyValuePair() {
   }
 }
 
+function updateJSON(index, newValue) {
+  try {
+    JSON.parse(newValue)
+    localKeyValuePairs.value[index].jsonError = ''
+  } catch (e) {
+    localKeyValuePairs.value[index].jsonError = 'JSON 格式错误'
+  }
+}
+
 function removeKeyValuePair(index) {
   localKeyValuePairs.value.splice(index, 1)
 }
@@ -254,6 +265,7 @@ function updateKey(index, newKey) {
 function confirmDialog() {
   const updatedValue = {}
   for (const pair of localKeyValuePairs.value) {
+    if (pair.type === 'json' && pair.jsonError) return
     let convertedValue = pair.value
     // 根据声明的类型进行转换
     switch (pair.type) {


### PR DESCRIPTION
部分LLM厂商自定义请求体参数不止是的基本类型，而是JSON。目前custom_extra_body只支持string、boolean、number，这里谈价JSON类型支持

### Modifications / 改动点
修改了dashboard/src/components/shared/ObjectEditor.vue，添加JSON类型的添加、回显、提交支持

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

<img width="612" height="431" alt="image" src="https://github.com/user-attachments/assets/9980ee87-0a0b-4f3e-a8c6-6647b8b96c60" />

<img width="1152" height="101" alt="image" src="https://github.com/user-attachments/assets/b7fdd0bf-7c80-4a0a-8bcb-96ac93d73c91" />

---

### Checklist / 检查清单

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

在用于 `custom_extra_body` 的仪表盘键值对象编辑器中添加对 JSON 类型值的支持。

新功能：
- 允许用户在对象编辑器中添加键值对时选择 `json` 作为值类型，并通过专用文本字段输入 JSON。
- 在编辑和提交过程中，通过适当的序列化和解析，在对象编辑器中持久化并恢复 JSON 值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for JSON-typed values in the dashboard key-value object editor used for custom_extra_body.

New Features:
- Allow users to select 'json' as a value type when adding key-value pairs in the object editor and input JSON through a dedicated text field.
- Persist and restore JSON values in the object editor by serializing and parsing them appropriately during editing and submission.

</details>