### PR TITLE
fix: when session_id including ":"

### DIFF
--- a/astrbot/core/platform/message_session.py
+++ b/astrbot/core/platform/message_session.py
@@ -23,7 +23,7 @@ class MessageSession:
 
     @staticmethod
     def from_str(session_str: str):
-        platform_id, message_type, session_id = session_str.split(":")
+        platform_id, message_type, session_id = session_str.split(":", 2)
         return MessageSession(platform_id, MessageType(message_type), session_id)
 
 


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

增强代码健全性，session_id可能包含冒号(如matrix的房间)

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

astrbot/core/platform/message_session.py

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<img width="1621" height="983" alt="image" src="https://github.com/user-attachments/assets/3dba9871-ddf3-4f74-80ca-3cca247b5216" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

错误修复：
- 修复会话字符串的解析方式，使包含冒号的会话 ID 能被正确处理，而不会被错误地拆分成额外的片段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix parsing of session strings so that session IDs containing colons are handled correctly instead of being split into extra segments.

</details>