### PR TITLE
feat: split config into providers.json and platforms.json

### DIFF
--- a/astrbot/core/backup/exporter.py
+++ b/astrbot/core/backup/exporter.py
@@ -157,14 +157,37 @@ class AstrBotExporter:
                             "kb_documents", total_kbs, total_kbs, "知识库文档导出完成"
                         )
 
-                # 3. 导出配置文件
+                # 3. 导出配置文件（包括拆分的配置文件）
                 if progress_callback:
                     await progress_callback("config", 0, 100, "正在导出配置文件...")
+
+                # 导出核心配置文件
                 if os.path.exists(self.config_path):
                     with open(self.config_path, encoding="utf-8") as f:
                         config_content = f.read()
                     zf.writestr("config/cmd_config.json", config_content)
                     self._add_checksum("config/cmd_config.json", config_content)
+
+                # 导出供应商配置文件
+                providers_config_path = os.path.join(
+                    get_astrbot_data_path(), "providers.json"
+                )
+                if os.path.exists(providers_config_path):
+                    with open(providers_config_path, encoding="utf-8") as f:
+                        providers_content = f.read()
+                    zf.writestr("config/providers.json", providers_content)
+                    self._add_checksum("config/providers.json", providers_content)
+
+                # 导出平台配置文件
+                platforms_config_path = os.path.join(
+                    get_astrbot_data_path(), "platforms.json"
+                )
+                if os.path.exists(platforms_config_path):
+                    with open(platforms_config_path, encoding="utf-8") as f:
+                        platforms_content = f.read()
+                    zf.writestr("config/platforms.json", platforms_content)
+                    self._add_checksum("config/platforms.json", platforms_content)
+
                 if progress_callback:
                     await progress_callback("config", 100, 100, "配置文件导出完成")
 

--- a/astrbot/core/backup/importer.py
+++ b/astrbot/core/backup/importer.py
@@ -368,10 +368,14 @@ class AstrBotImporter:
                     if progress_callback:
                         await progress_callback("kb", 100, 100, "知识库导入完成")
 
-                # 4. 导入配置文件
+                # 4. 导入配置文件（包括拆分的配置文件）
                 if progress_callback:
                     await progress_callback("config", 0, 100, "正在导入配置文件...")
 
+                config_count = 0
+                data_path = get_astrbot_data_path()
+
+                # 导入核心配置文件
                 if "config/cmd_config.json" in zf.namelist():
                     try:
                         config_content = zf.read("config/cmd_config.json")
@@ -382,9 +386,39 @@ class AstrBotImporter:
 
                         with open(self.config_path, "wb") as f:
                             f.write(config_content)
-                        result.imported_files["config"] = 1
+                        config_count += 1
                     except Exception as e:
-                        result.add_warning(f"导入配置文件失败: {e}")
+                        result.add_warning(f"导入核心配置文件失败: {e}")
+
+                # 导入供应商配置文件
+                if "config/providers.json" in zf.namelist():
+                    try:
+                        providers_path = os.path.join(data_path, "providers.json")
+                        providers_content = zf.read("config/providers.json")
+                        # 备份现有配置
+                        if os.path.exists(providers_path):
+                            shutil.copy2(providers_path, f"{providers_path}.bak")
+                        with open(providers_path, "wb") as f:
+                            f.write(providers_content)
+                        config_count += 1
+                    except Exception as e:
+                        result.add_warning(f"导入供应商配置文件失败: {e}")
+
+                # 导入平台配置文件
+                if "config/platforms.json" in zf.namelist():
+                    try:
+                        platforms_path = os.path.join(data_path, "platforms.json")
+                        platforms_content = zf.read("config/platforms.json")
+                        # 备份现有配置
+                        if os.path.exists(platforms_path):
+                            shutil.copy2(platforms_path, f"{platforms_path}.bak")
+                        with open(platforms_path, "wb") as f:
+                            f.write(platforms_content)
+                        config_count += 1
+                    except Exception as e:
+                        result.add_warning(f"导入平台配置文件失败: {e}")
+
+                result.imported_files["config"] = config_count
 
                 if progress_callback:
                     await progress_callback("config", 100, 100, "配置文件导入完成")

