### PR TITLE
feat(dashboard): center extension page toast hints with the global UI

### DIFF
--- a/dashboard/src/scss/_override.scss
+++ b/dashboard/src/scss/_override.scss
@@ -17,6 +17,11 @@ html {
   flex: unset;
 }
 
+.v-overlay.v-snackbar {
+  --v-layout-left: 0px !important;
+  --v-layout-right: 0px !important;
+}
+
 .customizer-btn .icon {
   animation: progress-circular-rotate 1.4s linear infinite;
   transform-origin: center center;

--- a/dashboard/src/views/ExtensionPage.vue
+++ b/dashboard/src/views/ExtensionPage.vue
@@ -397,7 +397,6 @@ const {
     :color="snack_success"
     v-model="snack_show"
     location="bottom center"
-    :style="{ '--v-layout-left': '0px', '--v-layout-right': '0px' }"
   >
     {{ snack_message }}
   </v-snackbar>


### PR DESCRIPTION
## Fixes #6022  

Closes #6022

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

插件页中的底部提示框（snackbar）视觉中心与安装弹窗、加载弹窗不一致。  
根因是 `VSnackbar` 会额外应用 Vuetify layout 的左右偏移量，导致提示框按主内容区居中，而弹窗更接近按整个 UI 视口居中，最终在插件栏目下表现为“偏心”。

本次改动仅针对插件页做最小修复：
- 显式将插件页 snackbar 定位为 `bottom center`
- 覆盖 snackbar 的 `--v-layout-left` / `--v-layout-right` 为 `0px`
- 让提示框按整个 UI 视口中心线显示，与插件页弹窗视觉对齐
- 不改动全局 toast 逻辑，不影响其他页面

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

**文件变更统计：**
- 新增文件：0 个
- 修改文件：1 个
- 删除文件：0 个

**详细变更：**
| 文件 | 变更类型 | 说明 |
|------|---------|------|
| `dashboard/src/views/ExtensionPage.vue` | 修改 | 调整插件页 snackbar 的定位与 layout 偏移，使其按整个 UI 居中显示 |

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

已本地构建验证，并同步前端产物到运行时优先读取的 `data/dist`。

**验证步骤：**
1. 打开 Dashboard 的“插件”栏目
2. 触发底部提示框，例如安装插件、刷新插件市场、插件操作提示
3. 对比提示框与安装弹窗/加载弹窗的水平中心线

**测试命令：**
```bash
cd dashboard
pnpm install --frozen-lockfile
pnpm build
rsync -a --delete dashboard/dist/ data/dist/
```

**测试结果：**
- `pnpm build` 通过
- 仅存在项目原有的 CSS minify warning，无新增构建错误
- 插件页底部提示框改为按整个 UI 视口居中显示

**运行视频：**  

https://github.com/user-attachments/assets/b553bb03-6f39-40a0-a355-471e5b3b58c7


---

### 补充说明：

根据 review 反馈，这次在原先仅修复插件页 snackbar 的基础上，进一步统一处理了 Dashboard 中其他页面的 snackbar 定位问题，保证整体视觉风格一致，效果如下：



https://github.com/user-attachments/assets/84837f85-dcec-4ee2-9bed-69339d1ec49d




### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

错误修复：
- 修复扩展页面上 snackbar 对齐不正确的问题，使其相对于完整界面居中，而不是相对于主内容区域居中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix misaligned snackbar on the extension page so it centers relative to the full UI instead of the main content area.

</details>