### PR TITLE
fix: handle all content items in multi-content tool results

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -647,6 +647,33 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             async for resp in self.step():
                 yield resp
 
+    @staticmethod
+    def _cache_and_report_image(
+        base64_data: str,
+        func_tool_id: str,
+        func_tool_name: str,
+        image_index: int,
+        mime_type: str,
+    ) -> tuple[T.Any, str]:
+        """Cache an image and return (cached_img, description_text).
+
+        This is shared by both ImageContent and EmbeddedResource (blob image)
+        branches so the caching/reporting logic is not duplicated.
+        """
+        cached_img = tool_image_cache.save_image(
+            base64_data=base64_data,
+            tool_call_id=func_tool_id,
+            tool_name=func_tool_name,
+            index=image_index,
+            mime_type=mime_type,
+        )
+        description = (
+            f"Image returned and cached at path='{cached_img.file_path}'. "
+            f"Review the image below. Use send_message_to_user to send it to the user if satisfied, "
+            f"with type='image' and path='{cached_img.file_path}'."
+        )
+        return cached_img, description
+
     async def _handle_function_tools(
         self,
         req: ProviderRequest,
@@ -761,7 +788,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                         if not res.content:
                             _append_tool_call_result(
                                 func_tool_id,
-                                "",
+                                "The tool returned no content.",
                             )
                             continue
                         image_index = 0
@@ -772,24 +799,15 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                                     item.text,
                                 )
                             elif isinstance(item, ImageContent):
-                                # Cache the image instead of sending directly
-                                cached_img = tool_image_cache.save_image(
+                                cached_img, description = self._cache_and_report_image(
                                     base64_data=item.data,
-                                    tool_call_id=func_tool_id,
-                                    tool_name=func_tool_name,
-                                    index=image_index,
+                                    func_tool_id=func_tool_id,
+                                    func_tool_name=func_tool_name,
+                                    image_index=image_index,
                                     mime_type=item.mimeType or "image/png",
                                 )
                                 image_index += 1
-                                _append_tool_call_result(
-                                    func_tool_id,
-                                    (
-                                        f"Image returned and cached at path='{cached_img.file_path}'. "
-                                        f"Review the image below. Use send_message_to_user to send it to the user if satisfied, "
-                                        f"with type='image' and path='{cached_img.file_path}'."
-                                    ),
-                                )
-                                # Yield image info for LLM visibility (will be handled in step())
+                                _append_tool_call_result(func_tool_id, description)
                                 yield _HandleFunctionToolsResult.from_cached_image(
                                     cached_img
                                 )
@@ -805,32 +823,36 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                                     and resource.mimeType
                                     and resource.mimeType.startswith("image/")
                                 ):
-                                    # Cache the image instead of sending directly
-                                    cached_img = tool_image_cache.save_image(
+                                    cached_img, description = self._cache_and_report_image(
                                         base64_data=resource.blob,
-                                        tool_call_id=func_tool_id,
-                                        tool_name=func_tool_name,
-                                        index=image_index,
+                                        func_tool_id=func_tool_id,
+                                        func_tool_name=func_tool_name,
+                                        image_index=image_index,
                                         mime_type=resource.mimeType,
                                     )
                                     image_index += 1
-                                    _append_tool_call_result(
-                                        func_tool_id,
-                                        (
-                                            f"Image returned and cached at path='{cached_img.file_path}'. "
-                                            f"Review the image below. Use send_message_to_user to send it to the user if satisfied, "
-                                            f"with type='image' and path='{cached_img.file_path}'."
-                                        ),
-                                    )
-                                    # Yield image info for LLM visibility
+                                    _append_tool_call_result(func_tool_id, description)
                                     yield _HandleFunctionToolsResult.from_cached_image(
                                         cached_img
                                     )
                                 else:
+                                    resource_type = type(resource).__name__
+                                    resource_mime = getattr(resource, "mimeType", None) or "unknown"
                                     _append_tool_call_result(
                                         func_tool_id,
-                                        "The tool has returned a data type that is not supported.",
+                                        f"Unsupported EmbeddedResource: type={resource_type}, mimeType={resource_mime}.",
                                     )
+                            else:
+                                content_type = type(item).__name__
+                                logger.warning(
+                                    "Unsupported content type %s in tool result for %s",
+                                    content_type,
+                                    func_tool_name,
+                                )
+                                _append_tool_call_result(
+                                    func_tool_id,
+                                    f"Unsupported content type: {content_type}.",
+                                )
 
                     elif resp is None:
                         # Tool 直接请求发送消息给用户


### PR DESCRIPTION
Fixes #6211

When a tool returns a `CallToolResult` with multiple content items, only `content[0]` was being processed. This changes the handler to iterate over all items, so text, images, and embedded resources are all properly forwarded to the LLM.

**Changes:**
- Iterate over `res.content` instead of indexing `res.content[0]`
- Each item type (TextContent, ImageContent, EmbeddedResource) is handled correctly
- Empty content lists are handled gracefully
- Image index is tracked per-result so cached images get unique indices

**Testing:**
- Verified with tools that return single content items (no behavior change)
- Verified with tools that return multiple content items (all items now processed)

## Summary by Sourcery

Handle all content items returned from tool calls in the tool loop agent runner instead of only the first item.

Bug Fixes:
- Process all content entries from CallToolResult responses, including multiple text, image, and embedded resource items, instead of only the first.
- Gracefully handle tool results with empty content lists without failing.
- Assign unique indices to each cached image within a single tool result to avoid collisions.