### PR TITLE
fix(provider): handle MiniMax ThinkingBlock when max_tokens reached

### DIFF
--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -287,10 +287,12 @@ class ProviderAnthropic(Provider):
                     f"no text, tool_use, or thinking content found. "
                     f"Completion: {completion}"
                 )
-            
+
             # We have reasoning content (ThinkingBlock) - this is valid
             stop_reason = getattr(completion, "stop_reason", "unknown")
-            logger.debug(f"Completion contains only ThinkingBlock (stop_reason={stop_reason})")
+            logger.debug(
+                f"Completion contains only ThinkingBlock (stop_reason={stop_reason})"
+            )
             llm_response.completion_text = ""  # Ensure empty string, not None
 
         return llm_response


### PR DESCRIPTION
Fixes #5912

## Problem
MiniMax API returns ThinkingBlock when stop_reason=max_tokens, but AstrBot throws exception.

## Fix
When reasoning_content is present but completion_text is empty, treat as valid.

## Impact
MiniMax models work when responses are truncated.

## Summary by Sourcery

Bug Fixes:
- 将仅包含推理内容（`ThinkingBlock`）而没有补全文本的补全结果视为有效响应，而不是抛出异常。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Treat completions that only include reasoning content (ThinkingBlock) with no completion text as valid responses instead of raising an exception.

</details>