### PR TITLE
fix: add namespace prefix to MCP tools to avoid conflicts with plugin tools

### DIFF
--- a/astrbot/core/agent/mcp_client.py
+++ b/astrbot/core/agent/mcp_client.py
@@ -8,6 +8,7 @@ from contextlib import AsyncExitStack
 from datetime import timedelta
 from pathlib import Path, PureWindowsPath
 from typing import Any, Generic
+from urllib.parse import quote
 
 from tenacity import (
     before_sleep_log,
@@ -657,8 +658,6 @@ class MCPTool(FunctionTool, Generic[TContext]):
     ) -> None:
         # Add namespace prefix to avoid conflicts with plugin tools
         # URL-encode the server name to create a safe and unique identifier part
-        from urllib.parse import quote
-
         normalized_server_name = quote(mcp_server_name, safe="")
         # Format: mcp_<normalized_server_name>__<tool_name>
         namespaced_name = f"mcp_{normalized_server_name}__{mcp_tool.name}"

--- a/astrbot/core/agent/mcp_client.py
+++ b/astrbot/core/agent/mcp_client.py
@@ -655,20 +655,28 @@ class MCPTool(FunctionTool, Generic[TContext]):
     def __init__(
         self, mcp_tool: mcp.Tool, mcp_client: MCPClient, mcp_server_name: str, **kwargs
     ) -> None:
+        # Add namespace prefix to avoid conflicts with plugin tools
+        # Format: mcp_<server_name>__<tool_name>
+        namespaced_name = f"mcp_{mcp_server_name}__{mcp_tool.name}"
+
         super().__init__(
-            name=mcp_tool.name,
+            name=namespaced_name,
             description=mcp_tool.description or "",
             parameters=_normalize_mcp_input_schema(mcp_tool.inputSchema),
         )
         self.mcp_tool = mcp_tool
         self.mcp_client = mcp_client
         self.mcp_server_name = mcp_server_name
+        self.original_tool_name = (
+            mcp_tool.name
+        )  # Store original name for display and calling
 
     async def call(
         self, context: ContextWrapper[TContext], **kwargs
     ) -> mcp.types.CallToolResult:
+        # Use original tool name when calling MCP server
         return await self.mcp_client.call_tool_with_reconnect(
-            tool_name=self.mcp_tool.name,
+            tool_name=self.original_tool_name,
             arguments=kwargs,
             read_timeout_seconds=timedelta(seconds=context.tool_call_timeout),
         )

--- a/astrbot/core/agent/mcp_client.py
+++ b/astrbot/core/agent/mcp_client.py
@@ -656,8 +656,14 @@ class MCPTool(FunctionTool, Generic[TContext]):
         self, mcp_tool: mcp.Tool, mcp_client: MCPClient, mcp_server_name: str, **kwargs
     ) -> None:
         # Add namespace prefix to avoid conflicts with plugin tools
-        # Format: mcp_<server_name>__<tool_name>
-        namespaced_name = f"mcp_{mcp_server_name}__{mcp_tool.name}"
+        # Normalize server name: remove spaces and special characters
+        normalized_server_name = mcp_server_name.replace(" ", "_").replace("-", "_")
+        # Remove any other special characters, keep only alphanumeric and underscore
+        normalized_server_name = "".join(
+            c for c in normalized_server_name if c.isalnum() or c == "_"
+        )
+        # Format: mcp_<normalized_server_name>__<tool_name>
+        namespaced_name = f"mcp_{normalized_server_name}__{mcp_tool.name}"
 
         super().__init__(
             name=namespaced_name,

--- a/astrbot/core/agent/mcp_client.py
+++ b/astrbot/core/agent/mcp_client.py
@@ -656,12 +656,10 @@ class MCPTool(FunctionTool, Generic[TContext]):
         self, mcp_tool: mcp.Tool, mcp_client: MCPClient, mcp_server_name: str, **kwargs
     ) -> None:
         # Add namespace prefix to avoid conflicts with plugin tools
-        # Normalize server name: remove spaces and special characters
-        normalized_server_name = mcp_server_name.replace(" ", "_").replace("-", "_")
-        # Remove any other special characters, keep only alphanumeric and underscore
-        normalized_server_name = "".join(
-            c for c in normalized_server_name if c.isalnum() or c == "_"
-        )
+        # URL-encode the server name to create a safe and unique identifier part
+        from urllib.parse import quote
+
+        normalized_server_name = quote(mcp_server_name, safe="")
         # Format: mcp_<normalized_server_name>__<tool_name>
         namespaced_name = f"mcp_{normalized_server_name}__{mcp_tool.name}"
 

