### PR TITLE
fix: dedupe preset messages

### DIFF
--- a/astrbot/core/agent/message.py
+++ b/astrbot/core/agent/message.py
@@ -3,7 +3,13 @@
 
 from typing import Any, ClassVar, Literal, cast
 
-from pydantic import BaseModel, GetCoreSchemaHandler, model_serializer, model_validator
+from pydantic import (
+    BaseModel,
+    GetCoreSchemaHandler,
+    PrivateAttr,
+    model_serializer,
+    model_validator,
+)
 from pydantic_core import core_schema
 
 
@@ -177,6 +183,8 @@ class Message(BaseModel):
 
     tool_call_id: str | None = None
     """The ID of the tool call."""
+
+    _no_save: bool = PrivateAttr(default=False)
 
     @model_validator(mode="after")
     def check_content_required(self):

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -149,7 +149,10 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
         messages = []
         # append existing messages in the run context
         for msg in request.contexts:
-            messages.append(Message.model_validate(msg))
+            m = Message.model_validate(msg)
+            if isinstance(msg, dict) and msg.get("_no_save"):
+                m._no_save = True
+            messages.append(m)
         if request.prompt is not None:
             m = await request.assemble_context()
             messages.append(Message.model_validate(m))

--- a/astrbot/core/persona_mgr.py
+++ b/astrbot/core/persona_mgr.py
@@ -313,7 +313,7 @@ class PersonaManager:
                         {
                             "role": "user" if user_turn else "assistant",
                             "content": dialog,
-                            "_no_save": None,  # 不持久化到 db
+                            "_no_save": True,  # 不持久化到 db
                         },
                     )
                     user_turn = not user_turn

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -355,9 +355,7 @@ class InternalAgentSubStage(Stage):
             if message.role == "system" and not skipped_initial_system:
                 skipped_initial_system = True
                 continue
-            if message.role in ["assistant", "user"] and getattr(
-                message, "_no_save", None
-            ):
+            if message.role in ["assistant", "user"] and message._no_save:
                 continue
             message_to_save.append(message.model_dump())
 


### PR DESCRIPTION
修复预设对话重复注入的问题

### Modifications / 改动点

添加_no_save私有字段

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

确保预设人物对话消息被视为不持久化的数据，这样它们就不会在会话历史中被反复重新注入。

Bug 修复：
- 通过遵守消息上的非持久化标记，防止预设人物对话消息被保存到会话历史中并从中被反复重新注入。

功能增强：
- 在 `Message` 上引入私有属性 `_no_save`，并在请求上下文中进行传递，以控制哪些助手和用户消息需要被持久化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure preset persona dialogue messages are treated as non-persisted so they are not repeatedly re-injected into conversation history.

Bug Fixes:
- Prevent preset persona dialogue messages from being saved to and repeatedly re-injected from conversation history by honoring a non-persisted flag on messages.

Enhancements:
- Introduce a private `_no_save` attribute on `Message` and propagate it through request contexts to control which assistant and user messages are persisted.

</details>

Bug 修复：
- 确保预设人格（persona）对话消息被标记为不持久化（non-persisted），从而不会被反复重新注入到对话历史中。

增强功能：
- 在 `Message` 上引入私有的 `_no_save` 标志，并通过请求上下文进行传递，以控制哪些消息需要被持久化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

确保预设人物对话消息被视为不持久化的数据，这样它们就不会在会话历史中被反复重新注入。

Bug 修复：
- 通过遵守消息上的非持久化标记，防止预设人物对话消息被保存到会话历史中并从中被反复重新注入。

功能增强：
- 在 `Message` 上引入私有属性 `_no_save`，并在请求上下文中进行传递，以控制哪些助手和用户消息需要被持久化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure preset persona dialogue messages are treated as non-persisted so they are not repeatedly re-injected into conversation history.

Bug Fixes:
- Prevent preset persona dialogue messages from being saved to and repeatedly re-injected from conversation history by honoring a non-persisted flag on messages.

Enhancements:
- Introduce a private `_no_save` attribute on `Message` and propagate it through request contexts to control which assistant and user messages are persisted.

</details>

</details>