### PR TITLE
fix: conversation token usage calculate wrongly and fix tool call infinitely

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -213,6 +213,8 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             if not llm_response.is_chunk and llm_response.usage:
                 # only count the token usage of the final response for computation purpose
                 self.stats.token_usage += llm_response.usage
+                if self.req.conversation:
+                    self.req.conversation.token_usage = llm_response.usage.total
             break  # got final response
 
         if not llm_resp_result:

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -363,7 +363,8 @@ class InternalAgentSubStage(Stage):
 
         token_usage = None
         if runner_stats:
-            token_usage = runner_stats.token_usage.total
+            # token_usage = runner_stats.token_usage.total
+            token_usage = llm_response.usage.total if llm_response.usage else None
 
         await self.conv_manager.update_conversation(
             event.unified_msg_origin,


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [ ] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [ ] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [ ] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

修复对话 token 使用情况的追踪，使其能够反映最终的 LLM 响应，并将其存储在对话对象上，以避免错误统计和潜在的无限工具调用循环。

Bug 修复：
- 通过使用最终的 LLM 响应使用情况，而不是运行器统计数据，来纠正 token 使用量的计算。
- 将最终响应的 token 使用情况持久化到对话对象上，以防止出现无限工具调用循环。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix conversation token usage tracking so it reflects the final LLM response and store it on the conversation object to avoid incorrect counts and potential infinite tool-calling loops.

Bug Fixes:
- Correct token usage calculation by using the final LLM response usage instead of runner statistics.
- Persist the final response token usage on the conversation to prevent infinite tool call loops.

</details>