### PR TITLE
fix: 将上游空回复纳入回退重试并将空回复报错显示传递给用户

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -15,10 +15,12 @@ from mcp.types import (
     TextResourceContents,
 )
 
+import astrbot.core.message.components as Comp
 from astrbot import logger
 from astrbot.core.agent.message import ImageURLPart, TextPart, ThinkPart
 from astrbot.core.agent.tool import ToolSet
 from astrbot.core.agent.tool_image_cache import tool_image_cache
+from astrbot.core.exceptions import LLMEmptyResponseError
 from astrbot.core.message.components import Json
 from astrbot.core.message.message_event_result import (
     MessageChain,
@@ -219,6 +221,41 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
         else:
             yield await self.provider.text_chat(**payload)
 
+    def _is_empty_llm_response(self, resp: LLMResponse) -> bool:
+        """Check if an LLM response is effectively empty.
+
+        This heuristic checks:
+        - completion_text is empty or whitespace only
+        - reasoning_content is empty or whitespace only
+        - tools_call_args is empty (no tool calls)
+        - result_chain has no meaningful content (Plain components with non-empty text,
+          or any non-Plain components like images, voice, etc.)
+
+        Returns True if the response contains no meaningful content.
+        """
+        completion_text_stripped = (resp.completion_text or "").strip()
+        reasoning_content_stripped = (resp.reasoning_content or "").strip()
+
+        # Check result_chain for meaningful non-empty content (e.g., images, non-empty text)
+        has_result_chain_content = False
+        if resp.result_chain and resp.result_chain.chain:
+            for comp in resp.result_chain.chain:
+                # Skip empty Plain components
+                if isinstance(comp, Comp.Plain):
+                    if comp.text and comp.text.strip():
+                        has_result_chain_content = True
+                        break
+                else:
+                    # Non-Plain components (e.g., images, voice) are considered valid content
+                    has_result_chain_content = True
+                    break
+
+        return (
+            not completion_text_stripped
+            and not reasoning_content_stripped
+            and not resp.tools_call_args
+            and not has_result_chain_content
+        )
     async def _iter_llm_responses_with_fallback(
         self,
     ) -> T.AsyncGenerator[LLMResponse, None]:
@@ -241,11 +278,25 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             has_stream_output = False
             try:
                 async for resp in self._iter_llm_responses(include_model=idx == 0):
+                    # 对于流式 chunk，不立即检查是否为空，因为单个 chunk 可能只是元数据/心跳
+                    # 流式响应的最终结果会在 resp.is_chunk=False 时返回
                     if resp.is_chunk:
                         has_stream_output = True
                         yield resp
                         continue
-
+                    # 如果回复为空且无工具调用 且不是最后一个回退渠道 则引发fallback
+                    # 此处不应判断整个消息链是否为空 因为消息链包含整个对话流 而空回复可能发生在任何阶段
+                    # 使用辅助函数检查是否为空回复
+                    if (
+                        (resp.role == "assistant" or resp.role == "tool")
+                        and self._is_empty_llm_response(resp)
+                        and not is_last_candidate
+                    ):
+                        logger.warning(
+                            "Chat Model %s returns empty response, trying fallback to next provider.",
+                            candidate_id,
+                        )
+                        break
                     if (
                         resp.role == "err"
                         and not has_stream_output
@@ -504,6 +555,25 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 logger.warning(
                     "LLM returned empty assistant message with no tool calls."
                 )
+                # 若所有fallback使用完毕后依然为空回复 则显示执行报错 避免静默
+                base_msg = "LLM returned empty assistant message with no tool calls."
+                model_id = getattr(self.run_context, "model_id", None)
+                provider_id = getattr(self.run_context, "provider_id", None)
+                run_id = getattr(self.run_context, "run_id", None)
+
+                ctx_parts = []
+                if model_id is not None:
+                    ctx_parts.append(f"model_id={model_id}")
+                if provider_id is not None:
+                    ctx_parts.append(f"provider_id={provider_id}")
+                if run_id is not None:
+                    ctx_parts.append(f"run_id={run_id}")
+
+                if ctx_parts:
+                    base_msg = f"{base_msg} Context: " + ", ".join(ctx_parts) + "."
+
+                raise LLMEmptyResponseError(base_msg)
+
             self.run_context.messages.append(Message(role="assistant", content=parts))
 
             # call the on_agent_done hook

--- a/astrbot/core/exceptions.py
+++ b/astrbot/core/exceptions.py
@@ -7,3 +7,7 @@ class AstrBotError(Exception):
 
 class ProviderNotFoundError(AstrBotError):
     """Raised when a specified provider is not found."""
+
+
+class LLMEmptyResponseError(AstrBotError):
+    """Raised when LLM returns an empty assistant message with no tool calls."""


### PR DESCRIPTION
fix:将上游空回复纳入回退重试并将空回复报错显示传递给用户
PR(#5610)的分散提交

### Modifications / 改动点

修改文件:`astrbot\core\agent\runners\tool_loop_agent_runner.py`

1. 增加空回复判断辅助函数_is_empty_llm_response
在_iter_llm_responses_with_fallback方法中的async for resp in self._iter_llm_responses(include_model=idx == 0)循环中使用_is_empty_llm_response来判断回复是否合法 并在不合法时触发回退机制

2. 为`LLM returned empty assistant message with no tool calls.`警告增加自定义的错误提醒 避免静默 让用户能够及时了解到模型执行结果 避免无意义的等待

修改文件:`astrbot\core\exceptions.py`

1. 增加了一个`LLMEmptyResponseError`自定义错误 以表示空回复

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Handle empty LLM responses by triggering provider fallback and surfacing explicit errors to users when all fallbacks are exhausted.

Bug Fixes:
- Treat upstream empty LLM responses without tool calls as failures that trigger fallback to the next provider.
- Raise a dedicated error when all fallback providers return empty assistant messages so users are informed instead of experiencing silent timeouts.

Enhancements:
- Introduce a helper to detect effectively empty LLM responses based on text, reasoning content, tool calls, and result chain content.
- Add a specific LLMEmptyResponseError exception to represent empty LLM replies with contextual metadata in the error message.