### PR TITLE
fix: reduce SSE streaming delay from 50ms to 5ms (#5949)

### DIFF
--- a/astrbot/dashboard/routes/chat.py
+++ b/astrbot/dashboard/routes/chat.py
@@ -389,7 +389,7 @@ class ChatRoute(Route):
 
                         try:
                             if not client_disconnected:
-                                await asyncio.sleep(0.05)
+                                await asyncio.sleep(0.005)
                         except asyncio.CancelledError:
                             logger.debug(f"[WebChat] 用户 {username} 断开聊天长连接。")
                             client_disconnected = True


### PR DESCRIPTION
## Summary

Fixes #5949 - Ollama local model streaming delay issue.

## Problem

The web UI showed delayed responses when using Ollama with local models (like Qwen2.5:1.5b). The root cause was an artificial 50ms delay (`await asyncio.sleep(0.05)`) in the SSE streaming endpoint that added unnecessary latency between each chunk sent to the client.

## Solution

Reduced the artificial delay from 50ms to 5ms in `astrbot/dashboard/routes/chat.py`. This provides a smooth streaming experience while still offering basic flow control to prevent overwhelming the client.

## Changes

- `astrbot/dashboard/routes/chat.py`: Changed `asyncio.sleep(0.05)` to `asyncio.sleep(0.005)` (line 392)

## Testing

Users can test this fix by:
1. Using Ollama with a local model (e.g., Qwen2.5:1.5b)
2. Enabling streaming in the web UI
3. Observing that responses now appear in real-time instead of with noticeable delay

## Impact

- **Before**: Each chunk had 50ms delay, causing cumulative delays for long responses
- **After**: Each chunk has 5ms delay, providing near real-time streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- 降低 SSE 流式传输端点中按数据块进行的 asyncio 休眠时间间隔，从而消除网页界面响应中可察觉的延迟。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Lower the per-chunk asyncio sleep interval in the SSE streaming endpoint to eliminate noticeable lag in web UI responses.

</details>