### PR TITLE
fix(slack): preserve thread context and always send fallback text

### DIFF
--- a/astrbot/core/platform/sources/slack/session_codec.py
+++ b/astrbot/core/platform/sources/slack/session_codec.py
@@ -12,6 +12,11 @@ SLACK_SAFE_TEXT_FALLBACK = SLACK_DEFAULT_TEXT_FALLBACKS["safe_text"]
 
 
 def build_slack_text_fallbacks(overrides: dict | None = None) -> dict[str, str]:
+    """Build Slack text fallback rules.
+
+    Only keys defined in `SLACK_DEFAULT_TEXT_FALLBACKS` are honored; unknown
+    override keys are intentionally ignored.
+    """
     text_fallbacks = dict(SLACK_DEFAULT_TEXT_FALLBACKS)
     if not isinstance(overrides, dict):
         return text_fallbacks
@@ -29,30 +34,17 @@ def encode_thread_session_id(channel_id: str, thread_ts: str) -> str:
     return f"{channel_id}{THREAD_SESSION_MARKER}{thread_ts}"
 
 
-def _decode_thread_session_id(session_id: str) -> tuple[str, str | None] | None:
-    if THREAD_SESSION_MARKER not in session_id:
-        return None
-    channel_id, thread_ts = session_id.split(THREAD_SESSION_MARKER, 1)
-    return channel_id, thread_ts or None
-
-
-def _decode_legacy_session_id(session_id: str) -> tuple[str, str | None] | None:
-    if not session_id.startswith(LEGACY_GROUP_SESSION_PREFIX):
-        return None
-    return session_id[len(LEGACY_GROUP_SESSION_PREFIX) :], None
-
-
 def decode_slack_session_id(session_id: str) -> tuple[str, str | None]:
+    """Decode a Slack session id into (channel_id, thread_ts|None)."""
     if not session_id:
         return "", None
 
-    decoded_thread_session = _decode_thread_session_id(session_id)
-    if decoded_thread_session is not None:
-        return decoded_thread_session
+    if THREAD_SESSION_MARKER in session_id:
+        channel_id, thread_ts = session_id.split(THREAD_SESSION_MARKER, 1)
+        return channel_id, thread_ts or None
 
-    decoded_legacy_session = _decode_legacy_session_id(session_id)
-    if decoded_legacy_session is not None:
-        return decoded_legacy_session
+    if session_id.startswith(LEGACY_GROUP_SESSION_PREFIX):
+        return session_id[len(LEGACY_GROUP_SESSION_PREFIX) :], None
 
     return session_id, None
 

--- a/astrbot/core/platform/sources/slack/session_codec.py
+++ b/astrbot/core/platform/sources/slack/session_codec.py
@@ -9,21 +9,74 @@ def encode_thread_session_id(channel_id: str, thread_ts: str) -> str:
     return f"{channel_id}{THREAD_SESSION_MARKER}{thread_ts}"
 
 
+def _decode_thread_session_id(session_id: str) -> tuple[str, str | None] | None:
+    if THREAD_SESSION_MARKER not in session_id:
+        return None
+    channel_id, thread_ts = session_id.split(THREAD_SESSION_MARKER, 1)
+    return channel_id, thread_ts or None
+
+
+def _decode_legacy_session_id(session_id: str) -> tuple[str, str | None] | None:
+    if not session_id.startswith(LEGACY_GROUP_SESSION_PREFIX):
+        return None
+    return session_id[len(LEGACY_GROUP_SESSION_PREFIX) :], None
+
+
 def decode_slack_session_id(session_id: str) -> tuple[str, str | None]:
     if not session_id:
         return "", None
 
-    if THREAD_SESSION_MARKER in session_id:
-        channel_id, thread_ts = session_id.split(THREAD_SESSION_MARKER, 1)
-        # Do not fallback to legacy parsing once thread marker is detected.
-        # Keep decoded channel_id even if thread_ts is missing.
-        return channel_id, thread_ts or None
+    decoded_thread_session = _decode_thread_session_id(session_id)
+    if decoded_thread_session is not None:
+        return decoded_thread_session
 
-    # Backward compatibility for historical IDs like "group_<channel_id>".
-    if session_id.startswith(LEGACY_GROUP_SESSION_PREFIX):
-        return session_id[len(LEGACY_GROUP_SESSION_PREFIX) :], None
+    decoded_legacy_session = _decode_legacy_session_id(session_id)
+    if decoded_legacy_session is not None:
+        return decoded_legacy_session
 
     return session_id, None
