### PR TITLE
fix:修复on_waiting_llm_request钩子没有检查消息有效性的问题

### DIFF
--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -364,7 +364,7 @@ class InternalAgentSubStage(Stage):
             # 检查消息内容是否有效，避免空消息触发钩子
             has_provider_request = event.get_extra("provider_request") is not None
             has_valid_message = bool(event.message_str and event.message_str.strip())
-            
+
             if not has_provider_request and not has_valid_message:
                 logger.debug("skip llm request: empty message and no provider_request")
                 return


### PR DESCRIPTION
###Motivation / 动机

修复了空消息（如 QQ 的 `input_status` "对方正在输入"事件）会错误触发 `OnWaitingLLMRequestEvent` 钩子的问题。

### Modifications / 改动点

**实现功能：**
- 在触发 `OnWaitingLLMRequestEvent` 钩子之前增加消息有效性检查，跳过如`用户正在输入`状态产生的空消息

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## 由 Sourcery 提供的摘要

错误修复：
- 防止在以下情况触发 `OnWaitingLLMRequestEvent`：消息为空，或处于输入状态且同时缺少 `provider_request` 并且内容为空。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent OnWaitingLLMRequestEvent from being triggered by empty or input-status messages lacking both provider_request and non-empty content.

</details>