### PR TITLE
feat: 添加通用 Rerank 适配器

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1616,7 +1616,7 @@ CONFIG_METADATA_2 = {
                     "通用 Rerank": {
                         "id": "openai_rerank",
                         "type": "openai_rerank",
-                        "provider": "openai",
+                        "provider": "generic",
                         "provider_type": "rerank",
                         "enable": True,
                         "rerank_api_key": "",

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1010,7 +1010,7 @@ CONFIG_METADATA_2 = {
                 "config_template": {
                     "OpenAI": {
                         "id": "openai",
-                        "provider": "openai",
+                        "provider": "generic",
                         "type": "openai_chat_completion",
                         "provider_type": "chat_completion",
                         "enable": True,
@@ -1613,6 +1613,17 @@ CONFIG_METADATA_2 = {
                         "return_documents": False,
                         "instruct": "",
                     },
+                    "通用 Rerank": {
+                        "id": "openai_rerank",
+                        "type": "openai_rerank",
+                        "provider": "openai",
+                        "provider_type": "rerank",
+                        "enable": True,
+                        "rerank_api_key": "",
+                        "rerank_api_base": "https://api.example.com/v1/rerank",
+                        "rerank_model": "",
+                        "timeout": 30,
+                    },
                     "Xinference STT": {
                         "id": "xinference_stt",
                         "type": "xinference_stt",
@@ -1648,9 +1659,9 @@ CONFIG_METADATA_2 = {
                         "condition": {"provider": "xai"},
                     },
                     "rerank_api_base": {
-                        "description": "重排序模型 API Base URL",
+                        "description": "重排序模型 API 地址",
                         "type": "string",
-                        "hint": "AstrBot 会在请求时在末尾加上 /v1/rerank。",
+                        "hint": "通用 Rerank / NewAPI 兼容接口需填写完整请求 URL（例如 https://api.example.com/v1/rerank）；AstrBot 不会自动补全 /v1/rerank。",
                     },
                     "rerank_api_key": {
                         "description": "API Key",

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1620,7 +1620,7 @@ CONFIG_METADATA_2 = {
                         "provider_type": "rerank",
                         "enable": True,
                         "rerank_api_key": "",
-                        "rerank_api_base": "https://api.example.com/v1/rerank",
+                        "rerank_api_url": "https://api.example.com/v1/rerank",
                         "rerank_model": "",
                         "timeout": 30,
                     },
@@ -1659,9 +1659,14 @@ CONFIG_METADATA_2 = {
                         "condition": {"provider": "xai"},
                     },
                     "rerank_api_base": {
-                        "description": "重排序模型 API 地址",
+                        "description": "重排序模型 API Base URL",
                         "type": "string",
-                        "hint": "通用 Rerank / NewAPI 兼容接口需填写完整请求 URL（例如 https://api.example.com/v1/rerank）；AstrBot 不会自动补全 /v1/rerank。",
+                        "hint": "AstrBot 会在请求时在末尾加上 /v1/rerank。",
+                    },
+                    "rerank_api_url": {
+                        "description": "通用 Rerank 完整请求 URL",
+                        "type": "string",
+                        "hint": "仅对通用 Rerank 适配器生效。请填写完整请求 URL（例如 https://api.example.com/v1/rerank）。",
                     },
                     "rerank_api_key": {
                         "description": "API Key",

--- a/astrbot/core/provider/manager.py
+++ b/astrbot/core/provider/manager.py
@@ -466,6 +466,10 @@ class ProviderManager:
                 from .sources.bailian_rerank_source import (
                     BailianRerankProvider as BailianRerankProvider,
                 )
+            case "openai_rerank":
+                from .sources.openai_rerank_source import (
+                    OpenAIRerankProvider as OpenAIRerankProvider,
+                )
 
     def get_merged_provider_config(self, provider_config: dict) -> dict:
         """获取 provider 配置和 provider_source 配置合并后的结果

--- a/astrbot/core/provider/sources/openai_rerank_source.py
+++ b/astrbot/core/provider/sources/openai_rerank_source.py
@@ -1,0 +1,171 @@
+from collections.abc import Mapping
+from typing import Any
+
+import aiohttp
+
+from astrbot import logger
+
+from ..entities import ProviderType, RerankResult
+from ..provider import RerankProvider
+from ..register import register_provider_adapter
+
+
+@register_provider_adapter(
+    "openai_rerank",
+    "通用 Rerank 适配器",
+    provider_type=ProviderType.RERANK,
+    default_config_tmpl={
+        "rerank_api_key": "",
+        "rerank_api_base": "https://api.example.com/v1/rerank",
+        "rerank_model": "",
+        "timeout": 30,
+    },
+    provider_display_name="通用 Rerank",
+)
+class OpenAIRerankProvider(RerankProvider):
+    def __init__(self, provider_config: dict, provider_settings: dict) -> None:
+        super().__init__(provider_config, provider_settings)
+
+        self.api_key = str(provider_config.get("rerank_api_key", "")).strip()
+        self.api_url = str(provider_config.get("rerank_api_base", "")).strip()
+        self.model = str(provider_config.get("rerank_model", "")).strip()
+        self.timeout = int(provider_config.get("timeout", 30))
+
+        if not self.api_url:
+            raise ValueError("通用 Rerank API URL 不能为空。")
+        if not self.api_key:
+            raise ValueError("通用 Rerank API Key 不能为空。")
+
+        self.client = aiohttp.ClientSession(
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            },
+            timeout=aiohttp.ClientTimeout(total=self.timeout),
+        )
+
+        self.set_model(self.model)
+        logger.info(f"AstrBot 通用 Rerank 初始化完成。API URL: {self.api_url}")
+
+    @staticmethod
+    def _normalize_documents(documents: list[Any]) -> list[str | dict[str, Any]]:
+        normalized_documents: list[str | dict[str, Any]] = []
+        for index, document in enumerate(documents):
+            if isinstance(document, str):
+                normalized_documents.append(document)
+                continue
+            if isinstance(document, Mapping):
+                normalized_documents.append(dict(document))
+                continue
+            raise TypeError(
+                f"documents[{index}] 必须是字符串或对象，当前类型为 {type(document).__name__}。"
+            )
+
+        return normalized_documents
+
+    def _build_payload(
+        self,
+        query: str,
+        documents: list[str | dict[str, Any]],
+        top_n: int | None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "query": query,
+            "documents": documents,
+        }
+
+        if self.model:
+            payload["model"] = self.model
+
+        if top_n is not None:
+            if top_n <= 0:
+                raise ValueError("top_n 必须大于 0。")
+            top_k = min(top_n, 100)
+            if top_k != top_n:
+                logger.warning(
+                    f"通用 Rerank top_n={top_n} 超出接口限制，已截断为 {top_k}。"
+                )
+            payload["top_k"] = top_k
+
+        return payload
+
+    @staticmethod
+    def _parse_results(response_data: Any) -> list[RerankResult]:
+        if not isinstance(response_data, dict):
+            raise ValueError("通用 Rerank 返回格式错误，响应不是 JSON 对象。")
+
+        results = response_data.get("results", [])
+        if not isinstance(results, list):
+            logger.warning(f"通用 Rerank 返回异常 results 字段: {response_data}")
+            return []
+
+        parsed_results: list[RerankResult] = []
+        for idx, result in enumerate(results):
+            if not isinstance(result, dict):
+                logger.warning(f"通用 Rerank 第 {idx} 个结果格式异常: {result}")
+                continue
+
+            try:
+                result_index = int(result.get("index", idx))
+                relevance_score = float(
+                    result.get("relevance_score", result.get("score", 0.0))
+                )
+            except (TypeError, ValueError) as exc:
+                logger.warning(
+                    f"通用 Rerank 第 {idx} 个结果缺少有效 index 或 score: {result}"
+                )
+                logger.debug("通用 Rerank 结果解析失败", exc_info=exc)
+                continue
+
+            parsed_results.append(
+                RerankResult(
+                    index=result_index,
+                    relevance_score=relevance_score,
+                )
+            )
+
+        if not parsed_results:
+            logger.warning(f"通用 Rerank 返回空结果: {response_data}")
+
+        return parsed_results
+
+    async def rerank(
+        self,
+        query: str,
+        documents: list[str],
+        top_n: int | None = None,
+    ) -> list[RerankResult]:
+        if not documents:
+            return []
+        if not query.strip():
+            logger.warning("通用 Rerank 查询文本为空，返回空结果。")
+            return []
+        if not self.client:
+            logger.error("通用 Rerank 客户端会话已关闭，返回空结果。")
+            return []
+
+        payload = self._build_payload(
+            query=query,
+            documents=self._normalize_documents(documents),
+            top_n=top_n,
+        )
+
+        try:
+            async with self.client.post(self.api_url, json=payload) as response:
+                if response.status >= 400:
+                    response_text = await response.text()
+                    raise RuntimeError(
+                        f"通用 Rerank API 请求失败: HTTP {response.status}, {response_text}"
+                    )
+
+                response_data = await response.json(content_type=None)
+        except aiohttp.ClientError as exc:
+            logger.error(f"通用 Rerank 请求失败: {exc}")
+            raise
+
+        return self._parse_results(response_data)
+
+    async def terminate(self) -> None:
+        if self.client:
+            await self.client.close()
+            self.client = None

--- a/astrbot/core/provider/sources/openai_rerank_source.py
+++ b/astrbot/core/provider/sources/openai_rerank_source.py
@@ -9,6 +9,9 @@ from ..entities import ProviderType, RerankResult
 from ..provider import RerankProvider
 from ..register import register_provider_adapter
 
+DocumentInput = str | Mapping[str, Any]
+NormalizedDocument = str | dict[str, Any]
+
 
 @register_provider_adapter(
     "openai_rerank",
@@ -23,6 +26,8 @@ from ..register import register_provider_adapter
     provider_display_name="通用 Rerank",
 )
 class OpenAIRerankProvider(RerankProvider):
+    _ERROR_RESPONSE_SNIPPET_MAX_CHARS = 200
+
     def __init__(self, provider_config: dict, provider_settings: dict) -> None:
         super().__init__(provider_config, provider_settings)
 
@@ -39,20 +44,21 @@ class OpenAIRerankProvider(RerankProvider):
         if not self.api_key:
             raise ValueError("通用 Rerank API Key 不能为空。")
 
-        self.client = aiohttp.ClientSession(
-            headers={
-                "Authorization": f"Bearer {self.api_key}",
-                "Content-Type": "application/json",
-            },
-            timeout=aiohttp.ClientTimeout(total=self.timeout),
-        )
+        self.client: aiohttp.ClientSession | None = None
+        self.client_headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        self.client_timeout = aiohttp.ClientTimeout(total=self.timeout)
 
         self.set_model(self.model)
         logger.info(f"AstrBot 通用 Rerank 初始化完成。API URL: {self.api_url}")
 
     @staticmethod
-    def _normalize_documents(documents: list[Any]) -> list[str | dict[str, Any]]:
-        normalized_documents: list[str | dict[str, Any]] = []
+    def _normalize_documents(
+        documents: list[DocumentInput],
+    ) -> list[NormalizedDocument]:
+        normalized_documents: list[NormalizedDocument] = []
         for index, document in enumerate(documents):
             if isinstance(document, str):
                 normalized_documents.append(document)
@@ -69,7 +75,7 @@ class OpenAIRerankProvider(RerankProvider):
     def _build_payload(
         self,
         query: str,
-        documents: list[str | dict[str, Any]],
+        documents: list[NormalizedDocument],
         top_n: int | None,
     ) -> dict[str, Any]:
         payload: dict[str, Any] = {
@@ -132,10 +138,25 @@ class OpenAIRerankProvider(RerankProvider):
 
         return parsed_results
 
+    async def _get_client(self) -> aiohttp.ClientSession:
+        if self.client is None or self.client.closed:
+            self.client = aiohttp.ClientSession(
+                headers=self.client_headers,
+                timeout=self.client_timeout,
+            )
+        return self.client
+
+    @classmethod
+    def _truncate_error_response(cls, response_text: str) -> str:
+        snippet = response_text[: cls._ERROR_RESPONSE_SNIPPET_MAX_CHARS]
+        if len(response_text) > cls._ERROR_RESPONSE_SNIPPET_MAX_CHARS:
+            return f"{snippet}...[truncated]"
+        return snippet
+
     async def rerank(
         self,
         query: str,
-        documents: list[str],
+        documents: list[DocumentInput],
         top_n: int | None = None,
     ) -> list[RerankResult]:
         if not documents:
@@ -143,22 +164,25 @@ class OpenAIRerankProvider(RerankProvider):
         if not query.strip():
             logger.warning("通用 Rerank 查询文本为空，返回空结果。")
             return []
-        if not self.client:
-            logger.error("通用 Rerank 客户端会话已关闭，返回空结果。")
-            return []
 
         payload = self._build_payload(
             query=query,
             documents=self._normalize_documents(documents),
             top_n=top_n,
         )
+        client = await self._get_client()
 
         try:
-            async with self.client.post(self.api_url, json=payload) as response:
+            async with client.post(self.api_url, json=payload) as response:
                 if response.status >= 400:
                     response_text = await response.text()
+                    logger.warning(
+                        "通用 Rerank API 请求失败: HTTP %s, body snippet: %s",
+                        response.status,
+                        self._truncate_error_response(response_text),
+                    )
                     raise RuntimeError(
-                        f"通用 Rerank API 请求失败: HTTP {response.status}, {response_text}"
+                        f"通用 Rerank API 请求失败: HTTP {response.status}"
                     )
 
                 response_data = await response.json(content_type=None)

--- a/astrbot/core/provider/sources/openai_rerank_source.py
+++ b/astrbot/core/provider/sources/openai_rerank_source.py
@@ -16,7 +16,7 @@ from ..register import register_provider_adapter
     provider_type=ProviderType.RERANK,
     default_config_tmpl={
         "rerank_api_key": "",
-        "rerank_api_base": "https://api.example.com/v1/rerank",
+        "rerank_api_url": "https://api.example.com/v1/rerank",
         "rerank_model": "",
         "timeout": 30,
     },
@@ -27,7 +27,10 @@ class OpenAIRerankProvider(RerankProvider):
         super().__init__(provider_config, provider_settings)
 
         self.api_key = str(provider_config.get("rerank_api_key", "")).strip()
-        self.api_url = str(provider_config.get("rerank_api_base", "")).strip()
+        self.api_url = str(
+            provider_config.get("rerank_api_url")
+            or provider_config.get("rerank_api_base", "")
+        ).strip()
         self.model = str(provider_config.get("rerank_model", "")).strip()
         self.timeout = int(provider_config.get("timeout", 30))
 

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -1005,8 +1005,12 @@
         "hint": "When enabled, uses xAI Chat Completions native Live Search for web queries (billed on demand). Only applies to xAI providers."
       },
       "rerank_api_base": {
-        "description": "Rerank Model API URL",
-        "hint": "For the generic Rerank / NewAPI-compatible adapter, enter the full request URL (for example, https://api.example.com/v1/rerank); AstrBot will not append /v1/rerank automatically."
+        "description": "Rerank Model API Base URL",
+        "hint": "AstrBot appends /v1/rerank to the request URL."
+      },
+      "rerank_api_url": {
+        "description": "Generic Rerank Full Request URL",
+        "hint": "Only applies to the generic rerank adapter. Enter the full request URL (for example, https://api.example.com/v1/rerank)."
       },
       "rerank_api_key": {
         "description": "API Key",

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -1005,8 +1005,8 @@
         "hint": "When enabled, uses xAI Chat Completions native Live Search for web queries (billed on demand). Only applies to xAI providers."
       },
       "rerank_api_base": {
-        "description": "Rerank Model API Base URL",
-        "hint": "AstrBot appends /v1/rerank to the request URL."
+        "description": "Rerank Model API URL",
+        "hint": "For the generic Rerank / NewAPI-compatible adapter, enter the full request URL (for example, https://api.example.com/v1/rerank); AstrBot will not append /v1/rerank automatically."
       },
       "rerank_api_key": {
         "description": "API Key",

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -1008,8 +1008,8 @@
         "hint": "启用后，将通过 xAI 的 Chat Completions 原生 Live Search 进行联网检索（按需计费）。仅对 xAI 提供商生效。"
       },
       "rerank_api_base": {
-        "description": "重排序模型 API Base URL",
-        "hint": "AstrBot 会在请求时在末尾加上 /v1/rerank。"
+        "description": "重排序模型 API 地址",
+        "hint": "通用 Rerank / NewAPI 兼容接口需填写完整请求 URL（例如 https://api.example.com/v1/rerank）；AstrBot 不会自动补全 /v1/rerank。"
       },
       "rerank_api_key": {
         "description": "API Key",

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -1008,8 +1008,12 @@
         "hint": "启用后，将通过 xAI 的 Chat Completions 原生 Live Search 进行联网检索（按需计费）。仅对 xAI 提供商生效。"
       },
       "rerank_api_base": {
-        "description": "重排序模型 API 地址",
-        "hint": "通用 Rerank / NewAPI 兼容接口需填写完整请求 URL（例如 https://api.example.com/v1/rerank）；AstrBot 不会自动补全 /v1/rerank。"
+        "description": "重排序模型 API Base URL",
+        "hint": "AstrBot 会在请求时在末尾加上 /v1/rerank。"
+      },
+      "rerank_api_url": {
+        "description": "通用 Rerank 完整请求 URL",
+        "hint": "仅对通用 Rerank 适配器生效。请填写完整请求 URL（例如 https://api.example.com/v1/rerank）。"
       },
       "rerank_api_key": {
         "description": "API Key",

--- a/tests/test_openai_rerank_source.py
+++ b/tests/test_openai_rerank_source.py
@@ -1,0 +1,117 @@
+import pytest
+
+from astrbot.core.provider.sources.openai_rerank_source import OpenAIRerankProvider
+
+
+class _MockResponse:
+    def __init__(self, payload: dict, status: int = 200, text: str = ""):
+        self._payload = payload
+        self.status = status
+        self._text = text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def json(self, content_type=None):
+        return self._payload
+
+    async def text(self):
+        return self._text
+
+
+class _MockClient:
+    def __init__(self, response: _MockResponse):
+        self.response = response
+        self.calls: list[tuple[str, dict]] = []
+        self.closed = False
+
+    def post(self, url: str, json: dict):
+        self.calls.append((url, json))
+        return self.response
+
+    async def close(self):
+        self.closed = True
+
+
+def _make_provider(overrides: dict | None = None) -> OpenAIRerankProvider:
+    provider_config = {
+        "id": "test-openai-rerank",
+        "type": "openai_rerank",
+        "rerank_api_key": "test-key",
+        "rerank_api_base": "https://api.example.com/v1/rerank",
+        "rerank_model": "test-model",
+        "timeout": 30,
+    }
+    if overrides:
+        provider_config.update(overrides)
+    return OpenAIRerankProvider(provider_config=provider_config, provider_settings={})
+
+
+def test_init_requires_api_key_and_url():
+    with pytest.raises(ValueError, match="API Key"):
+        _make_provider({"rerank_api_key": ""})
+
+    with pytest.raises(ValueError, match="API URL"):
+        _make_provider({"rerank_api_base": ""})
+
+
+@pytest.mark.asyncio
+async def test_rerank_maps_top_n_to_top_k_and_accepts_object_documents():
+    provider = _make_provider()
+    mock_client = _MockClient(
+        _MockResponse(
+            {
+                "results": [
+                    {"index": 1, "relevance_score": 0.95},
+                    {"index": 0, "relevance_score": "0.52"},
+                ]
+            }
+        )
+    )
+    provider.client = mock_client
+
+    try:
+        results = await provider.rerank(
+            query="astrbot rerank",
+            documents=[
+                "plain text document",
+                {"id": "doc-2", "title": "Title", "content": "Body"},
+            ],
+            top_n=120,
+        )
+    finally:
+        await provider.terminate()
+
+    assert mock_client.calls == [
+        (
+            "https://api.example.com/v1/rerank",
+            {
+                "query": "astrbot rerank",
+                "documents": [
+                    "plain text document",
+                    {"id": "doc-2", "title": "Title", "content": "Body"},
+                ],
+                "model": "test-model",
+                "top_k": 100,
+            },
+        )
+    ]
+    assert [result.index for result in results] == [1, 0]
+    assert [result.relevance_score for result in results] == pytest.approx([0.95, 0.52])
+
+
+@pytest.mark.asyncio
+async def test_rerank_rejects_unsupported_document_types():
+    provider = _make_provider()
+
+    try:
+        with pytest.raises(TypeError, match=r"documents\[0\]"):
+            await provider.rerank(
+                query="astrbot rerank",
+                documents=[123],
+            )
+    finally:
+        await provider.terminate()

--- a/tests/test_openai_rerank_source.py
+++ b/tests/test_openai_rerank_source.py
@@ -41,7 +41,7 @@ def _make_provider(overrides: dict | None = None) -> OpenAIRerankProvider:
         "id": "test-openai-rerank",
         "type": "openai_rerank",
         "rerank_api_key": "test-key",
-        "rerank_api_base": "https://api.example.com/v1/rerank",
+        "rerank_api_url": "https://api.example.com/v1/rerank",
         "rerank_model": "test-model",
         "timeout": 30,
     }
@@ -55,7 +55,7 @@ def test_init_requires_api_key_and_url():
         _make_provider({"rerank_api_key": ""})
 
     with pytest.raises(ValueError, match="API URL"):
-        _make_provider({"rerank_api_base": ""})
+        _make_provider({"rerank_api_url": ""})
 
 
 @pytest.mark.asyncio

--- a/tests/test_openai_rerank_source.py
+++ b/tests/test_openai_rerank_source.py
@@ -115,3 +115,15 @@ async def test_rerank_rejects_unsupported_document_types():
             )
     finally:
         await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_terminate_closes_and_nulls_client():
+    provider = _make_provider()
+    mock_client = _MockClient(_MockResponse({}))
+    provider.client = mock_client
+
+    await provider.terminate()
+
+    assert mock_client.closed is True
+    assert provider.client is None


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

新增一个面向 NewAPI 兼容 Rerank 接口的通用重排序供应商适配器，用于解决当前缺少可复用通用适配器的问题。

主要解决以下场景：

- 用户需要直接填写完整的重排序请求地址
- 使用 Bearer Token 进行认证
- 请求体与返回结果兼容 NewAPI 风格

同时修正了配置文案，明确说明这里需要填写完整请求 URL，AstrBot 不会自动在末尾补全 `/v1/rerank`。

### Modifications / 改动点

<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- 在 `astrbot/core/provider/sources/openai_rerank_source.py` 中新增通用 Rerank 适配器实现
- 在 `astrbot/core/provider/manager.py` 中注册新的 Rerank 供应商
- 在 `astrbot/core/config/default.py` 中补充默认配置模板，并更新重排序相关配置提示文案
- 更新前端i18n文案：
  - `dashboard/src/i18n/locales/zh-CN/features/config-metadata.json`
  - `dashboard/src/i18n/locales/en-US/features/config-metadata.json`
- 在 `tests/test_openai_rerank_source.py` 中补充定向测试

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

验证步骤：

启动填写过后点击测试

测试结果：

<img width="1941" height="1432" alt="image" src="https://github.com/user-attachments/assets/953640a6-af56-4795-996f-b5a260025eec" />
<img width="1649" height="609" alt="image" src="https://github.com/user-attachments/assets/b14d6189-b66d-4342-81c2-ef37a3a3b1cd" />
<img width="3281" height="1788" alt="image" src="https://github.com/user-attachments/assets/d672b49c-5c99-4315-b6b4-a121fdd162f3" />
<img width="1351" height="810" alt="image" src="https://github.com/user-attachments/assets/bf342867-6790-4841-a498-052653e226aa" />

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。/ My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.

## Summary by Sourcery

Add a generic rerank provider adapter compatible with NewAPI-style rerank endpoints and wire it into the providerManager and default configuration.

New Features:
- Introduce a generic OpenAI-style rerank provider adapter that calls arbitrary NewAPI-compatible rerank HTTP endpoints using Bearer token authentication.

Enhancements:
- Extend default provider configuration templates to include a generic rerank provider with explicit URL-based configuration.
- Clarify rerank configuration metadata and hints, including the requirement to specify the full rerank request URL and support for the new generic adapter.
- Register the new generic rerank provider type in the dynamic provider manager for runtime loading.

Documentation:
- Update dashboard i18n configuration metadata in both Chinese and English to reflect the new generic rerank option and revised URL hint text.

Tests:
- Add unit tests for the generic rerank provider covering initialization validation, payload construction and result parsing, document type handling, and client termination behavior.