### PR TITLE
fix: 修复插件热重载时平台适配器未清理导致注册冲突的问题

### DIFF
--- a/astrbot/core/platform/platform_metadata.py
+++ b/astrbot/core/platform/platform_metadata.py
@@ -21,3 +21,6 @@ class PlatformMetadata:
     """平台是否支持真实流式传输"""
     support_proactive_message: bool = True
     """平台是否支持主动消息推送（非用户触发）"""
+
+    module_path: str | None = None
+    """注册该适配器的模块路径，用于插件热重载时清理"""

--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -15,6 +15,7 @@ import yaml
 from astrbot.core import logger, pip_installer, sp
 from astrbot.core.agent.handoff import FunctionTool, HandoffTool
 from astrbot.core.config.astrbot_config import AstrBotConfig
+from astrbot.core.platform.register import unregister_platform_adapters_by_module
 from astrbot.core.provider.register import llm_tools
 from astrbot.core.utils.astrbot_path import (
     get_astrbot_config_path,
@@ -841,6 +842,18 @@ class PluginManager:
                 to_remove.append(func_tool)
         for func_tool in to_remove:
             llm_tools.func_list.remove(func_tool)
+
+        # Unregister platform adapters registered by this plugin
+        # module_path is like "data.plugins.my_plugin.main", extract prefix like "data.plugins.my_plugin"
+        module_prefix = ".".join(plugin_module_path.split(".")[:-1])
+        if module_prefix:
+            unregistered_adapters = unregister_platform_adapters_by_module(
+                module_prefix
+            )
+            for adapter_name in unregistered_adapters:
+                logger.info(
+                    f"移除了插件 {plugin_name} 的平台适配器 {adapter_name}",
+                )
 
         if plugin is None:
             return


### PR DESCRIPTION
### Motivation / 动机
修复插件热重载时平台适配器未清理导致注册冲突的问题。当插件注册了平台适配器后，在热重载时这些适配器没有被清理，导致插件再次启动时重复注册新的平台实例，抛出 "平台适配器已经注册过了" 的错误

### Modifications / 改动点

- **`astrbot/core/platform/platform_metadata.py`**: 在 `PlatformMetadata` 类中添加 `module_path` 字段，用于记录注册该适配器的模块路径
- **`astrbot/core/platform/register.py`**: 
  - 修改 `register_platform_adapter` 装饰器，自动记录被装饰类的模块路径
  - 新增 `unregister_platform_adapters_by_module()` 函数，根据模块路径前缀注销平台适配器
- **`astrbot/core/star/star_manager.py`**: 在 `_unbind_plugin` 方法中调用清理逻辑，在插件卸载或热重载时自动注销该插件注册的所有平台适配器

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

确保由插件注册的平台适配器在插件卸载或热重载期间被正确清理，以避免适配器注册冲突。

Bug 修复：
- 通过在插件卸载或热重载时注销与该插件相关联的适配器，防止重复的平台适配器注册错误。

增强功能：
- 在平台适配器的元数据中跟踪模块路径，并在插件清理期间使用该模块路径前缀批量注销适配器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure platform adapters registered by plugins are properly cleaned up during plugin unload or hot reload to avoid adapter registration conflicts.

Bug Fixes:
- Prevent duplicate platform adapter registration errors by unregistering adapters associated with a plugin when it is unloaded or hot reloaded.

Enhancements:
- Track the module path on platform adapter metadata and use it to bulk-unregister adapters by module prefix during plugin cleanup.

</details>