### PR TITLE
fix: clarify unsupported DashScope realtime VC models

### DIFF
--- a/astrbot/core/provider/sources/dashscope_tts.py
+++ b/astrbot/core/provider/sources/dashscope_tts.py
@@ -64,6 +64,12 @@ class ProviderDashscopeTTSAPI(TTSProvider):
         return path
 
     def _call_qwen_tts(self, model: str, text: str):
+        if self._is_qwen_realtime_vc_model(model):
+            raise RuntimeError(
+                f"DashScope realtime voice-clone model '{model}' is not supported by the built-in dashscope_tts provider yet. "
+                "Please use a non-realtime DashScope TTS model or the astrbot_plugin_qwen_tts plugin instead.",
+            )
+
         if MultiModalConversation is None:
             raise RuntimeError(
                 "dashscope SDK missing MultiModalConversation. Please upgrade the dashscope package to use Qwen TTS models.",
@@ -161,3 +167,7 @@ class ProviderDashscopeTTSAPI(TTSProvider):
     def _is_qwen_tts_model(self, model: str) -> bool:
         model_lower = model.lower()
         return "tts" in model_lower and model_lower.startswith("qwen")
+
+    def _is_qwen_realtime_vc_model(self, model: str) -> bool:
+        model_lower = model.lower()
+        return model_lower.startswith("qwen") and "tts-vc-realtime" in model_lower

--- a/tests/test_dashscope_tts.py
+++ b/tests/test_dashscope_tts.py
@@ -1,0 +1,65 @@
+from astrbot.core.provider.sources import dashscope_tts
+from astrbot.core.provider.sources.dashscope_tts import ProviderDashscopeTTSAPI
+
+
+def make_provider(model: str) -> ProviderDashscopeTTSAPI:
+    return ProviderDashscopeTTSAPI(
+        {
+            "id": "dashscope_tts",
+            "type": "dashscope_tts",
+            "model": model,
+            "api_key": "test-key",
+            "dashscope_tts_voice": "test-voice",
+        },
+        {},
+    )
+
+
+def test_realtime_qwen_vc_models_raise_clear_error(monkeypatch):
+    provider = make_provider("qwen3-tts-vc-realtime-2026-01-15")
+    called = False
+
+    class FakeMultiModalConversation:
+        @staticmethod
+        def call(**kwargs):
+            nonlocal called
+            called = True
+            return kwargs
+
+    monkeypatch.setattr(
+        dashscope_tts, "MultiModalConversation", FakeMultiModalConversation
+    )
+
+    try:
+        provider._call_qwen_tts(provider.get_model(), "hello")
+    except RuntimeError as exc:
+        message = str(exc)
+    else:  # pragma: no cover - defensive branch for clearer assertion failure
+        raise AssertionError("Expected realtime Qwen VC model to raise RuntimeError")
+
+    assert "realtime voice-clone model" in message
+    assert "astrbot_plugin_qwen_tts" in message
+    assert not called
+
+
+def test_regular_qwen_tts_models_still_use_multimodal_conversation(monkeypatch):
+    provider = make_provider("qwen-tts-latest")
+    captured = {}
+
+    class FakeMultiModalConversation:
+        @staticmethod
+        def call(**kwargs):
+            captured.update(kwargs)
+            return {"ok": True}
+
+    monkeypatch.setattr(
+        dashscope_tts, "MultiModalConversation", FakeMultiModalConversation
+    )
+
+    result = provider._call_qwen_tts(provider.get_model(), "hello")
+
+    assert result == {"ok": True}
+    assert captured["model"] == "qwen-tts-latest"
+    assert captured["messages"] is None
+    assert captured["voice"] == "test-voice"
+    assert captured["text"] == "hello"


### PR DESCRIPTION
Closes #6045

### Modifications / 改动点

- fail fast for `qwen*-tts-vc-realtime*` models in the built-in `dashscope_tts` provider instead of sending them through the generic `MultiModalConversation` flow
- return a clear error that explains the built-in provider does not support DashScope realtime voice-clone models yet and points users to a non-realtime model or `astrbot_plugin_qwen_tts`
- add focused coverage for the new guard so realtime VC models raise the clearer error while regular Qwen TTS models still use `MultiModalConversation`

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```bash
python -m ruff check astrbot/core/provider/sources/dashscope_tts.py tests/test_dashscope_tts.py
# All checks passed!

python3.11 -m py_compile astrbot/core/provider/sources/dashscope_tts.py tests/test_dashscope_tts.py
# success

python3.11 <focused verification script>
# verification-ok
```

---

### Checklist / 检查清单

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

在内置提供方中对不受支持的 DashScope 实时 Qwen 语音克隆 TTS 模型进行防护，确保它们能够快速失败并给出清晰的指引信息，同时保持对已受支持的 Qwen TTS 模型的现有行为不变。

Bug 修复：
- 通过抛出清晰的错误，阻止不受支持的 DashScope 实时 Qwen 语音克隆 TTS 模型被路由到通用的 MultiModalConversation 流程中。

测试：
- 添加单元测试，验证实时 Qwen 语音克隆 TTS 模型会抛出新的描述性错误，并且普通的 Qwen TTS 模型仍然像之前一样使用 MultiModalConversation。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard unsupported DashScope realtime Qwen voice-clone TTS models in the built-in provider and ensure they fail fast with a clear guidance message while preserving existing behavior for supported Qwen TTS models.

Bug Fixes:
- Prevent unsupported DashScope realtime Qwen voice-clone TTS models from being routed through the generic MultiModalConversation flow by raising a clear error instead.

Tests:
- Add unit tests verifying that realtime Qwen voice-clone TTS models raise the new descriptive error and that regular Qwen TTS models still use MultiModalConversation as before.

</details>