### PR TITLE
fix: stop webchat stream from crashing on queue polling errors

### DIFF
--- a/astrbot/dashboard/routes/chat.py
+++ b/astrbot/dashboard/routes/chat.py
@@ -36,6 +36,20 @@ async def track_conversation(convs: dict, conv_id: str):
         convs.pop(conv_id, None)
 
 
+async def _poll_webchat_stream_result(back_queue, username: str):
+    try:
+        result = await asyncio.wait_for(back_queue.get(), timeout=1)
+    except asyncio.TimeoutError:
+        return None, False
+    except asyncio.CancelledError:
+        logger.debug(f"[WebChat] 用户 {username} 断开聊天长连接。")
+        return None, True
+    except Exception as e:
+        logger.error(f"WebChat stream error: {e}")
+        return None, False
+    return result, False
+
+
 class ChatRoute(Route):
     def __init__(
         self,
@@ -342,16 +356,12 @@ class ChatRoute(Route):
 
                 async with track_conversation(self.running_convs, webchat_conv_id):
                     while True:
-                        try:
-                            result = await asyncio.wait_for(back_queue.get(), timeout=1)
-                        except asyncio.TimeoutError:
-                            continue
-                        except asyncio.CancelledError:
-                            logger.debug(f"[WebChat] 用户 {username} 断开聊天长连接。")
+                        result, should_break = await _poll_webchat_stream_result(
+                            back_queue, username
+                        )
+                        if should_break:
                             client_disconnected = True
-                        except Exception as e:
-                            logger.error(f"WebChat stream error: {e}")
-
+                            break
                         if not result:
                             continue
 

--- a/tests/test_chat_route.py
+++ b/tests/test_chat_route.py
@@ -1,0 +1,56 @@
+import asyncio
+
+import pytest
+
+from astrbot.dashboard.routes.chat import _poll_webchat_stream_result
+
+
+class _QueueThatRaises:
+    def __init__(self, exc: BaseException):
+        self._exc = exc
+
+    async def get(self):
+        raise self._exc
+
+
+class _QueueWithResult:
+    def __init__(self, result):
+        self._result = result
+
+    async def get(self):
+        return self._result
+
+
+@pytest.mark.asyncio
+async def test_poll_webchat_stream_result_breaks_on_cancelled_error():
+    result, should_break = await _poll_webchat_stream_result(
+        _QueueThatRaises(asyncio.CancelledError()),
+        "alice",
+    )
+
+    assert result is None
+    assert should_break is True
+
+
+@pytest.mark.asyncio
+async def test_poll_webchat_stream_result_continues_on_generic_exception():
+    result, should_break = await _poll_webchat_stream_result(
+        _QueueThatRaises(RuntimeError("boom")),
+        "alice",
+    )
+
+    assert result is None
+    assert should_break is False
+
+
+@pytest.mark.asyncio
+async def test_poll_webchat_stream_result_returns_queue_payload():
+    payload = {"type": "end", "data": ""}
+
+    result, should_break = await _poll_webchat_stream_result(
+        _QueueWithResult(payload),
+        "alice",
+    )
+
+    assert result == payload
+    assert should_break is False


### PR DESCRIPTION
### Modifications / 改动点

- Fix the webchat SSE loop in `astrbot/dashboard/routes/chat.py` so queue polling errors do not fall through to `if not result` with an unbound local.
- Treat `CancelledError` as a clean client disconnect (`break`) and keep generic queue polling errors non-fatal (`continue`).
- Add regression tests for the new polling helper to cover success, generic exceptions, and `CancelledError`.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```bash
python3.11 -m pytest tests/test_chat_route.py -q
...                                                                      [100%]
3 passed, 3 warnings in 1.36s

python3 -m compileall astrbot/dashboard/routes/chat.py
Compiling 'astrbot/dashboard/routes/chat.py'...
```

Closes #6118.

---

### Checklist / 检查清单

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

更稳健地处理网页聊天流式队列轮询错误，防止 SSE 崩溃，并更干净地处理客户端断开连接。

Bug Fixes:
- 当队列轮询抛出异常或返回空结果时，防止网页聊天 SSE 流式传输崩溃。

Tests:
- 为网页聊天轮询辅助工具添加异步单元测试，覆盖正常队列负载、通用轮询异常以及 `CancelledError` 处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle webchat streaming queue polling errors more robustly to prevent SSE crashes and treat client disconnects cleanly.

Bug Fixes:
- Prevent webchat SSE streaming from crashing when queue polling raises exceptions or returns no result.

Tests:
- Add async unit tests covering normal queue payloads, generic polling exceptions, and CancelledError handling in the webchat polling helper.

</details>