### PR TITLE
fix: only pass dimensions when explicitly configured in embedding config

### DIFF
--- a/astrbot/core/provider/sources/openai_embedding_source.py
+++ b/astrbot/core/provider/sources/openai_embedding_source.py
@@ -65,7 +65,9 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
             try:
                 kwargs["dimensions"] = int(self.provider_config["embedding_dimensions"])
             except (ValueError, TypeError):
-                logger.warning(f"配置中的 embedding_dimensions 值无效: '{self.provider_config['embedding_dimensions']}'，已忽略。")
+                logger.warning(
+                    f"embedding_dimensions in embedding configs is not a valid integer: '{self.provider_config['embedding_dimensions']}', ignored."
+                )
         return kwargs
 
     def get_dim(self) -> int:
@@ -74,7 +76,9 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
             try:
                 return int(self.provider_config["embedding_dimensions"])
             except (ValueError, TypeError):
-                logger.warning(f"配置中的 embedding_dimensions 值无效: '{self.provider_config['embedding_dimensions']}'")
+                logger.warning(
+                    f"embedding_dimensions in embedding configs is not a valid integer: '{self.provider_config['embedding_dimensions']}', ignored."
+                )
         return 0
 
     async def terminate(self):


### PR DESCRIPTION
## 问题

使用不支持 `dimensions` 参数的嵌入模型（如 bge-m3）时，OpenAI embedding 接口返回 HTTP 400 错误。

原因是 `get_embedding` / `get_embeddings` 始终传递 `dimensions` 参数，即使用户没有配置 `embedding_dimensions`，也会传递默认值 1024。

## 修复

仅在用户显式配置了 `embedding_dimensions` 时才在请求中包含 `dimensions` 参数。未配置时不传递该参数，让模型使用其默认维度。

Closes #6421

Signed-off-by: JiangNan <1394485448@qq.com>

## Summary by Sourcery

Bug Fixes:
- Avoid sending a default dimensions value in OpenAI embedding requests when embedding_dimensions is not explicitly configured, allowing models to use their native dimensions.