### PR TITLE
fix: resolve unhandled UTC timezone offset for timestamps in conversation records

### DIFF
--- a/astrbot/core/conversation_mgr.py
+++ b/astrbot/core/conversation_mgr.py
@@ -6,12 +6,12 @@
 
 import json
 from collections.abc import Awaitable, Callable
-from datetime import timezone
 
 from astrbot.core import sp
 from astrbot.core.agent.message import AssistantMessageSegment, UserMessageSegment
 from astrbot.core.db import BaseDatabase
 from astrbot.core.db.po import Conversation, ConversationV2
+from astrbot.core.utils.datetime_utils import to_utc_timestamp
 
 
 class ConversationManager:
@@ -59,8 +59,10 @@ class ConversationManager:
 
     def _convert_conv_from_v2_to_v1(self, conv_v2: ConversationV2) -> Conversation:
         """将 ConversationV2 对象转换为 Conversation 对象"""
-        created_at = int(conv_v2.created_at.replace(tzinfo=timezone.utc).timestamp()) if conv_v2.created_at else 0
-        updated_at = int(conv_v2.updated_at.replace(tzinfo=timezone.utc).timestamp()) if conv_v2.updated_at else 0
+        created_ts = to_utc_timestamp(conv_v2.created_at)
+        updated_ts = to_utc_timestamp(conv_v2.updated_at)
+        created_at = int(created_ts) if created_ts is not None else 0
+        updated_at = int(updated_ts) if updated_ts is not None else 0
         return Conversation(
             platform_id=conv_v2.platform_id,
             user_id=conv_v2.user_id,

--- a/astrbot/core/utils/datetime_utils.py
+++ b/astrbot/core/utils/datetime_utils.py
@@ -1,0 +1,27 @@
+from datetime import datetime, timezone
+
+
+def normalize_datetime_utc(dt: datetime | None) -> datetime | None:
+    """Normalize datetime values to UTC.
+
+    Naive datetimes are interpreted as UTC to match SQLite storage behavior.
+    """
+    if dt is None:
+        return None
+    if dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def to_utc_isoformat(dt: datetime | None) -> str | None:
+    normalized = normalize_datetime_utc(dt)
+    if normalized is None:
+        return None
+    return normalized.isoformat()
+
+
+def to_utc_timestamp(dt: datetime | None) -> float | None:
+    normalized = normalize_datetime_utc(dt)
+    if normalized is None:
+        return None
+    return normalized.timestamp()

--- a/astrbot/dashboard/routes/api_key.py
+++ b/astrbot/dashboard/routes/api_key.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 from quart import g, request
 
 from astrbot.core.db import BaseDatabase
+from astrbot.core.utils.datetime_utils import normalize_datetime_utc
 
 from .route import Response, Route, RouteContext
 
@@ -25,11 +26,7 @@ class ApiKeyRoute(Route):
 
     @staticmethod
     def _normalize_utc(dt: datetime | None) -> datetime | None:
-        if dt is None:
-            return None
-        if dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None:
-            return dt.replace(tzinfo=timezone.utc)
-        return dt.astimezone(timezone.utc)
+        return normalize_datetime_utc(dt)
 
     @classmethod
     def _serialize_datetime(cls, dt: datetime | None) -> str | None:

--- a/astrbot/dashboard/routes/chat.py
+++ b/astrbot/dashboard/routes/chat.py
@@ -4,7 +4,6 @@ import os
 import re
 import uuid
 from contextlib import asynccontextmanager
-from datetime import timezone
 from typing import cast
 
 from quart import Response as QuartResponse
@@ -23,6 +22,7 @@ from astrbot.core.platform.sources.webchat.message_parts_helper import (
 from astrbot.core.platform.sources.webchat.webchat_queue_mgr import webchat_queue_mgr
 from astrbot.core.utils.active_event_registry import active_event_registry
 from astrbot.core.utils.astrbot_path import get_astrbot_data_path
+from astrbot.core.utils.datetime_utils import to_utc_isoformat
 
 from .route import Response, Route, RouteContext
 
@@ -487,7 +487,9 @@ class ChatRoute(Route):
                                     "type": "message_saved",
                                     "data": {
                                         "id": saved_record.id,
-                                        "created_at": saved_record.created_at.replace(tzinfo=timezone.utc).isoformat(),
+                                        "created_at": to_utc_isoformat(
+                                            saved_record.created_at
+                                        ),
                                     },
                                 }
                                 try:
@@ -719,8 +721,8 @@ class ChatRoute(Route):
                     "creator": session.creator,
                     "display_name": session.display_name,
                     "is_group": session.is_group,
-                    "created_at": session.created_at.replace(tzinfo=timezone.utc).isoformat(),
-                    "updated_at": session.updated_at.replace(tzinfo=timezone.utc).isoformat(),
+                    "created_at": to_utc_isoformat(session.created_at),
+                    "updated_at": to_utc_isoformat(session.updated_at),
                 }
             )
 

