### PR TITLE
fix: prefer named weekday cron examples

### DIFF
--- a/astrbot/core/tools/cron_tools.py
+++ b/astrbot/core/tools/cron_tools.py
@@ -30,7 +30,7 @@ class CreateActiveCronTool(FunctionTool[AstrAgentContext]):
             "properties": {
                 "cron_expression": {
                     "type": "string",
-                    "description": "Cron expression defining recurring schedule (e.g., '0 8 * * *').",
+                    "description": "Cron expression defining recurring schedule (e.g., '0 8 * * *' or '0 23 * * mon-fri'). Prefer named weekdays like 'mon-fri' or 'sat,sun' instead of numeric day-of-week ranges such as '1-5' to avoid ambiguity across cron implementations.",
                 },
                 "run_at": {
                     "type": "string",

--- a/tests/unit/test_cron_tools.py
+++ b/tests/unit/test_cron_tools.py
@@ -1,0 +1,15 @@
+"""Tests for cron tool metadata."""
+
+from astrbot.core.tools.cron_tools import CreateActiveCronTool
+
+
+def test_create_future_task_cron_description_prefers_named_weekdays():
+    """The cron tool should steer users toward unambiguous named weekdays."""
+    tool = CreateActiveCronTool()
+
+    description = tool.parameters["properties"]["cron_expression"]["description"]
+
+    assert "mon-fri" in description
+    assert "sat,sun" in description
+    assert "1-5" in description
+    assert "avoid ambiguity" in description


### PR DESCRIPTION
## Summary
- update the `create_future_task` cron parameter description to recommend named weekdays like `mon-fri` / `sat,sun`
- keep the existing generic cron example while adding an explicit named-weekday example
- add a unit test covering the new guidance so the tool metadata does not regress

## Testing
- `PYTHONPATH=. pytest tests/unit/test_cron_tools.py tests/unit/test_cron_manager.py --test-profile=blocking`

Closes #5680.

## Summary by Sourcery

在 cron 工具的元数据中澄清 cron 调度说明，并添加测试覆盖来强制执行新的描述。

增强内容：
- 更新 cron 表达式参数的描述，以优先使用命名的星期格式，而不是数字的星期范围，从而提高清晰度和可移植性。

测试：
- 添加单元测试，确保 cron 工具的说明持续推荐使用命名的星期形式，并提及数字范围存在的歧义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify cron schedule guidance in the cron tool metadata and add test coverage to enforce the new description.

Enhancements:
- Update the cron expression parameter description to prefer named weekday notation over numeric day-of-week ranges for clarity and portability.

Tests:
- Add a unit test ensuring the cron tool description continues to recommend named weekdays and mention ambiguity of numeric ranges.

</details>