### PR TITLE
fix: add missing spaces in cron prompt and replace deprecated utcnow()

### DIFF
--- a/astrbot/core/cron/manager.py
+++ b/astrbot/core/cron/manager.py
@@ -332,9 +332,9 @@ class CronJobManager:
             cron_job=cron_job_str
         )
         req.prompt = (
-            "You are now responding to a scheduled task"
+            "You are now responding to a scheduled task. "
             "Proceed according to your system instructions. "
-            "Output using same language as previous conversation."
+            "Output using same language as previous conversation. "
             "After completing your task, summarize and output your actions and results."
         )
         if not req.func_tool:

--- a/astrbot/dashboard/routes/auth.py
+++ b/astrbot/dashboard/routes/auth.py
@@ -82,7 +82,7 @@ class AuthRoute(Route):
     def generate_jwt(self, username):
         payload = {
             "username": username,
-            "exp": datetime.datetime.utcnow() + datetime.timedelta(days=7),
+            "exp": datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=7),
         }
         jwt_token = self.config["dashboard"].get("jwt_secret", None)
         if not jwt_token:


### PR DESCRIPTION
## Summary

Two small but impactful fixes:

1. **Fix missing spaces in cron job wake prompt** (`astrbot/core/cron/manager.py:334-338`)
   - Python implicit string concatenation was missing trailing spaces, producing garbled text:
     `"...scheduled taskProceed..."` and `"...conversation.After..."`
   - The LLM agent received broken instructions, causing unreliable cron job execution

2. **Replace deprecated `datetime.utcnow()`** (`astrbot/dashboard/routes/auth.py:85`)
   - `datetime.utcnow()` is deprecated since Python 3.12 and returns a naive datetime
   - Replaced with `datetime.now(datetime.timezone.utc)` which returns timezone-aware datetime
   - Prevents incorrect JWT token expiry on systems with non-UTC clocks

## Related Issues

Closes #6103 — Cron jobs intermittently fail (garbled prompt causes LLM to miss `send_message_to_user` call)
Closes #6165 — QQ official scheduled tasks execute but don't send messages to users

## Changes

| File | Change |
|------|--------|
| `astrbot/core/cron/manager.py` | Add missing spaces between concatenated prompt strings |
| `astrbot/dashboard/routes/auth.py` | `datetime.utcnow()` → `datetime.now(datetime.timezone.utc)` |

## Test plan

- [ ] Verify cron jobs send messages reliably after the prompt fix
- [ ] Verify JWT tokens have correct expiry timestamps

## Summary by Sourcery

Fix cron job agent prompt text and update JWT expiry time handling to use a timezone-aware timestamp.

Bug Fixes:
- Correct cron job wake prompt text so the LLM receives clear, properly spaced instructions.
- Use a timezone-aware current UTC datetime when generating JWT expiry to avoid incorrect token lifetimes.