### PR TITLE
fix: pipeline scheduler not found after creating platform bot via using 'create new config'

### DIFF
--- a/astrbot/dashboard/routes/config.py
+++ b/astrbot/dashboard/routes/config.py
@@ -610,6 +610,7 @@ class ConfigRoute(Route):
 
         try:
             conf_id = self.acm.create_conf(name=name, config=config)
+            await self.core_lifecycle.reload_pipeline_scheduler(conf_id)
             return Response().ok(message="创建成功", data={"conf_id": conf_id}).__dict__
         except ValueError as e:
             return Response().error(str(e)).__dict__
@@ -649,6 +650,7 @@ class ConfigRoute(Route):
         try:
             success = self.acm.delete_conf(conf_id)
             if success:
+                self.core_lifecycle.pipeline_scheduler_mapping.pop(conf_id, None)
                 return Response().ok(message="删除成功").__dict__
             return Response().error("删除失败").__dict__
         except ValueError as e:


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [ ] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [ ] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [ ] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## 由 Sourcery 总结

确保在创建或删除平台机器人配置时，流水线调度器状态保持同步。

错误修复：
- 在新配置创建后立即初始化该配置的流水线调度器，以便能够被发现和使用。
- 在配置被删除时清理对应的流水线调度器映射，避免残留过期的调度器条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure pipeline scheduler state stays in sync when creating or deleting platform bot configurations.

Bug Fixes:
- Initialize the pipeline scheduler for a new configuration immediately after it is created so it can be found and used.
- Clean up the pipeline scheduler mapping when a configuration is deleted to avoid stale scheduler entries.

</details>