### PR TITLE
fix(pipeline): skip @ mention for cron-triggered messages to avoid Get Uid Error

### DIFF
--- a/astrbot/core/cron/events.py
+++ b/astrbot/core/cron/events.py
@@ -63,5 +63,9 @@ class CronMessageEvent(AstrMessageEvent):
         async for chain in generator:
             await self.send(chain)
 
+    def can_be_mentioned(self) -> bool:
+        """Cron events have a synthetic sender and cannot be @-mentioned."""
+        return False
+
 
 __all__ = ["CronMessageEvent"]

--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -5,7 +5,6 @@ import traceback
 from collections.abc import AsyncGenerator
 
 from astrbot.core import file_token_service, html_renderer, logger
-from astrbot.core.cron.events import CronMessageEvent
 from astrbot.core.message.components import At, Image, Node, Plain, Record, Reply
 from astrbot.core.message.message_event_result import ResultContentType
 from astrbot.core.pipeline.content_safety_check.stage import ContentSafetyCheckStage
@@ -393,9 +392,7 @@ class ResultDecorateStage(Stage):
                 if (
                     self.reply_with_mention
                     and event.get_message_type() != MessageType.FRIEND_MESSAGE
-                    and not isinstance(
-                        event, CronMessageEvent
-                    )  # Skip @ mention for cron events
+                    and event.can_be_mentioned()
                 ):
                     result.chain.insert(
                         0,

--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -393,7 +393,9 @@ class ResultDecorateStage(Stage):
                 if (
                     self.reply_with_mention
                     and event.get_message_type() != MessageType.FRIEND_MESSAGE
-                    and not isinstance(event, CronMessageEvent)  # Skip @ mention for cron events
+                    and not isinstance(
+                        event, CronMessageEvent
+                    )  # Skip @ mention for cron events
                 ):
                     result.chain.insert(
                         0,

--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -5,6 +5,7 @@ import traceback
 from collections.abc import AsyncGenerator
 
 from astrbot.core import file_token_service, html_renderer, logger
+from astrbot.core.cron.events import CronMessageEvent
 from astrbot.core.message.components import At, Image, Node, Plain, Record, Reply
 from astrbot.core.message.message_event_result import ResultContentType
 from astrbot.core.pipeline.content_safety_check.stage import ContentSafetyCheckStage
@@ -392,6 +393,7 @@ class ResultDecorateStage(Stage):
                 if (
                     self.reply_with_mention
                     and event.get_message_type() != MessageType.FRIEND_MESSAGE
+                    and not isinstance(event, CronMessageEvent)  # Skip @ mention for cron events
                 ):
                     result.chain.insert(
                         0,

--- a/astrbot/core/platform/astr_message_event.py
+++ b/astrbot/core/platform/astr_message_event.py
@@ -467,3 +467,12 @@ class AstrMessageEvent(abc.ABC):
 
         - aiocqhttp(OneBotv11)
         """
+
+    def can_be_mentioned(self) -> bool:
+        """Whether the sender of this event can be @-mentioned in a reply.
+
+        Returns:
+            True if the sender can be mentioned (default), False otherwise.
+            Override in subclasses for events with synthetic senders.
+        """
+        return True


### PR DESCRIPTION
Fixes #5888

## Problem

When 'reply_with_mention' is enabled and a cron job triggers a message to a group chat, the system tries to @ mention the sender. However, cron events use a synthetic sender ID (e.g., `c0442716f164495d9444d5161e2217f1`) which is not a real QQ number, causing 'Get Uid Error' when the platform tries to resolve it.

### Error Example
```
[Core] [ERRO] Get Uid Error
```

### Root Cause

In `result_decorate/stage.py`, when `reply_with_mention` is True, the system adds:
```python
At(qq=event.get_sender_id(), name=event.get_sender_name())
```

For `CronMessageEvent`, `get_sender_id()` returns a synthetic ID, not a real QQ number.

## Solution

Add a check to skip @ mention when the event is a `CronMessageEvent`:

```python
if (
    self.reply_with_mention
    and event.get_message_type() != MessageType.FRIEND_MESSAGE
    and not isinstance(event, CronMessageEvent)  # Skip @ mention for cron events
):
```

## Changes

- Import `CronMessageEvent` in `result_decorate/stage.py`
- Add check to skip @ mention when event is `CronMessageEvent`

## Testing

- Normal group messages: @ mention still works when `reply_with_mention` is enabled
- Cron-triggered messages: No more 'Get Uid Error', messages sent successfully without @ mention

## Summary by Sourcery

Bug Fixes:
- Skip adding @ mentions when handling cron-triggered message events so synthetic sender IDs no longer cause UID lookup failures.