--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -323,9 +323,10 @@ class FunctionToolManager:
     def _find_mcp_tool_by_original_name(self, name: str) -> MCPTool | None:
         """Best-effort lookup of an MCP tool by its original (pre-namespaced) name.
 
-        When multiple MCP servers expose a tool with the same original name,
-        the one with the lexicographically smallest namespaced name is
-        returned for deterministic behavior, and a warning is logged.
+        Prefers active tools to stay consistent with the active-first rule
+        applied for exact-name matches. When multiple candidates remain, the
+        one with the lexicographically smallest namespaced name is returned
+        for deterministic behavior, and a warning is logged.
         """
         matches = [
             f
@@ -336,14 +337,17 @@ class FunctionToolManager:
         if not matches:
             return None
 
-        if len(matches) > 1:
-            matches.sort(key=lambda f: f.name)
+        active_matches = [f for f in matches if getattr(f, "active", True)]
+        candidates = active_matches or matches
+
+        if len(candidates) > 1:
+            candidates.sort(key=lambda f: f.name)
             logger.warning(
                 f"Multiple MCP tools found with original name '{name}': "
-                f"{[f.name for f in matches]}. Using {matches[0].name}"
+                f"{[f.name for f in candidates]}. Using {candidates[0].name}"
             )
 
-        return matches[0]
+        return candidates[0]
 
     def get_func(self, name) -> FuncTool | None:
         # 优先返回已激活的工具（后加载的覆盖前面的，与 ToolSet.add_tool 保持一致）

--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -330,6 +330,24 @@ class FunctionToolManager:
         for f in reversed(self.func_list):
             if f.name == name:
                 return f
+
+        # Fallback: try to find MCP tool by original name for backward compatibility
+        # This handles cases where personas reference tools by their original names
+        if isinstance(name, str):
+            mcp_matches = []
+            for f in self.func_list:
+                if isinstance(f, MCPTool) and f.original_tool_name == name:
+                    mcp_matches.append(f)
+
+            if len(mcp_matches) == 1:
+                return mcp_matches[0]
+            elif len(mcp_matches) > 1:
+                logger.warning(
+                    f"Multiple MCP tools found with original name '{name}': "
+                    f"{[f.name for f in mcp_matches]}. Using {mcp_matches[0].name}"
+                )
+                return mcp_matches[0]
+
         if isinstance(name, str):
             try:
                 builtin_tool = self.get_builtin_tool(name)
@@ -373,6 +391,26 @@ class FunctionToolManager:
     def is_builtin_tool(self, name: str) -> bool:
         ensure_builtin_tools_loaded()
         return get_builtin_tool_class(name) is not None
+
+        # Fallback: try to find MCP tool by original name for backward compatibility
+        # This handles cases where personas reference tools by their original names
+        mcp_matches = []
+        for f in self.func_list:
+            if isinstance(f, MCPTool) and f.original_tool_name == name:
+                mcp_matches.append(f)
+
+        if len(mcp_matches) == 1:
+            return mcp_matches[0]
+        elif len(mcp_matches) > 1:
+            # Multiple MCP servers provide the same tool name
+            # Log warning and return the first one
+            logger.warning(
+                f"Multiple MCP tools found with original name '{name}': "
+                f"{[f.name for f in mcp_matches]}. Using {mcp_matches[0].name}"
+            )
+            return mcp_matches[0]
+
+        return None
 
     def get_full_tool_set(self) -> ToolSet:
         """获取完整工具集

--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -321,13 +321,7 @@ class FunctionToolManager:
                 break
 
     def _find_mcp_tool_by_original_name(self, name: str) -> MCPTool | None:
-        """Best-effort lookup of an MCP tool by its original (pre-namespaced) name.
-
-        Prefers active tools to stay consistent with the active-first rule
-        applied for exact-name matches. When multiple candidates remain, the
-        one with the lexicographically smallest namespaced name is returned
-        for deterministic behavior, and a warning is logged.
-        """
+        """按原始（命名空间前）名查找 MCP 工具，active 优先。"""
         matches = [
             f
             for f in self.func_list
@@ -361,8 +355,7 @@ class FunctionToolManager:
                 return f
 
         if isinstance(name, str):
-            # Fallback: look up MCP tool by original (pre-namespaced) name
-            # for backward compatibility with legacy persona configurations.
+            # 老 persona 配置按原始 MCP 名回查
             mcp_tool = self._find_mcp_tool_by_original_name(name)
             if mcp_tool is not None:
                 return mcp_tool
@@ -609,8 +602,13 @@ class FunctionToolManager:
 
         lifecycle_task = asyncio.create_task(lifecycle(), name=f"mcp-client:{name}")
         async with self._runtime_lock:
-            # After successful initialization, mcp_client is guaranteed to be non-None
-            assert mcp_client is not None
+            # After successful initialization mcp_client is logically non-None;
+            # raise explicitly so this invariant still holds under `python -O`
+            # (which strips `assert`).
+            if mcp_client is None:
+                raise RuntimeError(
+                    f"MCP client {name} unexpectedly None after successful initialization"
+                )
             self._mcp_server_runtime[name] = _MCPServerRuntime(
                 name=name,
                 client=mcp_client,

--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -320,6 +320,31 @@ class FunctionToolManager:
                 self.func_list.pop(i)
                 break
 
+    def _find_mcp_tool_by_original_name(self, name: str) -> MCPTool | None:
+        """Best-effort lookup of an MCP tool by its original (pre-namespaced) name.
+
+        When multiple MCP servers expose a tool with the same original name,
+        the one with the lexicographically smallest namespaced name is
+        returned for deterministic behavior, and a warning is logged.
+        """
+        matches = [
+            f
+            for f in self.func_list
+            if isinstance(f, MCPTool) and f.original_tool_name == name
+        ]
+
+        if not matches:
+            return None
+
+        if len(matches) > 1:
+            matches.sort(key=lambda f: f.name)
+            logger.warning(
+                f"Multiple MCP tools found with original name '{name}': "
+                f"{[f.name for f in matches]}. Using {matches[0].name}"
+            )
+
+        return matches[0]
+
     def get_func(self, name) -> FuncTool | None:
         # 优先返回已激活的工具（后加载的覆盖前面的，与 ToolSet.add_tool 保持一致）
         # 使用 getattr(..., True) 与 ToolSet.add_tool 保持一致：没有 active 属性的工具视为已激活
@@ -331,24 +356,13 @@ class FunctionToolManager:
             if f.name == name:
                 return f
 
-        # Fallback: try to find MCP tool by original name for backward compatibility
-        # This handles cases where personas reference tools by their original names
         if isinstance(name, str):
-            mcp_matches = []
-            for f in self.func_list:
-                if isinstance(f, MCPTool) and f.original_tool_name == name:
-                    mcp_matches.append(f)
+            # Fallback: look up MCP tool by original (pre-namespaced) name
+            # for backward compatibility with legacy persona configurations.
+            mcp_tool = self._find_mcp_tool_by_original_name(name)
+            if mcp_tool is not None:
+                return mcp_tool
 
-            if len(mcp_matches) == 1:
-                return mcp_matches[0]
-            elif len(mcp_matches) > 1:
-                logger.warning(
-                    f"Multiple MCP tools found with original name '{name}': "
-                    f"{[f.name for f in mcp_matches]}. Using {mcp_matches[0].name}"
-                )
-                return mcp_matches[0]
-
-        if isinstance(name, str):
             try:
                 builtin_tool = self.get_builtin_tool(name)
             except KeyError:
@@ -391,27 +405,6 @@ class FunctionToolManager:
     def is_builtin_tool(self, name: str) -> bool:
         ensure_builtin_tools_loaded()
         return get_builtin_tool_class(name) is not None
-
-        # Fallback: try to find MCP tool by original name for backward compatibility
-        # This handles cases where personas reference tools by their original names
-        mcp_matches = []
-        for f in self.func_list:
-            if isinstance(f, MCPTool) and f.original_tool_name == name:
-                mcp_matches.append(f)
-
-        if len(mcp_matches) == 1:
-            return mcp_matches[0]
-        elif len(mcp_matches) > 1:
-            # Multiple MCP servers provide the same tool name
-            # Sort by namespaced name for deterministic selection
-            mcp_matches.sort(key=lambda f: f.name)
-            logger.warning(
-                f"Multiple MCP tools found with original name '{name}': "
-                f"{[f.name for f in mcp_matches]}. Using {mcp_matches[0].name}"
-            )
-            return mcp_matches[0]
-
-        return None
 
     def get_full_tool_set(self) -> ToolSet:
         """获取完整工具集

--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -403,7 +403,8 @@ class FunctionToolManager:
             return mcp_matches[0]
         elif len(mcp_matches) > 1:
             # Multiple MCP servers provide the same tool name
-            # Log warning and return the first one
+            # Sort by namespaced name for deterministic selection
+            mcp_matches.sort(key=lambda f: f.name)
             logger.warning(
                 f"Multiple MCP tools found with original name '{name}': "
                 f"{[f.name for f in mcp_matches]}. Using {mcp_matches[0].name}"
@@ -611,6 +612,8 @@ class FunctionToolManager:
 
         lifecycle_task = asyncio.create_task(lifecycle(), name=f"mcp-client:{name}")
         async with self._runtime_lock:
+            # After successful initialization, mcp_client is guaranteed to be non-None
+            assert mcp_client is not None
             self._mcp_server_runtime[name] = _MCPServerRuntime(
                 name=name,
                 client=mcp_client,

--- a/astrbot/dashboard/routes/tools.py
+++ b/astrbot/dashboard/routes/tools.py
@@ -489,8 +489,10 @@ class ToolsRoute(Route):
                 elif isinstance(tool, MCPTool):
                     origin = "mcp"
                     origin_name = tool.mcp_server_name
-                    # Add original tool name for MCP tools
-                    display_name = getattr(tool, "original_tool_name", tool.name)
+                    # Format: <ServerName>_<ToolName> for MCP tools
+                    # Normalize server name for display
+                    normalized_server = tool.mcp_server_name.replace(" ", "")
+                    display_name = f"{normalized_server}_{tool.original_tool_name}"
                 elif tool.handler_module_path and star_map.get(
                     tool.handler_module_path
                 ):
@@ -505,7 +507,7 @@ class ToolsRoute(Route):
 
                 tool_info = {
                     "name": tool.name,  # Keep namespaced name for internal use
-                    "display_name": display_name,  # Original name for display
+                    "display_name": display_name,  # Friendly name for display
                     "description": tool.description,
                     "parameters": tool.parameters,
                     "active": tool.active,

--- a/astrbot/dashboard/routes/tools.py
+++ b/astrbot/dashboard/routes/tools.py
@@ -472,6 +472,7 @@ class ToolsRoute(Route):
                 if self.tool_mgr.is_builtin_tool(tool.name):
                     origin = "builtin"
                     origin_name = "AstrBot Core"
+                    display_name = tool.name
                     readonly = True
                     builtin_config_statuses = get_builtin_tool_config_statuses(
                         tool.name,

--- a/astrbot/dashboard/routes/tools.py
+++ b/astrbot/dashboard/routes/tools.py
@@ -83,6 +83,14 @@ class ToolsRoute(Route):
                 )
                 mcp_servers = {}
 
+            # 按 server 名预分组 MCP 工具，避免每台服务器都扫一遍 func_list
+            mcp_tools_by_server: dict[str, list[MCPTool]] = {}
+            for f in self.tool_mgr.func_list:
+                if isinstance(f, MCPTool):
+                    mcp_tools_by_server.setdefault(f.mcp_server_name, []).append(f)
+
+            runtime_view = self.tool_mgr.mcp_server_runtime_view
+
             # 获取所有服务器并添加它们的工具列表
             for name, server_config in mcp_servers.items():
                 if not isinstance(server_config, dict):
@@ -103,20 +111,14 @@ class ToolsRoute(Route):
 
                 # tools 为 namespaced 名（与 personaForm.tools 匹配），
                 # original_tool_names 为原始名（给 UI 显示）
-                for name_key, runtime in self.tool_mgr.mcp_server_runtime_view.items():
-                    if name_key == name:
-                        mcp_client = runtime.client
-                        mcp_tools = [
-                            f
-                            for f in self.tool_mgr.func_list
-                            if isinstance(f, MCPTool) and f.mcp_server_name == name
-                        ]
-                        server_info["tools"] = [f.name for f in mcp_tools]
-                        server_info["original_tool_names"] = [
-                            f.original_tool_name for f in mcp_tools
-                        ]
-                        server_info["errlogs"] = mcp_client.server_errlogs
-                        break
+                runtime = runtime_view.get(name)
+                if runtime is not None:
+                    mcp_tools = mcp_tools_by_server.get(name, [])
+                    server_info["tools"] = [f.name for f in mcp_tools]
+                    server_info["original_tool_names"] = [
+                        f.original_tool_name for f in mcp_tools
+                    ]
+                    server_info["errlogs"] = runtime.client.server_errlogs
                 else:
                     server_info["tools"] = []
                     server_info["original_tool_names"] = []

--- a/astrbot/dashboard/routes/tools.py
+++ b/astrbot/dashboard/routes/tools.py
@@ -101,17 +101,13 @@ class ToolsRoute(Route):
                     if key != "active":  # active 已经处理
                         server_info[key] = value
 
-                # 如果MCP客户端已初始化，从客户端获取工具名称
+                # If MCP client is initialized, get tool names from client
+                # Note: mcp_client.tools contains raw MCP tools (mcp.Tool), not MCPTool
+                # So we use tool.name directly (no namespace prefix to strip)
                 for name_key, runtime in self.tool_mgr.mcp_server_runtime_view.items():
                     if name_key == name:
                         mcp_client = runtime.client
-                        # Display original tool names without namespace prefix
-                        server_info["tools"] = [
-                            tool.name.split("__", 1)[1]
-                            if tool.name.startswith(f"mcp_{name}__")
-                            else tool.name
-                            for tool in mcp_client.tools
-                        ]
+                        server_info["tools"] = [tool.name for tool in mcp_client.tools]
                         server_info["errlogs"] = mcp_client.server_errlogs
                         break
                 else:

--- a/astrbot/dashboard/routes/tools.py
+++ b/astrbot/dashboard/routes/tools.py
@@ -101,17 +101,25 @@ class ToolsRoute(Route):
                     if key != "active":  # active 已经处理
                         server_info[key] = value
 
-                # If MCP client is initialized, get tool names from client
-                # Note: mcp_client.tools contains raw MCP tools (mcp.Tool), not MCPTool
-                # So we use tool.name directly (no namespace prefix to strip)
+                # tools 为 namespaced 名（与 personaForm.tools 匹配），
+                # original_tool_names 为原始名（给 UI 显示）
                 for name_key, runtime in self.tool_mgr.mcp_server_runtime_view.items():
                     if name_key == name:
                         mcp_client = runtime.client
-                        server_info["tools"] = [tool.name for tool in mcp_client.tools]
+                        mcp_tools = [
+                            f
+                            for f in self.tool_mgr.func_list
+                            if isinstance(f, MCPTool) and f.mcp_server_name == name
+                        ]
+                        server_info["tools"] = [f.name for f in mcp_tools]
+                        server_info["original_tool_names"] = [
+                            f.original_tool_name for f in mcp_tools
+                        ]
                         server_info["errlogs"] = mcp_client.server_errlogs
                         break
                 else:
                     server_info["tools"] = []
+                    server_info["original_tool_names"] = []
 
                 servers.append(server_info)
 

--- a/astrbot/dashboard/routes/tools.py
+++ b/astrbot/dashboard/routes/tools.py
@@ -105,7 +105,13 @@ class ToolsRoute(Route):
                 for name_key, runtime in self.tool_mgr.mcp_server_runtime_view.items():
                     if name_key == name:
                         mcp_client = runtime.client
-                        server_info["tools"] = [tool.name for tool in mcp_client.tools]
+                        # Display original tool names without namespace prefix
+                        server_info["tools"] = [
+                            tool.name.split("__", 1)[1]
+                            if tool.name.startswith(f"mcp_{name}__")
+                            else tool.name
+                            for tool in mcp_client.tools
+                        ]
                         server_info["errlogs"] = mcp_client.server_errlogs
                         break
                 else:
@@ -483,18 +489,23 @@ class ToolsRoute(Route):
                 elif isinstance(tool, MCPTool):
                     origin = "mcp"
                     origin_name = tool.mcp_server_name
+                    # Add original tool name for MCP tools
+                    display_name = getattr(tool, "original_tool_name", tool.name)
                 elif tool.handler_module_path and star_map.get(
                     tool.handler_module_path
                 ):
                     star = star_map[tool.handler_module_path]
                     origin = "plugin"
                     origin_name = star.name
+                    display_name = tool.name
                 else:
                     origin = "unknown"
                     origin_name = "unknown"
+                    display_name = tool.name
 
                 tool_info = {
-                    "name": tool.name,
+                    "name": tool.name,  # Keep namespaced name for internal use
+                    "display_name": display_name,  # Original name for display
                     "description": tool.description,
                     "parameters": tool.parameters,
                     "active": tool.active,

--- a/dashboard/src/components/extension/McpServersSection.vue
+++ b/dashboard/src/components/extension/McpServersSection.vue
@@ -52,7 +52,7 @@
                             </v-card-title>
                             <v-card-text>
                               <ul>
-                                <li v-for="(tool, idx) in item.tools" :key="idx" style="margin: 8px 0px;">{{ tool }}</li>
+                                <li v-for="(tool, idx) in (item.original_tool_names || item.tools)" :key="idx" style="margin: 8px 0px;">{{ tool }}</li>
                               </ul>
                             </v-card-text>
                             <v-card-actions class="d-flex justify-end">

--- a/dashboard/src/components/extension/componentPanel/components/ToolTable.vue
+++ b/dashboard/src/components/extension/componentPanel/components/ToolTable.vue
@@ -86,7 +86,7 @@ const enabledConfigTags = (tool: ToolItem): BuiltinToolConfigTag[] => {
         <div class="py-2">
           <div class="d-flex flex-wrap align-center ga-1">
             <v-icon color="primary" class="mr-1" size="18">
-              {{ item.name.includes(':') ? 'mdi-server-network' : 'mdi-function-variant' }}
+              {{ item.origin === 'mcp' ? 'mdi-server-network' : 'mdi-function-variant' }}
             </v-icon>
             <div class="tool-name text-body-2 font-weight-medium">{{ item.display_name || item.name }}</div>
             <v-tooltip

--- a/dashboard/src/components/extension/componentPanel/components/ToolTable.vue
+++ b/dashboard/src/components/extension/componentPanel/components/ToolTable.vue
@@ -85,7 +85,10 @@ const enabledConfigTags = (tool: ToolItem): BuiltinToolConfigTag[] => {
       <template #item.name="{ item }">
         <div class="py-2">
           <div class="d-flex flex-wrap align-center ga-1">
-            <div class="tool-name text-body-2 font-weight-medium">{{ item.name }}</div>
+            <v-icon color="primary" class="mr-1" size="18">
+              {{ item.name.includes(':') ? 'mdi-server-network' : 'mdi-function-variant' }}
+            </v-icon>
+            <div class="tool-name text-body-2 font-weight-medium">{{ item.display_name || item.name }}</div>
             <v-tooltip
               v-for="tag in enabledConfigTags(item)"
               :key="`${item.name}-${tag.conf_id}`"

--- a/dashboard/src/components/extension/componentPanel/index.vue
+++ b/dashboard/src/components/extension/componentPanel/index.vue
@@ -84,11 +84,9 @@ const {
   openDetailsDialog
 } = useCommandActions(toast, () => fetchCommands(tm('messages.loadFailed')));
 
-const filteredTools = computed(() => {
-  const query = normalizeTextInput(toolSearch.value).trim().toLowerCase();
-  if (!query) return tools.value;
-  return tools.value.filter(tool => matchesToolSearch(tool, query));
-});
+const filteredTools = computed(() =>
+  tools.value.filter(tool => matchesToolSearch(tool, toolSearch.value))
+);
 
 // 处理切换指令状态
 const handleToggleCommand = async (cmd: CommandItem) => {

--- a/dashboard/src/components/extension/componentPanel/index.vue
+++ b/dashboard/src/components/extension/componentPanel/index.vue
@@ -16,6 +16,7 @@ import { computed, onActivated, onMounted, ref, watch} from 'vue';
 import axios from 'axios';
 import { useModuleI18n } from '@/i18n/composables';
 import { normalizeTextInput } from '@/utils/inputValue';
+import { matchesToolSearch } from '@/utils/toolDisplayName';
 
 // Composables
 import { useComponentData } from './composables/useComponentData';
@@ -86,10 +87,7 @@ const {
 const filteredTools = computed(() => {
   const query = normalizeTextInput(toolSearch.value).trim().toLowerCase();
   if (!query) return tools.value;
-  return tools.value.filter(tool => 
-    tool.name?.toLowerCase().includes(query) ||
-    tool.description?.toLowerCase().includes(query)
-  );
+  return tools.value.filter(tool => matchesToolSearch(tool, query));
 });
 
 // 处理切换指令状态

--- a/dashboard/src/components/extension/componentPanel/types.ts
+++ b/dashboard/src/components/extension/componentPanel/types.ts
@@ -109,6 +109,7 @@ export interface BuiltinToolConfigTag {
 /** MCP/函数工具对象 */
 export interface ToolItem {
   name: string;
+  display_name?: string;
   description: string;
   active: boolean;
   readonly?: boolean;

--- a/dashboard/src/components/shared/PersonaForm.vue
+++ b/dashboard/src/components/shared/PersonaForm.vue
@@ -115,7 +115,7 @@
                                                                 </template>
 
                                                                 <v-list-item-title>
-                                                                    {{ item.name }}
+                                                                    {{ item.display_name || item.name }}
 
                                                                     <v-chip v-if="item.origin" size="x-small" color="info" class="mr-2"
                                                                         variant="tonal">
@@ -191,7 +191,7 @@
                                                         :closable="!isBuiltinToolName(toolName)"
                                                         @click:close="removeTool(toolName)"
                                                     >
-                                                        {{ toolName }}
+                                                        {{ getToolDisplayName(toolName) }}
                                                     </v-chip>
                                                 </template>
                                                 <span>{{ tm('form.builtinToolDisabledHint') }}</span>
@@ -868,6 +868,12 @@ export default {
             // 检查服务器的所有工具是否都已选中
             return Array.isArray(this.personaForm.tools) &&
                 server.tools.every(toolName => this.personaForm.tools.includes(toolName));
+        },
+
+        getToolDisplayName(toolName) {
+            // Find tool in availableTools and return display_name if available
+            const tool = this.availableTools.find(t => t.name === toolName);
+            return tool?.display_name || toolName;
         }
     }
 }

--- a/dashboard/src/components/shared/PersonaForm.vue
+++ b/dashboard/src/components/shared/PersonaForm.vue
@@ -365,6 +365,7 @@ import {
     askForConfirmation as askForConfirmationDialog,
     useConfirmDialog
 } from '@/utils/confirmDialog';
+import { matchesToolSearch, resolveToolDisplayName } from '@/utils/toolDisplayName';
 
 export default {
     name: 'PersonaForm',
@@ -441,12 +442,7 @@ export default {
             if (!this.toolSearch) {
                 return this.availableTools;
             }
-            const search = this.toolSearch.toLowerCase();
-            return this.availableTools.filter(tool =>
-                tool.name.toLowerCase().includes(search) ||
-                (tool.description && tool.description.toLowerCase().includes(search)) ||
-                (tool.mcp_server_name && tool.mcp_server_name.toLowerCase().includes(search))
-            );
+            return this.availableTools.filter(tool => matchesToolSearch(tool, this.toolSearch));
         },
         filteredSkills() {
             if (!this.skillSearch) {
@@ -871,9 +867,7 @@ export default {
         },
 
         getToolDisplayName(toolName) {
-            // Find tool in availableTools and return display_name if available
-            const tool = this.availableTools.find(t => t.name === toolName);
-            return tool?.display_name || toolName;
+            return resolveToolDisplayName(toolName, this.availableTools);
         }
     }
 }

--- a/dashboard/src/components/shared/PersonaQuickPreview.vue
+++ b/dashboard/src/components/shared/PersonaQuickPreview.vue
@@ -125,7 +125,7 @@ const resolvedTools = computed(() =>
   normalizedTools.value.map((toolName) => {
     const meta = toolMetaMap.value[toolName] || {}
     return {
-      name: toolName,
+      name: meta.display_name || toolName,  // Use display_name for showing
       origin: meta.origin || '',
       origin_name: meta.origin_name || '',
       active: meta.active
@@ -144,6 +144,7 @@ async function loadToolsMeta() {
           continue
         }
         nextMap[tool.name] = {
+          display_name: tool.display_name || tool.name,
           origin: tool.origin || '',
           origin_name: tool.origin_name || '',
           active: tool.active

--- a/dashboard/src/utils/toolDisplayName.ts
+++ b/dashboard/src/utils/toolDisplayName.ts
@@ -1,0 +1,27 @@
+import type { ToolItem } from '@/components/extension/componentPanel/types';
+
+type ToolDisplayNameSource = Pick<ToolItem, 'name' | 'display_name'>;
+type ToolSearchSource = Pick<ToolItem, 'name' | 'display_name' | 'description' | 'origin' | 'origin_name'>;
+
+export function resolveToolDisplayName(
+    toolName: string,
+    availableTools: ToolDisplayNameSource[] = []
+): string {
+    const tool = availableTools.find(item => item.name === toolName);
+    return tool?.display_name || toolName;
+}
+
+export function matchesToolSearch(tool: ToolSearchSource, rawQuery: string): boolean {
+    const query = rawQuery.trim().toLowerCase();
+    if (!query) {
+        return true;
+    }
+
+    return [
+        tool.display_name,
+        tool.name,
+        tool.description,
+        tool.origin,
+        tool.origin_name,
+    ].some(value => value?.toLowerCase().includes(query));
+}

--- a/dashboard/src/views/persona/PersonaManager.vue
+++ b/dashboard/src/views/persona/PersonaManager.vue
@@ -281,6 +281,7 @@ import {
     askForConfirmation as askForConfirmationDialog,
     useConfirmDialog
 } from '@/utils/confirmDialog';
+import { resolveToolDisplayName } from '@/utils/toolDisplayName';
 
 import type { Folder, FolderTreeNode } from '@/components/folder/types';
 
@@ -432,8 +433,7 @@ export default defineComponent({
         },
 
         getToolDisplayName(toolName: string): string {
-            const tool = this.availableTools.find(t => t.name === toolName);
-            return tool?.display_name || toolName;
+            return resolveToolDisplayName(toolName, this.availableTools);
         },
 
         // Persona 操作

--- a/dashboard/src/views/persona/PersonaManager.vue
+++ b/dashboard/src/views/persona/PersonaManager.vue
@@ -164,7 +164,7 @@
                             class="d-flex flex-wrap ga-1">
                             <v-chip v-for="toolName in viewingPersona.tools" :key="toolName" size="small"
                                 color="primary" variant="tonal">
-                                {{ toolName }}
+                                {{ getToolDisplayName(toolName) }}
                             </v-chip>
                         </div>
                         <div v-else class="text-body-2 text-medium-emphasis">
@@ -265,6 +265,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import axios from 'axios';
 import { useI18n, useModuleI18n } from '@/i18n/composables';
 import { usePersonaStore } from '@/stores/personaStore';
 import { mapState, mapActions } from 'pinia';
@@ -347,7 +348,10 @@ export default defineComponent({
 
             // 骨架屏延迟显示控制
             showSkeleton: false,
-            skeletonTimer: null as ReturnType<typeof setTimeout> | null
+            skeletonTimer: null as ReturnType<typeof setTimeout> | null,
+
+            // 工具列表用于显示名称
+            availableTools: [] as any[]
         };
     },
     computed: {
@@ -411,8 +415,25 @@ export default defineComponent({
         async initialize() {
             await Promise.all([
                 this.loadFolderTree(),
-                this.navigateToFolder(null)
+                this.navigateToFolder(null),
+                this.loadTools()
             ]);
+        },
+
+        async loadTools() {
+            try {
+                const response = await axios.get('/api/tools/list');
+                if (response.data.status === 'ok') {
+                    this.availableTools = response.data.data || [];
+                }
+            } catch (error) {
+                console.error('Failed to load tools:', error);
+            }
+        },
+
+        getToolDisplayName(toolName: string): string {
+            const tool = this.availableTools.find(t => t.name === toolName);
+            return tool?.display_name || toolName;
         },
 
         // Persona 操作

--- a/dashboard/src/views/persona/PersonaManager.vue
+++ b/dashboard/src/views/persona/PersonaManager.vue
@@ -283,6 +283,7 @@ import {
 } from '@/utils/confirmDialog';
 import { resolveToolDisplayName } from '@/utils/toolDisplayName';
 
+import type { ToolItem } from '@/components/extension/componentPanel/types';
 import type { Folder, FolderTreeNode } from '@/components/folder/types';
 
 interface Persona {
@@ -352,7 +353,7 @@ export default defineComponent({
             skeletonTimer: null as ReturnType<typeof setTimeout> | null,
 
             // 工具列表用于显示名称
-            availableTools: [] as any[]
+            availableTools: [] as ToolItem[]
         };
     },
     computed: {


### PR DESCRIPTION
Closes #5689

## Description / 描述

This PR fixes the conflict where MCP tools and plugin tools with the same name could not coexist, which previously caused one tool to overwrite the other during registration. The fix introduces namespaced internal names for MCP tools while preserving backward compatibility for existing persona configurations. It also includes follow-up UI, review-feedback, and maintainability fixes so friendly tool names, search behavior, and MCP-specific rendering stay consistent across the dashboard.

此 PR 修复了 MCP 工具和插件工具同名时无法共存的问题。此前工具注册时会发生覆盖，导致两者不能同时启用。修复方案为 MCP 工具引入命名空间内部名称，同时保持对现有 persona 配置的向后兼容；并补充了若干前端、审查反馈和可维护性修复，确保仪表盘中的友好名称展示、搜索行为以及 MCP 相关渲染保持一致。

### Relation to #5925 / 与 #5925 的关系

#5925 已合并，通过在 `get_func()` 中优先返回已激活的工具来缓解同名工具互相"连坐"的问题。它是冲突发生时的选择策略，保证至少一个工具能用。本 PR 解决的是更上一层的问题：通过为 MCP 工具加命名空间前缀 `mcp_<server>__<tool>`，让同名的 MCP 工具和插件工具可以同时注册、同时被 LLM 调用，而不是二选一。两者不冲突——合并本 PR 后 #5925 的激活优先逻辑继续保留，作为同名场景下的通用 tie-breaker。

#5925 is already merged and mitigates the "both disabled" problem by having `get_func()` prefer the active tool when names collide — a resolution policy ensuring at least one tool remains usable. This PR addresses the layer above: by namespacing MCP tool internal names as `mcp_<server>__<tool>`, same-named MCP tools and plugin tools can both register and both be invoked by the LLM, instead of one overriding the other. The two changes are complementary — #5925's active-preference logic stays intact after this PR merges, continuing to serve as a generic tie-breaker for same-name scenarios.

### Root Cause / 根本原因

The `ToolSet.add_tool()` method uses the tool name as the unique identifier. When an MCP tool and a plugin tool share the same name, the later registration replaces the earlier one instead of allowing both to coexist.

`ToolSet.add_tool()` 方法使用工具名称作为唯一标识。当 MCP 工具与插件工具同名时，后注册的工具会覆盖先注册的工具，而不是允许两者共存。

### Solution / 解决方案

1. **Namespaced Internal Names**: MCP tools now use the internal format `mcp_<encoded_server_name>__<tool_name>` to avoid collisions.
2. **Original Name Preservation**: The original MCP tool name is stored in `MCPTool.original_tool_name` and is still used when calling the MCP server.
3. **Backward Compatibility**: `get_func()` falls back to a shared `_find_mcp_tool_by_original_name` helper that prefers active MCP tools, so legacy persona configurations continue to resolve. The fallback sits after the upstream active-first exact match (introduced in #5925), so it only triggers when the namespaced name isn't found — no behavior change for current configurations.
4. **Friendly Display Names**: The tool list API returns both internal `name` and user-facing `display_name`; the MCP "available tools" popup reads a parallel `original_tool_names` field so it shows raw tool names while persona matching keeps using namespaced identifiers.
5. **Frontend Consistency**: Vue components use shared display-name and tool-search helpers, and search-query normalization is centralized in the helper to avoid redundant work on the caller side.
6. **MCP Detection Fix**: Tool icons now use `origin === 'mcp'` instead of parsing the tool name format.
7. **Production Safety**: The post-init invariant in `_start_mcp_server` raises an explicit `RuntimeError` instead of relying on `assert`, so it still holds under `python -O`.

### Modifications / 改动点

**Backend / 后端:**
- `astrbot/core/agent/mcp_client.py`
  - Add namespaced MCP tool names using `mcp_<encoded_server_name>__<tool_name>`
  - URL-encode server names to avoid normalization collisions
  - Store original tool name in `original_tool_name`
  - Move `quote` import to module scope

- `astrbot/core/provider/func_tool_manager.py`
  - Extract `_find_mcp_tool_by_original_name` helper shared by `get_func()`; active matches take priority, deterministic tie-break with warning when multiple MCP servers expose the same original tool name
  - Keep `is_builtin_tool` as a pure boolean predicate (remove prior unreachable MCP fallback)
  - Replace `assert mcp_client is not None` in `_start_mcp_server` with an explicit `RuntimeError` so the invariant survives `python -O`

- `astrbot/dashboard/routes/tools.py`
  - Add `display_name` to the tool list API
  - Return MCP origin metadata for UI rendering
  - Initialize `display_name` in the builtin-tool branch to stay compatible with the builtin tool registry introduced upstream
  - `get_mcp_servers` pre-indexes `MCPTool` instances by server once and uses dict lookup on the runtime view, avoiding an `O(#servers × #tools)` rescan
  - Expose both `tools` (namespaced, for `personaForm.tools` set matching) and `original_tool_names` (for UI display) on each MCP server

**Frontend / 前端:**
- `dashboard/src/components/extension/componentPanel/types.ts`
  - Add `display_name` to the `ToolItem` interface

- `dashboard/src/utils/toolDisplayName.ts`
  - Centralize tool display-name resolution and search matching logic; `matchesToolSearch` handles all query normalization internally

- `dashboard/src/components/shared/PersonaForm.vue`
  - Use `display_name` for tool selection and selected tool rendering
  - Reuse shared display-name and search-matching helpers
  - Remove outdated search dependency on old MCP-specific fields

- `dashboard/src/components/shared/PersonaQuickPreview.vue`
  - Use `display_name` for tool preview display

- `dashboard/src/views/persona/PersonaManager.vue`
  - Use `display_name` for persona detail display
  - Reuse shared display-name helper
  - Type `availableTools` as `ToolItem[]` instead of `any[]`

- `dashboard/src/components/extension/componentPanel/components/ToolTable.vue`
  - Use `origin === 'mcp'` for icon rendering instead of name parsing
  - Use `display_name` for user-facing display
  - Keep the builtin-tool config-tag tooltip introduced upstream

- `dashboard/src/components/extension/componentPanel/index.vue`
  - Use shared tool-search matching so friendly names are searchable in the component panel
  - Drop redundant pre-normalization; delegate trim/lowercase to `matchesToolSearch`

- `dashboard/src/components/extension/McpServersSection.vue`
  - Render the "available tools" popup from `original_tool_names` with a fallback to `tools` for forward compatibility

### Key Improvements / 关键改进

- MCP tools and plugin tools with the same original name can now coexist
- Existing persona configurations continue to work without modification
- MCP server names are encoded safely to avoid namespace collisions
- UI consistently shows friendly MCP tool names instead of internal namespaced identifiers
- The MCP "available tools" popup continues to show raw MCP tool names while namespaced names power set-based matching in persona forms
- Tool search behavior matches what users actually see in the UI
- MCP tool rendering no longer depends on fragile name-format heuristics
- Shared frontend helpers reduce duplicated logic and future drift
- `_start_mcp_server` fails loudly under `python -O` instead of silently skipping an `assert`

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Validation / 验证情况

- Rebased onto current `master`; conflicts with the upstream builtin tool registry (#7418) and related refactors were resolved, preserving upstream's active-first `get_func` behavior and the builtin-tool UI affordances
- Backward-compatibility path in `get_func()` reviewed against legacy persona tool references; falls through only after the active-first exact match, so it's a no-op for existing configs that already resolve by current name
- MCP tool display flow checked end-to-end through `/api/tools/list`, `/api/tools/mcp/servers`, and related Vue consumers
- `uv sync --group dev`, `ruff format --check` and `ruff check` pass on the modified Python files; `vue-tsc --noEmit` passes for the touched frontend files
- Local dashboard rebuilt with `pnpm run build` and copied into `data/dist/`; startup smoke test against `http://localhost:6185` succeeds with no initialization errors and both the tool management view and the MCP servers popup render the expected names
- Review follow-up items addressed in subsequent commits:
  - `quote` import moved to module scope
  - Duplicated display-name logic centralized in a shared helper
  - MCP icon detection switched from name parsing to `origin`
  - Stale search references updated to use shared matching logic
  - MCP fallback lookup extracted into a dedicated helper and made active-first
  - `is_builtin_tool` restored to a pure boolean predicate
  - `/api/tools/mcp/servers` returns a parallel `original_tool_names` field so the popup keeps showing raw tool names
  - `get_mcp_servers` no longer rescans `func_list` per server
  - Search-query normalization consolidated inside `matchesToolSearch`
  - `assert mcp_client is not None` replaced with an explicit `RuntimeError`

### Screenshots / 截图

<img width="2261" height="1245" alt="image" src="https://github.com/user-attachments/assets/4659d36b-3ff6-4fee-951f-86e0c258569b" />

<img width="2120" height="1306" alt="image" src="https://github.com/user-attachments/assets/0bfeff97-a185-4de0-82eb-bdf01763fef0" />

---

### Checklist / 检查清单

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的检查，并已在上方提供了验证说明和运行截图。/ My changes have been reviewed carefully, and validation notes and screenshots have been provided above.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.


## Summary by Sourcery

确保名称相同的 MCP 工具和插件工具可以共存，同时保持向后兼容性，并改进 UI 中工具名称的显示。

新功能：
- 为 MCP 工具引入带命名空间的内部标识符，以避免与插件工具发生冲突。
- 在 API 和前端组件中暴露更易于理解的工具 `display_name` 供用户查看。

缺陷修复：
- 允许旧版 persona 继续工作，这些 persona 仍通过原始名称引用 MCP 工具；通过在函数工具管理器中添加兼容性查找机制实现。

增强改进：
- 更新后端工具列表和与 persona 相关的 Vue 组件，使其使用 `display_name` 来显示工具名称，而不是内部名称。
- 通过在启动成功后断言 MCP 客户端可用，使 MCP 服务器运行时初始化过程更加健壮。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure MCP and plugin tools with identical names can coexist while preserving backward compatibility and improving tool name display in the UI.

New Features:
- Introduce namespaced internal identifiers for MCP tools to avoid collisions with plugin tools.
- Expose a user-friendly display_name for tools in the API and frontend components.

Bug Fixes:
- Allow legacy personas that reference MCP tools by their original names to continue functioning via a compatibility lookup in the function tool manager.

Enhancements:
- Update backend tool listing and persona-related Vue components to use display_name for showing tool names instead of internal names.
- Make MCP server runtime initialization more robust by asserting the MCP client is available after successful startup.

</details>

## Summary by Sourcery

Allow MCP and plugin tools with identical names to coexist by namespacing MCP tool identifiers while keeping existing personas and UI behavior compatible.

Bug Fixes:
- Add backward-compatible lookup of MCP tools by original name so existing personas continue to resolve tools after namespacing changes.
- Ensure MCP server runtime initialization stores a non-null MCP client after successful startup.

Enhancements:
- Namespace MCP tool internal names and preserve original names on the MCPTool object for display and server calls.
- Expose a user-facing display_name and origin metadata for tools via the tool list API and use them across persona and component panel views.
- Unify tool display-name resolution and search matching through shared frontend helpers so tool search and rendering stay consistent.
- Render MCP tools with a dedicated icon based on origin metadata instead of parsing tool names.

## Summary by Sourcery

Allow MCP tools and plugin tools with identical names to coexist by namespacing MCP tool identifiers while keeping existing personas and UI behavior compatible.

New Features:
- Introduce namespaced internal names for MCP tools to avoid collisions with plugin tools and other tools.

Bug Fixes:
- Resolve MCP and plugin tool registration conflicts so tools with the same original name no longer overwrite each other.
- Ensure MCP server runtime initialization always stores a non-null MCP client after successful startup.

Enhancements:
- Add a fallback lookup path to resolve MCP tools by their original names for legacy persona configurations.
- Expose user-facing display names and origin metadata for tools in the tool list API and propagate them through MCP server data.
- Standardize tool display names and search behavior across persona-related and component panel Vue components using shared helpers.
- Render MCP tools with a dedicated icon based on origin metadata and show original tool names in MCP server details for readability.
- Store original MCP tool names alongside namespaced identifiers to keep server calls and UI labels intuitive.