### PR TITLE
fix(core): fall back on Windows skill file encodings

### DIFF
--- a/astrbot/core/computer/booters/local.py
+++ b/astrbot/core/computer/booters/local.py
@@ -53,29 +53,43 @@ def _ensure_safe_path(path: str) -> str:
     return abs_path
 
 
-def _decode_shell_output(output: bytes | None) -> str:
+def _decode_bytes_with_fallback(
+    output: bytes | None,
+    *,
+    preferred_encoding: str | None = None,
+) -> str:
     if output is None:
         return ""
 
     preferred = locale.getpreferredencoding(False) or "utf-8"
-    try:
-        return output.decode("utf-8")
-    except (LookupError, UnicodeDecodeError):
-        pass
+    attempted_encodings: list[str] = []
+
+    def _try_decode(encoding: str) -> str | None:
+        normalized = encoding.lower()
+        if normalized in attempted_encodings:
+            return None
+        attempted_encodings.append(normalized)
+        try:
+            return output.decode(encoding)
+        except (LookupError, UnicodeDecodeError):
+            return None
+
+    for encoding in filter(None, [preferred_encoding, "utf-8", "utf-8-sig"]):
+        if decoded := _try_decode(encoding):
+            return decoded
 
     if os.name == "nt":
-        for encoding in ("mbcs", "cp936", "gbk", "gb18030"):
-            try:
-                return output.decode(encoding)
-            except (LookupError, UnicodeDecodeError):
-                continue
-
-    try:
-        return output.decode(preferred)
-    except (LookupError, UnicodeDecodeError):
-        pass
+        for encoding in ("mbcs", "cp936", "gbk", "gb18030", preferred):
+            if decoded := _try_decode(encoding):
+                return decoded
+    elif decoded := _try_decode(preferred):
+        return decoded
 
     return output.decode("utf-8", errors="replace")
+
+
+def _decode_shell_output(output: bytes | None) -> str:
+    return _decode_bytes_with_fallback(output, preferred_encoding="utf-8")
 
 
 @dataclass
@@ -184,8 +198,12 @@ class LocalFileSystemComponent(FileSystemComponent):
     async def read_file(self, path: str, encoding: str = "utf-8") -> dict[str, Any]:
         def _run() -> dict[str, Any]:
             abs_path = _ensure_safe_path(path)
-            with open(abs_path, encoding=encoding) as f:
-                content = f.read()
+            with open(abs_path, "rb") as f:
+                raw_content = f.read()
+            content = _decode_bytes_with_fallback(
+                raw_content,
+                preferred_encoding=encoding,
+            )
             return {"success": True, "content": content}
 
         return await asyncio.to_thread(_run)

--- a/tests/test_local_filesystem_component.py
+++ b/tests/test_local_filesystem_component.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from astrbot.core.computer.booters import local as local_booter
+from astrbot.core.computer.booters.local import LocalFileSystemComponent
+
+
+def _allow_tmp_root(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(local_booter, "get_astrbot_root", lambda: str(tmp_path))
+    monkeypatch.setattr(local_booter, "get_astrbot_data_path", lambda: str(tmp_path))
+    monkeypatch.setattr(local_booter, "get_astrbot_temp_path", lambda: str(tmp_path))
+
+
+def test_local_file_system_component_prefers_utf8_before_windows_locale(
+    monkeypatch,
+    tmp_path: Path,
+):
+    _allow_tmp_root(monkeypatch, tmp_path)
+    monkeypatch.setattr(local_booter.os, "name", "nt", raising=False)
+    monkeypatch.setattr(
+        local_booter.locale,
+        "getpreferredencoding",
+        lambda _do_setlocale=False: "cp936",
+    )
+
+    skill_path = tmp_path / "skills" / "demo.txt"
+    skill_path.parent.mkdir(parents=True, exist_ok=True)
+    skill_path.write_bytes("技能内容".encode("utf-8"))
+
+    result = asyncio.run(LocalFileSystemComponent().read_file(str(skill_path)))
+
+    assert result["success"] is True
+    assert result["content"] == "技能内容"
+
+
+def test_local_file_system_component_falls_back_to_gbk_on_windows(
+    monkeypatch,
+    tmp_path: Path,
+):
+    _allow_tmp_root(monkeypatch, tmp_path)
+    monkeypatch.setattr(local_booter.os, "name", "nt", raising=False)
+    monkeypatch.setattr(
+        local_booter.locale,
+        "getpreferredencoding",
+        lambda _do_setlocale=False: "cp1252",
+    )
+
+    skill_path = tmp_path / "skills" / "weibo-hot.txt"
+    skill_path.parent.mkdir(parents=True, exist_ok=True)
+    skill_path.write_bytes("微博热搜".encode("gbk"))
+
+    result = asyncio.run(LocalFileSystemComponent().read_file(str(skill_path)))
+
+    assert result["success"] is True
+    assert result["content"] == "微博热搜"


### PR DESCRIPTION
Fixes #6027

### Modifications / 改动点

- add a shared byte-decoding fallback helper for local computer runtime reads on Windows
- keep shell output preferring UTF-8 first, then fall back to common Windows encodings
- make `LocalFileSystemComponent.read_file()` read bytes and decode with the same fallback path instead of hard-failing on UTF-8-only reads
- add focused tests covering:
  - UTF-8 content still decoding correctly when the Windows locale prefers `cp936`
  - GBK-encoded skill content decoding correctly on Windows fallback paths

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Verification run locally:

```bash
python3.11 -m py_compile astrbot/core/computer/booters/local.py tests/test_local_filesystem_component.py
```

And a direct module-load smoke test (with stubbed app deps) verified both cases:

- UTF-8 file on Windows locale `cp936` -> `技能内容`
- GBK file on Windows locale `cp1252` -> `微博热搜`

---

### Checklist / 检查清单

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## 由 Sourcery 提供的摘要

通过引入共享的回退解码器，并在本地文件系统组件中使用它，改进 Windows 下 shell 输出和本地文件读取时的字节解码行为。

错误修复：
- 在 Windows 上读取非 UTF-8 文件时，通过回退到常见的 Windows 编码，防止读取失败。
- 在 Windows 上解码 shell 命令输出时，使用按优先级排列的一组编码，而不是仅假定为 UTF-8，从而提高解码健壮性。

增强内容：
- 引入可复用的字节解码助手，将各组件的编码优先级和回退逻辑进行集中管理。

测试：
- 增加测试，验证在读取技能文件时，UTF-8 文件优先于 Windows 区域设置编码。
- 增加测试，验证通过 Windows 特定的回退路径，能够正确解码 GBK 编码的技能文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Windows byte decoding behavior for shell output and local file reads by introducing a shared fallback decoder and using it in the local file system component.

Bug Fixes:
- Prevent failures when reading non-UTF-8 files on Windows by falling back to common Windows encodings.
- Ensure shell command output is decoded robustly on Windows using a prioritized set of encodings instead of assuming UTF-8 only.

Enhancements:
- Introduce a reusable byte-decoding helper that centralizes encoding preference and fallback logic across components.

Tests:
- Add tests verifying UTF-8 files are preferred over the Windows locale encoding when reading skills.
- Add tests verifying GBK-encoded skill files are correctly decoded via Windows-specific fallback paths.

</details>