+
+
+def _extract_raw_target(raw_message: dict | None) -> tuple[str, str | None]:
+    if not isinstance(raw_message, dict):
+        return "", None
+
+    raw_channel_id = ""
+    raw_thread_ts = None
+
+    raw_channel = raw_message.get("channel")
+    if raw_channel is not None and raw_channel != "":
+        raw_channel_id = str(raw_channel)
+
+    raw_thread = raw_message.get("thread_ts")
+    if raw_thread is not None and raw_thread != "":
+        raw_thread_ts = str(raw_thread)
+
+    return raw_channel_id, raw_thread_ts
+
+
+def resolve_target_from_event(
+    *,
+    session_id: str,
+    raw_message: dict,
+    group_id: str = "",
+) -> tuple[str, str | None]:
+    parsed_channel_id, parsed_thread_ts = decode_slack_session_id(session_id)
+    raw_channel_id, raw_thread_ts = _extract_raw_target(raw_message)
+
+    channel_id = group_id or raw_channel_id or parsed_channel_id
+    return channel_id, raw_thread_ts or parsed_thread_ts
+
+
+def resolve_target_from_session(
+    *,
+    session_id: str,
+    group_id: str = "",
+    fallback_channel_id: str = "",
+) -> tuple[str, str | None]:
+    parsed_channel_id, parsed_thread_ts = decode_slack_session_id(session_id)
+    channel_id = group_id or parsed_channel_id or fallback_channel_id
+    return channel_id, parsed_thread_ts
 
 
 def resolve_slack_message_target(
@@ -34,16 +87,7 @@ def resolve_slack_message_target(
     sender_id: str = "",
 ) -> tuple[str, str | None]:
     parsed_channel_id, parsed_thread_ts = decode_slack_session_id(session_id)
-
-    raw_channel_id = ""
-    raw_thread_ts = None
-    if isinstance(raw_message, dict):
-        raw_channel = raw_message.get("channel")
-        if raw_channel is not None and raw_channel != "":
-            raw_channel_id = str(raw_channel)
-        raw_thread = raw_message.get("thread_ts")
-        if raw_thread is not None and raw_thread != "":
-            raw_thread_ts = str(raw_thread)
+    raw_channel_id, raw_thread_ts = _extract_raw_target(raw_message)
 
     channel_id = group_id or raw_channel_id or parsed_channel_id or sender_id
     return channel_id, raw_thread_ts or parsed_thread_ts

--- a/astrbot/core/platform/sources/slack/session_codec.py
+++ b/astrbot/core/platform/sources/slack/session_codec.py
@@ -75,17 +75,37 @@ def _extract_raw_target(raw_message: dict | None) -> tuple[str, str | None]:
     return raw_channel_id, raw_thread_ts
 
 
+def _resolve_target_with_precedence(
+    *,
+    session_id: str,
+    raw_message: dict | None = None,
+    group_id: str = "",
+    fallback_channel_id: str = "",
+) -> tuple[str, str | None]:
+    """Resolve Slack target with a single precedence chain.
+
+    Precedence for channel: `group_id > raw_message.channel > parsed(session_id) > fallback_channel_id`.
+    Precedence for thread: `raw_message.thread_ts > parsed(session_id)`.
+    """
+    parsed_channel_id, parsed_thread_ts = decode_slack_session_id(session_id)
+    raw_channel_id, raw_thread_ts = _extract_raw_target(raw_message)
+
+    channel_id = group_id or raw_channel_id or parsed_channel_id or fallback_channel_id
+    return channel_id, raw_thread_ts or parsed_thread_ts
+
+
 def resolve_target_from_event(
     *,
     session_id: str,
     raw_message: dict,
     group_id: str = "",
 ) -> tuple[str, str | None]:
-    parsed_channel_id, parsed_thread_ts = decode_slack_session_id(session_id)
-    raw_channel_id, raw_thread_ts = _extract_raw_target(raw_message)
-
-    channel_id = group_id or raw_channel_id or parsed_channel_id
-    return channel_id, raw_thread_ts or parsed_thread_ts
+    """Resolve target for received Slack events (uses event raw payload)."""
+    return _resolve_target_with_precedence(
+        session_id=session_id,
+        raw_message=raw_message,
+        group_id=group_id,
+    )
 
 
 def resolve_target_from_session(
@@ -94,9 +114,12 @@ def resolve_target_from_session(
     group_id: str = "",
     fallback_channel_id: str = "",
 ) -> tuple[str, str | None]:
-    parsed_channel_id, parsed_thread_ts = decode_slack_session_id(session_id)
-    channel_id = group_id or parsed_channel_id or fallback_channel_id
-    return channel_id, parsed_thread_ts
+    """Resolve target when only session metadata is available (no raw event)."""
+    return _resolve_target_with_precedence(
+        session_id=session_id,
+        group_id=group_id,
+        fallback_channel_id=fallback_channel_id,
+    )
 
 
 def resolve_slack_message_target(
@@ -106,8 +129,10 @@ def resolve_slack_message_target(
     group_id: str = "",
     sender_id: str = "",
 ) -> tuple[str, str | None]:
-    parsed_channel_id, parsed_thread_ts = decode_slack_session_id(session_id)
-    raw_channel_id, raw_thread_ts = _extract_raw_target(raw_message)
-
-    channel_id = group_id or raw_channel_id or parsed_channel_id or sender_id
-    return channel_id, raw_thread_ts or parsed_thread_ts
+    """Backward-compatible resolver shared by legacy and new Slack call sites."""
+    return _resolve_target_with_precedence(
+        session_id=session_id,
+        raw_message=raw_message,
+        group_id=group_id,
+        fallback_channel_id=sender_id,
+    )

--- a/astrbot/core/platform/sources/slack/session_codec.py
+++ b/astrbot/core/platform/sources/slack/session_codec.py
@@ -1,6 +1,26 @@
 THREAD_SESSION_MARKER = "__thread__"
 LEGACY_GROUP_SESSION_PREFIX = "group_"
-SLACK_SAFE_TEXT_FALLBACK = "message"
+SLACK_DEFAULT_TEXT_FALLBACKS = {
+    "safe_text": "message",
+    "image": "[image]",
+    "file_template": "[file:{name}]",
+    "generic": "[message]",
+    "image_upload_failed": "Image upload failed",
+    "file_upload_failed": "File upload failed",
+}
+SLACK_SAFE_TEXT_FALLBACK = SLACK_DEFAULT_TEXT_FALLBACKS["safe_text"]
+
+
+def build_slack_text_fallbacks(overrides: dict | None = None) -> dict[str, str]:
+    text_fallbacks = dict(SLACK_DEFAULT_TEXT_FALLBACKS)
+    if not isinstance(overrides, dict):
+        return text_fallbacks
+
+    for key in text_fallbacks:
+        candidate = overrides.get(key)
+        if isinstance(candidate, str) and candidate.strip():
+            text_fallbacks[key] = candidate
+    return text_fallbacks
 
 
 def encode_thread_session_id(channel_id: str, thread_ts: str) -> str:

--- a/astrbot/core/platform/sources/slack/session_codec.py
+++ b/astrbot/core/platform/sources/slack/session_codec.py
@@ -1,4 +1,6 @@
 THREAD_SESSION_MARKER = "__thread__"
+LEGACY_GROUP_SESSION_PREFIX = "group_"
+SLACK_SAFE_TEXT_FALLBACK = "message"
 
 
 def encode_thread_session_id(channel_id: str, thread_ts: str) -> str:
@@ -13,11 +15,35 @@ def decode_slack_session_id(session_id: str) -> tuple[str, str | None]:
 
     if THREAD_SESSION_MARKER in session_id:
         channel_id, thread_ts = session_id.split(THREAD_SESSION_MARKER, 1)
-        if channel_id and thread_ts:
-            return channel_id, thread_ts
+        # Do not fallback to legacy parsing once thread marker is detected.
+        # Keep decoded channel_id even if thread_ts is missing.
+        return channel_id, thread_ts or None
 
     # Backward compatibility for historical IDs like "group_<channel_id>".
-    if "_" in session_id:
-        return session_id.rsplit("_", 1)[-1], None
+    if session_id.startswith(LEGACY_GROUP_SESSION_PREFIX):
+        return session_id[len(LEGACY_GROUP_SESSION_PREFIX) :], None
 
     return session_id, None
+
+
+def resolve_slack_message_target(
+    session_id: str,
+    *,
+    raw_message: dict | None = None,
+    group_id: str = "",
+    sender_id: str = "",
+) -> tuple[str, str | None]:
+    parsed_channel_id, parsed_thread_ts = decode_slack_session_id(session_id)
+
+    raw_channel_id = ""
+    raw_thread_ts = None
+    if isinstance(raw_message, dict):
+        raw_channel = raw_message.get("channel")
+        if raw_channel is not None and raw_channel != "":
+            raw_channel_id = str(raw_channel)
+        raw_thread = raw_message.get("thread_ts")
+        if raw_thread is not None and raw_thread != "":
+            raw_thread_ts = str(raw_thread)
+
+    channel_id = group_id or raw_channel_id or parsed_channel_id or sender_id
+    return channel_id, raw_thread_ts or parsed_thread_ts

--- a/astrbot/core/platform/sources/slack/session_codec.py
+++ b/astrbot/core/platform/sources/slack/session_codec.py
@@ -49,43 +49,6 @@ def decode_slack_session_id(session_id: str) -> tuple[str, str | None]:
     return session_id, None
 
 
-def _extract_raw_target(raw_message: dict | None) -> tuple[str, str | None]:
-    if not isinstance(raw_message, dict):
-        return "", None
-
-    raw_channel_id = ""
-    raw_thread_ts = None
-
-    raw_channel = raw_message.get("channel")
-    if raw_channel is not None and raw_channel != "":
-        raw_channel_id = str(raw_channel)
-
-    raw_thread = raw_message.get("thread_ts")
-    if raw_thread is not None and raw_thread != "":
-        raw_thread_ts = str(raw_thread)
-
-    return raw_channel_id, raw_thread_ts
-
-
-def _resolve_target_with_precedence(
-    *,
-    session_id: str,
-    raw_message: dict | None = None,
-    group_id: str = "",
-    fallback_channel_id: str = "",
-) -> tuple[str, str | None]:
-    """Resolve Slack target with a single precedence chain.
-
-    Precedence for channel: `group_id > raw_message.channel > parsed(session_id) > fallback_channel_id`.
-    Precedence for thread: `raw_message.thread_ts > parsed(session_id)`.
-    """
-    parsed_channel_id, parsed_thread_ts = decode_slack_session_id(session_id)
-    raw_channel_id, raw_thread_ts = _extract_raw_target(raw_message)
-
-    channel_id = group_id or raw_channel_id or parsed_channel_id or fallback_channel_id
-    return channel_id, raw_thread_ts or parsed_thread_ts
-
-
 def resolve_target_from_event(
     *,
     session_id: str,
@@ -93,7 +56,7 @@ def resolve_target_from_event(
     group_id: str = "",
 ) -> tuple[str, str | None]:
     """Resolve target for received Slack events (uses event raw payload)."""
-    return _resolve_target_with_precedence(
+    return resolve_slack_message_target(
         session_id=session_id,
         raw_message=raw_message,
         group_id=group_id,
@@ -107,10 +70,10 @@ def resolve_target_from_session(
     fallback_channel_id: str = "",
 ) -> tuple[str, str | None]:
     """Resolve target when only session metadata is available (no raw event)."""
-    return _resolve_target_with_precedence(
+    return resolve_slack_message_target(
         session_id=session_id,
         group_id=group_id,
-        fallback_channel_id=fallback_channel_id,
+        sender_id=fallback_channel_id,
     )
 
 
@@ -121,10 +84,24 @@ def resolve_slack_message_target(
     group_id: str = "",
     sender_id: str = "",
 ) -> tuple[str, str | None]:
-    """Backward-compatible resolver shared by legacy and new Slack call sites."""
-    return _resolve_target_with_precedence(
-        session_id=session_id,
-        raw_message=raw_message,
-        group_id=group_id,
-        fallback_channel_id=sender_id,
-    )
+    """Backward-compatible resolver shared by legacy and new Slack call sites.
+
+    Precedence for channel: group_id > raw_message.channel > parsed(session_id) > sender_id
+    Precedence for thread: raw_message.thread_ts > parsed(session_id)
+    """
+    parsed_channel_id, parsed_thread_ts = decode_slack_session_id(session_id)
+
+    raw_channel_id = ""
+    raw_thread_ts = None
+    if isinstance(raw_message, dict):
+        raw_channel = raw_message.get("channel")
+        if raw_channel not in (None, ""):
+            raw_channel_id = str(raw_channel)
+
+        raw_thread = raw_message.get("thread_ts")
+        if raw_thread not in (None, ""):
+            raw_thread_ts = str(raw_thread)
+
+    channel_id = group_id or raw_channel_id or parsed_channel_id or sender_id
+    thread_ts = raw_thread_ts or parsed_thread_ts
+    return channel_id, thread_ts

--- a/astrbot/core/platform/sources/slack/session_codec.py
+++ b/astrbot/core/platform/sources/slack/session_codec.py
@@ -1,0 +1,23 @@
+THREAD_SESSION_MARKER = "__thread__"
+
+
+def encode_thread_session_id(channel_id: str, thread_ts: str) -> str:
+    if not channel_id or not thread_ts:
+        return channel_id
+    return f"{channel_id}{THREAD_SESSION_MARKER}{thread_ts}"
+
+
+def decode_slack_session_id(session_id: str) -> tuple[str, str | None]:
+    if not session_id:
+        return "", None
+
+    if THREAD_SESSION_MARKER in session_id:
+        channel_id, thread_ts = session_id.split(THREAD_SESSION_MARKER, 1)
+        if channel_id and thread_ts:
+            return channel_id, thread_ts
+
+    # Backward compatibility for historical IDs like "group_<channel_id>".
+    if "_" in session_id:
+        return session_id.rsplit("_", 1)[-1], None
+
+    return session_id, None

--- a/astrbot/core/platform/sources/slack/slack_adapter.py
+++ b/astrbot/core/platform/sources/slack/slack_adapter.py
@@ -27,7 +27,7 @@ from .client import SlackSocketClient, SlackWebhookClient
 from .session_codec import (
     SLACK_SAFE_TEXT_FALLBACK,
     encode_thread_session_id,
-    resolve_slack_message_target,
+    resolve_target_from_session,
 )
 from .slack_event import SlackMessageEvent
 
@@ -94,10 +94,7 @@ class SlackAdapter(Platform):
         safe_text = text or SLACK_SAFE_TEXT_FALLBACK
 
         try:
-            channel_id, thread_ts = resolve_slack_message_target(
-                session_id=session.session_id,
-                sender_id=session.session_id,
-            )
+            channel_id, thread_ts = self._session_to_slack_target(session)
             message_payload = {
                 "channel": channel_id,
                 "text": safe_text,
@@ -112,9 +109,13 @@ class SlackAdapter(Platform):
         await super().send_by_session(session, message_chain)
 
     @staticmethod
-    def _normalize_event_payload(event: dict) -> dict:
-        # Socket Mode may deliver thread updates as message_replied envelopes.
-        # Unwrap nested "message" payload to preserve user/text/thread_ts fields.
+    def _session_to_slack_target(session: MessageSesion) -> tuple[str, str | None]:
+        """Map an AstrBot session to Slack target fields."""
+        return resolve_target_from_session(session_id=session.session_id)
+
+    @staticmethod
+    def _unwrap_message_replied_event(event: dict) -> dict:
+        """Flatten Slack message_replied envelopes for normal message processing."""
         if event.get("subtype") == "message_replied":
             nested_message = event.get("message")
             if isinstance(nested_message, dict):
@@ -126,7 +127,7 @@ class SlackAdapter(Platform):
         return event
 
     async def convert_message(self, event: dict) -> AstrBotMessage:
-        event = self._normalize_event_payload(event)
+        event = self._unwrap_message_replied_event(event)
         logger.debug(f"[slack] RawMessage {event}")
 
         abm = AstrBotMessage()
@@ -161,6 +162,7 @@ class SlackAdapter(Platform):
 
         # 设置会话ID
         channel_id_for_session = str(channel_id or "")
+        # thread_ts may come from unwrapped `message_replied` payloads.
         thread_ts = str(event.get("thread_ts", "") or "")
         if thread_ts and channel_id_for_session:
             # Slack threads can appear in channels and DMs.

--- a/astrbot/core/platform/sources/slack/slack_adapter.py
+++ b/astrbot/core/platform/sources/slack/slack_adapter.py
@@ -19,7 +19,7 @@ from astrbot.api.platform import (
     Platform,
     PlatformMetadata,
 )
-from astrbot.core.platform.astr_message_event import MessageSesion
+from astrbot.core.platform.astr_message_event import MessageSession
 from astrbot.core.utils.webhook_utils import log_webhook_info
 
 from ...register import register_platform_adapter
@@ -88,7 +88,7 @@ class SlackAdapter(Platform):
 
     async def send_by_session(
         self,
-        session: MessageSesion,
+        session: MessageSession,
         message_chain: MessageChain,
     ) -> None:
         blocks, text = await SlackMessageEvent._parse_slack_blocks(
@@ -100,9 +100,9 @@ class SlackAdapter(Platform):
             "safe_text",
             SLACK_SAFE_TEXT_FALLBACK,
         )
+        channel_id, thread_ts = self._session_to_slack_target(session)
 
         try:
-            channel_id, thread_ts = self._session_to_slack_target(session)
             message_payload = {
                 "channel": channel_id,
                 "text": safe_text,
@@ -111,13 +111,39 @@ class SlackAdapter(Platform):
             if thread_ts:
                 message_payload["thread_ts"] = thread_ts
             await self.web_client.chat_postMessage(**message_payload)
-        except Exception as e:
-            logger.error(f"Slack 发送消息失败: {e}")
+        except Exception:
+            logger.exception(
+                "Slack send_by_session failed, retrying with text-only payload. "
+                "session_id=%s channel_id=%s thread_ts=%s",
+                session.session_id,
+                channel_id,
+                thread_ts or "",
+            )
+            fallback_text = SlackMessageEvent._build_text_fallback_from_chain(
+                message_chain=message_chain,
+                text_fallbacks=self.text_fallbacks,
+            )
+            fallback_payload = {
+                "channel": channel_id,
+                "text": fallback_text,
+            }
+            if thread_ts:
+                fallback_payload["thread_ts"] = thread_ts
+            try:
+                await self.web_client.chat_postMessage(**fallback_payload)
+            except Exception:
+                logger.exception(
+                    "Slack send_by_session text-only fallback failed. "
+                    "session_id=%s channel_id=%s thread_ts=%s",
+                    session.session_id,
+                    channel_id,
+                    thread_ts or "",
+                )
 
         await super().send_by_session(session, message_chain)
 
     @staticmethod
-    def _session_to_slack_target(session: MessageSesion) -> tuple[str, str | None]:
+    def _session_to_slack_target(session: MessageSession) -> tuple[str, str | None]:
         """Map an AstrBot session to Slack target fields."""
         return resolve_target_from_session(session_id=session.session_id)
 

--- a/astrbot/core/platform/sources/slack/slack_adapter.py
+++ b/astrbot/core/platform/sources/slack/slack_adapter.py
@@ -25,12 +25,12 @@ from astrbot.core.utils.webhook_utils import log_webhook_info
 from ...register import register_platform_adapter
 from .client import SlackSocketClient, SlackWebhookClient
 from .session_codec import (
-    SLACK_SAFE_TEXT_FALLBACK,
     build_slack_text_fallbacks,
     encode_thread_session_id,
     resolve_target_from_session,
 )
 from .slack_event import SlackMessageEvent
+from .slack_send_utils import send_with_blocks_and_fallback
 
 
 @register_platform_adapter(
@@ -82,6 +82,8 @@ class SlackAdapter(Platform):
         self.webhook_client = None
 
         self.bot_self_id = None
+        # Canonical fallback configuration for Slack sends. Both adapter and event
+        # paths consume these via explicit arguments.
         self.text_fallbacks = build_slack_text_fallbacks(
             platform_config.get("text_fallbacks"),
         )
@@ -91,61 +93,21 @@ class SlackAdapter(Platform):
         session: MessageSession,
         message_chain: MessageChain,
     ) -> None:
-        blocks, text = await SlackMessageEvent._parse_slack_blocks(
-            message_chain=message_chain,
+        channel_id, thread_ts = resolve_target_from_session(
+            session_id=session.session_id
+        )
+        await send_with_blocks_and_fallback(
             web_client=self.web_client,
+            channel=channel_id,
+            thread_ts=thread_ts,
+            message_chain=message_chain,
             text_fallbacks=self.text_fallbacks,
+            parse_blocks=SlackMessageEvent._parse_slack_blocks,
+            build_text_fallback=SlackMessageEvent._build_text_fallback_from_chain,
+            session_id=session.session_id,
         )
-        safe_text = text or self.text_fallbacks.get(
-            "safe_text",
-            SLACK_SAFE_TEXT_FALLBACK,
-        )
-        channel_id, thread_ts = self._session_to_slack_target(session)
-
-        try:
-            message_payload = {
-                "channel": channel_id,
-                "text": safe_text,
-                "blocks": blocks if blocks else None,
-            }
-            if thread_ts:
-                message_payload["thread_ts"] = thread_ts
-            await self.web_client.chat_postMessage(**message_payload)
-        except Exception:
-            logger.exception(
-                "Slack send_by_session failed, retrying with text-only payload. "
-                "session_id=%s channel_id=%s thread_ts=%s",
-                session.session_id,
-                channel_id,
-                thread_ts or "",
-            )
-            fallback_text = SlackMessageEvent._build_text_fallback_from_chain(
-                message_chain=message_chain,
-                text_fallbacks=self.text_fallbacks,
-            )
-            fallback_payload = {
-                "channel": channel_id,
-                "text": fallback_text,
-            }
-            if thread_ts:
-                fallback_payload["thread_ts"] = thread_ts
-            try:
-                await self.web_client.chat_postMessage(**fallback_payload)
-            except Exception:
-                logger.exception(
-                    "Slack send_by_session text-only fallback failed. "
-                    "session_id=%s channel_id=%s thread_ts=%s",
-                    session.session_id,
-                    channel_id,
-                    thread_ts or "",
-                )
 
         await super().send_by_session(session, message_chain)
-
-    @staticmethod
-    def _session_to_slack_target(session: MessageSession) -> tuple[str, str | None]:
-        """Map an AstrBot session to Slack target fields."""
-        return resolve_target_from_session(session_id=session.session_id)
 
     @staticmethod
     def _unwrap_message_replied_event(event: dict) -> dict:

--- a/astrbot/core/platform/sources/slack/slack_adapter.py
+++ b/astrbot/core/platform/sources/slack/slack_adapter.py
@@ -24,6 +24,7 @@ from astrbot.core.utils.webhook_utils import log_webhook_info
 
 from ...register import register_platform_adapter
 from .client import SlackSocketClient, SlackWebhookClient
+from .session_codec import decode_slack_session_id, encode_thread_session_id
 from .slack_event import SlackMessageEvent
 
 
@@ -86,25 +87,36 @@ class SlackAdapter(Platform):
             message_chain=message_chain,
             web_client=self.web_client,
         )
+        safe_text = text or "消息"
 
         try:
+            channel_id_from_session, thread_ts_from_session = decode_slack_session_id(
+                session.session_id,
+            )
+            if thread_ts_from_session:
+                message_payload = {
+                    "channel": channel_id_from_session,
+                    "text": safe_text,
+                    "blocks": blocks if blocks else None,
+                    "thread_ts": thread_ts_from_session,
+                }
+                await self.web_client.chat_postMessage(**message_payload)
+                await super().send_by_session(session, message_chain)
+                return
+
             if session.message_type == MessageType.GROUP_MESSAGE:
-                # 发送到频道
-                channel_id = (
-                    session.session_id.split("_")[-1]
-                    if "_" in session.session_id
-                    else session.session_id
-                )
-                await self.web_client.chat_postMessage(
-                    channel=channel_id,
-                    text=text,
-                    blocks=blocks if blocks else None,
-                )
+                channel_id, _ = decode_slack_session_id(session.session_id)
+                message_payload = {
+                    "channel": channel_id,
+                    "text": safe_text,
+                    "blocks": blocks if blocks else None,
+                }
+                await self.web_client.chat_postMessage(**message_payload)
             else:
                 # 发送私信
                 await self.web_client.chat_postMessage(
                     channel=session.session_id,
-                    text=text,
+                    text=safe_text,
                     blocks=blocks if blocks else None,
                 )
         except Exception as e:
@@ -112,7 +124,22 @@ class SlackAdapter(Platform):
 
         await super().send_by_session(session, message_chain)
 
+    @staticmethod
+    def _normalize_event_payload(event: dict) -> dict:
+        # Socket Mode may deliver thread updates as message_replied envelopes.
+        # Unwrap nested "message" payload to preserve user/text/thread_ts fields.
+        if event.get("subtype") == "message_replied":
+            nested_message = event.get("message")
+            if isinstance(nested_message, dict):
+                merged = dict(event)
+                merged.update(nested_message)
+                if not merged.get("channel"):
+                    merged["channel"] = event.get("channel", "")
+                return merged
+        return event
+
     async def convert_message(self, event: dict) -> AstrBotMessage:
+        event = self._normalize_event_payload(event)
         logger.debug(f"[slack] RawMessage {event}")
 
         abm = AstrBotMessage()
@@ -146,7 +173,12 @@ class SlackAdapter(Platform):
             abm.group_id = channel_id
 
         # 设置会话ID
-        if abm.type == MessageType.GROUP_MESSAGE:
+        channel_id_for_session = str(channel_id or "")
+        thread_ts = str(event.get("thread_ts", "") or "")
+        if thread_ts and channel_id_for_session:
+            # Slack threads can appear in channels and DMs.
+            abm.session_id = encode_thread_session_id(channel_id_for_session, thread_ts)
+        elif abm.type == MessageType.GROUP_MESSAGE:
             abm.session_id = abm.group_id
         else:
             abm.session_id = user_id

--- a/astrbot/core/platform/sources/slack/slack_adapter.py
+++ b/astrbot/core/platform/sources/slack/slack_adapter.py
@@ -101,7 +101,7 @@ class SlackAdapter(Platform):
             channel=channel_id,
             thread_ts=thread_ts,
             message_chain=message_chain,
-            text_fallbacks=self.text_fallbacks,
+            fallbacks=self.text_fallbacks,
             parse_blocks=SlackMessageEvent._parse_slack_blocks,
             build_text_fallback=SlackMessageEvent._build_text_fallback_from_chain,
             session_id=session.session_id,

--- a/astrbot/core/platform/sources/slack/slack_adapter.py
+++ b/astrbot/core/platform/sources/slack/slack_adapter.py
@@ -24,7 +24,11 @@ from astrbot.core.utils.webhook_utils import log_webhook_info
 
 from ...register import register_platform_adapter
 from .client import SlackSocketClient, SlackWebhookClient
-from .session_codec import decode_slack_session_id, encode_thread_session_id
+from .session_codec import (
+    SLACK_SAFE_TEXT_FALLBACK,
+    encode_thread_session_id,
+    resolve_slack_message_target,
+)
 from .slack_event import SlackMessageEvent
 
 
@@ -87,38 +91,21 @@ class SlackAdapter(Platform):
             message_chain=message_chain,
             web_client=self.web_client,
         )
-        safe_text = text or "消息"
+        safe_text = text or SLACK_SAFE_TEXT_FALLBACK
 
         try:
-            channel_id_from_session, thread_ts_from_session = decode_slack_session_id(
-                session.session_id,
+            channel_id, thread_ts = resolve_slack_message_target(
+                session_id=session.session_id,
+                sender_id=session.session_id,
             )
-            if thread_ts_from_session:
-                message_payload = {
-                    "channel": channel_id_from_session,
-                    "text": safe_text,
-                    "blocks": blocks if blocks else None,
-                    "thread_ts": thread_ts_from_session,
-                }
-                await self.web_client.chat_postMessage(**message_payload)
-                await super().send_by_session(session, message_chain)
-                return
-
-            if session.message_type == MessageType.GROUP_MESSAGE:
-                channel_id, _ = decode_slack_session_id(session.session_id)
-                message_payload = {
-                    "channel": channel_id,
-                    "text": safe_text,
-                    "blocks": blocks if blocks else None,
-                }
-                await self.web_client.chat_postMessage(**message_payload)
-            else:
-                # 发送私信
-                await self.web_client.chat_postMessage(
-                    channel=session.session_id,
-                    text=safe_text,
-                    blocks=blocks if blocks else None,
-                )
+            message_payload = {
+                "channel": channel_id,
+                "text": safe_text,
+                "blocks": blocks if blocks else None,
+            }
+            if thread_ts:
+                message_payload["thread_ts"] = thread_ts
+            await self.web_client.chat_postMessage(**message_payload)
         except Exception as e:
             logger.error(f"Slack 发送消息失败: {e}")
 

--- a/astrbot/core/platform/sources/slack/slack_adapter.py
+++ b/astrbot/core/platform/sources/slack/slack_adapter.py
@@ -26,6 +26,7 @@ from ...register import register_platform_adapter
 from .client import SlackSocketClient, SlackWebhookClient
 from .session_codec import (
     SLACK_SAFE_TEXT_FALLBACK,
+    build_slack_text_fallbacks,
     encode_thread_session_id,
     resolve_target_from_session,
 )
@@ -81,6 +82,9 @@ class SlackAdapter(Platform):
         self.webhook_client = None
 
         self.bot_self_id = None
+        self.text_fallbacks = build_slack_text_fallbacks(
+            platform_config.get("text_fallbacks"),
+        )
 
     async def send_by_session(
         self,
@@ -90,8 +94,12 @@ class SlackAdapter(Platform):
         blocks, text = await SlackMessageEvent._parse_slack_blocks(
             message_chain=message_chain,
             web_client=self.web_client,
+            text_fallbacks=self.text_fallbacks,
         )
-        safe_text = text or SLACK_SAFE_TEXT_FALLBACK
+        safe_text = text or self.text_fallbacks.get(
+            "safe_text",
+            SLACK_SAFE_TEXT_FALLBACK,
+        )
 
         try:
             channel_id, thread_ts = self._session_to_slack_target(session)
@@ -439,6 +447,7 @@ class SlackAdapter(Platform):
             platform_meta=self.meta(),
             session_id=message.session_id,
             web_client=self.web_client,
+            text_fallbacks=self.text_fallbacks,
         )
 
         self.commit_event(message_event)

--- a/astrbot/core/platform/sources/slack/slack_event.py
+++ b/astrbot/core/platform/sources/slack/slack_event.py
@@ -176,9 +176,9 @@ class SlackMessageEvent(AstrMessageEvent):
             "safe_text",
             SLACK_SAFE_TEXT_FALLBACK,
         )
+        channel_id, thread_ts = self._resolve_target()
 
         try:
-            channel_id, thread_ts = self._resolve_target()
             message_payload = {
                 "channel": channel_id,
                 "text": safe_text,
@@ -188,6 +188,13 @@ class SlackMessageEvent(AstrMessageEvent):
                 message_payload["thread_ts"] = thread_ts
             await self.web_client.chat_postMessage(**message_payload)
         except Exception:
+            logger.exception(
+                "Slack block send failed, falling back to text-only payload. "
+                "session_id=%s channel_id=%s thread_ts=%s",
+                self.session_id,
+                channel_id,
+                thread_ts or "",
+            )
             # 如果块发送失败，尝试只发送文本
             parts = []
             for segment in message.chain:
@@ -206,7 +213,6 @@ class SlackMessageEvent(AstrMessageEvent):
                 SLACK_SAFE_TEXT_FALLBACK,
             )
 
-            channel_id, thread_ts = self._resolve_target()
             fallback_payload = {
                 "channel": channel_id,
                 "text": fallback_text,

--- a/astrbot/core/platform/sources/slack/slack_event.py
+++ b/astrbot/core/platform/sources/slack/slack_event.py
@@ -5,20 +5,22 @@ from typing import cast
 
 from slack_sdk.web.async_client import AsyncWebClient
 
-from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent, MessageChain
 from astrbot.api.message_components import (
     BaseMessageComponent,
-    File,
-    Image,
     Plain,
 )
 from astrbot.api.platform import Group, MessageMember
 
 from .session_codec import (
-    SLACK_SAFE_TEXT_FALLBACK,
     build_slack_text_fallbacks,
     resolve_target_from_event,
+)
+from .slack_send_utils import (
+    build_text_fallback_from_chain,
+    from_segment_to_slack_block,
+    parse_slack_blocks,
+    send_with_blocks_and_fallback,
 )
 
 
@@ -44,64 +46,11 @@ class SlackMessageEvent(AstrMessageEvent):
     ) -> dict | None:
         """将消息段转换为 Slack 块格式"""
         fallbacks = build_slack_text_fallbacks(text_fallbacks)
-        if isinstance(segment, Plain):
-            return {"type": "section", "text": {"type": "mrkdwn", "text": segment.text}}
-        if isinstance(segment, Image):
-            # upload file
-            url = segment.url or segment.file
-            if url and url.startswith("http"):
-                return {
-                    "type": "image",
-                    "image_url": url,
-                    "alt_text": "图片",
-                }
-            path = await segment.convert_to_file_path()
-            response = await web_client.files_upload_v2(
-                file=path,
-                filename="image.jpg",
-            )
-            if not response["ok"]:
-                logger.error(f"Slack file upload failed: {response['error']}")
-                return {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": fallbacks["image_upload_failed"],
-                    },
-                }
-            image_url = cast(list, response["files"])[0]["url_private"]
-            logger.debug(f"Slack file upload response: {response}")
-            return {
-                "type": "image",
-                "slack_file": {
-                    "url": image_url,
-                },
-                "alt_text": "图片",
-            }
-        if isinstance(segment, File):
-            # upload file
-            url = segment.url or segment.file
-            response = await web_client.files_upload_v2(
-                file=url,
-                filename=segment.name or "file",
-            )
-            if not response["ok"]:
-                logger.error(f"Slack file upload failed: {response['error']}")
-                return {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": fallbacks["file_upload_failed"],
-                    },
-                }
-            file_url = cast(list, response["files"])[0]["permalink"]
-            return {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f"file: <{file_url}|{segment.name or 'file'}>",
-                },
-            }
+        return await from_segment_to_slack_block(
+            segment=segment,
+            web_client=web_client,
+            fallbacks=fallbacks,
+        )
 
     @staticmethod
     async def _parse_slack_blocks(
@@ -110,53 +59,11 @@ class SlackMessageEvent(AstrMessageEvent):
         text_fallbacks: dict[str, str] | None = None,
     ):
         """解析成 Slack 块格式"""
-        fallbacks = build_slack_text_fallbacks(text_fallbacks)
-        blocks = []
-        text_content = ""
-        fallback_parts = []
-
-        for segment in message_chain.chain:
-            if isinstance(segment, Plain):
-                text_content += segment.text
-                fallback_parts.append(segment.text)
-            else:
-                # 如果有文本内容，先添加文本块
-                if text_content.strip():
-                    blocks.append(
-                        {
-                            "type": "section",
-                            "text": {"type": "mrkdwn", "text": text_content},
-                        },
-                    )
-                    text_content = ""
-
-                # 添加其他类型的块
-                block = await SlackMessageEvent._from_segment_to_slack_block(
-                    segment,
-                    web_client,
-                    text_fallbacks=fallbacks,
-                )
-                if block:
-                    blocks.append(block)
-                    if isinstance(segment, Image):
-                        fallback_parts.append(fallbacks["image"])
-                    elif isinstance(segment, File):
-                        fallback_parts.append(
-                            fallbacks["file_template"].format(
-                                name=segment.name or "file",
-                            ),
-                        )
-                    else:
-                        fallback_parts.append(fallbacks["generic"])
-
-        # 如果最后还有文本内容
-        if text_content.strip():
-            blocks.append(
-                {"type": "section", "text": {"type": "mrkdwn", "text": text_content}},
-            )
-
-        fallback_text = "".join(fallback_parts).strip() or fallbacks["safe_text"]
-        return blocks, fallback_text if blocks else text_content
+        return await parse_slack_blocks(
+            message_chain=message_chain,
+            web_client=web_client,
+            text_fallbacks=text_fallbacks,
+        )
 
     @staticmethod
     def _build_text_fallback_from_chain(
@@ -164,22 +71,10 @@ class SlackMessageEvent(AstrMessageEvent):
         text_fallbacks: dict[str, str] | None = None,
     ) -> str:
         """Build a safe text fallback for retries when block payload is rejected."""
-        fallbacks = build_slack_text_fallbacks(text_fallbacks)
-        parts = []
-        for segment in message_chain.chain:
-            if isinstance(segment, Plain):
-                parts.append(segment.text)
-            elif isinstance(segment, File):
-                parts.append(
-                    fallbacks["file_template"].format(
-                        name=segment.name or "file",
-                    )
-                )
-            elif isinstance(segment, Image):
-                parts.append(fallbacks["image"])
-            else:
-                parts.append(fallbacks["generic"])
-        return "".join(parts).strip() or fallbacks["safe_text"]
+        return build_text_fallback_from_chain(
+            message_chain=message_chain,
+            text_fallbacks=text_fallbacks,
+        )
 
     def _resolve_target(self) -> tuple[str, str | None]:
         raw_message = getattr(self.message_obj, "raw_message", None)
@@ -190,47 +85,17 @@ class SlackMessageEvent(AstrMessageEvent):
         )
 
     async def send(self, message: MessageChain) -> None:
-        blocks, text = await SlackMessageEvent._parse_slack_blocks(
-            message,
-            self.web_client,
-            text_fallbacks=self.text_fallbacks,
-        )
-        safe_text = text or self.text_fallbacks.get(
-            "safe_text",
-            SLACK_SAFE_TEXT_FALLBACK,
-        )
         channel_id, thread_ts = self._resolve_target()
-
-        try:
-            message_payload = {
-                "channel": channel_id,
-                "text": safe_text,
-                "blocks": blocks or None,
-            }
-            if thread_ts:
-                message_payload["thread_ts"] = thread_ts
-            await self.web_client.chat_postMessage(**message_payload)
-        except Exception:
-            logger.exception(
-                "Slack block send failed, falling back to text-only payload. "
-                "session_id=%s channel_id=%s thread_ts=%s",
-                self.session_id,
-                channel_id,
-                thread_ts or "",
-            )
-            # 如果块发送失败，尝试只发送文本
-            fallback_text = self._build_text_fallback_from_chain(
-                message_chain=message,
-                text_fallbacks=self.text_fallbacks,
-            )
-
-            fallback_payload = {
-                "channel": channel_id,
-                "text": fallback_text,
-            }
-            if thread_ts:
-                fallback_payload["thread_ts"] = thread_ts
-            await self.web_client.chat_postMessage(**fallback_payload)
+        await send_with_blocks_and_fallback(
+            web_client=self.web_client,
+            channel=channel_id,
+            thread_ts=thread_ts,
+            message_chain=message,
+            text_fallbacks=self.text_fallbacks,
+            parse_blocks=SlackMessageEvent._parse_slack_blocks,
+            build_text_fallback=SlackMessageEvent._build_text_fallback_from_chain,
+            session_id=self.session_id,
+        )
 
         await super().send(message)
 

--- a/astrbot/core/platform/sources/slack/slack_event.py
+++ b/astrbot/core/platform/sources/slack/slack_event.py
@@ -15,13 +15,11 @@ from astrbot.api.message_components import (
 )
 from astrbot.api.platform import Group, MessageMember
 
-from .session_codec import SLACK_SAFE_TEXT_FALLBACK, resolve_target_from_event
-
-SLACK_IMAGE_FALLBACK_TEXT = "[image]"
-SLACK_FILE_FALLBACK_TEMPLATE = "[file:{name}]"
-SLACK_GENERIC_FALLBACK_TEXT = "[message]"
-SLACK_IMAGE_UPLOAD_FAILED_TEXT = "Image upload failed"
-SLACK_FILE_UPLOAD_FAILED_TEXT = "File upload failed"
+from .session_codec import (
+    SLACK_SAFE_TEXT_FALLBACK,
+    build_slack_text_fallbacks,
+    resolve_target_from_event,
+)
 
 
 class SlackMessageEvent(AstrMessageEvent):
@@ -32,16 +30,20 @@ class SlackMessageEvent(AstrMessageEvent):
         platform_meta,
         session_id,
         web_client: AsyncWebClient,
+        text_fallbacks: dict[str, str] | None = None,
     ) -> None:
         super().__init__(message_str, message_obj, platform_meta, session_id)
         self.web_client = web_client
+        self.text_fallbacks = build_slack_text_fallbacks(text_fallbacks)
 
     @staticmethod
     async def _from_segment_to_slack_block(
         segment: BaseMessageComponent,
         web_client: AsyncWebClient,
+        text_fallbacks: dict[str, str] | None = None,
     ) -> dict | None:
         """将消息段转换为 Slack 块格式"""
+        fallbacks = build_slack_text_fallbacks(text_fallbacks)
         if isinstance(segment, Plain):
             return {"type": "section", "text": {"type": "mrkdwn", "text": segment.text}}
         if isinstance(segment, Image):
@@ -62,7 +64,10 @@ class SlackMessageEvent(AstrMessageEvent):
                 logger.error(f"Slack file upload failed: {response['error']}")
                 return {
                     "type": "section",
-                    "text": {"type": "mrkdwn", "text": SLACK_IMAGE_UPLOAD_FAILED_TEXT},
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": fallbacks["image_upload_failed"],
+                    },
                 }
             image_url = cast(list, response["files"])[0]["url_private"]
             logger.debug(f"Slack file upload response: {response}")
@@ -84,7 +89,10 @@ class SlackMessageEvent(AstrMessageEvent):
                 logger.error(f"Slack file upload failed: {response['error']}")
                 return {
                     "type": "section",
-                    "text": {"type": "mrkdwn", "text": SLACK_FILE_UPLOAD_FAILED_TEXT},
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": fallbacks["file_upload_failed"],
+                    },
                 }
             file_url = cast(list, response["files"])[0]["permalink"]
             return {
@@ -99,8 +107,10 @@ class SlackMessageEvent(AstrMessageEvent):
     async def _parse_slack_blocks(
         message_chain: MessageChain,
         web_client: AsyncWebClient,
+        text_fallbacks: dict[str, str] | None = None,
     ):
         """解析成 Slack 块格式"""
+        fallbacks = build_slack_text_fallbacks(text_fallbacks)
         blocks = []
         text_content = ""
         fallback_parts = []
@@ -124,19 +134,20 @@ class SlackMessageEvent(AstrMessageEvent):
                 block = await SlackMessageEvent._from_segment_to_slack_block(
                     segment,
                     web_client,
+                    text_fallbacks=fallbacks,
                 )
                 if block:
                     blocks.append(block)
                     if isinstance(segment, Image):
-                        fallback_parts.append(SLACK_IMAGE_FALLBACK_TEXT)
+                        fallback_parts.append(fallbacks["image"])
                     elif isinstance(segment, File):
                         fallback_parts.append(
-                            SLACK_FILE_FALLBACK_TEMPLATE.format(
+                            fallbacks["file_template"].format(
                                 name=segment.name or "file",
                             ),
                         )
                     else:
-                        fallback_parts.append(SLACK_GENERIC_FALLBACK_TEXT)
+                        fallback_parts.append(fallbacks["generic"])
 
         # 如果最后还有文本内容
         if text_content.strip():
@@ -144,7 +155,7 @@ class SlackMessageEvent(AstrMessageEvent):
                 {"type": "section", "text": {"type": "mrkdwn", "text": text_content}},
             )
 
-        fallback_text = "".join(fallback_parts).strip() or SLACK_SAFE_TEXT_FALLBACK
+        fallback_text = "".join(fallback_parts).strip() or fallbacks["safe_text"]
         return blocks, fallback_text if blocks else text_content
 
     def _resolve_target(self) -> tuple[str, str | None]:
@@ -159,8 +170,12 @@ class SlackMessageEvent(AstrMessageEvent):
         blocks, text = await SlackMessageEvent._parse_slack_blocks(
             message,
             self.web_client,
+            text_fallbacks=self.text_fallbacks,
         )
-        safe_text = text or SLACK_SAFE_TEXT_FALLBACK
+        safe_text = text or self.text_fallbacks.get(
+            "safe_text",
+            SLACK_SAFE_TEXT_FALLBACK,
+        )
 
         try:
             channel_id, thread_ts = self._resolve_target()
@@ -180,13 +195,16 @@ class SlackMessageEvent(AstrMessageEvent):
                     parts.append(segment.text)
                 elif isinstance(segment, File):
                     parts.append(
-                        SLACK_FILE_FALLBACK_TEMPLATE.format(
+                        self.text_fallbacks["file_template"].format(
                             name=segment.name or "file",
                         ),
                     )
                 elif isinstance(segment, Image):
-                    parts.append(SLACK_IMAGE_FALLBACK_TEXT)
-            fallback_text = "".join(parts) or SLACK_SAFE_TEXT_FALLBACK
+                    parts.append(self.text_fallbacks["image"])
+            fallback_text = "".join(parts) or self.text_fallbacks.get(
+                "safe_text",
+                SLACK_SAFE_TEXT_FALLBACK,
+            )
 
             channel_id, thread_ts = self._resolve_target()
             fallback_payload = {

--- a/astrbot/core/platform/sources/slack/slack_event.py
+++ b/astrbot/core/platform/sources/slack/slack_event.py
@@ -15,7 +15,13 @@ from astrbot.api.message_components import (
 )
 from astrbot.api.platform import Group, MessageMember
 
-from .session_codec import decode_slack_session_id
+from .session_codec import SLACK_SAFE_TEXT_FALLBACK, resolve_slack_message_target
+
+SLACK_IMAGE_FALLBACK_TEXT = "[image]"
+SLACK_FILE_FALLBACK_TEMPLATE = "[file:{name}]"
+SLACK_GENERIC_FALLBACK_TEXT = "[message]"
+SLACK_IMAGE_UPLOAD_FAILED_TEXT = "Image upload failed"
+SLACK_FILE_UPLOAD_FAILED_TEXT = "File upload failed"
 
 
 class SlackMessageEvent(AstrMessageEvent):
@@ -56,7 +62,7 @@ class SlackMessageEvent(AstrMessageEvent):
                 logger.error(f"Slack file upload failed: {response['error']}")
                 return {
                     "type": "section",
-                    "text": {"type": "mrkdwn", "text": "图片上传失败"},
+                    "text": {"type": "mrkdwn", "text": SLACK_IMAGE_UPLOAD_FAILED_TEXT},
                 }
             image_url = cast(list, response["files"])[0]["url_private"]
             logger.debug(f"Slack file upload response: {response}")
@@ -78,14 +84,14 @@ class SlackMessageEvent(AstrMessageEvent):
                 logger.error(f"Slack file upload failed: {response['error']}")
                 return {
                     "type": "section",
-                    "text": {"type": "mrkdwn", "text": "文件上传失败"},
+                    "text": {"type": "mrkdwn", "text": SLACK_FILE_UPLOAD_FAILED_TEXT},
                 }
             file_url = cast(list, response["files"])[0]["permalink"]
             return {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"文件: <{file_url}|{segment.name or '文件'}>",
+                    "text": f"file: <{file_url}|{segment.name or 'file'}>",
                 },
             }
 
@@ -122,13 +128,15 @@ class SlackMessageEvent(AstrMessageEvent):
                 if block:
                     blocks.append(block)
                     if isinstance(segment, Image):
-                        fallback_parts.append("[图片]")
+                        fallback_parts.append(SLACK_IMAGE_FALLBACK_TEXT)
                     elif isinstance(segment, File):
                         fallback_parts.append(
-                            f"[文件:{segment.name or '文件'}]",
+                            SLACK_FILE_FALLBACK_TEMPLATE.format(
+                                name=segment.name or "file",
+                            ),
                         )
                     else:
-                        fallback_parts.append("[消息]")
+                        fallback_parts.append(SLACK_GENERIC_FALLBACK_TEXT)
 
         # 如果最后还有文本内容
         if text_content.strip():
@@ -136,67 +144,34 @@ class SlackMessageEvent(AstrMessageEvent):
                 {"type": "section", "text": {"type": "mrkdwn", "text": text_content}},
             )
 
-        fallback_text = "".join(fallback_parts).strip() or "消息"
+        fallback_text = "".join(fallback_parts).strip() or SLACK_SAFE_TEXT_FALLBACK
         return blocks, fallback_text if blocks else text_content
 
-    def _resolve_group_target(self) -> tuple[str, str | None]:
-        channel_id = self.get_group_id()
-        parsed_channel_id, parsed_thread_ts = decode_slack_session_id(self.session_id)
-        if not channel_id:
-            channel_id = parsed_channel_id
-
-        raw_message = getattr(self.message_obj, "raw_message", None)
-        raw_thread_ts = None
-        if isinstance(raw_message, dict):
-            raw_thread_ts = raw_message.get("thread_ts")
-        if raw_thread_ts is not None and raw_thread_ts != "":
-            return channel_id, str(raw_thread_ts)
-        return channel_id, parsed_thread_ts
-
-    def _resolve_friend_target(self) -> tuple[str, str | None]:
-        parsed_channel_id, parsed_thread_ts = decode_slack_session_id(self.session_id)
-        raw_message = getattr(self.message_obj, "raw_message", None)
-        raw_channel_id = ""
-        raw_thread_ts = None
-        if isinstance(raw_message, dict):
-            raw_channel = raw_message.get("channel")
-            if raw_channel is not None and raw_channel != "":
-                raw_channel_id = str(raw_channel)
-            raw_thread_ts = raw_message.get("thread_ts")
-
-        channel_id = raw_channel_id or parsed_channel_id or self.get_sender_id()
-        if raw_thread_ts is not None and raw_thread_ts != "":
-            return channel_id, str(raw_thread_ts)
-        return channel_id, parsed_thread_ts
+    def _resolve_target(self) -> tuple[str, str | None]:
+        return resolve_slack_message_target(
+            session_id=self.session_id,
+            raw_message=getattr(self.message_obj, "raw_message", None),
+            group_id=self.get_group_id(),
+            sender_id=self.get_sender_id(),
+        )
 
     async def send(self, message: MessageChain) -> None:
         blocks, text = await SlackMessageEvent._parse_slack_blocks(
             message,
             self.web_client,
         )
-        safe_text = text or "消息"
+        safe_text = text or SLACK_SAFE_TEXT_FALLBACK
 
         try:
-            if self.get_group_id():
-                channel_id, thread_ts = self._resolve_group_target()
-                message_payload = {
-                    "channel": channel_id,
-                    "text": safe_text,
-                    "blocks": blocks or None,
-                }
-                if thread_ts:
-                    message_payload["thread_ts"] = thread_ts
-                await self.web_client.chat_postMessage(**message_payload)
-            else:
-                channel_id, thread_ts = self._resolve_friend_target()
-                message_payload = {
-                    "channel": channel_id,
-                    "text": safe_text,
-                    "blocks": blocks or None,
-                }
-                if thread_ts:
-                    message_payload["thread_ts"] = thread_ts
-                await self.web_client.chat_postMessage(**message_payload)
+            channel_id, thread_ts = self._resolve_target()
+            message_payload = {
+                "channel": channel_id,
+                "text": safe_text,
+                "blocks": blocks or None,
+            }
+            if thread_ts:
+                message_payload["thread_ts"] = thread_ts
+            await self.web_client.chat_postMessage(**message_payload)
         except Exception:
             # 如果块发送失败，尝试只发送文本
             parts = []
@@ -204,29 +179,23 @@ class SlackMessageEvent(AstrMessageEvent):
                 if isinstance(segment, Plain):
                     parts.append(segment.text)
                 elif isinstance(segment, File):
-                    parts.append(f" [文件: {segment.name}] ")
+                    parts.append(
+                        SLACK_FILE_FALLBACK_TEMPLATE.format(
+                            name=segment.name or "file",
+                        ),
+                    )
                 elif isinstance(segment, Image):
-                    parts.append(" [图片] ")
-            fallback_text = "".join(parts) or "消息"
+                    parts.append(SLACK_IMAGE_FALLBACK_TEXT)
+            fallback_text = "".join(parts) or SLACK_SAFE_TEXT_FALLBACK
 
-            if self.get_group_id():
-                channel_id, thread_ts = self._resolve_group_target()
-                fallback_payload = {
-                    "channel": channel_id,
-                    "text": fallback_text,
-                }
-                if thread_ts:
-                    fallback_payload["thread_ts"] = thread_ts
-                await self.web_client.chat_postMessage(**fallback_payload)
-            else:
-                channel_id, thread_ts = self._resolve_friend_target()
-                fallback_payload = {
-                    "channel": channel_id,
-                    "text": fallback_text,
-                }
-                if thread_ts:
-                    fallback_payload["thread_ts"] = thread_ts
-                await self.web_client.chat_postMessage(**fallback_payload)
+            channel_id, thread_ts = self._resolve_target()
+            fallback_payload = {
+                "channel": channel_id,
+                "text": fallback_text,
+            }
+            if thread_ts:
+                fallback_payload["thread_ts"] = thread_ts
+            await self.web_client.chat_postMessage(**fallback_payload)
 
         await super().send(message)
 

--- a/astrbot/core/platform/sources/slack/slack_event.py
+++ b/astrbot/core/platform/sources/slack/slack_event.py
@@ -15,6 +15,8 @@ from astrbot.api.message_components import (
 )
 from astrbot.api.platform import Group, MessageMember
 
+from .session_codec import decode_slack_session_id
+
 
 class SlackMessageEvent(AstrMessageEvent):
     def __init__(
@@ -95,10 +97,12 @@ class SlackMessageEvent(AstrMessageEvent):
         """解析成 Slack 块格式"""
         blocks = []
         text_content = ""
+        fallback_parts = []
 
         for segment in message_chain.chain:
             if isinstance(segment, Plain):
                 text_content += segment.text
+                fallback_parts.append(segment.text)
             else:
                 # 如果有文本内容，先添加文本块
                 if text_content.strip():
@@ -117,6 +121,14 @@ class SlackMessageEvent(AstrMessageEvent):
                 )
                 if block:
                     blocks.append(block)
+                    if isinstance(segment, Image):
+                        fallback_parts.append("[图片]")
+                    elif isinstance(segment, File):
+                        fallback_parts.append(
+                            f"[文件:{segment.name or '文件'}]",
+                        )
+                    else:
+                        fallback_parts.append("[消息]")
 
         # 如果最后还有文本内容
         if text_content.strip():
@@ -124,29 +136,67 @@ class SlackMessageEvent(AstrMessageEvent):
                 {"type": "section", "text": {"type": "mrkdwn", "text": text_content}},
             )
 
-        return blocks, "" if blocks else text_content
+        fallback_text = "".join(fallback_parts).strip() or "消息"
+        return blocks, fallback_text if blocks else text_content
+
+    def _resolve_group_target(self) -> tuple[str, str | None]:
+        channel_id = self.get_group_id()
+        parsed_channel_id, parsed_thread_ts = decode_slack_session_id(self.session_id)
+        if not channel_id:
+            channel_id = parsed_channel_id
+
+        raw_message = getattr(self.message_obj, "raw_message", None)
+        raw_thread_ts = None
+        if isinstance(raw_message, dict):
+            raw_thread_ts = raw_message.get("thread_ts")
+        if raw_thread_ts is not None and raw_thread_ts != "":
+            return channel_id, str(raw_thread_ts)
+        return channel_id, parsed_thread_ts
+
+    def _resolve_friend_target(self) -> tuple[str, str | None]:
+        parsed_channel_id, parsed_thread_ts = decode_slack_session_id(self.session_id)
+        raw_message = getattr(self.message_obj, "raw_message", None)
+        raw_channel_id = ""
+        raw_thread_ts = None
+        if isinstance(raw_message, dict):
+            raw_channel = raw_message.get("channel")
+            if raw_channel is not None and raw_channel != "":
+                raw_channel_id = str(raw_channel)
+            raw_thread_ts = raw_message.get("thread_ts")
+
+        channel_id = raw_channel_id or parsed_channel_id or self.get_sender_id()
+        if raw_thread_ts is not None and raw_thread_ts != "":
+            return channel_id, str(raw_thread_ts)
+        return channel_id, parsed_thread_ts
 
     async def send(self, message: MessageChain) -> None:
         blocks, text = await SlackMessageEvent._parse_slack_blocks(
             message,
             self.web_client,
         )
+        safe_text = text or "消息"
 
         try:
             if self.get_group_id():
-                # 发送到频道
-                await self.web_client.chat_postMessage(
-                    channel=self.get_group_id(),
-                    text=text,
-                    blocks=blocks or None,
-                )
+                channel_id, thread_ts = self._resolve_group_target()
+                message_payload = {
+                    "channel": channel_id,
+                    "text": safe_text,
+                    "blocks": blocks or None,
+                }
+                if thread_ts:
+                    message_payload["thread_ts"] = thread_ts
+                await self.web_client.chat_postMessage(**message_payload)
             else:
-                # 发送私信
-                await self.web_client.chat_postMessage(
-                    channel=self.get_sender_id(),
-                    text=text,
-                    blocks=blocks or None,
-                )
+                channel_id, thread_ts = self._resolve_friend_target()
+                message_payload = {
+                    "channel": channel_id,
+                    "text": safe_text,
+                    "blocks": blocks or None,
+                }
+                if thread_ts:
+                    message_payload["thread_ts"] = thread_ts
+                await self.web_client.chat_postMessage(**message_payload)
         except Exception:
             # 如果块发送失败，尝试只发送文本
             parts = []
@@ -157,18 +207,26 @@ class SlackMessageEvent(AstrMessageEvent):
                     parts.append(f" [文件: {segment.name}] ")
                 elif isinstance(segment, Image):
                     parts.append(" [图片] ")
-            fallback_text = "".join(parts)
+            fallback_text = "".join(parts) or "消息"
 
             if self.get_group_id():
-                await self.web_client.chat_postMessage(
-                    channel=self.get_group_id(),
-                    text=fallback_text,
-                )
+                channel_id, thread_ts = self._resolve_group_target()
+                fallback_payload = {
+                    "channel": channel_id,
+                    "text": fallback_text,
+                }
+                if thread_ts:
+                    fallback_payload["thread_ts"] = thread_ts
+                await self.web_client.chat_postMessage(**fallback_payload)
             else:
-                await self.web_client.chat_postMessage(
-                    channel=self.get_sender_id(),
-                    text=fallback_text,
-                )
+                channel_id, thread_ts = self._resolve_friend_target()
+                fallback_payload = {
+                    "channel": channel_id,
+                    "text": fallback_text,
+                }
+                if thread_ts:
+                    fallback_payload["thread_ts"] = thread_ts
+                await self.web_client.chat_postMessage(**fallback_payload)
 
         await super().send(message)
 

--- a/astrbot/core/platform/sources/slack/slack_event.py
+++ b/astrbot/core/platform/sources/slack/slack_event.py
@@ -158,6 +158,29 @@ class SlackMessageEvent(AstrMessageEvent):
         fallback_text = "".join(fallback_parts).strip() or fallbacks["safe_text"]
         return blocks, fallback_text if blocks else text_content
 
+    @staticmethod
+    def _build_text_fallback_from_chain(
+        message_chain: MessageChain,
+        text_fallbacks: dict[str, str] | None = None,
+    ) -> str:
+        """Build a safe text fallback for retries when block payload is rejected."""
+        fallbacks = build_slack_text_fallbacks(text_fallbacks)
+        parts = []
+        for segment in message_chain.chain:
+            if isinstance(segment, Plain):
+                parts.append(segment.text)
+            elif isinstance(segment, File):
+                parts.append(
+                    fallbacks["file_template"].format(
+                        name=segment.name or "file",
+                    )
+                )
+            elif isinstance(segment, Image):
+                parts.append(fallbacks["image"])
+            else:
+                parts.append(fallbacks["generic"])
+        return "".join(parts).strip() or fallbacks["safe_text"]
+
     def _resolve_target(self) -> tuple[str, str | None]:
         raw_message = getattr(self.message_obj, "raw_message", None)
         return resolve_target_from_event(
@@ -196,21 +219,9 @@ class SlackMessageEvent(AstrMessageEvent):
                 thread_ts or "",
             )
             # 如果块发送失败，尝试只发送文本
-            parts = []
-            for segment in message.chain:
-                if isinstance(segment, Plain):
-                    parts.append(segment.text)
-                elif isinstance(segment, File):
-                    parts.append(
-                        self.text_fallbacks["file_template"].format(
-                            name=segment.name or "file",
-                        ),
-                    )
-                elif isinstance(segment, Image):
-                    parts.append(self.text_fallbacks["image"])
-            fallback_text = "".join(parts) or self.text_fallbacks.get(
-                "safe_text",
-                SLACK_SAFE_TEXT_FALLBACK,
+            fallback_text = self._build_text_fallback_from_chain(
+                message_chain=message,
+                text_fallbacks=self.text_fallbacks,
             )
 
             fallback_payload = {

--- a/astrbot/core/platform/sources/slack/slack_event.py
+++ b/astrbot/core/platform/sources/slack/slack_event.py
@@ -15,7 +15,7 @@ from astrbot.api.message_components import (
 )
 from astrbot.api.platform import Group, MessageMember
 
-from .session_codec import SLACK_SAFE_TEXT_FALLBACK, resolve_slack_message_target
+from .session_codec import SLACK_SAFE_TEXT_FALLBACK, resolve_target_from_event
 
 SLACK_IMAGE_FALLBACK_TEXT = "[image]"
 SLACK_FILE_FALLBACK_TEMPLATE = "[file:{name}]"
@@ -148,11 +148,11 @@ class SlackMessageEvent(AstrMessageEvent):
         return blocks, fallback_text if blocks else text_content
 
     def _resolve_target(self) -> tuple[str, str | None]:
-        return resolve_slack_message_target(
+        raw_message = getattr(self.message_obj, "raw_message", None)
+        return resolve_target_from_event(
             session_id=self.session_id,
-            raw_message=getattr(self.message_obj, "raw_message", None),
+            raw_message=raw_message if isinstance(raw_message, dict) else {},
             group_id=self.get_group_id(),
-            sender_id=self.get_sender_id(),
         )
 
     async def send(self, message: MessageChain) -> None:

--- a/astrbot/core/platform/sources/slack/slack_event.py
+++ b/astrbot/core/platform/sources/slack/slack_event.py
@@ -42,10 +42,9 @@ class SlackMessageEvent(AstrMessageEvent):
     async def _from_segment_to_slack_block(
         segment: BaseMessageComponent,
         web_client: AsyncWebClient,
-        text_fallbacks: dict[str, str] | None = None,
+        fallbacks: dict[str, str] | None = None,
     ) -> dict | None:
         """将消息段转换为 Slack 块格式"""
-        fallbacks = build_slack_text_fallbacks(text_fallbacks)
         return await from_segment_to_slack_block(
             segment=segment,
             web_client=web_client,
@@ -56,24 +55,24 @@ class SlackMessageEvent(AstrMessageEvent):
     async def _parse_slack_blocks(
         message_chain: MessageChain,
         web_client: AsyncWebClient,
-        text_fallbacks: dict[str, str] | None = None,
+        fallbacks: dict[str, str] | None = None,
     ):
         """解析成 Slack 块格式"""
         return await parse_slack_blocks(
             message_chain=message_chain,
             web_client=web_client,
-            text_fallbacks=text_fallbacks,
+            fallbacks=fallbacks,
         )
 
     @staticmethod
     def _build_text_fallback_from_chain(
         message_chain: MessageChain,
-        text_fallbacks: dict[str, str] | None = None,
+        fallbacks: dict[str, str] | None = None,
     ) -> str:
         """Build a safe text fallback for retries when block payload is rejected."""
         return build_text_fallback_from_chain(
             message_chain=message_chain,
-            text_fallbacks=text_fallbacks,
+            fallbacks=fallbacks,
         )
 
     def _resolve_target(self) -> tuple[str, str | None]:
@@ -91,7 +90,7 @@ class SlackMessageEvent(AstrMessageEvent):
             channel=channel_id,
             thread_ts=thread_ts,
             message_chain=message,
-            text_fallbacks=self.text_fallbacks,
+            fallbacks=self.text_fallbacks,
             parse_blocks=SlackMessageEvent._parse_slack_blocks,
             build_text_fallback=SlackMessageEvent._build_text_fallback_from_chain,
             session_id=self.session_id,

--- a/astrbot/core/platform/sources/slack/slack_send_utils.py
+++ b/astrbot/core/platform/sources/slack/slack_send_utils.py
@@ -141,7 +141,7 @@ async def parse_slack_blocks(
         )
 
     fallback_text = "".join(fallback_parts).strip() or resolved_fallbacks["safe_text"]
-    return blocks, fallback_text if blocks else text_content
+    return blocks, fallback_text
 
 
 def build_text_fallback_from_chain(
@@ -175,7 +175,6 @@ async def send_with_blocks_and_fallback(
     channel: str,
     thread_ts: str | None,
     message_chain: MessageChain,
-    text_fallbacks: dict[str, str] | None = None,
     fallbacks: dict[str, str] | None = None,
     parse_blocks: ParseSlackBlocksFn = parse_slack_blocks,
     build_text_fallback: BuildTextFallbackFn = build_text_fallback_from_chain,
@@ -183,8 +182,15 @@ async def send_with_blocks_and_fallback(
 ) -> None:
     """Send Slack message with blocks first, then fallback to text-only on failure."""
     resolved_fallbacks = (
-        build_slack_text_fallbacks(text_fallbacks) if fallbacks is None else fallbacks
+        build_slack_text_fallbacks(None) if fallbacks is None else fallbacks
     )
+    if not channel:
+        logger.warning(
+            "Skip Slack send because channel_id is empty. session_id=%s thread_ts=%s",
+            session_id,
+            thread_ts or "",
+        )
+        return
     blocks, text = await parse_blocks(
         message_chain,
         web_client,

--- a/astrbot/core/platform/sources/slack/slack_send_utils.py
+++ b/astrbot/core/platform/sources/slack/slack_send_utils.py
@@ -24,7 +24,9 @@ async def from_segment_to_slack_block(
     """Convert a message segment into a Slack block."""
     # Use caller-provided, pre-normalized fallbacks when available to avoid
     # repeated normalization per segment.
-    resolved_fallbacks = fallbacks or build_slack_text_fallbacks(None)
+    resolved_fallbacks = (
+        build_slack_text_fallbacks(None) if fallbacks is None else fallbacks
+    )
     if isinstance(segment, Plain):
         return {"type": "section", "text": {"type": "mrkdwn", "text": segment.text}}
     if isinstance(segment, Image):
@@ -88,10 +90,12 @@ async def from_segment_to_slack_block(
 async def parse_slack_blocks(
     message_chain: MessageChain,
     web_client: AsyncWebClient,
-    text_fallbacks: dict[str, str] | None = None,
+    fallbacks: dict[str, str] | None = None,
 ) -> tuple[list[dict[str, Any]], str]:
     """Parse a message chain into Slack blocks and fallback text."""
-    fallbacks = build_slack_text_fallbacks(text_fallbacks)
+    resolved_fallbacks = (
+        build_slack_text_fallbacks(None) if fallbacks is None else fallbacks
+    )
     blocks: list[dict[str, Any]] = []
     text_content = ""
     fallback_parts = []
@@ -114,53 +118,55 @@ async def parse_slack_blocks(
         block = await from_segment_to_slack_block(
             segment,
             web_client,
-            fallbacks=fallbacks,
+            fallbacks=resolved_fallbacks,
         )
         if not block:
             continue
 
         blocks.append(block)
         if isinstance(segment, Image):
-            fallback_parts.append(fallbacks["image"])
+            fallback_parts.append(resolved_fallbacks["image"])
         elif isinstance(segment, File):
             fallback_parts.append(
-                fallbacks["file_template"].format(
+                resolved_fallbacks["file_template"].format(
                     name=segment.name or "file",
                 ),
             )
         else:
-            fallback_parts.append(fallbacks["generic"])
+            fallback_parts.append(resolved_fallbacks["generic"])
 
     if text_content.strip():
         blocks.append(
             {"type": "section", "text": {"type": "mrkdwn", "text": text_content}},
         )
 
-    fallback_text = "".join(fallback_parts).strip() or fallbacks["safe_text"]
+    fallback_text = "".join(fallback_parts).strip() or resolved_fallbacks["safe_text"]
     return blocks, fallback_text if blocks else text_content
 
 
 def build_text_fallback_from_chain(
     message_chain: MessageChain,
-    text_fallbacks: dict[str, str] | None = None,
+    fallbacks: dict[str, str] | None = None,
 ) -> str:
     """Build safe text fallback when block payload is rejected."""
-    fallbacks = build_slack_text_fallbacks(text_fallbacks)
+    resolved_fallbacks = (
+        build_slack_text_fallbacks(None) if fallbacks is None else fallbacks
+    )
     parts = []
     for segment in message_chain.chain:
         if isinstance(segment, Plain):
             parts.append(segment.text)
         elif isinstance(segment, File):
             parts.append(
-                fallbacks["file_template"].format(
+                resolved_fallbacks["file_template"].format(
                     name=segment.name or "file",
                 ),
             )
         elif isinstance(segment, Image):
-            parts.append(fallbacks["image"])
+            parts.append(resolved_fallbacks["image"])
         else:
-            parts.append(fallbacks["generic"])
-    return "".join(parts).strip() or fallbacks["safe_text"]
+            parts.append(resolved_fallbacks["generic"])
+    return "".join(parts).strip() or resolved_fallbacks["safe_text"]
 
 
 async def send_with_blocks_and_fallback(
@@ -170,18 +176,21 @@ async def send_with_blocks_and_fallback(
     thread_ts: str | None,
     message_chain: MessageChain,
     text_fallbacks: dict[str, str] | None = None,
+    fallbacks: dict[str, str] | None = None,
     parse_blocks: ParseSlackBlocksFn = parse_slack_blocks,
     build_text_fallback: BuildTextFallbackFn = build_text_fallback_from_chain,
     session_id: str = "",
 ) -> None:
     """Send Slack message with blocks first, then fallback to text-only on failure."""
-    fallbacks = build_slack_text_fallbacks(text_fallbacks)
+    resolved_fallbacks = (
+        build_slack_text_fallbacks(text_fallbacks) if fallbacks is None else fallbacks
+    )
     blocks, text = await parse_blocks(
         message_chain,
         web_client,
-        fallbacks,
+        resolved_fallbacks,
     )
-    safe_text = text or fallbacks.get("safe_text", SLACK_SAFE_TEXT_FALLBACK)
+    safe_text = text or resolved_fallbacks.get("safe_text", SLACK_SAFE_TEXT_FALLBACK)
 
     message_payload: dict[str, Any] = {
         "channel": channel,
@@ -203,7 +212,7 @@ async def send_with_blocks_and_fallback(
             thread_ts or "",
         )
 
-    fallback_text = build_text_fallback(message_chain, fallbacks)
+    fallback_text = build_text_fallback(message_chain, resolved_fallbacks)
     fallback_payload: dict[str, Any] = {
         "channel": channel,
         "text": fallback_text,

--- a/astrbot/core/platform/sources/slack/slack_send_utils.py
+++ b/astrbot/core/platform/sources/slack/slack_send_utils.py
@@ -219,9 +219,8 @@ async def send_with_blocks_and_fallback(
         )
 
     fallback_text = build_text_fallback(message_chain, resolved_fallbacks)
-    fallback_text = (
-        (fallback_text or "").strip()
-        or resolved_fallbacks.get("safe_text", SLACK_SAFE_TEXT_FALLBACK)
+    fallback_text = (fallback_text or "").strip() or resolved_fallbacks.get(
+        "safe_text", SLACK_SAFE_TEXT_FALLBACK
     )
     fallback_payload: dict[str, Any] = {
         "channel": channel,

--- a/astrbot/core/platform/sources/slack/slack_send_utils.py
+++ b/astrbot/core/platform/sources/slack/slack_send_utils.py
@@ -1,0 +1,223 @@
+from collections.abc import Awaitable, Callable
+from typing import Any, cast
+
+from slack_sdk.web.async_client import AsyncWebClient
+
+from astrbot.api import logger
+from astrbot.api.event import MessageChain
+from astrbot.api.message_components import BaseMessageComponent, File, Image, Plain
+
+from .session_codec import SLACK_SAFE_TEXT_FALLBACK, build_slack_text_fallbacks
+
+ParseSlackBlocksFn = Callable[
+    [MessageChain, AsyncWebClient, dict[str, str] | None],
+    Awaitable[tuple[list[dict[str, Any]], str]],
+]
+BuildTextFallbackFn = Callable[[MessageChain, dict[str, str] | None], str]
+
+
+async def from_segment_to_slack_block(
+    segment: BaseMessageComponent,
+    web_client: AsyncWebClient,
+    fallbacks: dict[str, str] | None = None,
+) -> dict[str, Any] | None:
+    """Convert a message segment into a Slack block."""
+    # Use caller-provided, pre-normalized fallbacks when available to avoid
+    # repeated normalization per segment.
+    resolved_fallbacks = fallbacks or build_slack_text_fallbacks(None)
+    if isinstance(segment, Plain):
+        return {"type": "section", "text": {"type": "mrkdwn", "text": segment.text}}
+    if isinstance(segment, Image):
+        url = segment.url or segment.file
+        if url and url.startswith("http"):
+            return {
+                "type": "image",
+                "image_url": url,
+                "alt_text": "图片",
+            }
+        path = await segment.convert_to_file_path()
+        response = await web_client.files_upload_v2(
+            file=path,
+            filename="image.jpg",
+        )
+        if not response["ok"]:
+            logger.error(f"Slack file upload failed: {response['error']}")
+            return {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": resolved_fallbacks["image_upload_failed"],
+                },
+            }
+        image_url = cast(list, response["files"])[0]["url_private"]
+        logger.debug(f"Slack file upload response: {response}")
+        return {
+            "type": "image",
+            "slack_file": {
+                "url": image_url,
+            },
+            "alt_text": "图片",
+        }
+    if isinstance(segment, File):
+        url = segment.url or segment.file
+        response = await web_client.files_upload_v2(
+            file=url,
+            filename=segment.name or "file",
+        )
+        if not response["ok"]:
+            logger.error(f"Slack file upload failed: {response['error']}")
+            return {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": resolved_fallbacks["file_upload_failed"],
+                },
+            }
+        file_url = cast(list, response["files"])[0]["permalink"]
+        return {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"file: <{file_url}|{segment.name or 'file'}>",
+            },
+        }
+
+    return None
+
+
+async def parse_slack_blocks(
+    message_chain: MessageChain,
+    web_client: AsyncWebClient,
+    text_fallbacks: dict[str, str] | None = None,
+) -> tuple[list[dict[str, Any]], str]:
+    """Parse a message chain into Slack blocks and fallback text."""
+    fallbacks = build_slack_text_fallbacks(text_fallbacks)
+    blocks: list[dict[str, Any]] = []
+    text_content = ""
+    fallback_parts = []
+
+    for segment in message_chain.chain:
+        if isinstance(segment, Plain):
+            text_content += segment.text
+            fallback_parts.append(segment.text)
+            continue
+
+        if text_content.strip():
+            blocks.append(
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": text_content},
+                },
+            )
+            text_content = ""
+
+        block = await from_segment_to_slack_block(
+            segment,
+            web_client,
+            fallbacks=fallbacks,
+        )
+        if not block:
+            continue
+
+        blocks.append(block)
+        if isinstance(segment, Image):
+            fallback_parts.append(fallbacks["image"])
+        elif isinstance(segment, File):
+            fallback_parts.append(
+                fallbacks["file_template"].format(
+                    name=segment.name or "file",
+                ),
+            )
+        else:
+            fallback_parts.append(fallbacks["generic"])
+
+    if text_content.strip():
+        blocks.append(
+            {"type": "section", "text": {"type": "mrkdwn", "text": text_content}},
+        )
+
+    fallback_text = "".join(fallback_parts).strip() or fallbacks["safe_text"]
+    return blocks, fallback_text if blocks else text_content
+
+
+def build_text_fallback_from_chain(
+    message_chain: MessageChain,
+    text_fallbacks: dict[str, str] | None = None,
+) -> str:
+    """Build safe text fallback when block payload is rejected."""
+    fallbacks = build_slack_text_fallbacks(text_fallbacks)
+    parts = []
+    for segment in message_chain.chain:
+        if isinstance(segment, Plain):
+            parts.append(segment.text)
+        elif isinstance(segment, File):
+            parts.append(
+                fallbacks["file_template"].format(
+                    name=segment.name or "file",
+                ),
+            )
+        elif isinstance(segment, Image):
+            parts.append(fallbacks["image"])
+        else:
+            parts.append(fallbacks["generic"])
+    return "".join(parts).strip() or fallbacks["safe_text"]
+
+
+async def send_with_blocks_and_fallback(
+    *,
+    web_client: AsyncWebClient,
+    channel: str,
+    thread_ts: str | None,
+    message_chain: MessageChain,
+    text_fallbacks: dict[str, str] | None = None,
+    parse_blocks: ParseSlackBlocksFn = parse_slack_blocks,
+    build_text_fallback: BuildTextFallbackFn = build_text_fallback_from_chain,
+    session_id: str = "",
+) -> None:
+    """Send Slack message with blocks first, then fallback to text-only on failure."""
+    fallbacks = build_slack_text_fallbacks(text_fallbacks)
+    blocks, text = await parse_blocks(
+        message_chain,
+        web_client,
+        fallbacks,
+    )
+    safe_text = text or fallbacks.get("safe_text", SLACK_SAFE_TEXT_FALLBACK)
+
+    message_payload: dict[str, Any] = {
+        "channel": channel,
+        "text": safe_text,
+        "blocks": blocks or None,
+    }
+    if thread_ts:
+        message_payload["thread_ts"] = thread_ts
+
+    try:
+        await web_client.chat_postMessage(**message_payload)
+        return
+    except Exception:
+        logger.exception(
+            "Slack send failed, retrying with text-only payload. "
+            "session_id=%s channel_id=%s thread_ts=%s",
+            session_id,
+            channel,
+            thread_ts or "",
+        )
+
+    fallback_text = build_text_fallback(message_chain, fallbacks)
+    fallback_payload: dict[str, Any] = {
+        "channel": channel,
+        "text": fallback_text,
+    }
+    if thread_ts:
+        fallback_payload["thread_ts"] = thread_ts
+
+    try:
+        await web_client.chat_postMessage(**fallback_payload)
+    except Exception:
+        logger.exception(
+            "Slack send text-only fallback failed. "
+            "session_id=%s channel_id=%s thread_ts=%s",
+            session_id,
+            channel,
+            thread_ts or "",
+        )

--- a/astrbot/core/platform/sources/slack/slack_send_utils.py
+++ b/astrbot/core/platform/sources/slack/slack_send_utils.py
@@ -219,6 +219,10 @@ async def send_with_blocks_and_fallback(
         )
 
     fallback_text = build_text_fallback(message_chain, resolved_fallbacks)
+    fallback_text = (
+        (fallback_text or "").strip()
+        or resolved_fallbacks.get("safe_text", SLACK_SAFE_TEXT_FALLBACK)
+    )
     fallback_payload: dict[str, Any] = {
         "channel": channel,
         "text": fallback_text,

--- a/tests/unit/test_slack_thread_session.py
+++ b/tests/unit/test_slack_thread_session.py
@@ -10,6 +10,7 @@ from astrbot.core.platform.message_session import MessageSession
 from astrbot.core.platform.message_type import MessageType
 from astrbot.core.platform.platform_metadata import PlatformMetadata
 from astrbot.core.platform.sources.slack.session_codec import (
+    build_slack_text_fallbacks,
     decode_slack_session_id,
     resolve_slack_message_target,
     resolve_target_from_event,
@@ -265,6 +266,58 @@ async def test_parse_slack_blocks_includes_non_empty_fallback_text():
 
     assert blocks
     assert text == "hello"
+
+
+@pytest.mark.asyncio
+async def test_send_by_session_uses_configured_safe_text_fallback(monkeypatch):
+    adapter = SlackAdapter(
+        platform_config={
+            "id": "slack_test",
+            "bot_token": "xoxb-test",
+            "app_token": "xapp-test",
+            "text_fallbacks": {"safe_text": "fallback-message"},
+        },
+        platform_settings={},
+        event_queue=asyncio.Queue(),
+    )
+    adapter.bot_self_id = "B0001"
+    adapter.web_client = AsyncMock()
+    monkeypatch.setattr(
+        SlackMessageEvent,
+        "_parse_slack_blocks",
+        AsyncMock(return_value=([], "")),
+    )
+    session = MessageSession(
+        platform_name="slack_test",
+        message_type=MessageType.GROUP_MESSAGE,
+        session_id="C0001",
+    )
+
+    await adapter.send_by_session(
+        session=session,
+        message_chain=MessageChain([Plain(text="ignored")]),
+    )
+
+    adapter.web_client.chat_postMessage.assert_awaited_once_with(
+        channel="C0001",
+        text="fallback-message",
+        blocks=None,
+    )
+
+
+def test_build_slack_text_fallbacks_accepts_overrides():
+    fallbacks = build_slack_text_fallbacks(
+        {
+            "safe_text": "msg",
+            "image": "[img]",
+            "file_template": "[doc:{name}]",
+        }
+    )
+
+    assert fallbacks["safe_text"] == "msg"
+    assert fallbacks["image"] == "[img]"
+    assert fallbacks["file_template"] == "[doc:{name}]"
+    assert "generic" in fallbacks
 
 
 def test_decode_slack_session_id_thread_marker_does_not_fallback_to_legacy():

--- a/tests/unit/test_slack_thread_session.py
+++ b/tests/unit/test_slack_thread_session.py
@@ -12,6 +12,8 @@ from astrbot.core.platform.platform_metadata import PlatformMetadata
 from astrbot.core.platform.sources.slack.session_codec import (
     decode_slack_session_id,
     resolve_slack_message_target,
+    resolve_target_from_event,
+    resolve_target_from_session,
 )
 from astrbot.core.platform.sources.slack.slack_adapter import SlackAdapter
 from astrbot.core.platform.sources.slack.slack_event import SlackMessageEvent
@@ -289,3 +291,23 @@ def test_resolve_slack_message_target_prefers_raw_message_thread_ts():
 
     assert channel_id == "C123"
     assert thread_ts == "333.444"
+
+
+def test_resolve_target_from_event_prefers_raw_thread_and_group_precedence():
+    channel_id, thread_ts = resolve_target_from_event(
+        session_id="C123__thread__111.222",
+        raw_message={"channel": "C333", "thread_ts": "333.444"},
+        group_id="C999",
+    )
+
+    assert channel_id == "C999"
+    assert thread_ts == "333.444"
+
+
+def test_resolve_target_from_session_uses_parsed_thread():
+    channel_id, thread_ts = resolve_target_from_session(
+        session_id="D123__thread__1710000000.500",
+    )
+
+    assert channel_id == "D123"
+    assert thread_ts == "1710000000.500"

--- a/tests/unit/test_slack_thread_session.py
+++ b/tests/unit/test_slack_thread_session.py
@@ -9,6 +9,10 @@ from astrbot.core.platform.astrbot_message import AstrBotMessage, MessageMember
 from astrbot.core.platform.message_session import MessageSession
 from astrbot.core.platform.message_type import MessageType
 from astrbot.core.platform.platform_metadata import PlatformMetadata
+from astrbot.core.platform.sources.slack.session_codec import (
+    decode_slack_session_id,
+    resolve_slack_message_target,
+)
 from astrbot.core.platform.sources.slack.slack_adapter import SlackAdapter
 from astrbot.core.platform.sources.slack.slack_event import SlackMessageEvent
 from astrbot.core.utils.metrics import Metric
@@ -259,3 +263,29 @@ async def test_parse_slack_blocks_includes_non_empty_fallback_text():
 
     assert blocks
     assert text == "hello"
+
+
+def test_decode_slack_session_id_thread_marker_does_not_fallback_to_legacy():
+    channel_id, thread_ts = decode_slack_session_id("C123__thread__")
+
+    assert channel_id == "C123"
+    assert thread_ts is None
+
+
+def test_decode_slack_session_id_supports_legacy_group_prefix():
+    channel_id, thread_ts = decode_slack_session_id("group_C123")
+
+    assert channel_id == "C123"
+    assert thread_ts is None
+
+
+def test_resolve_slack_message_target_prefers_raw_message_thread_ts():
+    channel_id, thread_ts = resolve_slack_message_target(
+        session_id="C123__thread__111.222",
+        raw_message={"channel": "C123", "thread_ts": "333.444"},
+        group_id="",
+        sender_id="U123",
+    )
+
+    assert channel_id == "C123"
+    assert thread_ts == "333.444"

--- a/tests/unit/test_slack_thread_session.py
+++ b/tests/unit/test_slack_thread_session.py
@@ -370,6 +370,37 @@ async def test_send_with_blocks_and_fallback_skips_when_channel_empty(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_send_with_blocks_and_fallback_uses_safe_text_when_custom_builder_empty():
+    web_client = AsyncMock()
+    web_client.chat_postMessage = AsyncMock(side_effect=[RuntimeError("boom"), None])
+
+    async def _parse_blocks(_message_chain, _web_client, _fallbacks):
+        return (
+            [{"type": "section", "text": {"type": "mrkdwn", "text": "reply"}}],
+            "reply",
+        )
+
+    def _empty_builder(_message_chain, _fallbacks):
+        return ""
+
+    await slack_send_utils_module.send_with_blocks_and_fallback(
+        web_client=web_client,
+        channel="C0001",
+        thread_ts="1710000000.500",
+        message_chain=MessageChain([Plain(text="reply")]),
+        fallbacks=build_slack_text_fallbacks({"safe_text": "fallback-message"}),
+        parse_blocks=_parse_blocks,
+        build_text_fallback=_empty_builder,
+        session_id="C0001__thread__1710000000.500",
+    )
+
+    assert web_client.chat_postMessage.await_count == 2
+    second_call_kwargs = web_client.chat_postMessage.await_args_list[1].kwargs
+    assert second_call_kwargs["text"] == "fallback-message"
+    assert "blocks" not in second_call_kwargs
+
+
+@pytest.mark.asyncio
 async def test_send_by_session_uses_configured_safe_text_fallback(monkeypatch):
     adapter = SlackAdapter(
         platform_config={

--- a/tests/unit/test_slack_thread_session.py
+++ b/tests/unit/test_slack_thread_session.py
@@ -334,6 +334,42 @@ async def test_parse_slack_blocks_includes_non_empty_fallback_text():
 
 
 @pytest.mark.asyncio
+async def test_parse_slack_blocks_whitespace_plain_returns_safe_fallback_text():
+    custom_fallbacks = build_slack_text_fallbacks({"safe_text": "fallback-message"})
+    blocks, text = await SlackMessageEvent._parse_slack_blocks(
+        MessageChain([Plain(text="   ")]),
+        AsyncMock(),
+        custom_fallbacks,
+    )
+
+    assert blocks == []
+    assert text == "fallback-message"
+
+
+@pytest.mark.asyncio
+async def test_send_with_blocks_and_fallback_skips_when_channel_empty(monkeypatch):
+    web_client = AsyncMock()
+    mocked_warning_logger = MagicMock()
+    monkeypatch.setattr(
+        slack_send_utils_module.logger,
+        "warning",
+        mocked_warning_logger,
+    )
+
+    await slack_send_utils_module.send_with_blocks_and_fallback(
+        web_client=web_client,
+        channel="",
+        thread_ts="1710000000.500",
+        message_chain=MessageChain([Plain(text="reply")]),
+        fallbacks=build_slack_text_fallbacks(None),
+        session_id="C0001__thread__1710000000.500",
+    )
+
+    web_client.chat_postMessage.assert_not_awaited()
+    assert mocked_warning_logger.called
+
+
+@pytest.mark.asyncio
 async def test_send_by_session_uses_configured_safe_text_fallback(monkeypatch):
     adapter = SlackAdapter(
         platform_config={

--- a/tests/unit/test_slack_thread_session.py
+++ b/tests/unit/test_slack_thread_session.py
@@ -9,6 +9,7 @@ from astrbot.core.platform.astrbot_message import AstrBotMessage, MessageMember
 from astrbot.core.platform.message_session import MessageSession
 from astrbot.core.platform.message_type import MessageType
 from astrbot.core.platform.platform_metadata import PlatformMetadata
+from astrbot.core.platform.sources.slack import slack_adapter as slack_adapter_module
 from astrbot.core.platform.sources.slack import slack_event as slack_event_module
 from astrbot.core.platform.sources.slack.session_codec import (
     build_slack_text_fallbacks,
@@ -362,6 +363,62 @@ async def test_send_by_session_uses_configured_safe_text_fallback(monkeypatch):
         text="fallback-message",
         blocks=None,
     )
+
+
+@pytest.mark.asyncio
+async def test_send_by_session_retries_text_only_when_block_send_fails(monkeypatch):
+    adapter = SlackAdapter(
+        platform_config={
+            "id": "slack_test",
+            "bot_token": "xoxb-test",
+            "app_token": "xapp-test",
+        },
+        platform_settings={},
+        event_queue=asyncio.Queue(),
+    )
+    adapter.bot_self_id = "B0001"
+    adapter.web_client = AsyncMock()
+    adapter.web_client.chat_postMessage = AsyncMock(
+        side_effect=[RuntimeError("boom"), None]
+    )
+    monkeypatch.setattr(
+        SlackMessageEvent,
+        "_parse_slack_blocks",
+        AsyncMock(
+            return_value=(
+                [{"type": "section", "text": {"type": "mrkdwn", "text": "reply"}}],
+                "reply",
+            )
+        ),
+    )
+    mocked_exception_logger = MagicMock()
+    monkeypatch.setattr(
+        slack_adapter_module.logger,
+        "exception",
+        mocked_exception_logger,
+    )
+
+    session = MessageSession(
+        platform_name="slack_test",
+        message_type=MessageType.GROUP_MESSAGE,
+        session_id="C0001__thread__1710000000.500",
+    )
+    await adapter.send_by_session(
+        session=session,
+        message_chain=MessageChain([Plain(text="reply")]),
+    )
+
+    assert adapter.web_client.chat_postMessage.await_count == 2
+    first_call_kwargs = adapter.web_client.chat_postMessage.await_args_list[0].kwargs
+    second_call_kwargs = adapter.web_client.chat_postMessage.await_args_list[1].kwargs
+    assert first_call_kwargs["channel"] == "C0001"
+    assert first_call_kwargs["thread_ts"] == "1710000000.500"
+    assert first_call_kwargs["blocks"]
+    assert second_call_kwargs["channel"] == "C0001"
+    assert second_call_kwargs["thread_ts"] == "1710000000.500"
+    assert second_call_kwargs["text"] == "reply"
+    assert "blocks" not in second_call_kwargs
+    assert mocked_exception_logger.called
 
 
 def test_build_slack_text_fallbacks_accepts_overrides():

--- a/tests/unit/test_slack_thread_session.py
+++ b/tests/unit/test_slack_thread_session.py
@@ -9,8 +9,9 @@ from astrbot.core.platform.astrbot_message import AstrBotMessage, MessageMember
 from astrbot.core.platform.message_session import MessageSession
 from astrbot.core.platform.message_type import MessageType
 from astrbot.core.platform.platform_metadata import PlatformMetadata
-from astrbot.core.platform.sources.slack import slack_adapter as slack_adapter_module
-from astrbot.core.platform.sources.slack import slack_event as slack_event_module
+from astrbot.core.platform.sources.slack import (
+    slack_send_utils as slack_send_utils_module,
+)
 from astrbot.core.platform.sources.slack.session_codec import (
     build_slack_text_fallbacks,
     decode_slack_session_id,
@@ -284,7 +285,11 @@ async def test_slack_event_send_logs_exception_before_text_fallback(monkeypatch)
         ),
     )
     mocked_exception_logger = MagicMock()
-    monkeypatch.setattr(slack_event_module.logger, "exception", mocked_exception_logger)
+    monkeypatch.setattr(
+        slack_send_utils_module.logger,
+        "exception",
+        mocked_exception_logger,
+    )
 
     event = SlackMessageEvent(
         message_str=message_obj.message_str,
@@ -393,7 +398,7 @@ async def test_send_by_session_retries_text_only_when_block_send_fails(monkeypat
     )
     mocked_exception_logger = MagicMock()
     monkeypatch.setattr(
-        slack_adapter_module.logger,
+        slack_send_utils_module.logger,
         "exception",
         mocked_exception_logger,
     )

--- a/tests/unit/test_slack_thread_session.py
+++ b/tests/unit/test_slack_thread_session.py
@@ -1,0 +1,261 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from astrbot.api.event import MessageChain
+from astrbot.api.message_components import Plain
+from astrbot.core.platform.astrbot_message import AstrBotMessage, MessageMember
+from astrbot.core.platform.message_session import MessageSession
+from astrbot.core.platform.message_type import MessageType
+from astrbot.core.platform.platform_metadata import PlatformMetadata
+from astrbot.core.platform.sources.slack.slack_adapter import SlackAdapter
+from astrbot.core.platform.sources.slack.slack_event import SlackMessageEvent
+from astrbot.core.utils.metrics import Metric
+
+
+@pytest.fixture(autouse=True)
+def _disable_metric_upload(monkeypatch):
+    monkeypatch.setattr(Metric, "upload", AsyncMock())
+
+
+@pytest.fixture
+def slack_adapter():
+    adapter = SlackAdapter(
+        platform_config={
+            "id": "slack_test",
+            "bot_token": "xoxb-test",
+            "app_token": "xapp-test",
+        },
+        platform_settings={},
+        event_queue=asyncio.Queue(),
+    )
+    adapter.bot_self_id = "B0001"
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_convert_message_group_thread_uses_thread_session(slack_adapter):
+    slack_adapter.web_client = AsyncMock()
+    slack_adapter.web_client.users_info = AsyncMock(
+        return_value={"user": {"real_name": "Alice", "name": "alice"}},
+    )
+    slack_adapter.web_client.conversations_info = AsyncMock(
+        return_value={"channel": {"is_im": False}},
+    )
+
+    abm = await slack_adapter.convert_message(
+        {
+            "user": "U0001",
+            "channel": "C0001",
+            "text": "hello",
+            "client_msg_id": "m-1",
+            "ts": "1710000001.100",
+            "thread_ts": "1710000000.500",
+        },
+    )
+
+    assert abm.type == MessageType.GROUP_MESSAGE
+    assert abm.group_id == "C0001"
+    assert abm.session_id == "C0001__thread__1710000000.500"
+
+
+@pytest.mark.asyncio
+async def test_convert_message_friend_thread_uses_thread_session(slack_adapter):
+    slack_adapter.web_client = AsyncMock()
+    slack_adapter.web_client.users_info = AsyncMock(
+        return_value={"user": {"real_name": "Alice", "name": "alice"}},
+    )
+    slack_adapter.web_client.conversations_info = AsyncMock(
+        return_value={"channel": {"is_im": True}},
+    )
+
+    abm = await slack_adapter.convert_message(
+        {
+            "user": "U0001",
+            "channel": "D0001",
+            "text": "hello in dm thread",
+            "client_msg_id": "m-friend-1",
+            "ts": "1710000010.100",
+            "thread_ts": "1710000009.500",
+        },
+    )
+
+    assert abm.type == MessageType.FRIEND_MESSAGE
+    assert abm.session_id == "D0001__thread__1710000009.500"
+
+
+@pytest.mark.asyncio
+async def test_convert_message_unwraps_message_replied_event(slack_adapter):
+    slack_adapter.web_client = AsyncMock()
+    slack_adapter.web_client.users_info = AsyncMock(
+        return_value={"user": {"real_name": "Alice", "name": "alice"}},
+    )
+    slack_adapter.web_client.conversations_info = AsyncMock(
+        return_value={"channel": {"is_im": False}},
+    )
+
+    abm = await slack_adapter.convert_message(
+        {
+            "type": "message",
+            "subtype": "message_replied",
+            "channel": "C0001",
+            "message": {
+                "user": "U0001",
+                "text": "reply",
+                "ts": "1710000200.001",
+                "thread_ts": "1710000000.500",
+                "client_msg_id": "m-replied-1",
+            },
+        },
+    )
+
+    assert abm.sender.user_id == "U0001"
+    assert abm.message_str == "reply"
+    assert abm.session_id == "C0001__thread__1710000000.500"
+
+
+@pytest.mark.asyncio
+async def test_send_by_session_group_thread_posts_with_thread_ts(slack_adapter, monkeypatch):
+    slack_adapter.web_client = AsyncMock()
+    monkeypatch.setattr(
+        SlackMessageEvent,
+        "_parse_slack_blocks",
+        AsyncMock(return_value=([], "reply")),
+    )
+    session = MessageSession(
+        platform_name="slack_test",
+        message_type=MessageType.GROUP_MESSAGE,
+        session_id="C0001__thread__1710000000.500",
+    )
+
+    await slack_adapter.send_by_session(
+        session=session,
+        message_chain=MessageChain([Plain(text="reply")]),
+    )
+
+    slack_adapter.web_client.chat_postMessage.assert_awaited_once_with(
+        channel="C0001",
+        text="reply",
+        blocks=None,
+        thread_ts="1710000000.500",
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_by_session_friend_thread_posts_with_thread_ts(slack_adapter, monkeypatch):
+    slack_adapter.web_client = AsyncMock()
+    monkeypatch.setattr(
+        SlackMessageEvent,
+        "_parse_slack_blocks",
+        AsyncMock(return_value=([], "reply")),
+    )
+    session = MessageSession(
+        platform_name="slack_test",
+        message_type=MessageType.FRIEND_MESSAGE,
+        session_id="D0001__thread__1710000000.500",
+    )
+
+    await slack_adapter.send_by_session(
+        session=session,
+        message_chain=MessageChain([Plain(text="reply")]),
+    )
+
+    slack_adapter.web_client.chat_postMessage.assert_awaited_once_with(
+        channel="D0001",
+        text="reply",
+        blocks=None,
+        thread_ts="1710000000.500",
+    )
+
+
+@pytest.mark.asyncio
+async def test_slack_event_send_group_thread_posts_with_thread_ts(monkeypatch):
+    message_obj = AstrBotMessage()
+    message_obj.type = MessageType.GROUP_MESSAGE
+    message_obj.group_id = "C0001"
+    message_obj.session_id = "C0001__thread__1710000000.500"
+    message_obj.message_id = "m-2"
+    message_obj.sender = MessageMember(user_id="U0001", nickname="Alice")
+    message_obj.message = [Plain(text="hello")]
+    message_obj.message_str = "hello"
+    message_obj.raw_message = {"thread_ts": "1710000000.500"}
+
+    web_client = AsyncMock()
+    monkeypatch.setattr(
+        SlackMessageEvent,
+        "_parse_slack_blocks",
+        AsyncMock(return_value=([], "reply")),
+    )
+
+    event = SlackMessageEvent(
+        message_str=message_obj.message_str,
+        message_obj=message_obj,
+        platform_meta=PlatformMetadata(
+            name="slack",
+            description="Slack test",
+            id="slack_test",
+        ),
+        session_id=message_obj.session_id,
+        web_client=web_client,
+    )
+
+    await event.send(MessageChain([Plain(text="reply")]))
+
+    web_client.chat_postMessage.assert_awaited_once_with(
+        channel="C0001",
+        text="reply",
+        blocks=None,
+        thread_ts="1710000000.500",
+    )
+
+
+@pytest.mark.asyncio
+async def test_slack_event_send_friend_thread_posts_with_thread_ts(monkeypatch):
+    message_obj = AstrBotMessage()
+    message_obj.type = MessageType.FRIEND_MESSAGE
+    message_obj.session_id = "D0001__thread__1710000000.500"
+    message_obj.message_id = "m-friend-2"
+    message_obj.sender = MessageMember(user_id="U0001", nickname="Alice")
+    message_obj.message = [Plain(text="hello")]
+    message_obj.message_str = "hello"
+    message_obj.raw_message = {"channel": "D0001", "thread_ts": "1710000000.500"}
+
+    web_client = AsyncMock()
+    monkeypatch.setattr(
+        SlackMessageEvent,
+        "_parse_slack_blocks",
+        AsyncMock(return_value=([], "reply")),
+    )
+
+    event = SlackMessageEvent(
+        message_str=message_obj.message_str,
+        message_obj=message_obj,
+        platform_meta=PlatformMetadata(
+            name="slack",
+            description="Slack test",
+            id="slack_test",
+        ),
+        session_id=message_obj.session_id,
+        web_client=web_client,
+    )
+
+    await event.send(MessageChain([Plain(text="reply")]))
+
+    web_client.chat_postMessage.assert_awaited_once_with(
+        channel="D0001",
+        text="reply",
+        blocks=None,
+        thread_ts="1710000000.500",
+    )
+
+
+@pytest.mark.asyncio
+async def test_parse_slack_blocks_includes_non_empty_fallback_text():
+    blocks, text = await SlackMessageEvent._parse_slack_blocks(
+        MessageChain([Plain(text="hello")]),
+        AsyncMock(),
+    )
+
+    assert blocks
+    assert text == "hello"

--- a/tests/unit/test_slack_thread_session.py
+++ b/tests/unit/test_slack_thread_session.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -9,6 +9,7 @@ from astrbot.core.platform.astrbot_message import AstrBotMessage, MessageMember
 from astrbot.core.platform.message_session import MessageSession
 from astrbot.core.platform.message_type import MessageType
 from astrbot.core.platform.platform_metadata import PlatformMetadata
+from astrbot.core.platform.sources.slack import slack_event as slack_event_module
 from astrbot.core.platform.sources.slack.session_codec import (
     build_slack_text_fallbacks,
     decode_slack_session_id,
@@ -258,6 +259,64 @@ async def test_slack_event_send_friend_thread_posts_with_thread_ts(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_slack_event_send_logs_exception_before_text_fallback(monkeypatch):
+    message_obj = AstrBotMessage()
+    message_obj.type = MessageType.GROUP_MESSAGE
+    message_obj.group_id = "C0001"
+    message_obj.session_id = "C0001__thread__1710000000.500"
+    message_obj.message_id = "m-err-1"
+    message_obj.sender = MessageMember(user_id="U0001", nickname="Alice")
+    message_obj.message = [Plain(text="hello")]
+    message_obj.message_str = "hello"
+    message_obj.raw_message = {"channel": "C0001", "thread_ts": "1710000000.500"}
+
+    web_client = AsyncMock()
+    web_client.chat_postMessage = AsyncMock(side_effect=[RuntimeError("boom"), None])
+    monkeypatch.setattr(
+        SlackMessageEvent,
+        "_parse_slack_blocks",
+        AsyncMock(
+            return_value=(
+                [{"type": "section", "text": {"type": "mrkdwn", "text": "reply"}}],
+                "reply",
+            )
+        ),
+    )
+    mocked_exception_logger = MagicMock()
+    monkeypatch.setattr(slack_event_module.logger, "exception", mocked_exception_logger)
+
+    event = SlackMessageEvent(
+        message_str=message_obj.message_str,
+        message_obj=message_obj,
+        platform_meta=PlatformMetadata(
+            name="slack",
+            description="Slack test",
+            id="slack_test",
+        ),
+        session_id=message_obj.session_id,
+        web_client=web_client,
+    )
+
+    await event.send(MessageChain([Plain(text="reply")]))
+
+    assert web_client.chat_postMessage.await_count == 2
+    first_call_kwargs = web_client.chat_postMessage.await_args_list[0].kwargs
+    second_call_kwargs = web_client.chat_postMessage.await_args_list[1].kwargs
+    assert first_call_kwargs["channel"] == "C0001"
+    assert first_call_kwargs["thread_ts"] == "1710000000.500"
+    assert first_call_kwargs["blocks"]
+    assert second_call_kwargs["channel"] == "C0001"
+    assert second_call_kwargs["thread_ts"] == "1710000000.500"
+    assert second_call_kwargs["text"] == "reply"
+    assert "blocks" not in second_call_kwargs
+
+    assert mocked_exception_logger.called
+    assert mocked_exception_logger.call_args.args[1] == "C0001__thread__1710000000.500"
+    assert mocked_exception_logger.call_args.args[2] == "C0001"
+    assert mocked_exception_logger.call_args.args[3] == "1710000000.500"
+
+
+@pytest.mark.asyncio
 async def test_parse_slack_blocks_includes_non_empty_fallback_text():
     blocks, text = await SlackMessageEvent._parse_slack_blocks(
         MessageChain([Plain(text="hello")]),
@@ -364,3 +423,25 @@ def test_resolve_target_from_session_uses_parsed_thread():
 
     assert channel_id == "D123"
     assert thread_ts == "1710000000.500"
+
+
+def test_target_resolution_helpers_share_same_precedence():
+    event_resolved = resolve_target_from_event(
+        session_id="C123__thread__111.222",
+        raw_message={"channel": "C333", "thread_ts": "333.444"},
+        group_id="C999",
+    )
+    legacy_resolved = resolve_slack_message_target(
+        session_id="C123__thread__111.222",
+        raw_message={"channel": "C333", "thread_ts": "333.444"},
+        group_id="C999",
+        sender_id="U123",
+    )
+    session_resolved = resolve_target_from_session(
+        session_id="",
+        group_id="",
+        fallback_channel_id="U123",
+    )
+
+    assert event_resolved == legacy_resolved
+    assert session_resolved == ("U123", None)


### PR DESCRIPTION
### Motivation / 动机

  Slack 适配器在线程场景存在两个实际问题：

  1. 线程上下文丢失：收到线程消息时未稳定纳入线程维度会话，导致 thread 内对话记忆无法隔离。
  2. 回复位置不稳定：发送消息时未统一透传 `thread_ts`，导致部分回复落回主频道而非线程。
  3. 运行期告警：`chat.postMessage` 在 blocks-only 场景可能出现空 `text`，触发 Slack SDK warning（`The top-level text argument is missing...`）。

  本 PR 统一修复上述问题，并补充回归测试。

  ### Modifications / 改动点

  - 新增 Slack 会话编解码工具：
    - `astrbot/core/platform/sources/slack/session_codec.py`
    - 统一编码线程会话并兼容历史会话格式解析。

  - 修复 Slack 消息接收与会话构建：
    - `astrbot/core/platform/sources/slack/slack_adapter.py`
    - 对 `message_replied` 事件做归一化处理，确保 `user/text/thread_ts/channel` 可被正确提取。
    - 当存在 `thread_ts` 时（群聊或私聊），会话 ID 使用线程维度，确保线程上下文隔离。

  - 修复 Slack 消息发送路径：
    - `astrbot/core/platform/sources/slack/slack_adapter.py`
    - `astrbot/core/platform/sources/slack/slack_event.py`
    - 统一从会话/原始消息解析并透传 `thread_ts`，保证在线程内回复。
    - 增加 `text` fallback（非空兜底）以满足 Slack `chat.postMessage` 最佳实践，消除运行期 warning。

  - 新增单元测试：
    - `tests/unit/test_slack_thread_session.py`
    - 覆盖群聊线程、私聊线程、`message_replied` 归一化、线程发送与 fallback 文本行为。

  - [x] This is NOT a breaking change. / 这不是一个破坏性变更。

  ### Screenshots or Test Results / 运行截图或测试结果

  本地验证命令与结果：

  1. `uv run ruff check astrbot/core/platform/sources/slack/slack_adapter.py astrbot/core/platform/sources/slack/slack_event.py astrbot/core/platform/sources/slack/session_codec.py tests/unit/test_slack_thread_session.py`
     - `All checks passed!`

  2. `uv run pytest -q tests/unit/test_slack_thread_session.py`
     - `8 passed, 3 warnings in 1.27s`

  运行期验证：
  - 在线程中连续对话，机器人保持线程内回复且上下文连续。
  - 服务日志中不再出现 `chat.postMessage` 缺失顶层 `text` 的 warning（新重启后日志窗口内验证）。

  ---

  ### Checklist / 检查清单

  - [x] 😊 该 PR 为 bugfix，不引入新功能，无需新增功能预讨论。/ This PR is a bugfix and does not introduce a new feature.
  - [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图/日志结果”**。/ Changes are tested and verification logs are provided above.
  - [x] 🤓 我确保没有引入新依赖库。/ No new dependencies introduced.
  - [x] 😮 我的更改没有引入恶意代码。/ No malicious code introduced.

## Summary by Sourcery

Improve Slack adapter to keep replies within threads, preserve thread-based session context, and ensure all outgoing messages include a safe text fallback alongside blocks.

Bug Fixes:
- Preserve Slack thread context in both group and direct message conversations by encoding sessions at the thread level when thread_ts is present.
- Normalize Slack message_replied events so replies are parsed consistently and mapped to the correct sender, text, and thread session.
- Ensure Slack replies are posted back into the correct thread by resolving channel and thread_ts consistently from events and sessions.
- Avoid Slack SDK warnings by always providing a non-empty text fallback when sending block-based messages and retrying with text-only payloads on failures.

Enhancements:
- Extract shared Slack sending logic into slack_send_utils with unified block parsing, file/image upload handling, and centralized fallback text building.
- Introduce a Slack session codec to encode/decode thread-aware session IDs and to configure overridable but validated text fallback templates.

Tests:
- Add comprehensive unit tests for Slack thread session handling, target resolution helpers, safe text fallback behavior, and send retry logic for both adapter- and event-based sending paths.