### PR TITLE
Fix: 修复首个 token 超过 60s 未返回时协程被取消，result 未初始化导致 UnboundLocalError

### DIFF
--- a/astrbot/dashboard/routes/chat.py
+++ b/astrbot/dashboard/routes/chat.py
@@ -342,6 +342,9 @@ class ChatRoute(Route):
 
                 async with track_conversation(self.running_convs, webchat_conv_id):
                     while True:
+                        # 每次循环重置，防止异常分支未赋值导致 UnboundLocalError
+                        # Reset each iteration to avoid UnboundLocalError in exception branches
+                        result = None 
                         try:
                             result = await asyncio.wait_for(back_queue.get(), timeout=1)
                         except asyncio.TimeoutError:


### PR DESCRIPTION
**Fix: 修复首个 token 超过 60s 未返回时协程被取消，`result` 未初始化导致 `UnboundLocalError`**

### Motivation / 动机

When the model fails to return the first token within 60 seconds, the parent coroutine times out and raises `CancelledError`. Due to a missing `continue` in the exception branch, execution falls through to `if not result` where `result` was never assigned, causing:

当模型首个 token 超过 60 秒未返回时，上层协程超时并发出取消信号，`CancelledError` 被捕获后缺少 `continue`，代码继续执行到 `if not result`，而此时 `result` 从未被赋值，导致：
```
UnboundLocalError: cannot access local variable 'result' where it is not associated with a value
```

### Modifications / 改动点

- Modified `astrbot/dashboard/routes/chat.py`
- Initialize `result = None` at the top of each `while True` iteration to ensure all exception branches have a valid value.

- 修改 `astrbot/dashboard/routes/chat.py`
- 在 `while True` 循环顶部将 `result` 初始化为 `None`，确保 `CancelledError` 或其他异常分支下所有代码路径均有合法值。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

**Reproduction log / 复现日志:**
```
[2026-03-10 05:10:56.728] [Core] [INFO] 应用流式输出(webchat)
[2026-03-10 05:11:56.673] [Core] [ERRO] WebChat stream unexpected error: cannot access local variable 'result' where it is not associated with a value
```

Consistently reproduced when first token exceeds 60s timeout.

稳定复现于首个 token 超过 60s 超时取消的场景。

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。
- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**. / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。
- [x] 🤓 I have ensured that no new dependencies are introduced. / 我确保没有引入新依赖库。
- [x] 😮 My changes do not introduce malicious code. / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- 确保在流式聊天循环的每次迭代中都初始化 `result` 变量，这样在超时或取消的路径中将不再触发 `UnboundLocalError`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure the streaming chat loop initializes the result variable on each iteration so timeout or cancellation paths no longer raise UnboundLocalError.

</details>