### PR TITLE
fix: stabilize plugin logo loading across extension views

### DIFF
--- a/astrbot/core/file_token_service.py
+++ b/astrbot/core/file_token_service.py
@@ -18,7 +18,7 @@ class FileTokenService:
         """清理过期的令牌"""
         now = time.time()
         expired_tokens = [
-            token for token, (_, expire) in self.staged_files.items() if expire < now
+            token for token, payload in self.staged_files.items() if payload[1] < now
         ]
         for token in expired_tokens:
             self.staged_files.pop(token, None)

--- a/astrbot/core/file_token_service.py
+++ b/astrbot/core/file_token_service.py
@@ -11,7 +11,7 @@ class FileTokenService:
 
     def __init__(self, default_timeout: float = 300) -> None:
         self.lock = asyncio.Lock()
-        self.staged_files = {}  # token: (file_path, expire_time)
+        self.staged_files = {}  # token: (file_path, expire_time, single_use)
         self.default_timeout = default_timeout
 
     async def _cleanup_expired_tokens(self) -> None:
@@ -28,7 +28,13 @@ class FileTokenService:
             await self._cleanup_expired_tokens()
             return file_token not in self.staged_files
 
-    async def register_file(self, file_path: str, timeout: float | None = None) -> str:
+    async def register_file(
+        self,
+        file_path: str,
+        timeout_seconds: float | None = None,
+        single_use: bool = True,
+        **kwargs,
+    ) -> str:
         """向令牌服务注册一个文件。
 
         Args:
@@ -64,16 +70,19 @@ class FileTokenService:
                     f"文件不存在: {local_path} (原始输入: {file_path})",
                 )
 
+            if timeout_seconds is None and "timeout" in kwargs:
+                timeout_seconds = kwargs["timeout"]
+
             file_token = str(uuid.uuid4())
             expire_time = time.time() + (
-                timeout if timeout is not None else self.default_timeout
+                timeout_seconds if timeout_seconds is not None else self.default_timeout
             )
             # 存储转换后的真实路径
-            self.staged_files[file_token] = (local_path, expire_time)
+            self.staged_files[file_token] = (local_path, expire_time, single_use)
             return file_token
 
     async def handle_file(self, file_token: str) -> str:
-        """根据令牌获取文件路径，使用后令牌失效。
+        """根据令牌获取文件路径。
 
         Args:
             file_token(str): 注册时返回的令牌
@@ -92,7 +101,16 @@ class FileTokenService:
             if file_token not in self.staged_files:
                 raise KeyError(f"无效或过期的文件 token: {file_token}")
 
-            file_path, _ = self.staged_files.pop(file_token)
-            if not os.path.exists(file_path):
+            token_payload = self.staged_files[file_token]
+            if len(token_payload) == 2:
+                # Backward compatibility for in-memory payload created before single_use was introduced.
+                file_path, _ = token_payload
+                single_use = True
+            else:
+                file_path, _, single_use = token_payload
+
+            if single_use:
+                self.staged_files.pop(file_token, None)
+            if not await asyncio.to_thread(os.path.exists, file_path):
                 raise FileNotFoundError(f"文件不存在: {file_path}")
             return file_path

--- a/astrbot/core/file_token_service.py
+++ b/astrbot/core/file_token_service.py
@@ -65,13 +65,14 @@ class FileTokenService:
         async with self.lock:
             await self._cleanup_expired_tokens()
 
-            if not os.path.exists(local_path):
+            if not await asyncio.to_thread(os.path.exists, local_path):
                 raise FileNotFoundError(
                     f"文件不存在: {local_path} (原始输入: {file_path})",
                 )
 
-            if timeout_seconds is None and "timeout" in kwargs:
-                timeout_seconds = kwargs["timeout"]
+            legacy_timeout = kwargs.pop("timeout", None)
+            if legacy_timeout is not None:
+                timeout_seconds = float(legacy_timeout)
 
             file_token = str(uuid.uuid4())
             expire_time = time.time() + (

--- a/astrbot/core/file_token_service.py
+++ b/astrbot/core/file_token_service.py
@@ -39,7 +39,7 @@ class FileTokenService:
 
         Args:
             file_path(str): 文件路径
-            timeout(float): 超时时间，单位秒（可选）
+            timeout_seconds(float): 超时时间，单位秒（可选）
 
         Returns:
             str: 一个单次令牌

--- a/astrbot/dashboard/routes/plugin.py
+++ b/astrbot/dashboard/routes/plugin.py
@@ -345,7 +345,11 @@ class PluginRoute(Route):
             if token := self._logo_cache.get(logo_path):
                 if not await file_token_service.check_token_expired(token):
                     return self._logo_cache[logo_path]
-            token = await file_token_service.register_file(logo_path, timeout=300)
+            token = await file_token_service.register_file(
+                logo_path,
+                timeout=300,
+                single_use=False,
+            )
             self._logo_cache[logo_path] = token
             return token
         except Exception as e:

--- a/dashboard/src/components/extension/MarketPluginCard.vue
+++ b/dashboard/src/components/extension/MarketPluginCard.vue
@@ -35,6 +35,13 @@ const handleInstall = (plugin) => {
   emit("install", plugin);
 };
 
+const handlePluginLogoError = (event) => {
+  const target = event?.target;
+  if (!target || target.dataset.fallbackApplied === "1") return;
+  target.dataset.fallbackApplied = "1";
+  target.src = props.defaultPluginIcon;
+};
+
 </script>
 
 <template>
@@ -75,6 +82,7 @@ const handleInstall = (plugin) => {
         <img
           :src="plugin?.logo || defaultPluginIcon"
           :alt="plugin.name"
+          @error="handlePluginLogoError"
           style="
             height: 75px;
             width: 75px;

--- a/dashboard/src/views/extension/InstalledPluginsTab.vue
+++ b/dashboard/src/views/extension/InstalledPluginsTab.vue
@@ -3,6 +3,13 @@ import ExtensionCard from "@/components/shared/ExtensionCard.vue";
 import StyledMenu from "@/components/shared/StyledMenu.vue";
 import defaultPluginIcon from "@/assets/images/plugin_icon.png";
 
+const handlePluginLogoError = (event) => {
+  const target = event?.target;
+  if (!target || target.dataset.fallbackApplied === "1") return;
+  target.dataset.fallbackApplied = "1";
+  target.src = defaultPluginIcon;
+};
+
 const props = defineProps({
   state: {
     type: Object,
@@ -318,6 +325,7 @@ const {
                           <img
                             :src="item.logo"
                             :alt="item.name"
+                            @error="handlePluginLogoError"
                             style="
                               height: 40px;
                               width: 40px;


### PR DESCRIPTION
### Modifications / 改动点

This change fixes plugin logo image instability when switching between card/list views in the dashboard.
本次改动修复了 Dashboard 插件页在卡片/列表切换时插件 logo 随机失效、回退默认图或破图的问题。

- Updated `astrbot/core/file_token_service.py`:
  - Added `single_use: bool = True` to `register_file(...)` to keep backward-compatible default behavior.
  - Extended staged token payload from `(file_path, expire_time)` to `(file_path, expire_time, single_use)`.
  - Updated `handle_file(...)` to support reusable tokens when `single_use=False`, while preserving one-time behavior by default.
  - Fixed expiry cleanup compatibility for mixed payload structures by reading expire time via index.
- Updated `astrbot/dashboard/routes/plugin.py`:
  - Plugin logo tokens are now registered with `single_use=False` (still TTL-based), so logo URLs remain valid across repeated UI renders in the valid window.
- Updated `dashboard/src/views/extension/InstalledPluginsTab.vue`:
  - Added image load error fallback handler to default plugin icon in list view.
- Updated `dashboard/src/components/extension/MarketPluginCard.vue`:
  - Added image load error fallback handler to default plugin icon in market cards.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Verification steps:
1. Open Extension page with plugins that have custom logos.
2. Switch between card view and list view multiple times.
3. Verify plugin logos remain stable (no random broken image due to token consumption).
4. Verify broken/invalid logo URLs in list and market views fallback to default icon.
5. Confirm default single-use token behavior remains unchanged for non-logo call sites.

Logs:
- `ruff check astrbot/core/file_token_service.py` passed.
- Commits in this PR:
  - `15847925` fix(core): support reusable file tokens with single-use compatibility
  - `3e50e9bd` fix(plugin): use reusable tokens for plugin logos
  - `4c6d6bc3` fix(dashboard): add plugin logo fallback in list and market views
  - `249d6151` fix(core): handle mixed token payloads in expiry cleanup

---

### Checklist / 检查清单

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## 由 Sourcery 提供的总结

通过支持可复用的文件令牌并在扩展视图中为损坏的 logo 图片增加 UI 兜底方案，稳定插件 logo 的加载。

新功能：
- 允许将文件令牌注册为可复用，而不是仅限一次使用，同时保留现有的单次使用默认行为。

错误修复：
- 通过为 logo 资源使用可复用文件令牌，确保在多次渲染仪表盘视图时插件 logo 的 URL 仍然有效。
- 当插件 logo 图片在列表和市场视图中加载失败时，优雅地回退到默认插件图标。

改进：
- 使文件令牌过期清理与传统和扩展两种令牌负载格式都兼容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize plugin logo loading by supporting reusable file tokens and adding UI fallbacks for broken logo images across extension views.

New Features:
- Allow file tokens to be registered as reusable instead of single-use while preserving the existing single-use default behavior.

Bug Fixes:
- Ensure plugin logo URLs remain valid across repeated dashboard view renders by using reusable file tokens for logo assets.
- Provide graceful fallbacks to a default plugin icon when plugin logo images fail to load in list and market views.

Enhancements:
- Make file token expiration cleanup compatible with both legacy and extended token payload formats.

</details>