### PR TITLE
fix: use re.search instead of re.match in RegexFilter

### DIFF
--- a/astrbot/core/star/filter/regex.py
+++ b/astrbot/core/star/filter/regex.py
@@ -15,4 +15,4 @@ class RegexFilter(HandlerFilter):
         self.regex = re.compile(regex)
 
     def filter(self, event: AstrMessageEvent, cfg: AstrBotConfig) -> bool:
-        return bool(self.regex.match(event.get_message_str().strip()))
+        return bool(self.regex.search(event.get_message_str().strip()))


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
`RegexFilter` was using `re.match()` to evaluate `@filter.regex` patterns, but `re.match()` implicitly anchors the match to the start of the string — equivalent to prepending `^` to every pattern. This means patterns without an explicit `^` would silently behave as if one were present, causing messages where the pattern appears mid-sentence to not trigger the handler. This violates standard regex semantics and surprises plugin developers who expect unanchored patterns to match anywhere in the message.
### Modifications / 改动点
- `astrbot/core/star/filter/regex.py`: Replace `self.regex.match(...)` with `self.regex.search(...)` so that unanchored patterns match anywhere in the message. Plugins that require start-of-string matching can still use an explicit `^` anchor.
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

Bug Fixes:
- 确保在未显式使用锚点的情况下，RegexFilter 模式可以匹配消息文本中的任意位置，而不仅仅是从开头开始匹配。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure RegexFilter patterns without explicit anchors can match anywhere in the message text instead of only at the beginning.

</details>