### PR TITLE
fix: convert non-WAV audio to PCM WAV before silk encoding

### DIFF
--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -22,7 +22,7 @@ from astrbot.api.message_components import File, Image, Plain, Record, Video
 from astrbot.api.platform import AstrBotMessage, PlatformMetadata
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
 from astrbot.core.utils.io import download_image_by_url, file_to_base64
-from astrbot.core.utils.tencent_record_helper import wav_to_tencent_silk
+from astrbot.core.utils.tencent_record_helper import convert_to_pcm_wav, wav_to_tencent_silk
 
 
 def _patch_qq_botpy_formdata() -> None:
@@ -602,8 +602,18 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                 image_base64 = image_base64.removeprefix("base64://")
             elif isinstance(i, Record):
                 if i.file:
-                    record_wav_path = await i.convert_to_file_path()  # wav 路径
+                    record_audio_path = await i.convert_to_file_path()
                     temp_dir = get_astrbot_temp_path()
+                    # 如果不是 WAV 格式，先转换为 PCM WAV
+                    ext = os.path.splitext(record_audio_path)[1].lower()
+                    if ext != ".wav":
+                        record_wav_path = os.path.join(
+                            temp_dir,
+                            f"qqofficial_{uuid.uuid4()}.wav",
+                        )
+                        await convert_to_pcm_wav(record_audio_path, record_wav_path)
+                    else:
+                        record_wav_path = record_audio_path
                     record_tecent_silk_path = os.path.join(
                         temp_dir,
                         f"qqofficial_{uuid.uuid4()}.silk",

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -3,6 +3,7 @@ import base64
 import os
 import random
 import uuid
+import wave
 from typing import cast
 
 import aiofiles
@@ -43,6 +44,50 @@ def _patch_qq_botpy_formdata() -> None:
 
 
 _patch_qq_botpy_formdata()
+
+
+_TENCENT_PCM_RATES = (8000, 12000, 16000, 24000, 32000, 44100, 48000)
+
+
+def _normalize_tencent_pcm_rate(rate: int) -> int:
+    """Map an arbitrary sample rate to the nearest Tencent-compatible rate."""
+
+    return min(_TENCENT_PCM_RATES, key=lambda candidate: abs(candidate - rate))
+
+
+def _is_tencent_ready_wav(file_path: str) -> bool:
+    """Return whether a WAV file already matches QQ official voice requirements.
+
+    The Tencent silk encoder can accept several sample rates, but the input still
+    needs to be mono, 16-bit PCM. Merely checking the `.wav` suffix is not
+    sufficient because plugins may export 44.1kHz/stereo WAV files, which can lead
+    to slowed-down, lower-pitched playback after silk conversion.
+    """
+
+    try:
+        with wave.open(file_path, "rb") as wav_file:
+            return (
+                wav_file.getframerate() in _TENCENT_PCM_RATES
+                and wav_file.getnchannels() == 1
+                and wav_file.getsampwidth() == 2
+                and wav_file.getcomptype() == "NONE"
+            )
+    except (OSError, wave.Error) as exc:
+        logger.warning(f"[QQOfficial] 读取 WAV 参数失败，将重新转换: {file_path}, {exc}")
+        return False
+
+
+def _get_tencent_target_rate(file_path: str) -> int:
+    """Choose the least-destructive re-encode sample rate for Tencent voice."""
+
+    try:
+        with wave.open(file_path, "rb") as wav_file:
+            return _normalize_tencent_pcm_rate(wav_file.getframerate())
+    except (OSError, wave.Error) as exc:
+        logger.warning(
+            f"[QQOfficial] 读取 WAV 采样率失败，回退到 24000Hz: {file_path}, {exc}"
+        )
+        return 24000
 
 
 class QQOfficialMessageEvent(AstrMessageEvent):
@@ -604,14 +649,29 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                 if i.file:
                     record_audio_path = await i.convert_to_file_path()
                     temp_dir = get_astrbot_temp_path()
-                    # 如果不是 WAV 格式，先转换为 PCM WAV
+                    # 统一确保输入给 silk 编码器的是受支持采样率的单声道 16-bit PCM WAV。
+                    # 仅凭 `.wav` 扩展名无法保证规格正确，立体声 WAV 会导致 QQ 语音变慢变沉。
                     ext = os.path.splitext(record_audio_path)[1].lower()
-                    if ext != ".wav":
+                    if ext != ".wav" or not _is_tencent_ready_wav(record_audio_path):
                         record_wav_path = os.path.join(
                             temp_dir,
                             f"qqofficial_{uuid.uuid4()}.wav",
                         )
-                        await convert_to_pcm_wav(record_audio_path, record_wav_path)
+                        target_rate = (
+                            _get_tencent_target_rate(record_audio_path)
+                            if ext == ".wav"
+                            else 24000
+                        )
+                        if ext == ".wav":
+                            logger.info(
+                                "[QQOfficial] 检测到非标准 WAV，正在重新标准化: "
+                                f"{record_audio_path} -> {target_rate}Hz mono PCM"
+                            )
+                        await convert_to_pcm_wav(
+                            record_audio_path,
+                            record_wav_path,
+                            sample_rate=target_rate,
+                        )
                     else:
                         record_wav_path = record_audio_path
                     record_tecent_silk_path = os.path.join(

--- a/astrbot/core/utils/tencent_record_helper.py
+++ b/astrbot/core/utils/tencent_record_helper.py
@@ -60,15 +60,24 @@ async def wav_to_tencent_silk(wav_path: str, output_path: str) -> int:
         return duration
 
 
-async def convert_to_pcm_wav(input_path: str, output_path: str) -> str:
-    """将 MP3 或其他音频格式转换为 PCM 16bit WAV，采样率24000Hz，单声道。
+async def convert_to_pcm_wav(
+    input_path: str, output_path: str, sample_rate: int = 24000
+) -> str:
+    """将音频转换为 PCM 16bit WAV，单声道。
+
+    默认采样率为 24000Hz，以保持现有调用方行为不变；对于 QQ 官方语音等
+    场景，可显式传入更高的受支持采样率，以减少不必要的音质损失。
     若转换失败则抛出异常。
     """
     try:
         from pyffmpeg import FFmpeg
 
         ff = FFmpeg()
-        ff.convert(input_file=input_path, output_file=output_path)
+        ff.options(
+            f"-y -i \"{input_path}\" -acodec pcm_s16le -ar {sample_rate} -ac 1 "
+            f"-af apad=pad_dur=2 -fflags +genpts -hide_banner \"{output_path}\""
+        )
+        ff.run()
     except Exception as e:
         logger.debug(f"pyffmpeg 转换失败: {e}, 尝试使用 ffmpeg 命令行进行转换")
 
@@ -80,7 +89,7 @@ async def convert_to_pcm_wav(input_path: str, output_path: str) -> str:
             "-acodec",
             "pcm_s16le",
             "-ar",
-            "24000",
+            str(sample_rate),
             "-ac",
             "1",
             "-af",

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ python-telegram-bot>=22.6
 qq-botpy>=1.2.1
 quart>=0.20.0
 readability-lxml>=0.8.4.1
+pilk>=0.2.4
 silk-python>=0.2.6
 slack-sdk>=3.35.0
 sqlalchemy[asyncio]>=2.0.41


### PR DESCRIPTION
## Summary

- `Record.convert_to_file_path()` 返回的音频文件不一定是 WAV 格式（可能是 MP3、silk 等），但 `wav_to_tencent_silk()` 中 `wave.open()` 要求文件必须是 WAV 格式（以 RIFF 头开始），导致 `file does not start with RIFF id` 错误
- 在调用 `wav_to_tencent_silk` 之前，检查文件扩展名，如果不是 `.wav` 则先通过 `convert_to_pcm_wav()` 转换为 PCM WAV 格式
- 添加缺失的 `pilk` 依赖到 `requirements.txt`

## Test plan

- [ ] 使用 QQ 官方平台发送非 WAV 格式的语音消息（如 MP3），验证不再报错
- [ ] 使用 QQ 官方平台发送 WAV 格式的语音消息，验证正常工作不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle non-WAV voice messages by converting them to PCM WAV before Silk encoding in QQ official platform integration.

Bug Fixes:
- Prevent errors when encoding non-WAV audio by converting input recordings to PCM WAV format before passing them to the Silk encoder.

Build:
- Add the missing pilk dependency required for audio format conversion to the project requirements.