### PR TITLE
feat: enable computer-use tools for subagent handoff

### DIFF
--- a/astrbot/core/astr_agent_tool_exec.py
+++ b/astrbot/core/astr_agent_tool_exec.py
@@ -17,6 +17,12 @@ from astrbot.core.agent.tool_executor import BaseFunctionToolExecutor
 from astrbot.core.astr_agent_context import AstrAgentContext
 from astrbot.core.astr_main_agent_resources import (
     BACKGROUND_TASK_RESULT_WOKE_SYSTEM_PROMPT,
+    EXECUTE_SHELL_TOOL,
+    FILE_DOWNLOAD_TOOL,
+    FILE_UPLOAD_TOOL,
+    LOCAL_EXECUTE_SHELL_TOOL,
+    LOCAL_PYTHON_TOOL,
+    PYTHON_TOOL,
     SEND_MESSAGE_TO_USER_TOOL,
 )
 from astrbot.core.cron.events import CronMessageEvent
@@ -92,6 +98,65 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
             return
 
     @classmethod
+    def _get_runtime_computer_tools(cls, runtime: str) -> dict[str, FunctionTool]:
+        if runtime == "sandbox":
+            return {
+                EXECUTE_SHELL_TOOL.name: EXECUTE_SHELL_TOOL,
+                PYTHON_TOOL.name: PYTHON_TOOL,
+                FILE_UPLOAD_TOOL.name: FILE_UPLOAD_TOOL,
+                FILE_DOWNLOAD_TOOL.name: FILE_DOWNLOAD_TOOL,
+            }
+        if runtime == "local":
+            return {
+                LOCAL_EXECUTE_SHELL_TOOL.name: LOCAL_EXECUTE_SHELL_TOOL,
+                LOCAL_PYTHON_TOOL.name: LOCAL_PYTHON_TOOL,
+            }
+        return {}
+
+    @classmethod
+    def _build_handoff_toolset(
+        cls,
+        run_context: ContextWrapper[AstrAgentContext],
+        tools: list[str | FunctionTool] | None,
+    ) -> ToolSet | None:
+        ctx = run_context.context.context
+        event = run_context.context.event
+        cfg = ctx.get_config(umo=event.unified_msg_origin)
+        provider_settings = cfg.get("provider_settings", {})
+        runtime = str(provider_settings.get("computer_use_runtime", "local"))
+        runtime_computer_tools = cls._get_runtime_computer_tools(runtime)
+
+        # Keep persona semantics aligned with the main agent: tools=None means
+        # "all tools", including runtime computer-use tools.
+        if tools is None:
+            toolset = ToolSet()
+            for registered_tool in llm_tools.func_list:
+                if isinstance(registered_tool, HandoffTool):
+                    continue
+                if registered_tool.active:
+                    toolset.add_tool(registered_tool)
+            for runtime_tool in runtime_computer_tools.values():
+                toolset.add_tool(runtime_tool)
+            return None if toolset.empty() else toolset
+
+        if not tools:
+            return None
+
+        toolset = ToolSet()
+        for tool_name_or_obj in tools:
+            if isinstance(tool_name_or_obj, str):
+                registered_tool = llm_tools.get_func(tool_name_or_obj)
+                if registered_tool and registered_tool.active:
+                    toolset.add_tool(registered_tool)
+                    continue
+                runtime_tool = runtime_computer_tools.get(tool_name_or_obj)
+                if runtime_tool:
+                    toolset.add_tool(runtime_tool)
+            elif isinstance(tool_name_or_obj, FunctionTool):
+                toolset.add_tool(tool_name_or_obj)
+        return None if toolset.empty() else toolset
+
+    @classmethod
     async def _execute_handoff(
         cls,
         tool: HandoffTool,
@@ -101,19 +166,8 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
         input_ = tool_args.get("input")
         image_urls = tool_args.get("image_urls")
 
-        # make toolset for the agent
-        tools = tool.agent.tools
-        if tools:
-            toolset = ToolSet()
-            for t in tools:
-                if isinstance(t, str):
-                    _t = llm_tools.get_func(t)
-                    if _t:
-                        toolset.add_tool(_t)
-                elif isinstance(t, FunctionTool):
-                    toolset.add_tool(t)
-        else:
-            toolset = None
+        # Build handoff toolset from registered tools plus runtime computer tools.
+        toolset = cls._build_handoff_toolset(run_context, tool.agent.tools)
 
         ctx = run_context.context.context
         event = run_context.context.event


### PR DESCRIPTION
### Motivation / 动机

  SubAgent handoff previously could not reliably use runtime Computer Use tools (`local` / `sandbox`), because these tools are dynamically mounted for the main agent and were not fully
  resolved in subagent handoff toolset building.
  Also, when subagent `tools=None` (all tools), handoff did not align with main-agent semantics.

  为了解决 SubAgent 在 handoff 场景下无法稳定使用 Computer Use 工具的问题（主 Agent 是运行时动态挂载），并修复 `tools=None` 时行为与主 Agent 不一致的问题。

  ### Modifications / 改动点

  Core file changed:
  - `astrbot/core/astr_agent_tool_exec.py`

  Implemented:
  1. Added runtime computer-tool resolver in handoff path:
     - maps `provider_settings.computer_use_runtime` to runtime tools:
       - `sandbox`: shell/ipython/upload/download
       - `local`: local shell/local python
  2. Added a unified handoff toolset builder:
     - if `tools is None`: mount all active registered tools + runtime computer tools
     - if explicit tool names: resolve from registered tools first, then fallback to runtime computer tools
  3. Replaced old `_execute_handoff` toolset-building logic with the new helper.

  - [x] This is NOT a breaking change. / 这不是一个破坏性变更。

  ### Screenshots or Test Results / 运行截图或测试结果

  Verification steps:
  1. Configure a subagent and trigger `transfer_to_*` handoff.
  2. Set `computer_use_runtime` to `local` or `sandbox`.
  3. Confirm subagent can call the corresponding computer-use tools in handoff flow.
  4. Confirm static checks pass.

  Local checks:
  - `ruff format .`
  - `ruff check .`
  - `uv run python -m py_compile astrbot/core/astr_agent_tool_exec.py`

  <img width="1499" height="221" alt="image" src="https://github.com/user-attachments/assets/9931e2ed-06bc-4664-b256-66cad5310a92" />

mentioned in #5394 
  
---

  ### Checklist / 检查清单

  - [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  - [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  - [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if
  new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  - [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

通过统一交接（handoff）工具集的构建方式，并将运行时的电脑使用（computer-use）工具纳入其中，使子代理的交接工具解析方式与主代理语义保持一致。

增强内容：
- 引入一个辅助方法，用于根据沙盒和本地运行时的提供方配置来解析运行时电脑使用工具。
- 统一交接工具集的构建逻辑：当未显式指定工具时，工具集应包含所有已激活且已注册的工具，以及适用的运行时电脑使用工具。
- 更新子代理的交接执行逻辑，使其依赖共享的工具集构建器，而不再使用临时的（ad-hoc）工具列表处理方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align subagent handoff tool resolution with main-agent semantics by unifying handoff toolset construction and incorporating runtime computer-use tools.

Enhancements:
- Introduce a helper to resolve runtime computer-use tools based on provider configuration for sandbox and local runtimes.
- Unify handoff toolset construction to include all active registered tools plus applicable runtime computer-use tools when tools are unspecified.
- Update subagent handoff execution to rely on the shared toolset builder instead of ad-hoc tool list handling.

</details>