### PR TITLE
Add support for Json, Xml, and other components

### DIFF
--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -41,7 +41,6 @@ class RespondStage(Stage):
         Comp.Location: lambda comp: bool(comp.lat is not None and comp.lon is not None), # 位置
         Comp.Contact: lambda comp: bool(comp._type and comp.id), # 推荐好友 or 群
         Comp.Shake: lambda _: True, # 窗口抖动（戳一戳）
-        Comp.Anonymous: lambda _: True, # 匿名发消息
         Comp.Dice: lambda _: True, # 掷骰子魔法表情
         Comp.RPS: lambda _: True, # 猜拳魔法表情
         Comp.Unknown: lambda comp: bool(comp.text and comp.text.strip()),


### PR DESCRIPTION
修复发送 JSON 消息时遇到 “消息为空，跳过发送阶段” 的问题。

### Modifications / 改动点

- **/astrbot/core/pipeline/respond/stage.py** : 补全 JSON 消息判断，并顺带补全其它缺失的消息类型判断。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

``
[2026-02-18 18:59:19.431] [Core] [INFO] [core.event_bus:59]: [default] [NapCat(aiocqhttp)] 皮皮喵酪灰/3525987739: 点歌1 
[2026-02-18 18:59:19.432] [Core] [DBUG] [waking_check.stage:157]: enabled_plugins_name: ['*']
[2026-02-18 18:59:19.436] [Core] [DBUG] [method.star_request:44]: plugin -> session_controller - handle_session_control_agent
[2026-02-18 18:59:19.436] [Core] [DBUG] [method.star_request:44]: plugin -> session_controller - handle_empty_mention
[2026-02-18 18:59:19.436] [Core] [DBUG] [method.star_request:44]: plugin -> astrbot_plugin_meting - play_song_by_index
[2026-02-18 18:59:19.718] [Plug] [INFO] [astrbot_plugin_meting.main:175]: 音乐卡片签名成功，发送卡片
[2026-02-18 18:59:19.719] [Plug] [INFO] [astrbot_plugin_meting.main:176]: 卡片数据: type=<ComponentType.Json: 'Json'> data={'app': 'com.tencent.music.lua', 'bizsrc': 'qqconnect.sdkshare_music', 'config': {'ctime': 1771411966, 'forward': 1, 'token': 'e79a964c581706afcbbfa0fb963e18eb', 'type': 'normal'}, 'extra': {'app_type': 1, 'appid': 100495085, 'uin': 3264925726}, 'meta': {'music': {'app_type': 1, 'appid': 100495085, 'ctime': 1771411966, 'desc': '小星星Aurora', 'jumpUrl': 'https://music.163.com/#/song?id=1351520305', 'musicUrl': 'https://metingapi.nanorocky.top/?server=netease&type=url&id=1351520305', 'preview': 'https://p3.music.126.net/-kDO5LiKki3bmeF21MaCuQ==/109951163917806959.jpg?param=320x320', 'tag': '网易云音乐', 'tagIcon': 'https://i.gtimg.cn/open/app_icon/00/49/50/85/100495085_100_m.png', 'title': '坠落星空', 'uin': 3264925726}}, 'prompt': '[分享]坠落星空', 'ver': '0.0.0.1', 'view': 'music'}
[2026-02-18 18:59:19.719] [Core] [DBUG] [result_decorate.stage:165]: hook(on_decorating_result) -> meme_manager - on_decorating_result
[2026-02-18 18:59:19.719] [Plug] [DBUG] [astrbot_plugin_meme_manager.main:766]: [meme_manager] on_decorating_result 开始处理
[2026-02-18 18:59:19.719] [Plug] [DBUG] [astrbot_plugin_meme_manager.main:914]: [meme_manager] on_decorating_result 处理完成
[2026-02-18 18:59:19.721] [Core] [INFO] [respond.stage:170]: Prepare to send - 皮皮喵酪灰/3525987739: [ComponentType.Json] 
[2026-02-18 18:59:19.844] [Core] [DBUG] [pipeline.context_utils:95]: hook(OnAfterMessageSentEvent) -> meme_manager - after_message_sent
[2026-02-18 18:59:19.845] [Core] [DBUG] [pipeline.context_utils:95]: hook(OnAfterMessageSentEvent) -> astrbot - after_message_sent
[2026-02-18 18:59:19.845] [Core] [DBUG] [method.star_request:44]: plugin -> meme_manager - handle_upload_image
[2026-02-18 18:59:19.845] [Core] [DBUG] [method.star_request:44]: plugin -> astrbot - on_message
[2026-02-18 18:59:19.845] [Core] [DBUG] [pipeline.scheduler:88]: pipeline 执行完毕。
``

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

---

### A short story
<img width="1440" height="15838" alt="Image_1771415347973_644" src="https://github.com/user-attachments/assets/7dddf5dc-7173-449b-ab2d-857529f7824e" />

---

close #5198 <br>
Co-authored-by: Pizero <zhaory200707@outlook.com>