### PR TITLE
fix: cancel platform tasks before adapter shutdown

### DIFF
--- a/astrbot/core/platform/manager.py
+++ b/astrbot/core/platform/manager.py
@@ -68,21 +68,25 @@ class PlatformManager:
 
     async def _terminate_inst_and_tasks(self, inst: Platform) -> None:
         client_id = inst.client_self_id
-        try:
-            if getattr(inst, "terminate", None):
-                try:
-                    await inst.terminate()
-                except asyncio.CancelledError:
-                    raise
-                except Exception as e:
-                    logger.error(
-                        "终止平台适配器失败: client_id=%s, error=%s",
-                        client_id,
-                        e,
-                    )
-                    logger.error(traceback.format_exc())
-        finally:
-            await self._stop_platform_task(client_id)
+
+        # Stop the platform run/wrapper tasks before awaiting adapter-specific
+        # shutdown hooks. Some websocket clients (for example qq-botpy) keep
+        # receiving events until their long-running task is cancelled, so
+        # awaiting terminate() first can leave a deleted adapter alive.
+        await self._stop_platform_task(client_id)
+
+        if getattr(inst, "terminate", None):
+            try:
+                await inst.terminate()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.error(
+                    "终止平台适配器失败: client_id=%s, error=%s",
+                    client_id,
+                    e,
+                )
+                logger.error(traceback.format_exc())
 
     async def initialize(self) -> None:
         """初始化所有平台适配器"""

--- a/tests/unit/test_platform_manager.py
+++ b/tests/unit/test_platform_manager.py
@@ -1,0 +1,41 @@
+import asyncio
+
+import pytest
+
+from astrbot.core.platform.manager import PlatformManager, PlatformTasks
+
+
+class _PlatformThatNeedsTaskStopped:
+    def __init__(self) -> None:
+        self.client_self_id = "dummy-client"
+        self.run_task_cancelled = asyncio.Event()
+
+    async def terminate(self) -> None:
+        await asyncio.wait_for(self.run_task_cancelled.wait(), timeout=1)
+
+
+async def _run_until_cancelled(cancelled: asyncio.Event) -> None:
+    try:
+        await asyncio.sleep(3600)
+    except asyncio.CancelledError:
+        cancelled.set()
+        raise
+
+
+@pytest.mark.asyncio
+async def test_terminate_stops_platform_tasks_before_adapter_shutdown() -> None:
+    manager = PlatformManager({"platform": [], "platform_settings": {}}, asyncio.Queue())
+    inst = _PlatformThatNeedsTaskStopped()
+
+    run_task = asyncio.create_task(_run_until_cancelled(inst.run_task_cancelled))
+    wrapper_task = asyncio.create_task(asyncio.sleep(3600))
+    manager._platform_tasks[inst.client_self_id] = PlatformTasks(
+        run=run_task,
+        wrapper=wrapper_task,
+    )
+
+    await asyncio.wait_for(manager._terminate_inst_and_tasks(inst), timeout=1)
+
+    assert inst.run_task_cancelled.is_set()
+    assert run_task.cancelled()
+    assert wrapper_task.cancelled()


### PR DESCRIPTION
Fixes #6100.

### Modifications / 改动点

- cancel a platform adapter's run/wrapper tasks before awaiting its `terminate()` hook
- document why this order matters for websocket-based adapters such as `qq_official`
- add a regression test covering adapters whose shutdown depends on their background task being cancelled first

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```bash
python3.11 -m pytest tests/unit/test_platform_manager.py -q
.                                                                        [100%]
1 passed in 1.29s

git diff --check
# no output
```

---

### Checklist / 检查清单

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

确保在调用适配器特定的终止钩子之前，平台适配器的关闭过程会先停止后台任务，从而避免残留的 WebSocket 客户端。

Bug 修复：
- 通过在等待 `terminate()` 之前取消适配器的运行任务和包装任务，防止基于 WebSocket 的平台适配器在关闭期间继续接收事件。

测试：
- 添加一个回归测试，验证平台管理器在关闭时，会在调用适配器的终止钩子之前取消适配器的运行任务和包装任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure platform adapter shutdown stops background tasks before invoking adapter-specific terminate hooks to avoid lingering websocket clients.

Bug Fixes:
- Prevent websocket-based platform adapters from continuing to receive events during shutdown by cancelling their run and wrapper tasks before terminate() is awaited.

Tests:
- Add a regression test verifying that platform manager shutdown cancels adapter run and wrapper tasks before calling the adapter's terminate hook.

</details>