### PR TITLE
fix: SQLite 'database is locked' under concurrent writes

### DIFF
--- a/astrbot/core/db/__init__.py
+++ b/astrbot/core/db/__init__.py
@@ -33,10 +33,18 @@ class BaseDatabase(abc.ABC):
     DATABASE_URL = ""
 
     def __init__(self) -> None:
+        # SQLite only supports a single writer at a time.  Without a busy
+        # timeout the driver raises "database is locked" instantly when a
+        # second write is attempted.  Setting timeout=30 tells SQLite to
+        # wait up to 30 s for the lock, which is enough to ride out brief
+        # write bursts from concurrent agent/metrics/session operations.
+        is_sqlite = "sqlite" in self.DATABASE_URL
+        connect_args = {"timeout": 30} if is_sqlite else {}
         self.engine = create_async_engine(
             self.DATABASE_URL,
             echo=False,
             future=True,
+            connect_args=connect_args,
         )
         self.AsyncSessionLocal = async_sessionmaker(
             self.engine,


### PR DESCRIPTION
## Problem

AstrBot frequently hits `(sqlite3.OperationalError) database is locked` when multiple async operations (agent responses, metrics inserts, session updates) write to SQLite concurrently. This affects both Windows and Linux deployments and is especially noticeable after importing personas or during rapid conversations.

## Root Cause

`create_async_engine()` in `BaseDatabase.__init__` doesn't set a busy timeout:

```python
self.engine = create_async_engine(
    self.DATABASE_URL,
    echo=False,
    future=True,
    # no connect_args → SQLite default timeout is 5s (or 0 depending on driver)
)
```

SQLite only supports one writer at a time. Without a timeout, the second concurrent write fails immediately instead of waiting for the lock to be released.

## Fix

Add `connect_args={"timeout": 30}` for SQLite engines. This tells the driver to wait up to 30 seconds for the write lock before raising an error — more than enough to handle the typical concurrent write bursts.

Combined with the existing WAL journal mode (set in `SQLiteDatabase.initialize()`), this provides concurrent reads + serialized writes with proper backpressure.

Fixes #6443

## Summary by Sourcery

Bug Fixes:
- Prevent frequent `sqlite3.OperationalError: database is locked` errors during concurrent SQLite writes by adding a busy timeout to async engine creation.