--- a/astrbot/core/config/config_migration.py
+++ b/astrbot/core/config/config_migration.py
@@ -1,0 +1,199 @@
+"""配置文件迁移工具 - 将旧的单一配置拆分为多个独立配置文件"""
+
+import json
+import logging
+import os
+
+from astrbot.core.utils.astrbot_path import get_astrbot_data_path
+
+from .platforms_default import PLATFORMS_CONFIG_KEYS, PLATFORMS_DEFAULT_CONFIG
+from .providers_default import PROVIDERS_CONFIG_KEYS, PROVIDERS_DEFAULT_CONFIG
+
+logger = logging.getLogger("astrbot")
+
+# 配置文件路径
+DATA_PATH = get_astrbot_data_path()
+CORE_CONFIG_PATH = os.path.join(DATA_PATH, "cmd_config.json")
+PROVIDERS_CONFIG_PATH = os.path.join(DATA_PATH, "providers.json")
+PLATFORMS_CONFIG_PATH = os.path.join(DATA_PATH, "platforms.json")
+
+
+def load_json_file(path: str) -> dict | None:
+    """安全加载 JSON 文件"""
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, encoding="utf-8-sig") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        logger.error(f"加载配置文件失败 {path}: {e}")
+        return None
+
+
+def save_json_file(path: str, data: dict) -> bool:
+    """保存 JSON 文件"""
+    try:
+        with open(path, "w", encoding="utf-8-sig") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+        return True
+    except OSError as e:
+        logger.error(f"保存配置文件失败 {path}: {e}")
+        return False
+
+
+def extract_config_keys(source: dict, keys: list[str]) -> dict:
+    """从源配置中提取指定的键"""
+    extracted = {}
+    for key in keys:
+        if key in source:
+            extracted[key] = source[key]
+    return extracted
+
+
+def remove_config_keys(source: dict, keys: list[str]) -> dict:
+    """从源配置中移除指定的键（返回副本）"""
+    result = source.copy()
+    for key in keys:
+        result.pop(key, None)
+    return result
+
+
+def needs_migration() -> bool:
+    """检查是否需要配置迁移
+
+    如果核心配置存在且包含供应商/平台配置键，且独立配置文件不存在，则需要迁移。
+    """
+    if not os.path.exists(CORE_CONFIG_PATH):
+        return False
+
+    # 如果独立配置文件都存在，无需迁移
+    if os.path.exists(PROVIDERS_CONFIG_PATH) and os.path.exists(PLATFORMS_CONFIG_PATH):
+        return False
+
+    # 检查核心配置是否包含需要迁移的键
+    core_config = load_json_file(CORE_CONFIG_PATH)
+    if core_config is None:
+        return False
+
+    has_provider_keys = any(key in core_config for key in PROVIDERS_CONFIG_KEYS)
+    has_platform_keys = any(key in core_config for key in PLATFORMS_CONFIG_KEYS)
+
+    return has_provider_keys or has_platform_keys
+
+
+def migrate_config() -> tuple[bool, str]:
+    """执行配置迁移
+
+    Returns:
+        (success: bool, message: str)
+    """
+    logger.info("开始配置迁移...")
+
+    core_config = load_json_file(CORE_CONFIG_PATH)
+    if core_config is None:
+        return False, "无法加载核心配置文件"
+
+    # 如果供应商配置文件不存在，提取并创建
+    if not os.path.exists(PROVIDERS_CONFIG_PATH):
+        providers_config = extract_config_keys(core_config, PROVIDERS_CONFIG_KEYS)
+        if providers_config:
+            if save_json_file(PROVIDERS_CONFIG_PATH, providers_config):
+                logger.info(f"已创建供应商配置文件: {PROVIDERS_CONFIG_PATH}")
+            else:
+                return False, "无法创建供应商配置文件"
+        else:
+            # 如果没有供应商配置，使用默认值创建
+            if not save_json_file(PROVIDERS_CONFIG_PATH, PROVIDERS_DEFAULT_CONFIG):
+                return False, "无法创建默认供应商配置文件"
+            logger.info(f"已使用默认值创建供应商配置文件: {PROVIDERS_CONFIG_PATH}")
+
+    # 如果平台配置文件不存在，提取并创建
+    if not os.path.exists(PLATFORMS_CONFIG_PATH):
+        platforms_config = extract_config_keys(core_config, PLATFORMS_CONFIG_KEYS)
+        if platforms_config:
+            if save_json_file(PLATFORMS_CONFIG_PATH, platforms_config):
+                logger.info(f"已创建平台配置文件: {PLATFORMS_CONFIG_PATH}")
+            else:
+                return False, "无法创建平台配置文件"
+        else:
+            # 如果没有平台配置，使用默认值创建
+            if not save_json_file(PLATFORMS_CONFIG_PATH, PLATFORMS_DEFAULT_CONFIG):
+                return False, "无法创建默认平台配置文件"
+            logger.info(f"已使用默认值创建平台配置文件: {PLATFORMS_CONFIG_PATH}")
+
+    # 从核心配置中移除已迁移的键
+    keys_to_remove = PROVIDERS_CONFIG_KEYS + PLATFORMS_CONFIG_KEYS
+    updated_core = remove_config_keys(core_config, keys_to_remove)
+
+    if len(updated_core) != len(core_config):
+        if save_json_file(CORE_CONFIG_PATH, updated_core):
+            removed_count = len(core_config) - len(updated_core)
+            logger.info(f"已从核心配置中移除 {removed_count} 个已迁移的配置项")
+        else:
+            return False, "无法更新核心配置文件"
+
+    logger.info("配置迁移完成")
+    return True, "配置迁移成功"
+
+
+def get_merged_config(core_conf: dict | None = None) -> dict:
+    """获取合并后的完整配置
+
+    Args:
+        core_conf: 可选的核心配置字典。如果未提供，将从文件加载。
+
+    Returns:
+        合并后的完整配置字典
+    """
+    merged = {}
+
+    # 加载核心配置
+    if core_conf is not None:
+        merged.update(core_conf)
+    else:
+        loaded_core = load_json_file(CORE_CONFIG_PATH)
+        if loaded_core:
+            merged.update(loaded_core)
+
+    # 加载供应商配置
+    providers_config = load_json_file(PROVIDERS_CONFIG_PATH)
+    if providers_config:
+        merged.update(providers_config)
+
+    # 加载平台配置
+    platforms_config = load_json_file(PLATFORMS_CONFIG_PATH)
+    if platforms_config:
+        merged.update(platforms_config)
+
+    return merged
+
+
+def save_config_by_category(full_config: dict) -> bool:
+    """将完整配置按类别保存到对应文件
+
+    Args:
+        full_config: 包含所有配置的完整字典
+
+    Returns:
+        是否保存成功
+    """
+    # 提取供应商配置
+    providers_config = extract_config_keys(full_config, PROVIDERS_CONFIG_KEYS)
+    if providers_config:
+        if not save_json_file(PROVIDERS_CONFIG_PATH, providers_config):
+            return False
+
+    # 提取平台配置
+    platforms_config = extract_config_keys(full_config, PLATFORMS_CONFIG_KEYS)
+    if platforms_config:
+        if not save_json_file(PLATFORMS_CONFIG_PATH, platforms_config):
+            return False
+
+    # 剩余的保存到核心配置
+    core_config = remove_config_keys(
+        full_config, PROVIDERS_CONFIG_KEYS + PLATFORMS_CONFIG_KEYS
+    )
+    if not save_json_file(CORE_CONFIG_PATH, core_config):
+        return False
+
+    return True

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -17,7 +17,90 @@ WEBHOOK_SUPPORTED_PLATFORMS = [
     "lark",
 ]
 
