### PR TITLE
Fix core dependency constraint blocking compatible plugin upgrades

### DIFF
--- a/astrbot/core/utils/core_constraints.py
+++ b/astrbot/core/utils/core_constraints.py
@@ -80,9 +80,14 @@ def _get_core_constraints(core_dist_name: str | None) -> tuple[str, ...]:
                 continue
             name = canonicalize_distribution_name(req.name)
             if name in installed:
-                # Use >= instead of == so plugins can pull in newer compatible
-                # versions while still preventing downgrades below what's installed.
-                constraints.append(f"{name}>={installed[name]}")
+                ver = installed[name]
+                try:
+                    next_major = int(str(ver).split(".")[0]) + 1
+                except (ValueError, TypeError):
+                    constraints.append(f"{name}=={ver}")
+                else:
+                    # Allow compatible upgrades but block next major version
+                    constraints.append(f"{name}>={ver},<{next_major}")
         except Exception:
             continue
 

--- a/astrbot/core/utils/core_constraints.py
+++ b/astrbot/core/utils/core_constraints.py
@@ -80,7 +80,9 @@ def _get_core_constraints(core_dist_name: str | None) -> tuple[str, ...]:
                 continue
             name = canonicalize_distribution_name(req.name)
             if name in installed:
-                constraints.append(f"{name}=={installed[name]}")
+                # Use >= instead of == so plugins can pull in newer compatible
+                # versions while still preventing downgrades below what's installed.
+                constraints.append(f"{name}>={installed[name]}")
         except Exception:
             continue
 

--- a/astrbot/core/utils/core_constraints.py
+++ b/astrbot/core/utils/core_constraints.py
@@ -6,6 +6,7 @@ import os
 from collections.abc import Iterator
 
 from packaging.requirements import Requirement
+from packaging.version import InvalidVersion, Version
 
 from astrbot.core.utils.requirements_utils import (
     canonicalize_distribution_name,
@@ -82,12 +83,20 @@ def _get_core_constraints(core_dist_name: str | None) -> tuple[str, ...]:
             if name in installed:
                 ver = installed[name]
                 try:
-                    next_major = int(str(ver).split(".")[0]) + 1
-                except (ValueError, TypeError):
+                    parsed_version = Version(ver)
+                except InvalidVersion:
                     constraints.append(f"{name}=={ver}")
                 else:
                     # Allow compatible upgrades but block next major version
-                    constraints.append(f"{name}>={ver},<{next_major}")
+                    next_major = parsed_version.major + 1
+                    upper_bound = (
+                        f"{parsed_version.epoch}!{next_major}"
+                        if parsed_version.epoch
+                        else str(next_major)
+                    )
+                    constraints.append(
+                        f"{name}>={parsed_version.public},<{upper_bound}"
+                    )
         except Exception:
             continue
 

--- a/tests/test_pip_helper_modules.py
+++ b/tests/test_pip_helper_modules.py
@@ -21,8 +21,20 @@ def test_requirements_utils_parse_package_install_input_collects_specs_and_names
     assert parsed.requirement_names == {"demo-package", "another-package"}
 
 
-def test_core_constraints_provider_writes_constraints_file_from_fallback_distribution(
+@pytest.mark.parametrize(
+    ("installed_version", "expected_constraint"),
+    [
+        ("2.4.1", "shared-lib>=2.4.1,<3"),
+        ("v4.2.0rc1", "shared-lib>=4.2.0rc1,<5"),
+        ("1!2.3", "shared-lib>=1!2.3,<1!3"),
+        ("2.4.1+linux.1", "shared-lib>=2.4.1,<3"),
+        ("not-a-version", "shared-lib==not-a-version"),
+    ],
+)
+def test_core_constraints_provider_writes_installed_version_range(
     monkeypatch,
+    installed_version,
+    expected_constraint,
 ):
     class FakeFallbackDistribution:
         metadata = {"Name": "AstrBot-App"}
@@ -59,7 +71,7 @@ def test_core_constraints_provider_writes_constraints_file_from_fallback_distrib
     monkeypatch.setattr(
         core_constraints_module,
         "collect_installed_distribution_versions",
-        lambda paths: {"shared-lib": "2.0"},
+        lambda paths: {"shared-lib": installed_version},
     )
 
     core_constraints_module._get_core_constraints.cache_clear()
@@ -68,7 +80,8 @@ def test_core_constraints_provider_writes_constraints_file_from_fallback_distrib
         with provider.constraints_file() as constraints_path:
             assert constraints_path is not None
             assert (
-                Path(constraints_path).read_text(encoding="utf-8") == "shared-lib==2.0"
+                Path(constraints_path).read_text(encoding="utf-8")
+                == expected_constraint
             )
     finally:
         core_constraints_module._get_core_constraints.cache_clear()

--- a/tests/test_pip_installer.py
+++ b/tests/test_pip_installer.py
@@ -533,8 +533,8 @@ def test_get_core_constraints_caches_fallback_resolution(monkeypatch):
     finally:
         core_constraints_module._get_core_constraints.cache_clear()
 
-    assert first == ("shared-lib==2.0",)
-    assert second == ("shared-lib==2.0",)
+    assert first == ("shared-lib>=2.0,<3",)
+    assert second == ("shared-lib>=2.0,<3",)
     assert distribution_calls == ["AstrBot", "AstrBot-App"]
     assert distributions_calls == ["scan"]
 
@@ -596,7 +596,7 @@ def test_get_core_constraints_skips_distributions_with_unreadable_top_level(
     finally:
         core_constraints_module._get_core_constraints.cache_clear()
 
-    assert constraints == ("shared-lib==2.0",)
+    assert constraints == ("shared-lib>=2.0,<3",)
 
 
 def test_core_constraints_file_propagates_inner_conflict_without_fake_warning(


### PR DESCRIPTION
## Problem

The core dependency protection mechanism pins dependencies to the exact installed version using `==`:

```python
constraints.append(f"{name}=={installed[name]}")  # e.g. aiosqlite==0.21.0
```

This prevents plugins from installing newer compatible versions. For example, a plugin requiring `aiosqlite>=0.22.1` fails with:

```
DependencyConflictError: 检测到核心依赖版本保护冲突。
冲突详情: aiosqlite>=0.22.1 vs (constraint) aiosqlite==0.21.0
```

Even though `0.22.1 >= 0.21.0` and is backward-compatible.

## Fix

Change `==` to `>=` in the constraint generation:

```python
constraints.append(f"{name}>={installed[name]}")  # e.g. aiosqlite>=0.21.0
```

This preserves the protection against downgrades (plugins can't install older versions than what's running) while allowing compatible upgrades.

Fixes #6420

## Summary by Sourcery

Bug Fixes:
- Allow plugins to install newer compatible versions of core dependencies by changing exact version pinning to a minimum-version constraint.