### PR TITLE
Fix CreateSkillPayloadTool array schema missing items field

### DIFF
--- a/astrbot/core/computer/tools/neo_skills.py
+++ b/astrbot/core/computer/tools/neo_skills.py
@@ -164,7 +164,7 @@ class CreateSkillPayloadTool(NeoSkillToolBase):
             "type": "object",
             "properties": {
                 "payload": {
-                    "anyOf": [{"type": "object"}, {"type": "array"}],
+                    "anyOf": [{"type": "object"}, {"type": "array", "items": {"type": "object"}}],
                     "description": (
                         "Skill payload JSON. Typical schema: {skill_markdown, inputs, outputs, meta}. "
                         "This only stores content and returns payload_ref; it does not create a candidate or release."


### PR DESCRIPTION
## Problem

`CreateSkillPayloadTool`'s `payload` parameter uses `anyOf: [{type: object}, {type: array}]` but the `array` variant doesn't specify an `items` field. Gemini API requires `items` for array type schemas and rejects the tool declaration with:

```
400 Bad Request: parameters.properties[payload].any_of[1].items: missing field.
```

## Fix

Add `items: {type: object}` to the array variant, matching the actual payload API behavior where array elements are objects.

Fixes #6279

## Summary by Sourcery

Bug Fixes:
- Define the array variant of CreateSkillPayloadTool.payload with object items to prevent Gemini API validation errors for missing items.