### PR TITLE
feat: add confirmation dialog for update all plugins button to preven…

### DIFF
--- a/dashboard/src/i18n/locales/en-US/features/extension.json
+++ b/dashboard/src/i18n/locales/en-US/features/extension.json
@@ -151,6 +151,11 @@
       "title": "No New Version Detected",
       "message": "No new version detected for this plugin. Do you want to force reinstall? This will pull the latest code from the remote repository.",
       "confirm": "Force Update"
+    },
+    "updateAllConfirm": {
+      "title": "Confirm Update All Plugins",
+      "message": "Are you sure you want to update all {count} plugins? This operation may take some time.",
+      "confirm": "Confirm Update"
     }
   },
   "messages": {

--- a/dashboard/src/i18n/locales/zh-CN/features/extension.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/extension.json
@@ -151,6 +151,11 @@
       "title": "未检测到新版本",
       "message": "当前插件未检测到新版本，是否强制重新安装？这将从远程仓库拉取最新代码。",
       "confirm": "强制更新"
+    },
+    "updateAllConfirm": {
+      "title": "确认更新全部插件",
+      "message": "确定要更新全部 {count} 个插件吗？此操作可能需要一些时间。",
+      "confirm": "确认更新"
     }
   },
   "messages": {

--- a/dashboard/src/views/ExtensionPage.vue
+++ b/dashboard/src/views/ExtensionPage.vue
@@ -92,6 +92,11 @@ const forceUpdateDialog = reactive({
   extensionName: "",
 });
 
+// 更新全部插件确认对话框
+const updateAllConfirmDialog = reactive({
+  show: false,
+});
+
 // 插件更新日志对话框（复用 ReadmeDialog）
 const changelogDialog = reactive({
   show: false,
@@ -471,6 +476,23 @@ const updateExtension = async (extension_name, forceUpdate = false) => {
 };
 
 // 确认强制更新
+// 显示更新全部插件确认对话框
+const showUpdateAllConfirm = () => {
+  if (updatableExtensions.value.length === 0) return;
+  updateAllConfirmDialog.show = true;
+};
+
+// 确认更新全部插件
+const confirmUpdateAll = () => {
+  updateAllConfirmDialog.show = false;
+  updateAllExtensions();
+};
+
+// 取消更新全部插件
+const cancelUpdateAll = () => {
+  updateAllConfirmDialog.show = false;
+};
+
 const confirmForceUpdate = () => {
   const name = forceUpdateDialog.extensionName;
   forceUpdateDialog.show = false;
@@ -1128,7 +1150,7 @@ watch(isListView, (newVal) => {
                   variant="tonal"
                   :disabled="updatableExtensions.length === 0"
                   :loading="updatingAll"
-                  @click="updateAllExtensions"
+                  @click="showUpdateAllConfirm"
                 >
                   <v-icon>mdi-update</v-icon>
                   {{ tm("buttons.updateAll") }}
@@ -2278,6 +2300,34 @@ watch(isListView, (newVal) => {
     v-model="showUninstallDialog"
     @confirm="handleUninstallConfirm"
   />
+
+  <!-- 更新全部插件确认对话框 -->
+  <v-dialog v-model="updateAllConfirmDialog.show" max-width="420">
+    <v-card class="rounded-lg">
+      <v-card-title class="d-flex align-center pa-4">
+        <v-icon color="warning" class="mr-2">mdi-update</v-icon>
+        {{ tm("dialogs.updateAllConfirm.title") }}
+      </v-card-title>
+      <v-card-text>
+        <p class="text-body-1">
+          {{ tm("dialogs.updateAllConfirm.message", { count: updatableExtensions.length }) }}
+        </p>
+      </v-card-text>
+      <v-card-actions class="pa-4">
+        <v-spacer></v-spacer>
+        <v-btn
+          variant="text"
+          @click="cancelUpdateAll"
+        >{{ tm("buttons.cancel") }}</v-btn>
+        <v-btn
+          color="warning"
+          variant="flat"
+          @click="confirmUpdateAll"
+        >{{ tm("dialogs.updateAllConfirm.confirm") }}</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+
 
   <!-- 指令冲突提示对话框 -->
   <v-dialog v-model="conflictDialog.show" max-width="420">


### PR DESCRIPTION
…t accidental clicks #4300

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
修复了[issue #4300 ](https://github.com/AstrBotDevs/AstrBot/issues/4300)  添加了更新所有插件二次确认

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- **[dashboard/src/views/ExtensionPage.vue](cci:7://file:///D:/Github/AstrBot/dashboard/src/views/ExtensionPage.vue:0:0-0:0)**: 添加确认对话框变量、方法和模板，修改按钮点击事件
- **[dashboard/src/i18n/locales/zh-CN/features/extension.json](cci:7://file:///D:/Github/AstrBot/dashboard/src/i18n/locales/zh-CN/features/extension.json:0:0-0:0)**: 添加中文国际化文本
- **[dashboard/src/i18n/locales/en-US/features/extension.json](cci:7://file:///D:/Github/AstrBot/dashboard/src/i18n/locales/en-US/features/extension.json:0:0-0:0)**: 添加英文国际化文本

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行"验证步骤"的证据，证明此改动有效。-->

点击"更新全部插件"按钮后弹出确认对话框，可选择取消或确认更新。

<img width="2069" height="1138" alt="屏幕截图 2026-01-24 151336" src="https://github.com/user-attachments/assets/9214c883-f569-4756-af57-5502273b2084" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

在扩展仪表盘中，在触发“更新所有插件”操作之前添加确认对话框。

新功能:
- 在扩展页面更新所有插件之前，加入会弹出的确认对话框。

增强改进:
- 将全局插件更新按钮接入新的确认流程，以防止误触发批量更新。
- 为新的“全部更新”确认对话框新增本地化文案，支持英文和中文。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a confirmation dialog before triggering the "update all plugins" action on the extensions dashboard.

New Features:
- Introduce a confirmation dialog that appears before updating all plugins from the extensions page.

Enhancements:
- Wire the global plugins update button to the new confirmation flow to prevent accidental bulk updates.
- Add localized text entries for the new update-all confirmation dialog in both English and Chinese.

</details>

## Summary by Sourcery

在扩展页触发「更新所有插件」操作前新增确认流程，以防止意外批量更新。

新功能：
- 引入确认对话框，在从扩展页更新所有插件之前弹出。

增强优化：
- 将全局「更新所有插件」按钮连接到新的确认对话框流程，而不是立即执行更新。
- 为更新全部的确认对话框新增本地化文本条目，支持英文和中文。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a confirmation flow before triggering the "update all plugins" action on the extensions page to prevent accidental bulk updates.

New Features:
- Introduce a confirmation dialog that appears before updating all plugins from the extensions page.

Enhancements:
- Wire the global "update all plugins" button to the new confirmation dialog flow instead of updating immediately.
- Add localized text entries for the update-all confirmation dialog in both English and Chinese.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在扩展页触发「更新所有插件」操作前新增确认流程，以防止意外批量更新。

新功能：
- 引入确认对话框，在从扩展页更新所有插件之前弹出。

增强优化：
- 将全局「更新所有插件」按钮连接到新的确认对话框流程，而不是立即执行更新。
- 为更新全部的确认对话框新增本地化文本条目，支持英文和中文。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a confirmation flow before triggering the "update all plugins" action on the extensions page to prevent accidental bulk updates.

New Features:
- Introduce a confirmation dialog that appears before updating all plugins from the extensions page.

Enhancements:
- Wire the global "update all plugins" button to the new confirmation dialog flow instead of updating immediately.
- Add localized text entries for the update-all confirmation dialog in both English and Chinese.

</details>

</details>