### PR TITLE
fix(dashboard): restore README dialog anchor navigation

### DIFF
--- a/dashboard/src/components/shared/ReadmeDialog.vue
+++ b/dashboard/src/components/shared/ReadmeDialog.vue
@@ -48,6 +48,24 @@ const loading = ref(false);
 const isEmpty = ref(false);
 const copyFeedbackTimer = ref(null);
 const lastRequestId = ref(0);
+const scrollContainer = ref(null);
+
+function slugifyHeading(text, slugCounts) {
+  const base = (text || "")
+    .trim()
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^\p{Letter}\p{Number}\s-]/gu, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+
+  if (!base) return "";
+
+  const count = slugCounts.get(base) || 0;
+  slugCounts.set(base, count + 1);
+  return count === 0 ? base : `${base}-${count}`;
+}
 
 onUnmounted(() => {
   if (copyFeedbackTimer.value) clearTimeout(copyFeedbackTimer.value);
@@ -153,6 +171,18 @@ const renderedHtml = computed(() => {
   // 3. 后处理方案：完全隔离，安全性最高
   const tempDiv = document.createElement("div");
   tempDiv.innerHTML = cleanHtml;
+
+  const slugCounts = new Map();
+  tempDiv.querySelectorAll("h1, h2, h3, h4, h5, h6").forEach((heading) => {
+    if (heading.id) {
+      slugCounts.set(heading.id, (slugCounts.get(heading.id) || 0) + 1);
+      return;
+    }
+
+    const slug = slugifyHeading(heading.textContent, slugCounts);
+    if (slug) heading.id = slug;
+  });
+
   tempDiv.querySelectorAll("a").forEach((link) => {
     const href = link.getAttribute("href");
     // 强制所有外部链接使用安全的 _blank 策略
@@ -251,18 +281,35 @@ watch(
 
 function handleContainerClick(event) {
   const btn = event.target.closest(".copy-code-btn");
-  if (!btn) return;
-  const code = btn.closest(".code-block-wrapper")?.querySelector("code");
-  if (code) {
-    if (navigator.clipboard?.writeText) {
-      navigator.clipboard
-        .writeText(code.textContent)
-        .then(() => showCopyFeedback(btn, true))
-        .catch(() => tryFallbackCopy(code.textContent, btn));
-    } else {
-      tryFallbackCopy(code.textContent, btn);
+  if (btn) {
+    const code = btn.closest(".code-block-wrapper")?.querySelector("code");
+    if (code) {
+      if (navigator.clipboard?.writeText) {
+        navigator.clipboard
+          .writeText(code.textContent)
+          .then(() => showCopyFeedback(btn, true))
+          .catch(() => tryFallbackCopy(code.textContent, btn));
+      } else {
+        tryFallbackCopy(code.textContent, btn);
+      }
     }
+    return;
   }
+
+  const anchor = event.target.closest('a[href^="#"]');
+  if (!anchor) return;
+
+  const rawHref = anchor.getAttribute("href");
+  const targetId = rawHref ? decodeURIComponent(rawHref.slice(1)) : "";
+  if (!targetId) return;
+
+  const target = scrollContainer.value?.querySelector(
+    `#${CSS.escape(targetId)}`,
+  );
+  if (!target) return;
+
+  event.preventDefault();
+  target.scrollIntoView({ behavior: "smooth", block: "start" });
 }
 
 function tryFallbackCopy(text, btn) {
@@ -326,7 +373,7 @@ const showActionArea = computed(() => {
           <v-icon>mdi-close</v-icon>
         </v-btn>
       </v-card-title>
-      <v-card-text style="overflow-y: auto">
+      <v-card-text ref="scrollContainer" style="overflow-y: auto">
         <div v-if="showActionArea" class="d-flex justify-space-between mb-4">
           <v-btn
             v-if="modeConfig.showGithubButton && repoUrl"
@@ -436,6 +483,7 @@ const showActionArea = computed(() => {
   margin-bottom: 16px;
   font-weight: 600;
   line-height: 1.25;
+  scroll-margin-top: 12px;
 }
 
 :deep(.markdown-body h1) {


### PR DESCRIPTION
## Summary
- generate stable heading ids for rendered README headings in `ReadmeDialog`
- intercept in-dialog `#anchor` clicks and smoothly scroll the dialog container to the matching section
- add a small heading scroll margin so target sections aren't jammed against the top edge

## Verification
- `corepack pnpm run typecheck`
- `corepack pnpm run build`

Closes #5914.

## Summary by Sourcery

在 README 对话框中恢复对话框内锚点导航和标题定位行为。

Bug Fixes:
- 确保对话框中的 README 标题获得稳定且去重的 ID，以支持锚点链接。
- 处理对话框内的哈希链接点击事件，使 README 对话框容器平滑滚动到目标区域，而不是导航整个页面。

Enhancements:
- 为对话框中的 README 标题添加滚动边距，使滚动到的部分不会紧贴顶部边缘。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore in-dialog anchor navigation and heading targeting behavior in the README dialog.

Bug Fixes:
- Ensure README headings in the dialog receive stable, de-duplicated IDs to support anchor links.
- Handle in-dialog hash link clicks by smoothly scrolling the README dialog container to the targeted section instead of navigating the page.

Enhancements:
- Add a scroll margin to README headings in the dialog so scrolled-to sections are not flush against the top edge.

</details>