### PR TITLE
ci(stale): Increase the operations-per-run limit for stale actions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/stale@v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          operations-per-run: 200
 
           # 只处理带 bug 标签的 Issue
           any-of-labels: 'bug'


### PR DESCRIPTION
从 action 日志看出 stale 的 operations-per-run 默认值 30 比较保守（仅使用 16/5000 Github API rate），不够处理本仓库的已有 issue 数量，故设定为 200
<img width="508" height="542" alt="image" src="https://github.com/user-attachments/assets/38f23b6b-6765-498e-b545-7e899d74d894" />

## 由 Sourcery 提供的摘要

CI：
- 在 GitHub Actions 工作流程中，将 stale action 的每次运行操作数设置从默认值提升到 200。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Raise the stale action operations-per-run setting from the default to 200 in the GitHub Actions workflow.

</details>