### PR TITLE
fix(provider): improve error message for MCP tool race condition

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -530,7 +530,9 @@ class ProviderOpenAIOfficial(Provider):
                         break
                 if not tool_found:
                     # Handle both object and string tool calls
-                    if hasattr(tool_call, "function") and hasattr(tool_call.function, "name"):
+                    if hasattr(tool_call, "function") and hasattr(
+                        tool_call.function, "name"
+                    ):
                         unhandled_tool_calls.append(tool_call.function.name)
                     else:
                         unhandled_tool_calls.append(str(tool_call))

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -498,6 +498,7 @@ class ProviderOpenAIOfficial(Provider):
             func_name_ls = []
             tool_call_ids = []
             tool_call_extra_content_dict = {}
+            unhandled_tool_calls = []
             for tool_call in choice.message.tool_calls:
                 if isinstance(tool_call, str):
                     # workaround for #1359
@@ -506,6 +507,7 @@ class ProviderOpenAIOfficial(Provider):
                     # 工具集未提供
                     # Should be unreachable
                     raise Exception("工具集未提供")
+                tool_found = False
                 for tool in tools.func_list:
                     if (
                         tool_call.type == "function"
@@ -524,6 +526,15 @@ class ProviderOpenAIOfficial(Provider):
                         extra_content = getattr(tool_call, "extra_content", None)
                         if extra_content is not None:
                             tool_call_extra_content_dict[tool_call.id] = extra_content
+                        tool_found = True
+                        break
+                if not tool_found:
+                    unhandled_tool_calls.append(tool_call.function.name)
+            if unhandled_tool_calls:
+                logger.warning(
+                    f"Tool calls not found in registered tools: {unhandled_tool_calls}. "
+                    f"This may be a race condition if MCP tools are still loading."
+                )
             llm_response.role = "tool"
             llm_response.tools_call_args = args_ls
             llm_response.tools_call_name = func_name_ls
@@ -535,6 +546,18 @@ class ProviderOpenAIOfficial(Provider):
                 "API 返回的 completion 由于内容安全过滤被拒绝(非 AstrBot)。",
             )
         if llm_response.completion_text is None and not llm_response.tools_call_args:
+            if choice.message.tool_calls and tools is not None:
+                # Tool calls were present but no matching tools found
+                tool_names = [tc.function.name for tc in choice.message.tool_calls]
+                logger.error(
+                    f"Tool calls requested but no matching tools found in func_list. "
+                    f"Requested: {tool_names}, Available: {[t.name for t in tools.func_list]}. "
+                    f"This may be a race condition - MCP tools may still be loading."
+                )
+                raise Exception(
+                    f"AI requested tools that are not yet available: {tool_names}. "
+                    f"Please wait a few seconds after startup before sending messages."
+                )
             logger.error(f"API 返回的 completion 无法解析：{completion}。")
             raise Exception(f"API 返回的 completion 无法解析：{completion}。")
 

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -529,11 +529,17 @@ class ProviderOpenAIOfficial(Provider):
                         tool_found = True
                         break
                 if not tool_found:
-                    unhandled_tool_calls.append(tool_call.function.name)
-            if unhandled_tool_calls:
+                    # Handle both object and string tool calls
+                    if hasattr(tool_call, "function") and hasattr(tool_call.function, "name"):
+                        unhandled_tool_calls.append(tool_call.function.name)
+                    else:
+                        unhandled_tool_calls.append(str(tool_call))
+            # Only log warning if some tools were processed successfully
+            # (avoid redundant logging when error will be raised shortly)
+            if unhandled_tool_calls and args_ls:
                 logger.warning(
-                    f"Tool calls not found in registered tools: {unhandled_tool_calls}. "
-                    f"This may be a race condition if MCP tools are still loading."
+                    f"Some tool calls were not found in registered tools: {unhandled_tool_calls}. "
+                    f"This may indicate that MCP tools are still loading or failed to load."
                 )
             llm_response.role = "tool"
             llm_response.tools_call_args = args_ls
@@ -548,11 +554,16 @@ class ProviderOpenAIOfficial(Provider):
         if llm_response.completion_text is None and not llm_response.tools_call_args:
             if choice.message.tool_calls and tools is not None:
                 # Tool calls were present but no matching tools found
-                tool_names = [tc.function.name for tc in choice.message.tool_calls]
+                tool_names = []
+                for tc in choice.message.tool_calls:
+                    if hasattr(tc, "function") and hasattr(tc.function, "name"):
+                        tool_names.append(tc.function.name)
+                    else:
+                        tool_names.append(str(tc))
                 logger.error(
                     f"Tool calls requested but no matching tools found in func_list. "
                     f"Requested: {tool_names}, Available: {[t.name for t in tools.func_list]}. "
-                    f"This may be a race condition - MCP tools may still be loading."
+                    f"MCP tools may still be loading."
                 )
                 raise Exception(
                     f"AI requested tools that are not yet available: {tool_names}. "


### PR DESCRIPTION
Fixes #5530

## Problem

When AstrBot starts up and a message is sent immediately (within 1-2 seconds), MCP tools may not have finished loading. If the AI tries to call a tool that doesn't exist in `func_list` yet, it causes:

```
Exception: API 返回的 completion 无法解析：ChatCompletion(...)
```

This error message is confusing and doesn't explain the root cause.

### Root Cause

Race condition:
1. AstrBot starts
2. User sends message immediately
3. AI returns tool_calls for MCP tools
4. MCP tools haven't finished loading into `func_list`
5. No matching tools found → `tools_call_args` is empty → generic error

## Solution

Improve error handling and messaging:

1. Track tool calls that don't match registered tools
2. Log warning when tool calls can't be matched
3. Provide clearer error message explaining the race condition
4. Suggest user wait a few seconds after startup

### Changes

```python
# Track unhandled tool calls
unhandled_tool_calls = []
for tool_call in choice.message.tool_calls:
    tool_found = False
    for tool in tools.func_list:
        if tool.name == tool_call.function.name:
            # ... process tool ...
            tool_found = True
            break
    if not tool_found:
        unhandled_tool_calls.append(tool_call.function.name)

# Log warning
if unhandled_tool_calls:
    logger.warning(
        f"Tool calls not found in registered tools: {unhandled_tool_calls}. "
        f"This may be a race condition if MCP tools are still loading."
    )

# Better error message
if llm_response.completion_text is None and not llm_response.tools_call_args:
    if choice.message.tool_calls and tools is not None:
        tool_names = [tc.function.name for tc in choice.message.tool_calls]
        raise Exception(
            f"AI requested tools that are not yet available: {tool_names}. "
            f"Please wait a few seconds after startup before sending messages."
        )
```

## Testing

- Before: Generic "无法解析" error
- After: Clear message explaining tools not yet available + suggestion to wait

## Summary by Sourcery

Improve handling of OpenAI tool call responses when MCP tools are not yet loaded to surface clearer race-condition errors instead of a generic completion parse failure.

Bug Fixes:
- Detect and report the case where the AI requests tools that are not yet registered due to MCP startup race conditions, replacing the generic 'completion cannot be parsed' error.

Enhancements:
- Track unmatched tool calls, logging warnings and detailed error information about missing tools and available tool names to aid debugging of MCP tool loading issues.