### PR TITLE
fix: use infer_single for GSVI TTS API

### DIFF
--- a/astrbot/core/provider/sources/gsvi_tts_source.py
+++ b/astrbot/core/provider/sources/gsvi_tts_source.py
@@ -4,6 +4,7 @@ import uuid
 
 import aiohttp
 
+from astrbot import logger
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
 
 from ..entities import ProviderType
@@ -27,33 +28,227 @@ class ProviderGSVITTS(TTSProvider):
         self.api_base = self.api_base.removesuffix("/")
         self.character = provider_config.get("character")
         self.emotion = provider_config.get("emotion")
+        self.version = provider_config.get("version")
+        self.api_key = provider_config.get("api_key", "")
+        self.timeout = int(provider_config.get("timeout", 20))
+        self.media_type = provider_config.get("media_type", "wav")
+        self.text_lang = provider_config.get("text_lang")
 
     async def get_audio(self, text: str) -> str:
+        if not text.strip():
+            raise ValueError("GSVI TTS text cannot be empty")
+
         temp_dir = get_astrbot_temp_path()
+        os.makedirs(temp_dir, exist_ok=True)
         path = os.path.join(temp_dir, f"gsvi_tts_{uuid.uuid4()}.wav")
-        params = {"text": text}
+        timeout = aiohttp.ClientTimeout(total=self.timeout)
 
-        if self.character:
-            params["character"] = self.character
-        if self.emotion:
-            params["emotion"] = self.emotion
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            if not self.character:
+                logger.warning("[GSVI TTS] character is not configured; falling back to legacy /tts")
+                await self._download_legacy_tts(session, text, path)
+                return path
 
-        query_parts = []
-        for key, value in params.items():
-            encoded_value = urllib.parse.quote(str(value))
-            query_parts.append(f"{key}={encoded_value}")
-
-        url = f"{self.api_base}/tts?{'&'.join(query_parts)}"
-
-        async with aiohttp.ClientSession() as session:
-            async with session.get(url) as response:
-                if response.status == 200:
-                    with open(path, "wb") as f:
-                        f.write(await response.read())
-                else:
-                    error_text = await response.text()
-                    raise Exception(
-                        f"GSVI TTS API 请求失败，状态码: {response.status}，错误: {error_text}",
-                    )
+            infer_config = await self._resolve_infer_config(session)
+            payload = self._build_infer_payload(text, infer_config)
+            audio_url = await self._request_infer_audio(session, payload)
+            await self._download_binary(session, audio_url, path)
 
         return path
