### PR TITLE
fix(provider): caption images before DashScope agent handoff

### DIFF
--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/third_party.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/third_party.py
@@ -161,6 +161,48 @@ async def _close_runner_if_supported(runner: "BaseAgentRunner") -> None:
         logger.warning(f"Failed to close third-party runner cleanly: {e}")
 
 
+async def _prepare_images_for_third_party_runner(
+    *,
+    req: ProviderRequest,
+    runner_type: str,
+    provider_settings: dict,
+    plugin_context,
+) -> None:
+    """Normalize image input for third-party runners that cannot consume images directly."""
+    if runner_type != "dashscope" or not req.image_urls:
+        return
+
+    prompt = (req.prompt or "").strip()
+    image_caption_provider_id = (
+        provider_settings.get("default_image_caption_provider_id") or ""
+    )
+
+    if image_caption_provider_id:
+        try:
+            from astrbot.core.astr_main_agent import _request_img_caption
+
+            caption = await _request_img_caption(
+                image_caption_provider_id,
+                provider_settings,
+                req.image_urls,
+                plugin_context,
+            )
+            if caption:
+                caption_block = f"<image_caption>{caption}</image_caption>"
+                req.prompt = f"{prompt}\n{caption_block}" if prompt else caption_block
+                req.image_urls = []
+                return
+        except Exception as exc:  # noqa: BLE001
+            logger.error("第三方 Agent 图片转述失败: %s", exc)
+
+    req.prompt = prompt or "[图片]"
+    req.image_urls = []
+    logger.warning(
+        "第三方 Agent Runner `%s` 暂不支持图片输入，已回退为文本占位。",
+        runner_type,
+    )
+
+
 class ThirdPartyAgentSubStage(Stage):
     async def initialize(self, ctx: PipelineContext) -> None:
         self.ctx = ctx
@@ -317,6 +359,17 @@ class ThirdPartyAgentSubStage(Stage):
             if isinstance(comp, Image):
                 image_path = await comp.convert_to_base64()
                 req.image_urls.append(image_path)
+
+        provider_settings = (
+            self.ctx.plugin_manager.context.get_config(umo=event.unified_msg_origin)
+            or {}
+        ).get("provider_settings", {})
+        await _prepare_images_for_third_party_runner(
+            req=req,
+            runner_type=self.runner_type,
+            provider_settings=provider_settings,
+            plugin_context=self.ctx.plugin_manager.context,
+        )
 
         if not req.prompt and not req.image_urls:
             return

--- a/tests/unit/test_third_party_runner_image_prep.py
+++ b/tests/unit/test_third_party_runner_image_prep.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from astrbot.core.pipeline.process_stage.method.agent_sub_stages.third_party import (
+    _prepare_images_for_third_party_runner,
+)
+from astrbot.core.provider.entities import ProviderRequest
+
+
+@pytest.mark.asyncio
+async def test_prepare_images_for_dashscope_uses_default_image_caption_provider() -> None:
+    req = ProviderRequest(prompt="请帮我分析这张图", image_urls=["base64://image-data"])
+
+    with patch(
+        "astrbot.core.astr_main_agent._request_img_caption",
+        new=AsyncMock(return_value="图片里有一只猫"),
+    ) as request_img_caption:
+        await _prepare_images_for_third_party_runner(
+            req=req,
+            runner_type="dashscope",
+            provider_settings={"default_image_caption_provider_id": "vision-model"},
+            plugin_context=object(),
+        )
+
+    request_img_caption.assert_awaited_once()
+    assert req.prompt == "请帮我分析这张图\n<image_caption>图片里有一只猫</image_caption>"
+    assert req.image_urls == []
+
+
+@pytest.mark.asyncio
+async def test_prepare_images_for_dashscope_falls_back_to_placeholder_when_needed() -> None:
+    req = ProviderRequest(prompt=None, image_urls=["base64://image-data"])
+
+    await _prepare_images_for_third_party_runner(
+        req=req,
+        runner_type="dashscope",
+        provider_settings={},
+        plugin_context=object(),
+    )
+
+    assert req.prompt == "[图片]"
+    assert req.image_urls == []
+
+
+@pytest.mark.asyncio
+async def test_prepare_images_for_non_dashscope_keeps_images_untouched() -> None:
+    req = ProviderRequest(prompt="hello", image_urls=["base64://image-data"])
+
+    await _prepare_images_for_third_party_runner(
+        req=req,
+        runner_type="coze",
+        provider_settings={"default_image_caption_provider_id": "vision-model"},
+        plugin_context=object(),
+    )
+
+    assert req.prompt == "hello"
+    assert req.image_urls == ["base64://image-data"]


### PR DESCRIPTION
## Summary
- caption image attachments before handing requests to the DashScope third-party agent runner
- fall back to the existing image placeholder when no caption provider is configured
- add focused tests for captioned, placeholder, and non-DashScope paths

## Testing
- python3.11 -m pytest tests/unit/test_third_party_runner_image_prep.py tests/test_smoke.py -q
- ruff check astrbot/core/pipeline/process_stage/method/agent_sub_stages/third_party.py tests/unit/test_third_party_runner_image_prep.py

Closes #6055

## Summary by Sourcery

通过为 DashScope 第三方运行器对图像输入进行描述（captioning），或在无法描述时回退到占位文本，来规范化图像输入，并为该新行为添加测试。

Bug Fixes:
- 当可用图像描述功能时，确保 DashScope 第三方运行器接收到的是图像的文字描述，而不是原始图像数据。
- 当存在图像但未为 DashScope 运行器配置图像描述提供方时，回退到使用文本占位符。

Tests:
- 添加单元测试，覆盖带描述的图像处理、占位符回退逻辑，以及第三方运行器在非 DashScope 场景下的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize image inputs for DashScope third-party runners by captioning or falling back to a placeholder, and add tests around the new behavior.

Bug Fixes:
- Ensure DashScope third-party runners receive text captions instead of raw image data when image captioning is available.
- Fall back to a text placeholder when images are present but no image caption provider is configured for DashScope runners.

Tests:
- Add unit tests covering captioned image handling, placeholder fallback, and non-DashScope behavior for third-party runners.

</details>