### PR TITLE
fix: conversation was still saved to the context after `stop_event`

### DIFF
--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -522,13 +522,15 @@ class InternalAgentSubStage(Stage):
                     ):
                         yield
 
-                await self._save_to_history(
-                    event,
-                    req,
-                    agent_runner.get_final_llm_resp(),
-                    agent_runner.run_context.messages,
-                    agent_runner.stats,
-                )
+                # 检查事件是否被停止，如果被停止则不保存历史记录
+                if not event.is_stopped():
+                    await self._save_to_history(
+                        event,
+                        req,
+                        agent_runner.get_final_llm_resp(),
+                        agent_runner.run_context.messages,
+                        agent_runner.stats,
+                    )
 
             # 异步处理 WebChat 特殊情况
             if event.get_platform_name() == "webchat":


### PR DESCRIPTION
### Motivation / 动机

修复了在 `OnLLMResponseEvent` 钩子中调用 `stop_event()` 后，本轮对话仍会被保存到上下文的问题。

之前的行为：当插件在 `OnLLMResponseEvent` 钩子中调用 `event.stop_event()` 时，虽然本次回复不会输出给用户，但对话历史（包括用户消息和 LLM 响应）仍然会被保存到会话上下文中，导致后续对话会包含这次被"停止"的对话内容。

期望行为：调用 `stop_event()` 后，本轮对话既不输出，也不保存到上下文。

### Modifications / 改动点

*核心文件修改：**
- `astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py`
  - 在调用 `_save_to_history()` 前增加 `event.is_stopped()` 检查
  - 只有在事件未被停止时才保存对话历史到会话上下文

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

错误修复：
- 当事件已被标记为停止时，跳过保存会话历史，确保已停止的回复既不会被输出，也不会存储在上下文中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Skip saving conversation history when an event has been marked as stopped, ensuring stopped responses are neither output nor stored in context.

</details>