### PR TITLE
修复: persona老旧povider逻辑

### DIFF
--- a/astrbot/builtin_stars/builtin_commands/commands/persona.py
+++ b/astrbot/builtin_stars/builtin_commands/commands/persona.py
@@ -50,6 +50,14 @@ class PersonaCommands:
 
         return lines
 
+    def _get_persona_by_id(self, persona_id: str) -> "Persona | None":
+        if not persona_id:
+            return None
+        return next(
+            (p for p in self.context.persona_manager.personas if p.persona_id == persona_id),
+            None,
+        )
+
     async def persona(self, message: AstrMessageEvent) -> None:
         l = message.message_str.split(" ")  # noqa: E741
         umo = message.unified_msg_origin
@@ -149,23 +157,19 @@ class PersonaCommands:
 
             msg = "\n".join(lines)
             message.set_result(MessageEventResult().message(msg).use_t2i(False))
+            
         elif l[1] == "view":
             if len(l) == 2:
                 message.set_result(MessageEventResult().message("请输入人格情景名"))
                 return
             ps = l[2].strip()
-            if persona := next(
-                builtins.filter(
-                    lambda p: p.persona_id == ps, # 替换字典取值
-                    self.context.persona_manager.personas, # 替换错误的数据源
-                ),
-                None,
-            ):
+            if persona := self._get_persona_by_id(ps):
                 msg = f"人格{ps}的详细信息：\n"
-                msg += f"{persona.system_prompt}\n" # 替换字典取值 prompt -> system_prompt
+                msg += f"{persona.system_prompt}\n"
             else:
                 msg = f"人格{ps}不存在"
             message.set_result(MessageEventResult().message(msg))
+            
         elif l[1] == "unset":
             if not cid:
                 message.set_result(
@@ -177,6 +181,7 @@ class PersonaCommands:
                 "[%None]",
             )
             message.set_result(MessageEventResult().message("取消人格成功。"))
+            
         else:
             ps = "".join(l[1:]).strip()
             if not cid:
@@ -186,13 +191,7 @@ class PersonaCommands:
                     ),
                 )
                 return
-            if persona := next(
-                builtins.filter(
-                    lambda p: p.persona_id == ps, # 替换字典取值
-                    self.context.persona_manager.personas, # 替换错误的数据源
-                ),
-                None,
-            ):
+            if persona := self._get_persona_by_id(ps):
                 await self.context.conversation_manager.update_conversation_persona_id(
                     message.unified_msg_origin,
                     ps,

--- a/astrbot/builtin_stars/builtin_commands/commands/persona.py
+++ b/astrbot/builtin_stars/builtin_commands/commands/persona.py
@@ -156,13 +156,13 @@ class PersonaCommands:
             ps = l[2].strip()
             if persona := next(
                 builtins.filter(
-                    lambda persona: persona["name"] == ps,
-                    self.context.provider_manager.personas,
+                    lambda p: p.persona_id == ps, # 替换字典取值
+                    self.context.persona_manager.personas, # 替换错误的数据源
                 ),
                 None,
             ):
                 msg = f"人格{ps}的详细信息：\n"
-                msg += f"{persona['prompt']}\n"
+                msg += f"{persona.system_prompt}\n" # 替换字典取值 prompt -> system_prompt
             else:
                 msg = f"人格{ps}不存在"
             message.set_result(MessageEventResult().message(msg))
@@ -188,8 +188,8 @@ class PersonaCommands:
                 return
             if persona := next(
                 builtins.filter(
-                    lambda persona: persona["name"] == ps,
-                    self.context.provider_manager.personas,
+                    lambda p: p.persona_id == ps, # 替换字典取值
+                    self.context.persona_manager.personas, # 替换错误的数据源
                 ),
                 None,
             ):


### PR DESCRIPTION
```markdown
修复了 `/persona` 指令（如查看详情、切换人格等）失效的问题。之前的代码仍在使用过时的数据源和 Dict 字典获取逻辑，导致无法正确匹配新版本下的人格对象模型。

### Modifications / 改动点

主要修改了核心命令文件 `astrbot/builtin_stars/builtin_commands/commands/persona.py`：
1. **数据源修正**：将获取人格的逻辑由 `self.context.provider_manager.personas` 更正为使用最新的 `self.context.persona_manager.personas`。
2. **对象结构适配**：适配了新版 Persona 数据库对象结构，将原先的字典取值逻辑（获取 `name` 和 `prompt`）重构为规范的对象属性访问（使用 `p.persona_id` 和 `p.system_prompt`）。

**具体代码修改逻辑对比如下：**

```python
# ❌ 修改前 (旧逻辑)
# if persona := next(
#    builtins.filter(
#         lambda persona: persona["name"] == ps,
#         self.context.provider_manager.personas, 
#     ),
#     None,
# ):
#     # ...
#     msg += f"{persona['prompt']}\n"

# ✅ 修改后 (新逻辑)
if persona := next(
    builtins.filter(
        lambda p: p.persona_id == ps, # 替换为对象属性访问
        self.context.persona_manager.personas, # 替换为正确的数据源
    ),
    None,
):
    # ...
    msg += f"{persona.system_prompt}\n" # 替换为对象属性 system_prompt
```

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

已在本地编写测试脚本进行验证，证明新版逻辑可以直接安全地访问对象属性并读取正确的全量数据。以下是验证成功的日志截图：

```log
[15:19:00.373] [Core] [INFO] [core.event_bus:59]: [default] [webchat(webchat)] feifei/feifei: /test_persona a
[15:19:00.376] [Core] [INFO] [respond.stage:184]: Prepare to send - feifei/feifei: 🔍 **全字段透视测试** (目标: a)
━━━━━━━━━━━━━━━━━━
❌ **老版本格式 (Dict 字典)**
{'prompt': '23tgrgfwefwsdncbhfg', 'name': 'a', 'begin_dialogs': [], 'mood_imitation_dialogs': [], 'tools': None, 'skills': None, '_begin_dialogs_processed': [], '_mood_imitation_dialogs_processed': ''}

✅ **新版本格式 (Persona 数据库对象全字段)**
{
  "updated_at": "2026-03-16 12:11:26.232145",
  "system_prompt": "23tgrgfwefwsdncbhfg",
  "id": "1",
  "tools": "None",
  "folder_id": "None",
  "persona_id": "a",
  "created_at": "2026-03-16 12:11:26.232145",
  "begin_dialogs": "[]",
  "skills": "None",
  "sort_order": "0"
}

[15:19:14.136] [Core] [INFO] [core.event_bus:59]: [default] [webchat(webchat)] feifei/feifei: /verify_persona a
[15:19:14.141] [Core] [INFO] [respond.stage:184]: Prepare to send - feifei/feifei: ✅ **最新逻辑验证成功！** 找到了人格: a
━━━━━━━━━━━━━━━━━━
🎯 **对象属性直接访问测试**:
• persona_id: a
• system_prompt: 23tgrgfwefwsdncbhfg
• tools: None

📦 **完整底层数据读取**:
{
  "updated_at": "2026-03-16 12:11:26.232145",
  "system_prompt": "23tgrgfwefwsdncbhfg",
  "id": "1",
  "tools": "None",
  "folder_id": "None",
  "persona_id": "a",
  "created_at": "2026-03-16 12:11:26.232145",
  "begin_dialogs": "[]",
  "skills": "None",
  "sort_order": "0"
}

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。
```

## Summary by Sourcery

Bug Fixes:
- Restore /persona subcommands such as viewing details and switching personas by using the correct persona manager and matching on the current persona object fields instead of outdated dict-based data.