### PR TITLE
test(skill_manager): update sandbox cache path expectations 

### DIFF
--- a/tests/test_skill_manager_sandbox_cache.py
+++ b/tests/test_skill_manager_sandbox_cache.py
@@ -150,6 +150,8 @@ def test_sandbox_and_local_path_resolution_with_show_sandbox_path_false(
 
     assert sorted(by_name) == ["custom-local", "python-sandbox"]
     assert by_name["custom-local"].description == "local description"
-    assert by_name["custom-local"].path.endswith("/skills/custom-local/SKILL.md")
+    local_skill_path = Path(by_name["custom-local"].path)
+    assert local_skill_path.is_relative_to(skills_root)
+    assert local_skill_path == skills_root / "custom-local" / "SKILL.md"
     assert by_name["python-sandbox"].path == "/app/skills/python-sandbox/SKILL.md"
 


### PR DESCRIPTION
修复单元测试skill部分
### Modifications / 改动点

修正 sandbox 路径断言，强化“sandbox 缓存技能不可停用”的权限校验，新增 show_sandbox_path=False 的覆盖测试。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<img width="1023" height="1044" alt="image" src="https://github.com/user-attachments/assets/ad5bbdf6-2664-4f92-af5b-e3aaa0eccdde" />


---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

更新技能管理器沙箱缓存测试，以匹配新的路径解析行为和沙箱技能的权限规则。

Bug 修复：
- 在 `list_skills` 测试中，更正对内置技能的预期沙箱技能路径。
- 使测试与以下规则保持一致：沙箱缓存的技能不能被停用，尝试停用时应抛出 `PermissionError`。

测试：
- 在 `show_sandbox_path` 为 `False` 时，增加对沙箱和本地路径解析的覆盖，以确保本地覆盖生效并正确暴露路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update skill manager sandbox cache tests to match new path resolution behavior and permission rules for sandboxed skills.

Bug Fixes:
- Correct expected sandbox skill path for built-in skills in list_skills tests.
- Align tests with the rule that sandbox-cached skills cannot be deactivated and should raise PermissionError when attempted.

Tests:
- Add coverage for sandbox and local path resolution when show_sandbox_path is False, ensuring local overrides and correct path exposure.

</details>