### PR TITLE
Fix 修正shell工具未正确应用工具调用超时的问题

### DIFF
--- a/astrbot/core/computer/tools/shell.py
+++ b/astrbot/core/computer/tools/shell.py
@@ -61,10 +61,10 @@ class ExecuteShellTool(FunctionTool):
             config = context.context.context.get_config(
                 umo=context.context.event.unified_msg_origin
             )
-            timeout = config.get("provider_settings", {}).get("tool_call_timeout", 30)
-            # 将timeout转为int
-            timeout = int(timeout)
-
+            try:
+                timeout = int(config.get("provider_settings", {}).get("tool_call_timeout", 30))
+            except (ValueError, TypeError):
+                timeout = 30
             result = await sb.shell.exec(
                 command, background=background, env=env, timeout=timeout
             )


### PR DESCRIPTION
某些特殊技能脚本可能需要更长的执行时间 且需要将执行结果实时返回给LLM(如使用yt-dlp库在youtube上抓取字幕 该库在游客身份下获取字幕列表后 必须等待60秒才能够进行字幕下载 否则会报429错误)
该PR对shell工具引入了工具调用超时参数 使其能够正确接收工具调用超时设置而非硬编码的30秒
修改自PR(#6076)

### Modifications / 改动点

修改文件:`astrbot/core/computer/tools/shell.py`
1. 修改`call`方法中的`sb.shell.exec`调用 传入系统配置(tool_call_timeout)

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。
  / If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.

- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。
  / My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.

- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
  / I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.

- [x] 😮 我的更改没有引入恶意代码。
  / My changes do not introduce malicious code.

- [x] ⚠️ 我已认真阅读并理解以上所有内容，确保本次提交符合规范。
  / I have read and understood all the above and confirm this PR follows the rules.

- [x] 🚀 我确保本次开发**基于 dev 分支**，并将代码合并至**开发分支**（除非极其紧急，才允许合并到主分支）。
   / I confirm that this development is **based on the dev branch** and will be merged into the **development branch**, unless it is extremely urgent to merge into the main branch.

- [ ] ⚠️ 我**没有**认真阅读以上内容，直接提交。
  / I **did not** read the above carefully before submitting.

## Summary by Sourcery

Bug Fixes:
- Use the provider_settings.tool_call_timeout configuration value for shell tool executions, falling back to 30 seconds if not set.