### PR TITLE
修复切换页面或直连URL时被重置为第一个会话 和一些小問題

### DIFF
--- a/dashboard/src/composables/useSessions.ts
+++ b/dashboard/src/composables/useSessions.ts
@@ -33,56 +33,32 @@ export function useSessions(chatboxMode: boolean = false) {
      // 進入chat 會先執行這個  舊版發生一些小問題導致一定會跑到 第一頁面
     async function getSessions() {
         try {
-            const response = await axios.get('/api/chat/sessions');
-            sessions.value = response.data.data;
-    
-            const routeId = route.params.id as string;
-    
-            // 🥇 1. pending（最高優先）
-            if (pendingSessionId.value) {
-                const session = sessions.value.find(s => s.session_id === pendingSessionId.value);
-                if (session) {
-                    currSessionId.value = pendingSessionId.value;
-                    selectedSessions.value = [pendingSessionId.value];
-                    pendingSessionId.value = null;
-                    return;
-                }
-            }
-    
-            // 🥈 2. URL（關鍵🔥）
-            if (routeId) {
-                const session = sessions.value.find(s => s.session_id === routeId);
-                if (session) {
-                    currSessionId.value = routeId;
-                    selectedSessions.value = [routeId];
-                    return;
-                }
-            }
-    
-            // 🥉 3. 已有 currSessionId
-            if (currSessionId.value) {
-                const session = sessions.value.find(s => s.session_id === currSessionId.value);
-                if (session) {
-                    selectedSessions.value = [currSessionId.value];
-                    return;
-                }
-            }
-    
-            // 🧨 4. fallback（最後才用）
-            if (sessions.value.length > 0) {
-                const firstSession = sessions.value[0];
-                currSessionId.value = firstSession.session_id;
-                selectedSessions.value = [firstSession.session_id];
-            }
-    
+          const response = await axios.get('/api/chat/sessions');
+          sessions.value = response.data.data;
+      
+          const sessionId = resolveSessionId(sessions.value, {
+            pendingId: pendingSessionId.value,
+            routeId: route.params.id as string,
+            currentId: currSessionId.value
+          });
+      
+          if (!sessionId) return;
+      
+          currSessionId.value = sessionId;
+          selectedSessions.value = [sessionId];
+      
+          // 清掉 pending（只在用到時）
+          if (sessionId === pendingSessionId.value) {
+            pendingSessionId.value = null;
+          }
+      
         } catch (err: any) {
-            if (err.response?.status === 401) {
-                router.push('/auth/login?redirect=/chatbox');
-            }
-            console.error(err);
+          if (err.response?.status === 401) {
+            router.push('/auth/login?redirect=/chatbox');
+          }
+          console.error(err);
         }
     }
-
     async function newSession() {
         try {
             const selectedConfigId = getStoredSelectedChatConfigId();
@@ -242,6 +218,33 @@ export function useSessions(chatboxMode: boolean = false) {
         if (closeMobileSidebar) {
             closeMobileSidebar();
         }
+    }
+    function resolveSessionId(
+        sessions: any[],
+        options: {
+          pendingId?: string | null;
+          routeId?: string;
+          currentId?: string;
+        }
+      ): string | null {
+        const { pendingId, routeId, currentId } = options;
+      
+        const exists = (id?: string | null) =>
+          id && sessions.some(s => s.session_id === id);
+      
+        // 🥇 pending
+        if (exists(pendingId)) return pendingId!;
+      
+        // 🥈 route
+        if (exists(routeId)) return routeId!;
+      
+        // 🥉 current
+        if (exists(currentId)) return currentId!;
+      
+        // 🧨 fallback
+        if (sessions.length > 0) return sessions[0].session_id;
+      
+        return null;
     }
 
     return {

--- a/dashboard/src/layouts/full/vertical-header/VerticalHeader.vue
+++ b/dashboard/src/layouts/full/vertical-header/VerticalHeader.vue
@@ -417,25 +417,23 @@ const viewMode = computed({
 // 监听 viewMode 变化，切换到 bot 模式时跳转到首页
 // 保存 bot 模式的最後路由
 // 監聽 route 變化，保存最後一次 bot 路由
-watch(() => route.fullPath, (newPath) => {
+watch(() => route.fullPath, () => {
   if (typeof window === 'undefined') return;
 
   try {
-    const isChatRoute = newPath.startsWith('/chat');
+    const isChatRoute = route.path.startsWith('/chat');
 
-    // ✅ bot：只存「非 chat 頁」
+    // 🟦 bot：存完整 path
     if (!isChatRoute) {
-      localStorage.setItem(LAST_BOT_ROUTE_KEY, newPath);
+      localStorage.setItem(LAST_BOT_ROUTE_KEY, route.fullPath);
+      return;
     }
 
-    // ✅ chat：只存 sessionId
-    if (isChatRoute) {
-      const parts = newPath.split('/');
-      const sessionId = parts[2];
+    // 🟩 chat：存 sessionId（用 params！）
+    const sessionId = route.params.id as string | undefined;
 
-      if (sessionId) {
-        localStorage.setItem(LAST_CHAT_ROUTE_KEY, sessionId);
-      }
+    if (sessionId) {
+      localStorage.setItem(LAST_CHAT_ROUTE_KEY, sessionId);
     }
 
   } catch (e) {

--- a/dashboard/src/router/MainRoutes.ts
+++ b/dashboard/src/router/MainRoutes.ts
@@ -146,7 +146,7 @@ const MainRoutes = {
     // },
     {
       name: 'Chat',
-      path: '/chat',
+      path: '/chat/:id',
       component: () => import('@/views/ChatPage.vue'),
       children: [
         {


### PR DESCRIPTION
暫時修復
假設
http://localhost:3001/#/chat/dff272e8-884a-469d-a015-f19a336d4807
為對話1
http://localhost:3001/#/chat/320d5478-7d28-4bc0-b8bc-333df1f8c9e1
為對話2
連結輸入
http://localhost:3001/#/chat/320d5478-7d28-4bc0-b8bc-333df1f8c9e1
會被強制導航 對話1
http://localhost:3001/#/chat/dff272e8-884a-469d-a015-f19a336d4807

並暫時修復
BOT頁面時 輸入http://localhost:3001/#/chat/dff272e8-884a-469d-a015-f19a336d4807
切換CHAT頁面 會存到不該存的chat 頁面

Modifications / 改动点
修改AstrBot\dashboard\src\layouts\full\vertical-header\VerticalHeader.vue
新增const LAST_CHAT_ROUTE_KEY = 'astrbot:last_chat_route'; 紀錄上次 chat頁面

修改AstrBot\dashboard\src\composables\useSessions.ts
使其能夠接受直鏈網址的參數 而非強制導航到第一對話

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
![QQ20260317-123728](https://github.com/user-attachments/assets/fa109432-33de-4ecc-9687-67740b81e2df)

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Preserve and restore the correct chat or bot page when switching view modes or opening chats via direct URLs, avoiding unwanted resets to the first session.

Bug Fixes:
- Respect chat session IDs from the URL when loading sessions instead of always defaulting to the first session.
- Prevent bot view navigation state from being polluted by chat routes when switching between bot and chat views.

Enhancements:
- Persist and reuse the last visited chat session ID and bot route in localStorage to restore user context when toggling between bot and chat views.
- Improve session selection logic to consistently resolve the active session from pending, route, or current IDs with a safe fallback.
- Update chat routing to use a parameterized path (`/chat/:id`) to support direct linking to specific sessions.