### PR TITLE
feat(wecom): add user nickname/avatar display and fix timezone issue

### DIFF
--- a/astrbot/core/agent/message.py
+++ b/astrbot/core/agent/message.py
@@ -172,6 +172,9 @@ class Message(BaseModel):
     content: str | list[ContentPart] | None = None
     """The content of the message."""
 
+    name: str | None = None
+    """Optional name of the sender, used to identify different users in conversation."""
+
     tool_calls: list[ToolCall] | list[dict] | None = None
     """The tool calls of the message."""
 
@@ -198,6 +201,8 @@ class Message(BaseModel):
             data.pop("tool_calls", None)
         if self.tool_call_id is None:
             data.pop("tool_call_id", None)
+        if self.name is None:
+            data.pop("name", None)
         return data
 
 

--- a/astrbot/core/db/__init__.py
+++ b/astrbot/core/db/__init__.py
@@ -145,6 +145,8 @@ class BaseDatabase(abc.ABC):
         cid: str | None = None,
         created_at: datetime.datetime | None = None,
         updated_at: datetime.datetime | None = None,
+        user_name: str | None = None,
+        avatar: str | None = None,
     ) -> ConversationV2:
         """Create a new conversation."""
         ...
@@ -157,6 +159,8 @@ class BaseDatabase(abc.ABC):
         persona_id: str | None = None,
         content: list[dict] | None = None,
         token_usage: int | None = None,
+        user_name: str | None = None,
+        avatar: str | None = None,
     ) -> None:
         """Update a conversation's history."""
         ...

--- a/astrbot/core/db/po.py
+++ b/astrbot/core/db/po.py
@@ -54,6 +54,9 @@ class ConversationV2(TimestampMixin, SQLModel, table=True):
     )
     platform_id: str = Field(nullable=False)
     user_id: str = Field(nullable=False)
+    user_name: str | None = Field(default=None, max_length=255)
+    avatar: str | None = Field(default=None, max_length=512)
+    """用户头像 URL"""
     content: list | None = Field(default=None, sa_type=JSON)
 
     title: str | None = Field(default=None, max_length=255)
@@ -418,6 +421,10 @@ class Conversation:
     updated_at: int = 0
     token_usage: int = 0
     """对话的总 token 数量。AstrBot 会保留最近一次 LLM 请求返回的总 token 数，方便统计。token_usage 可能为 0，表示未知。"""
+    user_name: str | None = None
+    """发送消息的用户名称"""
+    avatar: str | None = None
+    """用户头像 URL"""
 
 
 class Personality(TypedDict):

--- a/astrbot/core/platform/astr_message_event.py
+++ b/astrbot/core/platform/astr_message_event.py
@@ -191,6 +191,12 @@ class AstrMessageEvent(abc.ABC):
             return self.message_obj.sender.nickname
         return ""
 
+    def get_sender_avatar(self) -> str | None:
+        """获取消息发送者的头像 URL。(可能会返回 None)"""
+        if hasattr(self.message_obj.sender, 'avatar'):
+            return self.message_obj.sender.avatar
+        return None
+
     def set_extra(self, key, value):
         """设置额外的信息。"""
         self._extras[key] = value

--- a/astrbot/core/platform/astrbot_message.py
+++ b/astrbot/core/platform/astrbot_message.py
@@ -10,6 +10,8 @@ from .message_type import MessageType
 class MessageMember:
     user_id: str  # 发送者id
     nickname: str | None = None
+    avatar: str | None = None
+    """用户头像 URL"""
 
     def __str__(self):
         # 使用 f-string 来构建返回的字符串表示形式

--- a/astrbot/dashboard/routes/conversation.py
+++ b/astrbot/dashboard/routes/conversation.py
@@ -1,5 +1,6 @@
 import json
 import traceback
+from dataclasses import asdict
 from datetime import datetime
 from io import BytesIO
 
@@ -88,8 +89,11 @@ class ConversationRoute(Route):
                 (total_count + page_size - 1) // page_size if total_count > 0 else 1
             )
 