+
+    def _auth_headers(self) -> dict[str, str]:
+        if self.api_key:
+            return {"Authorization": f"Bearer {self.api_key}"}
+        if "acgnai.top" in self.api_base:
+            return {"Authorization": "Bearer guest"}
+        return {}
+
+    async def _get_json(self, session: aiohttp.ClientSession, url: str) -> dict:
+        async with session.get(url, headers=self._auth_headers()) as response:
+            if response.status != 200:
+                error_text = await response.text()
+                raise Exception(
+                    f"GSVI TTS API request failed: GET {url} -> {response.status}, error: {error_text}",
+                )
+            return await response.json(content_type=None)
+
+    async def _post_json(
+        self,
+        session: aiohttp.ClientSession,
+        url: str,
+        payload: dict,
+    ) -> dict:
+        async with session.post(
+            url,
+            headers={
+                "Content-Type": "application/json",
+                **self._auth_headers(),
+            },
+            json=payload,
+        ) as response:
+            if response.status != 200:
+                error_text = await response.text()
+                raise Exception(
+                    f"GSVI TTS API request failed: POST {url} -> {response.status}, error: {error_text}",
+                )
+            return await response.json(content_type=None)
+
+    async def _resolve_infer_config(self, session: aiohttp.ClientSession) -> dict[str, str]:
+        versions = []
+        if self.version:
+            versions.append(self.version)
+
+        version_data = await self._get_json(session, f"{self.api_base}/version")
+        for version in version_data.get("support_versions", []):
+            if version not in versions:
+                versions.append(version)
+
+        for version in versions:
+            model_data = await self._get_json(session, f"{self.api_base}/models/{version}")
+            language_map = (model_data.get("models") or {}).get(self.character) or {}
+            if not language_map:
+                continue
+
+            prompt_text_lang = self._select_prompt_text_lang(language_map)
+            emotions = language_map.get(prompt_text_lang) or []
+            emotion = self._select_emotion(emotions)
+
+            return {
+                "version": version,
+                "prompt_text_lang": prompt_text_lang,
+                "emotion": emotion,
+            }
+
+        raise Exception(
+            f"GSVI TTS model not found in remote catalog: {self.character}",
+        )
+
+    def _select_prompt_text_lang(self, language_map: dict[str, list[str]]) -> str:
+        if not language_map:
+            raise Exception("GSVI TTS model has no prompt_text_lang options")
+
+        non_empty_languages = [lang for lang, emotions in language_map.items() if emotions]
+        if non_empty_languages:
+            return non_empty_languages[0]
+
+        return next(iter(language_map))
+
+    def _normalize_emotion(self, emotion: str | None) -> str:
+        if not emotion:
+            return "默认"
+
+        normalized = emotion.strip()
+        english_aliases = {
+            "default": "默认",
+            "neutral": "中立",
+            "happy": "开心",
+            "sad": "难过",
+            "angry": "生气",
+            "fear": "恐惧",
+            "surprise": "吃惊",
+            "surprised": "吃惊",
+            "disgust": "厌恶",
+            "other": "其他",
+            "random": "随机",
+        }
+        return english_aliases.get(normalized.lower(), normalized)
+
+    def _select_emotion(self, emotions: list[str]) -> str:
+        requested = self._normalize_emotion(self.emotion)
+        if requested in emotions:
+            return requested
+        if "默认" in emotions:
+            return "默认"
+        if emotions:
+            return emotions[0]
+        return requested
+
+    def _resolve_text_lang(self, prompt_text_lang: str) -> str:
+        if self.text_lang:
+            return self.text_lang
+
+        mapping = {
+            "中文": "中文",
+            "zh": "中文",
+            "zh_cn": "中文",
+            "英语": "英语",
+            "en": "英语",
+            "日语": "日语",
+            "ja": "日语",
+            "jp": "日语",
+            "粤语": "粤语",
+            "yue": "粤语",
+            "韩语": "韩语",
+            "ko": "韩语",
+        }
+        return mapping.get(prompt_text_lang.lower(), prompt_text_lang)
+
+    def _build_infer_payload(self, text: str, infer_config: dict[str, str]) -> dict:
+        return {
+            "version": infer_config["version"],
+            "model_name": self.character,
+            "prompt_text_lang": infer_config["prompt_text_lang"],
+            "emotion": infer_config["emotion"],
+            "text": text,
+            "text_lang": self._resolve_text_lang(infer_config["prompt_text_lang"]),
+            "top_k": 10,
+            "top_p": 1,
+            "temperature": 1,
+            "text_split_method": "凑四句一切",
+            "batch_size": 1,
+            "batch_threshold": 0.75,
+            "split_bucket": True,
+            "speed_facter": 1,
+            "fragment_interval": 0.3,
+            "media_type": self.media_type,
+            "parallel_infer": True,
+            "repetition_penalty": 1.35,
+            "seed": -1,
+            "sample_steps": 16,
+            "if_sr": False,
+        }
+
+    async def _request_infer_audio(
+        self,
+        session: aiohttp.ClientSession,
+        payload: dict,
+    ) -> str:
+        data = await self._post_json(session, f"{self.api_base}/infer_single", payload)
+        audio_url = data.get("audio_url", "")
+        if not audio_url:
+            raise Exception(data.get("msg", "GSVI TTS infer_single did not return audio_url"))
+        return audio_url
+
+    async def _download_binary(
+        self,
+        session: aiohttp.ClientSession,
+        url: str,
+        path: str,
+    ) -> None:
+        async with session.get(url) as response:
+            if response.status != 200:
+                error_text = await response.text()
+                raise Exception(
+                    f"Failed to download synthesized audio: GET {url} -> {response.status}, error: {error_text}",
+                )
+            with open(path, "wb") as f:
+                f.write(await response.read())
+
+    async def _download_legacy_tts(
+        self,
+        session: aiohttp.ClientSession,
+        text: str,
+        path: str,
+    ) -> None:
+        encoded_text = urllib.parse.quote(str(text))
+        url = f"{self.api_base}/tts?text={encoded_text}"
+
+        async with session.get(url, headers=self._auth_headers()) as response:
+            if response.status == 200:
+                with open(path, "wb") as f:
+                    f.write(await response.read())
+            else:
+                error_text = await response.text()
+                raise Exception(
+                    f"GSVI TTS API legacy /tts request failed, status: {response.status}, error: {error_text}",
+                )

