### PR TITLE
fix(telegram): avoid treating normal replies as topic threads

### DIFF
--- a/astrbot/core/platform/sources/telegram/tg_adapter.py
+++ b/astrbot/core/platform/sources/telegram/tg_adapter.py
@@ -289,8 +289,8 @@ class TelegramPlatformAdapter(Platform):
         else:
             message.type = MessageType.GROUP_MESSAGE
             message.group_id = str(update.message.chat.id)
-            if update.message.message_thread_id:
-                # Topic Group
+            if update.message.is_topic_message and update.message.message_thread_id:
+                # Telegram Topic Group: include thread id to isolate per-topic sessions.
                 message.group_id += "#" + str(update.message.message_thread_id)
                 message.session_id = message.group_id
         message.message_id = str(update.message.message_id)


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

Error message when reply a message in whitelisted group:

```
[Core] [INFO] [whitelist_check.stage:65]: 会话 ID telegram:GroupMessage:-1001234567890#602671 不在会话白名单中，已终止事件传播。请在配置文件中添加该会话 ID 到白名单。
```

When replying to messages in Telegram groups, the bot incorrectly appended the reply message ID or thread ID to the `group_id` and `session_id`, creating a new session for each reply. This caused whitelist verification to fail because:

- Whitelist contained: `telegram:GroupMessage:-1001234567890`
- Actual session ID: `telegram:GroupMessage:-1001234567890#602671`

The mismatch occurred because `message_thread_id` was present in replied messages, but the code unconditionally appended it to the session ID without checking if it was actually a Topic Group message.

Additionally, an incorrect session ID might also prevent the bot from correctly retrieving the context, or cause it to store data under the wrong ID.

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

In `astrbot/core/platform/sources/telegram/tg_adapter.py` (line ~292).

Add an additional check for `is_topic_message` property to distinguish:

 - True Topic Group messages: Include `message_thread_id` in session ID for proper topic isolation
 - Regular reply messages: Keep the base group session ID unchanged

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

Reply messages from whitelist group `telegram:GroupMessage:-1001234567890` will work correctly now.

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

Bug Fixes:
- 通过仅为话题消息附加 `message_thread_id`，防止在普通回复消息中创建新的 Telegram 群组会话。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent creation of new Telegram group sessions for normal reply messages by only appending message_thread_id for topic messages.

</details>