### PR TITLE
fix: chatui cannot persist file segment

### DIFF
--- a/astrbot/core/platform/sources/webchat/webchat_event.py
+++ b/astrbot/core/platform/sources/webchat/webchat_event.py
@@ -11,13 +11,13 @@ from astrbot.core.utils.astrbot_path import get_astrbot_data_path
 
 from .webchat_queue_mgr import webchat_queue_mgr
 
-imgs_dir = os.path.join(get_astrbot_data_path(), "webchat", "imgs")
+attachments_dir = os.path.join(get_astrbot_data_path(), "attachments")
 
 
 class WebChatMessageEvent(AstrMessageEvent):
     def __init__(self, message_str, message_obj, platform_meta, session_id) -> None:
         super().__init__(message_str, message_obj, platform_meta, session_id)
-        os.makedirs(imgs_dir, exist_ok=True)
+        os.makedirs(attachments_dir, exist_ok=True)
 
     @staticmethod
     async def _send(
@@ -69,7 +69,7 @@ class WebChatMessageEvent(AstrMessageEvent):
             elif isinstance(comp, Image):
                 # save image to local
                 filename = f"{str(uuid.uuid4())}.jpg"
-                path = os.path.join(imgs_dir, filename)
+                path = os.path.join(attachments_dir, filename)
                 image_base64 = await comp.convert_to_base64()
                 with open(path, "wb") as f:
                     f.write(base64.b64decode(image_base64))
@@ -85,7 +85,7 @@ class WebChatMessageEvent(AstrMessageEvent):
             elif isinstance(comp, Record):
                 # save record to local
                 filename = f"{str(uuid.uuid4())}.wav"
-                path = os.path.join(imgs_dir, filename)
+                path = os.path.join(attachments_dir, filename)
                 record_base64 = await comp.convert_to_base64()
                 with open(path, "wb") as f:
                     f.write(base64.b64decode(record_base64))
@@ -104,7 +104,7 @@ class WebChatMessageEvent(AstrMessageEvent):
                 original_name = comp.name or os.path.basename(file_path)
                 ext = os.path.splitext(original_name)[1] or ""
                 filename = f"{uuid.uuid4()!s}{ext}"
-                dest_path = os.path.join(imgs_dir, filename)
+                dest_path = os.path.join(attachments_dir, filename)
                 shutil.copy2(file_path, dest_path)
                 data = f"[FILE]{filename}"
                 await web_chat_back_queue.put(

--- a/astrbot/dashboard/routes/chat.py
+++ b/astrbot/dashboard/routes/chat.py
@@ -215,8 +215,13 @@ class ChatRoute(Route):
             filename: 存储的文件名
             attach_type: 附件类型 (image, record, file, video)
         """
-        file_path = os.path.join(self.attachments_dir, os.path.basename(filename))
-        if not os.path.exists(file_path):
+        basename = os.path.basename(filename)
+        candidate_paths = [
+            os.path.join(self.attachments_dir, basename),
+            os.path.join(self.legacy_img_dir, basename),
+        ]
+        file_path = next((p for p in candidate_paths if os.path.exists(p)), None)
+        if not file_path:
             return None
 
         # guess mime type


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [ ] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [ ] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [ ] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## 由 Sourcery 提供的摘要

在统一的附件目录下持久化存储网页聊天附件，并新增对从旧版图片目录加载附件的向后兼容支持。

Bug 修复：
- 确保网页聊天中的图片、音频和文件片段被保存到共享附件目录中，以实现正确的持久化存储。
- 当文件仍存放在旧位置时，允许附件检索回退到旧版图片目录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Persist web chat attachments under a unified attachments directory and add backward-compatible loading of attachments from the legacy image directory.

Bug Fixes:
- Ensure web chat image, audio, and file segments are saved to the shared attachments directory for proper persistence.
- Allow attachment retrieval to fall back to the legacy image directory when files are stored in the old location.

</details>