### PR TITLE
fix: deduplicate repeated QQ webhook retry callbacks

### DIFF
--- a/astrbot/core/platform/sources/qqofficial_webhook/qo_webhook_server.py
+++ b/astrbot/core/platform/sources/qqofficial_webhook/qo_webhook_server.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import time
 from typing import cast
 
 import quart
@@ -39,6 +40,9 @@ class QQOfficialWebhook:
         self.client = botpy_client
         self.event_queue = event_queue
         self.shutdown_event = asyncio.Event()
+        # Deduplication cache for webhook retry callbacks.
+        self._seen_event_ids: dict[str, float] = {}
+        self._dedup_ttl: int = 60  # seconds
 
     async def initialize(self) -> None:
         logger.info("正在登录到 QQ 官方机器人...")
@@ -105,6 +109,22 @@ class QQOfficialWebhook:
             signed = await self.webhook_validation(cast(dict, data))
             print(signed)
             return signed
+
+        event_id = msg.get("id")
+        if event_id:
+            now = time.monotonic()
+            # Lazily evict expired entries to prevent unbounded growth.
+            expired = [
+                k
+                for k, ts in self._seen_event_ids.items()
+                if now - ts > self._dedup_ttl
+            ]
+            for k in expired:
+                del self._seen_event_ids[k]
+            if event_id in self._seen_event_ids:
+                logger.debug(f"Duplicate webhook event {event_id!r}, skipping.")
+                return {"opcode": 12}
+            self._seen_event_ids[event_id] = now
 
         if event and opcode == BotWebSocket.WS_DISPATCH_EVENT:
             event = msg["t"].lower()


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
Related issues #5788 

When the QQ Bot server perceives that the receiver (AstrBot) did not respond in time, it retries the same webhook callback up to 3 times. Each retry carries an identical top-level `id` field. Without deduplication, AstrBot treats all three retries as independent events, causing a single user message to be processed 2–3 times — resulting in duplicate bot responses or duplicate side-effects.
### Modifications / 改动点
- qo_webhook_server.py: Added a TTL-based in-memory deduplication cache (`_seen_event_ids`, TTL = 60 s) to `QQOfficialWebhook`. In `handle_callback`, duplicate events (identified by the payload's top-level `id` field) are immediately acknowledged with `{"opcode": 12}` and skipped before botpy parses them. First-seen events are recorded and processed normally. Expired cache entries are lazily evicted on each callback invocation. The fix applies to both the standalone port server and the unified Webhook route (`/api/platform/webhook/<uuid>`), as both paths call `handle_callback`.
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

Bug Fixes:
- Prevent duplicate handling of QQ webhook events when the QQ Bot server retries callbacks with the same event ID.