### PR TITLE
fix:为用户设置了多个模型提供商但是未在WebUI指定默认对话模型的情况增加了日志进行提醒

### DIFF
--- a/astrbot/core/provider/manager.py
+++ b/astrbot/core/provider/manager.py
@@ -308,17 +308,12 @@ class ProviderManager:
         )
         if not self.curr_provider_inst and self.provider_insts:
             self.curr_provider_inst = self.provider_insts[0]
-        if len(self.provider_insts) > 1:
-            if selected_provider_id:
-                if not isinstance(temp_provider, Provider):
-                    logger.warning(
-                        "无法加载指定的默认对话模型提供商 '%s'，已自动使用第一个可用的提供商 '%s'。请检查您的配置或在 WebUI 中重新设置。",
-                        selected_provider_id,
-                        self.curr_provider_inst.meta().id,
-                    )
-            else:
-                logger.warning(
-                    "检测到配置了多个对话模型提供商，但未指定默认对话模型。"
+            if (
+                len(self.provider_insts) > 1
+                and not self.provider_settings.get("default_provider_id")
+            ):
+                logger.info(
+                    "检测到已配置多个对话模型提供商，但未设置 provider_settings.default_provider_id。"
                     "当前将默认使用第一个提供商：%s。建议在 WebUI 中设置默认对话模型。",
                     self.curr_provider_inst.meta().id,
                 )


### PR DESCRIPTION
为用户设置了多个模型提供商但是未在WebUI指定默认对话模型的情况增加了日志进行提醒

### Modifications / 改动点
改动了astrbot/core/provider/manager.py

- [✓] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果
Validation
- File status checked: astrbot/core/provider/manager.py
- Compile check passed:
  python -m py_compile astrbot/core/provider/manager.py
- Exit code: 0
---

### Checklist / 检查清单
- [✓] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [✓] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [✓] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [✓] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

Add logging to warn when multiple conversation model providers are configured but no valid default is set, falling back to the first available provider.

Bug Fixes:
- Log a warning when the configured default conversation model provider cannot be loaded and the system falls back to the first available provider.

Enhancements:
- Log a warning when multiple conversation model providers exist but no default is specified in the WebUI, indicating that the first provider will be used by default and suggesting configuring a default.
- 当存在多个会话模型提供商但未配置默认提供商时，记录一条信息级别的提醒日志，说明将默认使用第一个提供商，并建议在 WebUI 中设置默认提供商。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add logging to warn when multiple conversation model providers are configured but no valid default is set, falling back to the first available provider.

Bug Fixes:
- Log a warning when the configured default conversation model provider cannot be loaded and the system falls back to the first available provider.

Enhancements:
- Log a warning when multiple conversation model providers exist but no default is specified in the WebUI, indicating that the first provider will be used by default and suggesting configuring a default.

</details>