### PR TITLE
fix: normalize invalid MCP required flags in MCP schemas

### DIFF
--- a/astrbot/core/agent/mcp_client.py
+++ b/astrbot/core/agent/mcp_client.py
@@ -372,12 +372,7 @@ def _normalize_mcp_input_schema(schema: dict[str, Any]) -> dict[str, Any]:
                         required_list.append(prop_name)
 
             if required_list:
-                seen: set[str] = set()
-                normalized["required"] = [
-                    name
-                    for name in required_list
-                    if not (name in seen or seen.add(name))
-                ]
+                normalized["required"] = list(dict.fromkeys(required_list))
             elif isinstance(required, list):
                 normalized.pop("required", None)
 

--- a/tests/unit/test_mcp_client_schema.py
+++ b/tests/unit/test_mcp_client_schema.py
@@ -76,6 +76,25 @@ class TestNormalizeMcpInputSchema:
             not in normalized["properties"]["server"]["properties"]["transport"]
         )
 
+    def test_ignores_non_boolean_required_values_and_non_dict_properties(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "server": "invalid-property-schema",
+                "market": {"type": "string", "required": "yes"},
+                "stock_code": {"type": "string", "required": True},
+            },
+        }
+
+        normalized = _normalize_mcp_input_schema(schema)
+
+        assert normalized["required"] == ["stock_code"]
+        assert normalized["properties"]["server"] == "invalid-property-schema"
+        assert normalized["properties"]["market"]["required"] == "yes"
+        assert "required" not in normalized["properties"]["stock_code"]
+        assert schema["properties"]["server"] == "invalid-property-schema"
+        assert schema["properties"]["market"]["required"] == "yes"
+
 
 class TestMCPToolSchemaNormalization:
     def test_mcp_tool_accepts_property_level_required_booleans(self):


### PR DESCRIPTION
## Summary
- normalize non-standard MCP property-level `required: true/false` flags into the parent object's `required` array before validating tool schemas
- keep validation strict for real schema errors instead of disabling it entirely
- add focused regression coverage for top-level and nested MCP input schemas

## Testing
- PYTHONPATH=. pytest -q tests/unit/test_mcp_client_schema.py

Closes #5972

## Summary by Sourcery

Normalize MCP tool input schemas to support non-standard required flags while preserving strict JSON Schema validation.

Bug Fixes:
- Handle MCP schemas that incorrectly use boolean property-level required flags by lifting them into the parent object's required array.

Tests:
- Add unit tests for schema normalization across top-level and nested MCP input schemas, including integration-style coverage for MCPTool parameter handling.

Bug 修复：
- 支持那些错误地在各个属性上使用布尔值标记必填属性的 MCP 模式，通过将这些属性提升到父级的 `required` 数组中进行修正。

测试：
- 为模式规范化行为添加单元测试，包括嵌套对象，以及在使用非标准 `required` 标记时与 MCPTool 的集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize MCP tool input schemas to support non-standard required flags while preserving strict JSON Schema validation.

Bug Fixes:
- Handle MCP schemas that incorrectly use boolean property-level required flags by lifting them into the parent object's required array.

Tests:
- Add unit tests for schema normalization across top-level and nested MCP input schemas, including integration-style coverage for MCPTool parameter handling.

</details>