### PR TITLE
feat: add check plugin updates button

### DIFF
--- a/dashboard/src/i18n/locales/en-US/features/extension.json
+++ b/dashboard/src/i18n/locales/en-US/features/extension.json
@@ -52,6 +52,7 @@
     "selectFile": "Select File",
     "refresh": "Refresh",
     "updateAll": "Update All",
+    "checkUpdates": "Check Updates",
     "deleteSource": "Delete Source",
     "reshuffle": "Shuffle Again"
   },
@@ -214,7 +215,9 @@
     "updateAllFailed": "{failed} of {total} extensions failed to update:",
     "fillSourceNameAndUrl": "Please fill in the complete source name and URL",
     "invalidUrl": "Please enter a valid URL",
-    "enterJsonUrl": "Please enter a URL that returns plugin list JSON data"
+    "enterJsonUrl": "Please enter a URL that returns plugin list JSON data",
+    "checkUpdatesSuccess": "Update check complete, {count} plugin(s) have updates available",
+    "checkUpdatesFailed": "Failed to check for plugin updates:"
   },
   "upload": {
     "fromFile": "Install from File",

--- a/dashboard/src/i18n/locales/zh-CN/features/extension.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/extension.json
@@ -52,6 +52,7 @@
     "selectFile": "选择文件",
     "refresh": "刷新",
     "updateAll": "更新全部插件",
+    "checkUpdates": "检查插件更新",
     "deleteSource": "删除源",
     "reshuffle": "随机一发"
   },
@@ -214,7 +215,9 @@
     "updateAllFailed": "有 {failed}/{total} 个插件更新失败:",
     "fillSourceNameAndUrl": "请填写完整的插件源名称和地址",
     "invalidUrl": "请输入有效的URL地址",
-    "enterJsonUrl": "请输入返回插件列表JSON数据的URL地址"
+    "enterJsonUrl": "请输入返回插件列表JSON数据的URL地址",
+    "checkUpdatesSuccess": "插件更新检查完成，{count} 个插件有更新",
+    "checkUpdatesFailed": "检查插件更新失败:"
   },
   "upload": {
     "fromFile": "从文件安装",

--- a/dashboard/src/views/extension/InstalledPluginsTab.vue
+++ b/dashboard/src/views/extension/InstalledPluginsTab.vue
@@ -151,6 +151,8 @@ const {
   selectedInstallPlugin,
   checkInstallCompatibility,
   refreshPluginMarket,
+  isCheckingUpdates,
+  checkPluginUpdates,
   handleLocaleChange,
   searchDebounceTimer,
 } = props.state;
@@ -214,6 +216,16 @@ const {
                     >
                       <v-icon>mdi-update</v-icon>
                       {{ tm("buttons.updateAll") }}
+                    </v-btn>
+
+                    <v-btn
+                      color="info"
+                      variant="tonal"
+                      :loading="isCheckingUpdates"
+                      @click="checkPluginUpdates"
+                    >
+                      <v-icon>mdi-cloud-sync</v-icon>
+                      {{ tm("buttons.checkUpdates") }}
                     </v-btn>
                   </div>
 

--- a/dashboard/src/views/extension/useExtensionPage.js
+++ b/dashboard/src/views/extension/useExtensionPage.js
@@ -1426,7 +1426,7 @@ export const useExtensionPage = () => {
   
       toast(tm("messages.refreshSuccess"), "success");
     } catch (err) {
-      toast(tm("messages.refreshFailed") + " " + err, "error");
+      toast(resolveErrorMessage(err, tm("messages.refreshFailed")), "error");
     } finally {
       refreshingMarket.value = false;
     }
@@ -1448,7 +1448,7 @@ export const useExtensionPage = () => {
       const updateCount = updatableExtensions.value.length;
       toast(tm("messages.checkUpdatesSuccess", { count: updateCount }), "success");
     } catch (err) {
-      toast(tm("messages.checkUpdatesFailed") + " " + err, "error");
+      toast(resolveErrorMessage(err, tm("messages.checkUpdatesFailed")), "error");
     } finally {
       isCheckingUpdates.value = false;
     }

--- a/dashboard/src/views/extension/useExtensionPage.js
+++ b/dashboard/src/views/extension/useExtensionPage.js
@@ -1431,6 +1431,28 @@ export const useExtensionPage = () => {
       refreshingMarket.value = false;
     }
   };
+
+  // 手动检查插件更新：刷新市场数据并重新比对已安装插件版本
+  const isCheckingUpdates = ref(false);
+  const checkPluginUpdates = async () => {
+    isCheckingUpdates.value = true;
+    try {
+      const data = await commonStore.getPluginCollections(
+        true,
+        selectedSource.value,
+      );
+      pluginMarketData.value = data;
+      trimExtensionName();
+      checkAlreadyInstalled();
+      checkUpdate();
+      const updateCount = updatableExtensions.value.length;
+      toast(tm("messages.checkUpdatesSuccess", { count: updateCount }), "success");
+    } catch (err) {
+      toast(tm("messages.checkUpdatesFailed") + " " + err, "error");
+    } finally {
+      isCheckingUpdates.value = false;
+    }
+  };
   
   // 生命周期
   onMounted(async () => {
@@ -1695,6 +1717,8 @@ export const useExtensionPage = () => {
     selectedInstallPlugin,
     checkInstallCompatibility,
     refreshPluginMarket,
+    isCheckingUpdates,
+    checkPluginUpdates,
     handleLocaleChange,
     searchDebounceTimer,
   };


### PR DESCRIPTION
This PR adds a "Check Updates" button to the installed plugins tab, next to the "Update All" button. It triggers a refresh of the market data and re-checks the installed plugins for updates. Localized across en-US and zh-CN.

## 由 Sourcery 提供的摘要

在已安装插件视图中添加手动检查插件更新的操作，包括相应的 UI 控件以及支持的状态管理和消息提示。

新功能：
- 在已安装插件标签页中添加 “检查更新” 按钮，用于手动刷新插件市场数据并重新评估已安装插件是否有可用更新。

增强内容：
- 在检查插件更新时跟踪独立的加载状态，并通过本地化的成功或失败提示（toast）来反馈操作结果。
- 扩展与扩展程序相关的 i18n 资源，使其覆盖新的检查更新操作，支持英文和中文本地化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a manual plugin update check action to the installed plugins view, including UI controls and supporting state and messaging.

New Features:
- Add a "Check Updates" button to the installed plugins tab to manually refresh plugin market data and re-evaluate installed plugins for updates.

Enhancements:
- Track a dedicated loading state while checking plugin updates and surface localized success or failure toasts for the operation.
- Extend extension-related i18n resources to cover the new check-updates action in both English and Chinese locales.

</details>