### PR TITLE
feat: add Anthropic Claude Code OAuth provider and adaptive thinking support

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -978,7 +978,19 @@ CONFIG_METADATA_2 = {
                         "api_base": "https://api.anthropic.com/v1",
                         "timeout": 120,
                         "proxy": "",
-                        "anth_thinking_config": {"budget": 0},
+                        "anth_thinking_config": {"type": "", "budget": 0, "effort": ""},
+                    },
+                    "Anthropic (Claude Code OAuth)": {
+                        "id": "anthropic_claude_code_oauth",
+                        "provider": "anthropic",
+                        "type": "anthropic_oauth",
+                        "provider_type": "chat_completion",
+                        "enable": True,
+                        "api_base": "https://api.anthropic.com",
+                        "timeout": 120,
+                        "proxy": "",
+                        "anth_thinking_config": {"type": "", "budget": 0, "effort": ""},
+                        "oauth_token": "",
                     },
                     "Moonshot": {
                         "id": "moonshot",
@@ -1528,6 +1540,11 @@ CONFIG_METADATA_2 = {
                         "hint": "启用后，将通过 xAI 的 Chat Completions 原生 Live Search 进行联网检索（按需计费）。仅对 xAI 提供商生效。",
                         "condition": {"provider": "xai"},
                     },
+                    "oauth_token": {
+                        "description": "OAuth Token",
+                        "type": "string",
+                        "hint": "在终端运行 `claude setup-token` 获取长期有效的 OAuth Token，然后粘贴到此处。Token 有效期为 1 年。",
+                    },
                     "rerank_api_base": {
                         "description": "重排序模型 API Base URL",
                         "type": "string",
@@ -1939,13 +1956,25 @@ CONFIG_METADATA_2 = {
                         },
                     },
                     "anth_thinking_config": {
-                        "description": "Thinking Config",
+                        "description": "思考配置",
                         "type": "object",
                         "items": {
+                            "type": {
+                                "description": "思考类型",
+                                "type": "string",
+                                "options": ["", "adaptive"],
+                                "hint": "Opus 4.6+ / Sonnet 4.6+ 推荐设为 'adaptive'。留空则使用手动 budget 模式。参见: https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking",
+                            },
                             "budget": {
-                                "description": "Thinking Budget",
+                                "description": "思考预算",
                                 "type": "int",
-                                "hint": "Anthropic thinking.budget_tokens param. Must >= 1024. See: https://platform.claude.com/docs/en/build-with-claude/extended-thinking",
+                                "hint": "手动 budget_tokens，需 >= 1024。仅在 type 为空时生效。Opus 4.6 / Sonnet 4.6 上已弃用。参见: https://platform.claude.com/docs/en/build-with-claude/extended-thinking",
+                            },
+                            "effort": {
+                                "description": "思考深度",
+                                "type": "string",
+                                "options": ["", "low", "medium", "high", "max"],
+                                "hint": "type 为 'adaptive' 时控制思考深度。默认 'high'。'max' 仅限 Opus 4.6。参见: https://platform.claude.com/docs/en/build-with-claude/effort",
                             },
                         },
                     },

--- a/astrbot/core/provider/manager.py
+++ b/astrbot/core/provider/manager.py
@@ -299,6 +299,10 @@ class ProviderManager:
                 from .sources.anthropic_source import (
                     ProviderAnthropic as ProviderAnthropic,
                 )
+            case "anthropic_oauth":
+                from .sources.anthropic_oauth_source import (
+                    ProviderAnthropicOAuth as ProviderAnthropicOAuth,
+                )
             case "googlegenai_chat_completion":
                 from .sources.gemini_source import (
                     ProviderGoogleGenAI as ProviderGoogleGenAI,

--- a/astrbot/core/provider/sources/anthropic_oauth_source.py
+++ b/astrbot/core/provider/sources/anthropic_oauth_source.py
@@ -1,0 +1,146 @@
+from collections.abc import AsyncGenerator
+
+from anthropic import AsyncAnthropic
+
+from astrbot import logger
+from astrbot.core.provider.entities import LLMResponse
+
+from ..register import register_provider_adapter
+from .anthropic_source import ProviderAnthropic
+
+_OAUTH_DEFAULT_HEADERS = {
+    "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,context-1m-2025-08-07",
+    "user-agent": "claude-cli/1.0.0 (external, cli)",
+    "x-app": "cli",
+    "anthropic-dangerous-direct-browser-access": "true",
+}
+
+_CLAUDE_CODE_SYSTEM_PREFIX = (
+    "You are Claude Code, Anthropic's official CLI for Claude.\n\n"
+)
+
+# 支持 1M 上下文窗口的模型前缀（需配合 context-1m beta header）。
+# 新增 4.6+ 模型时需同步更新此列表。
+_1M_CONTEXT_MODEL_PREFIXES = (
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+)
+
+
+@register_provider_adapter(
+    "anthropic_oauth",
+    "Anthropic Claude Code OAuth provider adapter",
+)
+class ProviderAnthropicOAuth(ProviderAnthropic):
+    def __init__(
+        self,
+        provider_config: dict,
+        provider_settings: dict,
+    ) -> None:
+        # 从配置中读取长期 OAuth token（由 `claude setup-token` 生成）
+        token = provider_config.get("oauth_token", "")
+        if not token:
+            raise ValueError(
+                "Missing 'oauth_token' in provider config. "
+                "Please run `claude setup-token` to obtain a long-lived token."
+            )
+
+        self.chosen_api_key: str = token
+        self.api_keys: list = []
+
+        # use_api_key=False 跳过父类的 _init_api_key()
+        super().__init__(provider_config, provider_settings, use_api_key=False)
+
+        # 使用 auth_token 发送 Authorization: Bearer 头（OAuth 必须）
+        self.client = AsyncAnthropic(
+            auth_token=token,
+            timeout=self.timeout,
+            base_url=self.base_url,
+            default_headers=_OAUTH_DEFAULT_HEADERS,
+            http_client=self._create_http_client(provider_config),
+        )
+
+    def set_model(self, model_name: str) -> None:
+        super().set_model(model_name)
+        if any(model_name.startswith(p) for p in _1M_CONTEXT_MODEL_PREFIXES):
+            if self.provider_config.get("max_context_tokens", 0) <= 0:
+                self.provider_config["max_context_tokens"] = 1_000_000
+
+    def get_model_metadata_overrides(self, model_ids: list[str]) -> dict[str, dict]:
+        overrides = {}
+        for mid in model_ids:
+            if any(mid.startswith(p) for p in _1M_CONTEXT_MODEL_PREFIXES):
+                overrides[mid] = {"limit": {"context": 1_000_000}}
+        return overrides
+
+    def get_current_key(self) -> str:
+        return self.chosen_api_key
+
+    def get_keys(self) -> list[str]:
+        return []
+
+    def set_key(self, key: str) -> None:
+        logger.warning("OAuth provider does not support manual key switching.")
+
+    async def get_models(self) -> list[str]:
+        return await super().get_models()
+
+    async def test(self, timeout: float = 45.0) -> None:
+        await super().test(timeout)
+
+    async def text_chat(
+        self,
+        prompt=None,
+        session_id=None,
+        image_urls=None,
+        func_tool=None,
+        contexts=None,
+        system_prompt=None,
+        tool_calls_result=None,
+        model=None,
+        extra_user_content_parts=None,
+        **kwargs,
+    ) -> LLMResponse:
+        system_prompt = _CLAUDE_CODE_SYSTEM_PREFIX + (system_prompt or "")
+
+        return await super().text_chat(
+            prompt=prompt,
+            session_id=session_id,
+            image_urls=image_urls,
+            func_tool=func_tool,
+            contexts=contexts,
+            system_prompt=system_prompt,
+            tool_calls_result=tool_calls_result,
+            model=model,
+            extra_user_content_parts=extra_user_content_parts,
+            **kwargs,
+        )
+
+    async def text_chat_stream(
+        self,
+        prompt=None,
+        session_id=None,
+        image_urls=None,
+        func_tool=None,
+        contexts=None,
+        system_prompt=None,
+        tool_calls_result=None,
+        model=None,
+        extra_user_content_parts=None,
+        **kwargs,
+    ) -> AsyncGenerator[LLMResponse, None]:
+        system_prompt = _CLAUDE_CODE_SYSTEM_PREFIX + (system_prompt or "")
+
+        async for llm_response in super().text_chat_stream(
+            prompt=prompt,
+            session_id=session_id,
+            image_urls=image_urls,
+            func_tool=func_tool,
+            contexts=contexts,
+            system_prompt=system_prompt,
+            tool_calls_result=tool_calls_result,
+            model=model,
+            extra_user_content_parts=extra_user_content_parts,
+            **kwargs,
+        ):
+            yield llm_response

--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -33,20 +33,29 @@ class ProviderAnthropic(Provider):
         self,
         provider_config,
         provider_settings,
+        *,
+        use_api_key: bool = True,
     ) -> None:
         super().__init__(
             provider_config,
             provider_settings,
         )
 
-        self.chosen_api_key: str = ""
-        self.api_keys: list = super().get_keys()
-        self.chosen_api_key = self.api_keys[0] if len(self.api_keys) > 0 else ""
         self.base_url = provider_config.get("api_base", "https://api.anthropic.com")
         self.timeout = provider_config.get("timeout", 120)
         if isinstance(self.timeout, str):
             self.timeout = int(self.timeout)
+        self.thinking_config = provider_config.get("anth_thinking_config", {})
 
+        if use_api_key:
+            self._init_api_key(provider_config)
+
+        self.set_model(provider_config.get("model", "unknown"))
+
+    def _init_api_key(self, provider_config: dict) -> None:
+        self.chosen_api_key: str = ""
+        self.api_keys: list = super().get_keys()
+        self.chosen_api_key = self.api_keys[0] if len(self.api_keys) > 0 else ""
         self.client = AsyncAnthropic(
             api_key=self.chosen_api_key,
             timeout=self.timeout,
@@ -54,14 +63,26 @@ class ProviderAnthropic(Provider):
             http_client=self._create_http_client(provider_config),
         )
 
-        self.thinking_config = provider_config.get("anth_thinking_config", {})
-
-        self.set_model(provider_config.get("model", "unknown"))
-
     def _create_http_client(self, provider_config: dict) -> httpx.AsyncClient | None:
         """创建带代理的 HTTP 客户端"""
         proxy = provider_config.get("proxy", "")
         return create_proxy_client("Anthropic", proxy)
+
+    def _apply_thinking_config(self, payloads: dict) -> None:
+        thinking_type = self.thinking_config.get("type", "")
+        if thinking_type == "adaptive":
+            payloads["thinking"] = {"type": "adaptive"}
+            effort = self.thinking_config.get("effort", "")
+            output_cfg = dict(payloads.get("output_config", {}))
+            if effort:
+                output_cfg["effort"] = effort
+            if output_cfg:
+                payloads["output_config"] = output_cfg
+        elif self.thinking_config.get("budget"):
+            payloads["thinking"] = {
+                "budget_tokens": self.thinking_config.get("budget"),
+                "type": "enabled",
+            }
 
     def _prepare_payload(self, messages: list[dict]):
         """准备 Anthropic API 的请求 payload
@@ -213,11 +234,7 @@ class ProviderAnthropic(Provider):
 
         if "max_tokens" not in payloads:
             payloads["max_tokens"] = 1024
-        if self.thinking_config.get("budget"):
-            payloads["thinking"] = {
-                "budget_tokens": self.thinking_config.get("budget"),
-                "type": "enabled",
-            }
+        self._apply_thinking_config(payloads)
 
         try:
             completion = await self.client.messages.create(
@@ -287,11 +304,7 @@ class ProviderAnthropic(Provider):
 
         if "max_tokens" not in payloads:
             payloads["max_tokens"] = 1024
-        if self.thinking_config.get("budget"):
-            payloads["thinking"] = {
-                "budget_tokens": self.thinking_config.get("budget"),
-                "type": "enabled",
-            }
+        self._apply_thinking_config(payloads)
 
         async with self.client.messages.stream(
             **payloads, extra_body=extra_body

--- a/astrbot/dashboard/routes/config.py
+++ b/astrbot/dashboard/routes/config.py
@@ -40,6 +40,19 @@ from .util import (
 MAX_FILE_BYTES = 500 * 1024 * 1024
 
 
+def _apply_provider_metadata_overrides(
+    provider: Any, model_ids: list[str], metadata_map: dict
+) -> None:
+    override_fn = getattr(provider, "get_model_metadata_overrides", None)
+    if not callable(override_fn):
+        return
+    for mid, overrides in override_fn(model_ids).items():
+        merged = dict(metadata_map.get(mid, {}))
+        if "limit" in overrides:
+            merged["limit"] = {**merged.get("limit", {}), **overrides["limit"]}
+        metadata_map[mid] = merged
+
+
 def try_cast(value: Any, type_: str):
     if type_ == "int":
         try:
@@ -727,6 +740,8 @@ class ConfigRoute(Route):
                 if meta:
                     metadata_map[model_id] = meta
 
+            _apply_provider_metadata_overrides(provider, models, metadata_map)
+
             ret = {
                 "models": models,
                 "provider_id": provider_id,
@@ -871,6 +886,8 @@ class ConfigRoute(Route):
                 meta = LLM_METADATAS.get(model_id)
                 if meta:
                     metadata_map[model_id] = meta
+
+            _apply_provider_metadata_overrides(inst, models, metadata_map)
 
             # 销毁实例（如果有 terminate 方法）
             terminate_fn = getattr(inst, "terminate", None)

--- a/dashboard/src/composables/useProviderSources.ts
+++ b/dashboard/src/composables/useProviderSources.ts
@@ -182,7 +182,8 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
   const basicSourceConfig = computed(() => {
     if (!editableProviderSource.value) return null
 
-    const fields = ['id', 'key', 'api_base']
+    const isOAuth = editableProviderSource.value.type === 'anthropic_oauth'
+    const fields = isOAuth ? ['id', 'oauth_token', 'api_base'] : ['id', 'key', 'api_base']
     const basic: Record<string, any> = {}
 
     fields.forEach((field) => {
@@ -203,7 +204,7 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
   const advancedSourceConfig = computed(() => {
     if (!editableProviderSource.value) return null
 
-    const excluded = ['id', 'key', 'api_base', 'enable', 'type', 'provider_type', 'provider']
+    const excluded = ['id', 'key', 'oauth_token', 'api_base', 'enable', 'type', 'provider_type', 'provider']
     const advanced: Record<string, any> = {}
 
     for (const key of Object.keys(editableProviderSource.value)) {
@@ -243,6 +244,10 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
       customSchema.provider.items.id.hint = tm('providerSources.hints.id')
       customSchema.provider.items.key.hint = tm('providerSources.hints.key')
       customSchema.provider.items.api_base.hint = tm('providerSources.hints.apiBase')
+    }
+    // 为 oauth_token 字段添加自定义 hint
+    if (customSchema.provider?.items?.oauth_token) {
+      customSchema.provider.items.oauth_token.hint = tm('providerSources.hints.oauthToken')
     }
     // 为 proxy 字段添加描述和提示
     if (customSchema.provider?.items?.proxy) {

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -1174,10 +1174,22 @@
       },
       "anth_thinking_config": {
         "description": "Thinking Config",
+        "type": {
+          "description": "Thinking Type",
+          "hint": "Set 'adaptive' for Opus 4.6+ / Sonnet 4.6+ (recommended). Leave empty to use manual budget mode. See: https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking"
+        },
         "budget": {
           "description": "Thinking Budget",
-          "hint": "Anthropic thinking.budget_tokens param. Must >= 1024. See: https://platform.claude.com/docs/en/build-with-claude/extended-thinking"
+          "hint": "Anthropic thinking.budget_tokens param. Must >= 1024. Only used when type is empty. Deprecated on Opus 4.6 / Sonnet 4.6. See: https://platform.claude.com/docs/en/build-with-claude/extended-thinking"
+        },
+        "effort": {
+          "description": "Effort Level",
+          "hint": "Controls thinking depth when type is 'adaptive'. 'high' is the default. 'max' is Opus 4.6 only. See: https://platform.claude.com/docs/en/build-with-claude/effort"
         }
+      },
+      "oauth_token": {
+        "description": "OAuth Token",
+        "hint": "Run `claude setup-token` in your terminal to get a long-lived OAuth token, then paste it here. Token is valid for 1 year."
       },
       "minimax-group-id": {
         "description": "User group",

--- a/dashboard/src/i18n/locales/en-US/features/provider.json
+++ b/dashboard/src/i18n/locales/en-US/features/provider.json
@@ -114,6 +114,7 @@
     "hints": {
       "id": "Provider source ID (not provider ID)",
       "key": "API key for authentication",
+      "oauthToken": "Run `claude setup-token` in your terminal to get a long-lived OAuth token, then paste it here. Token is valid for 1 year.",
       "apiBase": "Custom API endpoint URL",
       "proxy": "HTTP/HTTPS proxy address, e.g. http://127.0.0.1:7890. Only affects this provider's API requests, doesn't interfere with Docker internal networking."
     },

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -1177,10 +1177,22 @@
       },
       "anth_thinking_config": {
         "description": "思考配置",
+        "type": {
+          "description": "思考类型",
+          "hint": "设为 'adaptive' 以使用自适应思考（推荐 Opus 4.6+ / Sonnet 4.6+）。留空则使用手动预算模式。参见: https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking"
+        },
         "budget": {
           "description": "思考预算",
-          "hint": "Anthropic thinking.budget_tokens 参数。必须 >= 1024。参见: https://platform.claude.com/docs/en/build-with-claude/extended-thinking"
+          "hint": "Anthropic thinking.budget_tokens 参数。必须 >= 1024。仅在思考类型为空时生效。Opus 4.6 / Sonnet 4.6 已弃用。参见: https://platform.claude.com/docs/en/build-with-claude/extended-thinking"
+        },
+        "effort": {
+          "description": "思考深度",
+          "hint": "当思考类型为 'adaptive' 时控制思考深度。'high' 为默认值。'max' 仅限 Opus 4.6。参见: https://platform.claude.com/docs/en/build-with-claude/effort"
         }
+      },
+      "oauth_token": {
+        "description": "OAuth Token",
+        "hint": "在终端运行 `claude setup-token` 获取长期有效的 OAuth Token，然后粘贴到此处。Token 有效期为 1 年。"
       },
       "minimax-group-id": {
         "description": "用户组",

--- a/dashboard/src/i18n/locales/zh-CN/features/provider.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/provider.json
@@ -115,6 +115,7 @@
     "hints": {
       "id": "提供商源唯一 ID（不是提供商 ID）",
       "key": "API 密钥",
+      "oauthToken": "在终端运行 `claude setup-token` 获取长期有效的 OAuth Token，然后粘贴到此处。Token 有效期为 1 年。",
       "apiBase": "自定义 API 端点 URL",
       "proxy": "HTTP/HTTPS 代理地址，格式如 http://127.0.0.1:7890。仅对该提供商的 API 请求生效，不影响 Docker 内网通信。"
     },


### PR DESCRIPTION
支持使用 Anthropic Claude Code OAuth 订阅作为 AstrBot 的 LLM Provider，同时为 Claude 4.6+ 模型增加自适应思考（adaptive thinking）配置。

## 改动点

### 新增文件：`astrbot/core/provider/sources/anthropic_oauth_source.py`（约 350 行）

- 完整的 OAuth Provider 适配器，从 `~/.claude/.credentials.json`（Claude Code CLI）读取凭证
- 通过 `auth_token=` 使用 Bearer 认证，附带必要的 OAuth headers（`claude-code-20250219`、`oauth-2025-04-20`、`context-1m-2025-08-07`）
- 自动刷新 token，原子写入凭证文件（`mkstemp` + `os.replace`）
- 并发安全的 `_ensure_valid_token()`：`asyncio.Lock`、磁盘重载与回滚、覆盖 6 种边界场景（过期 / 新鲜 / 损坏 / 竞态等）
- Opus 4.6 / Sonnet 4.6 模型自动检测 1M 上下文窗口
- Dashboard 元数据覆盖，正确显示上下文窗口大小
- 注入 OAuth 端点所需的系统提示前缀（`"You are Claude Code..."`）

### 修改：`astrbot/core/provider/sources/anthropic_source.py`

- 将 API key 初始化逻辑抽取为 `_init_api_key()` 方法，新增 `use_api_key=True` 参数供子类控制
- 抽取 `_apply_thinking_config()` 共享方法，同时支持 `adaptive`（4.6+ 推荐）和 `budget_tokens`（传统）两种思考模式
- 替换了 `_query` 和 `_query_stream` 中重复的内联思考逻辑

### 修改：`astrbot/core/provider/manager.py`

- 新增 `case "anthropic_oauth"` 分支用于动态加载 Provider

### 修改：`astrbot/core/config/default.py`

- 新增 `Anthropic (Claude Code OAuth)` Provider 模板，`key: []` 以兼容 Dashboard
- 扩展 `anth_thinking_config`：新增 `type`（adaptive / 留空）、`effort`（low / medium / high / max）、`budget` 子字段
- 新增 `claude_code_credentials_path` 元数据，带 `condition: {"type": "anthropic_oauth"}`

### 修改：`astrbot/dashboard/routes/config.py`

- 新增 `_apply_provider_metadata_overrides()` 辅助函数，将 Provider 特定的元数据（如 1M 上下文）合并到模型列表 API 响应中

### 修改：i18n 文件（zh-CN、en-US）

- 为所有新配置字段添加翻译

## 运行截图或测试结果

- 在远程服务器上完成 E2E 测试：`text_chat`、`text_chat_stream` 和模型列表均正常工作
- Dashboard UI 验证通过：所有新字段（思考类型、effort、凭证路径）正确渲染并支持 i18n
- `ruff check .` 和 `ruff format .` 均通过
- 经过 6 轮深度 Code Review，共发现并修复 20 个问题（并发、原子性、回滚、客户端同步等）
<img width="1329" height="900" alt="image" src="https://github.com/user-attachments/assets/c10949af-d2b5-45c8-82b0-dc73c6e43f05" />

<img width="1317" height="888" alt="image" src="https://github.com/user-attachments/assets/4752c49d-277c-44f3-874f-9ac6014b1740" />

<img width="1013" height="646" alt="image" src="https://github.com/user-attachments/assets/a32b83a5-0483-45f1-be3c-ebb8ccc2a53a" />

---

## 检查清单

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.