### PR TITLE
fix: 改进微信公众号被动回复处理机制，引入缓冲与分片回复，并优化超时行为

### DIFF
--- a/astrbot/core/platform/sources/weixin_official_account/weixin_offacc_event.py
+++ b/astrbot/core/platform/sources/weixin_official_account/weixin_offacc_event.py
@@ -1,15 +1,16 @@
 import asyncio
 import os
-from typing import cast, Any
+from typing import Any, cast
 
 from wechatpy import WeChatClient
-from wechatpy.replies import ImageReply, TextReply, VoiceReply
+from wechatpy.replies import ImageReply, VoiceReply
 
 from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent, MessageChain
 from astrbot.api.message_components import Image, Plain, Record
 from astrbot.api.platform import AstrBotMessage, PlatformMetadata
 from astrbot.core.utils.media_utils import convert_audio_to_amr
+
 
 class WeixinOfficialAccountPlatformEvent(AstrMessageEvent):
     def __init__(
@@ -19,7 +20,7 @@ class WeixinOfficialAccountPlatformEvent(AstrMessageEvent):
         platform_meta: PlatformMetadata,
         session_id: str,
         client: WeChatClient,
-        message_out: dict[Any, Any]
+        message_out: dict[Any, Any],
     ) -> None:
         super().__init__(message_str, message_obj, platform_meta, session_id)
         self.client = client
@@ -92,9 +93,11 @@ class WeixinOfficialAccountPlatformEvent(AstrMessageEvent):
                     for chunk in plain_chunks:
                         self.client.message.send_text(message_obj.sender.user_id, chunk)
                 else:
-                    # disable passive sending, just store the chunks in 
-                    logger.debug(f"split plain into {len(plain_chunks)} chunks for passive reply. Message not sent.")
-                    self.message_out['cached_xml']=plain_chunks
+                    # disable passive sending, just store the chunks in
+                    logger.debug(
+                        f"split plain into {len(plain_chunks)} chunks for passive reply. Message not sent."
+                    )
+                    self.message_out["cached_xml"] = plain_chunks
             elif isinstance(comp, Image):
                 img_path = await comp.convert_to_file_path()
 


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

fixes: #2076

### Modifications / 改动点

- 保留所有主动回复逻辑，（即使我个人认为这些方法在大多数个人公众号上没有办法实现。
- 修改了被动回复的逻辑，针对微信平台添加了`user_buffer`实现异步存储功能，修复了 AstrBotDevs/AstrBot/issues/2076
- 缩小了wechat的分段逻辑来保留系统指引所需要的字符，原本2048字符在部分特殊情况下（中文字符过多）时可能导致发送失败。
- 根据新增的方法添加了debug log和额外的info
- 增加了额外的preview和被动回复模板，保证微信用户在不访问后台的情况下查看目前正在思考的进程。

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
  - 所有文件修改仅局限于wechat-offical，未修改其他代码逻辑。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

在本人个人公众号上测试后修复有效，新增代码能正常回复提示消息和在微信公众号post窗口内进行分段回复。并能正常返回pipline的所有信息，包括报错消息。

以下是客户端截图
<img width="298" height="646" alt="4fde1be39b5ed950366cf6fd5905784d_0" src="https://github.com/user-attachments/assets/4d5c9090-83e3-4a10-9652-80ba3ec015a1" />
<img width="298" height="646" alt="30c85920762dcf41c7d9e1196bd7d486_0" src="https://github.com/user-attachments/assets/a1349d5d-8643-4833-bc3f-30c90be9ccbd" />
<img width="298" height="646" alt="37c3675b51695542dd92bcfc276a6ca1_0" src="https://github.com/user-attachments/assets/746d7067-12be-4a81-9e61-817621f85f01" />

以下是服务器端截图

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

<img width="1605" height="360" alt="error_report" src="https://github.com/user-attachments/assets/ef610ceb-4216-4979-bb70-b3badc89152a" />

<img width="1605" height="624" alt="partition" src="https://github.com/user-attachments/assets/83e14402-eb8e-46b9-bcea-0226f1d883a3" />

---
### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

### 测试时发现的额外补充

- 由于在被动回复模式下，微信服务器仍然可能发送部分重复的信息，本人对本项目pipline和AstrBotMessage相关的future class的了解比较有限，针对极端条件下微信服务器在被动模式下反复发送同一条信息时可能导致部分回复消息丢失，目前没有较好的解决方案。
- 目前拆分的回复buffer只支持文本消息，后续对message chain的支持没有想到特别好的解决方案。

## Summary by Sourcery

改进微信公众号被动回复处理机制，引入缓冲与分片回复，并优化超时行为。

New Features:
- 为微信公众号消息的多步被动回复增加用户级缓冲区和预览占位符支持。

Bug Fixes:
- 通过严格遵守 5 秒响应限制，并更健壮地处理微信重试机制，修复微信公众号被动回复失败问题。

Enhancements:
- 优化微信公众号长文本拆分逻辑，支持可配置的更小分片，以减少边缘情况下的发送失败。
- 统一公众号在主动发送与被动回复模式下的回调处理方式，并延长回调超时时间以适配更长链路的处理流程。
- 改进与微信公众号被动回复缓冲和超时相关的日志与错误信息，便于问题排查与调试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve WeChat Official Account passive reply handling with buffered, chunked responses and better timeout behavior.

New Features:
- Add user-level buffer and preview placeholders to support multi-step passive replies for WeChat Official Account messages.

Bug Fixes:
- Fix WeChat Official Account passive reply failures by aligning with the 5-second response constraint and handling WeChat retries more robustly.

Enhancements:
- Refine long-text splitting for WeChat messages with configurable smaller chunks to reduce send failures in edge cases.
- Unify WeChat Official Account callback handling for active and passive send modes and extend callback timeout duration for longer pipelines.
- Improve logging and error messages around WeChat passive reply buffering and timeout conditions for easier debugging.

</details>