--- a/tests/test_gsvi_tts_source.py
+++ b/tests/test_gsvi_tts_source.py
@@ -1,0 +1,92 @@
+from pathlib import Path
+
+import pytest
+
+from astrbot.core.provider.sources import gsvi_tts_source
+from astrbot.core.provider.sources.gsvi_tts_source import ProviderGSVITTS
+
+
+@pytest.mark.asyncio
+async def test_resolve_infer_config_discovers_version_and_normalizes_default_emotion(
+    monkeypatch,
+):
+    provider = ProviderGSVITTS(
+        {
+            "api_base": "https://gsv2p.example.com",
+            "character": "Model A",
+            "emotion": "default",
+        },
+        {},
+    )
+
+    async def fake_get_json(session, url):
+        if url.endswith("/version"):
+            return {"support_versions": ["v2", "v4"]}
+        if url.endswith("/models/v2"):
+            return {"models": {}}
+        if url.endswith("/models/v4"):
+            return {"models": {"Model A": {"中文": ["默认", "开心"]}}}
+        raise AssertionError(url)
+
+    monkeypatch.setattr(provider, "_get_json", fake_get_json)
+
+    infer_config = await provider._resolve_infer_config(object())
+
+    assert infer_config == {
+        "version": "v4",
+        "prompt_text_lang": "中文",
+        "emotion": "默认",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_audio_uses_infer_single_and_downloads_audio(monkeypatch, tmp_path: Path):
+    provider = ProviderGSVITTS(
+        {
+            "api_base": "https://gsv2p.example.com",
+            "character": "Model A",
+            "emotion": "default",
+        },
+        {},
+    )
+
+    class FakeClientSession:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    async def fake_resolve_infer_config(session):
+        return {
+            "version": "v4",
+            "prompt_text_lang": "zh",
+            "emotion": "默认",
+        }
+
+    async def fake_request_infer_audio(session, payload):
+        assert payload["version"] == "v4"
+        assert payload["model_name"] == "Model A"
+        assert payload["prompt_text_lang"] == "zh"
+        assert payload["emotion"] == "默认"
+        assert payload["text"] == "你好"
+        assert payload["text_lang"] == "中文"
+        return "https://cdn.example.com/audio.wav"
+
+    async def fake_download_binary(session, url, path):
+        assert url == "https://cdn.example.com/audio.wav"
+        Path(path).write_bytes(b"wav-bytes")
+
+    monkeypatch.setattr(gsvi_tts_source, "get_astrbot_temp_path", lambda: str(tmp_path))
+    monkeypatch.setattr(gsvi_tts_source.aiohttp, "ClientSession", FakeClientSession)
+    monkeypatch.setattr(provider, "_resolve_infer_config", fake_resolve_infer_config)
+    monkeypatch.setattr(provider, "_request_infer_audio", fake_request_infer_audio)
+    monkeypatch.setattr(provider, "_download_binary", fake_download_binary)
+
+    audio_path = await provider.get_audio("你好")
+
+    assert Path(audio_path).read_bytes() == b"wav-bytes"
+    assert str(tmp_path) in audio_path


### PR DESCRIPTION
## Summary
- replace the GSVI provider's hard-coded `/tts` request path with remote catalog discovery + `infer_single`
- resolve the configured model across supported versions and normalize default English emotion labels like `default` -> `默认`
- download the returned synthesized audio URL and cover the new discovery/infer flow with focused tests

## Testing
- `PYTHONPATH=. pytest -q tests/test_gsvi_tts_source.py`

Closes #5638

## Summary by Sourcery

更新 GSVI TTS provider，使其使用远程目录发现（remote catalog discovery）和 `infer_single` 端点，而不是硬编码的 `/tts` 路径，并为新的流程添加测试。

新功能：
- 为 GSVI TTS API 提供远程模型和版本发现支持，包括可配置的版本、媒体类型、文本语言、超时时间以及 API Key 认证。

错误修复：
- 更稳健地处理空的 TTS 输入文本和缺失的角色配置，在必要时回退到旧版 `/tts` 端点。

增强优化：
- 在从远程目录解析模型和情绪时，将英文情绪标签规范化为 provider 预期的值。
- 优化 GSVI TTS 请求的情绪和语言选择逻辑，包括常见语言代码和情绪别名的映射。
- 改进 GSVI TTS HTTP 请求和音频下载的错误报告与日志记录。

测试：
- 添加单元测试，覆盖推理配置发现（infer config discovery）、情绪规范化，以及基于 `infer_single` 的新音频生成与下载流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the GSVI TTS provider to use remote catalog discovery and the infer_single endpoint instead of a hard-coded /tts path, and add tests for the new flow.

New Features:
- Support remote model and version discovery for the GSVI TTS API, including configurable version, media type, text language, timeout, and API key authentication.

Bug Fixes:
- Handle empty TTS input text and missing character configuration more robustly, falling back to the legacy /tts endpoint when necessary.

Enhancements:
- Normalize English emotion labels to the provider's expected values when resolving models and emotions from the remote catalog.
- Refine emotion and language selection logic for GSVI TTS requests, including mapping common language codes and emotion aliases.
- Improve error reporting and logging for GSVI TTS HTTP requests and audio downloads.

Tests:
- Add unit tests covering infer config discovery, emotion normalization, and the new infer_single-based audio generation and download flow.

</details>