### PR TITLE
fix: add image placeholder for non-vision models to fix no response in private chat

### DIFF
--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -194,16 +194,13 @@ class InternalAgentSubStage(Stage):
                 logger.debug(
                     f"用户设置提供商 {provider} 不支持图像，将图像替换为占位符。"
                 )
-                # 检查 prompt 中是否已经包含 [图片] 占位符
-                # 如果已经有了，就不再重复添加（某些 Provider 会自动添加）
-                if not req.prompt or "[图片]" not in req.prompt:
-                    # 为每个图片添加占位符到 prompt
-                    image_count = len(req.image_urls)
-                    placeholder = " ".join(["[图片]"] * image_count)
-                    if req.prompt:
-                        req.prompt = f"{placeholder} {req.prompt}"
-                    else:
-                        req.prompt = placeholder
+                # 为每个图片添加占位符到 prompt
+                image_count = len(req.image_urls)
+                placeholder = " ".join(["[图片]"] * image_count)
+                if req.prompt:
+                    req.prompt = f"{placeholder} {req.prompt}"
+                else:
+                    req.prompt = placeholder
                 req.image_urls = []
         if req.func_tool:
             provider_cfg = provider.provider_config.get("modalities", ["tool_use"])

--- a/astrbot/core/pipeline/waking_check/stage.py
+++ b/astrbot/core/pipeline/waking_check/stage.py
@@ -137,14 +137,11 @@ class WakingCheckStage(Stage):
                     event.is_at_or_wake_command = True
                     break
             # 检查是否是私聊
-            # 修复：私聊中即使没有文本内容（例如仅发送图片），也应该唤醒机器人
             if event.is_private_chat() and not self.friend_message_needs_wake_prefix:
-                # 检查是否有任何消息内容（文本或其他媒体）
-                if event.message_str or len(messages) > 0:
-                    is_wake = True
-                    event.is_wake = True
-                    event.is_at_or_wake_command = True
-                    wake_prefix = ""
+                is_wake = True
+                event.is_wake = True
+                event.is_at_or_wake_command = True
+                wake_prefix = ""
 
         # 检查插件的 handler filter
         activated_handlers = []


### PR DESCRIPTION
###Motivation / 动机
修复了私聊中单独发送图片时 bot 不会产生响应的问题。之前只有在发送"文字+图片"时才能触发响应，纯图片消息会被忽略。

### Modifications / 改动点
增加条件 if event.message_str or len(messages) > 0，确保有文本或媒体内容时才唤醒

新增 has_media_content 检查，识别消息链中的图片和文件，之前仅检查 message_str 是否为空，纯图片消息被跳过。修改后：即使 message_str 为空，只要包含媒体内容也允许继续处理。

在 _modalities_fix 方法中增强图片处理逻辑，之前，不支持视觉的模型直接清空 image_urls。修改后：将图片转换为 [图片] 占位符文本添加到 prompt 中


- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
<img width="2194" height="741" alt="image" src="https://github.com/user-attachments/assets/36c10f11-3772-4d91-a68d-89c1dd0cc54e" />
修复前
<img width="2193" height="499" alt="image" src="https://github.com/user-attachments/assets/26c99ffd-7744-4004-9213-7b0d6bc777b3" />
修复后


---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

确保仅包含媒体的私聊消息仍然可以唤醒机器人并被处理，并且在非视觉模型中通过将图片转换为文本占位符来保留图片上下文。

Bug Fixes:
- 允许仅包含图片或其他媒体的私聊消息触发机器人唤醒和处理，而不是被忽略。

Enhancements:
- 当所选服务提供方不支持图片输入时，将图片在提示中视为文本占位符“[图片]”，而不是在请求中悄悄丢弃这些图片。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure private chats containing only media still wake the bot and are processed, and preserve image context for non-vision models by converting images to textual placeholders.

Bug Fixes:
- Allow private chat messages that contain only images or other media to trigger bot wake and processing instead of being ignored.

Enhancements:
- Treat images as textual "[图片]" placeholders in prompts when the selected provider does not support image input, instead of silently dropping them from the request.

</details>