### PR TITLE
fix: repetition tool calls in gemini models

### DIFF
--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -382,22 +382,14 @@ class ProviderGoogleGenAI(Provider):
                     append_or_extend(gemini_contents, parts, types.ModelContent)
 
             elif role == "tool" and not native_tool_enabled:
-                # 1. 尝试获取真实的函数名称 (AstrBot/OpenAI 格式的消息通常包含 name)
-                # 如果 message 中没有 name，则回退使用 tool_call_id，便于在日志中追踪来源
                 func_name = message.get("name", message["tool_call_id"])
-
-                # 2. 创建 Part，注意 name 参数必须是函数名
                 part = types.Part.from_function_response(
                     name=func_name,
                     response={
-                        "name": func_name,  # 这里也需要是函数名
+                        "name": func_name,
                         "content": message["content"],
                     },
                 )
-
-                # 3. 【核心修复】显式注入 id
-                # Gemini SDK 的 from_function_response 可能不接受 id 参数
-                # 我们需要手动赋值，确保 Gemini 知道这个结果属于哪个调用 ID
                 if part.function_response:
                     part.function_response.id = message["tool_call_id"]
 


### PR DESCRIPTION

---

### Modifications / 改动点

**修复了 `ProviderGoogleGenAI` (Gemini) 适配器中导致工具调用无限循环的 Bug。**

在构建 `role == "tool"` 的历史消息时，原代码错误地将 `tool_call_id` 当作了函数 `name` 传入，且没有显式绑定 `id` 到 `function_response` 中。这导致 Gemini API 无法正确识别工具执行结果，从而让模型认为任务未完成并陷入死循环。

**主要修改 (`astrbot/core/provider/sources/gemini_source.py`):**

1. **修正函数名映射**：在 `types.Part.from_function_response` 中使用真实的函数名 (`message.get("name")`)，而不是 ID。
2. **显式绑定 ID**：手动赋值 `part.function_response.id = message["tool_call_id"]`，确保工具返回结果能正确匹配到对应的调用请求。

* [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

**Before Fix / 修复前:**
(日志显示模型不断重复调用 `chip_build`，无法识别工具返回结果，陷入死循环。)
<img width="752" height="568" alt="image" src="https://github.com/user-attachments/assets/7739d696-6d2b-4c94-ae40-c3555003f825" />

**After Fix / 修复后:**
<img width="765" height="553" alt="image" src="https://github.com/user-attachments/assets/6b0e7599-b300-4a4a-b9ad-dc807d977591" />

(Gemini 正确识别了工具执行结果，并成功输出了最终总结文本，跳出了循环。)

### Checklist / 检查清单

* [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. (Bug fix usually doesn't need this / 修复 Bug 通常不需要此项，可以不勾)
* [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
* [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
* [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.