### PR TITLE
fix(provider): sync providers_config after creating new provider

### DIFF
--- a/astrbot/core/provider/manager.py
+++ b/astrbot/core/provider/manager.py
@@ -808,6 +808,8 @@ class ProviderManager:
             config.save_config()
             # load instance
             await self.load_provider(new_config)
+            # sync in-memory config for API queries (e.g., embedding provider list)
+            self.providers_config = astrbot_config["provider"]
 
     async def terminate(self) -> None:
         if self._mcp_init_task and not self._mcp_init_task.done():


### PR DESCRIPTION
Fixes #6283

## Problem

When adding a new embedding provider (e.g., Gemini embedding), the knowledge base creation page did not show the new provider until the service was restarted.

### Root Cause

`create_provider()` method in `ProviderManager` did not update `self.providers_config`, which is used by `get_provider_config_list()` API to return provider lists to the frontend.

### Reproduction

1. Add a new embedding provider (e.g., Gemini embedding `gemini-embedding-001`)
2. Test connection - success
3. Go to knowledge base creation page - no embedding provider shown
4. Restart AstrBot
5. Go to knowledge base creation page - embedding provider now visible

## Solution

Sync `self.providers_config` after loading the new provider, consistent with how `reload()` handles config updates.

### Changes

```python
async def create_provider(self, new_config: dict) -> None:
    # ... existing code ...
    config.save_config()
    # load instance
    await self.load_provider(new_config)
    # sync in-memory config for API queries (e.g., embedding provider list)
    self.providers_config = astrbot_config["provider"]
```

## Testing

- Add new embedding provider via WebUI
- Navigate to knowledge base creation page immediately
- New provider should appear in the dropdown without restart

## Summary by Sourcery

Bug Fixes:
- Update provider manager to sync in-memory providers_config after creating and loading a new provider so it appears in frontend lists without a service restart.