-# 默认配置
+# 核心配置默认值（不包含 provider 和 platform 相关配置）
+CORE_DEFAULT_CONFIG = {
+    "config_version": 2,
+    "platform_settings": {
+        "unique_session": False,
+        "rate_limit": {
+            "time": 60,
+            "count": 30,
+            "strategy": "stall",  # stall, discard
+        },
+        "reply_prefix": "",
+        "forward_threshold": 1500,
+        "enable_id_white_list": True,
+        "id_whitelist": [],
+        "id_whitelist_log": True,
+        "wl_ignore_admin_on_group": True,
+        "wl_ignore_admin_on_friend": True,
+        "reply_with_mention": False,
+        "reply_with_quote": False,
+        "path_mapping": [],
+        "segmented_reply": {
+            "enable": False,
+            "only_llm_result": True,
+            "interval_method": "random",
+            "interval": "1.5,3.5",
+            "log_base": 2.6,
+            "words_count_threshold": 150,
+            "split_mode": "regex",  # regex 或 words
+            "regex": ".*?[。？！~…]+|.+$",
+            "split_words": [
+                "。",
+                "？",
+                "！",
+                "~",
+                "…",
+            ],  # 当 split_mode 为 words 时使用
+            "content_cleanup_rule": "",
+        },
+        "no_permission_reply": True,
+        "empty_mention_waiting": True,
+        "empty_mention_waiting_need_reply": True,
+        "friend_message_needs_wake_prefix": False,
+        "ignore_bot_self_message": False,
+        "ignore_at_all": False,
+    },
+    "content_safety": {
+        "also_use_in_response": False,
+        "internal_keywords": {"enable": True, "extra_keywords": []},
+        "baidu_aip": {"enable": False, "app_id": "", "api_key": "", "secret_key": ""},
+    },
+    "admins_id": ["astrbot"],
+    "t2i": False,
+    "t2i_word_threshold": 150,
+    "t2i_strategy": "remote",
+    "t2i_endpoint": "",
+    "t2i_use_file_service": False,
+    "t2i_active_template": "base",
+    "http_proxy": "",
+    "no_proxy": ["localhost", "127.0.0.1", "::1"],
+    "dashboard": {
+        "enable": True,
+        "username": "astrbot",
+        "password": "77b90590a8945a7d36c963981a307dc9",
+        "jwt_secret": "",
+        "host": "0.0.0.0",
+        "port": 6185,
+        "disable_access_log": True,
+    },
+    "wake_prefix": ["/"],
+    "log_level": "INFO",
+    "pip_install_arg": "",
+    "pypi_index_url": "https://mirrors.aliyun.com/pypi/simple/",
+    "timezone": "Asia/Shanghai",
+    "callback_api_base": "",
+    "default_kb_collection": "",  # 默认知识库名称, 已经过时
+    "plugin_set": ["*"],  # "*" 表示使用所有可用的插件, 空列表表示不使用任何插件
+    "kb_names": [],  # 默认知识库名称列表
+    "kb_fusion_top_k": 20,  # 知识库检索融合阶段返回结果数量
+    "kb_final_top_k": 5,  # 知识库检索最终返回结果数量
+    "kb_agentic_mode": False,
+    "disable_builtin_commands": False,
+}
+
+# 默认配置（合并所有配置，保持向后兼容）
 DEFAULT_CONFIG = {
     "config_version": 2,
     "platform_settings": {

--- a/astrbot/core/config/platforms_default.py
+++ b/astrbot/core/config/platforms_default.py
@@ -1,0 +1,23 @@
+"""平台适配器相关的默认配置"""
+
+# 平台默认配置
+PLATFORMS_DEFAULT_CONFIG = {
+    "platform": [],
+    "platform_specific": {
+        # 平台特异配置：按平台分类，平台下按功能分组
+        "lark": {
+            "pre_ack_emoji": {"enable": False, "emojis": ["Typing"]},
+        },
+        "telegram": {
+            "pre_ack_emoji": {"enable": False, "emojis": ["✍️"]},
+        },
+    },
+    "persona": [],  # deprecated
+}
+
+# 平台配置的键列表（用于迁移检测）
+PLATFORMS_CONFIG_KEYS = [
+    "platform",
+    "platform_specific",
+    "persona",
+]

--- a/astrbot/core/config/providers_default.py
+++ b/astrbot/core/config/providers_default.py
@@ -1,0 +1,100 @@
+"""供应商/Provider 相关的默认配置"""
+
+# 供应商默认配置
+PROVIDERS_DEFAULT_CONFIG = {
+    "provider_sources": [],  # provider sources
+    "provider": [],  # models from provider_sources
+    "provider_settings": {
+        "enable": True,
+        "default_provider_id": "",
+        "default_image_caption_provider_id": "",
+        "image_caption_prompt": "Please describe the image using Chinese.",
+        "provider_pool": ["*"],  # "*" 表示使用所有可用的提供者
+        "wake_prefix": "",
+        "web_search": False,
+        "websearch_provider": "default",
+        "websearch_tavily_key": [],
+        "websearch_baidu_app_builder_key": "",
+        "web_search_link": False,
+        "display_reasoning_text": False,
+        "identifier": False,
+        "group_name_display": False,
+        "datetime_system_prompt": True,
+        "default_personality": "default",
+        "persona_pool": ["*"],
+        "prompt_prefix": "{{prompt}}",
+        "context_limit_reached_strategy": "truncate_by_turns",  # or llm_compress
+        "llm_compress_instruction": (
+            "Based on our full conversation history, produce a concise summary of key takeaways and/or project progress.\n"
+            "1. Systematically cover all core topics discussed and the final conclusion/outcome for each; clearly highlight the latest primary focus.\n"
+            "2. If any tools were used, summarize tool usage (total call count) and extract the most valuable insights from tool outputs.\n"
+            "3. If there was an initial user goal, state it first and describe the current progress/status.\n"
+            "4. Write the summary in the user's language.\n"
+        ),
+        "llm_compress_keep_recent": 4,
+        "llm_compress_provider_id": "",
+        "max_context_length": -1,
+        "dequeue_context_length": 1,
+        "streaming_response": False,
+        "show_tool_use_status": False,
+        "sanitize_context_by_modalities": False,
+        "agent_runner_type": "local",
+        "dify_agent_runner_provider_id": "",
+        "coze_agent_runner_provider_id": "",
+        "dashscope_agent_runner_provider_id": "",
+        "unsupported_streaming_strategy": "realtime_segmenting",
+        "reachability_check": False,
+        "max_agent_step": 30,
+        "tool_call_timeout": 60,
+        "tool_schema_mode": "full",
+        "llm_safety_mode": True,
+        "safety_mode_strategy": "system_prompt",  # TODO: llm judge
+        "file_extract": {
+            "enable": False,
+            "provider": "moonshotai",
+            "moonshotai_api_key": "",
+        },
+        "sandbox": {
+            "enable": False,
+            "booter": "shipyard",
+            "shipyard_endpoint": "",
+            "shipyard_access_token": "",
+            "shipyard_ttl": 3600,
+            "shipyard_max_sessions": 10,
+        },
+        "skills": {"runtime": "sandbox"},
+    },
+    "provider_stt_settings": {
+        "enable": False,
+        "provider_id": "",
+    },
+    "provider_tts_settings": {
+        "enable": False,
+        "provider_id": "",
+        "dual_output": False,
+        "use_file_service": False,
+        "trigger_probability": 1.0,
+    },
+    "provider_ltm_settings": {
+        "group_icl_enable": False,
+        "group_message_max_cnt": 300,
+        "image_caption": False,
+        "image_caption_provider_id": "",
+        "active_reply": {
+            "enable": False,
+            "method": "possibility_reply",
+            "possibility_reply": 0.1,
+            "whitelist": [],
+        },
+    },
+}
+
+# 供应商配置的键列表（用于迁移检测）
+PROVIDERS_CONFIG_KEYS = [
+    "provider_sources",
+    "provider",
+    "provider_settings",
+    "provider_stt_settings",
+    "provider_tts_settings",
+    "provider_ltm_settings",
+]


### PR DESCRIPTION
# feat: split config into providers.json and platforms.json

- Create providers_default.py with LLM provider config defaults
- Create platforms_default.py with platform adapter config defaults
- Create config_migration.py for auto-migration from single file
- Update AstrBotConfig to load/save from multiple config files
- Update backup exporter/importer to handle new config files

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

根据 issue #4548 将单一的 `cmd_config.json` 配置文件拆分为模块化配置（`cmd_config.json`、`providers.json`、`platforms.json`），提高配置管理的可维护性。支持自动迁移，透明兼容现有功能。

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

**新增文件：**
- `astrbot/core/config/providers_default.py` - LLM 供应商配置默认值
- `astrbot/core/config/platforms_default.py` - 平台适配器配置默认值  
- `astrbot/core/config/config_migration.py` - 自动迁移工具

**修改文件：**
- `astrbot/core/config/astrbot_config.py` - 多文件加载/保存
- `astrbot/core/config/default.py` - 核心配置定义
- `astrbot/core/backup/exporter.py` - 导出新配置文件
- `astrbot/core/backup/importer.py` - 恢复新配置文件

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行"验证步骤"的证据，证明此改动有效。-->

```
========== test session starts ==========
159 passed, 2 warnings in 47.89s
```

```
Config loaded keys: 35
Has provider_settings: True
Has platform: True
Has dashboard: True
```

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

在保持向后兼容的同时，将配置拆分为核心（core）、提供方（provider）和平台（platform）配置文件，并支持从旧版单文件配置自动迁移。

新功能：
- 引入分别用于提供方和平台的独立默认配置文件，分别存储在 `providers.json` 和 `platforms.json` 中。
- 添加配置迁移工具，将旧版单文件配置拆分为模块化配置文件，并在加载时透明地合并。
- 允许在默认配置路径下，从多个按类别划分的文件中保存和加载主配置。
- 扩展备份导出和导入功能，将 `providers.json` 和 `platforms.json` 与核心配置文件一并包含在内。

增强：
- 重构核心默认配置，将与提供方和平台相关的设置移除并放入各自专用的默认配置中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Split configuration into core, provider, and platform files while preserving backward compatibility and supporting automatic migration from the legacy single-file config.

New Features:
- Introduce separate default configurations for providers and platforms stored in providers.json and platforms.json.
- Add a configuration migration utility to split legacy single-file configs into modular files and merge them transparently at load time.
- Allow the main configuration to be saved and loaded from multiple categorized files at the default config path.
- Extend backup export and import to include providers.json and platforms.json alongside the core config file.

Enhancements:
- Refactor core default configuration to exclude provider- and platform-specific settings and keep them in dedicated defaults.

</details>

新功能：
- 引入为提供方和平台分别设置的默认配置，分别存储在 `providers.json` 和 `platforms.json` 中。
- 添加配置迁移工具，用于将旧的单文件配置拆分为多个配置文件，并在加载时重新构建合并视图。
- 支持在默认配置路径下，从多个分类文件中保存和加载主配置。
- 扩展备份导出和导入功能，将新的 `providers.json` 和 `platforms.json` 与核心配置文件一起包含在内。

增强改进：
- 优化核心默认配置，将与提供方和平台相关的设置移除，放入各自专用的默认配置中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保持向后兼容的同时，将配置拆分为核心（core）、提供方（provider）和平台（platform）配置文件，并支持从旧版单文件配置自动迁移。

新功能：
- 引入分别用于提供方和平台的独立默认配置文件，分别存储在 `providers.json` 和 `platforms.json` 中。
- 添加配置迁移工具，将旧版单文件配置拆分为模块化配置文件，并在加载时透明地合并。
- 允许在默认配置路径下，从多个按类别划分的文件中保存和加载主配置。
- 扩展备份导出和导入功能，将 `providers.json` 和 `platforms.json` 与核心配置文件一并包含在内。

增强：
- 重构核心默认配置，将与提供方和平台相关的设置移除并放入各自专用的默认配置中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Split configuration into core, provider, and platform files while preserving backward compatibility and supporting automatic migration from the legacy single-file config.

New Features:
- Introduce separate default configurations for providers and platforms stored in providers.json and platforms.json.
- Add a configuration migration utility to split legacy single-file configs into modular files and merge them transparently at load time.
- Allow the main configuration to be saved and loaded from multiple categorized files at the default config path.
- Extend backup export and import to include providers.json and platforms.json alongside the core config file.

Enhancements:
- Refactor core default configuration to exclude provider- and platform-specific settings and keep them in dedicated defaults.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保持向后兼容的同时，将配置拆分为核心（core）、提供方（provider）和平台（platform）配置文件，并支持从旧版单文件配置自动迁移。

新功能：
- 引入分别用于提供方和平台的独立默认配置文件，分别存储在 `providers.json` 和 `platforms.json` 中。
- 添加配置迁移工具，将旧版单文件配置拆分为模块化配置文件，并在加载时透明地合并。
- 允许在默认配置路径下，从多个按类别划分的文件中保存和加载主配置。
- 扩展备份导出和导入功能，将 `providers.json` 和 `platforms.json` 与核心配置文件一并包含在内。

增强：
- 重构核心默认配置，将与提供方和平台相关的设置移除并放入各自专用的默认配置中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Split configuration into core, provider, and platform files while preserving backward compatibility and supporting automatic migration from the legacy single-file config.

New Features:
- Introduce separate default configurations for providers and platforms stored in providers.json and platforms.json.
- Add a configuration migration utility to split legacy single-file configs into modular files and merge them transparently at load time.
- Allow the main configuration to be saved and loaded from multiple categorized files at the default config path.
- Extend backup export and import to include providers.json and platforms.json alongside the core config file.

Enhancements:
- Refactor core default configuration to exclude provider- and platform-specific settings and keep them in dedicated defaults.

</details>

新功能：
- 引入为提供方和平台分别设置的默认配置，分别存储在 `providers.json` 和 `platforms.json` 中。
- 添加配置迁移工具，用于将旧的单文件配置拆分为多个配置文件，并在加载时重新构建合并视图。
- 支持在默认配置路径下，从多个分类文件中保存和加载主配置。
- 扩展备份导出和导入功能，将新的 `providers.json` 和 `platforms.json` 与核心配置文件一起包含在内。

增强改进：
- 优化核心默认配置，将与提供方和平台相关的设置移除，放入各自专用的默认配置中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保持向后兼容的同时，将配置拆分为核心（core）、提供方（provider）和平台（platform）配置文件，并支持从旧版单文件配置自动迁移。

新功能：
- 引入分别用于提供方和平台的独立默认配置文件，分别存储在 `providers.json` 和 `platforms.json` 中。
- 添加配置迁移工具，将旧版单文件配置拆分为模块化配置文件，并在加载时透明地合并。
- 允许在默认配置路径下，从多个按类别划分的文件中保存和加载主配置。
- 扩展备份导出和导入功能，将 `providers.json` 和 `platforms.json` 与核心配置文件一并包含在内。

增强：
- 重构核心默认配置，将与提供方和平台相关的设置移除并放入各自专用的默认配置中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Split configuration into core, provider, and platform files while preserving backward compatibility and supporting automatic migration from the legacy single-file config.

New Features:
- Introduce separate default configurations for providers and platforms stored in providers.json and platforms.json.
- Add a configuration migration utility to split legacy single-file configs into modular files and merge them transparently at load time.
- Allow the main configuration to be saved and loaded from multiple categorized files at the default config path.
- Extend backup export and import to include providers.json and platforms.json alongside the core config file.

Enhancements:
- Refactor core default configuration to exclude provider- and platform-specific settings and keep them in dedicated defaults.

</details>

</details>

</details>