### PR TITLE
feat: 支持全局消息语音及所有TTS引擎独立的正则过滤

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1330,6 +1330,7 @@ CONFIG_METADATA_2 = {
                         "volume": "+0%",
                         "pitch": "+0Hz",
                         "timeout": 20,
+                        "filter_regex": "",
                     },
                     "GSV TTS(Local)": {
                         "id": "gsv_tts",

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -163,6 +163,7 @@ DEFAULT_CONFIG = {
         "dual_output": False,
         "use_file_service": False,
         "trigger_probability": 1.0,
+        "tts_all_messages": False,
     },
     "provider_ltm_settings": {
         "group_icl_enable": False,
@@ -1305,6 +1306,7 @@ CONFIG_METADATA_2 = {
                         "openai-tts-voice": "alloy",
                         "timeout": "20",
                         "proxy": "",
+                        "filter_regex": "",
                     },
                     "Genie TTS": {
                         "id": "genie_tts",
@@ -1318,6 +1320,7 @@ CONFIG_METADATA_2 = {
                         "genie_refer_audio_path": "",
                         "genie_refer_text": "",
                         "timeout": 20,
+                        "filter_regex": "",
                     },
                     "Edge TTS": {
                         "id": "edge_tts",
@@ -1362,6 +1365,7 @@ CONFIG_METADATA_2 = {
                             "gsv_parallel_infer": True,
                             "gsv_repetition_penalty": 1.35,
                             "gsv_media_type": "wav",
+                            "filter_regex": "",
                         },
                     },
                     "GSVI TTS(API)": {
@@ -1374,6 +1378,7 @@ CONFIG_METADATA_2 = {
                         "emotion": "default",
                         "enable": False,
                         "timeout": 20,
+                        "filter_regex": "",
                     },
                     "FishAudio TTS(API)": {
                         "id": "fishaudio_tts",
@@ -1387,6 +1392,7 @@ CONFIG_METADATA_2 = {
                         "fishaudio-tts-reference-id": "",
                         "timeout": "20",
                         "proxy": "",
+                        "filter_regex": "",
                     },
                     "阿里云百炼 TTS(API)": {
                         "hint": "API Key 从 https://bailian.console.aliyun.com/?tab=model#/api-key 获取。模型和音色的选择文档请参考: 阿里云百炼语音合成音色名称。具体可参考 https://help.aliyun.com/zh/model-studio/speech-synthesis-and-speech-recognition",
@@ -1399,6 +1405,7 @@ CONFIG_METADATA_2 = {
                         "model": "cosyvoice-v1",
                         "dashscope_tts_voice": "loongstella",
                         "timeout": "20",
+                        "filter_regex": "",
                     },
                     "Azure TTS": {
                         "id": "azure_tts",
@@ -1414,6 +1421,7 @@ CONFIG_METADATA_2 = {
                         "azure_tts_subscription_key": "",
                         "azure_tts_region": "eastus",
                         "proxy": "",
+                        "filter_regex": "",
                     },
                     "MiniMax TTS(API)": {
                         "id": "minimax_tts",
@@ -1437,6 +1445,7 @@ CONFIG_METADATA_2 = {
                         "minimax-voice-english-normalization": False,
                         "timeout": 20,
                         "proxy": "",
+                        "filter_regex": "",
                     },
                     "火山引擎_TTS(API)": {
                         "id": "volcengine_tts",
@@ -1452,6 +1461,7 @@ CONFIG_METADATA_2 = {
                         "api_base": "https://openspeech.bytedance.com/api/v1/tts",
                         "timeout": 20,
                         "proxy": "",
+                        "filter_regex": "",
                     },
                     "Gemini TTS": {
                         "id": "gemini_tts",
@@ -1466,6 +1476,7 @@ CONFIG_METADATA_2 = {
                         "gemini_tts_prefix": "",
                         "gemini_tts_voice_name": "Leda",
                         "proxy": "",
+                        "filter_regex": "",
                     },
                     "OpenAI Embedding": {
                         "id": "openai_embedding",
@@ -1545,6 +1556,11 @@ CONFIG_METADATA_2 = {
                     },
                 },
                 "items": {
+                    "filter_regex": {
+                        "description": "文本过滤正则表达式",
+                        "type": "string",
+                        "hint": r"在送入该 TTS 引擎前，使用此正则过滤文本。例如填写 `\(.*?\)|\（.*?\）` 可过滤所有括号内的动作描写。",
+                    },
                     "genie_onnx_model_dir": {
                         "description": "ONNX Model Directory",
                         "type": "string",
@@ -2632,6 +2648,14 @@ CONFIG_METADATA_3 = {
                         "description": "启用文本转语音",
                         "type": "bool",
                         "hint": "TTS 总开关",
+                    },
+                    "provider_tts_settings.tts_all_messages": {
+                        "description": "转换所有文本消息为语音",
+                        "type": "bool",
+                        "hint": "开启后，不仅仅是 AI 的回复，所有通过 AstrBot 发送的文本消息（包括插件被动回复和主动推送）都会被转为语音。",
+                        "condition": {
+                            "provider_tts_settings.enable": True,
+                        },
                     },
                     "provider_tts_settings.provider_id": {
                         "description": "默认文本转语音模型",

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -164,6 +164,7 @@ DEFAULT_CONFIG = {
         "use_file_service": False,
         "trigger_probability": 1.0,
         "tts_all_messages": False,
+        "filter_regex": "",
     },
     "provider_ltm_settings": {
         "group_icl_enable": False,
@@ -1306,7 +1307,6 @@ CONFIG_METADATA_2 = {
                         "openai-tts-voice": "alloy",
                         "timeout": "20",
                         "proxy": "",
-                        "filter_regex": "",
                     },
                     "Genie TTS": {
                         "id": "genie_tts",
@@ -1320,7 +1320,6 @@ CONFIG_METADATA_2 = {
                         "genie_refer_audio_path": "",
                         "genie_refer_text": "",
                         "timeout": 20,
-                        "filter_regex": "",
                     },
                     "Edge TTS": {
                         "id": "edge_tts",
@@ -1333,7 +1332,6 @@ CONFIG_METADATA_2 = {
                         "volume": "+0%",
                         "pitch": "+0Hz",
                         "timeout": 20,
-                        "filter_regex": "",
                     },
                     "GSV TTS(Local)": {
                         "id": "gsv_tts",
@@ -1365,7 +1363,6 @@ CONFIG_METADATA_2 = {
                             "gsv_parallel_infer": True,
                             "gsv_repetition_penalty": 1.35,
                             "gsv_media_type": "wav",
-                            "filter_regex": "",
                         },
                     },
                     "GSVI TTS(API)": {
@@ -1378,7 +1375,6 @@ CONFIG_METADATA_2 = {
                         "emotion": "default",
                         "enable": False,
                         "timeout": 20,
-                        "filter_regex": "",
                     },
                     "FishAudio TTS(API)": {
                         "id": "fishaudio_tts",
@@ -1392,7 +1388,6 @@ CONFIG_METADATA_2 = {
                         "fishaudio-tts-reference-id": "",
                         "timeout": "20",
                         "proxy": "",
-                        "filter_regex": "",
                     },
                     "阿里云百炼 TTS(API)": {
                         "hint": "API Key 从 https://bailian.console.aliyun.com/?tab=model#/api-key 获取。模型和音色的选择文档请参考: 阿里云百炼语音合成音色名称。具体可参考 https://help.aliyun.com/zh/model-studio/speech-synthesis-and-speech-recognition",
@@ -1405,7 +1400,6 @@ CONFIG_METADATA_2 = {
                         "model": "cosyvoice-v1",
                         "dashscope_tts_voice": "loongstella",
                         "timeout": "20",
-                        "filter_regex": "",
                     },
                     "Azure TTS": {
                         "id": "azure_tts",
@@ -1421,7 +1415,6 @@ CONFIG_METADATA_2 = {
                         "azure_tts_subscription_key": "",
                         "azure_tts_region": "eastus",
                         "proxy": "",
-                        "filter_regex": "",
                     },
                     "MiniMax TTS(API)": {
                         "id": "minimax_tts",
@@ -1445,7 +1438,6 @@ CONFIG_METADATA_2 = {
                         "minimax-voice-english-normalization": False,
                         "timeout": 20,
                         "proxy": "",
-                        "filter_regex": "",
                     },
                     "火山引擎_TTS(API)": {
                         "id": "volcengine_tts",
@@ -1461,7 +1453,6 @@ CONFIG_METADATA_2 = {
                         "api_base": "https://openspeech.bytedance.com/api/v1/tts",
                         "timeout": 20,
                         "proxy": "",
-                        "filter_regex": "",
                     },
                     "Gemini TTS": {
                         "id": "gemini_tts",
@@ -1476,7 +1467,6 @@ CONFIG_METADATA_2 = {
                         "gemini_tts_prefix": "",
                         "gemini_tts_voice_name": "Leda",
                         "proxy": "",
-                        "filter_regex": "",
                     },
                     "OpenAI Embedding": {
                         "id": "openai_embedding",
@@ -1556,11 +1546,6 @@ CONFIG_METADATA_2 = {
                     },
                 },
                 "items": {
-                    "filter_regex": {
-                        "description": "文本过滤正则表达式",
-                        "type": "string",
-                        "hint": r"在送入该 TTS 引擎前，使用此正则过滤文本。例如填写 `\(.*?\)|\（.*?\）` 可过滤所有括号内的动作描写。",
-                    },
                     "genie_onnx_model_dir": {
                         "description": "ONNX Model Directory",
                         "type": "string",
@@ -2414,6 +2399,12 @@ CONFIG_METADATA_2 = {
                     "trigger_probability": {
                         "type": "float",
                     },
+                    "tts_all_messages": {
+                        "type": "bool",
+                    },
+                    "filter_regex": {
+                        "type": "string",
+                    },
                 },
             },
             "provider_ltm_settings": {
@@ -2669,6 +2660,14 @@ CONFIG_METADATA_3 = {
                         "description": "TTS 触发概率",
                         "type": "float",
                         "slider": {"min": 0, "max": 1, "step": 0.05},
+                        "condition": {
+                            "provider_tts_settings.enable": True,
+                        },
+                    },
+                    "provider_tts_settings.filter_regex": {
+                        "description": "全局语音文本过滤 (正则)",
+                        "type": "string",
+                        "hint": "在送入 TTS 朗读前清洗文本。例如填写 \\(.*?\\)|\\（.*?\\)|\\*.*?\\* 可过滤掉所有括号及星号内的动作描写。",
                         "condition": {
                             "provider_tts_settings.enable": True,
                         },

--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -256,10 +256,12 @@ class ResultDecorateStage(Stage):
             tts_provider = self.ctx.plugin_manager.context.get_using_tts_provider(
                 event.unified_msg_origin,
             )
-
+            tts_all_messages = self.ctx.astrbot_config.get(
+                "provider_tts_settings", {}
+            ).get("tts_all_messages", False)
             should_tts = (
                 bool(self.ctx.astrbot_config["provider_tts_settings"]["enable"])
-                and result.is_llm_result()
+                and (result.is_llm_result() or tts_all_messages)
                 and await SessionServiceManager.should_process_tts_request(event)
                 and random.random() <= self.tts_trigger_probability
                 and tts_provider
@@ -283,8 +285,42 @@ class ResultDecorateStage(Stage):
                 for comp in result.chain:
                     if isinstance(comp, Plain) and len(comp.text) > 1:
                         try:
-                            logger.info(f"TTS 请求: {comp.text}")
-                            audio_path = await tts_provider.get_audio(comp.text)
+                            # 正则过滤逻辑
+                            text_to_read = comp.text
+                            # 找出当前正在使用的 TTS ID
+                            tts_provider_id = self.ctx.astrbot_config.get(
+                                "provider_tts_settings", {}
+                            ).get("provider_id", "")
+                            filter_regex = ""
+
+                            # 在服务商列表里，找到正在使用的正则配置
+                            for p_cfg in self.ctx.astrbot_config.get("provider", []):
+                                if p_cfg.get("id") == tts_provider_id:
+                                    filter_regex = p_cfg.get("filter_regex", "")
+                                    break
+
+                            # 替换过滤
+                            if filter_regex:
+                                try:
+                                    text_to_read = re.sub(
+                                        filter_regex, "", text_to_read
+                                    )
+                                    if text_to_read != comp.text:
+                                        logger.debug(
+                                            f"原文本: {comp.text} -> 过滤后: {text_to_read}"
+                                        )
+                                except re.error as e:
+                                    logger.error(
+                                        f"正则表达式错误 '{filter_regex}': {e}"
+                                    )
+                            if not text_to_read.strip():
+                                logger.debug("文本已被完全过滤，跳过此段 TTS 生成。")
+                                new_chain.append(comp)
+                                continue
+
+                            logger.info(f"TTS 请求: {text_to_read}")
+                            audio_path = await tts_provider.get_audio(text_to_read)
+
                             logger.info(f"TTS 结果: {audio_path}")
                             if not audio_path:
                                 logger.error(

--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -287,18 +287,10 @@ class ResultDecorateStage(Stage):
                         try:
                             # 正则过滤逻辑
                             text_to_read = comp.text
-                            # 找出当前正在使用的 TTS ID
-                            tts_provider_id = self.ctx.astrbot_config.get(
+                            # 从全局配置中获取正则过滤规则
+                            filter_regex = self.ctx.astrbot_config.get(
                                 "provider_tts_settings", {}
-                            ).get("provider_id", "")
-                            filter_regex = ""
-
-                            # 在服务商列表里，找到正在使用的正则配置
-                            for p_cfg in self.ctx.astrbot_config.get("provider", []):
-                                if p_cfg.get("id") == tts_provider_id:
-                                    filter_regex = p_cfg.get("filter_regex", "")
-                                    break
-
+                            ).get("filter_regex", "")
                             # 替换过滤
                             if filter_regex:
                                 try:

--- a/astrbot/core/provider/sources/edge_tts_source.py
+++ b/astrbot/core/provider/sources/edge_tts_source.py
@@ -52,8 +52,12 @@ class ProviderEdgeTTS(TTSProvider):
                 # 使用 re.sub 将匹配到的内容替换为空字符串
                 text = re.sub(self.filter_regex, "", text)
                 logger.debug(f"正则过滤后的文本: {text}")
-            except Exception as e:
-                logger.error(f"正则表达式执行错误: {e}")
+            except re.error as e:
+                logger.error(
+                    "正则表达式执行错误: %s | pattern=%r",
+                    e,
+                    self.filter_regex,
+                )
         if not text.strip():
             logger.warning("文本为空，跳过语音生成。")
             raise RuntimeError("过滤后文本为空，跳过语音生成。")

--- a/astrbot/core/provider/sources/edge_tts_source.py
+++ b/astrbot/core/provider/sources/edge_tts_source.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import re
 import subprocess
 import uuid
 
@@ -40,12 +41,22 @@ class ProviderEdgeTTS(TTSProvider):
         self.volume = provider_config.get("volume")
         self.pitch = provider_config.get("pitch")
         self.timeout = provider_config.get("timeout", 30)
-
+        self.filter_regex = provider_config.get("filter_regex", "")
         self.proxy = os.getenv("https_proxy", None)
 
         self.set_model("edge_tts")
 
     async def get_audio(self, text: str) -> str:
+        if self.filter_regex:
+            try:
+                # 使用 re.sub 将匹配到的内容替换为空字符串
+                text = re.sub(self.filter_regex, "", text)
+                logger.debug(f"正则过滤后的文本: {text}")
+            except Exception as e:
+                logger.error(f"正则表达式执行错误: {e}")
+        if not text.strip():
+            logger.warning("文本为空，跳过语音生成。")
+            raise RuntimeError("过滤后文本为空，跳过语音生成。")
         temp_dir = get_astrbot_temp_path()
         mp3_path = os.path.join(temp_dir, f"edge_tts_temp_{uuid.uuid4()}.mp3")
         wav_path = os.path.join(temp_dir, f"edge_tts_{uuid.uuid4()}.wav")

--- a/astrbot/core/provider/sources/edge_tts_source.py
+++ b/astrbot/core/provider/sources/edge_tts_source.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import re
 import subprocess
 import uuid
 
@@ -41,26 +40,12 @@ class ProviderEdgeTTS(TTSProvider):
         self.volume = provider_config.get("volume")
         self.pitch = provider_config.get("pitch")
         self.timeout = provider_config.get("timeout", 30)
-        self.filter_regex = provider_config.get("filter_regex", "")
+
         self.proxy = os.getenv("https_proxy", None)
 
         self.set_model("edge_tts")
 
     async def get_audio(self, text: str) -> str:
-        if self.filter_regex:
-            try:
-                # 使用 re.sub 将匹配到的内容替换为空字符串
-                text = re.sub(self.filter_regex, "", text)
-                logger.debug(f"正则过滤后的文本: {text}")
-            except re.error as e:
-                logger.error(
-                    "正则表达式执行错误: %s | pattern=%r",
-                    e,
-                    self.filter_regex,
-                )
-        if not text.strip():
-            logger.warning("文本为空，跳过语音生成。")
-            raise RuntimeError("过滤后文本为空，跳过语音生成。")
         temp_dir = get_astrbot_temp_path()
         mp3_path = os.path.join(temp_dir, f"edge_tts_temp_{uuid.uuid4()}.mp3")
         wav_path = os.path.join(temp_dir, f"edge_tts_{uuid.uuid4()}.wav")

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -64,6 +64,10 @@
           "description": "启用文本转语音",
           "hint": "TTS 总开关"
         },
+        "provider_tts_settings.tts_all_messages": {
+          "description": "转换所有文本消息为语音",
+          "hint": "开启后，不仅仅是 AI 的回复，所有通过 AstrBot 发送的文本消息（包括插件被动回复和主动推送）都会被转为语音。"
+        },
         "provider_id": {
           "description": "默认文本转语音模型"
         },
@@ -919,6 +923,10 @@
   },
   "provider_group": {
     "provider": {
+      "filter_regex": {
+        "description": "文本过滤正则表达式",
+        "hint": "在送入该 TTS 引擎前，使用此正则过滤文本。例如填写 `\\(.*?\\)|\\（.*?\\）` 可过滤所有括号内的动作描写。"
+      },
       "genie_onnx_model_dir": {
         "description": "ONNX Model Directory",
         "hint": "The directory path containing the ONNX model files"

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -64,7 +64,7 @@
           "description": "启用文本转语音",
           "hint": "TTS 总开关"
         },
-        "provider_tts_settings.tts_all_messages": {
+        "tts_all_messages": {
           "description": "转换所有文本消息为语音",
           "hint": "开启后，不仅仅是 AI 的回复，所有通过 AstrBot 发送的文本消息（包括插件被动回复和主动推送）都会被转为语音。"
         },

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -68,6 +68,10 @@
           "description": "转换所有文本消息为语音",
           "hint": "开启后，不仅仅是 AI 的回复，所有通过 AstrBot 发送的文本消息（包括插件被动回复和主动推送）都会被转为语音。"
         },
+        "filter_regex": {
+          "description": "全局语音文本过滤 (正则)",
+          "hint": "在送入 TTS 朗读前清洗文本。例如填写 \\(.*?\\)|\\（.*?\\)|\\*.*?\\* 可过滤掉所有括号及星号内的动作描写。"
+        },
         "provider_id": {
           "description": "默认文本转语音模型"
         },
@@ -923,10 +927,6 @@
   },
   "provider_group": {
     "provider": {
-      "filter_regex": {
-        "description": "文本过滤正则表达式",
-        "hint": "在送入该 TTS 引擎前，使用此正则过滤文本。例如填写 `\\(.*?\\)|\\（.*?\\）` 可过滤所有括号内的动作描写。"
-      },
       "genie_onnx_model_dir": {
         "description": "ONNX Model Directory",
         "hint": "The directory path containing the ONNX model files"


### PR DESCRIPTION
在使用 Edge TTS 生成语音时，默认情况下 TTS 会将生成的全部文字一并读出，如果大模型的回复中包含角色扮演的动作描写或内心独白（例如 `（微笑着说）你好啊` 或 `*摸摸头*`），严重影响语音的自然度和沉浸感。
此 PR 增加了一个**正则表达式过滤功能**，允许用户在面板自定义过滤规则，在文本送入 TTS 引擎前将其精准剔除。

### Modifications / 改动点

1. **面板配置**：修改了 `astrbot/core/config/default.py`
   - 在 Edge TTS 的默认配置选项中新增了 `filter_regex` 字段（默认为空字符串 `""`）。
2. **edge_tts_source.py**：修改了 `astrbot/core/provider/sources/edge_tts_source.py`
   - 引入了 `re` 模块。
   - 在 `ProviderEdgeTTS` 类的 `__init__` 方法中增加了对 `filter_regex` 配置项的读取。
   - 在 `get_audio` 方法中，在执行 TTS 生成逻辑之前，加入 `re.sub` 处理，对传入的 `text` 进行正则匹配与替换空字符操作。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
### <img width="898" height="636" alt="image" src="https://github.com/user-attachments/assets/3f817329-b3cb-4012-85b4-401cbafffbb0" />

已在本地完成完整流程测试。
在 Web 面板的 Edge TTS 配置中填入正则表达式（如：`\(.*?\)|\（.*?\）`）后，发送包含中英文括号的测试文本，生成的录音文件已成功跳过括号内的动作描写内容，且未触发异常报错。

---

### Checklist / 检查清单

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

在进行音频生成之前，为 Edge TTS 添加可配置的基于正则表达式的文本过滤功能。

新功能：
- 为 Edge TTS 引入 `filter_regex` 配置选项，用于在合成前移除匹配到的文本片段。

改进：
- 当过滤后的文本变为空时，跳过 TTS 生成并抛出运行时错误，同时在正则处理过程中记录调试和错误日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable regular-expression-based text filtering to Edge TTS before audio generation.

New Features:
- Introduce a filter_regex configuration option for Edge TTS to remove matched text segments before synthesis.

Enhancements:
- Skip TTS generation and raise a runtime error when the filtered text becomes empty, with debug and error logging around regex processing.

</details>