--- a/astrbot/dashboard/routes/chatui_project.py
+++ b/astrbot/dashboard/routes/chatui_project.py
@@ -1,7 +1,7 @@
-from datetime import timezone
 from quart import g, request
 
 from astrbot.core.db import BaseDatabase
+from astrbot.core.utils.datetime_utils import to_utc_isoformat
 
 from .route import Response, Route, RouteContext
 
@@ -52,8 +52,8 @@ class ChatUIProjectRoute(Route):
                     "title": project.title,
                     "emoji": project.emoji,
                     "description": project.description,
-                    "created_at": project.created_at.replace(tzinfo=timezone.utc).isoformat(),
-                    "updated_at": project.updated_at.replace(tzinfo=timezone.utc).isoformat(),
+                    "created_at": to_utc_isoformat(project.created_at),
+                    "updated_at": to_utc_isoformat(project.updated_at),
                 }
             )
             .__dict__
@@ -71,8 +71,8 @@ class ChatUIProjectRoute(Route):
                 "title": project.title,
                 "emoji": project.emoji,
                 "description": project.description,
-                "created_at": project.created_at.replace(tzinfo=timezone.utc).isoformat(),
-                "updated_at": project.updated_at.replace(tzinfo=timezone.utc).isoformat(),
+                "created_at": to_utc_isoformat(project.created_at),
+                "updated_at": to_utc_isoformat(project.updated_at),
             }
             for project in projects
         ]
@@ -103,8 +103,8 @@ class ChatUIProjectRoute(Route):
                     "title": project.title,
                     "emoji": project.emoji,
                     "description": project.description,
-                    "created_at": project.created_at.replace(tzinfo=timezone.utc).isoformat(),
-                    "updated_at": project.updated_at.replace(tzinfo=timezone.utc).isoformat(),
+                    "created_at": to_utc_isoformat(project.created_at),
+                    "updated_at": to_utc_isoformat(project.updated_at),
                 }
             )
             .__dict__
@@ -237,8 +237,8 @@ class ChatUIProjectRoute(Route):
                 "creator": session.creator,
                 "display_name": session.display_name,
                 "is_group": session.is_group,
-                "created_at": session.created_at.replace(tzinfo=timezone.utc).isoformat(),
-                "updated_at": session.updated_at.replace(tzinfo=timezone.utc).isoformat(),
+                "created_at": to_utc_isoformat(session.created_at),
+                "updated_at": to_utc_isoformat(session.updated_at),
             }
             for session in sessions
         ]

--- a/astrbot/dashboard/routes/live_chat.py
+++ b/astrbot/dashboard/routes/live_chat.py
@@ -5,7 +5,6 @@ import re
 import time
 import uuid
 import wave
-from datetime import timezone
 from typing import Any
 
 import jwt
@@ -22,6 +21,7 @@ from astrbot.core.platform.sources.webchat.message_parts_helper import (
 )
 from astrbot.core.platform.sources.webchat.webchat_queue_mgr import webchat_queue_mgr
 from astrbot.core.utils.astrbot_path import get_astrbot_data_path, get_astrbot_temp_path
