### PR TITLE
fix: Fixed a bug where the front end still displayed a success messag…

### DIFF
--- a/dashboard/src/components/extension/SkillsSection.vue
+++ b/dashboard/src/components/extension/SkillsSection.vue
@@ -118,6 +118,16 @@ export default {
       }
     };
 
+    const handleApiResponse = (res, successMessage, failureMessageDefault, onSuccess) => {
+      if (res && res.data && res.data.status === "ok") {
+        showMessage(successMessage, "success");
+        if (onSuccess) onSuccess();
+      } else {
+        const msg = (res && res.data && res.data.message) || failureMessageDefault;
+        showMessage(msg, "error");
+      }
+    };
+
     const uploadSkill = async () => {
       if (!uploadFile.value) return;
       uploading.value = true;
@@ -134,14 +144,16 @@ export default {
         const res = await axios.post("/api/skills/upload", formData, {
           headers: { "Content-Type": "multipart/form-data" },
         });
-        if (res.data.status === "ok") {
-          showMessage(tm("skills.uploadSuccess"), "success");
-          uploadDialog.value = false;
-          uploadFile.value = null;
-          await fetchSkills();
-        } else {
-          showMessage(res.data.message || tm("skills.uploadFailed"), "error");
-        }
+        handleApiResponse(
+          res,
+          tm("skills.uploadSuccess"),
+          tm("skills.uploadFailed"),
+          async () => {
+            uploadDialog.value = false;
+            uploadFile.value = null;
+            await fetchSkills();
+          }
+        );
       } catch (err) {
         showMessage(tm("skills.uploadFailed"), "error");
       } finally {
@@ -157,12 +169,14 @@ export default {
           name: skill.name,
           active: nextActive,
         });
-        if (res.data.status === "ok") {
-          skill.active = nextActive;
-          showMessage(tm("skills.updateSuccess"), "success");
-        } else {
-          showMessage(res.data.message || tm("skills.updateFailed"), "error");
-        }
+        handleApiResponse(
+          res,
+          tm("skills.updateSuccess"),
+          tm("skills.updateFailed"),
+          () => {
+            skill.active = nextActive;
+          }
+        );
       } catch (err) {
         showMessage(tm("skills.updateFailed"), "error");
       } finally {
@@ -182,13 +196,15 @@ export default {
         const res = await axios.post("/api/skills/delete", {
           name: skillToDelete.value.name,
         });
-        if (res.data.status === "ok") {
-          showMessage(tm("skills.deleteSuccess"), "success");
-          deleteDialog.value = false;
-          await fetchSkills();
-        } else {
-          showMessage(res.data.message || tm("skills.deleteFailed"), "error");
-        }
+        handleApiResponse(
+          res,
+          tm("skills.deleteSuccess"),
+          tm("skills.deleteFailed"),
+          async () => {
+            deleteDialog.value = false;
+            await fetchSkills();
+          }
+        );
       } catch (err) {
         showMessage(tm("skills.deleteFailed"), "error");
       } finally {


### PR DESCRIPTION
修复skills上传失败时前端仍显示成功的bug

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
SkillsSection.vue
1. 上传功能 (uploadSkill)
   - 修改前：请求发出即视为成功，忽略了文件校验或解压可能失败的情况。
   - 修改后：增加响应解析逻辑。仅当后端返回 status === "ok"
  时才提示成功并刷新列表；若失败，则透传展示后端的错误提示 (message)。
2. 启停控制 (toggleSkill)
   - 修改前：采用“乐观更新”策略，点击即切换 UI 状态，未确认后端是否执行成功。
   - 修改后：改为“确认更新”策略。只有在接收到后端明确的成功响应后，才变更前端的开关状态
  防止状态不同步。
3. 删除操作 (deleteSkill)
   - 修改前：默认请求发送即成功，未处理删除失败的异常场景。
   - 修改后：引入状态检查机制，操作失败时直接反馈具体错误原因，避免误导用户。
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<img width="2560" height="1419" alt="E3REP08JGS}~RAT0}V`{)94" src="https://github.com/user-attachments/assets/44148862-7801-4e2c-ad27-e365236962bd" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

 - [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there
  are new features added in the PR, I have discussed it with the authors through
  issues/emails, etc.
 - [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My
  changes have been well-tested, **and "Verification Steps" and "Screenshots" have been
  provided above**.
 - [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt`
   和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are
  introduced, OR if new dependencies are introduced, they have been added to the
  appropriate locations in `requirements.txt` and `pyproject.toml`.
 - [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

确保技能上传、切换和删除操作只有在后端确认成功时才显示成功提示，否则应显示后端返回的错误信息。

Bug Fixes:
- 当后端调用失败或返回非 ok 状态时，防止技能上传显示成功消息。
- 通过仅在确认收到后端成功响应后才更新 UI 中的技能启用状态，避免 UI 与实际技能状态不同步。
- 处理技能删除失败场景：通过检查后端响应并显示对应的错误信息，而不是总是假定删除操作成功。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure skills upload, toggle, and delete actions only show success when the backend confirms the operation and otherwise surface backend error messages.

Bug Fixes:
- Prevent skills upload from showing a success message when the backend call fails or returns a non-ok status.
- Avoid desynchronizing skill active state in the UI by only updating it after a confirmed successful backend response.
- Handle skill deletion failures by checking the backend response and displaying the corresponding error message instead of always assuming success.

</details>