### PR TITLE
fix-correct-FIRST_NOTICE.md-locale-path-resolution (#5083)

### DIFF
--- a/astrbot/dashboard/routes/stat.py
+++ b/astrbot/dashboard/routes/stat.py
@@ -296,13 +296,14 @@ class StatRoute(Route):
                 candidates.append(base_path / f"FIRST_NOTICE.{locale}.md")
                 if locale.lower().startswith("zh"):
                     candidates.append(base_path / "FIRST_NOTICE.md")
+                    candidates.append(base_path / "FIRST_NOTICE.zh-CN.md")
                 elif locale.lower().startswith("en"):
                     candidates.append(base_path / "FIRST_NOTICE.en-US.md")
 
             candidates.extend(
                 [
-                    base_path / "FIRST_NOTICE.en-US.md",
                     base_path / "FIRST_NOTICE.md",
+                    base_path / "FIRST_NOTICE.en-US.md",
                 ],
             )
 


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

修理的问题是首次页面的文件目录名称问题
v4.16.0访问会出现i18n选择了中文，这个是英文的情况
Fixes #5083

<img width="648" height="384" alt="549167127-b5a92c1b-88bd-4a62-91c1-41d0906a564c" src="https://github.com/user-attachments/assets/821c7dc9-97cf-4a60-abaa-f27bd7f6cbed" />

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->


以下是代码错误的位置
```python
    async def get_first_notice(self):
        """读取项目根目录 FIRST_NOTICE.md 内容。"""
        try:
            locale = (request.args.get("locale") or "").strip()
            if not re.match(r"^[A-Za-z0-9_-]*$", locale):
                locale = ""

            base_path = Path(get_astrbot_path())
            candidates: list[Path] = []

            if locale:
                candidates.append(base_path / f"FIRST_NOTICE.{locale}.md")
                if locale.lower().startswith("zh"):
                    candidates.append(base_path / "FIRST_NOTICE.zh-CN.md")
                elif locale.lower().startswith("en"):
                    candidates.append(base_path / "FIRST_NOTICE.en-US.md")

            candidates.extend(
                [
                    base_path / "FIRST_NOTICE.en-US.md",
                    base_path / "FIRST_NOTICE.md",
                ],
            )

            for notice_path in candidates:
                if not notice_path.is_file():
                    continue
                content = notice_path.read_text(encoding="utf-8")
                if content.strip():
                    return Response().ok({"content": content}).__dict__

            return Response().ok({"content": None}).__dict__
        except Exception as e:
            logger.error(traceback.format_exc())
            return Response().error(f"Error: {e!s}").__dict__
```
其中
```python
                if locale.lower().startswith("zh"):
                    candidates.append(base_path / "FIRST_NOTICE.zh-CN.md")
```
的名称错误了，在文件中为FIRST_NOTICE.md

<img width="1289" height="768" alt="549174699-3492c291-767b-4114-9f31-7be435a3b0a5" src="https://github.com/user-attachments/assets/efa6778a-51bf-44e1-99b6-ee2bbe9919e4" />


- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

首次页面出现这个问题我无法进行测试
这个问题是个很简单的更改，这个修改方案应该是有效的

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ X ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- 没有新功能
- [ ] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- 首次页面出现这个问题我无法进行测试
- 这个问题是个很简单的更改，这个修改方案应该是有效的
- [ X ] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [ X ] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

Bug Fixes:
- 修正当选择中文区域设置时使用的 `FIRST_NOTICE` 文件路径，使其指向已有的 `FIRST_NOTICE.md` 文件，而不是不存在的 `zh-CN` 变体。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the FIRST_NOTICE file path used when a Chinese locale is selected so that it resolves to the existing FIRST_NOTICE.md file instead of a non-existent zh-CN variant.

</details>