### PR TITLE
fix: drop Groq reasoning_content from assistant history

### DIFF
--- a/astrbot/core/provider/sources/groq_source.py
+++ b/astrbot/core/provider/sources/groq_source.py
@@ -13,3 +13,11 @@ class ProviderGroq(ProviderOpenAIOfficial):
     ) -> None:
         super().__init__(provider_config, provider_settings)
         self.reasoning_key = "reasoning"
+
+    def _finally_convert_payload(self, payloads: dict) -> None:
+        """Groq rejects assistant history items that include reasoning_content."""
+        super()._finally_convert_payload(payloads)
+        for message in payloads.get("messages", []):
+            if message.get("role") == "assistant":
+                message.pop("reasoning_content", None)
+                message.pop("reasoning", None)

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from astrbot.core.provider.sources.groq_source import ProviderGroq
 from astrbot.core.provider.sources.openai_source import ProviderOpenAIOfficial
 
 
@@ -27,6 +28,21 @@ def _make_provider(overrides: dict | None = None) -> ProviderOpenAIOfficial:
     if overrides:
         provider_config.update(overrides)
     return ProviderOpenAIOfficial(
+        provider_config=provider_config,
+        provider_settings={},
+    )
+
+
+def _make_groq_provider(overrides: dict | None = None) -> ProviderGroq:
+    provider_config = {
+        "id": "test-groq",
+        "type": "groq_chat_completion",
+        "model": "qwen/qwen3-32b",
+        "key": ["test-key"],
+    }
+    if overrides:
+        provider_config.update(overrides)
+    return ProviderGroq(
         provider_config=provider_config,
         provider_settings={},
     )
@@ -196,6 +212,57 @@ def test_extract_error_text_candidates_truncates_long_response_text():
     assert max(len(candidate) for candidate in candidates) <= (
         ProviderOpenAIOfficial._ERROR_TEXT_CANDIDATE_MAX_CHARS
     )
+
+
+@pytest.mark.asyncio
+async def test_openai_payload_keeps_reasoning_content_in_assistant_history():
+    provider = _make_provider()
+    try:
+        payloads = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "think", "think": "step 1"},
+                        {"type": "text", "text": "final answer"},
+                    ],
+                }
+            ]
+        }
+
+        provider._finally_convert_payload(payloads)
+
+        assistant_message = payloads["messages"][0]
+        assert assistant_message["content"] == [{"type": "text", "text": "final answer"}]
+        assert assistant_message["reasoning_content"] == "step 1"
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_groq_payload_drops_reasoning_content_from_assistant_history():
+    provider = _make_groq_provider()
+    try:
+        payloads = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "think", "think": "step 1"},
+                        {"type": "text", "text": "final answer"},
+                    ],
+                }
+            ]
+        }
+
+        provider._finally_convert_payload(payloads)
+
+        assistant_message = payloads["messages"][0]
+        assert assistant_message["content"] == [{"type": "text", "text": "final answer"}]
+        assert "reasoning_content" not in assistant_message
+        assert "reasoning" not in assistant_message
+    finally:
+        await provider.terminate()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- strip `reasoning_content` / `reasoning` from assistant history before Groq requests
- keep the existing think-block cleanup from the OpenAI-compatible base provider
- add regression tests covering OpenAI vs Groq payload conversion behavior

## Why
Groq rejects assistant history messages that include `reasoning_content`, which breaks follow-up turns after prior responses contained reasoning. This keeps the cleaned assistant text while omitting the unsupported field for Groq.

Closes #5946

## Summary by Sourcery

调整 Groq 聊天补全（chat completion）请求负载的处理方式：在保留现有 OpenAI 行为的同时，从 assistant 历史消息中剥离不受支持的推理字段，并为两个提供商增加回归测试覆盖。

Bug Fixes:
- 通过从发出的请求负载中的 assistant 消息里移除 `reasoning` 和 `reasoning_content` 字段，防止 Groq 请求失败。

Tests:
- 添加回归测试，用于验证在负载转换过程中，OpenAI 会保留 assistant 历史中的 `reasoning_content` 字段，而 Groq 会丢弃推理相关字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust Groq chat completion payload handling to strip unsupported reasoning fields from assistant history while preserving existing OpenAI behavior and add regression coverage for both providers.

Bug Fixes:
- Prevent Groq requests from failing by removing reasoning and reasoning_content fields from assistant messages in the outgoing payload.

Tests:
- Add regression tests verifying OpenAI retains reasoning_content in assistant history while Groq drops reasoning fields during payload conversion.

</details>