### PR TITLE
fix: ensure Gemini array schemas always include items

### DIFF
--- a/astrbot/core/agent/tool.py
+++ b/astrbot/core/agent/tool.py
@@ -293,8 +293,15 @@ class ToolSet:
                 if properties:
                     result["properties"] = properties
 
-            if "items" in schema:
-                result["items"] = convert_schema(schema["items"])
+            if target_type == "array":
+                items_schema = schema.get("items")
+                if isinstance(items_schema, dict):
+                    result["items"] = convert_schema(items_schema)
+                else:
+                    # Gemini requires array schemas to include an `items` schema.
+                    # JSON Schema allows omitting it, so fall back to a permissive
+                    # string item schema instead of emitting an invalid declaration.
+                    result["items"] = {"type": "string"}
 
             return result
 

--- a/tests/unit/test_tool_google_schema.py
+++ b/tests/unit/test_tool_google_schema.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Generic, TypeVar
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL_MODULE_PATH = REPO_ROOT / "astrbot/core/agent/tool.py"
+
+
+def load_tool_module():
+    package_names = [
+        "astrbot",
+        "astrbot.core",
+        "astrbot.core.agent",
+        "astrbot.core.message",
+    ]
+    for name in package_names:
+        if name not in sys.modules:
+            module = types.ModuleType(name)
+            module.__path__ = []
+            sys.modules[name] = module
+
+    message_result_module = types.ModuleType(
+        "astrbot.core.message.message_event_result"
+    )
+    message_result_module.MessageEventResult = type("MessageEventResult", (), {})
+    sys.modules[message_result_module.__name__] = message_result_module
+
+    run_context_module = types.ModuleType("astrbot.core.agent.run_context")
+    run_context_module.TContext = TypeVar("TContext")
+
+    class ContextWrapper(Generic[run_context_module.TContext]):
+        pass
+
+    run_context_module.ContextWrapper = ContextWrapper
+    sys.modules[run_context_module.__name__] = run_context_module
+
+    spec = importlib.util.spec_from_file_location(
+        "astrbot.core.agent.tool", TOOL_MODULE_PATH
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_google_schema_fills_missing_array_items_with_string_schema():
+    tool_module = load_tool_module()
+    FunctionTool = tool_module.FunctionTool
+    ToolSet = tool_module.ToolSet
+
+    tool = FunctionTool(
+        name="search_sources",
+        description="Search sources by UUID.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "source_uuids": {
+                    "type": "array",
+                    "description": "Optional list of source UUIDs.",
+                }
+            },
+            "required": ["source_uuids"],
+        },
+    )
+
+    schema = ToolSet([tool]).google_schema()
+    source_uuids = schema["function_declarations"][0]["parameters"]["properties"][
+        "source_uuids"
+    ]
+
+    assert source_uuids["type"] == "array"
+    assert source_uuids["items"] == {"type": "string"}


### PR DESCRIPTION
Fixes #6029.

### Modifications / 改动点

- ensure `ToolSet.google_schema()` always emits an `items` schema for array parameters before building Gemini function declarations
- fall back to a permissive string item schema when the source JSON Schema leaves `items` unspecified, so Gemini no longer rejects the declaration as invalid
- add a focused regression test covering an array parameter without an explicit `items` schema

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

- `python -m pytest --noconftest tests/unit/test_tool_google_schema.py`
- `ruff check astrbot/core/agent/tool.py tests/unit/test_tool_google_schema.py`

---

### Checklist / 检查清单

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

确保与 Gemini 兼容的工具 schema 始终包含有效的数组元素定义，并为缺失的元素 schema 添加回归测试覆盖。

Bug Fixes:
- 保证 Gemini 工具 schema 中的数组参数始终包含 `items` schema；当源 JSON Schema 省略该字段时，回退为一个宽松的字符串元素 schema。

Tests:
- 添加回归测试，用于验证在源定义中未显式指定 `items` schema 的数组参数，会在生成的 Gemini 工具声明中自动带有默认的字符串元素 schema。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure Gemini-compatible tool schemas always include valid array item definitions and add regression coverage for missing item schemas.

Bug Fixes:
- Guarantee that array parameters in Gemini tool schemas always include an `items` schema, falling back to a permissive string item schema when the source JSON Schema omits it.

Tests:
- Add a regression test verifying that an array parameter without an explicit `items` schema is emitted with a default string item schema in the generated Gemini tool declaration.

</details>