### PR TITLE
fix: add null check for plugin list in config to fix empty list issue

### DIFF
--- a/dashboard/src/components/shared/PluginSetSelector.vue
+++ b/dashboard/src/components/shared/PluginSetSelector.vue
@@ -170,7 +170,11 @@ async function loadPlugins() {
       // 只显示已激活且非系统的插件，并按名称排序
       pluginList.value = (response.data.data || [])
         .filter(plugin => plugin.activated && !plugin.reserved)
-        .sort((a, b) => a.name.localeCompare(b.name))
+        .sort((a, b) => {
+          const nameA = a.name || '';
+          const nameB = b.name || '';
+          return nameA.localeCompare(nameB);
+        })
     }
   } catch (error) {
     console.error('加载插件列表失败:', error)

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -523,5 +523,13 @@
         "description": "Direct Connection Address List"
       }
     }
+  },
+  "help": {
+    "documentation": "Official Documentation",
+    "support": "Join Support Group",
+    "helpText": "Don't understand the configuration? See {documentation} or {support}.",
+    "helpPrefix": "Don't understand the configuration? See",
+    "helpMiddle": "or",
+    "helpSuffix": "."
   }
 }

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -521,5 +521,13 @@
         "description": "直连地址列表"
       }
     }
+  },
+  "help": {
+    "documentation": "官方文档",
+    "support": "加群询问",
+    "helpText": "不了解配置？请见 {documentation} 或 {support}。",
+    "helpPrefix": "不了解配置？请见",
+    "helpMiddle": "或",
+    "helpSuffix": "。"
   }
 }


### PR DESCRIPTION
### Motivation / 动机

修复了 Dashboard 配置页面中的两个错误：
1. 配置页面底部帮助信息显示 `Translation key not found: features.config-metadata.help.helpSuffix` 错误
2. 插件列表排序时出现 `TypeError: Cannot read properties of null (reading 'localeCompare')` 错误

这些错误导致：
- 配置页面底部的帮助链接无法正确显示
- 当插件的 name 属性为 null 时，插件选择器崩溃

### Modifications / 改动点

**核心文件修改：**

1. **dashboard/src/i18n/locales/zh-CN/features/config-metadata.json**
   - 添加缺失的 `help` 翻译对象，包含所有必需的键：`documentation`、`support`、`helpText`、`helpPrefix`、`helpMiddle`、`helpSuffix`

2. **dashboard/src/i18n/locales/en-US/features/config-metadata.json**
   - 添加英文版本的 `help` 翻译对象

3. **dashboard/src/components/shared/PluginSetSelector.vue**
   - 在插件列表排序逻辑中添加空值检查
   - 使用空字符串作为 null/undefined name 的默认值，避免 `localeCompare` 调用失败

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

---
### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<img width="917" height="635" alt="image" src="https://github.com/user-attachments/assets/2619c96f-afa7-4f05-8ed5-cbb8e33037b6" />
<img width="1027" height="163" alt="image" src="https://github.com/user-attachments/assets/da2a1de6-c083-4066-a6f8-1d51d1f28fb0" />
前
<img width="2560" height="1380" alt="image" src="https://github.com/user-attachments/assets/80ddc041-2676-41d9-96aa-773e91163d2c" />
后
---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

修复仪表盘配置页面上与缺失翻译以及插件列表排序错误相关的问题。

错误修复：
- 防止在插件名称为 `null` 或 `undefined` 时，插件列表排序抛出错误。
- 为配置帮助文本补充缺失的 i18n 条目，以避免在配置页面出现未翻译键的警告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix issues on the dashboard configuration page related to missing translations and plugin list sorting errors.

Bug Fixes:
- Prevent plugin list sorting from throwing errors when a plugin name is null or undefined.
- Add missing i18n entries for configuration help text to avoid untranslated key warnings on the configuration page.

</details>