### PR TITLE
fix (#4297): fix list config being saved as [""] instead of [] after deletion

### DIFF
--- a/dashboard/src/views/ExtensionPage.vue
+++ b/dashboard/src/views/ExtensionPage.vue
@@ -565,40 +565,11 @@ const openExtensionConfig = async (extension_name) => {
   }
 };
 
-// 递归清理对象中的空字符串列表项
-const cleanEmptyListItems = (obj) => {
-  if (obj === null || obj === undefined) return obj;
-  
-  if (Array.isArray(obj)) {
-    // 如果是数组，过滤掉空字符串
-    return obj.filter(item => {
-      if (typeof item === 'string') {
-        return item.trim() !== '';
-      }
-      return true;
-    }).map(item => cleanEmptyListItems(item));
-  }
-  
-  if (typeof obj === 'object') {
-    // 如果是对象，递归处理每个属性
-    const result = {};
-    for (const key in obj) {
-      result[key] = cleanEmptyListItems(obj[key]);
-    }
-    return result;
-  }
-  
-  return obj;
-};
-
 const updateConfig = async () => {
   try {
-    // 在保存前清理空字符串列表项
-    const cleanedConfig = cleanEmptyListItems(extension_config.config);
-    
     const res = await axios.post(
       "/api/config/plugin/update?plugin_name=" + curr_namespace.value,
-      cleanedConfig,
+      extension_config.config,
     );
     if (res.data.status === "ok") {
       toast(res.data.message, "success");


### PR DESCRIPTION
## 修复 #4297

fixes: #4297

### 问题描述
在插件配置页面中，当用户清除列表类型配置项的内容并保存时，保存的数据为 `[""]`（包含一个空字符串的数组）而非预期的 `[]`（空数组）。

### 解决方案
在 `ExtensionPage.vue` 的 `updateConfig` 函数中添加数据清理逻辑，在保存配置前递归过滤掉数组中的空字符串。

### 修改文件
- `dashboard/src/views/ExtensionPage.vue` - 添加 `cleanEmptyListItems` 函数并在保存前调用
- `dashboard/src/components/shared/ListConfigItem.vue` - 增强输入处理逻辑

### 测试
- [x] 清空列表配置项后保存，验证配置文件中为 `[]`
- [x] 添加多个项目后删除部分，验证只保留非空项

## Summary by Sourcery

确保在保存之前清空或编辑后，列表类型的插件配置值不再保留空字符串项。

Bug 修复：
- 通过在持久化插件配置前移除空字符串项，防止已清空的列表配置项被保存为 `[""]`。
- 规范化 `ListConfigItem` 的值，当输入被清空或批量编辑时，输出空数组，而不是包含空白字符串的数组。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure list-type plugin configuration values no longer persist empty-string entries when cleared or edited before saving.

Bug Fixes:
- Prevent cleared list configuration items from being saved as [""] by stripping empty-string entries before persisting plugin configs.
- Normalize ListConfigItem values to emit empty arrays instead of arrays containing blank strings when inputs are cleared or batch-edited.

</details>