### PR TITLE
fix(provider): strip GLM non-standard special tokens in zhipu adapter

### DIFF
--- a/tests/test_zhipu_source.py
+++ b/tests/test_zhipu_source.py
@@ -65,10 +65,12 @@ class TestCleanGLMSpecialTokens:
         assert ProviderZhipu._clean_glm_special_tokens("  <None>  ") == ""
 
     def test_null_token_case_insensitive_lower(self):
-        assert ProviderZhipu._clean_glm_special_tokens("<none>") == ""
+        # Without re.IGNORECASE, lowercase <none> is not a GLM token and must be preserved.
+        assert ProviderZhipu._clean_glm_special_tokens("<none>") == "<none>"
 
     def test_null_token_case_insensitive_upper(self):
-        assert ProviderZhipu._clean_glm_special_tokens("<NONE>") == ""
+        # Without re.IGNORECASE, uppercase <NONE> is not a GLM token and must be preserved.
+        assert ProviderZhipu._clean_glm_special_tokens("<NONE>") == "<NONE>"
 
     def test_null_token_in_middle_of_text(self):
         result = ProviderZhipu._clean_glm_special_tokens("hello <None> world")


### PR DESCRIPTION
GLM models (e.g. glm-4.6v-flash) can leak internal control tokens
into the visible reply content:

- `<None>`          – model's null-response signal
- `<|endoftext|>`   – end-of-sequence token
- `<|user|>`, `<|assistant|>`, `<|system|>`, `<|observation|>` – role tokens

Fix by overriding `_normalize_content` and `_parse_openai_completion` in
`ProviderZhipu` to apply a regex cleaning pass that removes these tokens
before the response is returned to the user.

Also corrects a wrong import (`star.func_tools` → `agent.tool`) that was
present in the original stub.

Closes #5556

## Summary by Sourcery

从 Zhipu 提供方的响应中剥离 GLM 特有的非标准特殊标记，防止泄露的控制标记出现在用户可见的输出中。

Bug Fixes:
- 从 Zhipu 适配器响应中清理 GLM 角色和空响应标记（例如 `<None>` 和 `<|endoftext|>`），包括组装后的流式补全结果，确保它们不再出现在助手回复中。

Tests:
- 为 ProviderZhipu 中的 GLM 特殊标记清理逻辑添加全面的单元测试和集成测试，覆盖独立清理器、内容规范化重写以及最终补全解析行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strip GLM-specific non-standard special tokens from Zhipu provider responses to prevent leaked control markers from appearing in user-visible output.

Bug Fixes:
- Clean GLM role and null-response tokens (such as <None> and <|endoftext|>) from Zhipu adapter responses, including assembled streaming completions, so they no longer appear in assistant replies.

Tests:
- Add comprehensive unit and integration tests for GLM special-token cleaning in ProviderZhipu, covering the standalone cleaner, content normalization override, and final completion parsing behavior.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

从 Zhipu 提供方的响应中剥离 GLM 特有的非标准特殊标记，防止泄露的控制标记出现在用户可见的输出中。

Bug Fixes:
- 从 Zhipu 适配器响应中清理 GLM 角色和空响应标记（例如 `<None>` 和 `<|endoftext|>`），包括组装后的流式补全结果，确保它们不再出现在助手回复中。

Tests:
- 为 ProviderZhipu 中的 GLM 特殊标记清理逻辑添加全面的单元测试和集成测试，覆盖独立清理器、内容规范化重写以及最终补全解析行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strip GLM-specific non-standard special tokens from Zhipu provider responses to prevent leaked control markers from appearing in user-visible output.

Bug Fixes:
- Clean GLM role and null-response tokens (such as <None> and <|endoftext|>) from Zhipu adapter responses, including assembled streaming completions, so they no longer appear in assistant replies.

Tests:
- Add comprehensive unit and integration tests for GLM special-token cleaning in ProviderZhipu, covering the standalone cleaner, content normalization override, and final completion parsing behavior.

</details>

</details>