### PR TITLE
fix(provider): 修复 dict 格式 content 导致的 JSON 残留问题

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -394,7 +394,7 @@ class ProviderOpenAIOfficial(Provider):
                 text_val = raw_content.get("text", "")
                 return str(text_val) if text_val is not None else ""
             # For other dict formats, return empty string and log
-            logger.warning(f"未预期的 dict 格式 content: {raw_content}")
+            logger.warning(f"Unexpected dict format content: {raw_content}")
             return ""
 
         if isinstance(raw_content, list):


### PR DESCRIPTION
## 问题描述

fixes: #5244

在使用 OpenAI 兼容 API 时，当 LLM provider 返回的 `content` 字段为 dict 格式（如 `{"type": "text", "text": "..."}`）时，`_normalize_content` 函数会直接调用 `str(raw_content)`，导致 `{'type': 'text', 'text': '...'}` 被原样写入消息内容并发送给用户。

该问题在 Agent 多轮工具调用场景下尤为明显，会形成嵌套累积的 dict 字符串残留。

## 修复内容

- 在 `_normalize_content` 函数中添加对 dict 类型的处理
- 当 content 为 dict 且包含 `text` 字段时，提取 `text` 值而非直接转为字符串
- 对于其他 dict 格式，记录警告日志并返回空字符串
- 改进 fallback 行为，对 None 值返回空字符串

## 测试

- 修复已通过 Ruff 代码检查

## 影响范围

- 仅影响 `openai_source.py` 中的 `_normalize_content` 函数
- 修复所有使用 OpenAI 兼容 API 的 provider（包括 Gemini、SiliconFlow 等）

## Summary by Sourcery

改进来自兼容 OpenAI 的 LLM 提供方内容的标准化处理，以正确处理基于字典（dict）的响应，避免将原始 JSON 泄露到用户可见的消息中。

Bug 修复：
- 从 LLM 响应中基于 dict 形式的内容提取文本，而不是序列化整个 dict，从而防止类似 JSON 的内容出现在消息中。
- 对于意外的 dict 内容格式，返回空字符串并记录警告日志，而不是将其直接透传。
- 确保回退的标准化逻辑对 `None` 值返回空字符串，以避免输出中出现字面量 `'None'`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve normalization of LLM provider content from OpenAI-compatible sources to correctly handle dict-based responses and avoid leaking raw JSON into user-visible messages.

Bug Fixes:
- Extract text from dict-form content in LLM responses instead of serializing the entire dict, preventing JSON-like artifacts from appearing in messages.
- Return empty string and log a warning for unexpected dict content formats instead of passing them through.
- Ensure fallback normalization returns an empty string for None values to avoid literal 'None' appearing in output.

</details>