### PR TITLE
Prevent empty tool_calls in skills_like mode for API compatibility

### DIFF
--- a/astrbot/core/agent/handoff.py
+++ b/astrbot/core/agent/handoff.py
@@ -15,7 +15,6 @@ class HandoffTool(FunctionTool, Generic[TContext]):
         tool_description: str | None = None,
         **kwargs,
     ) -> None:
-
         # Avoid passing duplicate `description` to the FunctionTool dataclass.
         # Some call sites (e.g. SubAgentOrchestrator) pass `description` via kwargs
         # to override what the main agent sees, while we also compute a default

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -946,8 +946,14 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                     model=self.req.model,
                     session_id=self.req.session_id,
                 )
-                if requery_resp:
+                if (requery_resp and requery_resp.tools_call_name and 
+                    len(requery_resp.tools_call_name) == len(requery_resp.tools_call_ids) == len(requery_resp.tools_call_args) > 0):
                     llm_resp = requery_resp
+                else:
+                    logger.warning(
+                        "LLM returned invalid or no tool calls during 'skills_like' parameter re-query. "
+                        "Falling back to original light-schema response to avoid empty tool_calls error."
+                    )
 
         return llm_resp, subset
 

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -946,8 +946,14 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                     model=self.req.model,
                     session_id=self.req.session_id,
                 )
