### PR TITLE
fix: prevent AttributeError when using tools with streaming enabled

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -322,7 +322,7 @@ class ProviderOpenAIOfficial(Provider):
             if reasoning:
                 llm_response.reasoning_content = reasoning
                 _y = True
-            if delta.content:
+            if delta and delta.content:
                 # Don't strip streaming chunks to preserve spaces between words
                 completion_text = self._normalize_content(delta.content, strip=False)
                 llm_response.result_chain = MessageChain(


### PR DESCRIPTION
## Description

Fixes  when the built-in agent uses tools while streaming is enabled.

## Root Cause

In streaming mode, the LLM may return a  object with  (typically when returning tool calls). The code at line 325 directly accesses  without checking if delta is None first.

## Fix

Add a null check before accessing :

```python
# Before
if delta.content:

# After
if delta and delta.content:
```

## Testing

- Verified the fix works on local AstrBot instance (v4.20.0)
- Shell tool now works correctly with streaming enabled

## Related

- Issue #6363 (closed)

## Summary by Sourcery

Bug Fixes:
- Avoid AttributeError in streaming mode by checking that the delta object exists before accessing its content during OpenAI response processing.