### PR TITLE
fix(SubAgentPage): 当中间的介绍文本非常长时，Flex 布局会自动挤压右侧的控制按钮区域

### DIFF
--- a/dashboard/src/views/SubAgentPage.vue
+++ b/dashboard/src/views/SubAgentPage.vue
@@ -138,14 +138,13 @@
             </div>
 
             <!-- Controls (stop propagation on clicks) -->
-            <div class="d-flex align-center gap-2" @click.stop>
+            <div class="d-flex align-center gap-2 flex-shrink-0" @click.stop>
               <v-switch
                 v-model="agent.enabled"
                 color="success"
                 hide-details
                 inset
                 density="compact"
-                class="mr-2"
               />
               <v-btn
                 icon="mdi-delete-outline"


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
#5304 

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
- 为开关和删除按钮的容器添加了 flex-shrink-0 属性，确保按钮始终保持其原始大小时，不会被压缩。
- 移除了开关按钮上多余的 mr-2 边距，并利用 Flex 容器的 gap 属性来处理间距，使布局更加整洁和稳定。
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<img width="1874" height="956" alt="image" src="https://github.com/user-attachments/assets/42f17444-b96b-44d4-9894-b6ef94c34ef6" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

防止当中间描述文本非常长时，SubAgent 页面上的控制按钮被压缩。

Bug 修复：
- 确保 SubAgentPage 中的切换和删除控件在相邻文本内容较长时仍然可见，并保持其原有尺寸。

增强优化：
- 通过依赖 flex 容器的 gap，而不是为每个控件单独设置 margin，简化 SubAgentPage 中控件之间的间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent SubAgent page control buttons from being compressed when the middle description text is very long.

Bug Fixes:
- Ensure the switch and delete controls in SubAgentPage remain visible and retain their size even when adjacent text content is lengthy.

Enhancements:
- Simplify spacing between controls in SubAgentPage by relying on flex container gaps instead of individual control margins.

</details>