### PR TITLE
refactor: Rag enhancement

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -10,6 +10,7 @@ import zoneinfo
 from collections.abc import Coroutine
 from dataclasses import dataclass, field
 
+from astrbot.api import sp
 from astrbot.core import logger
 from astrbot.core.agent.handoff import HandoffTool
 from astrbot.core.agent.mcp_client import MCPTool

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -41,6 +41,7 @@ from astrbot.core.astr_main_agent_resources import (
     LOCAL_PYTHON_TOOL,
     PROMOTE_SKILL_CANDIDATE_TOOL,
     PYTHON_TOOL,
+    READ_DOCUMENT_SECTION_TOOL,
     ROLLBACK_SKILL_RELEASE_TOOL,
     RUN_BROWSER_SKILL_TOOL,
     SANDBOX_MODE_PROMPT,
@@ -214,6 +215,24 @@ async def _apply_kb(
         if req.func_tool is None:
             req.func_tool = ToolSet()
         req.func_tool.add_tool(KNOWLEDGE_BASE_QUERY_TOOL)
+        session_config = await sp.session_get(
+            event.unified_msg_origin, "kb_config", default={}
+        )
+        kb_names = []
+        if session_config and "kb_ids" in session_config:
+            for kb_id in session_config.get("kb_ids", []):
+                kb_helper = await plugin_context.kb_manager.get_kb(kb_id)
+                if kb_helper:
+                    kb_names.append(kb_helper.kb.kb_name)
+        else:
+            kb_names = plugin_context.get_config(umo=event.unified_msg_origin).get(
+                "kb_names",
+                [],
+            )
+        if kb_names and await plugin_context.kb_manager.has_structured_docs_by_names(
+            kb_names
+        ):
+            req.func_tool.add_tool(READ_DOCUMENT_SECTION_TOOL)
 
 
 async def _apply_file_extract(

--- a/astrbot/core/astr_main_agent_resources.py
+++ b/astrbot/core/astr_main_agent_resources.py
@@ -199,7 +199,7 @@ class ReadDocumentSectionTool(FunctionTool[AstrAgentContext]):
                 "doc_id": {"type": "string", "description": "Document ID."},
                 "section_path": {
                     "type": "string",
-                    "description": "Section path, e.g. 'Chapter 1/API'.",
+                    "description": "Section path, e.g. 'Chapter 1 > API'.",
                 },
             },
             "required": ["doc_id", "section_path"],

--- a/astrbot/core/astr_main_agent_resources.py
+++ b/astrbot/core/astr_main_agent_resources.py
@@ -186,6 +186,46 @@ class KnowledgeBaseQueryTool(FunctionTool[AstrAgentContext]):
 
 
 @dataclass
+class ReadDocumentSectionTool(FunctionTool[AstrAgentContext]):
+    name: str = "astr_kb_read_section"
+    description: str = (
+        "Read full content of a specific structured section in knowledge base. "
+        "Use this when search results only provide a section path marker."
+    )
+    parameters: dict = Field(
+        default_factory=lambda: {
+            "type": "object",
+            "properties": {
+                "doc_id": {"type": "string", "description": "Document ID."},
+                "section_path": {
+                    "type": "string",
+                    "description": "Section path, e.g. 'Chapter 1/API'.",
+                },
+            },
+            "required": ["doc_id", "section_path"],
+        }
+    )
+
+    async def call(
+        self, context: ContextWrapper[AstrAgentContext], **kwargs
+    ) -> ToolExecResult:
+        doc_id = kwargs.get("doc_id", "")
+        section_path = kwargs.get("section_path", "")
+        if not doc_id or not section_path:
+            return "error: doc_id and section_path are required."
+
+        body = await read_knowledge_base_section(
+            doc_id=doc_id,
+            section_path=section_path,
+            umo=context.context.event.unified_msg_origin,
+            context=context.context.context,
+        )
+        if not body:
+            return f"No section found for doc_id={doc_id}, path={section_path}"
+        return body
+
+
+@dataclass
 class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
     name: str = "send_message_to_user"
     description: str = "Directly send message to the user. Only use this tool when you need to proactively message the user. Otherwise you can directly output the reply in the conversation."
@@ -394,42 +434,9 @@ async def retrieve_knowledge_base(
 
     # 1. 优先读取会话级配置
     session_config = await sp.session_get(umo, "kb_config", default={})
-
-    if session_config and "kb_ids" in session_config:
-        # 会话级配置
-        kb_ids = session_config.get("kb_ids", [])
-
-        # 如果配置为空列表，明确表示不使用知识库
-        if not kb_ids:
-            logger.info(f"[知识库] 会话 {umo} 已被配置为不使用知识库")
-            return
-
-        top_k = session_config.get("top_k", 5)
-
-        # 将 kb_ids 转换为 kb_names
-        kb_names = []
-        invalid_kb_ids = []
-        for kb_id in kb_ids:
-            kb_helper = await kb_mgr.get_kb(kb_id)
-            if kb_helper:
-                kb_names.append(kb_helper.kb.kb_name)
-            else:
-                logger.warning(f"[知识库] 知识库不存在或未加载: {kb_id}")
-                invalid_kb_ids.append(kb_id)
-
-        if invalid_kb_ids:
-            logger.warning(
-                f"[知识库] 会话 {umo} 配置的以下知识库无效: {invalid_kb_ids}",
-            )
-
-        if not kb_names:
-            return
-
-        logger.debug(f"[知识库] 使用会话级配置，知识库数量: {len(kb_names)}")
-    else:
-        kb_names = config.get("kb_names", [])
-        top_k = config.get("kb_final_top_k", 5)
-        logger.debug(f"[知识库] 使用全局配置，知识库数量: {len(kb_names)}")
+    kb_names, top_k = await _resolve_kb_names_for_session(
+        kb_mgr, config, session_config, umo
+    )
 
     top_k_fusion = config.get("kb_fusion_top_k", 20)
 
@@ -454,7 +461,56 @@ async def retrieve_knowledge_base(
         return formatted
 
 
+async def _resolve_kb_names_for_session(
+    kb_mgr, config: dict, session_config: dict, umo: str
+):
+    if session_config and "kb_ids" in session_config:
+        kb_ids = session_config.get("kb_ids", [])
+        if not kb_ids:
+            logger.info(f"[知识库] 会话 {umo} 已被配置为不使用知识库")
+            return [], session_config.get("top_k", 5)
+        top_k = session_config.get("top_k", 5)
+        kb_names = []
+        invalid_kb_ids = []
+        for kb_id in kb_ids:
+            kb_helper = await kb_mgr.get_kb(kb_id)
+            if kb_helper:
+                kb_names.append(kb_helper.kb.kb_name)
+            else:
+                invalid_kb_ids.append(kb_id)
+        if invalid_kb_ids:
+            logger.warning(
+                f"[知识库] 会话 {umo} 配置的以下知识库无效: {invalid_kb_ids}"
+            )
+        return kb_names, top_k
+    kb_names = config.get("kb_names", [])
+    top_k = config.get("kb_final_top_k", 5)
+    return kb_names, top_k
+
+
+async def read_knowledge_base_section(
+    doc_id: str,
+    section_path: str,
+    umo: str,
+    context: Context,
+) -> str | None:
+    kb_mgr = context.kb_manager
+    config = context.get_config(umo=umo)
+    session_config = await sp.session_get(umo, "kb_config", default={})
+    kb_names, _ = await _resolve_kb_names_for_session(
+        kb_mgr, config, session_config, umo
+    )
+    if not kb_names:
+        return None
+    return await kb_mgr.read_document_section(
+        kb_names=kb_names,
+        doc_id=doc_id,
+        section_path=section_path,
+    )
+
+
 KNOWLEDGE_BASE_QUERY_TOOL = KnowledgeBaseQueryTool()
+READ_DOCUMENT_SECTION_TOOL = ReadDocumentSectionTool()
 SEND_MESSAGE_TO_USER_TOOL = SendMessageToUserTool()
 
 EXECUTE_SHELL_TOOL = ExecuteShellTool()

--- a/astrbot/core/backup/constants.py
+++ b/astrbot/core/backup/constants.py
@@ -18,6 +18,7 @@ from astrbot.core.db.po import (
     Preference,
 )
 from astrbot.core.knowledge_base.models import (
+    DocSection,
     KBDocument,
     KBMedia,
     KnowledgeBase,
@@ -54,6 +55,7 @@ KB_METADATA_MODELS: dict[str, type[SQLModel]] = {
     "knowledge_bases": KnowledgeBase,
     "kb_documents": KBDocument,
     "kb_media": KBMedia,
+    "doc_sections": DocSection,
 }
 
 

--- a/astrbot/core/backup/exporter.py
+++ b/astrbot/core/backup/exporter.py
@@ -277,11 +277,11 @@ class AstrBotExporter:
     ) -> None:
         """导出 FAISS 索引文件"""
         try:
-            index_path = kb_helper.kb_dir / "index.faiss"
-            if index_path.exists():
-                archive_path = f"databases/kb_{kb_id}/index.faiss"
-                zf.write(str(index_path), archive_path)
-                logger.debug(f"导出 FAISS 索引: {archive_path}")
+            for index_path in kb_helper.kb_dir.glob("index*.faiss"):
+                if index_path.exists():
+                    archive_path = f"databases/kb_{kb_id}/{index_path.name}"
+                    zf.write(str(index_path), archive_path)
+                    logger.debug(f"导出 FAISS 索引: {archive_path}")
         except Exception as e:
             logger.warning(f"导出 FAISS 索引失败: {e}")
 
@@ -450,7 +450,7 @@ class AstrBotExporter:
             "origin": "exported",  # 标记备份来源：exported=本实例导出, uploaded=用户上传
             "schema_version": {
                 "main_db": "v4",
-                "kb_db": "v1",
+                "kb_db": "v3",
             },
             "tables": {
                 "main_db": list(main_data.keys()),

--- a/astrbot/core/backup/importer.py
+++ b/astrbot/core/backup/importer.py
@@ -748,11 +748,15 @@ class AstrBotImporter:
                 except Exception as e:
                     result.add_warning(f"导入知识库 {kb_id} 的文档失败: {e}")
 
-            # 导入 FAISS 索引
-            faiss_path = f"databases/kb_{kb_id}/index.faiss"
-            if faiss_path in zf.namelist():
+            # 导入 FAISS 索引（兼容旧版 index.faiss 与新版 index.{provider}.faiss）
+            faiss_paths = [
+                name
+                for name in zf.namelist()
+                if name.startswith(f"databases/kb_{kb_id}/") and name.endswith(".faiss")
+            ]
+            for faiss_path in faiss_paths:
                 try:
-                    target_path = kb_dir / "index.faiss"
+                    target_path = kb_dir / Path(faiss_path).name
                     with zf.open(faiss_path) as src, open(target_path, "wb") as dst:
                         dst.write(src.read())
                 except Exception as e:

--- a/astrbot/core/db/vec_db/faiss_impl/document_storage.py
+++ b/astrbot/core/db/vec_db/faiss_impl/document_storage.py
@@ -2,6 +2,7 @@ import json
 import os
 from contextlib import asynccontextmanager
 from datetime import datetime
+from hashlib import sha256
 
 from sqlalchemy import Column, Text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
@@ -28,6 +29,8 @@ class Document(BaseDocModel, table=True):
     doc_id: str = Field(nullable=False)
     text: str = Field(nullable=False)
     metadata_: str | None = Field(default=None, sa_column=Column("metadata", Text))
+    is_indexed: bool = Field(default=False)
+    source_hash: str | None = Field(default=None)
     created_at: datetime | None = Field(default=None)
     updated_at: datetime | None = Field(default=None)
 
@@ -73,6 +76,29 @@ class DocumentStorage:
                 await conn.execute(
                     text(
                         "CREATE INDEX IF NOT EXISTS idx_documents_user_id ON documents(user_id)",
+                    ),
+                )
+            except BaseException:
+                pass
+
+            try:
+                await conn.execute(
+                    text(
+                        "ALTER TABLE documents ADD COLUMN is_indexed BOOLEAN DEFAULT 0",
+                    ),
+                )
+            except BaseException:
+                pass
+            try:
+                await conn.execute(
+                    text("ALTER TABLE documents ADD COLUMN source_hash TEXT"),
+                )
+            except BaseException:
+                pass
+            try:
+                await conn.execute(
+                    text(
+                        "UPDATE documents SET is_indexed = 1 WHERE is_indexed = 0 OR is_indexed IS NULL",
                     ),
                 )
             except BaseException:
@@ -167,6 +193,8 @@ class DocumentStorage:
                 doc_id=doc_id,
                 text=text,
                 metadata_=json.dumps(metadata),
+                is_indexed=True,
+                source_hash=sha256(text.encode("utf-8")).hexdigest(),
                 created_at=datetime.now(),
                 updated_at=datetime.now(),
             )
@@ -202,6 +230,8 @@ class DocumentStorage:
                     doc_id=doc_id,
                     text=text,
                     metadata_=json.dumps(metadata),
+                    is_indexed=True,
+                    source_hash=sha256(text.encode("utf-8")).hexdigest(),
                     created_at=datetime.now(),
                     updated_at=datetime.now(),
                 )
@@ -339,6 +369,26 @@ class DocumentStorage:
             result = await session.execute(query)
             rows = result.fetchall()
             return [row[0] for row in rows]
+
+    async def get_all_int_ids(self) -> list[int]:
+        """Retrieve all integer ids from documents table."""
+        assert self.engine is not None, "Database connection is not initialized."
+        async with self.get_session() as session:
+            result = await session.execute(select(Document.id))
+            return [
+                int(doc_id) for doc_id in result.scalars().all() if doc_id is not None
+            ]
+
+    async def get_documents_by_int_ids(self, ids: list[int]) -> list[dict]:
+        """Retrieve documents by integer ids."""
+        if not ids:
+            return []
+        assert self.engine is not None, "Database connection is not initialized."
+        async with self.get_session() as session:
+            query = select(Document).where(col(Document.id).in_(ids))
+            result = await session.execute(query)
+            documents = result.scalars().all()
+            return [self._document_to_dict(doc) for doc in documents]
 
     def _document_to_dict(self, document: Document) -> dict:
         """Convert a Document model to a dictionary.

--- a/astrbot/core/db/vec_db/faiss_impl/embedding_storage.py
+++ b/astrbot/core/db/vec_db/faiss_impl/embedding_storage.py
@@ -14,6 +14,10 @@ class EmbeddingStorage:
         self.dimension = dimension
         self.path = path
         self.index = None
+        if self.path:
+            dirpath = os.path.dirname(self.path)
+            if dirpath:
+                os.makedirs(dirpath, exist_ok=True)
         if path and os.path.exists(path):
             self.index = faiss.read_index(path)
         else:
@@ -90,6 +94,20 @@ class EmbeddingStorage:
             path (str): 保存索引的路径
 
         """
-        if self.index is None:
+        if self.index is None or self.path is None:
             return
         faiss.write_index(self.index, self.path)
+
+    def get_all_ids(self) -> list[int]:
+        """Return all int ids in current index."""
+        assert self.index is not None, "FAISS index is not initialized."
+        if self.index.ntotal == 0:
+            return []
+        if hasattr(self.index, "id_map"):
+            return [int(x) for x in faiss.vector_to_array(self.index.id_map)]
+        return []
+
+    async def close(self) -> None:
+        """Persist index and release in-memory references."""
+        await self.save_index()
+        self.index = None

--- a/astrbot/core/db/vec_db/faiss_impl/vec_db.py
+++ b/astrbot/core/db/vec_db/faiss_impl/vec_db.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 import uuid
 
@@ -31,6 +32,7 @@ class FaissVecDB(BaseVecDB):
         )
         self.embedding_provider = embedding_provider
         self.rerank_provider = rerank_provider
+        self._index_switch_lock = asyncio.Lock()
 
     async def initialize(self) -> None:
         await self.document_storage.initialize()
@@ -45,15 +47,20 @@ class FaissVecDB(BaseVecDB):
         metadata = metadata or {}
         str_id = id or str(uuid.uuid4())  # 使用 UUID 作为原始 ID
 
-        vector = await self.embedding_provider.get_embedding(content)
-        vector = np.array(vector, dtype=np.float32)
+        async with self._index_switch_lock:
+            vector = await self.embedding_provider.get_embedding(content)
+            vector = np.array(vector, dtype=np.float32)
 
-        # 使用 DocumentStorage 的方法插入文档
-        int_id = await self.document_storage.insert_document(str_id, content, metadata)
+            # 使用 DocumentStorage 的方法插入文档
+            int_id = await self.document_storage.insert_document(
+                str_id,
+                content,
+                metadata,
+            )
 
-        # 插入向量到 FAISS
-        await self.embedding_storage.insert(vector, int_id)
-        return int_id
+            # 插入向量到 FAISS
+            await self.embedding_storage.insert(vector, int_id)
+            return int_id
 
     async def insert_batch(
         self,
@@ -71,34 +78,35 @@ class FaissVecDB(BaseVecDB):
             progress_callback: 进度回调函数，接收参数 (current, total)
 
         """
-        metadatas = metadatas or [{} for _ in contents]
-        ids = ids or [str(uuid.uuid4()) for _ in contents]
+        async with self._index_switch_lock:
+            metadatas = metadatas or [{} for _ in contents]
+            ids = ids or [str(uuid.uuid4()) for _ in contents]
 
-        start = time.time()
-        logger.debug(f"Generating embeddings for {len(contents)} contents...")
-        vectors = await self.embedding_provider.get_embeddings_batch(
-            contents,
-            batch_size=batch_size,
-            tasks_limit=tasks_limit,
-            max_retries=max_retries,
-            progress_callback=progress_callback,
-        )
-        end = time.time()
-        logger.debug(
-            f"Generated embeddings for {len(contents)} contents in {end - start:.2f} seconds.",
-        )
+            start = time.time()
+            logger.debug(f"Generating embeddings for {len(contents)} contents...")
+            vectors = await self.embedding_provider.get_embeddings_batch(
+                contents,
+                batch_size=batch_size,
+                tasks_limit=tasks_limit,
+                max_retries=max_retries,
+                progress_callback=progress_callback,
+            )
+            end = time.time()
+            logger.debug(
+                f"Generated embeddings for {len(contents)} contents in {end - start:.2f} seconds.",
+            )
 
-        # 使用 DocumentStorage 的批量插入方法
-        int_ids = await self.document_storage.insert_documents_batch(
-            ids,
-            contents,
-            metadatas,
-        )
+            # 使用 DocumentStorage 的批量插入方法
+            int_ids = await self.document_storage.insert_documents_batch(
+                ids,
+                contents,
+                metadatas,
+            )
 
-        # 批量插入向量到 FAISS
-        vectors_array = np.array(vectors).astype("float32")
-        await self.embedding_storage.insert_batch(vectors_array, int_ids)
-        return int_ids
+            # 批量插入向量到 FAISS
+            vectors_array = np.array(vectors).astype("float32")
+            await self.embedding_storage.insert_batch(vectors_array, int_ids)
+            return int_ids
 
     async def retrieve(
         self,
@@ -121,11 +129,12 @@ class FaissVecDB(BaseVecDB):
             List[Result]: 查询结果
 
         """
-        embedding = await self.embedding_provider.get_embedding(query)
-        scores, indices = await self.embedding_storage.search(
-            vector=np.array([embedding]).astype("float32"),
-            k=fetch_k if metadata_filters else k,
-        )
+        async with self._index_switch_lock:
+            embedding = await self.embedding_provider.get_embedding(query)
+            scores, indices = await self.embedding_storage.search(
+                vector=np.array([embedding]).astype("float32"),
+                k=fetch_k if metadata_filters else k,
+            )
         if len(indices[0]) == 0 or indices[0][0] == -1:
             return []
         # normalize scores
@@ -168,16 +177,20 @@ class FaissVecDB(BaseVecDB):
     async def delete(self, doc_id: str) -> None:
         """删除一条文档块（chunk）"""
         # 获得对应的 int id
-        result = await self.document_storage.get_document_by_doc_id(doc_id)
-        int_id = result["id"] if result else None
-        if int_id is None:
-            return
+        async with self._index_switch_lock:
+            result = await self.document_storage.get_document_by_doc_id(doc_id)
+            int_id = result["id"] if result else None
+            if int_id is None:
+                return
 
-        # 使用 DocumentStorage 的删除方法
-        await self.document_storage.delete_document_by_doc_id(doc_id)
-        await self.embedding_storage.delete([int_id])
+            # 使用 DocumentStorage 的删除方法
+            await self.document_storage.delete_document_by_doc_id(doc_id)
+            await self.embedding_storage.delete([int_id])
 
     async def close(self) -> None:
+        async with self._index_switch_lock:
+            if self.embedding_storage:
+                await self.embedding_storage.close()
         await self.document_storage.close()
 
     async def count_documents(self, metadata_filter: dict | None = None) -> int:
@@ -194,11 +207,42 @@ class FaissVecDB(BaseVecDB):
 
     async def delete_documents(self, metadata_filters: dict) -> None:
         """根据元数据过滤器删除文档"""
-        docs = await self.document_storage.get_documents(
-            metadata_filters=metadata_filters,
-            offset=None,
-            limit=None,
-        )
-        doc_ids: list[int] = [doc["id"] for doc in docs]
-        await self.embedding_storage.delete(doc_ids)
-        await self.document_storage.delete_documents(metadata_filters=metadata_filters)
+        async with self._index_switch_lock:
+            docs = await self.document_storage.get_documents(
+                metadata_filters=metadata_filters,
+                offset=None,
+                limit=None,
+            )
+            doc_ids: list[int] = [doc["id"] for doc in docs]
+            await self.embedding_storage.delete(doc_ids)
+            await self.document_storage.delete_documents(
+                metadata_filters=metadata_filters,
+            )
+
+    async def switch_index(
+        self,
+        index_store_path: str,
+        embedding_provider: EmbeddingProvider,
+        rerank_provider: RerankProvider | None = None,
+    ) -> None:
+        """Hot-switch to a new FAISS index and embedding provider."""
+        async with self._index_switch_lock:
+            old_storage = self.embedding_storage
+            try:
+                # Create new storage first; only swap after successful creation
+                new_storage = EmbeddingStorage(
+                    embedding_provider.get_dim(),
+                    index_store_path,
+                )
+            except Exception:
+                # If creation fails, keep old storage intact
+                raise
+            # document_storage keeps the same SQLite mapping (int id <-> chunk metadata),
+            # only embedding index file/provider changes here.
+            self.index_store_path = index_store_path
+            self.embedding_provider = embedding_provider
+            self.rerank_provider = rerank_provider
+            self.embedding_storage = new_storage
+            # Close old storage only after successful swap
+            if old_storage:
+                await old_storage.close()

--- a/astrbot/core/db/vec_db/faiss_impl/vec_db.py
+++ b/astrbot/core/db/vec_db/faiss_impl/vec_db.py
@@ -226,23 +226,20 @@ class FaissVecDB(BaseVecDB):
         rerank_provider: RerankProvider | None = None,
     ) -> None:
         """Hot-switch to a new FAISS index and embedding provider."""
+        new_storage = EmbeddingStorage(
+            embedding_provider.get_dim(),
+            index_store_path,
+        )
+
         async with self._index_switch_lock:
             old_storage = self.embedding_storage
-            try:
-                # Create new storage first; only swap after successful creation
-                new_storage = EmbeddingStorage(
-                    embedding_provider.get_dim(),
-                    index_store_path,
-                )
-            except Exception:
-                # If creation fails, keep old storage intact
-                raise
             # document_storage keeps the same SQLite mapping (int id <-> chunk metadata),
             # only embedding index file/provider changes here.
             self.index_store_path = index_store_path
             self.embedding_provider = embedding_provider
             self.rerank_provider = rerank_provider
             self.embedding_storage = new_storage
-            # Close old storage only after successful swap
-            if old_storage:
-                await old_storage.close()
+
+        # Close old storage only after successful swap.
+        if old_storage:
+            await old_storage.close()

--- a/astrbot/core/knowledge_base/index_path.py
+++ b/astrbot/core/knowledge_base/index_path.py
@@ -1,0 +1,15 @@
+import re
+from pathlib import Path
+
+
+def normalize_provider_id(provider_id: str) -> str:
+    """Normalize provider id to a file-system-safe token."""
+    return re.sub(r"[^a-zA-Z0-9_.-]", "_", provider_id)
+
+
+def build_index_filename(provider_id: str) -> str:
+    return f"index.{normalize_provider_id(provider_id)}.faiss"
+
+
+def build_index_path(kb_dir: Path, provider_id: str) -> Path:
+    return kb_dir / build_index_filename(provider_id)

--- a/astrbot/core/knowledge_base/index_rebuilder.py
+++ b/astrbot/core/knowledge_base/index_rebuilder.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import numpy as np
+
+from astrbot.core import logger
+from astrbot.core.db.vec_db.faiss_impl.embedding_storage import EmbeddingStorage
+from astrbot.core.provider.provider import EmbeddingProvider
+
+from .index_path import build_index_path
+
+
+class IndexRebuilder:
+    async def sync(
+        self,
+        kb_helper,
+        new_provider_id: str,
+        batch_size: int = 32,
+        progress_callback=None,
+    ) -> None:
+        """Incrementally sync vector index for a new embedding provider."""
+        provider = await kb_helper.get_embedding_provider_by_id(new_provider_id)
+        if not isinstance(provider, EmbeddingProvider):
+            raise ValueError(f"Provider {new_provider_id} is not an EmbeddingProvider")
+
+        new_index_path = build_index_path(kb_helper.kb_dir, new_provider_id)
+        storage = EmbeddingStorage(provider.get_dim(), str(new_index_path))
+
+        doc_int_ids = set(await kb_helper.vec_db.document_storage.get_all_int_ids())
+        index_int_ids = set(storage.get_all_ids())
+
+        to_delete = list(index_int_ids - doc_int_ids)
+        to_add = list(doc_int_ids - index_int_ids)
+
+        docs: list[dict] = []
+        if to_add:
+            docs = await kb_helper.vec_db.document_storage.get_documents_by_int_ids(
+                to_add
+            )
+            docs = [doc for doc in docs if isinstance(doc.get("text"), str)]
+        total = len(to_delete) + len(docs)
+        done = 0
+
+        if progress_callback:
+            await progress_callback("prepare", done, total)
+
+        if to_delete:
+            await storage.delete(to_delete)
+            done += len(to_delete)
+            if progress_callback:
+                await progress_callback("deleting", done, total)
+
+        if docs:
+            for i in range(0, len(docs), batch_size):
+                batch_docs = docs[i : i + batch_size]
+                batch_texts = [doc["text"] for doc in batch_docs]
+                batch_ids = [int(doc["id"]) for doc in batch_docs]
+                vectors = await provider.get_embeddings(batch_texts)
+                await storage.insert_batch(
+                    vectors=np.array(vectors, dtype=np.float32),
+                    ids=batch_ids,
+                )
+                done += len(batch_docs)
+                if progress_callback:
+                    await progress_callback("embedding", done, total)
+
+        # Switch runtime vec db first, then persist active provider.
+        try:
+            await kb_helper.vec_db.switch_index(
+                index_store_path=str(new_index_path),
+                embedding_provider=provider,
+                rerank_provider=await kb_helper.get_rp(),
+            )
+        except Exception:
+            logger.exception(
+                "Failed to switch index in runtime for kb=%s provider=%s",
+                kb_helper.kb.kb_id,
+                new_provider_id,
+            )
+            raise
+        kb_helper.kb.active_index_provider_id = new_provider_id
+        await kb_helper.persist_kb()
+        logger.info(
+            "KB index rebuild finished: kb=%s provider=%s docs=%s",
+            kb_helper.kb.kb_id,
+            new_provider_id,
+            len(doc_int_ids),
+        )
+        if progress_callback:
+            await progress_callback("finished", total, total)

--- a/astrbot/core/knowledge_base/index_rebuilder.py
+++ b/astrbot/core/knowledge_base/index_rebuilder.py
@@ -24,66 +24,86 @@ class IndexRebuilder:
 
         new_index_path = build_index_path(kb_helper.kb_dir, new_provider_id)
         storage = EmbeddingStorage(provider.get_dim(), str(new_index_path))
+        storage_closed = False
 
-        doc_int_ids = set(await kb_helper.vec_db.document_storage.get_all_int_ids())
-        index_int_ids = set(storage.get_all_ids())
-
-        to_delete = list(index_int_ids - doc_int_ids)
-        to_add = list(doc_int_ids - index_int_ids)
-
-        docs: list[dict] = []
-        if to_add:
-            docs = await kb_helper.vec_db.document_storage.get_documents_by_int_ids(
-                to_add
-            )
-            docs = [doc for doc in docs if isinstance(doc.get("text"), str)]
-        total = len(to_delete) + len(docs)
-        done = 0
-
-        if progress_callback:
-            await progress_callback("prepare", done, total)
-
-        if to_delete:
-            await storage.delete(to_delete)
-            done += len(to_delete)
-            if progress_callback:
-                await progress_callback("deleting", done, total)
-
-        if docs:
-            for i in range(0, len(docs), batch_size):
-                batch_docs = docs[i : i + batch_size]
-                batch_texts = [doc["text"] for doc in batch_docs]
-                batch_ids = [int(doc["id"]) for doc in batch_docs]
-                vectors = await provider.get_embeddings(batch_texts)
-                await storage.insert_batch(
-                    vectors=np.array(vectors, dtype=np.float32),
-                    ids=batch_ids,
-                )
-                done += len(batch_docs)
-                if progress_callback:
-                    await progress_callback("embedding", done, total)
-
-        # Switch runtime vec db first, then persist active provider.
         try:
-            await kb_helper.vec_db.switch_index(
-                index_store_path=str(new_index_path),
-                embedding_provider=provider,
-                rerank_provider=await kb_helper.get_rp(),
-            )
-        except Exception:
-            logger.exception(
-                "Failed to switch index in runtime for kb=%s provider=%s",
+            doc_int_ids = set(await kb_helper.vec_db.document_storage.get_all_int_ids())
+            index_int_ids = set(storage.get_all_ids())
+
+            to_delete = list(index_int_ids - doc_int_ids)
+            to_add = list(doc_int_ids - index_int_ids)
+
+            docs: list[dict] = []
+            if to_add:
+                docs = await kb_helper.vec_db.document_storage.get_documents_by_int_ids(
+                    to_add
+                )
+                docs = [doc for doc in docs if isinstance(doc.get("text"), str)]
+            total = len(to_delete) + len(docs)
+            done = 0
+
+            if progress_callback:
+                await progress_callback("prepare", done, total)
+
+            if to_delete:
+                await storage.delete(to_delete)
+                done += len(to_delete)
+                if progress_callback:
+                    await progress_callback("deleting", done, total)
+
+            if docs:
+                for i in range(0, len(docs), batch_size):
+                    batch_docs = docs[i : i + batch_size]
+                    batch_texts = [doc["text"] for doc in batch_docs]
+                    batch_ids = [int(doc["id"]) for doc in batch_docs]
+                    vectors = await provider.get_embeddings_batch(
+                        batch_texts,
+                        batch_size=batch_size,
+                    )
+                    await storage.insert_batch(
+                        vectors=np.array(vectors, dtype=np.float32),
+                        ids=batch_ids,
+                    )
+                    done += len(batch_docs)
+                    if progress_callback:
+                        await progress_callback("embedding", done, total)
+
+            # Ensure rebuilt index is flushed before runtime switch.
+            await storage.close()
+            storage_closed = True
+
+            # Switch runtime vec db first, then persist active provider.
+            try:
+                await kb_helper.vec_db.switch_index(
+                    index_store_path=str(new_index_path),
+                    embedding_provider=provider,
+                    rerank_provider=await kb_helper.get_rp(),
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to switch index in runtime for kb=%s provider=%s",
+                    kb_helper.kb.kb_id,
+                    new_provider_id,
+                )
+                raise
+            kb_helper.kb.active_index_provider_id = new_provider_id
+            await kb_helper.persist_kb()
+            logger.info(
+                "KB index rebuild finished: kb=%s provider=%s docs=%s",
                 kb_helper.kb.kb_id,
                 new_provider_id,
+                len(doc_int_ids),
             )
-            raise
-        kb_helper.kb.active_index_provider_id = new_provider_id
-        await kb_helper.persist_kb()
-        logger.info(
-            "KB index rebuild finished: kb=%s provider=%s docs=%s",
-            kb_helper.kb.kb_id,
-            new_provider_id,
-            len(doc_int_ids),
-        )
-        if progress_callback:
-            await progress_callback("finished", total, total)
+            if progress_callback:
+                await progress_callback("finished", total, total)
+        finally:
+            if not storage_closed:
+                try:
+                    await storage.close()
+                except Exception as e:
+                    logger.warning(
+                        "Failed to close temporary index storage for kb=%s provider=%s: %s",
+                        kb_helper.kb.kb_id,
+                        new_provider_id,
+                        e,
+                    )

--- a/astrbot/core/knowledge_base/kb_db_sqlite.py
+++ b/astrbot/core/knowledge_base/kb_db_sqlite.py
@@ -2,13 +2,16 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 from sqlalchemy import delete, func, select, text, update
+from sqlalchemy.exc import OperationalError, ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlmodel import col, desc
 
 from astrbot.core import logger
 from astrbot.core.db.vec_db.faiss_impl import FaissVecDB
+from astrbot.core.knowledge_base.index_path import build_index_path
 from astrbot.core.knowledge_base.models import (
     BaseKBModel,
+    DocSection,
     KBDocument,
     KBMedia,
     KnowledgeBase,
@@ -164,6 +167,123 @@ class KBSQLiteDatabase:
 
                 await session.commit()
 
+    async def migrate_to_v2(self, kb_root_dir: str) -> None:
+        """执行知识库数据库 v2 迁移
+
+        变更:
+        - knowledge_bases.active_index_provider_id
+        - 旧 index.faiss 迁移为 index.{provider}.faiss
+        """
+        async with self.get_db() as session:
+            session: AsyncSession
+            async with session.begin():
+                try:
+                    await session.execute(
+                        text(
+                            "ALTER TABLE knowledge_bases "
+                            "ADD COLUMN active_index_provider_id VARCHAR(100)",
+                        ),
+                    )
+                except (ProgrammingError, OperationalError) as e:
+                    err_msg = str(e).lower()
+                    if "duplicate column name" in err_msg:
+                        pass
+                    else:
+                        logger.error(
+                            "Failed to alter knowledge_bases for active_index_provider_id: %s",
+                            e,
+                        )
+                        raise
+
+                result = await session.execute(select(KnowledgeBase))
+                all_kbs = list(result.scalars().all())
+                kb_root = Path(kb_root_dir)
+                for kb in all_kbs:
+                    if not kb.active_index_provider_id and kb.embedding_provider_id:
+                        kb.active_index_provider_id = kb.embedding_provider_id
+
+                    rename_success = True
+                    if kb.embedding_provider_id:
+                        old_index_path = kb_root / kb.kb_id / "index.faiss"
+                        new_index_path = build_index_path(
+                            kb_root / kb.kb_id,
+                            kb.embedding_provider_id,
+                        )
+                        if old_index_path.exists() and not new_index_path.exists():
+                            try:
+                                old_index_path.rename(new_index_path)
+                            except OSError as e:
+                                logger.warning(
+                                    "Rename index failed for kb %s: %s -> %s, error: %s",
+                                    kb.kb_id,
+                                    old_index_path,
+                                    new_index_path,
+                                    e,
+                                )
+                                rename_success = False
+                            except Exception as e:
+                                logger.warning(
+                                    "Unexpected error when renaming index for kb %s: %s -> %s, error: %s",
+                                    kb.kb_id,
+                                    old_index_path,
+                                    new_index_path,
+                                    e,
+                                )
+                                rename_success = False
+                    # Only persist KB changes if rename succeeded (or no rename was needed)
+                    if rename_success:
+                        session.add(kb)
+
+                await session.commit()
+
+    async def migrate_to_v3(self) -> None:
+        """执行知识库数据库 v3 迁移
+
+        变更:
+        - knowledge_bases.default_index_mode
+        - kb_documents.index_mode
+        """
+        async with self.get_db() as session:
+            session: AsyncSession
+            async with session.begin():
+                try:
+                    await session.execute(
+                        text(
+                            "ALTER TABLE knowledge_bases "
+                            "ADD COLUMN default_index_mode VARCHAR(20) DEFAULT 'flat'",
+                        ),
+                    )
+                except Exception:
+                    pass
+                try:
+                    await session.execute(
+                        text(
+                            "ALTER TABLE kb_documents "
+                            "ADD COLUMN index_mode VARCHAR(20) DEFAULT 'flat'",
+                        ),
+                    )
+                except Exception:
+                    pass
+                try:
+                    await session.execute(
+                        text(
+                            "UPDATE knowledge_bases SET default_index_mode = 'flat' "
+                            "WHERE default_index_mode IS NULL OR default_index_mode = ''",
+                        ),
+                    )
+                except Exception:
+                    pass
+                try:
+                    await session.execute(
+                        text(
+                            "UPDATE kb_documents SET index_mode = 'flat' "
+                            "WHERE index_mode IS NULL OR index_mode = ''",
+                        ),
+                    )
+                except Exception:
+                    pass
+                await session.commit()
+
     async def close(self) -> None:
         """关闭数据库连接"""
         await self.engine.dispose()
@@ -316,6 +436,50 @@ class KBSQLiteDatabase:
             stmt = select(KBMedia).where(col(KBMedia.doc_id) == doc_id)
             result = await session.execute(stmt)
             return list(result.scalars().all())
+
+    async def has_structured_docs(self, kb_id: str) -> bool:
+        """Check if kb has any structured indexed documents."""
+        async with self.get_db() as session:
+            stmt = (
+                select(func.count(col(KBDocument.id)))
+                .where(col(KBDocument.kb_id) == kb_id)
+                .where(col(KBDocument.index_mode) == "structure")
+            )
+            result = await session.execute(stmt)
+            return (result.scalar() or 0) > 0
+
+    async def upsert_doc_section(self, section: DocSection) -> None:
+        async with self.get_db() as session:
+            async with session.begin():
+                await session.merge(section)
+
+    async def get_doc_section(
+        self,
+        kb_id: str,
+        doc_id: str,
+        section_path: str,
+    ) -> DocSection | None:
+        async with self.get_db() as session:
+            stmt = (
+                select(DocSection)
+                .where(col(DocSection.kb_id) == kb_id)
+                .where(col(DocSection.doc_id) == doc_id)
+                .where(col(DocSection.section_path) == section_path)
+            )
+            result = await session.execute(stmt)
+            section = result.scalar_one_or_none()
+            if section:
+                return section
+            stmt = (
+                select(DocSection)
+                .where(col(DocSection.kb_id) == kb_id)
+                .where(col(DocSection.doc_id) == doc_id)
+                .where(DocSection.section_path.contains(section_path, autoescape=True))
+                .order_by(DocSection.created_at.asc(), DocSection.id.asc())
+                .limit(1)
+            )
+            result = await session.execute(stmt)
+            return result.scalar_one_or_none()
 
     async def get_media_by_id(self, media_id: str) -> KBMedia | None:
         """根据 ID 获取多媒体资源"""

--- a/astrbot/core/knowledge_base/kb_db_sqlite.py
+++ b/astrbot/core/knowledge_base/kb_db_sqlite.py
@@ -451,6 +451,13 @@ class KBSQLiteDatabase:
     async def upsert_doc_section(self, section: DocSection) -> None:
         async with self.get_db() as session:
             async with session.begin():
+                existing_stmt = select(DocSection).where(
+                    col(DocSection.section_id) == section.section_id,
+                )
+                existing_result = await session.execute(existing_stmt)
+                existing = existing_result.scalar_one_or_none()
+                if existing and existing.id is not None:
+                    section.id = existing.id
                 await session.merge(section)
 
     async def get_doc_section(

--- a/astrbot/core/knowledge_base/kb_db_sqlite.py
+++ b/astrbot/core/knowledge_base/kb_db_sqlite.py
@@ -1,5 +1,6 @@
 from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from sqlalchemy import delete, func, select, text, update
 from sqlalchemy.exc import OperationalError, ProgrammingError
@@ -7,7 +8,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from sqlmodel import col, desc
 
 from astrbot.core import logger
-from astrbot.core.db.vec_db.faiss_impl import FaissVecDB
 from astrbot.core.knowledge_base.index_path import build_index_path
 from astrbot.core.knowledge_base.models import (
     BaseKBModel,
@@ -17,6 +17,9 @@ from astrbot.core.knowledge_base.models import (
     KnowledgeBase,
 )
 from astrbot.core.utils.astrbot_path import get_astrbot_knowledge_base_path
+
+if TYPE_CHECKING:
+    from astrbot.core.db.vec_db.faiss_impl import FaissVecDB
 
 
 class KBSQLiteDatabase:
@@ -276,8 +279,14 @@ class KBSQLiteDatabase:
                             "ADD COLUMN default_index_mode VARCHAR(20) DEFAULT 'flat'",
                         ),
                     )
-                except Exception:
-                    pass
+                except (ProgrammingError, OperationalError) as e:
+                    err_msg = str(e).lower()
+                    if "duplicate column name" not in err_msg:
+                        logger.error(
+                            "Failed to alter knowledge_bases for default_index_mode: %s",
+                            e,
+                        )
+                        raise
                 try:
                     await session.execute(
                         text(
@@ -285,26 +294,26 @@ class KBSQLiteDatabase:
                             "ADD COLUMN index_mode VARCHAR(20) DEFAULT 'flat'",
                         ),
                     )
-                except Exception:
-                    pass
-                try:
-                    await session.execute(
-                        text(
-                            "UPDATE knowledge_bases SET default_index_mode = 'flat' "
-                            "WHERE default_index_mode IS NULL OR default_index_mode = ''",
-                        ),
-                    )
-                except Exception:
-                    pass
-                try:
-                    await session.execute(
-                        text(
-                            "UPDATE kb_documents SET index_mode = 'flat' "
-                            "WHERE index_mode IS NULL OR index_mode = ''",
-                        ),
-                    )
-                except Exception:
-                    pass
+                except (ProgrammingError, OperationalError) as e:
+                    err_msg = str(e).lower()
+                    if "duplicate column name" not in err_msg:
+                        logger.error(
+                            "Failed to alter kb_documents for index_mode: %s",
+                            e,
+                        )
+                        raise
+                await session.execute(
+                    text(
+                        "UPDATE knowledge_bases SET default_index_mode = 'flat' "
+                        "WHERE default_index_mode IS NULL OR default_index_mode = ''",
+                    ),
+                )
+                await session.execute(
+                    text(
+                        "UPDATE kb_documents SET index_mode = 'flat' "
+                        "WHERE index_mode IS NULL OR index_mode = ''",
+                    ),
+                )
                 await session.commit()
 
     async def close(self) -> None:
@@ -439,7 +448,7 @@ class KBSQLiteDatabase:
 
         return metadata_map
 
-    async def delete_document_by_id(self, doc_id: str, vec_db: FaissVecDB) -> None:
+    async def delete_document_by_id(self, doc_id: str, vec_db: "FaissVecDB") -> None:
         """删除单个文档及其相关数据"""
         # 在知识库表中删除
         async with self.get_db() as session, session.begin():
@@ -483,6 +492,23 @@ class KBSQLiteDatabase:
                     section.id = existing.id
                 await session.merge(section)
 
+    async def upsert_doc_sections(self, sections: list[DocSection]) -> None:
+        if not sections:
+            return
+        async with self.get_db() as session:
+            async with session.begin():
+                section_ids = [section.section_id for section in sections]
+                existing_stmt = select(DocSection.section_id, DocSection.id).where(
+                    col(DocSection.section_id).in_(section_ids),
+                )
+                existing_result = await session.execute(existing_stmt)
+                existing_map = {row[0]: row[1] for row in existing_result.all()}
+                for section in sections:
+                    existing_id = existing_map.get(section.section_id)
+                    if existing_id is not None:
+                        section.id = existing_id
+                    await session.merge(section)
+
     async def get_doc_section(
         self,
         kb_id: str,
@@ -518,7 +544,7 @@ class KBSQLiteDatabase:
             result = await session.execute(stmt)
             return result.scalar_one_or_none()
 
-    async def update_kb_stats(self, kb_id: str, vec_db: FaissVecDB) -> None:
+    async def update_kb_stats(self, kb_id: str, vec_db: "FaissVecDB") -> None:
         """更新知识库统计信息"""
         chunk_cnt = await vec_db.count_documents()
 

--- a/astrbot/core/knowledge_base/kb_db_sqlite.py
+++ b/astrbot/core/knowledge_base/kb_db_sqlite.py
@@ -195,19 +195,28 @@ class KBSQLiteDatabase:
                         )
                         raise
 
-                result = await session.execute(select(KnowledgeBase))
-                all_kbs = list(result.scalars().all())
+                # Do not use ORM entity query here. During v2 migration, the on-disk
+                # schema may still miss newer columns defined in KnowledgeBase (v3+),
+                # which would make `select(KnowledgeBase)` fail before migration finishes.
+                result = await session.execute(
+                    text(
+                        "SELECT kb_id, embedding_provider_id, active_index_provider_id "
+                        "FROM knowledge_bases",
+                    ),
+                )
+                all_kbs = list(result.mappings().all())
                 kb_root = Path(kb_root_dir)
                 for kb in all_kbs:
-                    if not kb.active_index_provider_id and kb.embedding_provider_id:
-                        kb.active_index_provider_id = kb.embedding_provider_id
+                    kb_id = kb["kb_id"]
+                    embedding_provider_id = kb["embedding_provider_id"]
+                    active_index_provider_id = kb["active_index_provider_id"]
 
                     rename_success = True
-                    if kb.embedding_provider_id:
-                        old_index_path = kb_root / kb.kb_id / "index.faiss"
+                    if embedding_provider_id:
+                        old_index_path = kb_root / kb_id / "index.faiss"
                         new_index_path = build_index_path(
-                            kb_root / kb.kb_id,
-                            kb.embedding_provider_id,
+                            kb_root / kb_id,
+                            embedding_provider_id,
                         )
                         if old_index_path.exists() and not new_index_path.exists():
                             try:
@@ -215,7 +224,7 @@ class KBSQLiteDatabase:
                             except OSError as e:
                                 logger.warning(
                                     "Rename index failed for kb %s: %s -> %s, error: %s",
-                                    kb.kb_id,
+                                    kb_id,
                                     old_index_path,
                                     new_index_path,
                                     e,
@@ -224,15 +233,29 @@ class KBSQLiteDatabase:
                             except Exception as e:
                                 logger.warning(
                                     "Unexpected error when renaming index for kb %s: %s -> %s, error: %s",
-                                    kb.kb_id,
+                                    kb_id,
                                     old_index_path,
                                     new_index_path,
                                     e,
                                 )
                                 rename_success = False
                     # Only persist KB changes if rename succeeded (or no rename was needed)
-                    if rename_success:
-                        session.add(kb)
+                    if (
+                        rename_success
+                        and not active_index_provider_id
+                        and embedding_provider_id
+                    ):
+                        await session.execute(
+                            text(
+                                "UPDATE knowledge_bases "
+                                "SET active_index_provider_id = :provider_id "
+                                "WHERE kb_id = :kb_id",
+                            ),
+                            {
+                                "provider_id": embedding_provider_id,
+                                "kb_id": kb_id,
+                            },
+                        )
 
                 await session.commit()
 

--- a/astrbot/core/knowledge_base/kb_helper.py
+++ b/astrbot/core/knowledge_base/kb_helper.py
@@ -6,6 +6,7 @@ import uuid
 from pathlib import Path
 
 import aiofiles
+import numpy as np
 
 from astrbot.core import logger
 from astrbot.core.db.vec_db.base import BaseVecDB
@@ -21,11 +22,13 @@ from astrbot.core.provider.provider import (
 
 from .chunking.base import BaseChunker
 from .chunking.recursive import RecursiveCharacterChunker
+from .index_path import build_index_path
 from .kb_db_sqlite import KBSQLiteDatabase
-from .models import KBDocument, KBMedia, KnowledgeBase
+from .models import DocSection, KBDocument, KBMedia, KnowledgeBase
 from .parsers.url_parser import extract_text_from_url
 from .parsers.util import select_parser
 from .prompts import TEXT_REPAIR_SYSTEM_PROMPT
+from .structure_parser import StructureParser
 
 
 class RateLimiter:
@@ -129,21 +132,36 @@ class KBHelper:
 
         self.kb_medias_dir.mkdir(parents=True, exist_ok=True)
         self.kb_files_dir.mkdir(parents=True, exist_ok=True)
+        self.last_rebuild_task_id: str | None = None
 
     async def initialize(self) -> None:
+        if not self.kb.active_index_provider_id:
+            self.kb.active_index_provider_id = self.kb.embedding_provider_id
+            await self.persist_kb()
         await self._ensure_vec_db()
 
-    async def get_ep(self) -> EmbeddingProvider:
-        if not self.kb.embedding_provider_id:
-            raise ValueError(f"知识库 {self.kb.kb_name} 未配置 Embedding Provider")
+    async def get_embedding_provider_by_id(self, provider_id: str) -> EmbeddingProvider:
         ep: EmbeddingProvider = await self.prov_mgr.get_provider_by_id(
-            self.kb.embedding_provider_id,
+            provider_id,
         )  # type: ignore
         if not ep:
-            raise ValueError(
-                f"无法找到 ID 为 {self.kb.embedding_provider_id} 的 Embedding Provider",
-            )
+            raise ValueError(f"无法找到 ID 为 {provider_id} 的 Embedding Provider")
         return ep
+
+    def get_active_embedding_provider_id(self) -> str | None:
+        return self.kb.active_index_provider_id or self.kb.embedding_provider_id
+
+    def get_active_index_path(self) -> Path:
+        provider_id = self.get_active_embedding_provider_id()
+        if not provider_id:
+            return self.kb_dir / "index.faiss"
+        return build_index_path(self.kb_dir, provider_id)
+
+    async def get_ep(self) -> EmbeddingProvider:
+        provider_id = self.get_active_embedding_provider_id()
+        if not provider_id:
+            raise ValueError(f"知识库 {self.kb.kb_name} 未配置 Embedding Provider")
+        return await self.get_embedding_provider_by_id(provider_id)
 
     async def get_rp(self) -> RerankProvider | None:
         if not self.kb.rerank_provider_id:
@@ -158,7 +176,8 @@ class KBHelper:
         return rp
 
     async def _ensure_vec_db(self) -> FaissVecDB:
-        if not self.kb.embedding_provider_id:
+        provider_id = self.get_active_embedding_provider_id()
+        if not provider_id:
             raise ValueError(f"知识库 {self.kb.kb_name} 未配置 Embedding Provider")
 
         ep = await self.get_ep()
@@ -166,13 +185,18 @@ class KBHelper:
 
         vec_db = FaissVecDB(
             doc_store_path=str(self.kb_dir / "doc.db"),
-            index_store_path=str(self.kb_dir / "index.faiss"),
+            index_store_path=str(self.get_active_index_path()),
             embedding_provider=ep,
             rerank_provider=rp,
         )
         await vec_db.initialize()
         self.vec_db = vec_db
         return vec_db
+
+    async def persist_kb(self) -> None:
+        async with self.kb_db.get_db() as session:
+            async with session.begin():
+                self.kb = await session.merge(self.kb)
 
     async def delete_vec_db(self) -> None:
         """删除知识库的向量数据库和所有相关文件"""
@@ -191,6 +215,7 @@ class KBHelper:
         file_name: str,
         file_content: bytes | None,
         file_type: str,
+        index_mode: str | None = None,
         chunk_size: int = 512,
         chunk_overlap: int = 50,
         batch_size: int = 32,
@@ -217,6 +242,18 @@ class KBHelper:
                 - total: 总数
 
         """
+        mode = (index_mode or self.kb.default_index_mode or "flat").lower()
+        if mode == "structure" and pre_chunked_text is None:
+            return await self._upload_document_structured(
+                file_name=file_name,
+                file_content=file_content,
+                file_type=file_type,
+                batch_size=batch_size,
+                tasks_limit=tasks_limit,
+                max_retries=max_retries,
+                progress_callback=progress_callback,
+            )
+
         await self._ensure_vec_db()
         doc_id = str(uuid.uuid4())
         media_paths: list[Path] = []
@@ -315,6 +352,7 @@ class KBHelper:
                 file_size=file_size,
                 # file_path=str(file_path),
                 file_path="",
+                index_mode="flat",
                 chunk_count=len(chunks_text),
                 media_count=0,
             )
@@ -345,6 +383,126 @@ class KBHelper:
                     logger.warning(f"清理多媒体文件失败 {media_path}: {me}")
 
             raise e
+
+    async def _upload_document_structured(
+        self,
+        file_name: str,
+        file_content: bytes | None,
+        file_type: str,
+        batch_size: int = 32,
+        tasks_limit: int = 3,
+        max_retries: int = 3,
+        progress_callback=None,
+    ) -> KBDocument:
+        await self._ensure_vec_db()
+        if file_content is None:
+            raise ValueError("结构化上传需要 file_content")
+
+        doc_id = str(uuid.uuid4())
+        parser = await select_parser(f".{file_type}")
+        if progress_callback:
+            await progress_callback("parsing", 0, 100)
+        parse_result = await parser.parse(file_content, file_name)
+        if progress_callback:
+            await progress_callback("parsing", 100, 100)
+
+        structure_parser = StructureParser()
+        if progress_callback:
+            await progress_callback("chunking", 0, 100)
+        nodes = await structure_parser.parse_structure(parse_result.text, file_type)
+        sections = structure_parser.flatten(nodes)
+        if not sections:
+            logger.warning(
+                "Structured parse failed, fallback to flat mode for %s", file_name
+            )
+            return await self.upload_document(
+                file_name=file_name,
+                file_content=file_content,
+                file_type=file_type,
+                index_mode="flat",
+                batch_size=batch_size,
+                tasks_limit=tasks_limit,
+                max_retries=max_retries,
+                progress_callback=progress_callback,
+            )
+
+        contents = [section.path for section in sections]
+        chunk_ids = [str(uuid.uuid4()) for _ in sections]
+        metadatas = [
+            {
+                "kb_id": self.kb.kb_id,
+                "kb_doc_id": doc_id,
+                "chunk_index": i,
+                "index_mode": "structure",
+                "section_path": section.path,
+                "section_level": section.level,
+            }
+            for i, section in enumerate(sections)
+        ]
+        if progress_callback:
+            await progress_callback("chunking", 100, 100)
+
+        ep = await self.get_ep()
+
+        async def structured_embedding_progress(current: int, total: int) -> None:
+            if progress_callback:
+                await progress_callback("embedding", current, total)
+
+        vectors = await ep.get_embeddings_batch(
+            contents,
+            batch_size=batch_size,
+            tasks_limit=tasks_limit,
+            max_retries=max_retries,
+            progress_callback=structured_embedding_progress
+            if progress_callback
+            else None,
+        )
+        int_ids = await self.vec_db.document_storage.insert_documents_batch(
+            chunk_ids,
+            contents,
+            metadatas,
+        )
+        await self.vec_db.embedding_storage.insert_batch(
+            vectors=np.array(vectors, dtype=np.float32),
+            ids=int_ids,
+        )
+
+        kb_doc = KBDocument(
+            doc_id=doc_id,
+            kb_id=self.kb.kb_id,
+            doc_name=file_name,
+            file_type=file_type,
+            file_size=len(file_content),
+            file_path="",
+            index_mode="structure",
+            chunk_count=len(sections),
+            media_count=0,
+        )
+        async with self.kb_db.get_db() as session:
+            async with session.begin():
+                session.add(kb_doc)
+            await session.refresh(kb_doc)
+
+        for i, section in enumerate(sections):
+            await self.kb_db.upsert_doc_section(
+                DocSection(
+                    doc_id=doc_id,
+                    kb_id=self.kb.kb_id,
+                    section_path=section.path,
+                    section_level=section.level,
+                    section_title=section.title,
+                    section_body=section.body,
+                    parent_section_id=None,
+                    sort_order=i,
+                ),
+            )
+
+        if progress_callback:
+            await progress_callback("embedding", len(sections), len(sections))
+        await self.kb_db.update_kb_stats(kb_id=self.kb.kb_id, vec_db=self.vec_db)  # type: ignore[arg-type]
+        await self.refresh_kb()
+        await self.refresh_document(doc_id)
+        return kb_doc
 
     async def list_documents(
         self,

--- a/astrbot/core/knowledge_base/kb_helper.py
+++ b/astrbot/core/knowledge_base/kb_helper.py
@@ -483,19 +483,20 @@ class KBHelper:
                 session.add(kb_doc)
             await session.refresh(kb_doc)
 
-        for i, section in enumerate(sections):
-            await self.kb_db.upsert_doc_section(
-                DocSection(
-                    doc_id=doc_id,
-                    kb_id=self.kb.kb_id,
-                    section_path=section.path,
-                    section_level=section.level,
-                    section_title=section.title,
-                    section_body=section.body,
-                    parent_section_id=None,
-                    sort_order=i,
-                ),
+        section_models = [
+            DocSection(
+                doc_id=doc_id,
+                kb_id=self.kb.kb_id,
+                section_path=section.path,
+                section_level=section.level,
+                section_title=section.title,
+                section_body=section.body,
+                parent_section_id=None,
+                sort_order=i,
             )
+            for i, section in enumerate(sections)
+        ]
+        await self.kb_db.upsert_doc_sections(section_models)
 
         if progress_callback:
             await progress_callback("embedding", len(sections), len(sections))

--- a/astrbot/core/knowledge_base/kb_mgr.py
+++ b/astrbot/core/knowledge_base/kb_mgr.py
@@ -1,4 +1,6 @@
+import asyncio
 import traceback
+import uuid
 from pathlib import Path
 
 from astrbot.core import logger
@@ -7,6 +9,7 @@ from astrbot.core.utils.astrbot_path import get_astrbot_knowledge_base_path
 
 # from .chunking.fixed_size import FixedSizeChunker
 from .chunking.recursive import RecursiveCharacterChunker
+from .index_rebuilder import IndexRebuilder
 from .kb_db_sqlite import KBSQLiteDatabase
 from .kb_helper import KBHelper
 from .models import KBDocument, KnowledgeBase
@@ -33,6 +36,19 @@ class KnowledgeBaseManager:
         self._session_deleted_callback_registered = False
 
         self.kb_insts: dict[str, KBHelper] = {}
+        self.rebuild_tasks: dict[str, dict] = {}
+        self.kb_rebuild_task_map: dict[str, str] = {}
+        self._running_rebuild_tasks: dict[str, asyncio.Task] = {}
+        self.index_rebuilder = IndexRebuilder()
+
+    def _validate_index_mode(self, index_mode: str) -> str:
+        normalized = (index_mode or "").strip().lower()
+        allowed_modes = {"flat", "structure"}
+        if normalized not in allowed_modes:
+            raise ValueError(
+                f"default_index_mode 必须为 {sorted(allowed_modes)} 之一，实际为: {index_mode}",
+            )
+        return normalized
 
     async def initialize(self) -> None:
         """初始化知识库模块"""
@@ -63,6 +79,8 @@ class KnowledgeBaseManager:
         self.kb_db = KBSQLiteDatabase(DB_PATH.as_posix())
         await self.kb_db.initialize()
         await self.kb_db.migrate_to_v1()
+        await self.kb_db.migrate_to_v2(FILES_PATH)
+        await self.kb_db.migrate_to_v3()
         logger.info(f"KnowledgeBase database initialized: {DB_PATH}")
 
     async def load_kbs(self) -> None:
@@ -78,6 +96,14 @@ class KnowledgeBaseManager:
             )
             await kb_helper.initialize()
             self.kb_insts[record.kb_id] = kb_helper
+            if (
+                record.embedding_provider_id
+                and record.active_index_provider_id
+                and record.embedding_provider_id != record.active_index_provider_id
+            ):
+                await self.start_rebuild_index(
+                    record.kb_id, record.embedding_provider_id
+                )
 
     async def create_kb(
         self,
@@ -91,21 +117,26 @@ class KnowledgeBaseManager:
         top_k_dense: int | None = None,
         top_k_sparse: int | None = None,
         top_m_final: int | None = None,
+        default_index_mode: str | None = None,
     ) -> KBHelper:
         """创建新的知识库实例"""
         if embedding_provider_id is None:
             raise ValueError("创建知识库时必须提供embedding_provider_id")
+        if default_index_mode is not None:
+            default_index_mode = self._validate_index_mode(default_index_mode)
         kb = KnowledgeBase(
             kb_name=kb_name,
             description=description,
             emoji=emoji or "📚",
             embedding_provider_id=embedding_provider_id,
+            active_index_provider_id=embedding_provider_id,
             rerank_provider_id=rerank_provider_id,
             chunk_size=chunk_size if chunk_size is not None else 512,
             chunk_overlap=chunk_overlap if chunk_overlap is not None else 50,
             top_k_dense=top_k_dense if top_k_dense is not None else 50,
             top_k_sparse=top_k_sparse if top_k_sparse is not None else 50,
             top_m_final=top_m_final if top_m_final is not None else 5,
+            default_index_mode=default_index_mode or "flat",
         )
         try:
             async with self.kb_db.get_db() as session:
@@ -172,6 +203,7 @@ class KnowledgeBaseManager:
         top_k_dense: int | None = None,
         top_k_sparse: int | None = None,
         top_m_final: int | None = None,
+        default_index_mode: str | None = None,
     ) -> KBHelper | None:
         """更新知识库实例"""
         kb_helper = await self.get_kb(kb_id)
@@ -198,12 +230,130 @@ class KnowledgeBaseManager:
             kb.top_k_sparse = top_k_sparse
         if top_m_final is not None:
             kb.top_m_final = top_m_final
+        if default_index_mode is not None:
+            kb.default_index_mode = self._validate_index_mode(default_index_mode)
         async with self.kb_db.get_db() as session:
             session.add(kb)
             await session.commit()
             await session.refresh(kb)
 
+        if (
+            embedding_provider_id
+            and kb.active_index_provider_id
+            and embedding_provider_id != kb.active_index_provider_id
+        ):
+            await self.start_rebuild_index(kb.kb_id, embedding_provider_id)
+
         return kb_helper
+
+    async def has_structured_docs_by_names(self, kb_names: list[str]) -> bool:
+        for kb_name in kb_names:
+            kb_helper = await self.get_kb_by_name(kb_name)
+            if not kb_helper:
+                continue
+            if await self.kb_db.has_structured_docs(kb_helper.kb.kb_id):
+                return True
+        return False
+
+    async def read_document_section(
+        self,
+        kb_names: list[str],
+        doc_id: str,
+        section_path: str,
+    ) -> str | None:
+        for kb_name in kb_names:
+            kb_helper = await self.get_kb_by_name(kb_name)
+            if not kb_helper:
+                continue
+            section = await self.kb_db.get_doc_section(
+                kb_id=kb_helper.kb.kb_id,
+                doc_id=doc_id,
+                section_path=section_path,
+            )
+            if section:
+                return section.section_body
+        return None
+
+    async def start_rebuild_index(
+        self,
+        kb_id: str,
+        new_provider_id: str,
+        batch_size: int = 32,
+    ) -> str:
+        kb_helper = await self.get_kb(kb_id)
+        if not kb_helper:
+            raise ValueError("知识库不存在")
+
+        existing_task_id = self.kb_rebuild_task_map.get(kb_id)
+        if existing_task_id:
+            existing = self.rebuild_tasks.get(existing_task_id)
+            if existing and existing.get("status") == "processing":
+                return existing_task_id
+
+        task_id = str(uuid.uuid4())
+        kb_helper.last_rebuild_task_id = task_id
+        self.kb_rebuild_task_map[kb_id] = task_id
+        self.rebuild_tasks[task_id] = {
+            "task_id": task_id,
+            "kb_id": kb_id,
+            "provider_id": new_provider_id,
+            "status": "processing",
+            "stage": "prepare",
+            "current": 0,
+            "total": 0,
+            "error": None,
+        }
+
+        async def _progress(stage: str, current: int, total: int) -> None:
+            task = self.rebuild_tasks.get(task_id)
+            if not task:
+                return
+            task["stage"] = stage
+            task["current"] = current
+            task["total"] = total
+
+        async def _run():
+            try:
+                await self.index_rebuilder.sync(
+                    kb_helper=kb_helper,
+                    new_provider_id=new_provider_id,
+                    batch_size=batch_size,
+                    progress_callback=_progress,
+                )
+                task = self.rebuild_tasks.get(task_id)
+                if task:
+                    task["status"] = "completed"
+                    task["stage"] = "finished"
+            except Exception as e:
+                logger.error(
+                    "Index rebuild failed for kb %s provider %s: %s",
+                    kb_id,
+                    new_provider_id,
+                    e,
+                )
+                logger.error(traceback.format_exc())
+                task = self.rebuild_tasks.get(task_id)
+                if task:
+                    task["status"] = "failed"
+                    task["error"] = str(e)
+            finally:
+                self._running_rebuild_tasks.pop(task_id, None)
+
+        task = asyncio.create_task(_run())
+        self._running_rebuild_tasks[task_id] = task
+        return task_id
+
+    def get_rebuild_progress(
+        self,
+        kb_id: str | None = None,
+        task_id: str | None = None,
+    ) -> dict | None:
+        target_task_id = task_id
+        if not target_task_id and kb_id:
+            target_task_id = self.kb_rebuild_task_map.get(kb_id)
+        if not target_task_id:
+            return None
+        return self.rebuild_tasks.get(target_task_id)
 
     async def retrieve(
         self,
@@ -246,6 +396,7 @@ class KnowledgeBaseManager:
                 "content": r.content,
                 "score": r.score,
                 "char_count": r.metadata.get("char_count", 0),
+                "metadata": r.metadata,
             }
             for r in results
         ]
@@ -270,7 +421,15 @@ class KnowledgeBaseManager:
         for i, result in enumerate(results, 1):
             lines.append(f"【知识 {i}】")
             lines.append(f"来源: {result.kb_name} / {result.doc_name}")
-            lines.append(f"内容: {result.content}")
+            index_mode = result.metadata.get("index_mode", "flat")
+            section_path = result.metadata.get("section_path", "")
+            if index_mode == "structure" and section_path:
+                lines.append(f"内容: [📖 {section_path}]")
+                lines.append(
+                    f"提示: 如需正文，请调用 astr_kb_read_section(doc_id='{result.doc_id}', section_path='{section_path}')",
+                )
+            else:
+                lines.append(f"内容: {result.content}")
             lines.append(f"相关度: {result.score:.2f}")
             lines.append("")
 
@@ -278,6 +437,11 @@ class KnowledgeBaseManager:
 
     async def terminate(self) -> None:
         """终止所有知识库实例,关闭数据库连接"""
+        for task_id, task in list(self._running_rebuild_tasks.items()):
+            if not task.done():
+                task.cancel()
+            self._running_rebuild_tasks.pop(task_id, None)
+
         for kb_id, kb_helper in self.kb_insts.items():
             try:
                 await kb_helper.terminate()

--- a/astrbot/core/knowledge_base/models.py
+++ b/astrbot/core/knowledge_base/models.py
@@ -32,6 +32,8 @@ class KnowledgeBase(BaseKBModel, table=True):
     description: str | None = Field(default=None, sa_type=Text)
     emoji: str | None = Field(default="📚", max_length=10)
     embedding_provider_id: str | None = Field(default=None, max_length=100)
+    active_index_provider_id: str | None = Field(default=None, max_length=100)
+    default_index_mode: str = Field(default="flat", max_length=20)
     rerank_provider_id: str | None = Field(default=None, max_length=100)
     # 分块配置参数
     chunk_size: int | None = Field(default=512, nullable=True)
@@ -81,6 +83,7 @@ class KBDocument(BaseKBModel, table=True):
     file_type: str = Field(max_length=20, nullable=False)
     file_size: int = Field(nullable=False)
     file_path: str = Field(max_length=512, nullable=False)
+    index_mode: str = Field(default="flat", max_length=20)
     chunk_count: int = Field(default=0, nullable=False)
     media_count: int = Field(default=0, nullable=False)
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
@@ -118,3 +121,35 @@ class KBMedia(BaseKBModel, table=True):
     file_size: int = Field(nullable=False)
     mime_type: str = Field(max_length=100, nullable=False)
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class DocSection(BaseKBModel, table=True):
+    """Structured document sections table."""
+
+    __tablename__ = "doc_sections"  # type: ignore
+
+    id: int | None = Field(
+        primary_key=True,
+        sa_column_kwargs={"autoincrement": True},
+        default=None,
+    )
+    section_id: str = Field(
+        max_length=36,
+        nullable=False,
+        unique=True,
+        default_factory=lambda: str(uuid.uuid4()),
+        index=True,
+    )
+    doc_id: str = Field(max_length=36, nullable=False, index=True)
+    kb_id: str = Field(max_length=36, nullable=False, index=True)
+    section_path: str = Field(max_length=1024, nullable=False, index=True)
+    section_level: int = Field(nullable=False, default=1)
+    section_title: str = Field(max_length=255, nullable=False)
+    section_body: str = Field(nullable=False, sa_type=Text)
+    parent_section_id: str | None = Field(default=None, max_length=36)
+    sort_order: int = Field(default=0, nullable=False)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column_kwargs={"onupdate": datetime.now(timezone.utc)},
+    )

--- a/astrbot/core/knowledge_base/retrieval/manager.py
+++ b/astrbot/core/knowledge_base/retrieval/manager.py
@@ -160,6 +160,7 @@ class RetrievalManager:
                         content=fr.content,
                         score=fr.score,
                         metadata={
+                            **(fr.metadata or {}),
                             "chunk_index": fr.chunk_index,
                             "char_count": len(fr.content),
                         },

--- a/astrbot/core/knowledge_base/retrieval/rank_fusion.py
+++ b/astrbot/core/knowledge_base/retrieval/rank_fusion.py
@@ -21,6 +21,7 @@ class FusedResult:
     kb_id: str
     content: str
     score: float
+    metadata: dict
 
 
 class RankFusion:
@@ -122,6 +123,7 @@ class RankFusion:
                         kb_id=sr.kb_id,
                         content=sr.content,
                         score=rrf_scores[identifier],
+                        metadata=sr.metadata,
                     ),
                 )
             elif identifier in vec_doc_id_to_dense:
@@ -136,6 +138,7 @@ class RankFusion:
                         kb_id=chunk_md["kb_id"],
                         content=vec_result.data["text"],
                         score=rrf_scores[identifier],
+                        metadata=chunk_md,
                     ),
                 )
 

--- a/astrbot/core/knowledge_base/retrieval/sparse_retriever.py
+++ b/astrbot/core/knowledge_base/retrieval/sparse_retriever.py
@@ -24,6 +24,7 @@ class SparseResult:
     kb_id: str
     content: str
     score: float
+    metadata: dict
 
 
 class SparseRetriever:
@@ -89,6 +90,7 @@ class SparseRetriever:
                     "doc_id": chunk_md["kb_doc_id"],
                     "kb_id": kb_id,
                     "text": doc["text"],
+                    "metadata": chunk_md,
                 }
                 for doc, chunk_md in zip(result, chunk_mds)
             ]
@@ -128,6 +130,7 @@ class SparseRetriever:
                     kb_id=chunk["kb_id"],
                     content=chunk["text"],
                     score=float(score),
+                    metadata=chunk.get("metadata", {}),
                 ),
             )
 

--- a/astrbot/core/knowledge_base/structure_parser.py
+++ b/astrbot/core/knowledge_base/structure_parser.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+
+@dataclass
+class SectionNode:
+    title: str
+    level: int
+    path: str
+    body: str
+    children: list[SectionNode] = field(default_factory=list)
+
+
+class StructureParser:
+    HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
+
+    async def parse_structure(self, text: str, file_type: str) -> list[SectionNode]:
+        ft = file_type.lower().strip(".")
+        if ft in {"md", "markdown", "txt"}:
+            return self._parse_markdown(text)
+        return []
+
+    def flatten(self, nodes: list[SectionNode]) -> list[SectionNode]:
+        result: list[SectionNode] = []
+        for node in nodes:
+            result.append(node)
+            result.extend(self.flatten(node.children))
+        return result
+
+    def _parse_markdown(self, text: str) -> list[SectionNode]:
+        heading_matches = list(self.HEADING_RE.finditer(text))
+        if not heading_matches:
+            return []
+
+        headings: list[tuple[int, str, int, int]] = []
+        for idx, match in enumerate(heading_matches):
+            level = len(match.group(1))
+            title = match.group(2).strip()
+            content_start = match.end()
+            content_end = (
+                heading_matches[idx + 1].start()
+                if idx + 1 < len(heading_matches)
+                else len(text)
+            )
+            headings.append((level, title, content_start, content_end))
+
+        roots: list[SectionNode] = []
+        stack: list[SectionNode] = []
+        for level, title, start, end in headings:
+            body = text[start:end].strip()
+            while stack and stack[-1].level >= level:
+                stack.pop()
+
+            parent_path = stack[-1].path if stack else ""
+            path = f"{parent_path} > {title}" if parent_path else title
+            node = SectionNode(
+                title=title,
+                level=level,
+                path=path,
+                body=body,
+            )
+            if stack:
+                stack[-1].children.append(node)
+            else:
+                roots.append(node)
+            stack.append(node)
+
+        return roots

--- a/astrbot/dashboard/routes/knowledge_base.py
+++ b/astrbot/dashboard/routes/knowledge_base.py
@@ -45,6 +45,7 @@ class KnowledgeBaseRoute(Route):
             "/kb/create": ("POST", self.create_kb),
             "/kb/get": ("GET", self.get_kb),
             "/kb/update": ("POST", self.update_kb),
+            "/kb/rebuild/progress": ("GET", self.get_rebuild_progress),
             "/kb/delete": ("POST", self.delete_kb),
             "/kb/stats": ("GET", self.get_kb_stats),
             # 文档管理
@@ -133,6 +134,7 @@ class KnowledgeBaseRoute(Route):
         task_id: str,
         kb_helper,
         files_to_upload: list,
+        index_mode: str,
         chunk_size: int,
         chunk_overlap: int,
         batch_size: int,
@@ -177,6 +179,7 @@ class KnowledgeBaseRoute(Route):
                         file_name=file_info["file_name"],
                         file_content=file_info["file_content"],
                         file_type=file_info["file_type"],
+                        index_mode=index_mode,
                         chunk_size=chunk_size,
                         chunk_overlap=chunk_overlap,
                         batch_size=batch_size,
@@ -359,6 +362,7 @@ class KnowledgeBaseRoute(Route):
             top_k_dense = data.get("top_k_dense")
             top_k_sparse = data.get("top_k_sparse")
             top_m_final = data.get("top_m_final")
+            default_index_mode = data.get("default_index_mode")
 
             # pre-check embedding dim
             if not embedding_provider_id:
@@ -413,6 +417,7 @@ class KnowledgeBaseRoute(Route):
                 top_k_dense=top_k_dense,
                 top_k_sparse=top_k_sparse,
                 top_m_final=top_m_final,
+                default_index_mode=default_index_mode,
             )
             kb = kb_helper.kb
 
@@ -485,6 +490,7 @@ class KnowledgeBaseRoute(Route):
             top_k_dense = data.get("top_k_dense")
             top_k_sparse = data.get("top_k_sparse")
             top_m_final = data.get("top_m_final")
+            default_index_mode = data.get("default_index_mode")
 
             # 检查是否至少提供了一个更新字段
             if all(
@@ -500,6 +506,7 @@ class KnowledgeBaseRoute(Route):
                     top_k_dense,
                     top_k_sparse,
                     top_m_final,
+                    default_index_mode,
                 ]
             ):
                 return Response().error("至少需要提供一个更新字段").__dict__
@@ -516,13 +523,17 @@ class KnowledgeBaseRoute(Route):
                 top_k_dense=top_k_dense,
                 top_k_sparse=top_k_sparse,
                 top_m_final=top_m_final,
+                default_index_mode=default_index_mode,
             )
 
             if not kb_helper:
                 return Response().error("知识库不存在").__dict__
 
             kb = kb_helper.kb
-            return Response().ok(kb.model_dump(), "更新知识库成功").__dict__
+            response_data = kb.model_dump()
+            if kb_helper.last_rebuild_task_id:
+                response_data["rebuild_task_id"] = kb_helper.last_rebuild_task_id
+            return Response().ok(response_data, "更新知识库成功").__dict__
 
         except ValueError as e:
             return Response().error(str(e)).__dict__
@@ -557,6 +568,29 @@ class KnowledgeBaseRoute(Route):
             logger.error(f"删除知识库失败: {e}")
             logger.error(traceback.format_exc())
             return Response().error(f"删除知识库失败: {e!s}").__dict__
+
+    async def get_rebuild_progress(self):
+        """获取索引重建进度
+
+        Query 参数:
+        - kb_id: 知识库 ID (可选)
+        - task_id: 重建任务 ID (可选)
+        """
+        try:
+            kb_manager = self._get_kb_manager()
+            kb_id = request.args.get("kb_id")
+            task_id = request.args.get("task_id")
+            if not kb_id and not task_id:
+                return Response().error("缺少参数 kb_id 或 task_id").__dict__
+
+            progress = kb_manager.get_rebuild_progress(kb_id=kb_id, task_id=task_id)
+            if not progress:
+                return Response().error("找不到重建任务").__dict__
+            return Response().ok(progress).__dict__
+        except Exception as e:
+            logger.error(f"获取重建进度失败: {e}")
+            logger.error(traceback.format_exc())
+            return Response().error(f"获取重建进度失败: {e!s}").__dict__
 
     async def get_kb_stats(self):
         """获取知识库统计信息
@@ -666,6 +700,7 @@ class KnowledgeBaseRoute(Route):
             batch_size = 32
             tasks_limit = 3
             max_retries = 3
+            index_mode = "flat"
             files_to_upload = []  # 存储待上传的文件信息列表
 
             if content_type and "multipart/form-data" not in content_type:
@@ -681,6 +716,7 @@ class KnowledgeBaseRoute(Route):
             batch_size = int(form_data.get("batch_size", 32))
             tasks_limit = int(form_data.get("tasks_limit", 3))
             max_retries = int(form_data.get("max_retries", 3))
+            index_mode = form_data.get("index_mode", "flat")
             if not kb_id:
                 return Response().error("缺少参数 kb_id").__dict__
 
@@ -749,6 +785,7 @@ class KnowledgeBaseRoute(Route):
                     task_id=task_id,
                     kb_helper=kb_helper,
                     files_to_upload=files_to_upload,
+                    index_mode=index_mode,
                     chunk_size=chunk_size,
                     chunk_overlap=chunk_overlap,
                     batch_size=batch_size,

--- a/astrbot/dashboard/utils.py
+++ b/astrbot/dashboard/utils.py
@@ -50,7 +50,7 @@ async def generate_tsne_visualization(
             return None
 
         kb = kb_helper.kb
-        index_path = kb_helper.kb_dir / "index.faiss"
+        index_path = kb_helper.get_active_index_path()
 
         # 读取 FAISS 索引
         if not index_path.exists():

--- a/docs/knowledge-base-architecture.md
+++ b/docs/knowledge-base-architecture.md
@@ -148,7 +148,7 @@
 | section_id | VARCHAR(36) UNIQUE | 章节唯一标识 |
 | doc_id | VARCHAR(36) | 所属文档 |
 | kb_id | VARCHAR(36) | 所属知识库 |
-| section_path | VARCHAR(1024) | 章节路径，如 `"第一章/API 设计"` |
+| section_path | VARCHAR(1024) | 章节路径，如 `"第一章 > API 设计"` |
 | section_level | INTEGER | 标题层级 (1-6) |
 | section_title | VARCHAR(255) | 章节标题 |
 | section_body | TEXT | 章节正文内容 |
@@ -334,8 +334,8 @@ API 设计正文...
 输出（SectionNode 树）：
 ```
 SectionNode(title="第一章", level=1, path="第一章", body="正文内容...")
-├── SectionNode(title="API 设计", level=2, path="第一章/API 设计", body="API 设计正文...")
-└── SectionNode(title="数据模型", level=2, path="第一章/数据模型", body="数据模型正文...")
+├── SectionNode(title="API 设计", level=2, path="第一章 > API 设计", body="API 设计正文...")
+└── SectionNode(title="数据模型", level=2, path="第一章 > 数据模型", body="数据模型正文...")
 SectionNode(title="第二章", level=1, path="第二章", body="")
 ```
 
@@ -571,7 +571,7 @@ Dense 检索           Sparse 检索
 
 ### structure_parser.py
 
-`StructureParser` 类，解析 Markdown 标题层级为 `SectionNode` 树。`flatten()` 展平为列表，每个节点的 `path` 字段（如 `"第一章/API 设计"`）作为唯一标识。
+`StructureParser` 类，解析 Markdown 标题层级为 `SectionNode` 树。`flatten()` 展平为列表，每个节点的 `path` 字段（如 `"第一章 > API 设计"`）作为唯一标识。
 
 ### kb_helper.py
 

--- a/docs/knowledge-base-architecture.md
+++ b/docs/knowledge-base-architecture.md
@@ -1,0 +1,606 @@
+# 知识库底层架构设计说明
+
+> 对应 Issue: #5262
+> 分支: `rag-enhancement`
+> 最后更新: 2026-03-08
+
+---
+
+## 1. 概述
+
+本次重构在原有知识库系统的基础上引入两个核心能力：
+
+1. **Provider 隔离的 FAISS 索引** — 支持 Embedding 模型热切换，无需全量重建即可在不同模型间切换
+2. **结构化文档索引** — 支持按 Markdown 标题层级建立章节索引，由 LLM 按需读取正文
+
+整体目标是让知识库系统更灵活、可扩展，同时保持与旧版本的向后兼容。
+
+---
+
+## 2. 系统架构总览
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                     Dashboard / API                      │
+│  /kb/create  /kb/update  /kb/rebuild/progress  ...      │
+└───────────────────────────┬─────────────────────────────┘
+                            │
+                ┌───────────▼───────────┐
+                │  KnowledgeBaseManager  │
+                │      (kb_mgr.py)       │
+                │                        │
+                │  - kb_insts: dict      │
+                │  - rebuild_tasks       │
+                │  - index_rebuilder     │
+                └───────┬───────────────┘
+                        │
+          ┌─────────────▼──────────────┐
+          │         KBHelper            │
+          │       (kb_helper.py)        │
+          │                             │
+          │  - kb: KnowledgeBase        │
+          │  - vec_db: FaissVecDB       │
+          │  - kb_db: KBSQLiteDatabase  │
+          │  - chunker                  │
+          └──────┬──────────────┬───────┘
+                 │              │
+    ┌────────────▼───┐   ┌─────▼──────────────┐
+    │   FaissVecDB   │   │  KBSQLiteDatabase   │
+    │  (vec_db.py)   │   │ (kb_db_sqlite.py)   │
+    │                │   │                      │
+    │ ┌────────────┐ │   │  knowledge_bases     │
+    │ │ Document   │ │   │  kb_documents        │
+    │ │ Storage    │ │   │  kb_media            │
+    │ │ (doc.db)   │ │   │  doc_sections (NEW)  │
+    │ └────────────┘ │   └──────────────────────┘
+    │ ┌────────────┐ │
+    │ │ Embedding  │ │
+    │ │ Storage    │ │
+    │ │ (.faiss)   │ │
+    │ └────────────┘ │
+    └────────────────┘
+```
+
+### 关键数据流
+
+```
+用户上传文档
+    │
+    ├── flat 模式 ──→ 解析 → 分块(Chunker) → Embedding → FAISS + doc.db
+    │
+    └── structure 模式 ──→ 解析 → StructureParser → 章节 path Embedding → FAISS + doc.db + doc_sections
+```
+
+```
+用户检索
+    │
+    ├── Dense 检索 (FAISS 向量相似度)
+    ├── Sparse 检索 (BM25)
+    ├── RRF 融合
+    ├── Rerank (可选)
+    │
+    ├── flat 结果 ──→ 直接返回 chunk 正文
+    └── structure 结果 ──→ 返回章节路径标记 → LLM 调用 ReadDocumentSectionTool 获取正文
+```
+
+---
+
+## 3. 数据模型
+
+### 3.1 元数据库 (kb.db)
+
+位于 `data/knowledge_base/kb.db`，使用 SQLite + SQLAlchemy async，存储所有知识库的元数据。
+
+#### knowledge_bases 表
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| id | INTEGER PK | 自增主键 |
+| kb_id | VARCHAR(36) UNIQUE | 知识库唯一标识 |
+| kb_name | VARCHAR(100) UNIQUE | 知识库名称 |
+| description | TEXT | 描述 |
+| emoji | VARCHAR(10) | 图标 |
+| embedding_provider_id | VARCHAR(100) | **期望**使用的 Embedding Provider |
+| **active_index_provider_id** | VARCHAR(100) | **实际**生效的索引 Provider (NEW) |
+| **default_index_mode** | VARCHAR(20) | 默认索引模式: `flat` / `structure` (NEW) |
+| rerank_provider_id | VARCHAR(100) | Rerank Provider |
+| chunk_size | INTEGER | 分块大小 |
+| chunk_overlap | INTEGER | 分块重叠 |
+| top_k_dense | INTEGER | 稠密检索数量 |
+| top_k_sparse | INTEGER | 稀疏检索数量 |
+| top_m_final | INTEGER | 最终返回数量 |
+| doc_count | INTEGER | 文档计数 |
+| chunk_count | INTEGER | 块计数 |
+| created_at | DATETIME | 创建时间 |
+| updated_at | DATETIME | 更新时间 |
+
+**`embedding_provider_id` 与 `active_index_provider_id` 的区别：**
+
+- `embedding_provider_id`：用户在 Dashboard 上配置的"期望"使用的模型
+- `active_index_provider_id`：当前 FAISS 索引实际对应的模型
+
+当两者不一致时，系统会自动触发后台索引重建。重建完成后两者同步。
+
+#### kb_documents 表
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| id | INTEGER PK | 自增主键 |
+| doc_id | VARCHAR(36) UNIQUE | 文档唯一标识 |
+| kb_id | VARCHAR(36) | 所属知识库 |
+| doc_name | VARCHAR(255) | 文档名称 |
+| file_type | VARCHAR(20) | 文件类型 |
+| file_size | INTEGER | 文件大小 |
+| file_path | VARCHAR(512) | 文件路径 |
+| **index_mode** | VARCHAR(20) | 索引模式: `flat` / `structure` (NEW) |
+| chunk_count | INTEGER | 块数量 |
+| media_count | INTEGER | 媒体数量 |
+| created_at | DATETIME | 创建时间 |
+| updated_at | DATETIME | 更新时间 |
+
+#### doc_sections 表 (NEW)
+
+存储结构化文档的章节信息，供 LLM 按需读取正文。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| id | INTEGER PK | 自增主键 |
+| section_id | VARCHAR(36) UNIQUE | 章节唯一标识 |
+| doc_id | VARCHAR(36) | 所属文档 |
+| kb_id | VARCHAR(36) | 所属知识库 |
+| section_path | VARCHAR(1024) | 章节路径，如 `"第一章/API 设计"` |
+| section_level | INTEGER | 标题层级 (1-6) |
+| section_title | VARCHAR(255) | 章节标题 |
+| section_body | TEXT | 章节正文内容 |
+| parent_section_id | VARCHAR(36) | 父章节 ID |
+| sort_order | INTEGER | 排序序号 |
+
+### 3.2 向量文档库 (doc.db)
+
+每个知识库独立一份，位于 `data/knowledge_base/{kb_id}/doc.db`。
+
+#### documents 表
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| id | INTEGER PK | 自增主键，同时作为 FAISS 的 int ID |
+| doc_id | VARCHAR | chunk UUID |
+| text | TEXT | chunk 文本内容 |
+| metadata | TEXT (JSON) | 元数据 JSON |
+| is_indexed | BOOLEAN | 索引状态标记 (NEW) |
+| source_hash | TEXT | 内容 SHA256 哈希 (NEW) |
+| kb_doc_id | GENERATED | 从 metadata JSON 提取 |
+| user_id | GENERATED | 从 metadata JSON 提取 |
+| created_at | DATETIME | 创建时间 |
+| updated_at | DATETIME | 更新时间 |
+
+### 3.3 FAISS 索引文件
+
+```
+data/knowledge_base/{kb_id}/
+├── doc.db                                    # 向量文档数据库
+├── index.{provider_id}.faiss                 # Provider 隔离的 FAISS 索引 (NEW)
+├── medias/{kb_id}/                           # 媒体文件
+└── files/{kb_id}/                            # 原始文件
+```
+
+**旧版命名**：`index.faiss`
+**新版命名**：`index.{normalized_provider_id}.faiss`
+
+provider_id 通过 `normalize_provider_id()` 处理，将文件系统不安全字符替换为 `_`。
+
+---
+
+## 4. 功能一：Provider 隔离索引与热切换
+
+### 4.1 设计目标
+
+用户在 Dashboard 上切换 Embedding 模型时，系统应：
+
+1. 不阻塞当前服务 — 旧索引继续可用
+2. 后台增量重建新索引
+3. 重建完成后原子切换到新索引
+4. 支持进度查询
+
+### 4.2 索引路径规则
+
+```python
+# index_path.py
+
+def normalize_provider_id(provider_id: str) -> str:
+    """将 provider_id 中的非安全字符替换为下划线"""
+    return re.sub(r"[^a-zA-Z0-9_.-]", "_", provider_id)
+
+def build_index_path(kb_dir: Path, provider_id: str) -> Path:
+    return kb_dir / f"index.{normalize_provider_id(provider_id)}.faiss"
+```
+
+示例：
+- provider_id = `openai/text-embedding-3-small` → 文件名 `index.openai_text-embedding-3-small.faiss`
+- provider_id = `local-bge-m3` → 文件名 `index.local-bge-m3.faiss`
+
+### 4.3 索引加载流程
+
+```
+KBHelper.initialize()
+    │
+    ├── active_index_provider_id 为空？
+    │   └── 是 → 设为 embedding_provider_id，持久化
+    │
+    └── _ensure_vec_db()
+            │
+            └── get_active_index_path()
+                    │
+                    └── build_index_path(kb_dir, active_provider_id)
+                            │
+                            └── FaissVecDB(index_store_path=...)
+```
+
+### 4.4 索引重建流程
+
+触发条件：`embedding_provider_id != active_index_provider_id`
+
+```
+KnowledgeBaseManager.start_rebuild_index(kb_id, new_provider_id)
+    │
+    ├── 检查是否已有正在进行的重建任务
+    │
+    ├── 创建 task_id，记录到 rebuild_tasks
+    │
+    └── asyncio.create_task(_run())
+            │
+            └── IndexRebuilder.sync()
+                    │
+                    ├── 1. 获取新 Provider 实例
+                    ├── 2. 创建新的 EmbeddingStorage（新路径）
+                    ├── 3. 计算增量 diff：
+                    │       doc_int_ids = doc.db 中所有 ID
+                    │       index_int_ids = 新 FAISS 中已有 ID
+                    │       to_delete = index_int_ids - doc_int_ids
+                    │       to_add = doc_int_ids - index_int_ids
+                    ├── 4. 批量删除 to_delete
+                    ├── 5. 批量 embedding + 插入 to_add
+                    ├── 6. 更新 active_index_provider_id → persist_kb()
+                    └── 7. switch_index() 切换内存中的 FAISS 实例
+```
+
+### 4.5 进度查询
+
+Dashboard 可通过 `GET /kb/rebuild/progress?kb_id=xxx` 轮询重建进度：
+
+```json
+{
+  "task_id": "uuid",
+  "kb_id": "uuid",
+  "provider_id": "new-provider-id",
+  "status": "processing",   // processing | completed | failed
+  "stage": "embedding",     // prepare | deleting | embedding | finished
+  "current": 150,
+  "total": 500,
+  "error": null
+}
+```
+
+### 4.6 switch_index 热切换
+
+```python
+# vec_db.py
+async def switch_index(self, index_store_path, embedding_provider, rerank_provider=None):
+    self.index_store_path = index_store_path
+    self.embedding_provider = embedding_provider
+    self.rerank_provider = rerank_provider
+    self.embedding_storage = EmbeddingStorage(
+        embedding_provider.get_dim(),
+        index_store_path,
+    )
+```
+
+切换后，新的检索请求会使用新的 Provider 和新的 FAISS 索引，旧索引文件保留在磁盘上不删除。
+
+---
+
+## 5. 功能二：结构化文档索引
+
+### 5.1 设计目标
+
+对于有清晰标题层级的文档（如 Markdown），不做全文分块，而是按标题结构建立章节索引。检索时只返回匹配的章节路径，由 LLM 决定是否调用工具读取完整正文。
+
+**优势**：
+- 避免将长文档切成碎片导致上下文丢失
+- LLM 可以按需获取完整章节，保持内容完整性
+- 减少无关内容的 token 消耗
+
+### 5.2 结构解析
+
+`StructureParser` 解析 Markdown 标题层级：
+
+```python
+# structure_parser.py
+
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
+```
+
+输入：
+```markdown
+# 第一章
+正文内容...
+## API 设计
+API 设计正文...
+## 数据模型
+数据模型正文...
+# 第二章
+```
+
+输出（SectionNode 树）：
+```
+SectionNode(title="第一章", level=1, path="第一章", body="正文内容...")
+├── SectionNode(title="API 设计", level=2, path="第一章/API 设计", body="API 设计正文...")
+└── SectionNode(title="数据模型", level=2, path="第一章/数据模型", body="数据模型正文...")
+SectionNode(title="第二章", level=1, path="第二章", body="")
+```
+
+`flatten()` 将树形结构展平为列表，保留 path 字段作为唯一标识。
+
+支持的文件类型：`md`、`markdown`、`txt`。其他类型返回空列表，自动 fallback 到 flat 模式。
+
+### 5.3 结构化上传流程
+
+```
+kb_helper._upload_document_structured()
+    │
+    ├── 1. 解析文档 → parse_result.text
+    ├── 2. StructureParser.parse_structure() → SectionNode 树
+    ├── 3. flatten() → 章节列表
+    │
+    ├── 4. 如果章节列表为空 → fallback 到 flat 模式
+    │
+    ├── 5. 向量化：contents = [section.path for section in sections]
+    │       （当前嵌入的是章节路径字符串）
+    │
+    ├── 6. 插入 doc.db：documents 表（text = section.path, metadata 含 index_mode/section_path）
+    ├── 7. 插入 FAISS：embedding_storage.insert_batch()
+    │
+    ├── 8. 插入 kb.db：
+    │       ├── kb_documents 表（index_mode = "structure"）
+    │       └── doc_sections 表（每个章节一条记录，存储完整 body）
+    │
+    └── 9. 更新统计
+```
+
+### 5.4 结构化检索流程
+
+检索结果中，结构化文档的 chunk metadata 包含 `index_mode: "structure"` 和 `section_path`。
+
+**上下文格式化**（`kb_mgr._format_context`）：
+
+```python
+if index_mode == "structure" and section_path:
+    # 不直接返回正文，而是返回章节路径标记
+    lines.append(f"内容: [📖 {section_path}]")
+    lines.append(
+        f"提示: 如需正文，请调用 astr_kb_read_section("
+        f"doc_id='{result.doc_id}', section_path='{section_path}')"
+    )
+```
+
+### 5.5 ReadDocumentSectionTool
+
+LLM 可用的工具，按 doc_id + section_path 从 `doc_sections` 表读取完整正文：
+
+```python
+@dataclass
+class ReadDocumentSectionTool(FunctionTool[AstrAgentContext]):
+    name: str = "astr_kb_read_section"
+    # parameters: doc_id, section_path
+```
+
+调用链：
+```
+LLM 调用 astr_kb_read_section(doc_id, section_path)
+    → read_knowledge_base_section()
+        → kb_mgr.read_document_section(kb_names, doc_id, section_path)
+            → kb_db.get_doc_section(kb_id, doc_id, section_path)
+                → 精确匹配 section_path
+                → 如失败，LIKE 模糊匹配
+```
+
+该工具仅在知识库中存在结构化文档时注册（`has_structured_docs_by_names()`）。
+
+---
+
+## 6. 数据库迁移
+
+### 6.1 迁移链路
+
+```
+启动 → initialize() → create_all (建表) → migrate_to_v1 → migrate_to_v2 → migrate_to_v3
+```
+
+每次迁移都是幂等的，通过 `try/except` 在 `ALTER TABLE ADD COLUMN` 时捕获"列已存在"异常。
+
+### 6.2 migrate_to_v1
+
+创建查询优化索引（`CREATE INDEX IF NOT EXISTS`），纯幂等操作。
+
+### 6.3 migrate_to_v2
+
+**变更内容**：
+1. `knowledge_bases` 表添加 `active_index_provider_id` 列
+2. 遍历所有知识库，回填 `active_index_provider_id = embedding_provider_id`
+3. 重命名 FAISS 索引文件：`index.faiss` → `index.{provider_id}.faiss`
+
+**文件重命名逻辑**：
+```python
+old_index_path = kb_root / kb.kb_id / "index.faiss"
+new_index_path = build_index_path(kb_root / kb.kb_id, kb.embedding_provider_id)
+if old_index_path.exists() and not new_index_path.exists():
+    old_index_path.rename(new_index_path)
+```
+
+**安全性**：
+- 只在旧文件存在且新文件不存在时重命名，幂等
+- 重命名是原子操作（同一文件系统内）
+- 不删除任何数据，只是文件改名
+
+### 6.4 migrate_to_v3
+
+**变更内容**：
+1. `knowledge_bases` 表添加 `default_index_mode` 列（默认 `'flat'`）
+2. `kb_documents` 表添加 `index_mode` 列（默认 `'flat'`）
+3. 回填所有 NULL 值为 `'flat'`
+
+纯 schema 变更 + 数据回填，不涉及文件操作。
+
+### 6.5 DocumentStorage 迁移
+
+**变更内容**：
+1. `documents` 表添加 `is_indexed` 列
+2. `documents` 表添加 `source_hash` 列
+3. 回填 `is_indexed = 1`
+
+### 6.6 向后兼容
+
+- 所有迁移只做 **ADD COLUMN**，不 DROP / ALTER 现有列
+- `create_all` 只创建不存在的表，不修改已有表
+- 旧数据完全保留，新列以合理默认值填充
+- 旧版 FAISS 文件被重命名而非删除
+
+---
+
+## 7. 文件目录结构
+
+```
+data/knowledge_base/
+├── kb.db                                          # 元数据库（所有知识库共用）
+│
+├── {kb_id_1}/
+│   ├── doc.db                                     # 向量文档库
+│   ├── index.openai_text-embedding-3-small.faiss  # Provider A 的索引
+│   ├── index.local-bge-m3.faiss                   # Provider B 的索引（切换后保留）
+│   ├── medias/{kb_id_1}/                          # 文档中提取的媒体
+│   └── files/{kb_id_1}/                           # 原始上传文件
+│
+├── {kb_id_2}/
+│   ├── doc.db
+│   ├── index.{provider_id}.faiss
+│   └── ...
+```
+
+多个 `.faiss` 文件可以共存，只有 `active_index_provider_id` 对应的那个会被加载。
+
+---
+
+## 8. 检索管线
+
+```
+           查询文本
+              │
+    ┌─────────┼─────────┐
+    ▼                    ▼
+Dense 检索           Sparse 检索
+(FAISS L2)            (BM25)
+    │                    │
+    ▼                    ▼
+ 向量结果            稀疏结果
+    │                    │
+    └─────────┬──────────┘
+              ▼
+      RRF 融合排序
+        (top_k)
+              │
+              ▼
+     Rerank (可选)
+   (Cohere/BGE-reranker)
+              │
+              ▼
+       top_m 最终结果
+              │
+    ┌─────────┴─────────┐
+    ▼                    ▼
+ flat chunk         structure marker
+ → 直接返回正文      → 返回章节路径
+                     → LLM 按需调用
+                       ReadDocumentSectionTool
+```
+
+### 检索参数
+
+| 参数 | 说明 | 默认值 |
+|------|------|--------|
+| top_k_dense | Dense 检索返回数量 | 50 |
+| top_k_sparse | Sparse 检索返回数量 | 50 |
+| top_k_fusion | RRF 融合后保留数量 | 20 |
+| top_m_final | 最终返回给 LLM 的数量 | 5 |
+
+---
+
+## 9. API 接口
+
+### 新增接口
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/kb/rebuild/progress` | 查询索引重建进度 |
+
+### 变更接口
+
+| 方法 | 路径 | 变更 |
+|------|------|------|
+| POST | `/kb/create` | 新增 `default_index_mode` 参数 |
+| POST | `/kb/update` | 新增 `default_index_mode` 参数；切换 Provider 时返回 `rebuild_task_id` |
+| POST | `/kb/document/upload` | 新增 `index_mode` 参数 |
+
+### LLM 工具
+
+| 工具名 | 说明 | 注册条件 |
+|--------|------|----------|
+| `astr_kb_search` | 知识库检索（已有） | 知识库启用时 |
+| `astr_kb_read_section` | 读取结构化章节正文（NEW） | 存在 structure 模式文档时 |
+
+---
+
+## 10. 关键模块说明
+
+### index_path.py
+
+纯工具函数，无状态。负责构建文件系统安全的 FAISS 索引路径。
+
+### index_rebuilder.py
+
+`IndexRebuilder` 类，实现增量同步逻辑。通过比较 doc.db 中的文档 ID 集合和新 FAISS 索引中的 ID 集合，计算 `to_add` 和 `to_delete`，避免全量重建。
+
+### structure_parser.py
+
+`StructureParser` 类，解析 Markdown 标题层级为 `SectionNode` 树。`flatten()` 展平为列表，每个节点的 `path` 字段（如 `"第一章/API 设计"`）作为唯一标识。
+
+### kb_helper.py
+
+知识库实例的核心操作类。新增：
+- `get_active_index_path()` — 根据 active provider 构建索引路径
+- `persist_kb()` — 持久化 KB 元数据变更
+- `_upload_document_structured()` — 结构化文档上传
+
+### kb_mgr.py
+
+知识库管理器。新增：
+- `start_rebuild_index()` — 启动后台索引重建
+- `get_rebuild_progress()` — 查询重建进度
+- `has_structured_docs_by_names()` — 检查是否有结构化文档
+- `read_document_section()` — 读取章节正文
+- 启动时自检：Provider 不一致则自动触发重建
+
+---
+
+## 11. 备份与恢复
+
+### 导出
+
+- 使用 glob 模式 `index*.faiss` 匹配所有 Provider 的索引文件
+- `doc_sections` 表包含在 `KB_METADATA_MODELS` 中，随知识库元数据一起导出
+- `schema_version.kb_db` 标记为 `v3`
+
+### 导入
+
+- 兼容旧版单文件 `index.faiss` 和新版多文件 `index.{provider}.faiss`
+- 导入后调用 `load_kbs()` 重新初始化所有知识库实例
+- 如果导入的备份来自旧版本，`migrate_to_v2/v3` 会在 `_init_kb_database` 中自动执行

--- a/tests/core/test_kb_architecture_refactor.py
+++ b/tests/core/test_kb_architecture_refactor.py
@@ -1,0 +1,397 @@
+import asyncio
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from astrbot.core.db.vec_db.faiss_impl.vec_db import FaissVecDB
+from astrbot.core.knowledge_base.index_rebuilder import IndexRebuilder
+from astrbot.core.knowledge_base.kb_db_sqlite import KBSQLiteDatabase
+from astrbot.core.knowledge_base.kb_helper import KBHelper
+from astrbot.core.knowledge_base.kb_mgr import KnowledgeBaseManager
+from astrbot.core.knowledge_base.models import DocSection, KnowledgeBase
+from astrbot.core.knowledge_base.structure_parser import StructureParser
+from astrbot.core.provider.provider import EmbeddingProvider
+
+
+class _FakeEmbeddingProvider(EmbeddingProvider):
+    def __init__(self) -> None:
+        super().__init__(provider_config={"id": "test-ep", "type": "openai_embedding"}, provider_settings={})
+
+    def get_dim(self) -> int:
+        return 3
+
+    async def get_embedding(self, text: str) -> list[float]:
+        return [1.0, 0.0, 0.0]
+
+    async def get_embeddings(self, texts: list[str]) -> list[list[float]]:
+        return [[1.0, 0.0, 0.0] for _ in texts]
+
+    async def get_embeddings_batch(
+        self,
+        texts: list[str],
+        batch_size: int = 32,
+        tasks_limit: int = 3,
+        max_retries: int = 3,
+        progress_callback=None,
+    ) -> list[list[float]]:
+        if progress_callback:
+            await progress_callback(len(texts), len(texts))
+        return [[1.0, 0.0, 0.0] for _ in texts]
+
+
+class _FakeProviderManager:
+    def __init__(self, provider):
+        self._provider = provider
+
+    async def get_provider_by_id(self, provider_id: str):
+        return self._provider
+
+
+@pytest.mark.asyncio
+async def test_structure_parser_uses_unambiguous_separator() -> None:
+    parser = StructureParser()
+    text = "# API/REST Design\n## Endpoint/Users\nContent"
+    roots = await parser.parse_structure(text, "md")
+    nodes = parser.flatten(roots)
+    assert nodes[0].path == "API/REST Design"
+    assert nodes[1].path == "API/REST Design > Endpoint/Users"
+
+
+@pytest.mark.asyncio
+async def test_index_rebuilder_progress_total_uses_filtered_docs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeStorage:
+        def __init__(self, dimension: int, path: str) -> None:
+            self.dimension = dimension
+            self.path = path
+
+        def get_all_ids(self) -> list[int]:
+            return []
+
+        async def delete(self, ids: list[int]) -> None:
+            return None
+
+        async def insert_batch(self, vectors: np.ndarray, ids: list[int]) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "astrbot.core.knowledge_base.index_rebuilder.EmbeddingStorage",
+        _FakeStorage,
+    )
+
+    order: list[str] = []
+    progress_records: list[tuple[str, int, int]] = []
+
+    class _FakeDocStorage:
+        async def get_all_int_ids(self) -> list[int]:
+            return [1, 2]
+
+        async def get_documents_by_int_ids(self, ids: list[int]) -> list[dict]:
+            return [{"id": 1, "text": "valid text"}, {"id": 2, "text": None}]
+
+    class _FakeVecDB:
+        def __init__(self) -> None:
+            self.document_storage = _FakeDocStorage()
+
+        async def switch_index(self, **kwargs) -> None:
+            order.append("switch")
+
+    kb = SimpleNamespace(kb_id="kb-1", active_index_provider_id="old-provider")
+    kb_helper = SimpleNamespace(
+        kb=kb,
+        kb_dir=tmp_path / "kb1",
+        vec_db=_FakeVecDB(),
+        get_embedding_provider_by_id=lambda provider_id: asyncio.sleep(
+            0,
+            result=_FakeEmbeddingProvider(),
+        ),
+        get_rp=lambda: asyncio.sleep(0, result=None),
+    )
+
+    async def _persist_kb() -> None:
+        order.append("persist")
+
+    kb_helper.persist_kb = _persist_kb
+
+    rebuilder = IndexRebuilder()
+    await rebuilder.sync(
+        kb_helper=kb_helper,
+        new_provider_id="new-provider",
+        progress_callback=lambda s, c, t: asyncio.sleep(
+            0,
+            result=progress_records.append((s, c, t)),
+        ),
+    )
+
+    assert order == ["switch", "persist"]
+    assert kb.active_index_provider_id == "new-provider"
+    assert progress_records[0] == ("prepare", 0, 1)
+    assert progress_records[-1] == ("finished", 1, 1)
+
+
+@pytest.mark.asyncio
+async def test_index_rebuilder_does_not_persist_if_switch_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeStorage:
+        def __init__(self, dimension: int, path: str) -> None:
+            self.dimension = dimension
+            self.path = path
+
+        def get_all_ids(self) -> list[int]:
+            return []
+
+        async def delete(self, ids: list[int]) -> None:
+            return None
+
+        async def insert_batch(self, vectors: np.ndarray, ids: list[int]) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "astrbot.core.knowledge_base.index_rebuilder.EmbeddingStorage",
+        _FakeStorage,
+    )
+
+    class _FakeDocStorage:
+        async def get_all_int_ids(self) -> list[int]:
+            return [1]
+
+        async def get_documents_by_int_ids(self, ids: list[int]) -> list[dict]:
+            return [{"id": 1, "text": "valid text"}]
+
+    class _FakeVecDB:
+        def __init__(self) -> None:
+            self.document_storage = _FakeDocStorage()
+
+        async def switch_index(self, **kwargs) -> None:
+            raise RuntimeError("switch failed")
+
+    persisted = False
+    kb = SimpleNamespace(kb_id="kb-2", active_index_provider_id="old-provider")
+    kb_helper = SimpleNamespace(
+        kb=kb,
+        kb_dir=tmp_path / "kb2",
+        vec_db=_FakeVecDB(),
+        get_embedding_provider_by_id=lambda provider_id: asyncio.sleep(
+            0,
+            result=_FakeEmbeddingProvider(),
+        ),
+        get_rp=lambda: asyncio.sleep(0, result=None),
+    )
+
+    async def _persist_kb() -> None:
+        nonlocal persisted
+        persisted = True
+
+    kb_helper.persist_kb = _persist_kb
+
+    rebuilder = IndexRebuilder()
+    with pytest.raises(RuntimeError):
+        await rebuilder.sync(kb_helper=kb_helper, new_provider_id="new-provider")
+
+    assert persisted is False
+    assert kb.active_index_provider_id == "old-provider"
+
+
+@pytest.mark.asyncio
+async def test_kb_db_upsert_doc_section_and_deterministic_contains(
+    tmp_path: Path,
+) -> None:
+    db = KBSQLiteDatabase((tmp_path / "kb.db").as_posix())
+    await db.initialize()
+
+    section_id = "sec-fixed"
+    section_1 = DocSection(
+        section_id=section_id,
+        doc_id="doc-1",
+        kb_id="kb-1",
+        section_path="Guide > API",
+        section_level=1,
+        section_title="API",
+        section_body="old body",
+        sort_order=0,
+    )
+    await db.upsert_doc_section(section_1)
+    section_2 = DocSection(
+        section_id=section_id,
+        doc_id="doc-1",
+        kb_id="kb-1",
+        section_path="Guide > API",
+        section_level=1,
+        section_title="API",
+        section_body="new body",
+        sort_order=0,
+    )
+    await db.upsert_doc_section(section_2)
+
+    fetched = await db.get_doc_section("kb-1", "doc-1", "Guide > API")
+    assert fetched is not None
+    assert fetched.section_body == "new body"
+
+    now = datetime.now(timezone.utc)
+    s3 = DocSection(
+        section_id="sec-a",
+        doc_id="doc-2",
+        kb_id="kb-1",
+        section_path="prefix A% path 1",
+        section_level=1,
+        section_title="A1",
+        section_body="body 1",
+        sort_order=0,
+        created_at=now,
+        updated_at=now,
+    )
+    s4 = DocSection(
+        section_id="sec-b",
+        doc_id="doc-2",
+        kb_id="kb-1",
+        section_path="prefix A% path 2",
+        section_level=1,
+        section_title="A2",
+        section_body="body 2",
+        sort_order=1,
+        created_at=now + timedelta(seconds=1),
+        updated_at=now + timedelta(seconds=1),
+    )
+    await db.upsert_doc_section(s3)
+    await db.upsert_doc_section(s4)
+
+    contains_result = await db.get_doc_section("kb-1", "doc-2", "A%")
+    assert contains_result is not None
+    assert contains_result.section_path == "prefix A% path 1"
+
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_faiss_vecdb_switch_index_lock_and_close(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeStorage:
+        def __init__(self, dimension: int, path: str) -> None:
+            self.dimension = dimension
+            self.path = path
+            self.closed = False
+
+        async def close(self) -> None:
+            self.closed = True
+
+        async def search(self, vector: np.ndarray, k: int):
+            return np.array([[0.0]], dtype=np.float32), np.array([[-1]], dtype=np.int64)
+
+    monkeypatch.setattr(
+        "astrbot.core.db.vec_db.faiss_impl.vec_db.EmbeddingStorage",
+        _FakeStorage,
+    )
+
+    db = FaissVecDB.__new__(FaissVecDB)
+    db._index_switch_lock = asyncio.Lock()
+    db.embedding_provider = _FakeEmbeddingProvider()
+    db.rerank_provider = None
+    db.document_storage = SimpleNamespace(
+        get_documents=lambda **kwargs: asyncio.sleep(0, result=[]),
+    )
+    old_storage = _FakeStorage(3, "old.faiss")
+    db.embedding_storage = old_storage
+
+    provider = _FakeEmbeddingProvider()
+    await db._index_switch_lock.acquire()
+    switch_task = asyncio.create_task(
+        db.switch_index("new.faiss", provider, None),
+    )
+    await asyncio.sleep(0.05)
+    assert not switch_task.done()
+    db._index_switch_lock.release()
+    await switch_task
+    assert old_storage.closed is True
+
+    await db._index_switch_lock.acquire()
+    retrieve_task = asyncio.create_task(db.retrieve("q"))
+    await asyncio.sleep(0.05)
+    assert not retrieve_task.done()
+    db._index_switch_lock.release()
+    result = await retrieve_task
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_kb_helper_structured_upload_progress_order(tmp_path: Path) -> None:
+    kb_db = KBSQLiteDatabase((tmp_path / "kb_meta.db").as_posix())
+    await kb_db.initialize()
+    await kb_db.migrate_to_v1()
+    await kb_db.migrate_to_v2(tmp_path.as_posix())
+    await kb_db.migrate_to_v3()
+
+    provider = _FakeEmbeddingProvider()
+    kb = KnowledgeBase(
+        kb_name="kb-test",
+        embedding_provider_id="ep-1",
+        active_index_provider_id="ep-1",
+        default_index_mode="structure",
+    )
+    async with kb_db.get_db() as session:
+        session.add(kb)
+        await session.commit()
+
+    helper = KBHelper(
+        kb_db=kb_db,
+        kb=kb,
+        provider_manager=_FakeProviderManager(provider),  # type: ignore[arg-type]
+        kb_root_dir=tmp_path.as_posix(),
+        chunker=SimpleNamespace(chunk=lambda *args, **kwargs: asyncio.sleep(0, result=[])),
+    )
+    await helper.initialize()
+
+    records: list[tuple[str, int, int]] = []
+
+    async def _progress(stage: str, current: int, total: int) -> None:
+        records.append((stage, current, total))
+
+    doc = await helper.upload_document(
+        file_name="test.md",
+        file_content=b"# H1\n## H2\nbody",
+        file_type="md",
+        index_mode="structure",
+        progress_callback=_progress,
+    )
+    assert doc.index_mode == "structure"
+    first_chunking_done_idx = records.index(("chunking", 100, 100))
+    first_embedding_idx = next(i for i, r in enumerate(records) if r[0] == "embedding")
+    assert first_chunking_done_idx < first_embedding_idx
+
+    await helper.terminate()
+    await kb_db.close()
+
+
+@pytest.mark.asyncio
+async def test_kb_manager_rebuild_task_tracking_and_terminate_cancel() -> None:
+    mgr = KnowledgeBaseManager(provider_manager=MagicMock())
+    fake_helper = SimpleNamespace(last_rebuild_task_id=None)
+
+    async def _get_kb(_kb_id: str):
+        return fake_helper
+
+    mgr.get_kb = _get_kb  # type: ignore[method-assign]
+    gate = asyncio.Event()
+
+    async def _sync(**kwargs):
+        await gate.wait()
+
+    mgr.index_rebuilder.sync = _sync  # type: ignore[method-assign]
+    task_id = await mgr.start_rebuild_index("kb-id", "provider-id")
+    assert task_id in mgr._running_rebuild_tasks
+
+    task_obj = mgr._running_rebuild_tasks[task_id]
+    await mgr.terminate()
+    await asyncio.sleep(0)
+    assert task_obj.cancelled() or task_obj.done()
+    assert task_id not in mgr._running_rebuild_tasks
+
+    assert mgr._validate_index_mode("flat") == "flat"
+    with pytest.raises(ValueError):
+        mgr._validate_index_mode("invalid")


### PR DESCRIPTION
实现https://github.com/AstrBotDevs/AstrBot/issues/5262

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- 重构知识库底层架构，提升稳定性和健壮性
- 新增 `kb_db_sqlite.py` 知识库数据库抽象层
- 新增 `index_rebuilder.py` 索引重建器
- 新增 `structure_parser.py` 结构解析器
- 优化 FAISS 向量数据库实现 (`vec_db.py`, `document_storage.py`, `embedding_storage.py`)
- 完善知识库管理器和帮助类 (`kb_mgr.py`, `kb_helper.py`)
- 新增知识库回归测试 `tests/core/test_kb_architecture_refactor.py`
- 新增架构文档 `docs/knowledge-base-architecture.md`

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

---

### Screenshots or Test Results / 运行截图或测试结果

<img width="686" height="161" alt="image" src="https://github.com/user-attachments/assets/04c17d86-4a82-4a1d-9ca1-6de2be2833bc" />

单元测试和短期实机使用测试都已经进行。

但是前端还未修改，暂时还未做前端主动切换嵌入式模型时，重建向量索引的测试

---

### Checklist / 检查清单

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。
- [ ] 👀 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。
- [x] 🤓 我确保没有引入新依赖库。
- [x] 😮 我的更改没有引入恶意代码。

## Summary by Sourcery

优化知识库架构，以支持**按提供商隔离的 FAISS 索引**、**结构化文档索引**以及在保持备份与检索流程兼容的前提下进行**安全的在线索引重建**。

New Features:
- 引入按提供商隔离的 FAISS 索引文件，并支持在运行时为每个知识库在不同嵌入提供商之间进行热切换。
- 新增结构化索引模式，对文档进行层级化分段解析，分别存储各层级片段，并暴露一个工具，使 LLM 流程可以按需读取各分段正文。
- 暴露后台索引重建任务，支持进度追踪，同时提供仪表盘 API 用于监控在切换提供商时的索引重建操作。
- 允许通过仪表盘 API 为每个知识库配置默认索引模式，并为每次上传的文档单独配置索引模式。

Enhancements:
- 扩展 SQLite 知识库 schema，增加“当前索引提供商”“默认索引模式”“按文档索引模式”和结构化分段表，并附带相应的迁移。
- 加强 FAISS 向量数据库实现，引入索引切换锁、安全索引替换机制，以及额外的文档元数据（如索引标记和源哈希）。
- 在稀疏检索、融合检索和管理层中传播检索分块元数据，使消费方能够区分结构化结果与扁平结果，并据此作出相应处理。
- 重构会话级/全局知识库解析逻辑，并增加结构化文档检查，仅在相关时注册对应工具。
- 更新备份导出/导入逻辑，以处理多个按提供商划分的 FAISS 索引文件以及新的知识库 schema 版本。

Documentation:
- 新增一篇详细的知识库架构文档，说明按提供商隔离的索引、结构化索引、迁移流程以及数据流。

Tests:
- 新增全面测试，覆盖索引重建行为、结构化解析、文档分段的 upsert/查找语义、FAISS 索引切换与加锁、结构化上传进度，以及重建任务的生命周期管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the knowledge base architecture to support provider-specific FAISS indexes, structured document indexing, and safe online index rebuilding while keeping backups and retrieval flows compatible.

New Features:
- Introduce provider-isolated FAISS index files with runtime hot-switching between embedding providers per knowledge base.
- Add a structured indexing mode that parses documents into hierarchical sections, stores them separately, and exposes a tool to read section bodies on demand from LLM flows.
- Expose background index rebuild tasks with progress tracking and a dashboard API to monitor provider-switch rebuild operations.
- Allow configuring a default index mode per knowledge base and per-upload document index mode via the dashboard API.

Enhancements:
- Extend the SQLite knowledge base schema with active index provider, default index mode, per-document index mode, and structured section tables plus corresponding migrations.
- Harden the FAISS vector DB implementation with an index-switch lock, safe index swapping, and additional document metadata such as indexing flags and source hashes.
- Propagate retrieval chunk metadata through sparse, fusion, and manager layers so consumers can distinguish structured vs flat results and react accordingly.
- Refactor session/global KB resolution logic and add structured-doc checks so tools are only registered when relevant.
- Update backup export/import to handle multiple provider-specific FAISS index files and the new knowledge base schema version.

Documentation:
- Add a detailed knowledge base architecture document describing provider-isolated indexes, structured indexing, migrations, and data flows.

Tests:
- Add comprehensive tests covering index rebuilding behavior, structured parsing, doc section upsert/lookup semantics, FAISS index switching and locking, structured upload progress, and rebuild task lifecycle management.

</details>