### PR TITLE
feat:新增本地图片预压缩机制 避免原图体积过大造成的413错误(已作废)

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -4,11 +4,14 @@ import asyncio
 import base64
 import copy
 import datetime
+import io
 import json
 import os
 import zoneinfo
 from collections.abc import Coroutine
 from dataclasses import dataclass, field
+
+from PIL import Image as PILImage
 
 from astrbot.core import logger, sp
 from astrbot.core.agent.handoff import HandoffTool
@@ -1190,9 +1193,6 @@ async def _compress_image_internal(url_or_path: str) -> str:
                 data = f.read()
         if not data:
             return url_or_path
-        import io
-
-        from PIL import Image as PILImage
 
         img = PILImage.open(io.BytesIO(data))
         if img.mode in ("RGBA", "P"):


### PR DESCRIPTION
feat:新增本地图片预压缩机制 避免用户向agent发送手机原图 体积过大造成的413错误
fix:增强 `_ensure_img_caption` 的容错性避免解析图片失败时造成的框架整体性崩溃

### Modifications / 改动点

修改文件:`astrbot\core\astr_main_agent.py`

新增`_compress_image_internal`函数 用于对传入的本地图片进行压缩 原样返回远程图片url
1. 在`_ensure_img_caption`函数中引入新增的压缩函数
2. 在`_process_quote_message`函数中引入新增的函数

fix: 增强 `_ensure_img_caption` 的容错性避免解析图片失败时造成的框架整体性崩溃:
1. 修改`_ensure_img_caption`函数 增加finally块并清空image_urls  避免处理错误时导致的框架整体性崩溃

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Introduce local image pre-compression and improve robustness of image caption handling to prevent failures from large or invalid images.

New Features:
- Add an internal image compression helper to downscale and recompress large local images before sending them for captioning or LLM processing, while leaving remote image URLs unchanged.

Bug Fixes:
- Harden image caption generation by clearing image URLs and appending a fallback text message when caption processing fails, avoiding cascading framework crashes.