### PR TITLE
fix:Mobile QQ triggers empty messages that get sent to LLM

### DIFF
--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -130,6 +130,8 @@ class AiocqhttpAdapter(Platform):
 
         if event["post_type"] == "message":
             abm = await self._convert_handle_message_event(event)
+            if abm is None:
+                return None
             if abm.sender.user_id == "2854196310":
                 # 屏蔽 QQ 管家的消息
                 return None
@@ -165,7 +167,7 @@ class AiocqhttpAdapter(Platform):
         abm.raw_message = event
         return abm
 
-    async def _convert_handle_notice_event(self, event: Event) -> AstrBotMessage:
+    async def _convert_handle_notice_event(self, event: Event) -> AstrBotMessage | None:
         """OneBot V11 通知类事件"""
         abm = AstrBotMessage()
         abm.self_id = str(event.self_id)
@@ -193,13 +195,20 @@ class AiocqhttpAdapter(Platform):
             if event["sub_type"] == "poke" and "target_id" in event:
                 abm.message.append(Poke(id=str(event["target_id"])))
 
+        # Filter out notice events with no meaningful message content.
+        # e.g. mobile QQ sends an empty notice when the user taps the
+        # input box and then leaves the chat page.
+        if not abm.message:
+            logger.debug(f"[aiocqhttp] Ignored empty notice event: {event}")
+            return None
+
         return abm
 
     async def _convert_handle_message_event(
         self,
         event: Event,
         get_reply=True,
-    ) -> AstrBotMessage:
+    ) -> AstrBotMessage | None:
         """OneBot V11 消息类事件
 
         @param event: 事件对象
@@ -413,6 +422,12 @@ class AiocqhttpAdapter(Platform):
         abm.timestamp = int(time.time())
         abm.message_str = message_str
         abm.raw_message = event
+
+        # Filter out empty message events that some QQ protocol
+        # implementations push after certain operations (e.g. file sends).
+        if not abm.message and not message_str.strip():
+            logger.debug(f"[aiocqhttp] Ignored empty message event: {event}")
+            return None
 
         return abm
 


### PR DESCRIPTION
Mobile QQ sends an empty `notice` event (e.g. input status change) when the user taps the input box and then leaves the chat page. The aiocqhttp adapter did not filter out these empty notice events, causing them to enter the pipeline and get forwarded to the LLM as blank user messages.

手机 QQ 在用户点击输入框后离开聊天页面时，会发送一个空的 `notice` 事件（如输入状态变化通知）。aiocqhttp 适配器未过滤这些空通知事件，导致它们进入消息流水线并作为空白用户消息被转发给 LLM。

### Modifications / 改动点

**File:** `astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py`

1. **`_convert_handle_notice_event`** (core fix): Added a check at the end of the method — if no meaningful message component (e.g. Poke) was produced from the notice event, return `None` to prevent it from entering the pipeline. Updated return type annotation to `AstrBotMessage | None`.
2. **`convert_message`** (defensive): Added `None` check for `_convert_handle_message_event` return value before accessing `abm.sender.user_id`.

---

1. **`_convert_handle_notice_event`**（核心修复）：在方法末尾增加判断，若通知事件未产生任何有意义的消息组件（如 Poke），则返回 `None`，阻止其进入流水线。同时更新返回类型注解为 `AstrBotMessage | None`。
2. **`convert_message`**（防御性措施）：对 `_convert_handle_message_event` 的返回值增加 `None` 检查，防止访问 `abm.sender.user_id` 时出现异常。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

**Before fix / 修复前：**

```
[2026-03-06 15:38:17.743] [Core] [INFO] [respond.stage:184]: Prepare to send - LLLL/964389211: 哈？ 我一直活着！ 你才要确认活着没！ 别老问我这种废话…… [图片] 
[2026-03-06 15:41:47.405] [Core] [INFO] [routes.config:214]: Saving config, is_core=True
[2026-03-06 15:41:47.407] [Core] [INFO] [respond.stage:89]: 分段回复间隔时间：[1.5, 3.5]
[2026-03-06 15:49:59.923] [Core] [INFO] [core.event_bus:59]: [default] [test(aiocqhttp)] 964389211/964389211: 
[2026-03-06 15:50:08.156] [Core] [INFO] [core.event_bus:59]: [default] [test(aiocqhttp)] 964389211/964389211: 
```

Tapping the input box on mobile QQ and leaving the chat page produced empty messages that were sent to the LLM.

在手机 QQ 点击输入框后离开聊天页面，会产生空消息并被发送给 LLM。

**After fix / 修复后：**

Tapping the input box on mobile QQ and leaving the chat page no longer produces empty message logs. Normal messages are unaffected.

修复后，在手机 QQ 点击输入框后离开聊天页面不再产生空消息日志，正常消息不受影响。

### Checklist / 检查清单

- [x] 👀 我的更改经过了良好的测试，并已在上方提供了"验证步骤"和"运行截图"。/ My changes have been well-tested, and "Verification Steps" and "Screenshots" have been provided above.
- [x] 🤓 我确保没有引入新依赖库。/ I have ensured that no new dependencies are introduced.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

防止空的 aiocqhttp 通知事件被转换为用户消息，并强化消息转换的处理逻辑。

Bug 修复：
- 忽略不会产生有意义消息内容的通知事件，从而避免移动端 QQ 输入状态通知再生成发送给 LLM 的空消息。

增强：
- 为已转换的消息事件添加防御性 `None` 检查，并在 aiocqhttp 适配器中调整戳一戳（poke）通知消息的构造方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent empty aiocqhttp notice events from being converted into user messages and harden message conversion handling.

Bug Fixes:
- Ignore notice events that do not produce meaningful message content so that mobile QQ input-status notices no longer generate empty messages sent to the LLM.

Enhancements:
- Add a defensive None check for converted message events and adjust poke notice message construction in the aiocqhttp adapter.

</details>