### PR TITLE
支持未来任务配置多个目标会话，并修复多群场景串群

### DIFF
--- a/astrbot/core/astr_main_agent_resources.py
+++ b/astrbot/core/astr_main_agent_resources.py
@@ -270,7 +270,15 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
     async def call(
         self, context: ContextWrapper[AstrAgentContext], **kwargs
     ) -> ToolExecResult:
-        session = kwargs.get("session") or context.context.event.unified_msg_origin
+        event_session = getattr(context.context.event, "session", None)
+        if not isinstance(event_session, (str, MessageSession)):
+            event_session = None
+
+        session = (
+            kwargs.get("session")
+            or event_session
+            or context.context.event.unified_msg_origin
+        )
         messages = kwargs.get("messages")
 
         if not isinstance(messages, list) or not messages:

--- a/astrbot/core/cron/manager.py
+++ b/astrbot/core/cron/manager.py
@@ -233,12 +233,12 @@ class CronJobManager:
 
     async def _run_active_agent_job(self, job: CronJob, start_time: datetime) -> None:
         payload = job.payload or {}
-        session_str = payload.get("session")
-        if not session_str:
+        target_sessions = self._resolve_target_sessions(payload)
+        if not target_sessions:
             raise ValueError("ActiveAgentCronJob missing session.")
         note = payload.get("note") or job.description or job.name
 
