### PR TITLE
fix: align aiocqhttp poke segment with onebot v11

### DIFF
--- a/astrbot/core/message/components.py
+++ b/astrbot/core/message/components.py
@@ -539,13 +539,36 @@ class Reply(BaseMessageComponent):
 
 
 class Poke(BaseMessageComponent):
-    type: str = ComponentType.Poke
-    id: int | None = 0
-    qq: int | None = 0
+    type: ComponentType = ComponentType.Poke
+    _type: str | int = "126"
+    id: int | str | None = 0
+    qq: int | str | None = 0  # deprecated: legacy field, kept for compatibility
 
-    def __init__(self, type: str, **_) -> None:
-        type = f"Poke:{type}"
-        super().__init__(type=type, **_)
+    def __init__(self, poke_type: str | int | None = None, **_) -> None:
+        # Backward compatible with old signature: Poke(type="poke", ...)
+        legacy_type = _.pop("type", None)
+        if poke_type is None:
+            poke_type = legacy_type
+        if poke_type in (None, "", "poke", "Poke"):
+            poke_type = "126"
+        super().__init__(_type=str(poke_type), **_)
+
+    def target_id(self) -> str | None:
+        """Return normalized target id, compatible with old `qq` field."""
+        for value in (self.id, self.qq):
+            if value is None:
+                continue
+            text = str(value).strip()
+            if text and text != "0":
+                return text
+        return None
+
+    def toDict(self):
+        target_id = self.target_id()
+        data = {"type": str(self._type or "126")}
+        if target_id:
+            data["id"] = target_id
+        return {"type": "poke", "data": data}
 
 
 class Forward(BaseMessageComponent):

--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -28,7 +28,7 @@ class RespondStage(Stage):
         Comp.At: lambda comp: bool(comp.qq) or bool(comp.name),  # @
         Comp.Image: lambda comp: bool(comp.file),  # 图片
         Comp.Reply: lambda comp: bool(comp.id) and comp.sender_id is not None,  # 回复
-        Comp.Poke: lambda comp: comp.id != 0 and comp.qq != 0,  # 戳一戳
+        Comp.Poke: lambda comp: comp.target_id() is not None,  # 戳一戳
         Comp.Node: lambda comp: bool(comp.content),  # 转发节点
         Comp.Nodes: lambda comp: bool(comp.nodes),  # 多个转发节点
         Comp.File: lambda comp: bool(comp.file_ or comp.url),

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -191,7 +191,7 @@ class AiocqhttpAdapter(Platform):
 
         if "sub_type" in event:
             if event["sub_type"] == "poke" and "target_id" in event:
-                abm.message.append(Poke(qq=str(event["target_id"]), type="poke"))
+                abm.message.append(Poke(id=str(event["target_id"])))
 
         return abm
 

