### PR TITLE
fix: apply reply_with_quote and reply_with_mention to image-only response

### DIFF
--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -383,21 +383,19 @@ class ResultDecorateStage(Stage):
                     )
                     result.chain = [node]
 
-            has_plain = any(isinstance(item, Plain) for item in result.chain)
-            if has_plain:
-                # at 回复
-                if (
-                    self.reply_with_mention
-                    and event.get_message_type() != MessageType.FRIEND_MESSAGE
-                ):
-                    result.chain.insert(
-                        0,
-                        At(qq=event.get_sender_id(), name=event.get_sender_name()),
-                    )
-                    if len(result.chain) > 1 and isinstance(result.chain[1], Plain):
-                        result.chain[1].text = "\n" + result.chain[1].text
+            # at 回复
+            if (
+                self.reply_with_mention
+                and event.get_message_type() != MessageType.FRIEND_MESSAGE
+            ):
+                result.chain.insert(
+                    0,
+                    At(qq=event.get_sender_id(), name=event.get_sender_name()),
+                )
+                if len(result.chain) > 1 and isinstance(result.chain[1], Plain):
+                    result.chain[1].text = "\n" + result.chain[1].text
 
-                # 引用回复
-                if self.reply_with_quote:
-                    if not any(isinstance(item, File) for item in result.chain):
-                        result.chain.insert(0, Reply(id=event.message_obj.message_id))
+            # 引用回复
+            if self.reply_with_quote:
+                if not any(isinstance(item, File) for item in result.chain):
+                    result.chain.insert(0, Reply(id=event.message_obj.message_id))


### PR DESCRIPTION
When `reply_with_quote` or `reply_with_mention` is enabled, both features
were silently skipped whenever the response chain contained no `Plain` text
component (e.g. image-only outputs from Text-to-Image). The root cause was
an overly broad `if has_plain:` guard that wrapped both features together.
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点
- `astrbot/core/pipeline/result_decorate/stage.py`
  Removed the `has_plain` guard that gated both `reply_with_mention` (At)
  and `reply_with_quote` (Reply) on the presence of a Plain text component.
  Each feature now evaluates its own existing exclusion conditions
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

Bug Fixes:
- 修复在结果修饰阶段，对于仅包含图片或非纯文本响应时，`reply-with-mention` 和 `reply-with-quote` 被跳过的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix reply-with-mention and reply-with-quote being skipped for image-only or non-Plain responses in the result decoration stage.

</details>