### PR TITLE
fix(shell): handle encoding issues on Windows for shell commands

### DIFF
--- a/astrbot/core/computer/tools/shell.py
+++ b/astrbot/core/computer/tools/shell.py
@@ -65,11 +65,17 @@ class ExecuteShellTool(FunctionTool):
                 result = await sb.shell.exec(command, background=background, env=env)
                 return json.dumps(result)
             except Exception as e:
-                return f"Error executing background command: {str(e)}"
+                return json.dumps(
+                    {
+                        "stdout": None,
+                        "stderr": f"Error executing background command: {str(e)}",
+                        "exit_code": -1,
+                    }
+                )
 
         # For foreground sync commands, handle locally with proper encoding
         try:
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
 
             def run_subprocess():
                 proc = subprocess.Popen(
@@ -80,8 +86,18 @@ class ExecuteShellTool(FunctionTool):
                     text=True,
                     encoding="utf-8",
                     errors="replace",  # Handle encoding errors gracefully
+                    env=env if env else None,
                 )
-                stdout, stderr = proc.communicate()
+                try:
+                    stdout, stderr = proc.communicate(timeout=300)  # 5 minute timeout
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    stdout, stderr = proc.communicate()
+                    return {
+                        "stdout": stdout,
+                        "stderr": f"{stderr}\nCommand timed out after 300 seconds",
+                        "exit_code": -1,
+                    }
                 return {
                     "stdout": stdout,
                     "stderr": stderr,


### PR DESCRIPTION
Fixes #6027

## Problem

On Windows, shell commands with non-ASCII characters in output would fail due to encoding issues. The default encoding was not UTF-8, causing `UnicodeDecodeError` when reading skill files with Chinese characters.

### Error Example
```
UnicodeDecodeError: 'gbk' codec can't decode byte 0xXX in position XX
```

## Solution

For foreground synchronous commands, use `subprocess.Popen` with explicit UTF-8 encoding and `errors='replace'` to handle encoding errors gracefully.

### Changes

1. Add `asyncio` and `subprocess` imports
2. For foreground commands:
   - Use `subprocess.Popen` with `encoding='utf-8'` and `errors='replace'`
   - Run in thread pool to avoid blocking event loop
3. Background commands still delegate to booter for remote execution

### Credit

Fix provided by issue reporter in #6027.

## Testing

- Windows: Shell commands with Chinese characters now work correctly
- Linux/macOS: No change in behavior

## Summary by Sourcery

Handle foreground shell command execution locally with UTF-8-aware subprocess handling while keeping background commands delegated to the booter.

Bug Fixes:
- Fix Windows shell command failures caused by non-UTF-8 output encoding and resulting UnicodeDecodeError exceptions.

Enhancements:
- Standardize foreground shell command results into a JSON-serializable structure including stdout, stderr, and exit_code, even on error.