### PR TITLE
fix(dashboard): 自定义侧边栏中错误展开“更多功能”页面问题 (#5405)

### DIFF
--- a/dashboard/src/layouts/full/vertical-sidebar/NavItem.vue
+++ b/dashboard/src/layouts/full/vertical-sidebar/NavItem.vue
@@ -38,7 +38,7 @@ const isItemActive = computed(() => {
     </template>
 
     <!-- children -->
-    <template v-for="(child, index) in item.children" :key="index">
+    <template v-for="(child, index) in item.children" :key="child.title || child.to || `child-${index}`">
       <NavItem :item="child" :level="(level || 0) + 1" />
     </template>
   </v-list-group>


### PR DESCRIPTION
Fixes #5405

### Modifications / 改动点

本 PR 修复了侧边栏在自定义后分组状态不稳定的问题，并增强了本地持久化数据的容错能力。

- 修改 `dashboard/src/layouts/full/vertical-sidebar/NavItem.vue`
- 子项渲染 key 从索引改为稳定 key（`title/to/fallback`），避免 vnode 复用错位。

- 修改 `dashboard/src/layouts/full/vertical-sidebar/VerticalSidebar.vue`
- 对 `sidebar_openedItems` 做清洗，只保留当前菜单结构中有效的分组 key。
- 自定义变化后刷新菜单，并重新清洗展开状态。
- 顶层侧边栏渲染改为稳定 key。

- 修改 `dashboard/src/utils/sidebarCustomization.js`
- 规范化 main/more 项配置（去重、过滤无效项、处理冲突）。
- 将规范化后的结果回写 localStorage（自愈旧数据）。
- 增加非数组保护，避免脏 localStorage 数据触发运行时异常。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果
现在 v4.18.3 版本中测试现象为：当点击”平台日志“或其它功能时会连带展开“更多功能”，将其移出侧边栏后再移回去，该现象则会消失，但是当重启 AstrBot 后该现象依旧存在，如下视频，

https://github.com/user-attachments/assets/c810cfab-a4c7-4917-b944-43d48772791f

经修复过后，点击“平台日志”或其它功能不会连带展开“更多功能”，重启 AstrBot 后也不会有影响，测试结果如下视频，  

https://github.com/user-attachments/assets/5e40b026-ba30-4944-8b7f-723de5de2d48

验证步骤：
1. 在设置页调整侧边栏主区/更多区顺序与归属并保存。
2. 返回侧边栏页面，检查分组展开状态是否正常。
3. 刷新页面后再次检查状态是否与当前菜单一致。
4. （可选）多标签页测试自定义同步后状态是否正确。

本地验证：
- `cd dashboard && pnpm typecheck`：通过
- `cd dashboard && pnpm build`：通过（有既有 CSS minify warning，不影响构建）
- `cd dashboard && pnpm lint`：当前分支存在全局解析基线问题（非本 PR 引入）
- `ruff check .`：通过

说明：
- 记得 ctrl + F5 清一下浏览器缓存（泪目）
---

### Checklist / 检查清单

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

通过使项目键值和持久化状态对自定义及本地陈旧数据更具鲁棒性，稳定仪表盘垂直侧边栏的行为。

Bug 修复：
- 防止在侧边栏自定义或应用重启后，“More features” 分组和其他侧边栏部分被错误地一起展开。
- 避免由于 localStorage 中格式错误或过期的自定义数据而导致的运行时错误和侧边栏状态不一致问题。

改进：
- 规范化并去重主侧边栏/“更多”侧边栏的自定义条目配置，自动处理无效或冲突项，并将清理后的版本写回 localStorage。
- 过滤并同步持久化的侧边栏分组展开状态，只存储和恢复当前菜单结构中存在的有效分组。
- 为顶级和子级侧边栏条目使用稳定的键，以避免在菜单结构变化时出现 vnode 重用问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize the dashboard vertical sidebar behavior by making item keys and persisted state resilient to customization and stale local data.

Bug Fixes:
- Prevent the 'More features' group and other sidebar sections from incorrectly expanding together after sidebar customization or app restart.
- Avoid runtime errors and inconsistent sidebar state caused by malformed or outdated customization data in localStorage.

Enhancements:
- Normalize and de-duplicate customized main/more sidebar item configurations, automatically resolving invalid or conflicting entries and writing back a cleaned version to localStorage.
- Filter and synchronize persisted sidebar group expansion state so that only valid groups from the current menu structure are stored and restored.
- Use stable keys for top-level and child sidebar items to avoid vnode reuse issues when the menu structure changes.

</details>