### PR TITLE
Fix/cron agent tool call not triggered

### DIFF
--- a/astrbot/core/astr_main_agent_resources.py
+++ b/astrbot/core/astr_main_agent_resources.py
@@ -112,7 +112,7 @@ LIVE_MODE_SYSTEM_PROMPT = (
 PROACTIVE_AGENT_CRON_WOKE_SYSTEM_PROMPT = (
     "You are an autonomous proactive agent.\n\n"
     "You are awakened by a scheduled cron job, not by a user message.\n"
-    "You are given:"
+    "You are given:\n"
     "1. A cron job description explaining why you are activated.\n"
     "2. Historical conversation context between you and the user.\n"
     "3. Your available tools and skills.\n"
@@ -121,7 +121,7 @@ PROACTIVE_AGENT_CRON_WOKE_SYSTEM_PROMPT = (
     "2. Use historical conversation and memory to understand you and user's relationship, preferences, and context.\n"
     "3. If messaging the user: Explain WHY you are contacting them; Reference the cron task implicitly (not technical details).\n"
     "4. You can use your available tools and skills to finish the task if needed.\n"
-    "5. Use `send_message_to_user` tool to send message to user if needed."
+    "5. IMPORTANT: Your text output is NOT visible to the user. The ONLY way to deliver a message to the user is by calling the `send_message_to_user` tool. You MUST call this tool to send any message — do NOT just generate text.\n"
     "# CRON JOB CONTEXT\n"
     "The following object describes the scheduled task that triggered you:\n"
     "{cron_job}"

--- a/astrbot/core/cron/manager.py
+++ b/astrbot/core/cron/manager.py
@@ -332,10 +332,11 @@ class CronJobManager:
             cron_job=cron_job_str
         )
         req.prompt = (
-            "You are now responding to a scheduled task"
+            "A scheduled task has been triggered. "
             "Proceed according to your system instructions. "
-            "Output using same language as previous conversation."
-            "After completing your task, summarize and output your actions and results."
+            "You MUST call the `send_message_to_user` tool to deliver any message to the user. "
+            "Your direct text response is NOT visible to the user — only tool calls take effect. "
+            "Use the same language as the previous conversation."
         )
         if not req.func_tool:
             req.func_tool = ToolSet()
@@ -353,25 +354,34 @@ class CronJobManager:
             # agent will send message to user via using tools
             pass
         llm_resp = runner.get_final_llm_resp()
-        cron_meta = extras.get("cron_job", {}) if extras else {}
-        summary_note = (
-            f"[CronJob] {cron_meta.get('name') or cron_meta.get('id', 'unknown')}: {cron_meta.get('description', '')} "
-            f" triggered at {cron_meta.get('run_started_at', 'unknown time')}, "
-        )
-        if llm_resp and llm_resp.role == "assistant":
-            summary_note += (
-                f"I finished this job, here is the result: {llm_resp.completion_text}"
-            )
-
-        await persist_agent_history(
-            self.ctx.conversation_manager,
-            event=cron_event,
-            req=req,
-            summary_note=summary_note,
-        )
         if not llm_resp:
             logger.warning("Cron job agent got no response")
             return
+
+        # 仅当 agent 实际调用了工具时才写入历史，避免未发送消息的失败执行产生误导性记录
+        tool_was_called = any(msg.role == "tool" for msg in runner.run_context.messages)
+        if tool_was_called:
+            cron_meta = extras.get("cron_job", {}) if extras else {}
+            # role == "assistant" 表示 LLM 正常完成，排除 role="err" 的错误响应写入历史
+            status = "task completed successfully." if llm_resp.role == "assistant" else f"task ended with error: {llm_resp.completion_text}"
+            summary_note = (
+                f"[CronJob] {cron_meta.get('name') or cron_meta.get('id', 'unknown')}: "
+                f"{cron_meta.get('description', '')} "
+                f"triggered at {cron_meta.get('run_started_at', 'unknown time')}, "
+                f"{status}"
+            )
+            await persist_agent_history(
+                self.ctx.conversation_manager,
+                event=cron_event,
+                req=req,
+                summary_note=summary_note,
+            )
+        else:
+            logger.warning(
+                "Cron job agent did not call any tools. "
+                "The message was likely NOT delivered to the user. "
+                "Skipping history persistence to avoid misleading future context."
+            )
 
 
 __all__ = ["CronJobManager"]

--- a/tests/unit/test_cron_manager.py
+++ b/tests/unit/test_cron_manager.py
@@ -502,3 +502,277 @@ class TestGetNextRunTime:
         next_run = cron_manager._get_next_run_time("non-existent")
 
         assert next_run is None
+
+
+# ============================================================
+# TestWokeMainAgent —— 验证 _woke_main_agent 的核心行为
+# ============================================================
+
+
+def _make_mock_message(role: str):
+    """创建带 role 属性的简单 mock 消息对象。"""
+    m = MagicMock()
+    m.role = role
+    return m
+
+
+def _make_runner_mock(messages: list, final_resp=None):
+    """构造模拟 AgentRunner，包含 run_context.messages 和 get_final_llm_resp。"""
+    runner = MagicMock()
+    run_ctx = MagicMock()
+    run_ctx.messages = messages
+    runner.run_context = run_ctx
+    runner.get_final_llm_resp = MagicMock(return_value=final_resp)
+
+    async def _step_until_done(_max):
+        return
+        yield  # noqa: unreachable — makes this an async generator
+
+    runner.step_until_done = _step_until_done
+    return runner
+
+
+class TestWokeMainAgentPrompt:
+    """验证 _woke_main_agent 构造 req.prompt 与 system_prompt 时的正确性。"""
+
+    @pytest.mark.asyncio
+    async def test_prompt_contains_tool_call_instruction(self, cron_manager, mock_context):
+        """req.prompt 必须明确要求调用 send_message_to_user，而不是输出文本。"""
+        cron_manager.ctx = mock_context
+
+        captured_req = {}
+
+        async def fake_build_main_agent(*, event, plugin_context, config, req):
+            captured_req["req"] = req
+            # 返回一个带有空 runner 的 result mock
+            result = MagicMock()
+            result.agent_runner = _make_runner_mock(
+                messages=[],
+                final_resp=MagicMock(role="assistant", completion_text=""),
+            )
+            return result
+
+        mock_conv = MagicMock()
+        mock_conv.history = "[]"
+
+        with (
+            patch("astrbot.core.astr_main_agent.build_main_agent", fake_build_main_agent),
+            patch("astrbot.core.astr_main_agent._get_session_conv", AsyncMock(return_value=mock_conv)),
+            patch("astrbot.core.cron.manager.persist_agent_history", AsyncMock()),
+        ):
+            await cron_manager._woke_main_agent(
+                message="发送早安问候",
+                session_str="QQ:FriendMessage:123456",
+                extras={"cron_job": {"id": "test-id", "name": "morning"}, "cron_payload": {}},
+            )
+
+        req = captured_req.get("req")
+        assert req is not None, "build_main_agent 未被调用"
+        # prompt 必须明确说明文本不可见、必须用工具
+        assert "send_message_to_user" in req.prompt
+        assert "NOT visible" in req.prompt or "not visible" in req.prompt.lower()
+        assert "MUST" in req.prompt or "must" in req.prompt.lower()
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_contains_visibility_warning(self, cron_manager, mock_context):
+        """system_prompt 中的 PROACTIVE_AGENT_CRON_WOKE_SYSTEM_PROMPT 必须包含可见性警告。"""
+        from astrbot.core.astr_main_agent_resources import PROACTIVE_AGENT_CRON_WOKE_SYSTEM_PROMPT
+
+        # 验证 prompt 模板本身的关键内容
+        rendered = PROACTIVE_AGENT_CRON_WOKE_SYSTEM_PROMPT.format(cron_job="{}")
+        assert "NOT visible" in rendered
+        assert "send_message_to_user" in rendered
+        assert "MUST" in rendered
+        # CRON JOB CONTEXT 标题要有换行与前文分隔
+        assert "\n# CRON JOB CONTEXT" in rendered
+
+    def test_system_prompt_template_formatting(self):
+        """确保 PROACTIVE_AGENT_CRON_WOKE_SYSTEM_PROMPT 中各序号段落不会拼接在一起。"""
+        from astrbot.core.astr_main_agent_resources import PROACTIVE_AGENT_CRON_WOKE_SYSTEM_PROMPT
+
+        rendered = PROACTIVE_AGENT_CRON_WOKE_SYSTEM_PROMPT.format(cron_job="{}")
+        # "You are given:" 后应有换行，不能直接跟 "1."
+        assert "You are given:\n1." in rendered, (
+            "'You are given:' 后应紧跟换行再接 '1.'"
+        )
+
+
+class TestWokeMainAgentHistoryPersistence:
+    """验证 _woke_main_agent 仅在工具被调用时才写入历史记录。"""
+
+    @pytest.mark.asyncio
+    async def test_history_persisted_when_tool_called(self, cron_manager, mock_context):
+        """agent 调用了工具时，应写入对话历史。"""
+        cron_manager.ctx = mock_context
+        persist_mock = AsyncMock()
+
+        messages = [
+            _make_mock_message("system"),
+            _make_mock_message("user"),
+            _make_mock_message("assistant"),
+            _make_mock_message("tool"),   # 工具被调用
+        ]
+        final_resp = MagicMock()
+        final_resp.role = "assistant"
+        final_resp.completion_text = "任务完成"
+
+        mock_conv = MagicMock()
+        mock_conv.history = "[]"
+
+        async def fake_build(*_, **__):
+            result = MagicMock()
+            result.agent_runner = _make_runner_mock(messages=messages, final_resp=final_resp)
+            return result
+
+        with (
+            patch("astrbot.core.astr_main_agent.build_main_agent", fake_build),
+            patch("astrbot.core.astr_main_agent._get_session_conv", AsyncMock(return_value=mock_conv)),
+            patch("astrbot.core.cron.manager.persist_agent_history", persist_mock),
+        ):
+            await cron_manager._woke_main_agent(
+                message="发送消息",
+                session_str="QQ:FriendMessage:123456",
+                extras={"cron_job": {"id": "j1", "name": "test"}, "cron_payload": {}},
+            )
+
+        persist_mock.assert_awaited_once()
+        # summary_note 不应包含 LLM 原始文本（避免误导）
+        call_kwargs = persist_mock.call_args.kwargs
+        assert "task completed successfully" in call_kwargs["summary_note"]
+
+    @pytest.mark.asyncio
+    async def test_history_not_persisted_when_no_tool_called(self, cron_manager, mock_context):
+        """agent 未调用任何工具时（finish_reason='stop'），不写入历史，避免污染上下文。"""
+        cron_manager.ctx = mock_context
+        persist_mock = AsyncMock()
+
+        # 只有 system / user / assistant，没有 tool 消息
+        messages = [
+            _make_mock_message("system"),
+            _make_mock_message("user"),
+            _make_mock_message("assistant"),
+        ]
+        final_resp = MagicMock()
+        final_resp.role = "assistant"
+        final_resp.completion_text = "我已经完成了（但其实没发消息）"
+
+        mock_conv = MagicMock()
+        mock_conv.history = "[]"
+
+        async def fake_build(*_, **__):
+            result = MagicMock()
+            result.agent_runner = _make_runner_mock(messages=messages, final_resp=final_resp)
+            return result
+
+        with (
+            patch("astrbot.core.astr_main_agent.build_main_agent", fake_build),
+            patch("astrbot.core.astr_main_agent._get_session_conv", AsyncMock(return_value=mock_conv)),
+            patch("astrbot.core.cron.manager.persist_agent_history", persist_mock),
+        ):
+            await cron_manager._woke_main_agent(
+                message="发送消息",
+                session_str="QQ:FriendMessage:123456",
+                extras={"cron_job": {"id": "j2", "name": "test"}, "cron_payload": {}},
+            )
+
+        persist_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_history_not_persisted_when_no_llm_resp(self, cron_manager, mock_context):
+        """agent 无 LLM 响应时，不写入历史，函数正常返回。"""
+        cron_manager.ctx = mock_context
+        persist_mock = AsyncMock()
+
+        messages = [_make_mock_message("tool")]  # 有工具消息，但无最终 LLM 响应
+        mock_conv = MagicMock()
+        mock_conv.history = "[]"
+
+        async def fake_build(*_, **__):
+            result = MagicMock()
+            result.agent_runner = _make_runner_mock(messages=messages, final_resp=None)
+            return result
+
+        with (
+            patch("astrbot.core.astr_main_agent.build_main_agent", fake_build),
+            patch("astrbot.core.astr_main_agent._get_session_conv", AsyncMock(return_value=mock_conv)),
+            patch("astrbot.core.cron.manager.persist_agent_history", persist_mock),
+        ):
+            # 不应抛异常
+            await cron_manager._woke_main_agent(
+                message="发送消息",
+                session_str="QQ:FriendMessage:123456",
+                extras={"cron_job": {"id": "j3", "name": "test"}, "cron_payload": {}},
+            )
+
+        persist_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_warning_logged_when_no_tool_called(self, cron_manager, mock_context):
+        """agent 未调用工具时，应记录 warning 日志提示消息可能未送达。"""
+        cron_manager.ctx = mock_context
+
+        messages = [_make_mock_message("assistant")]
+        final_resp = MagicMock()
+        final_resp.role = "assistant"
+        final_resp.completion_text = "只有文本"
+
+        mock_conv = MagicMock()
+        mock_conv.history = "[]"
+
+        async def fake_build(*_, **__):
+            result = MagicMock()
+            result.agent_runner = _make_runner_mock(messages=messages, final_resp=final_resp)
+            return result
+
+        with (
+            patch("astrbot.core.astr_main_agent.build_main_agent", fake_build),
+            patch("astrbot.core.astr_main_agent._get_session_conv", AsyncMock(return_value=mock_conv)),
+            patch("astrbot.core.cron.manager.persist_agent_history", AsyncMock()),
+            patch("astrbot.core.cron.manager.logger") as mock_logger,
+        ):
+            await cron_manager._woke_main_agent(
+                message="发送消息",
+                session_str="QQ:FriendMessage:123456",
+                extras={"cron_job": {"id": "j4", "name": "test"}, "cron_payload": {}},
+            )
+
+        # 必须有相关警告
+        warning_calls = [str(c) for c in mock_logger.warning.call_args_list]
+        assert any("tool" in w.lower() or "NOT" in w for w in warning_calls), (
+            "未找到关于工具未被调用的 warning 日志"
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_message_to_user_tool_in_func_tool(self, cron_manager, mock_context):
+        """req.func_tool 必须包含 send_message_to_user 工具。"""
+        cron_manager.ctx = mock_context
+        captured_req = {}
+
+        mock_conv = MagicMock()
+        mock_conv.history = "[]"
+
+        async def fake_build(*, event, plugin_context, config, req):
+            captured_req["req"] = req
+            result = MagicMock()
+            result.agent_runner = _make_runner_mock(
+                messages=[],
+                final_resp=MagicMock(role="assistant", completion_text=""),
+            )
+            return result
+
+        with (
+            patch("astrbot.core.astr_main_agent.build_main_agent", fake_build),
+            patch("astrbot.core.astr_main_agent._get_session_conv", AsyncMock(return_value=mock_conv)),
+            patch("astrbot.core.cron.manager.persist_agent_history", AsyncMock()),
+        ):
+            await cron_manager._woke_main_agent(
+                message="发送消息",
+                session_str="QQ:FriendMessage:123456",
+                extras={"cron_job": {"id": "j5", "name": "test"}, "cron_payload": {}},
+            )
+
+        req = captured_req.get("req")
+        assert req is not None
+        assert req.func_tool is not None
+        tool_names = [t.name for t in req.func_tool.tools]
+        assert "send_message_to_user" in tool_names


### PR DESCRIPTION
## 问题描述

修复 #6103

定时任务触发后，Agent 不调用 `send_message_to_user` 工具，`finish_reason` 为 `stop`（纯文本输出），消息从未实际发送给用户。

## 根本原因

1. **`req.prompt` 误导**：末尾指令要求 LLM「总结并输出执行结果」，LLM 直接生成文本即认为任务完成，不调用工具。
2. **系统提示语义模糊**：`PROACTIVE_AGENT_CRON_WOKE_SYSTEM_PROMPT` 规则 5 写的是「if needed」，LLM 不知道文本对用户完全不可见；存在换行符缺失导致格式混乱。
3. **历史污染反馈循环**：失败执行（未调用工具）也写入对话历史，LLM 从历史中学到「文本输出 = 完成」，形成恶性循环。

## 修复方案

- **`req.prompt`**：明确说明文本不可见，必须调用工具才能传达消息给用户。
- **`PROACTIVE_AGENT_CRON_WOKE_SYSTEM_PROMPT`**：强制要求工具调用，修复换行符缺失。
- **`_woke_main_agent`**：仅在 `tool_was_called` 时写入历史，否则记录 warning 并跳过，打破反馈循环。

## Summary by Sourcery

确保由 cron 触发的代理通过工具调用可靠地向用户发送主动消息，并在未发生投递时避免污染会话历史。

Bug Fixes:
- 强制 cron 代理调用 `send_message_to_user` 工具，而不是发出不可见的纯文本响应，从而确保计划任务产生的消息实际能够发送给用户。
- 当某次 cron 运行中没有调用任何工具或不存在 LLM 响应时，不再持久化会话历史，避免在后续运行中产生误导性的上下文。
- 处理来自不支持 `/models` 端点的 Anthropic 兼容提供商的模型列出失败问题，改为返回空列表而不是抛出异常。

Enhancements:
- 明确并强化主动 cron 代理的系统提示词，清楚说明文本对用户不可见且 `send_message_to_user` 工具是唯一的投递机制，并修复模板中的格式问题以提高可读性。

Tests:
- 新增单元测试，覆盖 cron 代理提示词构造、系统提示词的可见性保证、基于工具使用情况和 LLM 响应的历史持久化行为、缺失工具调用的日志记录，以及在工具集中包含 `send_message_to_user` 等场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure cron-triggered agents reliably deliver proactive messages via tool calls and avoid polluting history when no delivery occurred.

Bug Fixes:
- Force cron agents to call the `send_message_to_user` tool instead of emitting invisible plain-text responses so scheduled messages are actually delivered to users.
- Avoid persisting conversation history for cron runs where no tools were called or no LLM response exists, preventing misleading context in future runs.
- Handle failures when listing models from Anthropic-compatible providers that do not support the /models endpoint by returning an empty list instead of raising.

Enhancements:
- Clarify and strengthen the proactive cron agent system prompt so that it explicitly states text is not user-visible and the `send_message_to_user` tool is the only delivery mechanism, and fix formatting issues in the template for better readability.

Tests:
- Add unit tests covering cron agent prompt construction, system prompt visibility guarantees, history persistence behavior based on tool usage and LLM responses, logging of missing tool calls, and inclusion of `send_message_to_user` in the toolset.

</details>