### PR TITLE
fix: handle null item-meta in ConfigItemRenderer

### DIFF
--- a/dashboard/src/components/shared/AstrBotConfig.vue
+++ b/dashboard/src/components/shared/AstrBotConfig.vue
@@ -203,9 +203,8 @@ function hasVisibleItemsAfter(items, currentIndex) {
 
             <v-col cols="12" sm="6" class="config-input">
               <ConfigItemRenderer
-                v-if="metadata[metadataKey].items[key]"
                 v-model="iterable[key]"
-                :item-meta="metadata[metadataKey].items[key]"
+                :item-meta="metadata[metadataKey].items[key] || null"
                 :loading="loadingEmbeddingDim"
                 :show-fullscreen-btn="!!metadata[metadataKey].items[key]?.editor_mode"
                 @get-embedding-dim="getEmbeddingDimensions(iterable)"

--- a/dashboard/src/components/shared/AstrBotConfigV4.vue
+++ b/dashboard/src/components/shared/AstrBotConfigV4.vue
@@ -219,7 +219,7 @@ function getSpecialSubtype(value) {
               <ConfigItemRenderer
                 v-else
                 v-model="createSelectorModel(itemKey).value"
-                :item-meta="itemMeta"
+                :item-meta="itemMeta || null"
                 :show-fullscreen-btn="!!itemMeta?.editor_mode"
                 @open-fullscreen="openEditorDialog(itemKey, iterable, itemMeta?.editor_theme, itemMeta?.editor_language)"
               />

--- a/dashboard/src/components/shared/ConfigItemRenderer.vue
+++ b/dashboard/src/components/shared/ConfigItemRenderer.vue
@@ -223,7 +223,7 @@ const props = defineProps({
   },
   itemMeta: {
     type: Object,
-    required: true
+    default: null
   },
   loading: {
     type: Boolean,


### PR DESCRIPTION
fixes: #4268

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

错误修复：
- 通过将 `itemMeta` 属性设为可选，并在元数据缺失时传递 `null`，允许 `ConfigItemRenderer` 即使在缺少条目元数据时也能进行渲染。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Allow ConfigItemRenderer to render even when item metadata is absent by making the itemMeta prop optional and passing null when metadata is missing.

</details>