### PR TITLE
feat: enhance long-term memory with structured chat records

### DIFF
--- a/astrbot/builtin_stars/astrbot/long_term_memory.py
+++ b/astrbot/builtin_stars/astrbot/long_term_memory.py
@@ -27,6 +27,7 @@ class ChatRecord:
     created_at: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
     """创建时间（ISO 格式），用于调试/扩展"""
 
+
 def _get_event_msg_id(event: AstrMessageEvent) -> str:
     """
     获取当前事件对应的消息 ID。


### PR DESCRIPTION
Fixes #4427：启用长期记忆后，同一条“当前用户消息”会同时出现在 system（历史）与 user（当前输入）中，导致一次请求内重复注入，影响模型理解且占用 token 。

### Modifications / 改动点

<!--核心改动位于 `astrbot/builtin_stars/astrbot/long_term_memory.py`：将群聊历史从纯字符串列表升级为结构化记录，并在拼接 system 历史时按 message_id 精准排除当前轮消息，避免“按文本去重”带来的误删风险（例如连续发送相同内容）。同时保持原有 active reply 行为与 max_cnt 截断逻辑。-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

- **`astrbot/builtin_stars/astrbot/long_term_memory.py`**
  - **结构化存储**：引入 `ChatRecord(msg_id/role/text/created_at)`，`session_chats` 存储为 `ChatRecord` 列表。
  - **稳定标识**：新增 `_get_event_msg_id()`，优先使用 `event.message_obj.message_id`，缺失时使用 `event.extra` 缓存生成的 ID，保证同一事件链路一致。
  - **精准过滤**：`on_req_llm()` 构造聊天历史时，过滤 `msg_id == current_msg_id` 的记录，确保当前轮消息只作为 user prompt 发送，不再被重复写入 system 历史。
  - **兼容保留**：保留原有 `max_cnt` 截断、图片描述（可选）与 active reply 分支逻辑。

### Screenshots or Test Results / 运行截图或测试结果

<img width="1753" height="846" alt="66c32e87980a84440f89c67fa59a86b9" src="https://github.com/user-attachments/assets/ec67fec4-4c71-4306-89e7-8c81512edf65" />

---

### Checklist / 检查清单

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

为长期聊天记忆记录建立结构化格式，以避免在单次 LLM 请求中将当前消息同时重复出现在历史记录和用户提示中。

Bug Fixes:
- 通过基于稳定的消息 ID 将当前用户消息从长期记忆历史中排除，防止其在单次请求中被注入两次。

Enhancements:
- 将长期聊天历史存储为结构化的 ChatRecord 条目，包含稳定的消息 ID、角色和时间戳，以支持精确过滤和未来的可扩展性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Structure long-term chat memory records to avoid duplicating the current message in both history and user prompt within a single LLM request.

Bug Fixes:
- Prevent the current user message from being injected twice in a single request by excluding it from the long-term memory history based on a stable message ID.

Enhancements:
- Store long-term chat history as structured ChatRecord entries with stable message IDs, roles, and timestamps to support precise filtering and future extensibility.

</details>