### PR TITLE
fix(skills): preserve cached sandbox skill paths

### DIFF
--- a/astrbot/core/skills/skill_manager.py
+++ b/astrbot/core/skills/skill_manager.py
@@ -154,10 +154,18 @@ def build_skills_prompt(skills: list[SkillInfo]) -> str:
                 description = "Read SKILL.md for details."
 
         if skill.source_type == "sandbox_only":
-            rendered_path = (
-                f"{str(SANDBOX_WORKSPACE_ROOT)}/{str(SANDBOX_SKILLS_ROOT)}/"
-                f"{display_name}/SKILL.md"
-            )
+            if display_name != skill.name:
+                rendered_path = (
+                    f"{str(SANDBOX_WORKSPACE_ROOT)}/{str(SANDBOX_SKILLS_ROOT)}/"
+                    f"{display_name}/SKILL.md"
+                )
+            else:
+                rendered_path = _sanitize_prompt_path_for_prompt(skill.path)
+                if not rendered_path:
+                    rendered_path = (
+                        f"{str(SANDBOX_WORKSPACE_ROOT)}/{str(SANDBOX_SKILLS_ROOT)}/"
+                        f"{display_name}/SKILL.md"
+                    )
         else:
             rendered_path = _sanitize_prompt_path_for_prompt(skill.path)
             if not rendered_path:
@@ -389,12 +397,9 @@ class SkillManager:
                 if active_only and not active:
                     continue
                 description = sandbox_cached_descriptions.get(skill_name, "")
-                if show_sandbox_path:
+                path_str = sandbox_cached_paths.get(skill_name, "")
+                if not path_str:
                     path_str = f"{SANDBOX_WORKSPACE_ROOT}/{SANDBOX_SKILLS_ROOT}/{skill_name}/SKILL.md"
-                else:
-                    path_str = sandbox_cached_paths.get(skill_name, "")
-                    if not path_str:
-                        path_str = f"{SANDBOX_WORKSPACE_ROOT}/{SANDBOX_SKILLS_ROOT}/{skill_name}/SKILL.md"
                 skills_by_name[skill_name] = SkillInfo(
                     name=skill_name,
                     description=description,

--- a/tests/test_skill_manager_sandbox_cache.py
+++ b/tests/test_skill_manager_sandbox_cache.py
@@ -58,7 +58,7 @@ def test_list_skills_merges_local_and_sandbox_cache(monkeypatch, tmp_path: Path)
     assert by_name["custom-local"].description == "local description"
     assert by_name["custom-local"].path == "skills/custom-local/SKILL.md"
     assert by_name["python-sandbox"].description == "ship built-in"
-    assert by_name["python-sandbox"].path == "/workspace/skills/python-sandbox/SKILL.md"
+    assert by_name["python-sandbox"].path == "/app/skills/python-sandbox/SKILL.md"
 
 
 def test_sandbox_cached_skill_respects_active_and_display_path(

--- a/tests/test_skill_metadata_enrichment.py
+++ b/tests/test_skill_metadata_enrichment.py
@@ -269,6 +269,26 @@ def test_build_skills_prompt_sanitizes_sandbox_skill_metadata_in_inventory():
     assert "`/workspace/skills/sandbox-skill/SKILL.md`" in prompt
 
 
+def test_build_skills_prompt_preserves_cached_absolute_sandbox_path():
+    skills = [
+        SkillInfo(
+            name="docx",
+            description="Read and write Word documents.",
+            path="/home/ship_0d0fba63/workspace/skills/docx/SKILL.md",
+            active=True,
+            source_type="sandbox_only",
+            source_label="sandbox_preset",
+            local_exists=False,
+            sandbox_exists=True,
+        )
+    ]
+
+    prompt = build_skills_prompt(skills)
+
+    assert "`/home/ship_0d0fba63/workspace/skills/docx/SKILL.md`" in prompt
+    assert "cat /home/ship_0d0fba63/workspace/skills/docx/SKILL.md" in prompt
+
+
 def test_build_skills_prompt_sanitizes_invalid_sandbox_skill_name_in_path():
     skills = [
         SkillInfo(


### PR DESCRIPTION
Closes #5922

### Modifications / 改动点

- preserve cached sandbox skill paths for sandbox-only skills instead of always rewriting them to `/workspace/skills/...`
- keep the existing fallback for invalid sandbox skill names so prompt-path sanitization still wins on untrusted metadata
- add regression coverage for both `SkillManager.list_skills(runtime="sandbox")` and `build_skills_prompt(...)` using cached absolute sandbox paths

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Verification steps run locally:

- `python3.11 -m py_compile astrbot/core/skills/skill_manager.py tests/test_skill_metadata_enrichment.py tests/test_skill_manager_sandbox_cache.py`
- focused regression script covering:
  - `build_skills_prompt(...)` preserves `/home/ship_*/workspace/skills/.../SKILL.md` for sandbox-only skills
  - invalid sandbox skill names still fall back to `/workspace/skills/<invalid_skill_name>/SKILL.md`
  - `SkillManager.list_skills(runtime="sandbox")` keeps the cached absolute sandbox path for cache-only skills

Regression script output:

```text
expanded-regression-check: ok
```

---

### Checklist / 检查清单

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

在保持对无效沙盒元数据安全回退机制的同时，保留并正确暴露已缓存的沙盒技能路径。

Bug 修复：
- 确保提示（prompts）中的仅限沙盒使用的技能在缓存的绝对沙盒路径有效时使用该路径，而不是总是重写为通用的工作区路径。
- 修复沙盒技能列表逻辑，使其在任何显示选项下都能保留仅限沙盒使用的技能的缓存绝对路径，并在不存在缓存路径时使用安全的默认值。

测试：
- 添加回归测试，以验证 `build_skills_prompt` 会保留缓存的绝对沙盒路径，同时仍然会清理无效的沙盒技能名称。
- 扩展沙盒缓存测试，以确认 `SkillManager.list_skills(runtime="sandbox")` 会为仅限沙盒使用的技能返回缓存的沙盒路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve and correctly surface cached sandbox skill paths while maintaining safe fallbacks for invalid sandbox metadata.

Bug Fixes:
- Ensure sandbox-only skills in prompts use their cached absolute sandbox paths when valid instead of always rewriting to a generic workspace path.
- Fix sandbox skill listing to retain cached absolute paths for sandbox-only skills regardless of display options, with a safe default when no cached path exists.

Tests:
- Add regression tests to verify `build_skills_prompt` preserves cached absolute sandbox paths and still sanitizes invalid sandbox skill names.
- Extend sandbox cache tests to confirm `SkillManager.list_skills(runtime="sandbox")` returns the cached sandbox path for sandbox-only skills.

</details>