### PR TITLE
fix: avoid duplicate replies after send_message_to_user

### DIFF
--- a/astrbot/core/astr_main_agent_resources.py
+++ b/astrbot/core/astr_main_agent_resources.py
@@ -382,6 +382,13 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
             MessageChain(chain=components),
         )
 
+        if str(target_session) == context.context.event.unified_msg_origin:
+            context.context.event._has_send_oper = True
+            context.context.event.set_extra(
+                "_send_message_to_user_current_session",
+                True,
+            )
+
         # if file_from_sandbox:
         #     try:
         #         os.remove(local_path)

--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -177,6 +177,11 @@ class RespondStage(Stage):
         if event.get_extra("_streaming_finished", False):
             # prevent some plugin make result content type to LLM_RESULT after streaming finished, lead to send again
             return
+        if event.get_extra("_send_message_to_user_current_session", False):
+            logger.info(
+                "send_message_to_user already delivered the reply for this session, skip respond stage",
+            )
+            return
         if result.result_content_type == ResultContentType.STREAMING_FINISH:
             event.set_extra("_streaming_finished", True)
             return

--- a/tests/unit/test_send_message_to_user_tool.py
+++ b/tests/unit/test_send_message_to_user_tool.py
@@ -1,0 +1,84 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from astrbot.core.agent.run_context import ContextWrapper
+from astrbot.core.astr_main_agent_resources import SendMessageToUserTool
+from astrbot.core.message.message_event_result import MessageEventResult
+from astrbot.core.pipeline.respond.stage import RespondStage
+
+
+class _DummyEvent:
+    def __init__(self) -> None:
+        self.unified_msg_origin = "test_platform_id:FriendMessage:session123"
+        self._has_send_oper = False
+        self._extras: dict[str, object] = {}
+        self._result = MessageEventResult().message("duplicate reply")
+        self.send = AsyncMock()
+
+    def set_extra(self, key: str, value: object) -> None:
+        self._extras[key] = value
+
+    def get_extra(self, key: str, default=None):
+        return self._extras.get(key, default)
+
+    def get_result(self):
+        return self._result
+
+
+@pytest.mark.asyncio
+async def test_send_message_to_user_marks_current_session_delivery():
+    event = _DummyEvent()
+    send_message = AsyncMock(return_value=True)
+    run_context = ContextWrapper(
+        context=SimpleNamespace(
+            event=event,
+            context=SimpleNamespace(send_message=send_message),
+        ),
+    )
+
+    tool = SendMessageToUserTool()
+    result = await tool.call(
+        run_context,
+        messages=[{"type": "plain", "text": "hello"}],
+    )
+
+    assert "Message sent to session" in result
+    send_message.assert_awaited_once()
+    assert event._has_send_oper is True
+    assert event.get_extra("_send_message_to_user_current_session") is True
+
+
+@pytest.mark.asyncio
+async def test_send_message_to_user_other_session_does_not_mark_current_session():
+    event = _DummyEvent()
+    send_message = AsyncMock(return_value=True)
+    run_context = ContextWrapper(
+        context=SimpleNamespace(
+            event=event,
+            context=SimpleNamespace(send_message=send_message),
+        ),
+    )
+
+    tool = SendMessageToUserTool()
+    await tool.call(
+        run_context,
+        session="test_platform_id:FriendMessage:another-session",
+        messages=[{"type": "plain", "text": "hello"}],
+    )
+
+    assert event._has_send_oper is False
+    assert event.get_extra("_send_message_to_user_current_session") is None
+
+
+@pytest.mark.asyncio
+async def test_respond_stage_skips_duplicate_after_send_message_to_user():
+    stage = RespondStage()
+    event = _DummyEvent()
+    event.set_extra("_send_message_to_user_current_session", True)
+
+    result = await stage.process(event)
+
+    assert result is None
+    event.send.assert_not_awaited()


### PR DESCRIPTION
## Summary
- mark same-session `send_message_to_user` deliveries on the originating event
- have `RespondStage` skip the final send when that tool already delivered the reply
- add regression tests covering current-session, cross-session, and respond-stage behavior

## Testing
- `PYTHONPATH=. pytest tests/unit/test_send_message_to_user_tool.py tests/unit/test_aiocqhttp_poke.py -q`
- `ruff check astrbot/core/astr_main_agent_resources.py astrbot/core/pipeline/respond/stage.py tests/unit/test_send_message_to_user_tool.py`

Closes #6005.
