### PR TITLE
feat: add a toggle to disable thinking mode in Ollama

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1225,6 +1225,7 @@ CONFIG_METADATA_2 = {
                         "api_base": "http://127.0.0.1:11434/v1",
                         "proxy": "",
                         "custom_headers": {},
+                        "ollama_disable_thinking": False,
                     },
                     "LM Studio": {
                         "id": "lm_studio",
@@ -1753,6 +1754,12 @@ CONFIG_METADATA_2 = {
                         "type": "dict",
                         "items": {},
                         "hint": "此处添加的键值对将被合并到 OpenAI SDK 的 default_headers 中，用于自定义 HTTP 请求头。值必须为字符串。",
+                    },
+                    "ollama_disable_thinking": {
+                        "description": "关闭思考模式",
+                        "type": "bool",
+                        "hint": "仅对 Ollama 提供商生效。启用后会通过 OpenAI 兼容接口注入 reasoning_effort=none，以稳定关闭 thinking；比 think:false 更可靠。",
+                        "condition": {"provider": "ollama"},
                     },
                     "custom_extra_body": {
                         "description": "自定义请求体参数",

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1758,8 +1758,7 @@ CONFIG_METADATA_2 = {
                     "ollama_disable_thinking": {
                         "description": "关闭思考模式",
                         "type": "bool",
-                        "hint": "仅对 Ollama 提供商生效。启用后会通过 OpenAI 兼容接口注入 reasoning_effort=none，以稳定关闭 thinking；比 think:false 更可靠。",
-                        "condition": {"provider": "ollama"},
+                        "hint": "关闭 Ollama 思考模式。",
                     },
                     "custom_extra_body": {
                         "description": "自定义请求体参数",

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -210,6 +210,26 @@ class ProviderOpenAIOfficial(Provider):
 
         self.reasoning_key = "reasoning_content"
 
+    def _ollama_disable_thinking_enabled(self) -> bool:
+        value = self.provider_config.get("ollama_disable_thinking", False)
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        return bool(value)
+
+    def _apply_provider_specific_extra_body_overrides(
+        self, extra_body: dict[str, Any]
+    ) -> None:
+        if self.provider_config.get("provider") != "ollama":
+            return
+        if not self._ollama_disable_thinking_enabled():
+            return
+
+        # Ollama's OpenAI-compatible endpoint reliably maps reasoning_effort=none
+        # to think=false, while direct think=false passthrough is not stable.
+        extra_body.pop("reasoning", None)
+        extra_body.pop("think", None)
+        extra_body["reasoning_effort"] = "none"
+
     async def get_models(self):
         try:
             models_str = []
@@ -245,6 +265,7 @@ class ProviderOpenAIOfficial(Provider):
         custom_extra_body = self.provider_config.get("custom_extra_body", {})
         if isinstance(custom_extra_body, dict):
             extra_body.update(custom_extra_body)
+        self._apply_provider_specific_extra_body_overrides(extra_body)
 
         model = payloads.get("model", "").lower()
 
@@ -295,6 +316,7 @@ class ProviderOpenAIOfficial(Provider):
                 to_del.append(key)
         for key in to_del:
             del payloads[key]
+        self._apply_provider_specific_extra_body_overrides(extra_body)
 
         stream = await self.client.chat.completions.create(
             **payloads,

--- a/dashboard/src/composables/useProviderSources.ts
+++ b/dashboard/src/composables/useProviderSources.ts
@@ -203,11 +203,10 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
   const advancedSourceConfig = computed(() => {
     if (!editableProviderSource.value) return null
 
-    const excluded = ['id', 'key', 'api_base', 'enable', 'type', 'provider_type', 'provider']
+    const excluded = new Set(['id', 'key', 'api_base', 'enable', 'type', 'provider_type', 'provider'])
     const advanced: Record<string, any> = {}
 
     for (const key of Object.keys(editableProviderSource.value)) {
-      if (excluded.includes(key)) continue
       Object.defineProperty(advanced, key, {
         get() {
           return editableProviderSource.value![key]
@@ -215,7 +214,7 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
         set(val) {
           editableProviderSource.value![key] = val
         },
-        enumerable: true
+        enumerable: !excluded.has(key)
       })
     }
 
@@ -344,13 +343,27 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
     selectedProviderSource.value = source
     selectedProviderSourceOriginalId.value = source?.id || null
     suppressSourceWatch = true
-    editableProviderSource.value = source ? JSON.parse(JSON.stringify(source)) : null
+    editableProviderSource.value = source
+      ? ensureProviderSourceDefaults(JSON.parse(JSON.stringify(source)))
+      : null
     nextTick(() => {
       suppressSourceWatch = false
     })
     availableModels.value = []
     modelMetadata.value = {}
     isSourceModified.value = false
+  }
+
+  function ensureProviderSourceDefaults(source: any) {
+    if (!source || typeof source !== 'object') {
+      return source
+    }
+
+    if (source.provider === 'ollama' && source.ollama_disable_thinking === undefined) {
+      source.ollama_disable_thinking = false
+    }
+
+    return source
   }
 
   function extractSourceFieldsFromTemplate(template: Record<string, any>) {
@@ -388,14 +401,14 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
     }
 
     const newId = generateUniqueSourceId(template.id)
-    const newSource = {
+    const newSource = ensureProviderSourceDefaults({
       ...extractSourceFieldsFromTemplate(template),
       id: newId,
       type: template.type,
       provider_type: template.provider_type,
       provider: template.provider,
       enable: true
-    }
+    })
 
     providerSources.value.push(newSource)
     selectedProviderSource.value = newSource

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -1068,6 +1068,10 @@
         "description": "Custom request headers",
         "hint": "Key/value pairs added here are merged into the OpenAI SDK default_headers for custom HTTP headers. Values must be strings."
       },
+      "ollama_disable_thinking": {
+        "description": "Disable thinking mode",
+        "hint": "Only applies to the Ollama provider. When enabled, AstrBot injects reasoning_effort=none on the OpenAI-compatible endpoint, which is more reliable than think:false."
+      },
       "custom_extra_body": {
         "description": "Custom request body parameters",
         "hint": "Add extra parameters to requests, such as temperature, top_p, max_tokens, etc.",

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -1070,7 +1070,7 @@
       },
       "ollama_disable_thinking": {
         "description": "Disable thinking mode",
-        "hint": "Only applies to the Ollama provider. When enabled, AstrBot injects reasoning_effort=none on the OpenAI-compatible endpoint, which is more reliable than think:false."
+        "hint": "Close Ollama thinking mode."
       },
       "custom_extra_body": {
         "description": "Custom request body parameters",

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -1071,6 +1071,10 @@
         "description": "自定义添加请求头",
         "hint": "此处添加的键值对将被合并到 OpenAI SDK 的 default_headers 中，用于自定义 HTTP 请求头。值必须为字符串。"
       },
+      "ollama_disable_thinking": {
+        "description": "关闭思考模式",
+        "hint": "仅对 Ollama 提供商生效。启用后会通过 OpenAI 兼容接口注入 reasoning_effort=none，以稳定关闭 thinking；比 think:false 更可靠。"
+      },
       "custom_extra_body": {
         "description": "自定义请求体参数",
         "hint": "用于在请求时添加额外的参数，如 temperature、top_p、max_tokens 等。",

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -1073,7 +1073,7 @@
       },
       "ollama_disable_thinking": {
         "description": "关闭思考模式",
-        "hint": "仅对 Ollama 提供商生效。启用后会通过 OpenAI 兼容接口注入 reasoning_effort=none，以稳定关闭 thinking；比 think:false 更可靠。"
+        "hint": "关闭 Ollama 思考模式。"
       },
       "custom_extra_body": {
         "description": "自定义请求体参数",

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 import pytest
+from openai.types.chat.chat_completion import ChatCompletion
 
 from astrbot.core.provider.sources.openai_source import ProviderOpenAIOfficial
 
@@ -378,5 +379,90 @@ async def test_handle_api_error_unknown_image_error_raises():
                 retry_cnt=0,
                 max_retries=10,
             )
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_apply_provider_specific_extra_body_overrides_disables_ollama_thinking():
+    provider = _make_provider(
+        {
+            "provider": "ollama",
+            "ollama_disable_thinking": True,
+        }
+    )
+    try:
+        extra_body = {
+            "reasoning": {"effort": "high"},
+            "reasoning_effort": "low",
+            "think": True,
+            "temperature": 0.2,
+        }
+
+        provider._apply_provider_specific_extra_body_overrides(extra_body)
+
+        assert extra_body["reasoning_effort"] == "none"
+        assert "reasoning" not in extra_body
+        assert "think" not in extra_body
+        assert extra_body["temperature"] == 0.2
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_query_injects_reasoning_effort_none_for_ollama(monkeypatch):
+    provider = _make_provider(
+        {
+            "provider": "ollama",
+            "ollama_disable_thinking": True,
+            "custom_extra_body": {
+                "reasoning": {"effort": "high"},
+                "temperature": 0.1,
+            },
+        }
+    )
+    try:
+        captured_kwargs = {}
+
+        async def fake_create(**kwargs):
+            captured_kwargs.update(kwargs)
+            return ChatCompletion.model_validate(
+                {
+                    "id": "chatcmpl-test",
+                    "object": "chat.completion",
+                    "created": 0,
+                    "model": "qwen3.5:4b",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {
+                                "role": "assistant",
+                                "content": "ok",
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                }
+            )
+
+        monkeypatch.setattr(provider.client.chat.completions, "create", fake_create)
+
+        await provider._query(
+            payloads={
+                "model": "qwen3.5:4b",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+            tools=None,
+        )
+
+        extra_body = captured_kwargs["extra_body"]
+        assert extra_body["reasoning_effort"] == "none"
+        assert "reasoning" not in extra_body
+        assert extra_body["temperature"] == 0.1
     finally:
         await provider.terminate()


### PR DESCRIPTION
closes #5714 
closes #5769

当前 AstrBot 中的 Ollama 提供商走的是 OpenAI 兼容接口，但在该接口下直接使用 `think:false` 不能稳定关闭 thinking。这个 PR 为 Ollama 提供商增加了一个专用开关，在启用时内部改为注入 `reasoning_effort=none`，从而更稳定地关闭思考模式，减少模型响应延迟。顺带一提，#5769 其实也是相似的问题，这里应该都能解决。

### Modifications / 改动点

- 为 Ollama 提供商源的高级配置新增 `关闭思考模式` 开关
- 在启用该开关时，对 Ollama 的 OpenAI 兼容请求注入 `reasoning_effort=none`
- 在开关开启时，移除冲突的 `reasoning` / `think` 额外请求参数
- 为旧的 Ollama provider source 配置补默认值，确保新字段能正常显示
- 补充该配置项的中英文文案
- 增加对应测试，覆盖 Ollama 请求覆盖逻辑

**文件变更说明**
- `astrbot/core/config/default.py`
  - 为 Ollama source 增加默认配置项和元数据定义
- `astrbot/core/provider/sources/openai_source.py`
  - 增加 Ollama 专用的 thinking 关闭逻辑，映射到 `reasoning_effort=none`
- `dashboard/src/composables/useProviderSources.ts`
  - 修复高级配置条件渲染所需的上下文保留问题，并兼容旧配置
- `dashboard/src/i18n/locales/en-US/features/config-metadata.json`
  - 增加英文文案
- `dashboard/src/i18n/locales/zh-CN/features/config-metadata.json`
  - 增加中文文案
- `tests/test_openai_source.py`
  - 增加相关单元测试

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

配置界面截图如下：

<img width="1510" height="813" alt="image" src="https://github.com/user-attachments/assets/f86a6554-1b64-4599-8558-07e1b9970089" />

测试视频如下：

https://github.com/user-attachments/assets/273240fc-9035-464d-ac65-df12411136f6

视频中未显示 工具调用 是否会有影响，但是我实际测试过，开关思考模式不会对工具调用产生影响。  

本地已完成以下验证：

```bash
ruff check .
uv run pytest tests/test_openai_source.py
cd dashboard && pnpm build
```

验证结果：
- `ruff check .` 通过
- `uv run pytest tests/test_openai_source.py` 通过，共 `12 passed`
- `pnpm build` 通过
- 在运行中的 Dashboard 中手动确认：
  - 已加载最新前端产物
  - Ollama 高级配置中已显示“关闭思考模式”开关
  - 开关可以正常勾选
- 对本地 Ollama 服务验证确认：
  - `reasoning_effort=none` 能在 OpenAI 兼容接口下更稳定地关闭 thinking
  - `think:false` 在该接口下不稳定，不适合作为 AstrBot 的实现方案

---

### Checklist / 检查清单

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

通过添加一个 Ollama 专用开关，更可靠地在 OpenAI 兼容提供方中禁用模型的思考模式，并确保现有的 Ollama 来源拥有安全的默认值。

New Features:
- 引入一个仅适用于 Ollama 的高级配置选项，用于禁用思考模式，其方式是通过 OpenAI 兼容端点将请求映射为 `reasoning_effort=none`。

Enhancements:
- 在 OpenAI 提供方中规范化并应用针对不同提供方的 `extra_body` 覆盖逻辑，使得在禁用思考模式时，Ollama 请求会移除冲突的 `reasoning`/`think` 参数。
- 确保仪表盘中的 Ollama 提供方来源能够为新的禁用思考标志回填默认值，并调整高级配置处理逻辑，在隐藏被排除的键以避免渲染的同时，仍然保留字段访问能力。

Tests:
- 添加单元测试，以验证在启用禁用思考选项时，Ollama 请求会注入 `reasoning_effort=none`，并移除冲突的 `reasoning`/`think` 字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an Ollama-specific toggle to more reliably disable the model’s thinking mode via the OpenAI-compatible provider, and ensure existing Ollama sources get a safe default.

New Features:
- Introduce an Ollama-only advanced configuration option to disable thinking mode by mapping requests to reasoning_effort=none via the OpenAI-compatible endpoint.

Enhancements:
- Normalize and apply provider-specific overrides to extra_body in the OpenAI provider so Ollama requests remove conflicting reasoning/think parameters when thinking is disabled.
- Ensure dashboard provider sources for Ollama backfill a default value for the new disable-thinking flag and adjust advanced-config handling to preserve field accessors while hiding excluded keys from rendering.

Tests:
- Add unit tests to validate that Ollama requests inject reasoning_effort=none and strip conflicting reasoning/think fields when the disable-thinking option is enabled.

</details>