-                if (requery_resp and requery_resp.tools_call_name and 
-                    len(requery_resp.tools_call_name) == len(requery_resp.tools_call_ids) == len(requery_resp.tools_call_args) > 0):
+                if (
+                    requery_resp
+                    and requery_resp.tools_call_name
+                    and len(requery_resp.tools_call_name)
+                    == len(requery_resp.tools_call_ids)
+                    == len(requery_resp.tools_call_args)
+                    > 0
+                ):
                     llm_resp = requery_resp
                 else:
                     logger.warning(

--- a/astrbot/core/provider/entities.py
+++ b/astrbot/core/provider/entities.py
@@ -70,11 +70,7 @@ class ToolCallsResult:
     """函数调用的结果"""
 
     def to_openai_messages(self) -> list[dict]:
-        ret = [
-            self.tool_calls_info.model_dump(),
-            *[item.model_dump() for item in self.tool_calls_result],
-        ]
-        return ret
+        return [item.model_dump() for item in self.to_openai_messages_model()]
 
     def to_openai_messages_model(
         self,
@@ -367,27 +363,17 @@ class LLMResponse:
         else:
             self._completion_text = value
 
-    def to_openai_tool_calls(self) -> list[dict]:
+    def to_openai_tool_calls(self) -> list[dict] | None:
         """Convert to OpenAI tool calls format. Deprecated, use to_openai_to_calls_model instead."""
-        ret = []
-        for idx, tool_call_arg in enumerate(self.tools_call_args):
-            payload = {
-                "id": self.tools_call_ids[idx],
-                "function": {
-                    "name": self.tools_call_name[idx],
-                    "arguments": json.dumps(tool_call_arg),
-                },
-                "type": "function",
-            }
-            if self.tools_call_extra_content.get(self.tools_call_ids[idx]):
-                payload["extra_content"] = self.tools_call_extra_content[
-                    self.tools_call_ids[idx]
-                ]
-            ret.append(payload)
-        return ret
+        res = self.to_openai_to_calls_model()
+        if res is None:
+            return None
+        return [tc.model_dump() for tc in res]
 
-    def to_openai_to_calls_model(self) -> list[ToolCall]:
+    def to_openai_to_calls_model(self) -> list[ToolCall] | None:
         """The same as to_openai_tool_calls but return pydantic model."""
+        if not self.tools_call_args:
+            return None
         ret = []
         for idx, tool_call_arg in enumerate(self.tools_call_args):
             ret.append(

--- a/astrbot/core/provider/entities.py
+++ b/astrbot/core/provider/entities.py
@@ -372,7 +372,13 @@ class LLMResponse:
 
     def to_openai_to_calls_model(self) -> list[ToolCall] | None:
         """The same as to_openai_tool_calls but return pydantic model."""
-        if not self.tools_call_args:
+        if (
+            not self.tools_call_args
+            or not self.tools_call_name
+            or not self.tools_call_ids
+            or len(self.tools_call_args) != len(self.tools_call_name)
+            or len(self.tools_call_args) != len(self.tools_call_ids)
+        ):
             return None
         ret = []
         for idx, tool_call_arg in enumerate(self.tools_call_args):

--- a/tests/unit/test_fix_skills_like_empty_calls.py
+++ b/tests/unit/test_fix_skills_like_empty_calls.py
@@ -1,14 +1,16 @@
-import pytest
-import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock
-from astrbot.core.agent.runners.tool_loop_agent_runner import ToolLoopAgentRunner
-from astrbot.core.agent.run_context import ContextWrapper
+
+import pytest
+
 from astrbot.core.agent.hooks import BaseAgentRunHooks
-from astrbot.core.agent.tool import ToolSet, FunctionTool
+from astrbot.core.agent.message import ToolCall
+from astrbot.core.agent.run_context import ContextWrapper
+from astrbot.core.agent.runners.tool_loop_agent_runner import ToolLoopAgentRunner
+from astrbot.core.agent.tool import FunctionTool, ToolSet
 from astrbot.core.provider.entities import LLMResponse, ProviderRequest, TokenUsage
 from astrbot.core.provider.provider import Provider
-from astrbot.core.agent.message import Message, ToolCall
+
 
 def test_llm_response_tool_calls_none_and_empty_list_behaviour():
     """
@@ -34,6 +36,7 @@ def test_llm_response_tool_calls_none_and_empty_list_behaviour():
 
     assert response_empty.to_openai_tool_calls() is None
     assert response_empty.to_openai_to_calls_model() is None
+
 
 def test_llm_response_tool_calls_non_empty_list_behaviour():
     """
@@ -65,11 +68,26 @@ def test_llm_response_tool_calls_non_empty_list_behaviour():
     assert tool_calls[0]["id"] == "call_1"
     assert tool_calls[0]["function"]["name"] == "test_tool"
     assert tool_calls[0]["function"]["arguments"] == json.dumps(tools_call_args[0])
-    
+
     assert isinstance(tool_calls_model[0], ToolCall)
     assert tool_calls_model[0].id == "call_1"
     assert tool_calls_model[0].function.name == "test_tool"
     assert tool_calls_model[0].function.arguments == json.dumps(tools_call_args[0])
+
+
+def test_llm_response_tool_calls_mismatched_metadata_returns_none():
+    """Incomplete tool call metadata should not serialize into OpenAI tool calls."""
+    response = LLMResponse(
+        role="assistant",
+        completion_text="test",
+        tools_call_args=[{}],
+        tools_call_name=["test_tool"],
+        tools_call_ids=[],
+    )
+
+    assert response.to_openai_tool_calls() is None
+    assert response.to_openai_to_calls_model() is None
+
 
 class MockSkillsLikeProvider(Provider):
     def __init__(self, fail_with_none=False):
@@ -88,7 +106,7 @@ class MockSkillsLikeProvider(Provider):
 
     async def text_chat(self, **kwargs) -> LLMResponse:
         self.call_count += 1
-        # 第一次调用：模拟 skills_like 模式下的轻量级调用，返回工具名但无参数
+        # First call: simulate the lightweight skills_like tool selection response.
         if self.call_count == 1:
             return LLMResponse(
                 role="assistant",
@@ -96,9 +114,9 @@ class MockSkillsLikeProvider(Provider):
                 tools_call_name=["test_tool"],
                 tools_call_ids=["call_1"],
                 tools_call_args=[{}],
-                usage=TokenUsage(output=5)
+                usage=TokenUsage(output=5),
             )
-        # 第二次调用：模拟 LLM 异常响应，不返回任何工具调用
+        # Second call: simulate an abnormal LLM response without tool calls.
         if self.fail_with_none:
             return LLMResponse(
                 role="assistant",
@@ -106,86 +124,95 @@ class MockSkillsLikeProvider(Provider):
                 tools_call_name=None,
                 tools_call_ids=None,
                 tools_call_args=None,
-                usage=TokenUsage(output=5)
+                usage=TokenUsage(output=5),
             )
-        else:
-            return LLMResponse(
-                role="assistant",
-                completion_text="Wait, I changed my mind.",
-                tools_call_name=[],
-                tools_call_ids=[],
-                tools_call_args=[],
-                usage=TokenUsage(output=5)
-            )
+
+        return LLMResponse(
+            role="assistant",
+            completion_text="Wait, I changed my mind.",
+            tools_call_name=[],
+            tools_call_ids=[],
+            tools_call_args=[],
+            usage=TokenUsage(output=5),
+        )
 
     async def text_chat_stream(self, **kwargs):
         yield await self.text_chat(**kwargs)
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("fail_with_none", [True, False])
 async def test_skills_like_empty_requery_fix(fail_with_none):
     """
-    测试在 skills_like 模式下，如果二次参数补全请求返回空（[] 或 None），
-    系统是否能正确处理而不产生非法的空 tool_calls 列表，
-    并且最终保留的 tool_calls 对应第一次调用而没有被空结果覆盖。
+    Verify that an empty second parameter re-query ([] or None) in
+    skills_like mode never produces an illegal empty tool_calls list and
+    still preserves the original tool call from the first response.
     """
     provider = MockSkillsLikeProvider(fail_with_none=fail_with_none)
-    
-    # 准备工具
+
+    # Prepare a single callable tool.
     tool = FunctionTool(
         name="test_tool",
         description="A test tool",
         parameters={"type": "object", "properties": {"p": {"type": "string"}}},
-        handler=AsyncMock()
+        handler=AsyncMock(),
     )
     tool_set = ToolSet(tools=[tool])
-    
-    # 准备 Runner
+
+    # Prepare the runner and a minimal wrapped context.
     runner = ToolLoopAgentRunner()
     request = ProviderRequest(prompt="Use tool", func_tool=tool_set)
-    # 模拟 ContextWrapper
+
+    # Mock the wrapped execution context.
     mock_context = MagicMock()
     run_context = ContextWrapper(context=mock_context)
     hooks = BaseAgentRunHooks()
-    
+
     await runner.reset(
         provider=provider,
         request=request,
         run_context=run_context,
         tool_executor=MagicMock(),
         agent_hooks=hooks,
-        tool_schema_mode="skills_like"
+        tool_schema_mode="skills_like",
     )
-    
-    # 执行一步
+
+    # Execute one runner step.
     async for _ in runner.step():
         pass
-    
-    # 确认 Provider 被调用了两次，以证明重试（re-query）路径生效
-    assert provider.call_count == 2, "Provider should be called twice to exercise the re-query path"
-    
-    # 验证逻辑层修复：
-    # 虽然 Provider 第二次返回了空，但 runner 应该保留或安全处理第一次的结果
+
+    # Confirm the provider was called twice so the re-query path ran.
+    assert provider.call_count == 2, (
+        "Provider should be called twice to exercise the re-query path"
+    )
+
+    # Even when the second response is empty, the runner should keep the
+    # original tool-calling result instead of recording an empty tool_calls list.
     assistant_msgs = [m for m in runner.run_context.messages if m.role == "assistant"]
-    assert assistant_msgs, "应至少有一条 assistant 消息"
-    
-    # 所有 assistant 消息要么没有 tool_calls 字段，要么为非空列表
+    assert assistant_msgs, "Expected at least one assistant message"
+
+    # Every assistant message should either omit tool_calls or keep them non-empty.
     for msg in assistant_msgs:
         if hasattr(msg, "tool_calls") and msg.tool_calls is not None:
-            assert len(msg.tool_calls) > 0, f"Assistant message has illegal empty tool_calls list!"
-            
-    # 最后一条 assistant 消息应保留有效的 tool_calls，且为第一次调用的工具
+            assert len(msg.tool_calls) > 0, (
+                "Assistant message has an illegal empty tool_calls list"
+            )
+
+    # The last assistant message should still carry the original tool call.
     final_assistant = assistant_msgs[-1]
-    assert final_assistant.tool_calls, "最终 assistant 消息必须包含有效的 tool_calls"
-    
-    # 检查第一个 tool call 的内容是否符合预期（来自第一轮响应）
+    assert final_assistant.tool_calls, (
+        "The final assistant message must keep a valid tool_calls payload"
+    )
+
+    # Verify that the retained tool call is the original first-round result.
     tc = final_assistant.tool_calls[0]
     if isinstance(tc, dict):
         assert tc["function"]["name"] == "test_tool"
         assert tc["id"] == "call_1"
     else:
-        # ToolCall object
         assert tc.function.name == "test_tool"
         assert tc.id == "call_1"
 
-    print(f"TEST PASSED (fail_with_none={fail_with_none}): Verified that no empty tool_calls list was generated and first call was retained.")
+    print(
+        f"TEST PASSED (fail_with_none={fail_with_none}): Verified that no empty tool_calls list was generated and the first tool call was retained."
+    )

--- a/tests/unit/test_fix_skills_like_empty_calls.py
+++ b/tests/unit/test_fix_skills_like_empty_calls.py
@@ -1,0 +1,191 @@
+import pytest
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+from astrbot.core.agent.runners.tool_loop_agent_runner import ToolLoopAgentRunner
+from astrbot.core.agent.run_context import ContextWrapper
+from astrbot.core.agent.hooks import BaseAgentRunHooks
+from astrbot.core.agent.tool import ToolSet, FunctionTool
+from astrbot.core.provider.entities import LLMResponse, ProviderRequest, TokenUsage
+from astrbot.core.provider.provider import Provider
+from astrbot.core.agent.message import Message, ToolCall
+
+def test_llm_response_tool_calls_none_and_empty_list_behaviour():
+    """
+    When tools_call_args is None or an empty list, both conversion helpers
+    should return None to match the OpenAI protocol expectations.
+    """
+    # tools_call_args = None (will be converted to [] in __init__)
+    response_none = LLMResponse(
+        role="assistant",
+        completion_text="test",
+        tools_call_args=None,
+    )
+
+    assert response_none.to_openai_tool_calls() is None
+    assert response_none.to_openai_to_calls_model() is None
+
+    # tools_call_args = []
+    response_empty = LLMResponse(
+        role="assistant",
+        completion_text="test",
+        tools_call_args=[],
+    )
+
+    assert response_empty.to_openai_tool_calls() is None
+    assert response_empty.to_openai_to_calls_model() is None
+
+def test_llm_response_tool_calls_non_empty_list_behaviour():
+    """
+    When tools_call_args has at least one item, both conversion helpers
+    should return a non-empty list.
+    """
+    tools_call_args = [{"arg": "value"}]
+    tools_call_name = ["test_tool"]
+    tools_call_ids = ["call_1"]
+
+    response = LLMResponse(
+        role="assistant",
+        completion_text="test",
+        tools_call_args=tools_call_args,
+        tools_call_name=tools_call_name,
+        tools_call_ids=tools_call_ids,
+    )
+
+    tool_calls = response.to_openai_tool_calls()
+    tool_calls_model = response.to_openai_to_calls_model()
+
+    # Both helpers should return a non-empty list
+    assert isinstance(tool_calls, list)
+    assert isinstance(tool_calls_model, list)
+    assert len(tool_calls) == 1
+    assert len(tool_calls_model) == 1
+
+    # Verify content
+    assert tool_calls[0]["id"] == "call_1"
+    assert tool_calls[0]["function"]["name"] == "test_tool"
+    assert tool_calls[0]["function"]["arguments"] == json.dumps(tools_call_args[0])
+    
+    assert isinstance(tool_calls_model[0], ToolCall)
+    assert tool_calls_model[0].id == "call_1"
+    assert tool_calls_model[0].function.name == "test_tool"
+    assert tool_calls_model[0].function.arguments == json.dumps(tools_call_args[0])
+
+class MockSkillsLikeProvider(Provider):
+    def __init__(self, fail_with_none=False):
+        super().__init__({"id": "test"}, {})
+        self.call_count = 0
+        self.fail_with_none = fail_with_none
+
+    def get_current_key(self) -> str:
+        return "test_key"
+
+    def set_key(self, key: str):
+        pass
+
+    async def get_models(self) -> list[str]:
+        return ["test_model"]
+
+    async def text_chat(self, **kwargs) -> LLMResponse:
+        self.call_count += 1
+        # 第一次调用：模拟 skills_like 模式下的轻量级调用，返回工具名但无参数
+        if self.call_count == 1:
+            return LLMResponse(
+                role="assistant",
+                completion_text="Calling tool...",
+                tools_call_name=["test_tool"],
+                tools_call_ids=["call_1"],
+                tools_call_args=[{}],
+                usage=TokenUsage(output=5)
+            )
+        # 第二次调用：模拟 LLM 异常响应，不返回任何工具调用
+        if self.fail_with_none:
+            return LLMResponse(
+                role="assistant",
+                completion_text="Wait, I changed my mind.",
+                tools_call_name=None,
+                tools_call_ids=None,
+                tools_call_args=None,
+                usage=TokenUsage(output=5)
+            )
+        else:
+            return LLMResponse(
+                role="assistant",
+                completion_text="Wait, I changed my mind.",
+                tools_call_name=[],
+                tools_call_ids=[],
+                tools_call_args=[],
+                usage=TokenUsage(output=5)
+            )
+
+    async def text_chat_stream(self, **kwargs):
+        yield await self.text_chat(**kwargs)
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fail_with_none", [True, False])
+async def test_skills_like_empty_requery_fix(fail_with_none):
+    """
+    测试在 skills_like 模式下，如果二次参数补全请求返回空（[] 或 None），
+    系统是否能正确处理而不产生非法的空 tool_calls 列表，
+    并且最终保留的 tool_calls 对应第一次调用而没有被空结果覆盖。
+    """
+    provider = MockSkillsLikeProvider(fail_with_none=fail_with_none)
+    
+    # 准备工具
+    tool = FunctionTool(
+        name="test_tool",
+        description="A test tool",
+        parameters={"type": "object", "properties": {"p": {"type": "string"}}},
+        handler=AsyncMock()
+    )
+    tool_set = ToolSet(tools=[tool])
+    
+    # 准备 Runner
+    runner = ToolLoopAgentRunner()
+    request = ProviderRequest(prompt="Use tool", func_tool=tool_set)
+    # 模拟 ContextWrapper
+    mock_context = MagicMock()
+    run_context = ContextWrapper(context=mock_context)
+    hooks = BaseAgentRunHooks()
+    
+    await runner.reset(
+        provider=provider,
+        request=request,
+        run_context=run_context,
+        tool_executor=MagicMock(),
+        agent_hooks=hooks,
+        tool_schema_mode="skills_like"
+    )
+    
+    # 执行一步
+    async for _ in runner.step():
+        pass
+    
+    # 确认 Provider 被调用了两次，以证明重试（re-query）路径生效
+    assert provider.call_count == 2, "Provider should be called twice to exercise the re-query path"
+    
+    # 验证逻辑层修复：
+    # 虽然 Provider 第二次返回了空，但 runner 应该保留或安全处理第一次的结果
+    assistant_msgs = [m for m in runner.run_context.messages if m.role == "assistant"]
+    assert assistant_msgs, "应至少有一条 assistant 消息"
+    
+    # 所有 assistant 消息要么没有 tool_calls 字段，要么为非空列表
+    for msg in assistant_msgs:
+        if hasattr(msg, "tool_calls") and msg.tool_calls is not None:
+            assert len(msg.tool_calls) > 0, f"Assistant message has illegal empty tool_calls list!"
+            
+    # 最后一条 assistant 消息应保留有效的 tool_calls，且为第一次调用的工具
+    final_assistant = assistant_msgs[-1]
+    assert final_assistant.tool_calls, "最终 assistant 消息必须包含有效的 tool_calls"
+    
+    # 检查第一个 tool call 的内容是否符合预期（来自第一轮响应）
+    tc = final_assistant.tool_calls[0]
+    if isinstance(tc, dict):
+        assert tc["function"]["name"] == "test_tool"
+        assert tc["id"] == "call_1"
+    else:
+        # ToolCall object
+        assert tc.function.name == "test_tool"
+        assert tc.id == "call_1"
+
+    print(f"TEST PASSED (fail_with_none={fail_with_none}): Verified that no empty tool_calls list was generated and first call was retained.")


### PR DESCRIPTION
PR Title
  fix: prevent empty tool_calls in skills_like mode to improve API compatibility


  Motivation
  在 skills_like 工具模式下，如果 LLM 在第二轮参数补全请求中没有返回工具调用（可能由于模型幻觉或响应异常），旧逻辑会用这个空结果覆盖第一轮的工具调用信息。这会导致最终写入一条 tool_calls=[] 的 assistant 消息。
  许多严格遵循 OpenAI 规范的接口（如 DeepSeek、某些中转接口）会因此报错：Empty tool_calls is not supported in message.
  此 PR 修复了这一兼容性问题。


  Modifications
   - astrbot/core/agent/runners/tool_loop_agent_runner.py:
       - 在 _resolve_tool_exec 方法中增加了校验：只有当二次查询确实返回了有效的 tools_call_name 时才更新响应。
       - 增加了警告日志，以便在模型表现不稳定时提供可观测性。
   - astrbot/core/provider/entities.py:
       - 优化了 LLMResponse.to_openai_to_calls_model 和 to_openai_tool_calls 方法，确保在没有工具调用时显式返回 None 而非空列表 []，从底层协议层面根除该问题。
   - tests/unit/test_fix_skills_like_empty_calls.py:
       - 新增了专门的回归测试用例，模拟 skills_like 二次调用失败的边缘情况。

   - [x] This is NOT a breaking change. / 这不是一个破坏性变更。

  Screenshots or Test Results
  单元测试通过日志：


   1 [Core] [DBUG] Agent state transition: AgentState.IDLE -> AgentState.RUNNING
   2 [Core] [WARN] LLM returned no tool calls during 'skills_like' parameter re-query. Falling back to original light-schema response to avoid empty tool_calls error.
   3 [Core] [INFO] Agent 使用工具: ['test_tool']
   4 [Core] [INFO] 使用工具：test_tool，参数：{}
   5 TEST PASSED: Verified that no empty tool_calls list was generated.

  ---


  Checklist
   - [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。
   - [x] 👀 我的更改经过了良好的测试，并已在上方提供了“验证步骤”和“运行截图”。
   - [x] 🤓 我确保没有引入新依赖库。
   - [x] 😮 我的更改没有引入恶意代码。

## Summary by Sourcery

确保 `skills_like` 工具 schema 模式不会生成空的 `tool_calls`，以实现更符合 OpenAI 行为的表现。

Enhancements:
- 当不存在任何 tool call 时，从 OpenAI `tool_calls` 转换辅助函数返回 `None` 而不是空列表。
- 在 `skills_like` 的二次请求流程中，只有当第二次响应中包含有效的 `tool_call` 名称时，才覆盖原始的 tool-calling 响应。

Tests:
- 添加一个回归测试，用于覆盖 `skills_like` 模式下第二次参数补全调用未返回任何 tool calls 的场景，以确保不会生成空的 `tool_calls` 列表。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure skills_like tool schema mode never produces empty tool_calls for better OpenAI-compatible behavior.

Enhancements:
- Return None instead of an empty list from OpenAI tool_calls conversion helpers when no tool calls are present.
- Avoid overwriting the original tool-calling response in skills_like requery flow unless the second response includes valid tool_call names.

Tests:
- Add a regression test covering skills_like mode when the second parameter completion call returns no tool calls, ensuring no empty tool_calls list is generated.

</details>