### PR TITLE
refactor: extract Voice_messages_forbidden fallback into shared helper with typed BadRequest exception

### DIFF
--- a/astrbot/core/platform/sources/telegram/tg_event.py
+++ b/astrbot/core/platform/sources/telegram/tg_event.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 import telegramify_markdown
 from telegram import ReactionTypeCustomEmoji, ReactionTypeEmoji
 from telegram.constants import ChatAction
+from telegram.error import BadRequest
 from telegram.ext import ExtBot
 
 from astrbot import logger
@@ -119,6 +120,65 @@ class TelegramPlatformEvent(AstrMessageEvent):
             client, user_name, ChatAction.TYPING, message_thread_id
         )
 
+    @classmethod
+    async def _send_voice_with_fallback(
+        cls,
+        client: ExtBot,
+        path: str,
+        payload: dict[str, Any],
+        *,
+        caption: str | None = None,
+        user_name: str = "",
+        message_thread_id: str | None = None,
+        use_media_action: bool = False,
+    ) -> None:
+        """Send a voice message, falling back to a document if the user's
+        privacy settings forbid voice messages (``BadRequest`` with
+        ``Voice_messages_forbidden``).
+
+        When *use_media_action* is ``True`` the helper wraps the send calls
+        with ``_send_media_with_action`` (used by the streaming path).
+        """
+        try:
+            if use_media_action:
+                await cls._send_media_with_action(
+                    client,
+                    ChatAction.UPLOAD_VOICE,
+                    client.send_voice,
+                    user_name=user_name,
+                    message_thread_id=message_thread_id,
+                    voice=path,
+                    **cast(Any, payload),
+                )
+            else:
+                await client.send_voice(voice=path, **cast(Any, payload))
+        except BadRequest as e:
+            # python-telegram-bot raises BadRequest for Voice_messages_forbidden;
+            # distinguish the voice-privacy case via the API error message.
+            if "Voice_messages_forbidden" not in e.message:
+                raise
+            logger.warning(
+                "User privacy settings prevent receiving voice messages, falling back to sending an audio file. "
+                "To enable voice messages, go to Telegram Settings → Privacy and Security → Voice Messages → set to 'Everyone'."
+            )
+            if use_media_action:
+                await cls._send_media_with_action(
+                    client,
+                    ChatAction.UPLOAD_DOCUMENT,
+                    client.send_document,
+                    user_name=user_name,
+                    message_thread_id=message_thread_id,
+                    document=path,
+                    caption=caption,
+                    **cast(Any, payload),
+                )
+            else:
+                await client.send_document(
+                    document=path,
+                    caption=caption,
+                    **cast(Any, payload),
+                )
+
     async def _ensure_typing(
         self,
         user_name: str,
@@ -211,7 +271,7 @@ class TelegramPlatformEvent(AstrMessageEvent):
                 )
             elif isinstance(i, Record):
                 path = await i.convert_to_file_path()
-                await client.send_voice(voice=path, **cast(Any, payload))
+                await cls._send_voice_with_fallback(client, path, payload)
 
     async def send(self, message: MessageChain) -> None:
         if self.get_message_type() == MessageType.GROUP_MESSAGE:
@@ -330,14 +390,14 @@ class TelegramPlatformEvent(AstrMessageEvent):
                         continue
                     elif isinstance(i, Record):
                         path = await i.convert_to_file_path()
-                        await self._send_media_with_action(
+                        await self._send_voice_with_fallback(
                             self.client,
-                            ChatAction.UPLOAD_VOICE,
-                            self.client.send_voice,
+                            path,
+                            payload,
+                            caption=delta or None,
                             user_name=user_name,
                             message_thread_id=message_thread_id,
-                            voice=path,
-                            **cast(Any, payload),
+                            use_media_action=True,
                         )
                         continue
                     else:


### PR DESCRIPTION
## Summary

Extracted the duplicated `Voice_messages_forbidden` handling from both `send_with_client` and `send_streaming` into a shared `_send_voice_with_fallback` classmethod.

## Changes

- Added `_send_voice_with_fallback` helper that encapsulates the voice-to-document fallback logic in one place.
- Catches `telegram.error.BadRequest` (the actual exception type raised by python-telegram-bot) instead of bare `Exception` with fragile `str(e)` string matching.
- Uses `e.message` attribute directly to distinguish the voice-privacy case.
- Both `send_with_client` and `send_streaming` now delegate to the shared helper, eliminating code duplication.

## Why BadRequest instead of Forbidden?

The python-telegram-bot library raises `BadRequest('Voice_messages_forbidden')` for this Telegram API error, not `Forbidden`. Confirmed via runtime stack trace.

## Summary by Sourcery

重构 Telegram 语音消息发送逻辑，将语音转文档的回退处理集中化，并对与隐私相关的失败使用带类型的 BadRequest 错误。

Bug 修复：
- 通过捕获正确的 `BadRequest('Voice_messages_forbidden')` 错误，而不是通用的 `Exception`，来处理 Telegram 语音隐私失败，确保回退行为正确执行。

增强：
- 将语音发送和语音转文档的回退逻辑提取到共享的 `_send_voice_with_fallback` 辅助函数中，由 `send_with_client` 和 `send_streaming` 共同复用，以消除重复并保持行为一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor Telegram voice message sending to centralize voice-to-document fallback handling and use typed BadRequest errors for privacy-related failures.

Bug Fixes:
- Handle Telegram voice privacy failures by catching the correct BadRequest('Voice_messages_forbidden') error instead of a generic Exception, ensuring proper fallback behavior.

Enhancements:
- Extract voice sending and voice-to-document fallback into a shared _send_voice_with_fallback helper reused by both send_with_client and send_streaming to remove duplication and keep behavior consistent.

</details>