### PR TITLE
fix(skills): use actual sandbox path from cache instead of hardcoded workspace root

### DIFF
--- a/astrbot/core/skills/skill_manager.py
+++ b/astrbot/core/skills/skill_manager.py
@@ -27,6 +27,28 @@ _SANDBOX_SKILLS_CACHE_VERSION = 1
 _SKILL_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 
 
+def _default_sandbox_skill_path(name: str) -> str:
+    return f"{SANDBOX_WORKSPACE_ROOT}/{SANDBOX_SKILLS_ROOT}/{name}/SKILL.md"
+
+
+def _normalize_cached_sandbox_skill_path(name: str, path: str) -> str:
+    normalized = str(path or "").strip().replace("\\", "/")
+    if not normalized:
+        return _default_sandbox_skill_path(name)
+
+    pure_path = PurePosixPath(normalized)
+    if ".." in pure_path.parts:
+        return _default_sandbox_skill_path(name)
+
+    if pure_path.name != "SKILL.md":
+        return _default_sandbox_skill_path(name)
+
+    if pure_path.parent.name != name:
+        return _default_sandbox_skill_path(name)
+
+    return str(pure_path)
+
+
 def _is_ignored_zip_entry(name: str) -> bool:
     parts = PurePosixPath(name).parts
     if not parts:
@@ -157,10 +179,7 @@ def build_skills_prompt(skills: list[SkillInfo]) -> str:
             # Prefer the actual path from sandbox cache if available
             rendered_path = _sanitize_prompt_path_for_prompt(skill.path)
             if not rendered_path:
-                rendered_path = (
-                    f"{str(SANDBOX_WORKSPACE_ROOT)}/{str(SANDBOX_SKILLS_ROOT)}/"
-                    f"{display_name}/SKILL.md"
-                )
+                rendered_path = _default_sandbox_skill_path(skill.name)
         else:
             rendered_path = _sanitize_prompt_path_for_prompt(skill.path)
             if not rendered_path:
@@ -274,13 +293,13 @@ class SkillManager:
             if not name or not _SKILL_NAME_RE.match(name):
                 continue
             description = str(item.get("description", "") or "")
-            path = str(item.get("path", "") or "")
-            if not path:
-                path = f"{SANDBOX_WORKSPACE_ROOT}/{SANDBOX_SKILLS_ROOT}/{name}/SKILL.md"
+            path = _normalize_cached_sandbox_skill_path(
+                name, str(item.get("path", "") or "")
+            )
             deduped[name] = {
                 "name": name,
                 "description": description,
-                "path": path.replace("\\", "/"),
+                "path": path,
             }
         cache = {
             "version": _SANDBOX_SKILLS_CACHE_VERSION,
@@ -324,12 +343,13 @@ class SkillManager:
             if not isinstance(item, dict):
                 continue
             name = str(item.get("name", "") or "").strip()
-            path = str(item.get("path", "") or "").strip().replace("\\", "/")
+            path = _normalize_cached_sandbox_skill_path(
+                name, str(item.get("path", "") or "")
+            )
             if not name or not _SKILL_NAME_RE.match(name):
                 continue
             sandbox_cached_descriptions[name] = str(item.get("description", "") or "")
-            if path:
-                sandbox_cached_paths[name] = path
+            sandbox_cached_paths[name] = path
 
         for entry in sorted(Path(self.skills_root).iterdir()):
             if not entry.is_dir():
@@ -356,9 +376,9 @@ class SkillManager:
             source_type = "both" if sandbox_exists else "local_only"
             source_label = "synced" if sandbox_exists else "local"
             if runtime == "sandbox" and show_sandbox_path:
-                path_str = sandbox_cached_paths.get(skill_name) or (
-                    f"{SANDBOX_WORKSPACE_ROOT}/{SANDBOX_SKILLS_ROOT}/{skill_name}/SKILL.md"
-                )
+                path_str = sandbox_cached_paths.get(
+                    skill_name
+                ) or _default_sandbox_skill_path(skill_name)
             else:
                 path_str = str(skill_md)
             path_str = path_str.replace("\\", "/")
@@ -395,10 +415,9 @@ class SkillManager:
                 # For sandbox_only skills, show_sandbox_path is implicitly True
                 # since there is no local path to show. Always prefer the
                 # actual path from sandbox cache.
-                path_str = (
-                    sandbox_cached_paths.get(skill_name)
-                    or f"{SANDBOX_WORKSPACE_ROOT}/{SANDBOX_SKILLS_ROOT}/{skill_name}/SKILL.md"
-                )
+                path_str = sandbox_cached_paths.get(
+                    skill_name
+                ) or _default_sandbox_skill_path(skill_name)
                 skills_by_name[skill_name] = SkillInfo(
                     name=skill_name,
                     description=description,


### PR DESCRIPTION
Fixes #6273

## Problem

When using the Shipyard booter, the sandbox workspace directory is `/home/ship_{session_id}/workspace/` instead of the hardcoded `/workspace`. This caused the Agent to fail reading SKILL.md files with `No such file or directory` error.

```
Tool `astrbot_execute_shell` Result: {"stderr": "cat: /workspace/skills/enhanced_search/SKILL.md: No such file or directory"}
```

### Root Cause

`skill_manager.py` hardcoded `SANDBOX_WORKSPACE_ROOT = "/workspace"` and used it to build skill paths for sandbox_only skills, ignoring the actual path from the sandbox cache.

### Actual Paths
- Skills location: `/home/ship_8f4a99ad/workspace/skills/enhanced_search/SKILL.md`
- Agent tried to read: `/workspace/skills/enhanced_search/SKILL.md`

## Solution

Prefer the actual path from sandbox cache (resolved at scan time via `Path.resolve()`) over the hardcoded `SANDBOX_WORKSPACE_ROOT` for sandbox_only skills.

### Changes

1. **`build_skills_prompt`**: For `sandbox_only` skills, prefer `skill.path` (from sandbox cache) over hardcoded path
2. **`list_skills`**: Always prefer `sandbox_cached_paths` over hardcoded path for `sandbox_only` skills

The actual path is correctly resolved at sandbox scan time via `Path.resolve()` in `_build_scan_command`, which returns the correct absolute path based on the sandbox's actual working directory.

## Testing

- Skills synced to Shipyard sandbox will now have correct paths in the prompt
- Agent can successfully read SKILL.md files using the paths provided
- Backward compatible: falls back to hardcoded path if cache is empty

## Note

This fix assumes that `_build_scan_command` successfully returns the correct absolute paths. If the scan returns empty payload (as mentioned in the issue), the root cause might be elsewhere, but this fix ensures that when paths are available in the cache, they are used correctly.

## Summary by Sourcery

Fix skill path resolution for sandbox-only skills by preferring cached sandbox paths over hardcoded workspace roots.

Bug Fixes:
- Ensure sandbox-only skills use the actual sandbox path from the cache when building SKILL.md prompt paths.
- Correct the listed SKILL.md paths for sandbox-only skills to default to cached sandbox paths and only fall back to the hardcoded workspace root when necessary.