### PR TITLE
feat: add send shortcut configuration for chatui

### DIFF
--- a/dashboard/src/components/chat/Chat.vue
+++ b/dashboard/src/components/chat/Chat.vue
@@ -11,6 +11,7 @@
                     :currSessionId="currSessionId"
                     :selectedProjectId="selectedProjectId"
                     :transportMode="transportMode"
+                    :sendShortcut="sendShortcut"
                     :isDark="isDark"
                     :chatboxMode="chatboxMode"
                     :isMobile="isMobile"
@@ -29,6 +30,7 @@
                     @editProject="showEditProjectDialog"
                     @deleteProject="handleDeleteProject"
                     @updateTransportMode="setTransportMode"
+                    @updateSendShortcut="setSendShortcut"
                 />
 
                 <!-- 右侧聊天内容区域 -->
@@ -79,6 +81,7 @@
                                 :session-id="currSessionId || null"
                                 :current-session="getCurrentSession"
                                 :replyTo="replyTo"
+                                :send-shortcut="sendShortcut"
                                 @send="handleSendMessage"
                                 @stop="handleStopMessage"
                                 @toggleStreaming="toggleStreaming"
@@ -110,6 +113,7 @@
                                 :session-id="currSessionId || null"
                                 :current-session="getCurrentSession"
                                 :replyTo="replyTo"
+                                :send-shortcut="sendShortcut"
                                 @send="handleSendMessage"
                                 @stop="handleStopMessage"
                                 @toggleStreaming="toggleStreaming"
@@ -140,6 +144,7 @@
                             :session-id="currSessionId || null"
                             :current-session="getCurrentSession"
                             :replyTo="replyTo"
+                            :send-shortcut="sendShortcut"
                             @send="handleSendMessage"
                             @stop="handleStopMessage"
                             @toggleStreaming="toggleStreaming"
@@ -226,6 +231,8 @@ import { useToast } from '@/utils/toast';
 interface Props {
     chatboxMode?: boolean;
 }
