### PR TITLE
fix: GIF sent as static image in Telegram adapter

### DIFF
--- a/astrbot/core/platform/sources/telegram/tg_event.py
+++ b/astrbot/core/platform/sources/telegram/tg_event.py
@@ -26,11 +26,11 @@ from astrbot.core.utils.metrics import Metric
 
 
 def _is_gif(path: str) -> bool:
-    if path.lower().endswith('.gif'):
+    if path.lower().endswith(".gif"):
         return True
     try:
-        with open(path, 'rb') as f:
-            return f.read(6) in (b'GIF87a', b'GIF89a')
+        with open(path, "rb") as f:
+            return f.read(6) in (b"GIF87a", b"GIF89a")
     except OSError:
         return False
 


### PR DESCRIPTION
在 Astrbot 中 使用 Telegram bot 时，bot 发送的表情如果为 GIF ，则会以静态图片形式呈现，而非动图。原因是适配器将所有 Image 组件统一路由到 send_photo，而 send_photo 只发送静态图片，不支持动图。此问题影响所有通过 `Image` 组件发送 GIF 的插件。

### Modifications / 改动点

修改了 `astrbot/core/platform/sources/telegram/tg_event.py`：
- 新增辅助函数 `_is_gif()`，通过文件扩展名或魔数（`GIF87a`/`GIF89a`）检测 GIF 文件
- 在 `send_with_client()` 中：检测到 GIF 时改用 `send_animation` 发送
- 在 `_process_chain_items` 中：检测到 GIF 时改用 `send_animation`，并将 ChatAction 修正为 `UPLOAD_VIDEO`

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

修复前截图
![img1](https://github.com/user-attachments/assets/4366954e-267b-48e1-8e0d-37c0bdf3c579)
![img2](https://github.com/user-attachments/assets/08fbbb6d-b7c5-49c5-b7ee-bc40af33174e)
修复后截图
![img3](https://github.com/user-attachments/assets/64228499-9577-43cb-b26b-923350bc23a9)
![img4](https://github.com/user-attachments/assets/55d508c9-ebba-47ae-9d02-f3c727771fa7)

---

### Checklist / 检查清单

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

Bug Fixes:
- Fix Telegram messages sending GIFs via Image components being delivered as static photos instead of animated media.