### PR TITLE
fix: accept reasoning-only OpenAI completions

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -534,7 +534,11 @@ class ProviderOpenAIOfficial(Provider):
             raise Exception(
                 "API 返回的 completion 由于内容安全过滤被拒绝(非 AstrBot)。",
             )
-        if llm_response.completion_text is None and not llm_response.tools_call_args:
+        if (
+            llm_response.completion_text is None
+            and not llm_response.tools_call_args
+            and not llm_response.reasoning_content
+        ):
             logger.error(f"API 返回的 completion 无法解析：{completion}。")
             raise Exception(f"API 返回的 completion 无法解析：{completion}。")
 

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -199,6 +199,37 @@ def test_extract_error_text_candidates_truncates_long_response_text():
 
 
 @pytest.mark.asyncio
+async def test_parse_openai_completion_accepts_reasoning_only_response(monkeypatch):
+    provider = _make_provider()
+    try:
+        completion = SimpleNamespace(
+            id="chatcmpl-test",
+            choices=[
+                SimpleNamespace(
+                    finish_reason="stop",
+                    message=SimpleNamespace(content=None, tool_calls=[]),
+                )
+            ],
+            usage=None,
+        )
+        monkeypatch.setattr(
+            provider,
+            "_extract_reasoning_content",
+            lambda _completion: "我先思考一下这个问题",
+        )
+
+        llm_response = await provider._parse_openai_completion(completion, tools=None)
+
+        assert llm_response.role == "assistant"
+        assert llm_response.completion_text is None
+        assert llm_response.reasoning_content == "我先思考一下这个问题"
+        assert llm_response.raw_completion is completion
+        assert llm_response.id == "chatcmpl-test"
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
 async def test_handle_api_error_content_moderated_without_images_raises():
     provider = _make_provider(
         {"image_moderation_error_patterns": ["file:content-moderated"]}


### PR DESCRIPTION
### Modifications / 改动点

- allow `_parse_openai_completion` to accept reasoning-only responses when `content` is empty and there are no tool calls
- add a regression test covering a completion that only carries `reasoning_content`
- keep the existing parse failure for completions that have neither text, tool calls, nor reasoning output

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```bash
python3.11 -m pytest tests/test_openai_source.py -q
# 11 passed, 3 warnings in 1.40s

ruff check astrbot/core/provider/sources/openai_source.py tests/test_openai_source.py
ruff format --check astrbot/core/provider/sources/openai_source.py tests/test_openai_source.py
# All checks passed!
```

Closes #6108.

## Summary by Sourcery

处理仅包含推理内容的 OpenAI 聊天补全结果，而不再将其视为解析失败。

Bug 修复：
- 允许解析那些内容为空、没有工具调用，但具有非空推理内容的 OpenAI 补全结果，同时对于既没有文本、也没有工具、也没有推理内容的补全结果仍然视为失败。

测试：
- 添加一个异步回归测试，用于验证仅含推理内容的 OpenAI 补全能够被正确解析为 assistant 响应。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle OpenAI chat completions that contain only reasoning content without treating them as parse failures.

Bug Fixes:
- Allow parsing of OpenAI completions that have empty content, no tool calls, but non-empty reasoning content, while still failing completions that have no text, tools, or reasoning.

Tests:
- Add an async regression test verifying reasoning-only OpenAI completions are parsed into assistant responses correctly.

</details>