### PR TITLE
feat: add admin permission checks config item for computer use feature

### DIFF
--- a/astrbot/core/computer/tools/python.py
+++ b/astrbot/core/computer/tools/python.py
@@ -26,6 +26,21 @@ param_schema = {
 }
 
 
+def _check_admin_permission(context: ContextWrapper[AstrAgentContext]) -> str | None:
+    cfg = context.context.context.get_config(
+        umo=context.context.event.unified_msg_origin
+    )
+    provider_settings = cfg.get("provider_settings", {})
+    require_admin = provider_settings.get("computer_use_require_admin", True)
+    if require_admin and context.context.event.role != "admin":
+        return (
+            "error: Permission denied. Python execution is only allowed for admin users. "
+            "Tell user to set admins in `AstrBot WebUI -> Config -> General Config` by adding their user ID to the admins list if they need this feature."
+            f"User's ID is: {context.context.event.get_sender_id()}. User's ID can be found by using /sid command."
+        )
+    return None
+
+
 async def handle_result(result: dict, event: AstrMessageEvent) -> ToolExecResult:
     data = result.get("data", {})
     output = data.get("output", {})
@@ -66,6 +81,8 @@ class PythonTool(FunctionTool):
     async def call(
         self, context: ContextWrapper[AstrAgentContext], code: str, silent: bool = False
     ) -> ToolExecResult:
+        if permission_error := _check_admin_permission(context):
+            return permission_error
         sb = await get_booter(
             context.context.context,
             context.context.event.unified_msg_origin,
@@ -87,12 +104,8 @@ class LocalPythonTool(FunctionTool):
     async def call(
         self, context: ContextWrapper[AstrAgentContext], code: str, silent: bool = False
     ) -> ToolExecResult:
-        if context.context.event.role != "admin":
-            return (
-                "error: Permission denied. Local Python execution is only allowed for admin users. "
-                "Tell user to set admins in `AstrBot WebUI -> Config -> General Config` by adding their user ID to the admins list if they need this feature."
-                f"User's ID is: {context.context.event.get_sender_id()}. User's ID can be found by using /sid command."
-            )
+        if permission_error := _check_admin_permission(context):
+            return permission_error
         sb = get_local_booter()
         try:
             result = await sb.python.exec(code, silent=silent)

--- a/astrbot/core/computer/tools/shell.py
+++ b/astrbot/core/computer/tools/shell.py
@@ -9,6 +9,21 @@ from astrbot.core.astr_agent_context import AstrAgentContext
 from ..computer_client import get_booter, get_local_booter
 
 
+def _check_admin_permission(context: ContextWrapper[AstrAgentContext]) -> str | None:
+    cfg = context.context.context.get_config(
+        umo=context.context.event.unified_msg_origin
+    )
+    provider_settings = cfg.get("provider_settings", {})
+    require_admin = provider_settings.get("computer_use_require_admin", True)
+    if require_admin and context.context.event.role != "admin":
+        return (
+            "error: Permission denied. Shell execution is only allowed for admin users. "
+            "Tell user to set admins in `AstrBot WebUI -> Config -> General Config` by adding their user ID to the admins list if they need this feature."
+            f"User's ID is: {context.context.event.get_sender_id()}. User's ID can be found by using /sid command."
+        )
+    return None
+
+
 @dataclass
 class ExecuteShellTool(FunctionTool):
     name: str = "astrbot_execute_shell"
@@ -46,12 +61,8 @@ class ExecuteShellTool(FunctionTool):
         background: bool = False,
         env: dict = {},
     ) -> ToolExecResult:
-        if context.context.event.role != "admin":
-            return (
-                "error: Permission denied. Local shell execution is only allowed for admin users. "
-                "Tell user to set admins in `AstrBot WebUI -> Config -> General Config` by adding their user ID to the admins list if they need this feature."
-                f"User's ID is: {context.context.event.get_sender_id()}. User's ID can be found by using /sid command."
-            )
+        if permission_error := _check_admin_permission(context):
+            return permission_error
 
         if self.is_local:
             sb = get_local_booter()

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -128,6 +128,7 @@ DEFAULT_CONFIG = {
             "add_cron_tools": True,
         },
         "computer_use_runtime": "local",
+        "computer_use_require_admin": True,
         "sandbox": {
             "booter": "shipyard",
             "shipyard_endpoint": "",
@@ -2736,6 +2737,11 @@ CONFIG_METADATA_3 = {
                         "options": ["none", "local", "sandbox"],
                         "labels": ["无", "本地", "沙箱"],
                         "hint": "选择 Computer Use 运行环境。",
+                    },
+                    "provider_settings.computer_use_require_admin": {
+                        "description": "需要 AstrBot 管理员权限",
+                        "type": "bool",
+                        "hint": "开启后，需要 AstrBot 管理员权限才能调用使用电脑能力。在平台配置->管理员中可添加管理员。使用 /sid 指令查看管理员 ID。",
                     },
                     "provider_settings.sandbox.booter": {
                         "description": "沙箱环境驱动器",

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -149,6 +149,10 @@
           "description": "Computer Use Runtime",
           "hint": "sandbox means running in a sandbox environment, local means running in a local environment, none means disabling Computer Use. If skills are uploaded, choosing none will cause them to not be usable by the Agent."
         },
+        "computer_use_require_admin": {
+          "description": "Require AstrBot Admin Permission",
+          "hint": "When enabled, AstrBot admin permission is required to use computer capabilities. Admins can be added in Platform Config. Use the /sid command to view admin IDs."
+        },
         "sandbox": {
           "booter": {
             "description": "Sandbox Environment Driver"

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -152,6 +152,10 @@
           "description": "运行环境",
           "hint": "sandbox 代表在沙箱环境中运行, local 代表在本地环境中运行, none 代表不启用。如果上传了 skills，选择 none 会导致其无法被 Agent 正常使用。"
         },
+        "computer_use_require_admin": {
+          "description": "需要 AstrBot 管理员权限",
+          "hint": "开启后，需要 AstrBot 管理员权限才能调用使用电脑能力。在平台配置->管理员中可添加管理员。使用 /sid 指令查看管理员 ID。"
+        },
         "sandbox": {
           "booter": {
             "description": "沙箱环境驱动器"


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [ ] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [ ] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [ ] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

将 Python 和 shell 的 computer-use 工具置于可配置的仅管理员权限之下，并在提供方配置元数据中暴露该设置。

新功能：
- 引入一个可配置的提供方设置 `computer_use_require_admin`，用于控制 Python 和 shell 的 computer-use 工具是否需要 AstrBot 管理员权限。
- 添加配置元数据和 i18n 条目，使得可以通过 Web UI 管理计算机使用所需的管理员权限。

增强：
- 将 Python 和 shell 执行工具的管理员权限检查进行集中化处理，以复用通用逻辑并提升权限处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Gate Python and shell computer-use tools behind configurable admin-only permissions and expose the setting in provider configuration metadata.

New Features:
- Introduce a configurable provider setting `computer_use_require_admin` to control whether Python and shell computer-use tools require AstrBot admin privileges.
- Add configuration metadata and i18n entries so the admin permission requirement for computer use can be managed via the Web UI.

Enhancements:
- Centralize admin-permission checks for Python and shell execution tools to reuse common logic and improve consistency of permission handling.

</details>