### PR TITLE
feat: Add OpenRouter chat completion provider adapter with custom header

### DIFF
--- a/astrbot/core/provider/sources/openrouter_source.py
+++ b/astrbot/core/provider/sources/openrouter_source.py
@@ -16,4 +16,7 @@ class ProviderOpenRouter(ProviderOpenAIOfficial):
         self.client._custom_headers["HTTP-Referer"] = (  # type: ignore
             "https://github.com/AstrBotDevs/AstrBot"
         )
-        self.client._custom_headers["X-TITLE"] = "AstrBot"  # type: ignore
+        self.client._custom_headers["X-OpenRouter-Title"] = "AstrBot"  # type: ignore
+        self.client._custom_headers["X-OpenRouter-Categories"] = (
+            "general-chat,personal-agent"  # type: ignore
+        )


### PR DESCRIPTION
Update OpenRouter attribution headers to use the new `X-OpenRouter-Title` header (replacing the deprecated `X-Title`) and add `X-OpenRouter-Categories` header for marketplace categorization.

Reference: https://openrouter.ai/docs/app-attribution

### Modifications / 改动点

- Updated `X-TITLE` to `X-OpenRouter-Title` in `astrbot/core/provider/sources/openrouter_source.py` to align with the latest OpenRouter API specification. The old `X-Title` header still works but is deprecated.
- Added `X-OpenRouter-Categories: general-chat,personal-agent` header to enable AstrBot to appear in the [OpenRouter Marketplace](https://openrouter.ai/apps) under the correct category groups.

With these headers properly set, AstrBot will be eligible to appear on:
- [OpenRouter Rankings](https://openrouter.ai/rankings) (daily/weekly/monthly leaderboards)
- Individual model pages' "Apps" tabs
- [OpenRouter Marketplace](https://openrouter.ai/apps) under the Productivity category

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Code change is minimal and only adds HTTP headers to outgoing requests. Verified with `ruff format` and `ruff check` — all checks passed.

```diff
- self.client._custom_headers["X-TITLE"] = "AstrBot"
+ self.client._custom_headers["X-OpenRouter-Title"] = "AstrBot"
+ self.client._custom_headers["X-OpenRouter-Categories"] = "general-chat,personal-agent"
```

---

### Checklist / 检查清单

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。
  / If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.

- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。
  / My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.

- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
  / I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.

- [x] 😮 我的更改没有引入恶意代码。
  / My changes do not introduce malicious code.

- [x] ⚠️ 我已认真阅读并理解以上所有内容，确保本次提交符合规范。
  / I have read and understood all the above and confirm this PR follows the rules.

- [x] 🚀 我确保本次开发**基于 dev 分支**，并将代码合并至**开发分支**（除非极其紧急，才允许合并到主分支）。
   / I confirm that this development is **based on the dev branch** and will be merged into the **development branch**, unless it is extremely urgent to merge into the main branch.

- [ ] ⚠️ 我**没有**认真阅读以上内容，直接提交。
  / I **did not** read the above carefully before submitting.

## Summary by Sourcery

Update OpenRouter chat provider attribution headers to align with the latest OpenRouter app marketplace requirements.

Enhancements:
- Replace deprecated X-TITLE header with X-OpenRouter-Title for OpenRouter attribution.
- Add X-OpenRouter-Categories header so AstrBot is correctly categorized and eligible for OpenRouter marketplace and rankings visibility.