### PR TITLE
fix(provider): 捕获 anthropic_source get_models 的端点异常

### DIFF
--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -649,10 +649,15 @@ class ProviderAnthropic(Provider):
 
     async def get_models(self) -> list[str]:
         models_str = []
-        models = await self.client.models.list()
-        models = sorted(models.data, key=lambda x: x.id)
-        for model in models:
-            models_str.append(model.id)
+        try:
+            models = await self.client.models.list()
+            models = sorted(models.data, key=lambda x: x.id)
+            for model in models:
+                models_str.append(model.id)
+        except Exception as e:
+            # 部分兼容 Anthropic API 的第三方提供商（如 MiniMax）不支持 /models 端点，
+            # 忽略错误并返回空列表，用户可手动添加模型。
+            logger.warning(f"获取模型列表失败，该提供商可能不支持 /models 端点：{e}")
         return models_str
 
     def set_key(self, key: str) -> None:

--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -654,7 +654,7 @@ class ProviderAnthropic(Provider):
             models = sorted(models.data, key=lambda x: x.id)
             for model in models:
                 models_str.append(model.id)
-        except Exception as e:
+        except (httpx.HTTPStatusError, anthropic.APIStatusError) as e:
             # 部分兼容 Anthropic API 的第三方提供商（如 MiniMax）不支持 /models 端点，
             # 忽略错误并返回空列表，用户可手动添加模型。
             logger.warning(f"获取模型列表失败，该提供商可能不支持 /models 端点：{e}")


### PR DESCRIPTION
- 部分兼容 Anthropic API 的第三方提供商（如 MiniMax）未实现GET /models 端点，调用时返回 404 导致整个获取流程报错崩溃。

- 添加 try/except 捕获异常，记录 warning 日志并返回空列表，用户可手动输入模型名称后继续正常使用。

close #5698

## 由 Sourcery 提供的摘要

在从兼容 Anthropic 的提供商列出模型时，处理失败情况，避免导致模型发现流程崩溃。

错误修复：
- 当第三方兼容 Anthropic 的提供商未实现 `/models` 端点时，通过捕获 API 错误并返回空的模型列表，防止发生崩溃。

增强功能：
- 在模型列出失败时记录警告日志，让用户了解该提供商可能不支持 `/models` 端点，并可以手动配置模型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle failures when listing models from Anthropic-compatible providers to avoid crashing the model discovery flow.

Bug Fixes:
- Prevent crashes when third-party Anthropic-compatible providers do not implement the /models endpoint by catching API errors and returning an empty model list.

Enhancements:
- Log a warning when model listing fails so users understand that the provider may not support the /models endpoint and can manually configure models.

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在从兼容 Anthropic 的提供商列出模型时，处理失败情况，避免导致模型发现流程崩溃。

错误修复：
- 当第三方兼容 Anthropic 的提供商未实现 `/models` 端点时，通过捕获 API 错误并返回空的模型列表，防止发生崩溃。

增强功能：
- 在模型列出失败时记录警告日志，让用户了解该提供商可能不支持 `/models` 端点，并可以手动配置模型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle failures when listing models from Anthropic-compatible providers to avoid crashing the model discovery flow.

Bug Fixes:
- Prevent crashes when third-party Anthropic-compatible providers do not implement the /models endpoint by catching API errors and returning an empty model list.

Enhancements:
- Log a warning when model listing fails so users understand that the provider may not support the /models endpoint and can manually configure models.

</details>

</details>