### PR TITLE
fix: flatten assistant content for openai payload

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -371,12 +371,21 @@ class ProviderOpenAIOfficial(Provider):
             ):
                 reasoning_content = ""
                 new_content = []  # not including think part
+                text_parts = []
+                has_non_text = False
                 for part in message["content"]:
                     if part.get("type") == "think":
                         reasoning_content += str(part.get("think"))
                     else:
                         new_content.append(part)
-                message["content"] = new_content
+                        if part.get("type") == "text":
+                            text_parts.append(str(part.get("text", "")))
+                        else:
+                            has_non_text = True
+                if not has_non_text:
+                    message["content"] = "".join(text_parts)
+                else:
+                    message["content"] = new_content
                 # reasoning key is "reasoning_content"
                 if reasoning_content:
                     message["reasoning_content"] = reasoning_content


### PR DESCRIPTION
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
修复 openai 兼容提供商在 assistant content 为数组时导致的上下文丢失问题（下游 OpenAI→Gemini 转换会忽略数组内容，导致复读）。

### Modifications / 改动点
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

- 在 `astrbot/core/provider/sources/openai_source.py` 的 `_finally_convert_payload` 中，
  当 assistant 的 content 为 list 且仅包含 text（剔除 think 后）时，合并为 string；
  若存在非 text 内容，则保留 list（多模态兼容）。

### Screenshots or Test Results / 运行截图或测试结果
复现步骤（修复前）：
1) openai_chat_completion 提供商指向 OpenAI 兼容网关（如 CLIProxyAPI）
2) 连续输入 A/B/C
3) B 回复重复 A，C 回复重复 A+B

修复后：assistant 历史保留，B/C 不再复读。

---

### Checklist / 检查清单
- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [ ] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [ ] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [ ] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

错误修复：
- 修复当助手内容为数组时导致助手上下文丢失的问题：通过将纯文本部分扁平化为单个字符串，同时保留非文本部分，以保持多模态兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix loss of assistant context when assistant content is an array by flattening pure-text parts into a single string while retaining non-text parts for multimodal compatibility.

</details>