### PR TITLE
Fix: GitHub proxy not displaying correctly in WebUI

### DIFF
--- a/dashboard/src/components/shared/ProxySelector.vue
+++ b/dashboard/src/components/shared/ProxySelector.vue
@@ -15,7 +15,7 @@
     <v-expand-transition>
         <div v-if="radioValue === '1'" style="margin-left: 16px;">
             <v-radio-group v-model="githubProxyRadioControl" class="mt-2" hide-details="true">
-                <v-radio color="success" v-for="(proxy, idx) in githubProxies" :key="proxy" :value="idx">
+                <v-radio color="success" v-for="(proxy, idx) in githubProxies" :key="proxy" :value="String(idx)">
                     <template v-slot:label>
                         <div class="d-flex align-center">
                             <span class="mr-2">{{ proxy }}</span>
@@ -37,7 +37,7 @@
                     </template>
                 </v-radio>
                 <v-radio color="primary" value="-1" :label="tm('network.proxySelector.custom')">
-                    <template v-slot:label v-if="githubProxyRadioControl === '-1'">
+                    <template v-slot:label v-if="String(githubProxyRadioControl) === '-1'">
                         <v-text-field density="compact" v-model="selectedGitHubProxy" variant="outlined"
                             style="width: 100vw;" :placeholder="tm('network.proxySelector.custom')" hide-details="true">
                         </v-text-field>
@@ -76,6 +76,17 @@ export default {
         }
     },
     methods: {
+        getProxyByControl(control) {
+            const normalizedControl = String(control);
+            if (normalizedControl === "-1") {
+                return "";
+            }
+            const index = Number.parseInt(normalizedControl, 10);
+            if (Number.isNaN(index)) {
+                return "";
+            }
+            return this.githubProxies[index] || "";
+        },
         async testSingleProxy(idx) {
             this.testingProxies[idx] = true;
             
@@ -123,14 +134,14 @@ export default {
 
         const savedProxy = localStorage.getItem('selectedGitHubProxy') || "";
         const savedRadio = localStorage.getItem('githubProxyRadioValue') || "0";
-        const savedControl = localStorage.getItem('githubProxyRadioControl') || "0";
+        const savedControl = String(localStorage.getItem('githubProxyRadioControl') || "0");
 
         this.radioValue = savedRadio;
         this.githubProxyRadioControl = savedControl;
 
         if (savedRadio === "1") {
             if (savedControl !== "-1") {
-                this.selectedGitHubProxy = this.githubProxies[savedControl] || "";
+                this.selectedGitHubProxy = this.getProxyByControl(savedControl);
             } else {
                 this.selectedGitHubProxy = savedProxy;
             }
@@ -155,23 +166,24 @@ export default {
                 return;
             }
             localStorage.setItem('githubProxyRadioValue', newVal);
-            if (newVal === "0") {
+            if (String(newVal) === "0") {
                 this.selectedGitHubProxy = "";
-            } else if (this.githubProxyRadioControl !== "-1") {
-                this.selectedGitHubProxy = this.githubProxies[this.githubProxyRadioControl] || "";
+            } else if (String(this.githubProxyRadioControl) !== "-1") {
+                this.selectedGitHubProxy = this.getProxyByControl(this.githubProxyRadioControl);
             }
         },
         githubProxyRadioControl: function (newVal) {
             if (this.initializing) {
                 return;
             }
-            localStorage.setItem('githubProxyRadioControl', newVal);
-            if (this.radioValue !== "1") {
+            const normalizedVal = String(newVal);
+            localStorage.setItem('githubProxyRadioControl', normalizedVal);
+            if (String(this.radioValue) !== "1") {
                 this.selectedGitHubProxy = "";
                 return;
             }
-            if (newVal !== "-1") {
-                this.selectedGitHubProxy = this.githubProxies[newVal] || "";
+            if (normalizedVal !== "-1") {
+                this.selectedGitHubProxy = this.getProxyByControl(normalizedVal);
             }
         }
     }


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
修复webui的设置界面中退出重进后没有正确显示之前选择的镜像地址的问题

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<img width="724" height="605" alt="image" src="https://github.com/user-attachments/assets/2a4fe5c6-19be-4414-ad2e-e53b06188f2a" />


---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

错误修复：
- 修复 GitHub 代理单选项和自定义 URL，在重新打开设置页面后能够正确显示的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix GitHub proxy radio selection and custom URL so they display correctly after reopening the settings page.

</details>