### PR TITLE
fix: handle Telegram Voice_messages_forbidden with typed exception and text caption

### DIFF
--- a/astrbot/core/message/components.py
+++ b/astrbot/core/message/components.py
@@ -119,6 +119,8 @@ class Record(BaseMessageComponent):
     cache: bool | None = True
     proxy: bool | None = True
     timeout: int | None = 0
+    # Original text content (e.g. TTS source text), used as caption in fallback scenarios
+    text: str | None = None
     # 额外
     path: str | None
 

--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -315,6 +315,7 @@ class ResultDecorateStage(Stage):
                                 Record(
                                     file=url or audio_path,
                                     url=url or audio_path,
+                                    text=comp.text,
                                 ),
                             )
                             if dual_output:


### PR DESCRIPTION
The duplicated Voice_messages_forbidden handling in send_with_client and send_streaming was fragile (bare Exception + string matching) and hard to maintain. This PR consolidates it into a single helper with proper typed exception handling.

### Modifications / 改动点

- strbot/core/platform/sources/telegram/tg_event.py: Extracted _send_voice_with_fallback helper to deduplicate voice forbidden fallback logic. Catches 	elegram.error.BadRequest instead of bare Exception. Added empty chat_id guard in _send_chat_action.
- strbot/core/message/components.py: Added optional 	ext field to Record to preserve TTS source text.
- strbot/core/pipeline/result_decorate/stage.py: Store original plain text into Record.text during TTS conversion, so it can be used as document caption on fallback.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Tested with a Telegram user whose privacy settings forbid voice messages.
<img width="978" height="328" alt="image" src="https://github.com/user-attachments/assets/4beb6d3d-6165-4ed6-894e-7c16833c7b89" />

---

### Checklist / 检查清单

- [x]  如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x]  我的更改经过了良好的测试，**并已在上方提供了「验证步骤」和「运行截图」**。/ My changes have been well-tested, **and `Verification Steps` and `Screenshots` have been provided above**.
- [x]  我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x]  我的更改没有引入恶意代码。/ My changes do not introduce malicious code.