### PR TITLE
fix(#4188): terminate the same plugin when install the plugin via file

### DIFF
--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -945,7 +945,7 @@ class PluginManager:
         dir_name = dir_name.removesuffix("-master").removesuffix("-main").lower()
         desti_dir = os.path.join(self.plugin_store_path, dir_name)
 
-        # 检查是否已安装同名插件，先终止旧插件
+        # 第一步：检查是否已安装同目录名的插件，先终止旧插件
         existing_plugin = None
         for star in self.context.get_all_stars():
             if star.root_dir_name == dir_name:
@@ -964,6 +964,28 @@ class PluginManager:
                 )
 
         self.updator.unzip_file(zip_file_path, desti_dir)
+
+        # 第二步：解压后，读取新插件的 metadata.yaml，检查是否存在同名但不同目录的插件
+        try:
+            new_metadata = self._load_plugin_metadata(desti_dir)
+            if new_metadata and new_metadata.name:
+                for star in self.context.get_all_stars():
+                    if (
+                        star.name == new_metadata.name
+                        and star.root_dir_name != dir_name
+                    ):
+                        logger.warning(
+                            f"检测到同名插件 {star.name} 存在于不同目录 {star.root_dir_name}，正在终止..."
+                        )
+                        try:
+                            await self._terminate_plugin(star)
+                        except Exception:
+                            logger.warning(traceback.format_exc())
+                        if star.name and star.module_path:
+                            await self._unbind_plugin(star.name, star.module_path)
+                        break  # 只处理第一个匹配的
+        except Exception as e:
+            logger.debug(f"读取新插件 metadata.yaml 失败，跳过同名检查: {e!s}")
 
         # remove the zip
         try:


### PR DESCRIPTION
Fixes #4188): 在从文件安装插件前先终止并解绑已存在的同名插件

## Summary by Sourcery

Bug Fixes:
- 在从文件安装插件之前，如果已存在同一目录名称的已安装插件，先终止并解绑该插件，以避免冲突。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Terminate and unbind an already-installed plugin with the same directory name before installing a plugin from a file to avoid conflicts.

</details>