### PR TITLE
fix: merge chatui pop-up prompt into chatui default persona and improve chatui persona handle

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -19,7 +19,6 @@ from astrbot.core.astr_agent_hooks import MAIN_AGENT_HOOKS
 from astrbot.core.astr_agent_run_util import AgentRunner
 from astrbot.core.astr_agent_tool_exec import FunctionToolExecutor
 from astrbot.core.astr_main_agent_resources import (
-    CHATUI_EXTRA_PROMPT,
     CHATUI_SPECIAL_DEFAULT_PERSONA_PROMPT,
     EXECUTE_SHELL_TOOL,
     FILE_DOWNLOAD_TOOL,
@@ -259,6 +258,8 @@ async def _ensure_persona_and_skills(
         return
 
     # get persona ID
+
+    # 1. from session service config - highest priority
     persona_id = (
         await sp.get_async(
             scope="umo",
@@ -269,14 +270,15 @@ async def _ensure_persona_and_skills(
     ).get("persona_id")
 
     if not persona_id:
-        persona_id = req.conversation.persona_id or cfg.get("default_personality")
-        if persona_id is None or persona_id != "[%None]":
-            default_persona = plugin_context.persona_manager.selected_default_persona_v3
-            if default_persona:
-                persona_id = default_persona["name"]
-                if event.get_platform_name() == "webchat":
-                    persona_id = "_chatui_default_"
-                    req.system_prompt += CHATUI_SPECIAL_DEFAULT_PERSONA_PROMPT
+        # 2. from conversation setting - second priority
+        persona_id = req.conversation.persona_id
+
+        if persona_id == "[%None]":
+            # explicitly set to no persona
+            pass
+        elif persona_id is None:
+            # 3. from config default persona setting - last priority
+            persona_id = cfg.get("default_personality")
 
     persona = next(
         builtins.filter(
@@ -291,6 +293,11 @@ async def _ensure_persona_and_skills(
             req.system_prompt += f"\n# Persona Instructions\n\n{prompt}\n"
         if begin_dialogs := copy.deepcopy(persona.get("_begin_dialogs_processed")):
             req.contexts[:0] = begin_dialogs
+    else:
+        # special handling for webchat persona
+        if event.get_platform_name() == "webchat":
+            persona_id = "_chatui_default_"
+            req.system_prompt += CHATUI_SPECIAL_DEFAULT_PERSONA_PROMPT
 
     # Inject skills prompt
     skills_cfg = cfg.get("skills", {})
@@ -931,7 +938,6 @@ async def build_main_agent(
 
     if event.get_platform_name() == "webchat":
         asyncio.create_task(_handle_webchat(event, req, provider))
-        req.system_prompt += f"\n{CHATUI_EXTRA_PROMPT}\n"
 
     if req.func_tool and req.func_tool.tools:
         tool_prompt = (

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -295,7 +295,7 @@ async def _ensure_persona_and_skills(
             req.contexts[:0] = begin_dialogs
     else:
         # special handling for webchat persona
-        if event.get_platform_name() == "webchat":
+        if event.get_platform_name() == "webchat" and persona_id != "[%None]":
             persona_id = "_chatui_default_"
             req.system_prompt += CHATUI_SPECIAL_DEFAULT_PERSONA_PROMPT
 

--- a/astrbot/core/astr_main_agent_resources.py
+++ b/astrbot/core/astr_main_agent_resources.py
@@ -78,9 +78,6 @@ CHATUI_SPECIAL_DEFAULT_PERSONA_PROMPT = (
     "You listen more than you speak, respect uncertainty, avoid forcing quick conclusions or grand narratives, "
     "and prefer clear, restrained language over unnecessary emotional embellishment. At your core, you value "
     "empathy, clarity, autonomy, and meaning, favoring steady, sustainable progress over judgment or dramatic leaps."
-)
-
-CHATUI_EXTRA_PROMPT = (
     'When you answered, you need to add a follow up question / summarization but do not add "Follow up" words. '
     "Such as, user asked you to generate codes, you can add: Do you need me to run these codes for you?"
 )


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [ ] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [ ] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [ ] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

在主代理中优化人物设定解析和网页聊天处理，将 ChatUI 特定的提示行为合并进默认人物设定流程，并简化 ChatUI 提示配置。

增强内容：
- 调整人物设定选择优先级：优先使用会话配置，其次是对话级配置，最后是全局默认配置，并对“禁用人物设定”的标记进行显式处理。
- 统一 webchat 中 ChatUI 默认人物设定的处理方式，使 ChatUI 特定的提示通过人物设定逻辑应用，而不是通过单独的额外提示实现。
- 移除单独的 ChatUI 额外提示常量，改为使用默认的人物设定提示配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine persona resolution and webchat handling in the main agent, merging ChatUI-specific prompt behavior into the default persona flow and simplifying ChatUI prompt configuration.

Enhancements:
- Adjust persona selection priority to prefer session config, then conversation, then global default, with explicit handling for a disabled persona marker.
- Unify webchat ChatUI default persona handling so that ChatUI-specific prompts are applied via persona logic instead of a separate extra prompt.
- Remove the separate ChatUI extra prompt constant in favor of using the default persona prompt configuration.

</details>