### PR TITLE
fix: 人格(persona)在创建新对话时无法正确继承的问题

### DIFF
--- a/astrbot/builtin_stars/builtin_commands/commands/conversation.py
+++ b/astrbot/builtin_stars/builtin_commands/commands/conversation.py
@@ -146,9 +146,11 @@ class ConversationCommands:
         session_curr_cid = await conv_mgr.get_curr_conversation_id(umo)
 
         if not session_curr_cid:
+            persona_id = await conv_mgr.get_current_persona_id(umo)
             session_curr_cid = await conv_mgr.new_conversation(
                 umo,
                 message.get_platform_id(),
+                persona_id=persona_id,
             )
 
         contexts, total_pages = await conv_mgr.get_human_readable_context(

--- a/astrbot/builtin_stars/session_controller/main.py
+++ b/astrbot/builtin_stars/session_controller/main.py
@@ -64,9 +64,13 @@ class Main(Star):
                                 )
                             else:
                                 # 创建新对话
+                                persona_id = await self.context.conversation_manager.get_current_persona_id(
+                                    event.unified_msg_origin
+                                )
                                 curr_cid = await self.context.conversation_manager.new_conversation(
                                     event.unified_msg_origin,
                                     platform_id=event.get_platform_id(),
+                                    persona_id=persona_id,
                                 )
 
                             # 使用 LLM 生成回复

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -177,10 +177,16 @@ async def _get_session_conv(
     umo = event.unified_msg_origin
     cid = await conv_mgr.get_curr_conversation_id(umo)
     if not cid:
-        cid = await conv_mgr.new_conversation(umo, event.get_platform_id())
+        persona_id = await conv_mgr.get_current_persona_id(umo)
+        cid = await conv_mgr.new_conversation(
+            umo, event.get_platform_id(), persona_id=persona_id
+        )
     conversation = await conv_mgr.get_conversation(umo, cid)
     if not conversation:
-        cid = await conv_mgr.new_conversation(umo, event.get_platform_id())
+        persona_id = await conv_mgr.get_current_persona_id(umo)
+        cid = await conv_mgr.new_conversation(
+            umo, event.get_platform_id(), persona_id=persona_id
+        )
         conversation = await conv_mgr.get_conversation(umo, cid)
     if not conversation:
         raise RuntimeError("无法创建新的对话。")

--- a/astrbot/core/conversation_mgr.py
+++ b/astrbot/core/conversation_mgr.py
@@ -173,6 +173,22 @@ class ConversationManager:
                 self.session_conversations[unified_msg_origin] = ret
         return ret
 
+    async def get_current_persona_id(self, unified_msg_origin: str) -> str | None:
+        """获取当前对话的persona_id，用于创建新对话时继承。
+
+        Args:
+            unified_msg_origin: 统一的消息来源字符串
+
+        Returns:
+            当前对话的persona_id，如果没有或为"[%None]"则返回None
+        """
+        curr_cid = await self.get_curr_conversation_id(unified_msg_origin)
+        if curr_cid:
+            conv = await self.db.get_conversation_by_id(cid=curr_cid)
+            if conv and conv.persona_id and conv.persona_id != "[%None]":
+                return conv.persona_id
+        return None
+
     async def get_conversation(
         self,
         unified_msg_origin: str,
@@ -192,7 +208,10 @@ class ConversationManager:
         conv = await self.db.get_conversation_by_id(cid=conversation_id)
         if not conv and create_if_not_exists:
             # 如果对话不存在且需要创建，则新建一个对话
-            conversation_id = await self.new_conversation(unified_msg_origin)
+            persona_id = await self.get_current_persona_id(unified_msg_origin)
+            conversation_id = await self.new_conversation(
+                unified_msg_origin, persona_id=persona_id
+            )
             conv = await self.db.get_conversation_by_id(cid=conversation_id)
         conv_res = None
         if conv:

--- a/astrbot/core/pipeline/session_status_check/stage.py
+++ b/astrbot/core/pipeline/session_status_check/stage.py
@@ -29,9 +29,13 @@ class SessionStatusCheckStage(Stage):
                 event.unified_msg_origin,
             )
             if not conv_id:
+                persona_id = await self.conv_mgr.get_current_persona_id(
+                    event.unified_msg_origin
+                )
                 await self.conv_mgr.new_conversation(
                     event.unified_msg_origin,
                     platform_id=event.get_platform_id(),
+                    persona_id=persona_id,
                 )
 
             event.stop_event()


### PR DESCRIPTION
## Summary

- 添加 `get_current_persona_id()` 方法到 `ConversationManager`，用于获取当前对话的 `persona_id`
- 修改所有 `new_conversation()` 调用点，在创建新对话时传递 `persona_id` 参数实现人格继承
- 支持 `[%None]` 特殊标记，当用户明确清除人格时不继承

## 修复场景

- ✅ 执行 `/new` 命令创建新对话时人格丢失
- ✅ 自动压缩历史上下文时人格丢失  
- ✅ 首次发送消息创建对话时人格丢失
- ✅ 会话被关闭后重新创建对话时人格丢失

## 技术细节

### 新增方法
```python
async def get_current_persona_id(self, unified_msg_origin: str) -> str | None:
    """获取当前对话的persona_id，用于创建新对话时继承。"""
    curr_cid = await self.get_curr_conversation_id(unified_msg_origin)
    if curr_cid:
        conv = await self.db.get_conversation_by_id(cid=curr_cid)
        if conv and conv.persona_id and conv.persona_id != "[%None]":
            return conv.persona_id
    return None
```

### 修改的文件
- `astrbot/core/conversation_mgr.py` - 添加辅助方法和修改内部调用
- `astrbot/core/astr_main_agent.py` - `_get_session_conv()` 函数
- `astrbot/builtin_stars/builtin_commands/commands/conversation.py` - `his()` 方法
- `astrbot/builtin_stars/session_controller/main.py` - `handle_empty_mention()` 方法
- `astrbot/core/pipeline/session_status_check/stage.py` - `process()` 方法

### 人格优先级
创建新对话时的优先级：
1. 当前对话的人格（`conversation.persona_id`）← 继承逻辑
2. 如果为 `[%None]` 或不存在 → `NULL`

## Test Plan

- [ ] 场景1：正常继承 - 用户在对话A中执行 `/persona psychologist`，然后执行 `/new`，新对话B的 `persona_id` 应为 `"psychologist"`
- [ ] 场景2：清除人格后不继承 - 用户在对话A中执行 `/persona none`，然后执行 `/new`，新对话B的 `persona_id` 应为 `NULL`
- [ ] 场景3：首次创建对话 - 新用户首次发送消息，创建的对话 `persona_id` 应为 `NULL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure conversations inherit the correct persona when new sessions are created from existing ones, while respecting explicit persona clearing.

Bug Fixes:
- Preserve the active persona when creating a new conversation implicitly or via commands instead of defaulting to no persona.
- Avoid inheriting personas that have been explicitly cleared by treating the special "[%None]" marker as absence of persona.

Enhancements:
- Add a helper on the conversation manager to fetch the current conversation's persona for reuse when creating new conversations across the codebase.