### PR TITLE
fix: 'HandoffTool' object has no attribute 'agent'

### DIFF
--- a/astrbot/core/agent/handoff.py
+++ b/astrbot/core/agent/handoff.py
@@ -33,6 +33,7 @@ class HandoffTool(FunctionTool, Generic[TContext]):
         # Optional provider override for this subagent. When set, the handoff
         # execution will use this chat provider id instead of the global/default.
         self.provider_id: str | None = None
+        # Note: Must assign after super().__init__() to prevent parent class from overriding this attribute
         self.agent = agent
 
     def default_parameters(self) -> dict:


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

在调用 HandoffTool 工具时，出现了 "HandoffTool 对象没有 'agent' 属性" 的错误。经过排查发现，问题出现在 HandoffTool 的 __init__ 方法中。在 self.agent = agent 赋值之后，调用 super().__init__() 会导致 self.agent 属性被意外覆盖或删除。
Fixes #5004

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

改变了astrbot.core.agent.handoff文件
将self.agent = agent移动到super().__init__之后
```python
    def __init__(
        self,
        agent: Agent[TContext],
        parameters: dict | None = None,
        tool_description: str | None = None,
        **kwargs,
    ) -> None:

        # Avoid passing duplicate `description` to the FunctionTool dataclass.
        # Some call sites (e.g. SubAgentOrchestrator) pass `description` via kwargs
        # to override what the main agent sees, while we also compute a default
        # description here.
        # `tool_description` is the public description shown to the main LLM.
        # Keep a separate kwarg to avoid conflicting with FunctionTool's `description`.
        description = tool_description or self.default_description(agent.name)
        super().__init__(
            name=f"transfer_to_{agent.name}",
            parameters=parameters or self.default_parameters(),
            description=description,
            **kwargs,
        )

        # Optional provider override for this subagent. When set, the handoff
        # execution will use this chat provider id instead of the global/default.
        self.provider_id: str | None = None
        self.agent = agent
```

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<img width="1556" height="6024" alt="6a615f34b2e14d7ab249863327542988" src="https://github.com/user-attachments/assets/1f268643-098f-4e42-9644-e4210c8e4dd8" />
<img width="661" height="464" alt="image" src="https://github.com/user-attachments/assets/c3f422d9-3783-4c4b-8361-77f0c79db4e9" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ X ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
没有新功能
- [ X ] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
验证步骤在iss里面,运行截图在上方
- [ X ] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
没有引入
- [ X ] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.
没有引入

## Summary by Sourcery

错误修复：
- 确保 `HandoffTool` 在基类初始化之后仍然保留其 `agent` 属性，以避免出现“object has no attribute agent”（对象没有 agent 属性）的错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure HandoffTool retains its agent attribute after base class initialization to avoid 'object has no attribute agent' errors.

</details>
- 修复在初始化过程中丢失 `HandoffTool.agent` 引用的问题，该问题会导致运行时错误：`'HandoffTool' object has no attribute 'agent'`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

错误修复：
- 确保 `HandoffTool` 在基类初始化之后仍然保留其 `agent` 属性，以避免出现“object has no attribute agent”（对象没有 agent 属性）的错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure HandoffTool retains its agent attribute after base class initialization to avoid 'object has no attribute agent' errors.

</details>

</details>