### PR TITLE
Fix: AI fails to send media files when tool-calling mode is set to "skills-like".

### DIFF
--- a/astrbot/core/astr_main_agent_resources.py
+++ b/astrbot/core/astr_main_agent_resources.py
@@ -188,7 +188,12 @@ class KnowledgeBaseQueryTool(FunctionTool[AstrAgentContext]):
 @dataclass
 class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
     name: str = "send_message_to_user"
-    description: str = "Send message to the user. Supports various message types including `plain`, `image`, `record`, `video`, `file`, and `mention_user`. Use this tool to send media files (`image`, `record`, `video`, `file`), or when you need to proactively message the user. For normal text replies, you can output directly."
+    description: str = (
+        "Send message to the user. "
+        "Supports various message types including `plain`, `image`, `record`, `video`, `file`, and `mention_user`. "
+        "Use this tool to send media files (`image`, `record`, `video`, `file`), "
+        "or when you need to proactively message the user(such as cron job). For normal text replies, you can output directly."
+    )
 
     parameters: dict = Field(
         default_factory=lambda: {


### PR DESCRIPTION
## Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)

在 `skills_like` 工具调用模式下，AI 无法知道 `send_message_to_user` 工具支持发送图片、语音、视频等多媒体消息。这是因为工具的 description 中没有明确列出支持的消息类型，导致 AI 绕弯路使用 python 工具来读取图片像素，而不是直接使用消息发送功能。

---

### Modifications / 改动点

- 修改了 `astrbot/core/astr_main_agent_resources.py` 中的 `SendMessageToUserTool.description`
- 明确列出支持的消息类型：text (plain), images, voice (record), video, files, user mentions
- 移除了可能产生误解的描述 "Only use this tool when you need to proactively message the user"

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

---

### Screenshots or Test Results / 运行截图或测试结果

修改前后对比：

**修改前：**
```
Directly send message to the user. Only use this tool when you need to proactively message the user. Otherwise you can directly output the reply in the conversation.
```

**修改后：**
```
Send message to the user. Supports various message types including `plain`, `image`, `record`, `video`, `file`, and `mention_user`. Use this tool to send media files (`image`, `record`, `video`, `file`), or when you need to proactively message the user. For normal text replies, you can output directly.
```

---

### Checklist / 检查清单

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.