+from astrbot.core.utils.datetime_utils import to_utc_isoformat
 
 from .route import Route, RouteContext
 
@@ -622,7 +622,9 @@ class LiveChatRoute(Route):
                                 "type": "message_saved",
                                 "data": {
                                     "id": saved_record.id,
-                                    "created_at": saved_record.created_at.replace(tzinfo=timezone.utc).isoformat(),
+                                    "created_at": to_utc_isoformat(
+                                        saved_record.created_at
+                                    ),
                                 },
                             },
                         )

--- a/astrbot/dashboard/routes/open_api.py
+++ b/astrbot/dashboard/routes/open_api.py
@@ -1,7 +1,6 @@
 import asyncio
 import hashlib
 import json
-from datetime import timezone
 from uuid import uuid4
 
 from quart import g, request, websocket
@@ -16,6 +15,7 @@ from astrbot.core.platform.sources.webchat.message_parts_helper import (
     webchat_message_parts_have_content,
 )
 from astrbot.core.platform.sources.webchat.webchat_queue_mgr import webchat_queue_mgr
+from astrbot.core.utils.datetime_utils import to_utc_isoformat
 
 from .api_key import ALL_OPEN_API_SCOPES
 from .chat import ChatRoute
@@ -482,7 +482,9 @@ class OpenApiRoute(Route):
                                 "type": "message_saved",
                                 "data": {
                                     "id": saved_record.id,
-                                    "created_at": saved_record.created_at.replace(tzinfo=timezone.utc).isoformat(),
+                                    "created_at": to_utc_isoformat(
+                                        saved_record.created_at
+                                    ),
                                 },
                                 "session_id": session_id,
                             }
@@ -580,8 +582,8 @@ class OpenApiRoute(Route):
                     "creator": session.creator,
                     "display_name": session.display_name,
                     "is_group": session.is_group,
-                    "created_at": session.created_at.replace(tzinfo=timezone.utc).isoformat(),
-                    "updated_at": session.updated_at.replace(tzinfo=timezone.utc).isoformat(),
+                    "created_at": to_utc_isoformat(session.created_at),
+                    "updated_at": to_utc_isoformat(session.updated_at),
                 }
             )
 


### PR DESCRIPTION
…tion records

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

在windows桌面端-更多功能-对话数据板块内，创建时间与更新时间显示与实际时间不符，经排查发现是SQLite 数据库不支持存储带时区的日期，取出的datetime对象是丢失了 UTC 标识的 naive datetime。此时在后端直接对其进行 JSON 序列化（转为字符串）或调用 `.timestamp()` / `.astimezone()` 时，Python 解释器会将其视作操作系统的“本地时区”强行发生偏移，导致正确原本存入的 UTC 时间被二次破坏。
### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

修复了由于后端输出 Naive Datetime 导致前端页面时间解析发生时差偏移的问题，仅涉及少量序列化拦截与格式替换：

- astrbot/dashboard/server.py: 自定义 AstrBotJSONProvider，在全局 JSON 序列化时拦截 datetime 对象，强制补充 UTC 零时区标识（+00:00）。
- astrbot/core/conversation_mgr.py: 将 datetime.timestamp() 运算改为 replace(tzinfo=timezone.utc).timestamp()，避免被本地环境带偏时区计算秒数。
- astrbot/dashboard/routes/chat.py
astrbot/dashboard/routes/chatui_project.py
astrbot/dashboard/routes/live_chat.py
astrbot/dashboard/routes/open_api.py
  （以上 4 个

文件）：移除多余的原生 astimezone() 调用，全部统一为 replace(tzinfo=timezone.utc).isoformat() 输出绝对 UTC 字符串，交由无感的前端浏览器接管并呈现安全的本地时区渲染。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

