### PR TITLE
feat(provider): 在请求头中新增 User-Agent 预设配置

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -969,6 +969,7 @@ CONFIG_METADATA_2 = {
                         },
                         "gm_thinking_config": {"budget": 0, "level": "HIGH"},
                         "proxy": "",
+                        "custom_headers": {},
                     },
                     "Anthropic": {
                         "id": "anthropic",
@@ -980,6 +981,7 @@ CONFIG_METADATA_2 = {
                         "api_base": "https://api.anthropic.com/v1",
                         "timeout": 120,
                         "proxy": "",
+                        "custom_headers": {},
                         "anth_thinking_config": {"type": "", "budget": 0, "effort": ""},
                     },
                     "Moonshot": {
@@ -1212,6 +1214,7 @@ CONFIG_METADATA_2 = {
                         "variables": {},
                         "timeout": 60,
                         "proxy": "",
+                        "custom_headers": {},
                     },
                     "Coze": {
                         "id": "coze",
@@ -1224,6 +1227,7 @@ CONFIG_METADATA_2 = {
                         "coze_api_base": "https://api.coze.cn",
                         "timeout": 60,
                         "proxy": "",
+                        "custom_headers": {},
                         # "auto_save_history": True,
                     },
                     "阿里云百炼应用": {
@@ -1243,6 +1247,7 @@ CONFIG_METADATA_2 = {
                         "variables": {},
                         "timeout": 60,
                         "proxy": "",
+                        "custom_headers": {},
                     },
                     "FastGPT": {
                         "id": "fastgpt",
@@ -1267,6 +1272,7 @@ CONFIG_METADATA_2 = {
                         "api_base": "",
                         "model": "whisper-1",
                         "proxy": "",
+                        "custom_headers": {},
                     },
                     "Whisper(Local)": {
                         "provider": "openai",
@@ -1275,6 +1281,7 @@ CONFIG_METADATA_2 = {
                         "enable": False,
                         "id": "whisper_selfhost",
                         "model": "tiny",
+                        "custom_headers": {},
                     },
                     "SenseVoice(Local)": {
                         "type": "sensevoice_stt_selfhost",
@@ -1284,6 +1291,7 @@ CONFIG_METADATA_2 = {
                         "id": "sensevoice",
                         "stt_model": "iic/SenseVoiceSmall",
                         "is_emotion": False,
+                        "custom_headers": {},
                     },
                     "OpenAI TTS(API)": {
                         "id": "openai_tts",
@@ -1297,6 +1305,7 @@ CONFIG_METADATA_2 = {
                         "openai-tts-voice": "alloy",
                         "timeout": "20",
                         "proxy": "",
+                        "custom_headers": {},
                     },
                     "Genie TTS": {
                         "id": "genie_tts",
@@ -1310,6 +1319,7 @@ CONFIG_METADATA_2 = {
                         "genie_refer_audio_path": "",
                         "genie_refer_text": "",
                         "timeout": 20,
+                        "custom_headers": {},
                     },
                     "Edge TTS": {
                         "id": "edge_tts",
@@ -1322,6 +1332,7 @@ CONFIG_METADATA_2 = {
                         "volume": "+0%",
                         "pitch": "+0Hz",
                         "timeout": 20,
+                        "custom_headers": {},
                     },
                     "GSV TTS(Local)": {
                         "id": "gsv_tts",
@@ -1333,6 +1344,7 @@ CONFIG_METADATA_2 = {
                         "gpt_weights_path": "",
                         "sovits_weights_path": "",
                         "timeout": 60,
+                        "custom_headers": {},
                         "gsv_default_parms": {
                             "gsv_ref_audio_path": "",
                             "gsv_prompt_text": "",
@@ -1365,6 +1377,7 @@ CONFIG_METADATA_2 = {
                         "emotion": "default",
                         "enable": False,
                         "timeout": 20,
+                        "custom_headers": {},
                     },
                     "FishAudio TTS(API)": {
                         "id": "fishaudio_tts",
@@ -1378,6 +1391,7 @@ CONFIG_METADATA_2 = {
                         "fishaudio-tts-reference-id": "",
                         "timeout": "20",
                         "proxy": "",
+                        "custom_headers": {},
                     },
                     "阿里云百炼 TTS(API)": {
                         "hint": "API Key 从 https://bailian.console.aliyun.com/?tab=model#/api-key 获取。模型和音色的选择文档请参考: 阿里云百炼语音合成音色名称。具体可参考 https://help.aliyun.com/zh/model-studio/speech-synthesis-and-speech-recognition",
@@ -1390,6 +1404,7 @@ CONFIG_METADATA_2 = {
                         "model": "cosyvoice-v1",
                         "dashscope_tts_voice": "loongstella",
                         "timeout": "20",
+                        "custom_headers": {},
                     },
                     "Azure TTS": {
                         "id": "azure_tts",
@@ -1405,6 +1420,7 @@ CONFIG_METADATA_2 = {
                         "azure_tts_subscription_key": "",
                         "azure_tts_region": "eastus",
                         "proxy": "",
+                        "custom_headers": {},
                     },
                     "MiniMax TTS(API)": {
                         "id": "minimax_tts",
@@ -1428,6 +1444,7 @@ CONFIG_METADATA_2 = {
                         "minimax-voice-english-normalization": False,
                         "timeout": 20,
                         "proxy": "",
+                        "custom_headers": {},
                     },
                     "火山引擎_TTS(API)": {
                         "id": "volcengine_tts",
@@ -1443,6 +1460,7 @@ CONFIG_METADATA_2 = {
                         "api_base": "https://openspeech.bytedance.com/api/v1/tts",
                         "timeout": 20,
                         "proxy": "",
+                        "custom_headers": {},
                     },
                     "Gemini TTS": {
                         "id": "gemini_tts",
@@ -1457,6 +1475,7 @@ CONFIG_METADATA_2 = {
                         "gemini_tts_prefix": "",
                         "gemini_tts_voice_name": "Leda",
                         "proxy": "",
+                        "custom_headers": {},
                     },
                     "OpenAI Embedding": {
                         "id": "openai_embedding",
@@ -1470,6 +1489,7 @@ CONFIG_METADATA_2 = {
                         "embedding_dimensions": 1024,
                         "timeout": 20,
                         "proxy": "",
+                        "custom_headers": {},
                     },
                     "Gemini Embedding": {
                         "id": "gemini_embedding",
@@ -1483,6 +1503,7 @@ CONFIG_METADATA_2 = {
                         "embedding_dimensions": 768,
                         "timeout": 20,
                         "proxy": "",
+                        "custom_headers": {},
                     },
                     "vLLM Rerank": {
                         "id": "vllm_rerank",
@@ -1494,6 +1515,7 @@ CONFIG_METADATA_2 = {
                         "rerank_api_base": "http://127.0.0.1:8000",
                         "rerank_model": "BAAI/bge-reranker-base",
                         "timeout": 20,
+                        "custom_headers": {},
                     },
                     "Xinference Rerank": {
                         "id": "xinference_rerank",
@@ -1506,6 +1528,7 @@ CONFIG_METADATA_2 = {
                         "rerank_model": "BAAI/bge-reranker-base",
                         "timeout": 20,
                         "launch_model_if_not_running": False,
+                        "custom_headers": {},
                     },
                     "阿里云百炼重排序": {
                         "id": "bailian_rerank",
@@ -1519,6 +1542,7 @@ CONFIG_METADATA_2 = {
                         "timeout": 30,
                         "return_documents": False,
                         "instruct": "",
+                        "custom_headers": {},
                     },
                     "Xinference STT": {
                         "id": "xinference_stt",
@@ -1531,6 +1555,7 @@ CONFIG_METADATA_2 = {
                         "model": "whisper-large-v3",
                         "timeout": 180,
                         "launch_model_if_not_running": False,
+                        "custom_headers": {},
                     },
                 },
                 "items": {
@@ -1597,6 +1622,29 @@ CONFIG_METADATA_2 = {
                         "type": "dict",
                         "items": {},
                         "hint": "此处添加的键值对将被合并到 OpenAI SDK 的 default_headers 中，用于自定义 HTTP 请求头。值必须为字符串。",
+                        "template_schema": {
+                            "User-Agent": {
+                                "name": "User-Agent",
+                                "description": "User-Agent 请求头",
+                                "hint": "用于覆盖默认客户端标识。",
+                                "type": "string",
+                                "default": "",
+                            },
+                            "Accept": {
+                                "name": "Accept",
+                                "description": "Accept 请求头",
+                                "hint": "声明可接受的响应类型，通常保持 application/json。",
+                                "type": "string",
+                                "default": "application/json",
+                            },
+                            "Accept-Language": {
+                                "name": "Accept-Language",
+                                "description": "Accept-Language 请求头",
+                                "hint": "声明偏好语言，例如 zh-CN,zh;q=0.9,en;q=0.8。",
+                                "type": "string",
+                                "default": "",
+                            },
+                        },
                     },
                     "custom_extra_body": {
                         "description": "自定义请求体参数",

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1633,9 +1633,9 @@ CONFIG_METADATA_2 = {
                             "Accept": {
                                 "name": "Accept",
                                 "description": "Accept 请求头",
-                                "hint": "声明可接受的响应类型，通常保持 application/json。",
+                                "hint": "声明可接受的响应类型。默认留空以使用 SDK/服务端默认值，仅在需要时显式覆盖（例如指定 application/json）。",
                                 "type": "string",
-                                "default": "application/json",
+                                "default": "",
                             },
                             "Accept-Language": {
                                 "name": "Accept-Language",

--- a/astrbot/dashboard/routes/config.py
+++ b/astrbot/dashboard/routes/config.py
@@ -288,6 +288,23 @@ class ConfigRoute(Route):
             ),
         }
         self.register_routes()
+    
+    @staticmethod
+    def _with_default_custom_headers(config: dict) -> dict:
+        normalized = dict(config) if isinstance(config, dict) else {}
+        headers = normalized.get("custom_headers")
+        if not isinstance(headers, dict):
+            normalized["custom_headers"] = {}
+        return normalized
+    # 在返回 provider_sources 和 provider 配置时，如果 custom_headers 字段不是 dict，则强制转换为 dict，避免前端使用时出错
+    def _normalize_custom_headers_configs(self, configs: list) -> list:
+        normalized = []
+        for config in configs:
+            if isinstance(config, dict):
+                normalized.append(self._with_default_custom_headers(config))
+            else:
+                normalized.append(config)
+        return normalized
 
     async def delete_provider_source(self):
         """删除 provider_source，并更新关联的 providers"""
@@ -344,6 +361,8 @@ class ConfigRoute(Route):
 
         if not isinstance(new_source_config, dict):
             return Response().error("缺少或错误的配置数据").__dict__
+
+        new_source_config = self._with_default_custom_headers(new_source_config)
 
         # 确保配置中有 id 字段
         if not new_source_config.get("id"):
@@ -426,8 +445,12 @@ class ConfigRoute(Route):
         }
         data = {
             "config_schema": config_schema,
-            "providers": astrbot_config["provider"],
-            "provider_sources": astrbot_config["provider_sources"],
+            "providers": self._normalize_custom_headers_configs(
+                astrbot_config["provider"]
+            ),
+            "provider_sources": self._normalize_custom_headers_configs(
+                astrbot_config["provider_sources"]
+            ),
         }
         return Response().ok(data=data).__dict__
 
@@ -1136,6 +1159,7 @@ class ConfigRoute(Route):
 
     async def post_new_provider(self):
         new_provider_config = await request.json
+        new_provider_config = self._with_default_custom_headers(new_provider_config)
 
         try:
             await self.core_lifecycle.provider_manager.create_provider(
@@ -1178,6 +1202,8 @@ class ConfigRoute(Route):
         new_config = update_provider_config.get("config", None)
         if not origin_provider_id or not new_config:
             return Response().error("参数错误").__dict__
+
+        new_config = self._with_default_custom_headers(new_config)
 
         try:
             await self.core_lifecycle.provider_manager.update_provider(

--- a/astrbot/dashboard/routes/config.py
+++ b/astrbot/dashboard/routes/config.py
@@ -288,7 +288,7 @@ class ConfigRoute(Route):
             ),
         }
         self.register_routes()
-    
+
     @staticmethod
     def _with_default_custom_headers(config: dict) -> dict:
         normalized = dict(config) if isinstance(config, dict) else {}
@@ -296,6 +296,7 @@ class ConfigRoute(Route):
         if not isinstance(headers, dict):
             normalized["custom_headers"] = {}
         return normalized
+
     # 在返回 provider_sources 和 provider 配置时，如果 custom_headers 字段不是 dict，则强制转换为 dict，避免前端使用时出错
     def _normalize_custom_headers_configs(self, configs: list) -> list:
         normalized = []

--- a/dashboard/src/composables/useProviderSources.ts
+++ b/dashboard/src/composables/useProviderSources.ts
@@ -40,6 +40,19 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
 
   const confirmDialog = useConfirmDialog()
 
+  function withDefaultCustomHeaders<T extends Record<string, any>>(entry: T): T {
+    const normalized = JSON.parse(JSON.stringify(entry || {}))
+    if (
+      !Object.prototype.hasOwnProperty.call(normalized, 'custom_headers') ||
+      typeof normalized.custom_headers !== 'object' ||
+      normalized.custom_headers === null ||
+      Array.isArray(normalized.custom_headers)
+    ) {
+      normalized.custom_headers = {}
+    }
+    return normalized as T
+  }
+
   async function askForConfirmation(message: string) {
     return askForConfirmationDialog(message, confirmDialog)
   }
@@ -549,6 +562,7 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
       provider_source_id: sourceId,
       model: modelName,
       modalities,
+      custom_headers: {},
       custom_extra_body: {},
       max_context_tokens: max_context_tokens
     }
@@ -614,8 +628,8 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
         if (configSchema.value.provider?.config_template) {
           providerTemplates.value = configSchema.value.provider.config_template
         }
-        providerSources.value = response.data.data.provider_sources || []
-        providers.value = response.data.data.providers || []
+        providerSources.value = (response.data.data.provider_sources || []).map((source: any) => withDefaultCustomHeaders(source))
+        providers.value = (response.data.data.providers || []).map((provider: any) => withDefaultCustomHeaders(provider))
       }
     } catch (error) {
       console.error('Failed to load provider template:', error)

--- a/dashboard/src/composables/useProviderSources.ts
+++ b/dashboard/src/composables/useProviderSources.ts
@@ -40,19 +40,6 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
 
   const confirmDialog = useConfirmDialog()
 
-  function withDefaultCustomHeaders<T extends Record<string, any>>(entry: T): T {
-    const normalized = JSON.parse(JSON.stringify(entry || {}))
-    if (
-      !Object.prototype.hasOwnProperty.call(normalized, 'custom_headers') ||
-      typeof normalized.custom_headers !== 'object' ||
-      normalized.custom_headers === null ||
-      Array.isArray(normalized.custom_headers)
-    ) {
-      normalized.custom_headers = {}
-    }
-    return normalized as T
-  }
-
   async function askForConfirmation(message: string) {
     return askForConfirmationDialog(message, confirmDialog)
   }
@@ -562,7 +549,6 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
       provider_source_id: sourceId,
       model: modelName,
       modalities,
-      custom_headers: {},
       custom_extra_body: {},
       max_context_tokens: max_context_tokens
     }
@@ -628,8 +614,8 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
         if (configSchema.value.provider?.config_template) {
           providerTemplates.value = configSchema.value.provider.config_template
         }
-        providerSources.value = (response.data.data.provider_sources || []).map((source: any) => withDefaultCustomHeaders(source))
-        providers.value = (response.data.data.providers || []).map((provider: any) => withDefaultCustomHeaders(provider))
+        providerSources.value = response.data.data.provider_sources || []
+        providers.value = response.data.data.providers || []
       }
     } catch (error) {
       console.error('Failed to load provider template:', error)

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -970,7 +970,7 @@
           },
           "Accept": {
             "description": "Accept header",
-            "hint": "Declares accepted response formats. Usually keep application/json.",
+            "hint": "Declares accepted response formats. Leave empty by default to use SDK/provider defaults and only override when needed (e.g. application/json).",
             "name": "Accept"
           },
           "Accept-Language": {

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -961,7 +961,24 @@
       },
       "custom_headers": {
         "description": "Custom request headers",
-        "hint": "Key/value pairs added here are merged into the OpenAI SDK default_headers for custom HTTP headers. Values must be strings."
+        "hint": "Key/value pairs added here are merged into the OpenAI SDK default_headers for custom HTTP headers. Values must be strings.",
+        "template_schema": {
+          "User-Agent": {
+            "description": "User-Agent header",
+            "hint": "Override the default client identity.",
+            "name": "User-Agent"
+          },
+          "Accept": {
+            "description": "Accept header",
+            "hint": "Declares accepted response formats. Usually keep application/json.",
+            "name": "Accept"
+          },
+          "Accept-Language": {
+            "description": "Accept-Language header",
+            "hint": "Declares preferred languages, e.g. zh-CN,zh;q=0.9,en;q=0.8.",
+            "name": "Accept-Language"
+          }
+        }
       },
       "custom_extra_body": {
         "description": "Custom request body parameters",

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -964,7 +964,24 @@
       },
       "custom_headers": {
         "description": "自定义添加请求头",
-        "hint": "此处添加的键值对将被合并到 OpenAI SDK 的 default_headers 中，用于自定义 HTTP 请求头。值必须为字符串。"
+        "hint": "此处添加的键值对将被合并到 OpenAI SDK 的 default_headers 中，用于自定义 HTTP 请求头。值必须为字符串。",
+        "template_schema": {
+          "User-Agent": {
+            "description": "User-Agent 请求头",
+            "hint": "用于覆盖默认客户端标识。",
+            "name": "User-Agent"
+          },
+          "Accept": {
+            "description": "Accept 请求头",
+            "hint": "声明可接受的响应类型，通常保持 application/json。",
+            "name": "Accept"
+          },
+          "Accept-Language": {
+            "description": "Accept-Language 请求头",
+            "hint": "声明偏好语言，例如 zh-CN,zh;q=0.9,en;q=0.8。",
+            "name": "Accept-Language"
+          }
+        }
       },
       "custom_extra_body": {
         "description": "自定义请求体参数",

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -973,7 +973,7 @@
           },
           "Accept": {
             "description": "Accept 请求头",
-            "hint": "声明可接受的响应类型，通常保持 application/json。",
+            "hint": "声明可接受的响应类型。默认留空以使用 SDK/服务端默认值，仅在需要时显式覆盖（例如指定 application/json）。",
             "name": "Accept"
           },
           "Accept-Language": {


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

主要解决 WebUI 中请求头配置不直观、且并非所有供应商都默认显示 custom_headers 的问题。通过统一展示并提供 User-Agent 等预设字段，降低某些api网站开启 Cloudflare Bot 被误拦截风险。

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- 修改 `astrbot/core/config/default.py`：
  - 为 `custom_headers` 增加 `template_schema` 预设字段：`User-Agent`、`Accept`、`Accept-Language`。
  - 为所有 provider `config_template`（chat_completion / agent_runner / speech_to_text / text_to_speech / embedding / rerank）补齐默认 `custom_headers: {}`。
- 修改 `dashboard/src/composables/useProviderSources.ts`：
  - 加载已有 `provider_sources` 与 `providers` 时自动补齐缺失的 `custom_headers`，保证旧配置在编辑时也能显示该项。
  - 新增模型 provider 时默认写入 `custom_headers: {}`。
- 修改i18n文案：
  - `dashboard/src/i18n/locales/zh-CN/features/config-metadata.json`
  - `dashboard/src/i18n/locales/en-US/features/config-metadata.json`
  - 补充 `custom_headers.template_schema` 的字段名称与提示信息。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<img width="675" height="538" alt="image" src="https://github.com/user-attachments/assets/d2ed4d2c-857b-4789-9fdb-8d165509b581" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

为所有 provider 配置添加可配置的 HTTP 自定义请求头预设，并确保它们在 Web 界面中可见且有默认值。

新功能：
- 在 provider 配置中引入自定义 HTTP 请求头的预设模板 schema，包括 `User-Agent`、`Accept` 和 `Accept-Language`。
- 在所有 provider 模板以及新创建的 provider 模型中，将 `custom_headers` 默认设置为空对象。

增强：
- 规范已加载的 provider 源和 provider，使其始终包含有效的 `custom_headers` 对象，以在控制台中保持向后兼容性。

文档：
- 更新中文和英文配置元数据文本，记录新的 `custom_headers` 预设字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable HTTP custom headers with presets to all provider configurations and ensure they are visible and defaulted in the Web UI.

New Features:
- Introduce a preset template schema for custom HTTP headers including User-Agent, Accept, and Accept-Language in provider configuration.
- Default custom_headers to an empty object across all provider templates and newly created provider models.

Enhancements:
- Normalize loaded provider sources and providers to always include a valid custom_headers object for backward compatibility in the dashboard.

Documentation:
- Update Chinese and English configuration metadata texts to document the new custom_headers preset fields.

</details>