### PR TITLE
feat: add OneBot V11 file API support for sending files

### DIFF
--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
@@ -179,7 +179,7 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
                 else:
                     await bot.send_private_file(
                         user_id=session_id_int, file=file_path, name=file_name
-                    ) (refactor: improve file sending logic robustness)
+                    )
             else:
                 messages = await cls._parse_onebot_json(MessageChain([seg]))
                 if not messages:


### PR DESCRIPTION
## Description

Add support for sending files via OneBot V11's dedicated file APIs ( / ) instead of regular message API.

## Changes

Modified :

- When sending a  segment, now uses:
  -  for group messages
  -  for private messages
- Supports both local file paths () and URLs ()
- Added warning log for invalid session_id

## Related Issue

Fixes #6403

## Testing

This change uses the standard OneBot V11 file APIs which are supported by most OneBot V11 implementations (Go-CQHTTP, LLOneBot, etc.)

## Summary by Sourcery

Add support for sending file segments via OneBot V11 dedicated file APIs for group and private messages, with validation of target session identifiers.

New Features:
- Use OneBot V11 group and private file APIs when sending file segments instead of the generic message API.
- Allow file segments to be sent using either local file paths or URLs as the file source.

Bug Fixes:
- Prevent attempts to send files when the session_id is invalid by validating it before dispatching.

Enhancements:
- Log a warning when a file send is skipped due to an invalid session_id to aid in debugging message routing issues.