### PR TITLE
fix(webui): treat naive datetime strings as UTC in cron job display

### DIFF
--- a/dashboard/src/views/CronJobPage.vue
+++ b/dashboard/src/views/CronJobPage.vue
@@ -147,7 +147,14 @@ function toast(message: string, color: 'success' | 'error' | 'warning' = 'succes
 function formatTime(val: any): string {
   if (!val) return tm('table.notAvailable')
   try {
-    return new Date(val).toLocaleString()
+    // If the datetime string doesn't have timezone info, assume it's UTC
+    // This handles cases where the backend returns naive datetime strings
+    let dateStr = val
+    if (typeof val === 'string' && val.includes('T') && !val.endsWith('Z') && !val.includes('+')) {
+      // ISO datetime without timezone suffix - treat as UTC
+      dateStr = val + 'Z'
+    }
+    return new Date(dateStr).toLocaleString()
   } catch (e) {
     return String(val)
   }

--- a/dashboard/src/views/CronJobPage.vue
+++ b/dashboard/src/views/CronJobPage.vue
@@ -150,9 +150,13 @@ function formatTime(val: any): string {
     // If the datetime string doesn't have timezone info, assume it's UTC
     // This handles cases where the backend returns naive datetime strings
     let dateStr = val
-    if (typeof val === 'string' && val.includes('T') && !val.endsWith('Z') && !val.includes('+')) {
-      // ISO datetime without timezone suffix - treat as UTC
-      dateStr = val + 'Z'
+    if (typeof val === 'string' && val.includes('T')) {
+      // Check for timezone suffix: Z, +HH:MM, -HH:MM, +HHMM, -HHMM
+      const hasTimezone = /[Zz]$|[+-]\d{2}:?\d{2}$/.test(val)
+      if (!hasTimezone) {
+        // ISO datetime without timezone suffix - treat as UTC
+        dateStr = val + 'Z'
+      }
     }
     return new Date(dateStr).toLocaleString()
   } catch (e) {


### PR DESCRIPTION
Fixes #6242

## Problem

The WebUI was displaying cron job times incorrectly when the backend returned naive datetime strings (without timezone info). The browser would interpret them as local time, causing an 8-hour offset for UTC+8 users.

### Example
- Backend returns: `2026-03-13T14:00:00` (stored as UTC)
- Before: displayed as `2026/3/13 14:00:00` (wrong, treated as local time)
- Actual trigger time: `2026/3/13 22:00:00` (UTC+8)

## Solution

In `formatTime()`, detect ISO datetime strings without timezone suffix and append `Z` to treat them as UTC. Then let `toLocaleString()` convert to the user's local timezone correctly.

### Changes
```javascript
// Before
return new Date(val).toLocaleString()

// After
let dateStr = val
if (typeof val === 'string' && val.includes('T') && !val.endsWith('Z') && !val.includes('+')) {
  dateStr = val + 'Z'  // Treat as UTC
}
return new Date(dateStr).toLocaleString()
```

## Testing

- For datetime with timezone (`2026-03-13T14:00:00+00:00`): works as before
- For datetime with Z suffix (`2026-03-13T14:00:00Z`): works as before
- For naive datetime (`2026-03-13T14:00:00`): now correctly treated as UTC

## Note

This is a frontend fix. A more robust solution would be to ensure the backend always returns datetime strings with timezone info (e.g., `+00:00` suffix for UTC).

## Summary by Sourcery

Bug Fixes:
- Correct cron job time display when the backend returns ISO datetime strings without explicit timezone information.