### PR TITLE
fix: 修复 aiocqhttp 管理员角色字段未透传的问题

### DIFF
--- a/astrbot/api/platform/__init__.py
+++ b/astrbot/api/platform/__init__.py
@@ -1,5 +1,7 @@
 from astrbot.core.message.components import *
 from astrbot.core.platform import (
+    ADMIN_MESSAGE_MEMBER_ROLES,
+    VALID_MESSAGE_MEMBER_ROLES,
     AstrBotMessage,
     AstrMessageEvent,
     Group,
@@ -7,10 +9,12 @@ from astrbot.core.platform import (
     MessageType,
     Platform,
     PlatformMetadata,
+    normalize_message_member_role,
 )
 from astrbot.core.platform.register import register_platform_adapter
 
 __all__ = [
+    "ADMIN_MESSAGE_MEMBER_ROLES",
     "AstrBotMessage",
     "AstrMessageEvent",
     "Group",
@@ -18,5 +22,7 @@ __all__ = [
     "MessageType",
     "Platform",
     "PlatformMetadata",
+    "VALID_MESSAGE_MEMBER_ROLES",
+    "normalize_message_member_role",
     "register_platform_adapter",
 ]

--- a/astrbot/core/platform/__init__.py
+++ b/astrbot/core/platform/__init__.py
@@ -1,9 +1,18 @@
 from .astr_message_event import AstrMessageEvent
-from .astrbot_message import AstrBotMessage, Group, MessageMember, MessageType
+from .astrbot_message import (
+    ADMIN_MESSAGE_MEMBER_ROLES,
+    VALID_MESSAGE_MEMBER_ROLES,
+    AstrBotMessage,
+    Group,
+    MessageMember,
+    MessageType,
+    normalize_message_member_role,
+)
 from .platform import Platform
 from .platform_metadata import PlatformMetadata
 
 __all__ = [
+    "ADMIN_MESSAGE_MEMBER_ROLES",
     "AstrBotMessage",
     "AstrMessageEvent",
     "Group",
@@ -11,4 +20,6 @@ __all__ = [
     "MessageType",
     "Platform",
     "PlatformMetadata",
+    "VALID_MESSAGE_MEMBER_ROLES",
+    "normalize_message_member_role",
 ]

--- a/astrbot/core/platform/astr_message_event.py
+++ b/astrbot/core/platform/astr_message_event.py
@@ -26,7 +26,12 @@ from astrbot.core.provider.entities import ProviderRequest
 from astrbot.core.utils.metrics import Metric
 from astrbot.core.utils.trace import TraceSpan
 
-from .astrbot_message import AstrBotMessage, Group
+from .astrbot_message import (
+    ADMIN_MESSAGE_MEMBER_ROLES,
+    AstrBotMessage,
+    Group,
+    normalize_message_member_role,
+)
 from .message_session import MessageSesion, MessageSession  # noqa
 from .platform_metadata import PlatformMetadata
 
@@ -45,11 +50,11 @@ class AstrMessageEvent(abc.ABC):
         """消息对象, AstrBotMessage。带有完整的消息结构。"""
         self.platform_meta = platform_meta
         """消息平台的信息, 其中 name 是平台的类型，如 aiocqhttp"""
-        sender_role = getattr(getattr(message_obj, "sender", None), "role", None)
-        self.role = (
-            sender_role if sender_role in {"admin", "owner", "member"} else "member"
+        sender_role = normalize_message_member_role(
+            getattr(getattr(message_obj, "sender", None), "role", None)
         )
-        """User role within the current context (e.g. group chat)."""
+        self.role = sender_role or "member"
+        """用户在当前上下文中的角色（例如群聊中的管理员/群主/成员）。"""
         self.is_wake = False
         """是否唤醒(是否通过 WakingStage)"""
         self.is_at_or_wake_command = False
@@ -241,7 +246,7 @@ class AstrMessageEvent(abc.ABC):
 
     def is_admin(self) -> bool:
         """是否是管理员。"""
-        return self.role in {"admin", "owner"}
+        return self.role in ADMIN_MESSAGE_MEMBER_ROLES
 
     async def process_buffer(self, buffer: str, pattern: re.Pattern) -> str:
         """将消息缓冲区中的文本按指定正则表达式分割后发送至消息平台，作为不支持流式输出平台的Fallback。"""

--- a/astrbot/core/platform/astr_message_event.py
+++ b/astrbot/core/platform/astr_message_event.py
@@ -45,12 +45,10 @@ class AstrMessageEvent(abc.ABC):
         """消息对象, AstrBotMessage。带有完整的消息结构。"""
         self.platform_meta = platform_meta
         """消息平台的信息, 其中 name 是平台的类型，如 aiocqhttp"""
-        sender = getattr(message_obj, "sender", None)
-        sender_role = getattr(sender, "role", None)
-        if sender_role in {"admin", "owner", "member"}:
-            self.role = sender_role
-        else:
-            self.role = "member"
+        sender_role = getattr(getattr(message_obj, "sender", None), "role", None)
+        self.role = (
+            sender_role if sender_role in {"admin", "owner", "member"} else "member"
+        )
         """User role within the current context (e.g. group chat)."""
         self.is_wake = False
         """是否唤醒(是否通过 WakingStage)"""

--- a/astrbot/core/platform/astr_message_event.py
+++ b/astrbot/core/platform/astr_message_event.py
@@ -45,8 +45,13 @@ class AstrMessageEvent(abc.ABC):
         """消息对象, AstrBotMessage。带有完整的消息结构。"""
         self.platform_meta = platform_meta
         """消息平台的信息, 其中 name 是平台的类型，如 aiocqhttp"""
-        self.role = "member"
-        """用户是否是管理员。如果是管理员，这里是 admin"""
+        sender = getattr(message_obj, "sender", None)
+        sender_role = getattr(sender, "role", None)
+        if sender_role in {"admin", "owner", "member"}:
+            self.role = sender_role
+        else:
+            self.role = "member"
+        """User role within the current context (e.g. group chat)."""
         self.is_wake = False
         """是否唤醒(是否通过 WakingStage)"""
         self.is_at_or_wake_command = False
@@ -238,7 +243,7 @@ class AstrMessageEvent(abc.ABC):
 
     def is_admin(self) -> bool:
         """是否是管理员。"""
-        return self.role == "admin"
+        return self.role in {"admin", "owner"}
 
     async def process_buffer(self, buffer: str, pattern: re.Pattern) -> str:
         """将消息缓冲区中的文本按指定正则表达式分割后发送至消息平台，作为不支持流式输出平台的Fallback。"""

--- a/astrbot/core/platform/astrbot_message.py
+++ b/astrbot/core/platform/astrbot_message.py
@@ -5,6 +5,16 @@ from astrbot.core.message.components import BaseMessageComponent
 
 from .message_type import MessageType
 
+VALID_MESSAGE_MEMBER_ROLES = frozenset({"admin", "owner", "member"})
+ADMIN_MESSAGE_MEMBER_ROLES = frozenset({"admin", "owner"})
+
+
+def normalize_message_member_role(role: object) -> str | None:
+    """Normalize platform member roles to the supported role set."""
+    if isinstance(role, str) and role in VALID_MESSAGE_MEMBER_ROLES:
+        return role
+    return None
+
 
 @dataclass
 class MessageMember:

--- a/astrbot/core/platform/astrbot_message.py
+++ b/astrbot/core/platform/astrbot_message.py
@@ -10,6 +10,7 @@ from .message_type import MessageType
 class MessageMember:
     user_id: str  # 发送者id
     nickname: str | None = None
+    role: str | None = None
 
     def __str__(self) -> str:
         # 使用 f-string 来构建返回的字符串表示形式

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
@@ -16,6 +16,7 @@ from astrbot.api.message_components import (
     Video,
 )
 from astrbot.api.platform import Group, MessageMember
+from astrbot.core.platform.astrbot_message import normalize_message_member_role
 
 
 class AiocqhttpMessageEvent(AstrMessageEvent):
@@ -244,7 +245,7 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
                 MessageMember(
                     user_id=member["user_id"],
                     nickname=member.get("nickname") or member.get("card"),
-                    role=member.get("role"),
+                    role=normalize_message_member_role(member.get("role")),
                 )
                 for member in members
             ],

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
@@ -244,6 +244,7 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
                 MessageMember(
                     user_id=member["user_id"],
                     nickname=member.get("nickname") or member.get("card"),
+                    role=member.get("role"),
                 )
                 for member in members
             ],

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -19,6 +19,7 @@ from astrbot.api.platform import (
     MessageType,
     Platform,
     PlatformMetadata,
+    normalize_message_member_role,
 )
 from astrbot.core.platform.astr_message_event import MessageSesion
 
@@ -208,9 +209,7 @@ class AiocqhttpAdapter(Platform):
         assert event.sender is not None
         abm = AstrBotMessage()
         abm.self_id = str(event.self_id)
-        sender_role = event.sender.get("role")
-        if sender_role not in {"admin", "owner", "member"}:
-            sender_role = None
+        sender_role = normalize_message_member_role(event.sender.get("role"))
         abm.sender = MessageMember(
             str(event.sender["user_id"]),
             event.sender.get("card") or event.sender.get("nickname", "N/A"),

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -208,9 +208,13 @@ class AiocqhttpAdapter(Platform):
         assert event.sender is not None
         abm = AstrBotMessage()
         abm.self_id = str(event.self_id)
+        sender_role = event.sender.get("role")
+        if sender_role not in {"admin", "owner", "member"}:
+            sender_role = None
         abm.sender = MessageMember(
             str(event.sender["user_id"]),
             event.sender.get("card") or event.sender.get("nickname", "N/A"),
+            role=sender_role,
         )
         if event["message_type"] == "group":
             abm.type = MessageType.GROUP_MESSAGE

--- a/tests/unit/test_aiocqhttp_message_event.py
+++ b/tests/unit/test_aiocqhttp_message_event.py
@@ -1,0 +1,57 @@
+import sys
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+
+from astrbot.core.platform.astrbot_message import AstrBotMessage, Group, MessageMember
+from astrbot.core.platform.message_type import MessageType
+from astrbot.core.platform.platform_metadata import PlatformMetadata
+
+
+@pytest.mark.asyncio
+async def test_get_group_normalizes_cached_member_roles():
+    sys.modules.setdefault(
+        "astrbot.core.star.star_tools",
+        types.SimpleNamespace(StarTools=object),
+    )
+    from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
+        AiocqhttpMessageEvent,
+    )
+
+    bot = AsyncMock()
+    bot.call_action.side_effect = [
+        {"group_name": "Test Group"},
+        [
+            {"user_id": "1001", "nickname": "Owner", "role": "owner"},
+            {"user_id": "1002", "nickname": "Admin", "role": "admin"},
+            {"user_id": "1003", "nickname": "Guest", "role": "super-admin"},
+        ],
+    ]
+
+    message = AstrBotMessage()
+    message.type = MessageType.GROUP_MESSAGE
+    message.group = Group(group_id="123456")
+    message.sender = MessageMember(user_id="1001", nickname="Owner", role="owner")
+    message.message = []
+    message.message_str = ""
+    message.raw_message = None
+
+    event = AiocqhttpMessageEvent(
+        message_str="",
+        message_obj=message,
+        platform_meta=PlatformMetadata(
+            name="aiocqhttp",
+            description="test",
+            id="aiocqhttp-test",
+        ),
+        session_id="123456",
+        bot=bot,
+    )
+
+    group = await event.get_group()
+
+    assert group is not None
+    assert group.group_owner == "1001"
+    assert group.group_admins == ["1002"]
+    assert [member.role for member in group.members] == ["owner", "admin", None]

--- a/tests/unit/test_astr_message_event.py
+++ b/tests/unit/test_astr_message_event.py
@@ -493,6 +493,11 @@ class TestIsAdmin:
         astr_message_event.role = "admin"
         assert astr_message_event.is_admin() is True
 
+    def test_is_admin_when_owner(self, astr_message_event):
+        """Test is_admin returns True when role is owner."""
+        astr_message_event.role = "owner"
+        assert astr_message_event.is_admin() is True
+
 
 class TestProcessBuffer:
     """Tests for process_buffer method."""

--- a/tests/unit/test_astr_message_event.py
+++ b/tests/unit/test_astr_message_event.py
@@ -105,6 +105,38 @@ class TestAstrMessageEventInit:
         assert astr_message_event.span is not None
         assert astr_message_event.trace == astr_message_event.span
 
+    def test_init_preserves_supported_sender_role(self, platform_meta, astrbot_message):
+        """Test supported sender roles are kept during initialization."""
+        astrbot_message.sender = MessageMember(
+            user_id="user123",
+            nickname="TestUser",
+            role="admin",
+        )
+        event = ConcreteAstrMessageEvent(
+            message_str="Hello world",
+            message_obj=astrbot_message,
+            platform_meta=platform_meta,
+            session_id="session123",
+        )
+        assert event.role == "admin"
+
+    def test_init_falls_back_to_member_for_invalid_sender_role(
+        self, platform_meta, astrbot_message
+    ):
+        """Test invalid sender roles fall back to member."""
+        astrbot_message.sender = MessageMember(
+            user_id="user123",
+            nickname="TestUser",
+            role="super-admin",
+        )
+        event = ConcreteAstrMessageEvent(
+            message_str="Hello world",
+            message_obj=astrbot_message,
+            platform_meta=platform_meta,
+            session_id="session123",
+        )
+        assert event.role == "member"
+
 
 class TestUnifiedMsgOrigin:
     """Tests for unified_msg_origin property."""
@@ -777,10 +809,12 @@ class TestDefensiveGetattr:
 
     def test_get_message_type_with_non_enum_type(self, astr_message_event):
         """get_message_type should handle message_obj.type that is not a MessageType."""
+
         class DummyMessage:
             def __init__(self):
                 self.type = "not_an_enum"
                 self.message = []
+
         astr_message_event.message_obj = DummyMessage()
         message_type = astr_message_event.get_message_type()
         assert isinstance(message_type, MessageType)

--- a/tests/unit/test_astrbot_message.py
+++ b/tests/unit/test_astrbot_message.py
@@ -4,12 +4,34 @@ import time
 from unittest.mock import patch
 
 from astrbot.core.message.components import Image, Plain
-from astrbot.core.platform.astrbot_message import AstrBotMessage, Group, MessageMember
+from astrbot.core.platform.astrbot_message import (
+    ADMIN_MESSAGE_MEMBER_ROLES,
+    AstrBotMessage,
+    Group,
+    MessageMember,
+    VALID_MESSAGE_MEMBER_ROLES,
+    normalize_message_member_role,
+)
 from astrbot.core.platform.message_type import MessageType
 
 
 class TestMessageMember:
     """Tests for MessageMember dataclass."""
+
+    def test_normalize_message_member_role_accepts_supported_roles(self):
+        """Test supported platform roles are preserved."""
+        for role in VALID_MESSAGE_MEMBER_ROLES:
+            assert normalize_message_member_role(role) == role
+
+    def test_normalize_message_member_role_rejects_invalid_values(self):
+        """Test unsupported platform roles are rejected."""
+        assert normalize_message_member_role("super-admin") is None
+        assert normalize_message_member_role(123) is None
+        assert normalize_message_member_role(None) is None
+
+    def test_admin_message_member_roles_constant(self):
+        """Test admin role constant stays aligned with role semantics."""
+        assert ADMIN_MESSAGE_MEMBER_ROLES == {"admin", "owner"}
 
     def test_message_member_creation_basic(self):
         """Test creating a MessageMember with required fields."""

--- a/tests/unit/test_astrbot_message.py
+++ b/tests/unit/test_astrbot_message.py
@@ -17,6 +17,7 @@ class TestMessageMember:
 
         assert member.user_id == "user123"
         assert member.nickname is None
+        assert member.role is None
 
     def test_message_member_creation_with_nickname(self):
         """Test creating a MessageMember with nickname."""
@@ -24,6 +25,7 @@ class TestMessageMember:
 
         assert member.user_id == "user123"
         assert member.nickname == "TestUser"
+        assert member.role is None
 
     def test_message_member_str_with_nickname(self):
         """Test __str__ method with nickname."""


### PR DESCRIPTION
修复 aiocqhttp / NapCat 群消息场景下发送者角色未正确透传到 AstrBot 事件对象的问题，导致群管理员和群主在插件侧被误判为普通成员，进而无法通过依赖 `event.is_admin()` 的管理命令校验。

### Modifications / 改动点

- 在 `astrbot/core/platform/astrbot_message.py` 的 `MessageMember` 中新增 `role` 字段，用于承载平台侧发送者角色。
- 在 `astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py` 中读取 `event.sender["role"]`，并在合法值为 `admin`、`owner`、`member` 时透传到 `MessageMember.role`。
- 在 `astrbot/core/platform/astr_message_event.py` 中优先从 `message_obj.sender.role` 初始化事件角色，并将 `owner` 与 `admin` 都视为管理员。
- 在 `astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py` 的群成员列表构建逻辑中补充 `role` 字段，保证成员缓存同步时也能拿到角色信息。
- 在 `tests/unit/test_astr_message_event.py` 和 `tests/unit/test_astrbot_message.py` 中补充对应单元测试，覆盖 `owner` 管理员判定和 `MessageMember.role` 默认值行为。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

执行结果：

```text
> uv run pytest -q tests/unit/test_astr_message_event.py tests/unit/test_astrbot_message.py
102 passed in 7.16s
> uv run ruff check .
All checks passed!
```

Checklist / 检查清单
- [x]  😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。
- [x] 👀 我的更改经过了良好的测试，并已在上方提供了“验证步骤”和“运行截图”。
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 requirements.txt 和 pyproject.toml 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码。

## Summary by Sourcery

将来自 aiocqhttp/NapCat 事件的发送者角色信息传递到 AstrBot 的消息和事件对象中，使群管理员和群主能够被正确识别为管理员。

Bug Fixes:
- 通过将平台的发送者角色正确映射到 AstrBot 事件中，修复了将群管理员和群主误判为普通成员的问题。

Enhancements:
- 扩展 `MessageMember`，新增可选的 `role` 字段，并从 aiocqhttp 群消息和成员缓存中为其赋值。
- 在事件角色检查中，将群主和管理员角色都视为管理员。

Tests:
- 添加单元测试，覆盖 `is_admin` 中对群主角色的处理，以及 `MessageMember` 的默认角色行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Propagate sender role information from aiocqhttp/NapCat events into AstrBot message and event objects so group admins and owners are correctly recognized as administrators.

Bug Fixes:
- Fix misclassification of group admins and owners as regular members by correctly mapping platform sender roles into AstrBot events.

Enhancements:
- Extend MessageMember to carry an optional role field and populate it from aiocqhttp group messages and member cache.
- Treat both owner and admin roles as administrators in event role checks.

Tests:
- Add unit tests covering owner role handling in is_admin and the default role behavior of MessageMember.

</details>