### PR TITLE
Add per-tool execution timeout to prevent agent hanging

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -674,7 +674,12 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                     )
                     raise
         finally:
-            await aiter.aclose()
+            try:
+                await aiter.aclose()
+            except Exception:
+                logger.warning(
+                    "Error while closing tool iterator for '%s'", label, exc_info=True
+                )
 
     async def _handle_function_tools(
         self,
@@ -776,11 +781,11 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 except Exception as e:
                     logger.error(f"Error in on_tool_start hook: {e}", exc_info=True)
 
-                tool_timeout = getattr(
-                    func_tool, "timeout", None
-                ) or self.provider.provider_config.get(
-                    "tool_exec_timeout", self.DEFAULT_TOOL_TIMEOUT
-                )
+                tool_timeout = getattr(func_tool, "timeout", None)
+                if tool_timeout is None:
+                    tool_timeout = self.provider.provider_config.get(
+                        "tool_exec_timeout", self.DEFAULT_TOOL_TIMEOUT
+                    )
 
                 executor = self.tool_executor.execute(
                     tool=func_tool,


### PR DESCRIPTION
## Problem

When an MCP tool or external service becomes unresponsive, the entire agent loop blocks indefinitely — one stuck tool call freezes the conversation with no recovery path. There's currently no timeout mechanism for individual tool executions.

## Solution

Wrap the tool executor's async generator with `asyncio.wait_for` to enforce a per-tool timeout. When a tool exceeds the limit:

1. `asyncio.TimeoutError` is raised and caught
2. A clear error message is recorded as the tool result: `"Tool 'xxx' timed out. Consider increasing the timeout or simplifying the request."`
3. The LLM sees the timeout error and can decide to retry, use an alternative approach, or inform the user
4. Remaining tool calls in the batch continue normally

## Configuration

Timeout is configurable at three levels (highest priority first):

| Level | How | Example |
|-------|-----|---------|
| Per-tool | `func_tool.timeout` attribute | For tools that are known to be slow |
| Per-provider | `provider_config["tool_exec_timeout"]` | Different timeout for different LLM configs |
| Global default | `DEFAULT_TOOL_TIMEOUT = 120s` | Reasonable default |

## Implementation

- `_iter_with_timeout()`: A static async generator wrapper that applies `asyncio.wait_for` to each iteration of the tool executor, with proper cleanup via `aclose()` on timeout
- Explicit `asyncio.TimeoutError` handler in the tool execution loop for a user-friendly error message (vs the generic `except Exception`)
- No behavioral change for tools that complete within the timeout

## Summary by Sourcery

Add a configurable per-tool execution timeout to prevent long-running or unresponsive tools from blocking the agent loop.

Enhancements:
- Introduce a default per-tool execution timeout with overrides at provider and per-tool levels.
- Wrap tool executor async generators with a timeout-aware iterator that enforces per-chunk execution limits and ensures cleanup on completion or timeout.
- Surface tool timeout errors as clear, user-visible tool call results while allowing remaining tool calls in the batch to continue.