### PR TITLE
fix(webui): align Extensions toasts with shared snackbar

### DIFF
--- a/dashboard/src/views/ExtensionPage.vue
+++ b/dashboard/src/views/ExtensionPage.vue
@@ -33,9 +33,6 @@ const {
   extension_data,
   getInitialShowReserved,
   showReserved,
-  snack_message,
-  snack_show,
-  snack_success,
   configDialog,
   extension_config,
   pluginMarketData,
@@ -390,15 +387,6 @@ const {
       </v-card-actions>
     </v-card>
   </v-dialog>
-
-  <v-snackbar
-    :timeout="2000"
-    elevation="24"
-    :color="snack_success"
-    v-model="snack_show"
-  >
-    {{ snack_message }}
-  </v-snackbar>
 
   <ReadmeDialog
     v-model:show="readmeDialog.show"

--- a/dashboard/src/views/extension/useExtensionPage.js
+++ b/dashboard/src/views/extension/useExtensionPage.js
@@ -3,6 +3,7 @@ import { useCommonStore } from "@/stores/common";
 import { useI18n, useModuleI18n } from "@/i18n/composables";
 import { getPlatformDisplayName } from "@/utils/platformUtils";
 import { resolveErrorMessage } from "@/utils/errorUtils";
+import { useToast } from "@/utils/toast";
 import {
   buildSearchQuery,
   matchesPluginSearch,
@@ -65,6 +66,7 @@ export const useExtensionPage = () => {
   const commonStore = useCommonStore();
   const { t } = useI18n();
   const { tm } = useModuleI18n("features/extension");
+  const { toast } = useToast();
   const router = useRouter();
   const route = useRoute();
   const { width } = useDisplay();
@@ -132,9 +134,6 @@ export const useExtensionPage = () => {
     return false;
   };
   const showReserved = ref(getInitialShowReserved());
-  const snack_message = ref("");
-  const snack_show = ref(false);
-  const snack_success = ref("success");
   const configDialog = ref(false);
   const extension_config = reactive({
     metadata: {},
@@ -544,12 +543,6 @@ export const useExtensionPage = () => {
     if (typeof window !== "undefined" && window.localStorage) {
       localStorage.setItem("showReservedPlugins", showReserved.value.toString());
     }
-  };
-  
-  const toast = (message, success) => {
-    snack_message.value = message;
-    snack_show.value = true;
-    snack_success.value = success;
   };
   
   const resetLoadingDialog = () => {
@@ -1569,9 +1562,6 @@ export const useExtensionPage = () => {
     extension_data,
     getInitialShowReserved,
     showReserved,
-    snack_message,
-    snack_show,
-    snack_success,
     configDialog,
     extension_config,
     pluginMarketData,


### PR DESCRIPTION
Fixes #6022.

### Modifications / 改动点

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
- remove the Extensions page's local snackbar state and inline snackbar markup
- switch the page composable to the shared app-level `useToast()` helper so dialog-related toasts render through the same global snackbar as the rest of the dashboard
- keep the diff small and behaviorally equivalent while avoiding the dialog/toast alignment mismatch reported in the issue

### Screenshots or Test Results / 运行截图或测试结果

- targeted syntax verification for the touched files:
  - `dashboard/src/views/extension/useExtensionPage.js`
  - `dashboard/src/views/ExtensionPage.vue`
- verification script parsed the JS file with TypeScript's parser and parsed/compiled the Vue SFC with `@vue/compiler-sfc`
- no new dependencies added

---

### Checklist / 检查清单

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

将扩展（Extensions）页面的 toast 处理方式与应用级共享 snackbar 系统对齐。

Bug 修复：
- 确保与扩展相关的对话框 toast 通过与仪表板其余部分相同的全局 snackbar 渲染，以修复对齐不一致的问题。

功能增强：
- 移除扩展页面的本地 snackbar 状态和内联 snackbar 组件，改用共享的 `useToast()` 辅助函数，实现统一的 toast 处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align the Extensions page toast handling with the shared app-level snackbar system.

Bug Fixes:
- Ensure extension-related dialog toasts render through the same global snackbar as the rest of the dashboard to fix alignment inconsistencies.

Enhancements:
- Remove the Extensions page’s local snackbar state and inline snackbar component in favor of the shared useToast() helper for unified toast handling.

</details>