### PR TITLE
fix: close unawaited reset coroutine on early return

### DIFF
--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -190,6 +190,8 @@ class InternalAgentSubStage(Stage):
                 )
 
                 if await call_event_hook(event, EventType.OnLLMRequestEvent, req):
+                    if reset_coro:
+                        reset_coro.close()
                     return
 
                 # apply reset


### PR DESCRIPTION
## Problem

Fixes #5032

When a plugin's `on_llm_request` hook stops event propagation via `event_stop()`, the `reset_coro` coroutine (created by `build_main_agent` with `apply_reset=False`) is never awaited, producing:

```
RuntimeWarning: coroutine 'ToolLoopAgentRunner.reset' was never awaited
```

## Root Cause

In `internal.py`, the early return after `call_event_hook(OnLLMRequestEvent)` returns `True` does not handle the pending `reset_coro`.

## Fix

Explicitly close the unawaited coroutine via `reset_coro.close()` before returning, which properly cleans up the coroutine without triggering the RuntimeWarning.

## Summary by Sourcery

Bug Fixes:
- 当某个 `OnLLMRequestEvent` 钩子阻止事件继续传递、导致函数提前返回时，先关闭未被等待的 reset 协程，以避免运行时警告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Close the unawaited reset coroutine before returning early when an OnLLMRequestEvent hook stops event propagation to avoid runtime warnings.

</details>