--- a/tests/unit/test_aiocqhttp_poke.py
+++ b/tests/unit/test_aiocqhttp_poke.py
@@ -1,0 +1,59 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+import astrbot.core.message.components as Comp
+from astrbot.core.message.message_event_result import MessageChain
+from astrbot.core.pipeline.respond.stage import RespondStage
+from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
+    AiocqhttpMessageEvent,
+)
+
+
+def test_poke_to_dict_matches_onebot_v11_segment_format():
+    poke = Comp.Poke(type="126", id=2003)
+    assert poke.toDict() == {
+        "type": "poke",
+        "data": {"type": "126", "id": "2003"},
+    }
+
+
+def test_poke_to_dict_keeps_legacy_qq_compatible():
+    poke = Comp.Poke(type="poke", qq=2916963017)
+    assert poke.toDict() == {
+        "type": "poke",
+        "data": {"type": "126", "id": "2916963017"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_respond_stage_treats_poke_with_target_as_non_empty():
+    stage = RespondStage()
+    chain = [Comp.Poke(type="126", id=2003)]
+    assert await stage._is_empty_message_chain(chain) is False
+
+
+@pytest.mark.asyncio
+async def test_aiocqhttp_parse_json_outputs_standard_poke_data():
+    chain = MessageChain([Comp.Poke(type="126", id=2003)])
+    data = await AiocqhttpMessageEvent._parse_onebot_json(chain)
+    assert data == [{"type": "poke", "data": {"type": "126", "id": "2003"}}]
+
+
+@pytest.mark.asyncio
+async def test_aiocqhttp_send_message_dispatches_onebot_v11_poke_payload():
+    bot = AsyncMock()
+    chain = MessageChain([Comp.Poke(type="126", id=2003)])
+
+    await AiocqhttpMessageEvent.send_message(
+        bot=bot,
+        message_chain=chain,
+        event=None,
+        is_group=True,
+        session_id="123456",
+    )
+
+    bot.send_group_msg.assert_awaited_once_with(
+        group_id=123456,
+        message=[{"type": "poke", "data": {"type": "126", "id": "2003"}}],
+    )


### PR DESCRIPTION
Fixes #5709

`Poke` segments in aiocqhttp flow were not aligned with OneBot V11, and respond-stage validation could drop valid poke segments.

### Modifications / 改动点

- **`astrbot/core/message/components.py`**
  - Refactor `Poke` serialization to output OneBot V11 segment shape:
    - `{"type": "poke", "data": {"type": "126", "id": "..."}}`
  - Keep backward compatibility for legacy calls (`type="poke"`, `qq=...`) and normalize target id.
- **`astrbot/core/pipeline/respond/stage.py`**
  - Update `Poke` validator to use normalized target id, so valid poke segments are not treated as empty.
- **`astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py`**
  - Build notice poke component with `id` (target) for OneBot-compatible output.
- **`tests/unit/test_aiocqhttp_poke.py`**
  - Add regression tests for:
    - OneBot V11 poke serialization
    - legacy `qq` compatibility
    - respond-stage non-empty detection
    - aiocqhttp parser output
    - `send_message` dispatch payload to `send_group_msg`

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Executed locally:

```bash
uv run pytest tests/unit/test_aiocqhttp_poke.py -q
# 5 passed

uv run pytest tests/unit/test_astr_message_event.py -q
# 77 passed

uv run ruff check astrbot/core/message/components.py astrbot/core/pipeline/respond/stage.py astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py tests/unit/test_aiocqhttp_poke.py
# All checks passed!
```

---

### Checklist / 检查清单

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.


我引入了新依赖库,不知道是否符合预期
<img width="1621" height="861" alt="image" src="https://github.com/user-attachments/assets/3313deb7-238b-4b93-9d24-d3eb930c9eef" />



## Summary by Sourcery

在保持向后兼容的前提下，使戳一戳消息片段与 OneBot V11 的行为保持一致，并补充回归测试。

Bug 修复：
- 当存在有效目标时，确保在 respond 阶段将戳一戳组件视为非空。
- 修复 aiocqhttp 的 notice 戳一戳事件，确保为下游处理填充正确的目标字段。

增强：
- 调整戳一戳消息的序列化逻辑，输出与 OneBot V11 兼容的消息片段，并对新旧字段中的目标 ID 进行统一规范化。

测试：
- 新增单元测试，覆盖 OneBot V11 戳一戳序列化、旧版 QQ 兼容性、respond 阶段的空消息检查、aiocqhttp JSON 解析，以及 send_message 分发载荷。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align poke message segments and handling with OneBot V11 while preserving backward compatibility and adding regression coverage.

Bug Fixes:
- Ensure poke components are treated as non-empty in the respond stage when a valid target is present.
- Fix aiocqhttp notice poke events to populate the correct target field for downstream processing.

Enhancements:
- Change poke message serialization to emit OneBot V11-compatible segments and normalize target IDs for both new and legacy fields.

Tests:
- Add unit tests covering OneBot V11 poke serialization, legacy qq compatibility, respond-stage emptiness checks, aiocqhttp JSON parsing, and send_message dispatch payloads.

</details>