### PR TITLE
fix: preserve subagent transfer tools under plugin filtering

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -778,9 +778,14 @@ def _plugin_tool_fix(event: AstrMessageEvent, req: ProviderRequest) -> None:
                 continue
             mp = tool.handler_module_path
             if not mp:
+                # 没有 plugin 归属信息的工具（如 subagent transfer_to_*）
+                # 不应受到会话插件过滤影响。
+                new_tool_set.add_tool(tool)
                 continue
             plugin = star_map.get(mp)
             if not plugin:
+                # 无法解析插件归属时，保守保留工具，避免误过滤。
+                new_tool_set.add_tool(tool)
                 continue
             if plugin.name in event.plugins_name or plugin.reserved:
                 new_tool_set.add_tool(tool)

--- a/tests/unit/test_astr_main_agent.py
+++ b/tests/unit/test_astr_main_agent.py
@@ -804,6 +804,28 @@ class TestPluginToolFix:
 
         assert "mcp_tool" in req.func_tool.names()
 
+    def test_plugin_tool_fix_preserves_tools_without_plugin_origin(self, mock_event):
+        """Tools without handler_module_path should not be filtered out."""
+        module = ama
+        handoff_tool = FunctionTool(
+            name="transfer_to_demo_agent",
+            description="Delegate to demo agent",
+            parameters={"type": "object", "properties": {}},
+            handler_module_path=None,
+            active=True,
+        )
+
+        tool_set = ToolSet()
+        tool_set.add_tool(handoff_tool)
+
+        req = ProviderRequest(func_tool=tool_set)
+        mock_event.plugins_name = ["other_plugin"]
+
+        with patch("astrbot.core.astr_main_agent.star_map"):
+            module._plugin_tool_fix(mock_event, req)
+
+        assert "transfer_to_demo_agent" in req.func_tool.names()
+
 
 class TestBuildMainAgent:
     """Tests for build_main_agent function."""


### PR DESCRIPTION
Fixes #6109

### Modifications / 改动点

- preserve tools that do not carry plugin origin metadata when applying session plugin filtering in `_plugin_tool_fix`
- keep `transfer_to_*` subagent handoff tools available even when the profile enables only a subset of plugins
- add a focused regression test covering tools without `handler_module_path`

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```bash
python3.11 -m pytest tests/unit/test_astr_main_agent.py -q
# 73 passed

python3.11 -m ruff format --check astrbot/core/astr_main_agent.py tests/unit/test_astr_main_agent.py
python3.11 -m ruff check astrbot/core/astr_main_agent.py tests/unit/test_astr_main_agent.py

git diff --check
```

This fixes the regression where `sel_persona.persona_toolset` still contains `transfer_to_*`, but `_plugin_tool_fix` drops those handoff tools from `astr_agent_prepare.tools` whenever the session plugin scope is not `[*]`.

---

### Checklist / 检查清单

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## 由 Sourcery 提供的摘要

在应用基于会话插件的工具过滤时，保留缺少插件来源元数据的子代理转移工具。

错误修复：
- 确保在插件作用域受限时，没有 `handler_module_path` 的工具（包括 `transfer_to_*` 子代理交接工具）不会被会话插件过滤移除。

测试：
- 添加一个回归测试，以验证在非全局插件作用域下，缺少插件来源元数据的工具会被 `_plugin_tool_fix` 保留。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve subagent transfer tools that lack plugin origin metadata when applying session plugin-based tool filtering.

Bug Fixes:
- Ensure tools without handler_module_path, including transfer_to_* subagent handoff tools, are not removed by session plugin filtering when their plugin scope is restricted.

Tests:
- Add a regression test verifying that tools without plugin origin metadata are preserved by _plugin_tool_fix under non-global plugin scopes.

</details>