### PR TITLE
feat: display latency when testing model connection

### DIFF
--- a/dashboard/src/composables/useProviderSources.ts
+++ b/dashboard/src/composables/useProviderSources.ts
@@ -590,9 +590,11 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
   async function testProvider(provider: any) {
     testingProviders.value.push(provider.id)
     try {
+      const startTime = performance.now()
       const response = await axios.get('/api/config/provider/check_one', { params: { id: provider.id } })
       if (response.data.status === 'ok' && response.data.data.error === null) {
-        showMessage(tm('models.testSuccess', { id: provider.id }))
+        const latency = Math.max(0, Math.round(performance.now() - startTime))
+        showMessage(tm('models.testSuccessWithLatency', { id: provider.id, latency }))
       } else {
         throw new Error(response.data.data.error || tm('models.testError'))
       }

--- a/dashboard/src/i18n/locales/en-US/features/provider.json
+++ b/dashboard/src/i18n/locales/en-US/features/provider.json
@@ -132,6 +132,7 @@
     "deleteSuccess": "Model deleted successfully",
     "deleteError": "Failed to delete model",
     "testSuccess": "Model {id} test passed",
+    "testSuccessWithLatency": "Model {id} test passed, latency {latency} ms",
     "testError": "Model test failed",
     "searchPlaceholder": "Search models or ID",
     "manualAddButton": "Custom Model",

--- a/dashboard/src/i18n/locales/zh-CN/features/provider.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/provider.json
@@ -133,6 +133,7 @@
     "deleteSuccess": "模型删除成功",
     "deleteError": "模型删除失败",
     "testSuccess": "模型 {id} 测试通过",
+    "testSuccessWithLatency": "模型 {id} 测试通过，延迟 {latency} ms",
     "testError": "模型测试失败",
     "searchPlaceholder": "搜索模型或 ID",
     "manualAddButton": "自定义模型",

--- a/dashboard/src/views/ProviderPage.vue
+++ b/dashboard/src/views/ProviderPage.vue
@@ -602,12 +602,15 @@ async function testSingleProvider(provider) {
       return
     }
 
+    const startTime = performance.now()
     const res = await axios.get(`/api/config/provider/check_one?id=${provider.id}`)
     if (res.data && res.data.status === 'ok') {
       const index = providerStatuses.value.findIndex(s => s.id === provider.id)
       if (index !== -1) {
         providerStatuses.value.splice(index, 1, res.data.data)
       }
+      const latency = Math.max(0, Math.round(performance.now() - startTime))
+      showMessage(tm('models.testSuccessWithLatency', { id: provider.id, latency }))
     } else {
       throw new Error(res.data?.message || `Failed to check status for ${provider.id}`)
     }


### PR DESCRIPTION
## 背景
当前在提供商页面点击“测试”时，只会提示模型测试是否通过，但无法直观看到一次完整测试请求的端到端耗时。

对于配置了多个来源、多个中转或多个同名模型的场景，仅知道“可用/不可用”通常还不够，用户还需要快速判断哪个来源响应更快，便于后续选择默认模型或优先使用的提供商。

## 改动内容
- 在提供商页面测试模型时，于前端统计一次测试请求的端到端耗时
- 测试成功后，在提示文案中追加“延迟 xxx ms”
- 补充中英文文案

示例：
- 模型 nimenyoudu/gpt-5.2 测试通过，延迟 3917 ms

## 设计说明
这次统计的是端到端延迟，即从前端发起测试请求开始，到收到接口响应结束为止的总耗时。

这样更贴近用户真实感知，也不依赖不同模型提供商对首 token、流式返回或中间链路的实现差异。

## 必要性
- 帮助用户更快比较不同来源的响应速度
- 帮助判断同一模型挂在不同来源下的实际可用体验
- 在“可用”之外补充一个更有决策价值的指标

## 灵感来源
灵感来自 one-api / new-api 一类面板中对请求耗时的展示方式。类似的信息对于运维和日常选型都很有帮助，可以更直观地了解端到端延迟，并辅助判断使用哪个来源的模型延迟更低。

## 影响范围
仅调整前端测试成功提示，不改变现有 provider 测试接口语义，也不影响正常对话流程。

## Summary by Sourcery

Display end-to-end latency in provider model test results on the provider page.

New Features:
- Show end-to-end latency for provider model tests in success notifications so users can compare response speed between sources.

Enhancements:
- Measure client-side end-to-end duration of provider test requests and use a dedicated i18n key for success messages with latency.