+            # 将 Conversation dataclass 对象转换为字典
+            conversations_dict = [asdict(conv) for conv in conversations]
+
             result = {
-                "conversations": conversations,
+                "conversations": conversations_dict,
                 "pagination": {
                     "page": page,
                     "page_size": page_size,

--- a/dashboard/src/i18n/locales/en-US/features/conversation.json
+++ b/dashboard/src/i18n/locales/en-US/features/conversation.json
@@ -28,6 +28,8 @@
       "cid": "Conversation ID",
       "umo": "Unified Message Origin",
       "sessionId": "Session ID",
+      "userName": "User Name",
+      "avatar": "Avatar",
       "createdAt": "Created At",
       "updatedAt": "Updated At",
       "actions": "Actions"

--- a/dashboard/src/i18n/locales/zh-CN/features/conversation.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/conversation.json
@@ -28,6 +28,8 @@
       "cid": "对话 ID",
       "umo": "消息会话来源",
       "sessionId": "会话 ID",
+      "userName": "用户名",
+      "avatar": "头像",
       "createdAt": "创建时间",
       "updatedAt": "更新时间",
       "actions": "操作"

--- a/dashboard/src/views/ConversationPage.vue
+++ b/dashboard/src/views/ConversationPage.vue
@@ -97,6 +97,17 @@
                             <span>{{ item.sessionInfo.sessionId || tm('status.unknown') }}</span>
                         </template>
 
+                        <template v-slot:item.user_name="{ item }">
+                            <span>{{ item.user_name || '-' }}</span>
+                        </template>
+
+                        <template v-slot:item.avatar="{ item }">
+                            <v-avatar v-if="item.avatar" size="32">
+                                <v-img :src="item.avatar" :alt="item.user_name || 'avatar'"></v-img>
+                            </v-avatar>
+                            <span v-else>-</span>
+                        </template>
+
                         <template v-slot:item.created_at="{ item }">
                             {{ formatTimestamp(item.created_at) }}
                         </template>
@@ -448,6 +459,8 @@ export default {
                         { title: this.tm('table.headers.sessionId'), key: 'sessionId', sortable: true, width: '100px' },
                     ],
                 },
+                { title: this.tm('table.headers.userName'), key: 'user_name', sortable: true, width: '120px' },
+                { title: this.tm('table.headers.avatar'), key: 'avatar', sortable: false, width: '80px' },
                 { title: this.tm('table.headers.createdAt'), key: 'created_at', sortable: true, width: '180px' },
                 { title: this.tm('table.headers.updatedAt'), key: 'updated_at', sortable: true, width: '180px' },
                 { title: this.tm('table.headers.actions'), key: 'actions', sortable: false, align: 'center' }


### PR DESCRIPTION
## WeChat KF improvements:
- Fix KeyError when sync_msg response lacks open_kfid field
- Fetch customer nickname and avatar via batchget_customer API

## Conversation history enhancements:
- Add user_name and avatar fields to database schema
- Display user name and avatar in WebUI conversation list
- Auto-migrate existing databases with new columns

## Bug fixes:
- Fix 8-hour timestamp offset caused by SQLite losing timezone info

### Modifications / 改动点

**Backend:**
- `astrbot/core/platform/sources/wecom/wecom_adapter.py` - Fixed `open_kfid` KeyError by injecting kfid before calling `convert_wechat_kf_message`; added `batchget_customer` API call to fetch customer nickname and avatar
- `astrbot/core/db/po.py` - Added `user_name` and `avatar` fields to `ConversationV2` and `Conversation` classes
- `astrbot/core/db/__init__.py` - Updated abstract method signatures for `create_conversation` and `update_conversation`
- `astrbot/core/db/sqlite.py` - Implemented new fields and added auto-migration methods `_ensure_conversation_user_name_column` and `_ensure_conversation_avatar_column`
- `astrbot/core/conversation_mgr.py` - Added timezone fix for SQLite datetime handling; updated conversion logic to include new fields
- `astrbot/core/astr_main_agent.py` - Updated `_get_session_conv` to pass user_name and avatar to conversation manager
- `astrbot/core/platform/astrbot_message.py` - Added `avatar` field to `MessageMember` dataclass
- `astrbot/core/platform/astr_message_event.py` - Added `get_sender_avatar()` method
- `astrbot/dashboard/routes/conversation.py` - Fixed serialization using `dataclasses.asdict()`

**Frontend:**
- `dashboard/src/views/ConversationPage.vue` - Added user_name and avatar columns to conversation history table
- `dashboard/src/i18n/locales/zh-CN/features/conversation.json` - Added Chinese translations
- `dashboard/src/i18n/locales/en-US/features/conversation.json` - Added English translations

- [√] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

*(请补充截图)*
<img width="1608" height="140" alt="QQ_1770285872691" src="https://github.com/user-attachments/assets/ddf1706e-7e68-4b42-87a1-19c513fde429" />

---

### Checklist / 检查清单

- [√] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [√ ] 👀 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [√] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [√] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

为会话新增对用户昵称和头像的存储和展示支持，并修复基于 SQLite 的时间戳时区处理问题。

New Features:
- 在数据库中的会话记录上存储可选的 `user_name` 和 `avatar` 字段，并通过会话管理器进行传递。
- 在消息和事件模型上暴露发送者头像和名称字段，以便渠道适配器提供更丰富的用户元数据。
- 在控制台的会话历史记录表中显示用户名和头像列。

Bug Fixes:
- 通过在转换后的消息中显式携带 `open_kfid` 字段，防止在处理此前缺少 `open_kfid` 字段的微信客服（WeChat KF）事件时出现 `KeyError`。
- 通过在转换为 Unix 秒数前确保从 SQLite 加载的会话时间戳被视为 UTC，修正了 8 小时的时间戳偏移问题。
- 在返回之前先将 `Conversation` 数据类实例序列化为字典，从而修复会话列表 API 的响应。

Enhancements:
- 自动迁移现有的 SQLite 数据库，在 `conversations` 表中新增 `user_name` 和 `avatar` 列，以保证向前兼容。
- 通过 `batchget_customer` API 获取微信客服用户的昵称和头像，并将其附加到入站消息中的发送者元数据上。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for storing and displaying user nicknames and avatars in conversations and fix timezone handling for SQLite-backed timestamps.

New Features:
- Store optional user_name and avatar fields on conversations in the database and propagate them through the conversation manager.
- Expose sender avatar and name on message and event models so channel adapters can provide richer user metadata.
- Display user name and avatar columns in the dashboard conversation history table.

Bug Fixes:
- Prevent KeyError when handling WeChat KF events that previously lacked the open_kfid field by explicitly carrying it into the converted message.
- Correct 8-hour timestamp offsets by ensuring SQLite-loaded conversation timestamps are treated as UTC before conversion to Unix seconds.
- Fix conversation list API responses by serializing Conversation dataclass instances to dictionaries before returning them.

Enhancements:
- Auto-migrate existing SQLite databases to add user_name and avatar columns to the conversations table for forward compatibility.
- Fetch WeChat KF customer nickname and avatar via the batchget_customer API and attach them to the sender metadata in incoming messages.

</details>