### PR TITLE
fix: 前端修正切換到 chat 切換後回 welcome 的配置保存最終切換頁面

### DIFF
--- a/dashboard/src/layouts/full/vertical-header/VerticalHeader.vue
+++ b/dashboard/src/layouts/full/vertical-header/VerticalHeader.vue
@@ -404,20 +404,31 @@ const viewMode = computed({
 
 // 监听 viewMode 变化，切换到 bot 模式时跳转到首页
 // 保存 bot 模式的最後路由
-watch(route, (newRoute) => {
-  if (customizer.viewMode === 'bot') {
-    localStorage.setItem(LAST_BOT_ROUTE_KEY, newRoute.fullPath);
+// 監聽 route 變化，保存最後一次 bot 路由
+watch(() => route.fullPath, (newPath) => {
+  if (customizer.viewMode === 'bot' && typeof window !== 'undefined') {
+    try {
+      localStorage.setItem(LAST_BOT_ROUTE_KEY, newPath);
+    } catch (e) {
+      console.error('Failed to save last bot route to localStorage:', e);
+    }
   }
 });
 
 // 監聽 viewMode 切換
 watch(() => customizer.viewMode, (newMode, oldMode) => {
-  if (newMode === 'bot' && oldMode === 'chat') {
+  if (newMode === 'bot' && oldMode === 'chat' && typeof window !== 'undefined') {
     // 從 chat 切換回 bot，跳轉到最後一次的 bot 路由
-    const lastBotRoute = localStorage.getItem(LAST_BOT_ROUTE_KEY) || '/';
+    let lastBotRoute = '/';
+    try {
+      lastBotRoute = localStorage.getItem(LAST_BOT_ROUTE_KEY) || '/';
+    } catch (e) {
+      console.error('Failed to read last bot route from localStorage:', e);
+    }
     router.push(lastBotRoute);
   }
 });
+
 // Merry Christmas! 🎄
 const isChristmas = computed(() => {
   const today = new Date();


### PR DESCRIPTION
解決了每次切換到chat頁面 回bot配置頁面都跑回  歡迎主頁面的問題
### Modifications / 改动点

修改 watch(() => customizer.viewMode (newMode, oldMode) 函數 切換回 /   改成lastBotRoute
新增 watch(route, (newRoute) ， 保存 bot 模式的最後路由

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
![123](https://github.com/user-attachments/assets/7e3f6ccb-defd-4832-afa3-9ff192f48208)

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

错误修复：
- 修复从聊天切换回机器人模式时的导航问题，现在用户会被重定向到他们上次访问的机器人路由，而不是根页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix navigation when switching from chat back to bot mode so users are redirected to their last bot route rather than the root page.

</details>