### PR TITLE
feat: implement Aliyun Bailian Chat provider and coding plan support

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1044,6 +1044,20 @@ CONFIG_METADATA_2 = {
                         "proxy": "",
                         "custom_headers": {},
                     },
+                    "百炼": {
+                        "id": "dashscope",
+                        "provider": "dashscope",
+                        "type": "bailian_chat_completion",
+                        "provider_type": "chat_completion",
+                        "enable": True,
+                        "key": [],
+                        "api_base": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+                        "bl_coding_plan": False,
+                        "bl_thinking": False,
+                        "timeout": 120,
+                        "proxy": "",
+                        "custom_headers": {},
+                    },
                     "AIHubMix": {
                         "id": "aihubmix",
                         "provider": "aihubmix",
@@ -1914,6 +1928,12 @@ CONFIG_METADATA_2 = {
                         "description": "启用原生搜索功能",
                         "type": "bool",
                         "hint": "启用后所有函数工具将全部失效，免费次数限制请查阅官方文档",
+                    },
+                    "bl_coding_plan": {
+                        "type": "bool",
+                    },
+                    "bl_thinking": {
+                        "type": "bool",
                     },
                     "gm_native_coderunner": {
                         "description": "启用原生代码执行器",

--- a/astrbot/core/provider/manager.py
+++ b/astrbot/core/provider/manager.py
@@ -449,6 +449,10 @@ class ProviderManager:
                 from .sources.bailian_rerank_source import (
                     BailianRerankProvider as BailianRerankProvider,
                 )
+            case "bailian_chat_completion":
+                from .sources.bailian_chat_source import (
+                    ProviderBailianChat as ProviderBailianChat,
+                )
 
     def get_merged_provider_config(self, provider_config: dict) -> dict:
         """获取 provider 配置和 provider_source 配置合并后的结果

--- a/astrbot/core/provider/sources/bailian_chat_source.py
+++ b/astrbot/core/provider/sources/bailian_chat_source.py
@@ -1,0 +1,45 @@
+from ..register import register_provider_adapter
+from .openai_source import ProviderOpenAIOfficial
+
+
+@register_provider_adapter(
+    "bailian_chat_completion",
+    "阿里云百炼 Chat Completion 提供商适配器",
+    provider_display_name="百炼",
+)
+class ProviderBailianChat(ProviderOpenAIOfficial):
+    def __init__(
+        self,
+        provider_config: dict,
+        provider_settings: dict,
+    ) -> None:
+        # 根据 Coding Plan 模式自动切换 API Base URL
+        is_coding_plan = provider_config.get("bl_coding_plan", False)
+        is_thinking = provider_config.get("bl_thinking", False)
+
+        if is_coding_plan:
+            provider_config["api_base"] = "https://coding.dashscope.aliyuncs.com/v1"
+        else:
+            provider_config["api_base"] = (
+                "https://dashscope.aliyuncs.com/compatible-mode/v1"
+            )
+
+        if is_thinking and not provider_config.get("model"):
+            if is_coding_plan:
+                provider_config["model"] = "qwen3.5-plus"
+            else:
+                provider_config["model"] = "qwen-plus"
+
+        super().__init__(provider_config, provider_settings)
+        self.is_thinking = is_thinking
+
+    def _finally_convert_payload(self, payloads: dict) -> None:
+        """添加百炼特定参数"""
+        super()._finally_convert_payload(payloads)
+
+        if self.is_thinking:
+            payloads["enable_thinking"] = True
+
+    def _extract_reasoning_content(self, completion) -> str:
+        """提取推理内容"""
+        return super()._extract_reasoning_content(completion)

--- a/astrbot/dashboard/routes/config.py
+++ b/astrbot/dashboard/routes/config.py
@@ -443,6 +443,14 @@ class ConfigRoute(Route):
         if not isinstance(new_source_config, dict):
             return Response().error("缺少或错误的配置数据").__dict__
 
+        # 百炼 Chat Completion: 根据 bl_coding_plan 强制设置正确的 api_base
+        if new_source_config.get("type") == "bailian_chat_completion":
+            is_coding_plan = new_source_config.get("bl_coding_plan", False)
+            if is_coding_plan:
+                new_source_config["api_base"] = "https://coding.dashscope.aliyuncs.com/v1"
+            else:
+                new_source_config["api_base"] = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+
         # 确保配置中有 id 字段
         if not new_source_config.get("id"):
             new_source_config["id"] = original_id

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -947,6 +947,14 @@
         "description": "Enable native search",
         "hint": "When enabled, uses xAI Chat Completions native Live Search for web queries (billed on demand). Only applies to xAI providers."
       },
+      "bl_coding_plan": {
+        "description": "Enable Coding Plan Mode",
+        "hint": "Uses Aliyun Bailian Coding Plan dedicated API. Requires sk-sp- prefixed API keys. Note: This mode doesn't support automatic model list fetching; please refer to [Supported Models](https://bailian.console.aliyun.com/cn-beijing/?tab=doc#/doc/?type=model&url=3005961) and add models manually."
+      },
+      "bl_thinking": {
+        "description": "Enable Thinking",
+        "hint": "Enables deep reasoning for detailed thought processes. Suitable for complex reasoning tasks."
+      },
       "rerank_api_base": {
         "description": "Rerank Model API Base URL",
         "hint": "AstrBot appends /v1/rerank to the request URL."

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -950,6 +950,14 @@
         "description": "启用原生搜索功能",
         "hint": "启用后，将通过 xAI 的 Chat Completions 原生 Live Search 进行联网检索（按需计费）。仅对 xAI 提供商生效。"
       },
+      "bl_coding_plan": {
+        "description": "启用 Coding Plan 模式",
+        "hint": "启用后将使用阿里云百炼 Coding Plan 专用 API，需要使用 sk-sp- 开头的专用 API Key。注意：Coding Plan 模式不支持自动获取模型列表，请参考 [支持模型列表](https://bailian.console.aliyun.com/cn-beijing/?tab=doc#/doc/?type=model&url=3005961) 手动添加。"
+      },
+      "bl_thinking": {
+        "description": "启用 Thinking",
+        "hint": "启用后模型将进行深度推理，提供更详细的思考过程。适用于需要复杂推理的任务。"
+      },
       "rerank_api_base": {
         "description": "重排序模型 API Base URL",
         "hint": "AstrBot 会在请求时在末尾加上 /v1/rerank。"


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
因为我刚刚订阅了阿里云百炼的coding plan，且这里没有预设，为了降低其他用户的上手难度。添加对阿里云百炼 (Aliyun Bailian / DashScope) 对话模型的原生支持，包括专用的 Coding Plan 模式和 Thinking 深度推理模式。

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
- 新增 `astrbot/core/provider/sources/bailian_chat_source.py`，实现百炼对话模型适配器，继承自 OpenAI 适配器并针对百炼特性进行优化。
- 修改 `astrbot/core/config/default.py`，注册百炼配置模板，新增 `bl_coding_plan` (Coding Plan 开关) 和 `bl_thinking` (深度推理开关) 配置项。
- 修改 `astrbot/core/provider/manager.py`，注册 `bailian_chat_completion` 提供商类型及其适配器映射。
- 修改 `astrbot/dashboard/routes/config.py`，在更新配置时针对百炼提供商增加逻辑，
- 更新 `dashboard/src/i18n/locales/` 下的 `zh-CN` 和 `en-US` 国际化文件，支持百炼专有配置项的中文/英文描述显示，并补全了前端切换通知词条。
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<img width="1385" height="1187" alt="e137d445-9af5-48b9-a93e-a349538a80cd" src="https://github.com/user-attachments/assets/491ad4be-e16d-485c-9f5c-c574a5d6b5c2" />
<img width="1391" height="1201" alt="cb31c62b-2ab3-47e2-b92a-748d4e8ca6c8" src="https://github.com/user-attachments/assets/d9ba2b15-3da2-4bab-96af-b884ab4ea669" />

有一个问题：当点击按钮进行切换的时候，理论上应实时变化url地址，然而我尝试了多种修改方式依然无法实现实时变化，但是存储的数据是正确的，点下按钮后保存的时候后端会正确匹配，重新点击下这个provider就会正常显示。主要是我debug的时候发现前端写console.log显示不出来，我不太懂，可能我的调试方式有问题吧。因为我精力有限，一段时间内无法再修改了。如果您认为此功能有用但我的代码有问题，可以在这基础上修改一下，，或者等我后续有空。

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

为阿里云百炼聊天补全新增原生 Provider 支持，包括 Coding Plan 和 Thinking 模式，并将其集成到配置和仪表盘流程中。

新功能：
- 引入基于 OpenAI Provider 的百炼聊天补全适配器，支持 Coding Plan 和 Thinking 模式。
- 注册一个默认的百炼 Provider 模板，并提供专用的 `bl_coding_plan` 和 `bl_thinking` 配置选项。

增强改进：
- 将百炼聊天补全 Provider 接入 Provider 管理器，实现适配器的动态加载。
- 确保在更新 Provider 时，可根据 Coding Plan 标志自动设置正确的百炼 API 基础 URL。
- 扩展仪表盘配置元数据和国际化（i18n）字符串，使百炼相关设置可在中文和英文界面中呈现。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add native provider support for Aliyun Bailian chat completion, including Coding Plan and Thinking modes, and integrate it into configuration and dashboard flows.

New Features:
- Introduce a Bailian chat completion provider adapter based on the OpenAI provider with support for Coding Plan and Thinking modes.
- Register a default Bailian provider template with dedicated bl_coding_plan and bl_thinking configuration options.

Enhancements:
- Wire the Bailian chat completion provider into the provider manager for dynamic adapter loading.
- Ensure provider updates automatically set the correct Bailian API base URL based on the Coding Plan flag.
- Extend dashboard configuration metadata and i18n strings to surface Bailian-specific settings in both Chinese and English.

</details>