### PR TITLE
fix: provide fallback items for Gemini array params

### DIFF
--- a/astrbot/core/agent/tool.py
+++ b/astrbot/core/agent/tool.py
@@ -293,7 +293,17 @@ class ToolSet:
                 if properties:
                     result["properties"] = properties
 
-            if "items" in schema:
+            if target_type == "array":
+                # Gemini rejects array schemas that omit `items`, while JSON Schema
+                # producers in the wild (especially external MCP tools) sometimes
+                # leave element types unspecified. Fall back to a permissive string
+                # item schema so tool calling stays functional instead of failing the
+                # whole request with `items: missing field`.
+                if isinstance(schema.get("items"), dict) and schema["items"]:
+                    result["items"] = convert_schema(schema["items"])
+                else:
+                    result["items"] = {"type": "string"}
+            elif "items" in schema:
                 result["items"] = convert_schema(schema["items"])
 
             return result

--- a/tests/unit/test_tool_google_schema.py
+++ b/tests/unit/test_tool_google_schema.py
@@ -1,0 +1,47 @@
+from astrbot.core.agent.tool import FunctionTool, ToolSet
+
+
+def test_google_schema_adds_default_items_for_array_parameters_without_items():
+    tool = FunctionTool(
+        name="lookup_sources",
+        description="Look up sources by UUID.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "source_uuids": {
+                    "type": "array",
+                    "description": "Source UUIDs to fetch.",
+                }
+            },
+        },
+    )
+
+    schema = ToolSet(tools=[tool]).google_schema()
+    source_uuids = schema["function_declarations"][0]["parameters"]["properties"][
+        "source_uuids"
+    ]
+
+    assert source_uuids["type"] == "array"
+    assert source_uuids["items"] == {"type": "string"}
+
+
+def test_google_schema_preserves_explicit_array_item_schema():
+    tool = FunctionTool(
+        name="lookup_numbers",
+        description="Look up integer values.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "numbers": {
+                    "type": "array",
+                    "items": {"type": "integer", "format": "int32"},
+                }
+            },
+        },
+    )
+
+    schema = ToolSet(tools=[tool]).google_schema()
+    numbers = schema["function_declarations"][0]["parameters"]["properties"]["numbers"]
+
+    assert numbers["type"] == "array"
+    assert numbers["items"] == {"type": "integer", "format": "int32"}


### PR DESCRIPTION
Fixes #6029.

### Modifications / 改动点

- add a Gemini schema compatibility fallback so array parameters without an explicit `items` schema still serialize with `items: {"type": "string"}` instead of failing the whole request
- preserve explicit array item schemas when they are already present
- add focused unit coverage for both the fallback path and the explicit-items path

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

- `python3.11 -m ruff format astrbot/core/agent/tool.py tests/unit/test_tool_google_schema.py`
- `python3.11 -m ruff check astrbot/core/agent/tool.py tests/unit/test_tool_google_schema.py`
- `python3.11 -m pytest tests/unit/test_tool_google_schema.py -q`
- `git diff --check`

---

### Checklist / 检查清单

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

确保当数组参数省略 `items` 定义时，Gemini 工具的模式依然保持有效。

Bug Fixes:
- 为缺少显式 `items` 定义的 Gemini 数组参数提供默认的字符串类型元素模式，避免请求失败。

Tests:
- 添加单元测试，用于验证在数组缺少 `items` 时会应用默认元素模式，以及在存在显式数组元素模式时能够被正确保留。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure Gemini tool schemas remain valid when array parameters omit item definitions.

Bug Fixes:
- Provide a default string item schema for Gemini array parameters that lack explicit items to avoid request failures.

Tests:
- Add unit tests verifying default item schemas for arrays without items and preservation of explicit array item schemas.

</details>