### PR TITLE
feat(webui): supports force update plugins

### DIFF
--- a/dashboard/src/components/shared/ExtensionCard.vue
+++ b/dashboard/src/components/shared/ExtensionCard.vue
@@ -145,9 +145,11 @@ const viewReadme = () => {
                   }})</v-list-item-title>
                 </v-list-item>
 
-                <v-list-item @click="updateExtension" :disabled="!extension?.has_update">
+                <v-list-item @click="updateExtension">
                   <v-list-item-title>
-                    {{ tm('card.actions.updateTo') }} {{ extension.online_version || extension.version }}
+                    {{ extension.has_update 
+                        ? tm('card.actions.updateTo') + ' ' + extension.online_version 
+                        : tm('card.actions.reinstall') }}
                   </v-list-item-title>
                 </v-list-item>
               </template>

--- a/dashboard/src/i18n/locales/en-US/features/extension.json
+++ b/dashboard/src/i18n/locales/en-US/features/extension.json
@@ -145,6 +145,11 @@
       "message": "This plugin has been flagged as containing security risks, including unsafe code or functionalities that may cause system malfunctions or data loss. Do you wish to proceed with the installation?",
       "confirm": "Continue",
       "cancel": "Cancel"
+    },
+    "forceUpdate": {
+      "title": "No New Version Detected",
+      "message": "No new version detected for this plugin. Do you want to force reinstall? This will pull the latest code from the remote repository.",
+      "confirm": "Force Update"
     }
   },
   "messages": {
@@ -185,7 +190,8 @@
       "reloadPlugin": "Reload Extension",
       "togglePlugin": "Extension",
       "viewHandlers": "View Handlers",
-      "updateTo": "Update to"
+      "updateTo": "Update to",
+      "reinstall": "Reinstall"
     },
     "status": {
       "hasUpdate": "New version available",

--- a/dashboard/src/i18n/locales/zh-CN/features/extension.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/extension.json
@@ -145,6 +145,11 @@
       "message": "该插件可能包含不安全的代码或功能，可能导致系统异常或数据损失等。请确认是否继续安装？",
       "confirm": "继续",
       "cancel": "取消"
+    },
+    "forceUpdate": {
+      "title": "未检测到新版本",
+      "message": "当前插件未检测到新版本，是否强制重新安装？这将从远程仓库拉取最新代码。",
+      "confirm": "强制更新"
     }
   },
   "messages": {
@@ -185,7 +190,8 @@
       "reloadPlugin": "重载插件",
       "togglePlugin": "插件",
       "viewHandlers": "查看行为",
-      "updateTo": "更新到"
+      "updateTo": "更新到",
+      "reinstall": "重新安装"
     },
     "status": {
       "hasUpdate": "有新版本可用",


### PR DESCRIPTION
### Motivation / 改动点描述

优化插件页面的更新体验。目前的更新按钮依赖插件市场数据加载逻辑，存在延迟且在未检测到新版本时无法操作。此改动允许用户随时点击更新按钮，并在无新版本时通过弹窗确认进行“强制重新安装”，方便用户手动拉取远程仓库的最新修改。

### Modifications / 改动点

- **ExtensionPage.vue**: 
  - 移除了列表视图更新按钮的显示限制（常亮）。
  - 修改 `updateExtension` 逻辑：无新版本时弹出强制更新确认对话框。
  - 添加了强制更新确认对话框组件。
- **ExtensionCard.vue**: 
  - 移除了卡片菜单中更新选项的禁用限制。
  - 根据是否有新版本动态显示“更新到 vX.X.X”或“重新安装”。
- **i18n**: 添加了中英文对应的翻译文本（强制更新提示、重新安装按钮文本）。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

**验证步骤 (Verification Steps):**
1. 进入“插件管理”页面。
2. 在**列表视图**中，确认所有已安装插件的“更新”按钮始终可见。
3. 对于无新版本的插件：点击“更新”应弹出确认框，确认后执行更新。
4. 在**卡片视图**中，确认菜单项在无新版本时显示“重新安装”且可点击。
5. 确认点击“重新安装”后也能正常弹出强制更新确认对话框。

**运行截图：**
<img width="474" height="179" alt="chrome_HetL2yeuLV" src="https://github.com/user-attachments/assets/b83a65ec-8d63-4cb4-90be-c80da061155f" />


---

### Checklist / 检查清单

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。
- [x] 👀 我的更改经过了良好的测试，并已在上方提供了“验证步骤”。
- [x] 🤓 我确保没有引入新依赖库。
- [x] 😮 我的更改没有引入恶意代码。

## Summary by Sourcery

允许用户在任何时间触发扩展更新，并在未检测到新版本时，增加强制重新安装的确认流程。

新功能：
- 即使未检测到新版本，也允许触发扩展更新，并在强制重新安装时显示确认对话框。
- 根据扩展更新的可用性，在卡片操作标签中区分“更新到新版本”和“重新安装当前版本”。

增强项：
- 在扩展列表和卡片视图中保持更新操作可见且可点击，以改进插件更新体验。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable users to trigger extension updates at any time and add a flow for confirming forced reinstalls when no new version is detected.

New Features:
- Allow triggering extension updates even when no new version has been detected, with a confirmation dialog for forced reinstall.
- Differentiate card action labels between updating to a new version and reinstalling the current version based on extension update availability.

Enhancements:
- Keep the update action visible and clickable in the extensions list and card views to improve the plugin update experience.

</details>