### PR TITLE
fix: skip empty knowledge-base embedding batches

### DIFF
--- a/astrbot/core/db/vec_db/faiss_impl/vec_db.py
+++ b/astrbot/core/db/vec_db/faiss_impl/vec_db.py
@@ -74,6 +74,10 @@ class FaissVecDB(BaseVecDB):
         metadatas = metadatas or [{} for _ in contents]
         ids = ids or [str(uuid.uuid4()) for _ in contents]
 
+        if not contents:
+            logger.debug("No contents provided for batch insert; skipping embedding generation.")
+            return []
+
         start = time.time()
         logger.debug(f"Generating embeddings for {len(contents)} contents...")
         vectors = await self.embedding_provider.get_embeddings_batch(

--- a/tests/unit/test_faiss_vec_db.py
+++ b/tests/unit/test_faiss_vec_db.py
@@ -1,0 +1,20 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from astrbot.core.db.vec_db.faiss_impl.vec_db import FaissVecDB
+
+
+@pytest.mark.asyncio
+async def test_insert_batch_skips_empty_contents() -> None:
+    vec_db = FaissVecDB.__new__(FaissVecDB)
+    vec_db.embedding_provider = AsyncMock()
+    vec_db.document_storage = AsyncMock()
+    vec_db.embedding_storage = AsyncMock()
+
+    result = await FaissVecDB.insert_batch(vec_db, [])
+
+    assert result == []
+    vec_db.embedding_provider.get_embeddings_batch.assert_not_awaited()
+    vec_db.document_storage.insert_documents_batch.assert_not_awaited()
+    vec_db.embedding_storage.insert_batch.assert_not_awaited()


### PR DESCRIPTION
Fixes #3709

### Modifications / 改动点

- short-circuit `FaissVecDB.insert_batch()` when the parser/chunker produces an empty batch instead of flowing into the embedding/document stores and crashing with `tuple index out of range`
- add a focused regression test to ensure empty knowledge-base batches return cleanly and never touch the embedding/document storage layer

This keeps PDF uploads from blowing up when a file yields zero indexable chunks (for example, scanned/image-only PDFs or PDFs whose extracted text is empty) and preserves the existing upload flow instead of surfacing an opaque vector-db exception.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Verification Steps:

```bash
python3.11 -m pytest tests/unit/test_faiss_vec_db.py -q
```

Result:

```text
1 passed in 1.01s
```

```bash
python3.11 -m ruff check astrbot/core/db/vec_db/faiss_impl/vec_db.py tests/unit/test_faiss_vec_db.py
```

Result:

```text
All checks passed!
```

---

### Checklist / 检查清单

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

在 FAISS 向量数据库的插入流程中安全地处理空知识库批次，当未生成可索引内容时避免出错。

Bug Fixes:
- 当解析后的内容列表为空时，阻止批量插入尝试执行嵌入和存储操作，从而避免在空上传场景下的运行时错误。

Tests:
- 添加一个异步回归测试，确保对空批次的插入返回空结果，并且从不调用嵌入层或文档存储层。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle empty knowledge-base batches safely in the FAISS vector database insert path to avoid errors when no indexable content is produced.

Bug Fixes:
- Prevent batch insert from attempting embedding and storage operations when the parsed contents list is empty, avoiding runtime errors on empty uploads.

Tests:
- Add an async regression test ensuring empty batch inserts return an empty result and never call embedding or document storage layers.

</details>