### PR TITLE
perf: add `Add` button to ListConfigItem

### DIFF
--- a/dashboard/src/components/shared/ListConfigItem.vue
+++ b/dashboard/src/components/shared/ListConfigItem.vue
@@ -23,7 +23,7 @@
       </div>
     </div>
     <v-btn size="small" color="primary" variant="tonal" @click="openDialog">
-      {{ preferSingleItem ? '添加更多' : (buttonText || t('core.common.list.modifyButton')) }}
+      {{ preferSingleItem ? t('core.common.list.addMore') : (buttonText || t('core.common.list.modifyButton')) }}
     </v-btn>
   </div>
 
@@ -48,6 +48,14 @@
             :placeholder="t('core.common.list.inputPlaceholder')"
             class="flex-grow-1">
           </v-text-field>
+          <v-btn
+            @click="addItem"
+            variant="tonal"
+            color="primary"
+            size="small"
+            :disabled="!newItem.trim()">
+            {{ t('core.common.list.addButton') }}
+          </v-btn>
           <v-btn 
             @click="showBatchImport = true" 
             variant="tonal" 

--- a/dashboard/src/i18n/locales/en-US/core/common.json
+++ b/dashboard/src/i18n/locales/en-US/core/common.json
@@ -74,6 +74,7 @@
   "list": {
     "addItemPlaceholder": "Add new item, press Enter to confirm",
     "addButton": "Add",
+    "addMore": "Add More",
     "batchImport": "Batch Import",
     "batchImportTitle": "Batch Import",
     "batchImportLabel": "One item per line",

--- a/dashboard/src/i18n/locales/zh-CN/core/common.json
+++ b/dashboard/src/i18n/locales/zh-CN/core/common.json
@@ -74,6 +74,7 @@
   "list": {
     "addItemPlaceholder": "添加新项，按回车确认添加",
     "addButton": "添加",
+    "addMore": "添加更多",
     "batchImport": "批量导入",
     "batchImportTitle": "批量导入",
     "batchImportLabel": "每行一个项目",


### PR DESCRIPTION
fixes: #4254

### Motivation
- Provide a clear, explicit way for users to add a new list entry from the `ListConfigItem` dialog instead of relying only on Enter key.
- Ensure the single-item mode label is localized and not a hard-coded string.
- Keep UX consistent with existing i18n strings in the dashboard.

### Description
- Use `t('core.common.list.addMore')` for the single-item mode action label instead of a hard-coded string in `ListConfigItem.vue`.
- Add an explicit `Add` button next to the new-item text field that calls `addItem()` and is disabled when the input is empty in `ListConfigItem.vue`.
- Add new i18n key `addMore` to `dashboard/src/i18n/locales/en-US/core/common.json` and `dashboard/src/i18n/locales/zh-CN/core/common.json`.
- Minor wiring only; no changes to business logic beyond adding the new UI control.

### Testing
- Started the dashboard dev server with `npm --prefix dashboard run dev` and confirmed Vite reported ready (succeeded).
- Captured a UI screenshot using a Playwright script (succeeded and produced an artifact screenshot).
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69537cc78a3483249b65d8e3b1aa2315)

## Summary by Sourcery

为列表配置对话框添加一个显式的、本地化的控件用于向列表中添加项目，同时使该组件与现有的 i18n 字符串保持一致。

New Features:
- 在 ListConfigItem 对话框的列表项输入字段旁新增一个 Add 按钮。

Enhancements:
- 使用现有的 i18n 基础设施，本地化 ListConfigItem 中单项模式操作标签。

Documentation:
- 在英文和中文的本地化文件中扩展与列表相关的、用于 Add 操作的新的 i18n 键。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an explicit, localized control for adding items to list configuration dialogs while aligning the component with existing i18n strings.

New Features:
- Introduce an Add button next to the list item input field in ListConfigItem dialogs.

Enhancements:
- Localize the single-item mode action label in ListConfigItem using existing i18n infrastructure.

Documentation:
- Extend English and Chinese locale files with new list-related i18n keys for the Add actions.

</details>