### PR TITLE
feat: add debug logging for final messages

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 import time
 import traceback
@@ -112,6 +113,19 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 Message(role="system", content=request.system_prompt),
             )
         self.run_context.messages = messages
+
+        # ========== DEBUG: dump final messages sent to LLM ==========
+        # 打印最终发给 LLM 的完整 messages 列表
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("===== [LLM Request Messages] =====")
+            for idx, msg in enumerate(messages):
+                role = msg.role if hasattr(msg, "role") else msg.get("role", "?")
+                content = (
+                    msg.content if hasattr(msg, "content") else msg.get("content", "")
+                )
+                logger.debug(f"  [{idx}] {role}: {content}")
+            logger.debug("===== [End LLM Request Messages] =====")
+        # =============================================================
 
         self.stats = AgentStats()
         self.stats.start_time = time.time()


### PR DESCRIPTION
### Motivation / 动机

添加调试功能：在 DEBUG 日志级别下，打印发送给 LLM 的完整 messages 列表，便于开发者排查 LLM 请求相关问题。

### Modifications / 改动点

- 修改 `astrbot/core/agent/runners/tool_loop_agent_runner.py`：
  - 新增 `import logging` 导入
  - 在调用 LLM 前添加 DEBUG 级别的日志输出，打印完整的 messages 列表（包括每条消息的索引、角色和内容）

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果
<img width="1180" height="874" alt="ba0aa2a369be802945d06f71fe3964f9" src="https://github.com/user-attachments/assets/e3648ea9-f79e-436d-bc9c-692068682790" />
---

### Checklist / 检查清单

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。
- [x] 🤓 我确保没有引入新依赖库。（`logging` 是 Python 标准库，无需额外安装）
- [x] 😮 我的更改没有引入恶意代码。