-        extras = {
+        base_extras = {
             "cron_job": {
                 "id": job.job_id,
                 "name": job.name,
@@ -254,11 +254,45 @@ class CronJobManager:
             "cron_payload": payload,
         }
 
-        await self._woke_main_agent(
-            message=note,
-            session_str=session_str,
-            extras=extras,
-        )
+        for index, session_str in enumerate(target_sessions):
+            extras = {
+                **base_extras,
+                "cron_job": {
+                    **base_extras["cron_job"],
+                    "target_session": session_str,
+                    "target_index": index,
+                    "target_count": len(target_sessions),
+                },
+            }
+
+            await self._woke_main_agent(
+                message=note,
+                session_str=session_str,
+                extras=extras,
+            )
+
+    @staticmethod
+    def _resolve_target_sessions(payload: dict[str, Any]) -> list[str]:
+        target_sessions = payload.get("target_sessions")
+        sessions: list[str] = []
+
+        if isinstance(target_sessions, list):
+            for item in target_sessions:
+                session = str(item).strip()
+                if session and session not in sessions:
+                    sessions.append(session)
+        elif isinstance(target_sessions, str):
+            session = target_sessions.strip()
+            if session:
+                sessions.append(session)
+
+        primary_session = payload.get("session")
+        if primary_session:
+            session = str(primary_session).strip()
+            if session and session not in sessions:
+                sessions.insert(0, session)
+
+        return sessions
 
     async def _woke_main_agent(
         self,

--- a/astrbot/dashboard/routes/cron.py
+++ b/astrbot/dashboard/routes/cron.py
@@ -30,12 +30,42 @@ class CronRoute(Route):
                 data[k] = data[k].isoformat()
         # expose note explicitly for UI (prefer payload.note then description)
         payload = data.get("payload") or {}
+        target_sessions = self._normalize_target_sessions(
+            payload.get("target_sessions"), payload.get("session")
+        )
         data["note"] = payload.get("note") or data.get("description") or ""
         data["run_at"] = payload.get("run_at")
         data["run_once"] = data.get("run_once", False)
+        data["target_sessions"] = target_sessions
+        data["session"] = target_sessions[0] if target_sessions else ""
         # status is internal; hide to avoid implying one-time completion for recurring jobs
         data.pop("status", None)
         return data
+
+    @staticmethod
+    def _normalize_target_sessions(
+        target_sessions, fallback_session: str | None = None
+    ) -> list[str]:
+        sessions: list[str] = []
+
+        if isinstance(target_sessions, list):
+            raw_items = target_sessions
+        elif isinstance(target_sessions, str):
+            raw_items = target_sessions.splitlines()
+        else:
+            raw_items = []
+
+        for item in raw_items:
+            session = str(item).strip()
+            if session and session not in sessions:
+                sessions.append(session)
+
+        if fallback_session:
+            session = str(fallback_session).strip()
+            if session and session not in sessions:
+                sessions.insert(0, session)
+
+        return sessions
 
     async def list_jobs(self):
         try:
@@ -68,6 +98,9 @@ class CronRoute(Route):
             cron_expression = payload.get("cron_expression")
             note = payload.get("note") or payload.get("description") or name
             session = payload.get("session")
+            target_sessions = self._normalize_target_sessions(
+                payload.get("target_sessions"), session
+            )
             persona_id = payload.get("persona_id")
             provider_id = payload.get("provider_id")
             timezone = payload.get("timezone")
@@ -75,8 +108,10 @@ class CronRoute(Route):
             run_once = bool(payload.get("run_once", False))
             run_at = payload.get("run_at")
 
-            if not session:
-                return jsonify(Response().error("session is required").__dict__)
+            if not target_sessions:
+                return jsonify(
+                    Response().error("at least one session is required").__dict__
+                )
             if run_once and not run_at:
                 return jsonify(
                     Response().error("run_at is required when run_once=true").__dict__
@@ -99,7 +134,8 @@ class CronRoute(Route):
                     )
 
             job_payload = {
-                "session": session,
+                "session": target_sessions[0],
+                "target_sessions": target_sessions,
                 "note": note,
                 "persona_id": persona_id,
                 "provider_id": provider_id,
@@ -135,22 +171,44 @@ class CronRoute(Route):
             if not isinstance(payload, dict):
                 return jsonify(Response().error("Invalid payload").__dict__)
 
+            existing_job = await cron_mgr.db.get_cron_job(job_id)
+            if not existing_job:
+                return jsonify(Response().error("Job not found").__dict__)
+
+            payload_data = dict(existing_job.payload or {})
+            if "note" in payload:
+                payload_data["note"] = payload.get("note")
+            if "run_at" in payload:
+                payload_data["run_at"] = payload.get("run_at")
+            if "persona_id" in payload:
+                payload_data["persona_id"] = payload.get("persona_id")
+            if "provider_id" in payload:
+                payload_data["provider_id"] = payload.get("provider_id")
+            if "session" in payload or "target_sessions" in payload:
+                target_sessions = self._normalize_target_sessions(
+                    payload.get("target_sessions"),
+                    payload.get("session"),
+                )
+                if not target_sessions:
+                    return jsonify(
+                        Response().error("at least one session is required").__dict__
+                    )
+                payload_data["session"] = target_sessions[0]
+                payload_data["target_sessions"] = target_sessions
+            if isinstance(payload.get("payload"), dict):
+                payload_data.update(payload["payload"])
+
             updates = {
                 "name": payload.get("name"),
                 "cron_expression": payload.get("cron_expression"),
-                "description": payload.get("description"),
+                "description": payload.get("note") or payload.get("description"),
                 "enabled": payload.get("enabled"),
                 "timezone": payload.get("timezone"),
                 "run_once": payload.get("run_once"),
-                "payload": payload.get("payload"),
+                "payload": payload_data,
             }
             # remove None values to avoid unwanted resets
             updates = {k: v for k, v in updates.items() if v is not None}
-            if "run_at" in payload:
-                updates.setdefault("payload", {})
-                if updates["payload"] is None:
-                    updates["payload"] = {}
-                updates["payload"]["run_at"] = payload.get("run_at")
 
             job = await cron_mgr.update_job(job_id, **updates)
             if not job:

--- a/dashboard/src/i18n/locales/en-US/features/cron.json
+++ b/dashboard/src/i18n/locales/en-US/features/cron.json
@@ -10,9 +10,11 @@
   },
   "actions": {
     "create": "New Task",
+    "edit": "Edit",
     "refresh": "Refresh",
     "delete": "Delete",
     "cancel": "Cancel",
+    "save": "Save",
     "submit": "Create"
   },
   "table": {
@@ -22,7 +24,7 @@
       "name": "Name",
       "type": "Type",
       "cron": "Cron",
-      "session": "Session ID",
+      "targetSessions": "Target Sessions",
       "nextRun": "Next Run",
       "lastRun": "Last Run",
       "note": "Note",
@@ -40,6 +42,7 @@
   },
   "form": {
     "title": "New Task",
+    "editTitle": "Edit Task",
     "chatHint": "You can ask AstrBot in chat to create future tasks instead of adding them here.",
     "runOnce": "One-off task",
     "name": "Task name",
@@ -47,16 +50,18 @@
     "cron": "Cron expression",
     "cronPlaceholder": "0 9 * * *",
     "runAt": "Run at",
-    "session": "Target session (platform_id:message_type:session_id)",
+    "targetSessions": "Target sessions (one per line)",
+    "targetSessionsPlaceholder": "wuju:GroupMessage:203014918\nwuju:GroupMessage:1043307527",
     "timezone": "Timezone (optional, e.g. Asia/Shanghai)",
     "enabled": "Enabled"
   },
   "messages": {
     "loadFailed": "Failed to load tasks",
     "updateFailed": "Failed to update",
+    "updateSuccess": "Saved successfully",
     "deleteSuccess": "Deleted",
     "deleteFailed": "Failed to delete",
-    "sessionRequired": "Session is required",
+    "targetSessionsRequired": "At least one target session is required",
     "noteRequired": "Description is required",
     "cronRequired": "Cron expression is required",
     "runAtRequired": "Please select run time",

--- a/dashboard/src/i18n/locales/ru-RU/features/cron.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/cron.json
@@ -10,9 +10,11 @@
     },
     "actions": {
         "create": "Новая задача",
+        "edit": "Изменить",
         "refresh": "Обновить",
         "delete": "Удалить",
         "cancel": "Отмена",
+        "save": "Сохранить",
         "submit": "Создать"
     },
     "table": {
@@ -22,7 +24,7 @@
             "name": "Имя",
             "type": "Тип",
             "cron": "Cron",
-            "session": "ID сессии",
+            "targetSessions": "Целевые сессии",
             "nextRun": "Следующий запуск",
             "lastRun": "Последний запуск",
             "note": "Описание",
@@ -40,6 +42,7 @@
     },
     "form": {
         "title": "Создать задачу",
+        "editTitle": "Изменить задачу",
         "chatHint": "Вы можете ставить задачи прямо в чате, AstrBot создаст их автоматически без заполнения этой формы.",
         "runOnce": "Разовая задача",
         "name": "Имя задачи",
@@ -47,16 +50,18 @@
         "cron": "Cron-выражения",
         "cronPlaceholder": "0 9 * * *",
         "runAt": "Время запуска",
-        "session": "Целевая сессия (platform_id:message_type:session_id)",
+        "targetSessions": "Целевые сессии (по одной на строку)",
+        "targetSessionsPlaceholder": "wuju:GroupMessage:203014918\nwuju:GroupMessage:1043307527",
         "timezone": "Часовой пояс (опционально, напр. Europe/Moscow)",
         "enabled": "Включено"
     },
     "messages": {
         "loadFailed": "Ошибка загрузки задач",
         "updateFailed": "Ошибка обновления",
+        "updateSuccess": "Сохранено",
         "deleteSuccess": "Удалено",
         "deleteFailed": "Ошибка удаления",
-        "sessionRequired": "Укажите сессию",
+        "targetSessionsRequired": "Укажите хотя бы одну целевую сессию",
         "noteRequired": "Заполните описание",
         "cronRequired": "Укажите Cron-выражение",
         "runAtRequired": "Выберите время запуска",

--- a/dashboard/src/i18n/locales/zh-CN/features/cron.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/cron.json
@@ -10,9 +10,11 @@
   },
   "actions": {
     "create": "新建任务",
+    "edit": "编辑",
     "refresh": "刷新",
     "delete": "删除",
     "cancel": "取消",
+    "save": "保存",
     "submit": "创建"
   },
   "table": {
@@ -22,7 +24,7 @@
       "name": "名称",
       "type": "类型",
       "cron": "Cron",
-      "session": "会话 ID",
+      "targetSessions": "目标会话",
       "nextRun": "下一次执行",
       "lastRun": "最近执行",
       "note": "说明",
@@ -40,6 +42,7 @@
   },
   "form": {
     "title": "新建任务",
+    "editTitle": "编辑任务",
     "chatHint": "你可以直接通过聊天的方式来让 AstrBot 创建未来任务，而不必在此添加。",
     "runOnce": "一次性任务",
     "name": "任务名称",
@@ -47,16 +50,18 @@
     "cron": "Cron 表达式",
     "cronPlaceholder": "0 9 * * *",
     "runAt": "执行时间",
-    "session": "目标 session (platform_id:message_type:session_id)",
+    "targetSessions": "目标 session 列表（每行一个）",
+    "targetSessionsPlaceholder": "wuju:GroupMessage:203014918\nwuju:GroupMessage:1043307527",
     "timezone": "时区（可选，如 Asia/Shanghai）",
     "enabled": "启用"
   },
   "messages": {
     "loadFailed": "获取任务失败",
     "updateFailed": "更新失败",
+    "updateSuccess": "保存成功",
     "deleteSuccess": "已删除",
     "deleteFailed": "删除失败",
-    "sessionRequired": "请填写 session",
+    "targetSessionsRequired": "请至少填写一个目标 session",
     "noteRequired": "请填写说明",
     "cronRequired": "请填写 Cron 表达式",
     "runAtRequired": "请选择执行时间",

--- a/dashboard/src/views/CronJobPage.vue
+++ b/dashboard/src/views/CronJobPage.vue
@@ -48,8 +48,11 @@
               <div class="text-caption text-medium-emphasis">{{ item.timezone || tm('table.timezoneLocal') }}</div>
             </div>
           </template>
-          <template #item.session="{ item }">
-            <div>{{ item.session || tm('table.notAvailable') }}</div>
+          <template #item.target_sessions="{ item }">
+            <div v-if="item.target_sessions?.length">
+              <div v-for="session in item.target_sessions" :key="session">{{ session }}</div>
+            </div>
+            <div v-else>{{ tm('table.notAvailable') }}</div>
           </template>
           <template #item.next_run_time="{ item }">{{ formatTime(item.next_run_time) }}</template>
           <template #item.last_run_at="{ item }">{{ formatTime(item.last_run_at) }}</template>
@@ -58,6 +61,9 @@
             <div class="d-flex align-center flex-nowrap" style="gap: 12px; min-width: 140px;">
               <v-switch v-model="item.enabled" inset density="compact" hide-details color="primary"
                 class="mt-0" @change="toggleJob(item)" />
+              <v-btn size="small" variant="text" color="primary" @click="openEdit(item)">
+                {{ tm('actions.edit') }}
+              </v-btn>
               <v-btn size="small" variant="text" color="error" @click="deleteJob(item)">
                 {{ tm('actions.delete') }}
               </v-btn>
@@ -73,7 +79,9 @@
 
     <v-dialog v-model="createDialog" max-width="560">
       <v-card>
-        <v-card-title class="text-h6">{{ tm('form.title') }}</v-card-title>
+        <v-card-title class="text-h6">
+          {{ editingJobId ? tm('form.editTitle') : tm('form.title') }}
+        </v-card-title>
         <v-card-subtitle class="text-body-2 text-medium-emphasis">
           {{ tm('form.chatHint') }}
         </v-card-subtitle>
@@ -85,15 +93,18 @@
             :placeholder="tm('form.cronPlaceholder')" variant="outlined" density="comfortable" />
           <v-text-field v-else v-model="newJob.run_at" :label="tm('form.runAt')" type="datetime-local"
             variant="outlined" density="comfortable" />
-          <v-text-field v-model="newJob.session" :label="tm('form.session')" variant="outlined" density="comfortable" />
+          <v-textarea v-model="newJob.target_sessions_text" :label="tm('form.targetSessions')"
+            :placeholder="tm('form.targetSessionsPlaceholder')" variant="outlined" density="comfortable"
+            rows="3" auto-grow />
           <v-text-field v-model="newJob.timezone" :label="tm('form.timezone')" variant="outlined"
             density="comfortable" />
           <v-switch v-model="newJob.enabled" :label="tm('form.enabled')" inset color="primary" hide-details />
         </v-card-text>
         <v-card-actions class="justify-end">
           <v-btn variant="text" @click="createDialog = false">{{ tm('actions.cancel') }}</v-btn>
-          <v-btn variant="tonal" color="primary" :loading="creating" @click="createJob">{{ tm('actions.submit')
-            }}</v-btn>
+          <v-btn variant="tonal" color="primary" :loading="creating" @click="submitJob">
+            {{ editingJobId ? tm('actions.save') : tm('actions.submit') }}
+          </v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>
@@ -112,13 +123,14 @@ const jobs = ref<any[]>([])
 const proactivePlatforms = ref<{ id: string; name: string; display_name?: string }[]>([])
 const createDialog = ref(false)
 const creating = ref(false)
+const editingJobId = ref<string | null>(null)
 const newJob = ref({
   run_once: false,
   name: '',
   note: '',
   cron_expression: '',
   run_at: '',
-  session: '',
+  target_sessions_text: '',
   timezone: '',
   enabled: true
 })
@@ -133,7 +145,7 @@ const headers = computed(() => [
   { title: tm('table.headers.name'), key: 'name', minWidth: '200px' },
   { title: tm('table.headers.type'), key: 'type', width: 110 },
   { title: tm('table.headers.cron'), key: 'cron_expression', minWidth: '160px' },
-  { title: tm('table.headers.session'), key: 'session', minWidth: '200px' },
+  { title: tm('table.headers.targetSessions'), key: 'target_sessions', minWidth: '220px' },
   { title: tm('table.headers.nextRun'), key: 'next_run_time', minWidth: '160px' },
   { title: tm('table.headers.lastRun'), key: 'last_run_at', minWidth: '160px' },
   { title: tm('table.headers.note'), key: 'note', minWidth: '220px' },
@@ -150,6 +162,31 @@ function formatTime(val: any): string {
     return new Date(val).toLocaleString()
   } catch (e) {
     return String(val)
+  }
+}
+
+function parseTargetSessions(text: string): string[] {
+  return Array.from(
+    new Set(
+      String(text || '')
+        .split(/\r?\n|,/)
+        .map((item) => item.trim())
+        .filter(Boolean)
+    )
+  )
+}
+
+function buildJobPayload() {
+  const target_sessions = parseTargetSessions(newJob.value.target_sessions_text)
+  return {
+    run_once: newJob.value.run_once,
+    name: newJob.value.name,
+    note: newJob.value.note,
+    cron_expression: newJob.value.cron_expression,
+    run_at: newJob.value.run_at,
+    target_sessions,
+    timezone: newJob.value.timezone,
+    enabled: newJob.value.enabled
   }
 }
 
@@ -171,7 +208,7 @@ async function loadJobs() {
       const data = Array.isArray(res.data.data) ? res.data.data : []
       jobs.value = data.map((job: any) => ({
         ...job,
-        session: job?.payload?.session || job?.session || ''
+        target_sessions: job?.target_sessions || job?.payload?.target_sessions || (job?.payload?.session ? [job.payload.session] : [])
       }))
     } else {
       toast(res.data.message || tm('messages.loadFailed'), 'error')
@@ -228,7 +265,23 @@ async function deleteJob(job: any) {
 }
 
 function openCreate() {
+  editingJobId.value = null
   resetNewJob()
+  createDialog.value = true
+}
+
+function openEdit(job: any) {
+  editingJobId.value = job.job_id
+  newJob.value = {
+    run_once: !!job.run_once,
+    name: job.name || '',
+    note: job.note || job.description || '',
+    cron_expression: job.cron_expression || '',
+    run_at: job.run_at ? String(job.run_at).slice(0, 16) : '',
+    target_sessions_text: (job.target_sessions || []).join('\n'),
+    timezone: job.timezone || '',
+    enabled: Boolean(job.enabled)
+  }
   createDialog.value = true
 }
 
@@ -239,15 +292,16 @@ function resetNewJob() {
     note: '',
     cron_expression: '',
     run_at: '',
-    session: '',
+    target_sessions_text: '',
     timezone: '',
     enabled: true
   }
 }
 
-async function createJob() {
-  if (!newJob.value.session) {
-    toast(tm('messages.sessionRequired'), 'warning')
+async function submitJob() {
+  const payload = buildJobPayload()
+  if (!payload.target_sessions.length) {
+    toast(tm('messages.targetSessionsRequired'), 'warning')
     return
   }
   if (!newJob.value.note) {
@@ -264,18 +318,32 @@ async function createJob() {
   }
   creating.value = true
   try {
-    const payload: any = { ...newJob.value }
-    const res = await axios.post('/api/cron/jobs', payload)
+    const url = editingJobId.value
+      ? `/api/cron/jobs/${editingJobId.value}`
+      : '/api/cron/jobs'
+    const method = editingJobId.value ? 'patch' : 'post'
+    const res = await axios({
+      url,
+      method,
+      data: payload
+    })
     if (res.data.status === 'ok') {
-      toast(tm('messages.createSuccess'))
+      toast(editingJobId.value ? tm('messages.updateSuccess') : tm('messages.createSuccess'))
       createDialog.value = false
+      editingJobId.value = null
       resetNewJob()
       await loadJobs()
     } else {
-      toast(res.data.message || tm('messages.createFailed'), 'error')
+      toast(
+        res.data.message || (editingJobId.value ? tm('messages.updateFailed') : tm('messages.createFailed')),
+        'error'
+      )
     }
   } catch (e: any) {
-    toast(e?.response?.data?.message || tm('messages.createFailed'), 'error')
+    toast(
+      e?.response?.data?.message || (editingJobId.value ? tm('messages.updateFailed') : tm('messages.createFailed')),
+      'error'
+    )
   } finally {
     creating.value = false
   }

--- a/tests/unit/test_astr_main_agent_resources.py
+++ b/tests/unit/test_astr_main_agent_resources.py
@@ -1,0 +1,31 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from astrbot.core.astr_main_agent_resources import SendMessageToUserTool
+from astrbot.core.platform.message_session import MessageSession
+
+
+@pytest.mark.asyncio
+async def test_send_message_to_user_prefers_event_session():
+    """Regression: cron events should send to the bound session, not stale unified_msg_origin."""
+    tool = SendMessageToUserTool()
+    expected_session = MessageSession.from_str("wuju:GroupMessage:203014918")
+
+    wrapper = MagicMock()
+    wrapper.context = MagicMock()
+    wrapper.context.event = MagicMock()
+    wrapper.context.event.session = expected_session
+    wrapper.context.event.unified_msg_origin = "wuju:GroupMessage:1087184344"
+    wrapper.context.context = MagicMock()
+    wrapper.context.context.send_message = AsyncMock()
+
+    result = await tool.call(
+        wrapper,
+        messages=[{"type": "plain", "text": "hello"}],
+    )
+
+    wrapper.context.context.send_message.assert_awaited_once()
+    sent_session = wrapper.context.context.send_message.await_args.args[0]
+    assert str(sent_session) == str(expected_session)
+    assert result == f"Message sent to session {expected_session}"

--- a/tests/unit/test_cron_manager.py
+++ b/tests/unit/test_cron_manager.py
@@ -447,6 +447,36 @@ class TestRunJob:
         mock_db.update_cron_job.assert_not_called()
 
 
+class TestRunActiveJob:
+    """Tests for active agent cron execution."""
+
+    @pytest.mark.asyncio
+    async def test_run_active_job_supports_multiple_target_sessions(
+        self, cron_manager, sample_cron_job
+    ):
+        """Cron payload target_sessions should be executed one by one."""
+        sample_cron_job.job_type = "active_agent"
+        sample_cron_job.payload = {
+            "session": "wuju:GroupMessage:203014918",
+            "target_sessions": [
+                "wuju:GroupMessage:203014918",
+                "wuju:GroupMessage:1043307527",
+            ],
+            "note": "send report",
+        }
+
+        with patch.object(cron_manager, "_woke_main_agent", new=AsyncMock()) as mock_woke:
+            await cron_manager._run_active_agent_job(
+                sample_cron_job, start_time=datetime.now(timezone.utc)
+            )
+
+        assert mock_woke.await_count == 2
+        assert [call.kwargs["session_str"] for call in mock_woke.await_args_list] == [
+            "wuju:GroupMessage:203014918",
+            "wuju:GroupMessage:1043307527",
+        ]
+
+
 class TestRunBasicJob:
     """Tests for _run_basic_job method."""
 


### PR DESCRIPTION
### 关联问题

- 关联 #6343

### 背景

当前 `active_agent` 类型未来任务在多群场景下有两个实际痛点：

1. 给多个群分别复制同类任务时，运行过程中可能串群。
2. WebUI 只能配置单个 `session`，无法直接表达“同一任务完成后同步发到多个目标群”。

### 本 PR 做了什么

1. `send_message_to_user` 优先使用事件上已经绑定好的 `session`
   - 避免 cron 任务在并发/交错执行时误用错误的 `unified_msg_origin`
   - 对普通消息场景保持向后兼容，没有 `event.session` 时仍然回退到原逻辑

2. `active_agent` cron 支持 `target_sessions`
   - 兼容旧字段 `session`
   - 如果配置了 `target_sessions`，会按目标会话顺序逐个执行
   - 不再需要通过复制多份几乎相同的任务来实现多群同步

3. WebUI 支持查看和编辑多个目标会话
   - 表格展示目标会话列表
   - 表单支持按行填写多个 `session`
   - 新增“编辑”入口，允许直接在 WebUI 修改未来任务的目标群

### 回归测试

- `uv run pytest tests/unit/test_cron_manager.py tests/unit/test_astr_main_agent_resources.py`

### 说明

这个实现优先解决实际线上遇到的“多群串群”和“WebUI 无法直接改多目标群”问题，因此改动集中在 `cron payload` 兼容扩展和发送默认会话绑定上，没有引入新的数据库 schema 变更。

## Summary by Sourcery

Support configuring and executing active agent cron jobs with multiple target sessions while ensuring messages are sent to the correct bound session in multi-group scenarios.

New Features:
- Allow active agent cron jobs to specify multiple target sessions via target_sessions in the payload and Web UI.
- Enable viewing and editing cron job target sessions in the dashboard, including an edit dialog and multi-line input.

Bug Fixes:
- Ensure SendMessageToUserTool prefers the event-bound session over unified_msg_origin to avoid cross-session message leakage in cron and multi-group scenarios.

Enhancements:
- Normalize and persist target_sessions alongside the primary session in cron job APIs and execution logic, preserving backward compatibility with legacy session fields.
- Extend cron job update handling to merge and validate payload fields, keeping description and note in sync and requiring at least one session.
- Execute active agent cron jobs sequentially for each target session and expose target session metadata via extras.

Tests:
- Add unit tests covering multi-target-session execution for active agent cron jobs and regression tests for SendMessageToUserTool session selection behavior.