+type SendShortcut = 'enter' | 'shift_enter';
+const SEND_SHORTCUT_STORAGE_KEY = 'chat_send_shortcut';
 
 const props = withDefaults(defineProps<Props>(), {
     chatboxMode: false
@@ -334,6 +341,12 @@ interface ReplyInfo {
 const replyTo = ref<ReplyInfo | null>(null);
 
 const isDark = computed(() => useCustomizerStore().uiTheme === 'PurpleThemeDark');
+const sendShortcut = ref<SendShortcut>('shift_enter');
+
+function setSendShortcut(mode: SendShortcut) {
+    sendShortcut.value = mode;
+    localStorage.setItem(SEND_SHORTCUT_STORAGE_KEY, mode);
+}
 
 // 检测是否为手机端
 function checkMobile() {
@@ -725,6 +738,10 @@ watch(sessions, (newSessions) => {
 });
 
 onMounted(() => {
+    const storedShortcut = localStorage.getItem(SEND_SHORTCUT_STORAGE_KEY);
+    if (storedShortcut === 'enter' || storedShortcut === 'shift_enter') {
+        sendShortcut.value = storedShortcut;
+    }
     checkMobile();
     window.addEventListener('resize', checkMobile);
     getSessions();

--- a/dashboard/src/components/chat/ChatInput.vue
+++ b/dashboard/src/components/chat/ChatInput.vue
@@ -173,6 +173,7 @@ interface Props {
     currentSession?: Session | null;
     configId?: string | null;
     replyTo?: ReplyInfo | null;
+    sendShortcut?: 'enter' | 'shift_enter';
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -180,7 +181,8 @@ const props = withDefaults(defineProps<Props>(), {
     currentSession: null,
     configId: null,
     stagedFiles: () => [],
-    replyTo: null
+    replyTo: null,
+    sendShortcut: 'shift_enter'
 });
 
 const emit = defineEmits<{
@@ -253,9 +255,29 @@ watch(localPrompt, () => {
 });
 
 function handleKeyDown(e: KeyboardEvent) {
-    // Enter 插入换行（桌面和手机端均如此，发送通过右下角发送按鈕）
-    // Shift+Enter 发送（Ctrl+Enter / Cmd+Enter 也保留）
-    if (e.keyCode === 13 && (e.shiftKey || e.ctrlKey || e.metaKey)) {
+    const isEnter = e.key === 'Enter';
+    if (!isEnter) {
+        // Ctrl+B 录音
+        if (e.ctrlKey && e.keyCode === 66) {
+            e.preventDefault();
+            if (ctrlKeyDown.value) return;
+
+            ctrlKeyDown.value = true;
+            ctrlKeyTimer.value = window.setTimeout(() => {
+                if (ctrlKeyDown.value && !props.isRecording) {
+                    emit('startRecording');
+                }
+            }, ctrlKeyLongPressThreshold);
+        }
+        return;
+    }
+
+    const isSendHotkey =
+        e.ctrlKey ||
+        e.metaKey ||
+        (props.sendShortcut === 'enter' ? !e.shiftKey : e.shiftKey);
+
+    if (isSendHotkey) {
         e.preventDefault();
         if (localPrompt.value.trim() === '/astr_live_dev') {
             emit('openLiveMode');
@@ -266,19 +288,6 @@ function handleKeyDown(e: KeyboardEvent) {
             emit('send');
         }
         return;
-    }
-
-    // Ctrl+B 录音
-    if (e.ctrlKey && e.keyCode === 66) {
-        e.preventDefault();
-        if (ctrlKeyDown.value) return;
-
-        ctrlKeyDown.value = true;
-        ctrlKeyTimer.value = window.setTimeout(() => {
-            if (ctrlKeyDown.value && !props.isRecording) {
-                emit('startRecording');
-            }
-        }, ctrlKeyLongPressThreshold);
     }
 }
 

--- a/dashboard/src/components/chat/ConversationSidebar.vue
+++ b/dashboard/src/components/chat/ConversationSidebar.vue
@@ -231,6 +231,50 @@
                     </v-card>
                 </v-menu>
 
+                <!-- 发送快捷键（分组） -->
+                <v-menu
+                    :open-on-hover="!isMobile"
+                    :open-on-click="isMobile"
+                    :open-delay="!isMobile ? 60 : 0"
+                    :close-delay="!isMobile ? 120 : 0"
+                    :location="isMobile ? 'bottom' : 'end center'"
+                    offset="8"
+                    close-on-content-click
+                >
+                    <template v-slot:activator="{ props: sendShortcutMenuProps }">
+                        <v-list-item
+                            v-bind="sendShortcutMenuProps"
+                            class="styled-menu-item chat-settings-group-trigger"
+                            rounded="md"
+                        >
+                            <template v-slot:prepend>
+                                <v-icon>mdi-keyboard-outline</v-icon>
+                            </template>
+                            <v-list-item-title>{{ tm('shortcuts.sendKey.title') }}</v-list-item-title>
+                            <template v-slot:append>
+                                <span class="chat-settings-group-current chat-settings-transport-current">{{ currentSendShortcutLabel }}</span>
+                                <v-icon size="18" class="chat-settings-group-arrow">mdi-chevron-right</v-icon>
+                            </template>
+                        </v-list-item>
+                    </template>
+
+                    <v-card class="styled-menu-card" style="min-width: 220px;" elevation="8" rounded="lg">
+                        <v-list density="compact" class="styled-menu-list pa-1">
+                            <v-list-item
+                                v-for="opt in sendShortcutOptions"
+                                :key="opt.value"
+                                :value="opt.value"
+                                @click="handleSendShortcutChange(opt.value)"
+                                :class="{ 'styled-menu-item-active': props.sendShortcut === opt.value }"
+                                class="styled-menu-item"
+                                rounded="md"
+                            >
+                                <v-list-item-title>{{ opt.label }}</v-list-item-title>
+                            </v-list-item>
+                        </v-list>
+                    </v-card>
+                </v-menu>
+
                 <!-- 全屏/退出全屏 -->
                 <v-list-item class="styled-menu-item" @click="$emit('toggleFullscreen')">
                     <template v-slot:prepend>
@@ -277,6 +321,7 @@ interface Props {
     isMobile: boolean;
     mobileMenuOpen: boolean;
     projects?: Project[];
+    sendShortcut: 'enter' | 'shift_enter';
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -297,6 +342,7 @@ const emit = defineEmits<{
     editProject: [project: Project];
     deleteProject: [projectId: string];
     updateTransportMode: [mode: 'sse' | 'websocket'];
+    updateSendShortcut: [mode: 'enter' | 'shift_enter'];
 }>();
 
 const { t } = useI18n();
@@ -357,6 +403,10 @@ const transportOptions = [
     { label: tm('transport.sse'), value: 'sse' as const },
     { label: tm('transport.websocket'), value: 'websocket' as const }
 ];
+const sendShortcutOptions = [
+    { label: tm('shortcuts.sendKey.enterToSend'), value: 'enter' as const },
+    { label: tm('shortcuts.sendKey.shiftEnterToSend'), value: 'shift_enter' as const }
+];
 
 // Language switcher
 const { languageOptions, currentLanguage, switchLanguage, locale } = useLanguageSwitcher();
@@ -374,6 +424,10 @@ const changeLanguage = async (langCode: string) => {
 
 const currentTransportLabel = computed(() => {
     const found = transportOptions.find(opt => opt.value === props.transportMode);
+    return found?.label ?? '';
+});
+const currentSendShortcutLabel = computed(() => {
+    const found = sendShortcutOptions.find(opt => opt.value === props.sendShortcut);
     return found?.label ?? '';
 });
 
@@ -401,6 +455,12 @@ async function handleDeleteConversation(session: Session) {
 function handleTransportModeChange(mode: string | null) {
     if (mode === 'sse' || mode === 'websocket') {
         emit('updateTransportMode', mode);
+    }
+}
+
+function handleSendShortcutChange(mode: string | null) {
+    if (mode === 'enter' || mode === 'shift_enter') {
+        emit('updateSendShortcut', mode);
     }
 }
 </script>

--- a/dashboard/src/i18n/locales/en-US/features/chat.json
+++ b/dashboard/src/i18n/locales/en-US/features/chat.json
@@ -71,10 +71,16 @@
   "modes": {
     "darkMode": "Switch to Dark Mode",
     "lightMode": "Switch to Light Mode"
-  },  "shortcuts": {
+  },
+  "shortcuts": {
     "help": "Get Help",
     "voiceRecord": "Record Voice",
-    "pasteImage": "Paste Image"
+    "pasteImage": "Paste Image",
+    "sendKey": {
+      "title": "Send Shortcut",
+      "enterToSend": "Enter to send",
+      "shiftEnterToSend": "Shift+Enter to send"
+    }
   },
   "streaming": {
     "enabled": "Streaming enabled",

--- a/dashboard/src/i18n/locales/ru-RU/features/chat.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/chat.json
@@ -75,7 +75,12 @@
     "shortcuts": {
         "help": "Справка",
         "voiceRecord": "Запись голоса",
-        "pasteImage": "Вставить изображение"
+        "pasteImage": "Вставить изображение",
+        "sendKey": {
+            "title": "Клавиша отправки",
+            "enterToSend": "Enter для отправки",
+            "shiftEnterToSend": "Shift+Enter для отправки"
+        }
     },
     "streaming": {
         "enabled": "Потоковый ответ включен",

--- a/dashboard/src/i18n/locales/zh-CN/features/chat.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/chat.json
@@ -71,10 +71,16 @@
   "modes": {
     "darkMode": "切换到夜间模式",
     "lightMode": "切换到日间模式"
-  },  "shortcuts": {
+  },
+  "shortcuts": {
     "help": "获取帮助",
     "voiceRecord": "录制语音",
-    "pasteImage": "粘贴图片"
+    "pasteImage": "粘贴图片",
+    "sendKey": {
+      "title": "发送快捷键",
+      "enterToSend": "Enter 发送",
+      "shiftEnterToSend": "Shift+Enter 发送"
+    }
   },
   "streaming": {
     "enabled": "流式响应已开启",


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [ ] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [ ] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [ ] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

Add configurable chat message send shortcut with persistence and localization support.

New Features:
- Allow users to choose between Enter and Shift+Enter as the chat message send shortcut from the conversation sidebar.
- Persist the selected send shortcut in localStorage and apply it across chat input instances.

Enhancements:
- Localize labels for the send shortcut options in existing chat i18n files.