### PR TITLE
fix: prevent ValueError when removing already-removed API key in retry loop

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -629,7 +629,8 @@ class ProviderOpenAIOfficial(Provider):
             # 最后一次不等待
             if retry_cnt < max_retries - 1:
                 await asyncio.sleep(1)
-            available_api_keys.remove(chosen_key)
+            if chosen_key in available_api_keys:
+                available_api_keys.remove(chosen_key)
             if len(available_api_keys) > 0:
                 chosen_key = random.choice(available_api_keys)
                 return (


### PR DESCRIPTION
## Summary

In `_handle_api_error()`, when a 429 rate-limit error is caught, the code calls `available_api_keys.remove(chosen_key)` to rotate to a different key. However, if the same key was already removed in a previous retry iteration, `list.remove()` raises `ValueError`, crashing the entire LLM request with an opaque error instead of properly retrying or falling back.

This fix adds a membership check (`if chosen_key in available_api_keys`) before calling `remove()`.

## Changes

| File | Change |
|------|--------|
| `astrbot/core/provider/sources/openai_source.py` | Guard `remove()` with `in` check |

## Test plan

- [ ] Trigger multiple 429 errors with the same API key to verify no `ValueError` crash
- [ ] Verify key rotation still works correctly when multiple keys are available

## Summary by Sourcery

Bug Fixes:
- Prevent ValueError crashes when attempting to remove an API key that has already been removed during 429 retry handling.