### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4.3.0
+        uses: pnpm/action-setup@v4.4.0
         with:
           version: 10.28.2
 


### PR DESCRIPTION
Bumps GitHub Actions to their latest versions for bug fixes and security patches.

## Changes

| Action | Old Version(s) | New Version | Compare | Files |
|--------|---------------|-------------|---------|-------|
| `pnpm/action-setup` | [`v4.3.0`](https://github.com/pnpm/action-setup/releases/tag/v4.3.0) | [`v4.4.0`](https://github.com/pnpm/action-setup/releases/tag/v4.4.0) | [Diff](https://github.com/pnpm/action-setup/compare/v4.3.0...v4.4.0) | release.yml |

## Notes

Worth running the workflows on a branch before merging to make sure everything still works.

## Validation Warnings

The following issues were detected by [actionlint](https://github.com/rhysd/actionlint):

- `dashboard_ci.yml: .github/workflows/dashboard_ci.yml:31:9: shellcheck reported issue in this script: SC2086:info:1:44: Double quote to prevent globbing and word splitting [shellcheck]`
- `dashboard_ci.yml: |`
- `dashboard_ci.yml: 31 |         run: |`
- `docker-image.yml: .github/workflows/docker-image.yml:26:11: input "fetch-tag" is not defined in action "actions/checkout@v6". available inputs are "clean", "fetch-depth", "fetch-tags", "filter", "github-server-url", "lfs", "path", "persist-credentials", "ref", "repository", "set-safe-directory", "show-progress", "sparse-checkout", "sparse-checkout-cone-mode", "ssh-key", "ssh-known-hosts", "ssh-strict", "ssh-user", "submodules", "token" [action]`
- `docker-image.yml: |`
- `docker-image.yml: 26 |           fetch-tag: true`
- `smoke_test.yml: .github/workflows/smoke_test.yml:41:9: shellcheck reported issue in this script: SC2034:warning:5:1: i appears unused. Verify use (or export if used externally) [shellcheck]`
- `smoke_test.yml: |`
- `smoke_test.yml: 41 |         run: |`

## Summary by Sourcery

CI:
- Bump pnpm/action-setup in the release workflow to v4.4.0 for up-to-date tooling and fixes.