### PR TITLE
fix: prevent duplicate error message when all LLM providers fail

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -357,6 +357,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                     ),
                 ),
             )
+            return
 
         if not llm_resp.tools_call_name:
             # 如果没有工具调用，转换到完成状态


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
When all configured chat model providers fail (e.g., due to `APIConnectionError`, `NotFoundError`, etc.), the bot sends two separate error messages to the user instead of one. This is confusing and exposes raw technical error details twice.
### Modifications / 改动点
Modified tool_loop_agent_runner.py (1 line added):

In `ToolLoopAgentRunner.step()`, after yielding `AgentResponse(type="err", ...)` for a failed LLM response, execution continued into the `if not llm_resp.tools_call_name:` branch (since error responses have no tool calls). This caused:

1. A second `AgentResponse(type="llm_result")` to be yielded with the raw error text
2. The agent state to be incorrectly overwritten from `ERROR` to `DONE`

Added `return` after the `type="err"` yield to stop further processing.
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

Bug Fixes:
- 确保在 LLM 提供商调用失败时，只向用户发送一次错误响应，并且代理状态保持在错误状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure only a single error response is sent to the user and the agent state remains in an error state when LLM provider calls fail.

</details>