### PR TITLE
Fix: 修复微信公众号 msg.id 类型不匹配导致重试失败 (#1679)

### DIFF
--- a/astrbot/core/platform/sources/weixin_official_account/weixin_offacc_adapter.py
+++ b/astrbot/core/platform/sources/weixin_official_account/weixin_offacc_adapter.py
@@ -191,7 +191,7 @@ class WeixinOfficialAccountPlatformAdapter(Platform):
                 if self.active_send_mode:
                     await self.convert_message(msg, None)
                 else:
-                    if msg.id in self.wexin_event_workers:
+                    if str(msg.id) in self.wexin_event_workers:
                         future = self.wexin_event_workers[str(cast(str | int, msg.id))]
                         logger.debug(f"duplicate message id checked: {msg.id}")
                     else:


### PR DESCRIPTION
## 🐛 问题描述

### 症状
- 控制台显示正常发送消息，但公众号未收到消息
- **处理时间 > 5秒的消息几乎总是失败**（如 AI 图片生成、长文本生成）
- 短消息（<5秒）正常工作

### 根本原因

**类型不匹配**：

```python
# msg.id 是整数类型
msg.id = 25302262838371742  # int

# 字典 key 使用字符串类型  
self.wexin_event_workers["25302262838371742"] = future  # str key

# 检查时类型不匹配
if msg.id in self.wexin_event_workers:
#   ^^^^^^ int != str ❌ 永远是 False
```

代码设计意图是做重复检测（避免微信重试时重复处理），但检查时忘记将 `msg.id` 转换为字符串。

---

## ✅ 修改内容

**文件**：`astrbot/core/platform/sources/weixin_official_account/weixin_offacc_adapter.py`

```diff
- if msg.id in self.wexin_event_workers:
+ if str(msg.id) in self.wexin_event_workers:
```

**一行修改，将整数类型的 `msg.id` 转换为字符串后再检查。**

---

## 🎯 场景对比：AI 图片生成

### ❌ 修改前（有 Bug）

```
[16:23:04] 第1次请求 → 创建 future_1 → 生成中...
[16:23:09] 微信5秒超时，第2次请求 → 创建 future_2 → 又生成...  ❌
[16:23:14] 微信再次超时，第3次请求 → 创建 future_3 → 再生成...  ❌

结果：3个 future，只有1个被设置，用户收不到图片 ❌
```

### ✅ 修改后（已修复）

```
[16:35:44] 第1次请求 → 创建 future → 生成中...
[16:35:49] 微信5秒超时，第2次请求 → 重用 future → 等待...  ✓
[16:35:53] 图片生成完成 → 所有请求返回 → 用户收到图片 ✅
```

---

## 📊 影响范围

| 场景 | 处理时间 | 修改前 | 修改后 |
|------|---------|--------|--------|
| 简单对话 | < 1秒 | ✅ 正常 | ✅ 正常 |
| AI 短文本 | 1-3秒 | ✅ 正常 | ✅ 正常 |
| AI 长文本 | 5-10秒 | ❌ 概率失败 | ✅ 正常 |
| AI 图片生成 | 7-10秒 | ❌ 几乎总是失败 | ✅ 正常 |

---

## 🧪 测试验证

- ✅ AI 图片生成（~9秒）：从总是失败 → 成功返回
- ✅ 长文本生成（~8秒）：从概率失败 → 稳定返回  
- ✅ 简单对话（<1秒）：保持正常

---

## ⚠️ 风险评估

- ✅ 仅影响微信公众号适配器
- ✅ 修改范围小（1行代码）
- ✅ 向后兼容
- ✅ 无性能影响
- ✅ 不影响其他平台

Fixes #1679

## Summary by Sourcery

Bug Fixes:
- 修正微信公众号适配器中的消息 ID 类型处理，使重试请求能够被正确识别为重复请求，并返回已生成的结果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct message ID type handling in the WeChat Official Account adapter so that retry requests are properly recognized as duplicates and return the generated result.

</details>