### PR TITLE
fix:exclude disabled commands from platform command registration

### DIFF
--- a/astrbot/core/platform/sources/discord/discord_platform_adapter.py
+++ b/astrbot/core/platform/sources/discord/discord_platform_adapter.py
@@ -370,6 +370,8 @@ class DiscordPlatformAdapter(Platform):
         for handler_md in star_handlers_registry:
             if not star_map[handler_md.handler_module_path].activated:
                 continue
+            if not handler_md.enabled:
+                continue
             for event_filter in handler_md.event_filters:
                 cmd_info = self._extract_command_info(event_filter, handler_md)
                 if not cmd_info:

--- a/astrbot/core/platform/sources/telegram/tg_adapter.py
+++ b/astrbot/core/platform/sources/telegram/tg_adapter.py
@@ -161,6 +161,8 @@ class TelegramPlatformAdapter(Platform):
             handler_metadata = handler_md
             if not star_map[handler_metadata.handler_module_path].activated:
                 continue
+            if not handler_metadata.enabled:
+                continue
             for event_filter in handler_metadata.event_filters:
                 cmd_info = self._extract_command_info(
                     event_filter,


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
Fixes a bug where disabled commands from enabled plugins were still being registered and displayed in Telegram and Discord command lists.

 Previously, both platform adapters only checked plugin-level activation status (`star_map[...].activated`) when collecting commands for registration. This meant that if a plugin was enabled but specific commands within that plugin were disabled (via `handler_metadata.enabled = False`), those disabled commands would still appear in the platform's command menu, confusing users when the commands didn't work.
### Modifications / 改动点
**Core files modified / 修改的核心文件：**
  - `astrbot/core/platform/sources/telegram/tg_adapter.py`
  - `astrbot/core/platform/sources/discord/discord_platform_adapter.py`

**Changes / 具体改动：**
  1. **Telegram Adapter** (`tg_adapter.py:164-165`):
     - Added `handler_metadata.enabled` check in `collect_commands()` method
     - Now filters out disabled commands before adding them to the registration list
  2. **Discord Adapter** (`discord_platform_adapter.py:373-374`):
     - Added `handler_md.enabled` check in `_collect_and_register_commands()` method
     - Now filters out disabled commands before creating slash commands
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## 由 Sourcery 提供的摘要

在 Telegram 和 Discord 的平台命令注册中排除已禁用的插件命令。

Bug 修复：
- 停止在 Telegram 命令菜单中注册和显示已启用插件中被禁用的命令。
- 防止已启用插件中被禁用的命令暴露为 Discord 斜杠命令（slash commands）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Exclude disabled plugin commands from platform command registration for Telegram and Discord.

Bug Fixes:
- Stop registering and displaying disabled commands from enabled plugins in Telegram command menus.
- Prevent disabled commands from enabled plugins from being exposed as Discord slash commands.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在 Telegram 和 Discord 的平台命令注册中排除已禁用的插件命令。

Bug 修复：
- 停止在 Telegram 命令菜单中注册和显示已启用插件中被禁用的命令。
- 防止已启用插件中被禁用的命令暴露为 Discord 斜杠命令（slash commands）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Exclude disabled plugin commands from platform command registration for Telegram and Discord.

Bug Fixes:
- Stop registering and displaying disabled commands from enabled plugins in Telegram command menus.
- Prevent disabled commands from enabled plugins from being exposed as Discord slash commands.

</details>

</details>