### PR TITLE
Update anthropic_source.py

### DIFF
--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -42,7 +42,7 @@ class ProviderAnthropic(Provider):
         )
 
         self.base_url = provider_config.get("api_base", "https://api.anthropic.com")
-        if self.base_url.rstrip("/").endswith("/v1"):
+        while self.base_url.rstrip("/").endswith("/v1"):
             self.base_url = self.base_url.rstrip("/")[:-3].rstrip("/")
         self.timeout = provider_config.get("timeout", 120)
         if isinstance(self.timeout, str):


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h3>Motivation / 动机</h3>
<p>When users configure <code>base_url</code> with a trailing <code>/v1</code> (e.g., <code>https://api.anthropic.com/v1</code> or <code>https://api.anthropic.com/v1/</code>), the SDK may end up constructing duplicate path segments like <code>/v1/v1/messages</code>, causing request failures. This change strips the trailing <code>/v1</code> during initialization so the URL is normalized before any API calls are made.</p>
<h3>Modifications / 改动点</h3>
<p>在 <code>anthropic_source</code> 初始化阶段增加了对 <code>base_url</code> 尾部 <code>/v1</code> 的规范化处理：</p>
<pre><code class="language-python">if self.base_url.rstrip("/").endswith("/v1"):
    self.base_url = self.base_url.rstrip("/")[:-3].rstrip("/")
</code></pre>
<p>处理逻辑覆盖以下常见用户输入场景：</p>

输入 | 规范化结果
-- | --
https://api.example.com/v1 | https://api.example.com
https://api.example.com/v1/ | https://api.example.com
https://api.example.com | 不变
https://api.example.com/ | 不变


<ul>
<li>[x] This is NOT a breaking change. / 这不是一个破坏性变更。</li>
</ul>
<h3>Checklist / 检查清单</h3>
<ul>
<li>[x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.</li>
<li>[x] 🤓 我确保没有引入新依赖库。/ I have ensured that no new dependencies are introduced.</li>
</ul></body></html><!--EndFragment-->
</body>
</html>

## Summary by Sourcery

Bug Fixes:
- Strip a trailing /v1 from the configured Anthropics API base URL so requests do not include duplicated /v1/v1 path segments.