### PR TITLE
Sanitize invalid platform IDs on load and add UI validation

### DIFF
--- a/dashboard/src/components/platform/AddNewPlatform.vue
+++ b/dashboard/src/components/platform/AddNewPlatform.vue
@@ -421,6 +421,10 @@ export default {
         return false;
       }
 
+      if (!this.isPlatformIdValid(this.selectedPlatformConfig?.id)) {
+        return false;
+      }
+
       // 如果是使用现有配置文件模式
       if (this.aBConfigRadioVal === '0') {
         return !!this.selectedAbConfId;
@@ -637,6 +641,12 @@ export default {
         return;
       }
 
+      if (!this.isPlatformIdValid(id)) {
+        this.loading = false;
+        this.showError(this.tm('dialog.invalidPlatformId'));
+        return;
+      }
+
       try {
         // 更新平台配置
         let resp = await axios.post('/api/config/platform/update', {
@@ -662,6 +672,12 @@ export default {
       }
     },
     async savePlatform() {
+      if (!this.isPlatformIdValid(this.selectedPlatformConfig?.id)) {
+        this.loading = false;
+        this.showError(this.tm('dialog.invalidPlatformId'));
+        return;
+      }
+
       // 检查 ID 是否已存在
       const existingPlatform = this.config_data.platform?.find(p => p.id === this.selectedPlatformConfig.id);
       if (existingPlatform || this.selectedPlatformConfig.id === 'webchat') {
@@ -806,6 +822,13 @@ export default {
 
     showError(message) {
       this.$emit('show-toast', { message: message, type: 'error' });
+    },
+
+    isPlatformIdValid(id) {
+      if (!id) {
+        return false;
+      }
+      return !/[!:]/.test(id);
     },
 
     // 获取该平台适配器使用的所有配置文件（新版本：直接操作路由表）

--- a/dashboard/src/i18n/locales/en-US/features/platform.json
+++ b/dashboard/src/i18n/locales/en-US/features/platform.json
@@ -42,7 +42,8 @@
       "title": "Security Warning",
       "aiocqhttpTokenMissing": "To enhance connection security, it is strongly recommended to set ws_reverse_token. Not setting a token may lead to security risks.",
       "learnMore": "Learn More"
-    }
+    },
+    "invalidPlatformId": "Platform ID cannot contain ':' or '!'."
   },
   "messages": {
     "updateSuccess": "Update successful!",

--- a/dashboard/src/i18n/locales/zh-CN/features/platform.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/platform.json
@@ -42,7 +42,8 @@
       "title": "安全提醒",
       "aiocqhttpTokenMissing": "为了增强连接安全性，强烈建议您设置 ws_reverse_token。未设置 Token 可能导致安全风险。",
       "learnMore": "了解更多"
-    }
+    },
+    "invalidPlatformId": "平台 ID 不能包含 ':' 或 '!'。"
   },
   "messages": {
     "updateSuccess": "更新成功!",


### PR DESCRIPTION
### Motivation
- Prevent platform IDs containing reserved characters `:` and `!` which break UMO routing and session matching.
- Do not skip loading such platforms; instead sanitize IDs (replace reserved chars with `_`) and persist the corrected value so the issue does not recur.
- Provide fast feedback in the web UI to block creation/update of invalid IDs and show a clear localized message.

### Description
- Add `_sanitize_platform_id` and update `load_platform` in `astrbot/core/platform/manager.py` to replace `:`/`!` with `_`, call `save_config()` when a change is made, and log a warning.  
- Add `isPlatformIdValid` and validation checks in `dashboard/src/components/platform/AddNewPlatform.vue` to block saving/updating invalid IDs and display `tm('dialog.invalidPlatformId')`.  
- Add `dialog.invalidPlatformId` localization entries to `dashboard/src/i18n/locales/en-US/features/platform.json` and `dashboard/src/i18n/locales/zh-CN/features/platform.json`.  
- Preserve existing UI validation and adapter loading flow while ensuring sanitized IDs are persisted and used going forward.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964cf795c408324b09ce2b1bbde6d8c)

## Summary by Sourcery

在加载平台时清理无效的平台 ID，并在前端强制校验，防止创建或更新包含保留字符的平台 ID。

New Features:
- 在后端添加对平台 ID 的自动清理：将保留字符替换为安全的替代字符，并持久化修正后的配置。
- 在控制面板 UI 中引入客户端校验，对无效的平台 ID 进行拦截并显示本地化的错误消息。

Enhancements:
- 在平台 ID 被清理时记录警告日志，并在平台 ID 缺失或无效时跳过适配器加载。
- 扩展平台本地化文件，以包含无效平台 ID 错误的相关消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Sanitize invalid platform IDs during platform loading and enforce front-end validation to prevent creation or update of platforms with reserved characters in their IDs.

New Features:
- Add automatic sanitization of platform IDs in the backend to replace reserved characters with safe alternatives and persist the corrected configuration.
- Introduce client-side validation for platform IDs in the dashboard UI to block invalid IDs and display a localized error message.

Enhancements:
- Log warnings when platform IDs are sanitized and skip loading adapters when IDs are missing or invalid.
- Extend platform localization files to include messages for invalid platform ID errors.

</details>