<img width="885" height="296" alt="949f4770-40d0-4fff-8327-8b96a0bd037a" src="https://github.com/user-attachments/assets/47501328-6843-4eb1-8bda-eee02f55d570" />
<img width="930" height="266" alt="9b71274f-4399-40e3-b179-2da5c8c82421" src="https://github.com/user-attachments/assets/932c726f-0ce6-4a66-a8ee-d8cea67f88a4" />
---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## 由 Sourcery 提供的摘要

确保所有仪表盘和会话相关的时间戳都作为带有 UTC 信息的时间值进行处理和序列化，以避免时区偏移问题。

错误修复：
- 修正仪表盘、聊天、实时聊天和 OpenAPI 响应中 `created_at` 和 `updated_at` 时间戳不正确的问题，该问题由“天真（naive）”的 datetime 被解释为本地时区导致。

改进内容：
- 引入共享的 datetime 工具，用于将“天真（naive）”的 datetime 规范化为 UTC，并将其转换为 ISO 8601 字符串或 Unix 时间戳。
- 将仪表盘的 Flask 应用配置为使用自定义 JSON provider，使其在序列化 datetime 对象时使用明确的 UTC ISO 8601 字符串。
- 在会话管理和仪表盘路由中统一时间戳的生成方式，始终使用基于 UTC 的辅助方法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure all dashboard and conversation timestamps are handled and serialized as UTC-aware values to avoid timezone offset issues.

Bug Fixes:
- Correct incorrect created_at and updated_at timestamps in dashboard, chat, live chat, and OpenAPI responses caused by naive datetimes being interpreted in the local timezone.

Enhancements:
- Introduce shared datetime utilities to normalize naive datetimes as UTC and convert them to ISO 8601 strings or Unix timestamps.
- Configure the dashboard Flask app to use a custom JSON provider that serializes datetime objects as explicit UTC ISO 8601 strings.
- Standardize timestamp generation across conversation management and dashboard routes to consistently use the UTC-based helpers.

</details>

Bug 修复：
- 修复仪表盘和聊天界面中 `created_at` 和 `updated_at` 时间显示不正确的问题。该问题是由于“naive” datetime 被解释为本地时区时间而非 UTC 所导致。

增强内容：
- 引入自定义 JSON 提供器，在 `tzinfo` 缺失时，将 datetime 对象序列化为带有显式 UTC 偏移量的 ISO 8601 字符串。
- 统一会话管理和仪表盘路由中的时间戳生成与序列化逻辑，在计算 Unix 时间戳或 ISO 字符串之前，始终将存储的 datetime 视为 UTC。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

确保所有仪表盘和会话相关的时间戳都作为带有 UTC 信息的时间值进行处理和序列化，以避免时区偏移问题。

错误修复：
- 修正仪表盘、聊天、实时聊天和 OpenAPI 响应中 `created_at` 和 `updated_at` 时间戳不正确的问题，该问题由“天真（naive）”的 datetime 被解释为本地时区导致。

改进内容：
- 引入共享的 datetime 工具，用于将“天真（naive）”的 datetime 规范化为 UTC，并将其转换为 ISO 8601 字符串或 Unix 时间戳。
- 将仪表盘的 Flask 应用配置为使用自定义 JSON provider，使其在序列化 datetime 对象时使用明确的 UTC ISO 8601 字符串。
- 在会话管理和仪表盘路由中统一时间戳的生成方式，始终使用基于 UTC 的辅助方法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure all dashboard and conversation timestamps are handled and serialized as UTC-aware values to avoid timezone offset issues.

Bug Fixes:
- Correct incorrect created_at and updated_at timestamps in dashboard, chat, live chat, and OpenAPI responses caused by naive datetimes being interpreted in the local timezone.

Enhancements:
- Introduce shared datetime utilities to normalize naive datetimes as UTC and convert them to ISO 8601 strings or Unix timestamps.
- Configure the dashboard Flask app to use a custom JSON provider that serializes datetime objects as explicit UTC ISO 8601 strings.
- Standardize timestamp generation across conversation management and dashboard routes to consistently use the UTC-based helpers.

</details>

</details>