### PR TITLE
fix: only allow HTTPS URLs to pass through directly in LINE adapter

### DIFF
--- a/astrbot/core/platform/sources/line/line_event.py
+++ b/astrbot/core/platform/sources/line/line_event.py
@@ -104,7 +104,7 @@ class LineMessageEvent(AstrMessageEvent):
     @staticmethod
     async def _resolve_image_url(segment: Image) -> str:
         candidate = (segment.url or segment.file or "").strip()
-        if candidate.startswith("http://") or candidate.startswith("https://"):
+        if candidate.startswith("https://"):
             return candidate
         try:
             return await segment.register_to_file_service()
@@ -115,7 +115,7 @@ class LineMessageEvent(AstrMessageEvent):
     @staticmethod
     async def _resolve_record_url(segment: Record) -> str:
         candidate = (segment.url or segment.file or "").strip()
-        if candidate.startswith("http://") or candidate.startswith("https://"):
+        if candidate.startswith("https://"):
             return candidate
         try:
             return await segment.register_to_file_service()
@@ -137,7 +137,7 @@ class LineMessageEvent(AstrMessageEvent):
     @staticmethod
     async def _resolve_video_url(segment: Video) -> str:
         candidate = (segment.file or "").strip()
-        if candidate.startswith("http://") or candidate.startswith("https://"):
+        if candidate.startswith("https://"):
             return candidate
         try:
             return await segment.register_to_file_service()
@@ -148,9 +148,7 @@ class LineMessageEvent(AstrMessageEvent):
     @staticmethod
     async def _resolve_video_preview_url(segment: Video) -> str:
         cover_candidate = (segment.cover or "").strip()
-        if cover_candidate.startswith("http://") or cover_candidate.startswith(
-            "https://"
-        ):
+        if cover_candidate.startswith("https://"):
             return cover_candidate
 
         if cover_candidate:
@@ -191,7 +189,7 @@ class LineMessageEvent(AstrMessageEvent):
 
     @staticmethod
     async def _resolve_file_url(segment: File) -> str:
-        if segment.url and segment.url.startswith(("http://", "https://")):
+        if segment.url and segment.url.startswith("https://"):
             return segment.url
         try:
             return await segment.register_to_file_service()


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
The LINE Messaging API strictly requires all media URLs (images, audio, video, files) to use HTTPS. The previous `_resolve_*_url` methods in the LINE adapter treated `http://` and `https://` URLs equally, passing both through directly without any conversion. This caused a 400 error (`Must be a valid HTTPS URL`) .
### Modifications / 改动点
- `astrbot/core/platform/sources/line/line_event.py`: 
Changed all five URL resolution methods (`_resolve_image_url`, `_resolve_record_url`, `_resolve_video_url`, `_resolve_video_preview_url`, `_resolve_file_url`) to only pass through `https://` URLs directly. Any `http://` URL now falls through to `register_to_file_service()`.
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
Before:
<img width="516" height="146" alt="image" src="https://github.com/user-attachments/assets/89f52886-25b8-4178-9e72-44f277e3bd6e" />
After:
No Error
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

错误修复：
- 通过禁止直接发送纯 HTTP URL，并改为通过文件服务进行注册，防止 LINE 媒体消息因 400 错误而发送失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent LINE media messages from failing with 400 errors by disallowing plain HTTP URLs from being sent directly and registering them via the file service instead.

</details>