### PR TITLE
chore: remove deprecated version field from compose.yml

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 # 当接入 QQ NapCat 时，请使用这个 compose 文件一键部署: https://github.com/NapNeko/NapCat-Docker/blob/main/compose/astrbot.yml
 
 services:


### PR DESCRIPTION
## Summary
- Removed the deprecated `version: '3.8'` field from compose.yml

## Details
The `version` field is no longer required in Docker Compose v2 and has been officially deprecated. Modern Docker Compose automatically uses the latest compose file format specification, making this field unnecessary.

## Test plan
- [ ] Docker Compose still works correctly without the version field
- [ ] `docker compose up` starts AstrBot successfully

## Summary by Sourcery

增强内容：
- 通过从 `compose.yml` 中移除已弃用的 `version` 字段来现代化 Docker Compose 配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Modernize Docker Compose configuration by dropping the deprecated version field from compose.yml.

</details>