### PR TITLE
perf(dashboard): 配置 UI 支持 Embedding/Rerank Provider 选择器 （特别是用于插件）

### DIFF
--- a/dashboard/src/components/shared/ConfigItemRenderer.vue
+++ b/dashboard/src/components/shared/ConfigItemRenderer.vue
@@ -10,6 +10,12 @@
     <template v-else-if="itemMeta?._special === 'select_provider_tts'">
       <ProviderSelector :model-value="modelValue" @update:model-value="emitUpdate" :provider-type="'text_to_speech'" />
     </template>
+    <template v-else-if="itemMeta?._special === 'select_provider_embedding'">
+      <ProviderSelector :model-value="modelValue" @update:model-value="emitUpdate" :provider-type="'embedding'" />
+    </template>
+    <template v-else-if="itemMeta?._special === 'select_provider_rerank'">
+      <ProviderSelector :model-value="modelValue" @update:model-value="emitUpdate" :provider-type="'rerank'" />
+    </template>
     <template v-else-if="itemMeta?._special === 'select_providers'">
       <ProviderSelector
         :model-value="modelValue"

--- a/dashboard/src/components/shared/ConfigItemRenderer.vue
+++ b/dashboard/src/components/shared/ConfigItemRenderer.vue
@@ -1,20 +1,9 @@
 <template>
   <div class="w-100">
     <!-- Special handling for specific metadata types -->
-    <template v-if="itemMeta?._special === 'select_provider'">
-      <ProviderSelector :model-value="modelValue" @update:model-value="emitUpdate" :provider-type="'chat_completion'" />
-    </template>
-    <template v-else-if="itemMeta?._special === 'select_provider_stt'">
-      <ProviderSelector :model-value="modelValue" @update:model-value="emitUpdate" :provider-type="'speech_to_text'" />
-    </template>
-    <template v-else-if="itemMeta?._special === 'select_provider_tts'">
-      <ProviderSelector :model-value="modelValue" @update:model-value="emitUpdate" :provider-type="'text_to_speech'" />
-    </template>
-    <template v-else-if="itemMeta?._special === 'select_provider_embedding'">
-      <ProviderSelector :model-value="modelValue" @update:model-value="emitUpdate" :provider-type="'embedding'" />
-    </template>
-    <template v-else-if="itemMeta?._special === 'select_provider_rerank'">
-      <ProviderSelector :model-value="modelValue" @update:model-value="emitUpdate" :provider-type="'rerank'" />
+    <!-- _special 值到 provider 类型的映射，详见 script 中的 specialProviderMap -->
+    <template v-if="specialProviderMap[itemMeta?._special]">
+      <ProviderSelector :model-value="modelValue" @update:model-value="emitUpdate" :provider-type="specialProviderMap[itemMeta?._special]" />
     </template>
     <template v-else-if="itemMeta?._special === 'select_providers'">
       <ProviderSelector
@@ -240,6 +229,15 @@ import KnowledgeBaseSelector from './KnowledgeBaseSelector.vue'
 import PluginSetSelector from './PluginSetSelector.vue'
 import T2ITemplateEditor from './T2ITemplateEditor.vue'
 import { useI18n, useModuleI18n } from '@/i18n/composables'
+
+// _special 值到 provider 类型的映射表，新增 provider 类型时在此添加
+const specialProviderMap = {
+  'select_provider': 'chat_completion',
+  'select_provider_stt': 'speech_to_text',
+  'select_provider_tts': 'text_to_speech',
+  'select_provider_embedding': 'embedding',
+  'select_provider_rerank': 'rerank',
+}
 
 const props = defineProps({
   modelValue: {


### PR DESCRIPTION
#6495
当前 AstrBot 插件配置中，embedding_provider_id 和 rerank_provider_id 这两个配置项只能手动填写 provider ID，而同插件的 provider_id（用于 LLM）已经支持通过下拉选择框选择。

这导致了：
  1. 用户体验不一致 - 同样是 provider 选择，有的能点选，有的只能手填
  2. 使用困难 - 用户要反复翻找具体的 provider ID 格式，容易填错
 
### Modifications / 改动点

  **修改的文件：**
  dashboard/src/components/shared/ConfigItemRenderer.vue

  **实现的功能：**
  添加了对两种新的 _special 类型的支持：

  1. select_provider_embedding - 用于选择 Embedding Provider
  2. select_provider_rerank - 用于选择 Rerank Provider

####   **改动：** （已重构）
  **使用 Map 替代 v-if-else-if 链**
```
    // _special 值到 provider 类型的映射表，新增 provider 类型时在此添加
    const specialProviderMap = {
      'select_provider': 'chat_completion',
      'select_provider_stt': 'speech_to_text',
      'select_provider_tts': 'text_to_speech',
      'select_provider_embedding': 'embedding',
      'select_provider_rerank': 'rerank',
    }
```

  **简化 template**
```
    <template v-if="specialProviderMap[itemMeta?._special]">
      <ProviderSelector ... :provider-type="specialProviderMap[itemMeta?._special]" />
    </template>
```

####  **效果：**
  插件开发者可以在 _conf_schema.json 中这样使用（仅需要添加_special字段）：

```
  "embedding_provider_id": {
    "type": "string",
    "_special": "select_provider_embedding",
    ...
  },
  "rerank_provider_id": {
    "type": "string",
    "_special": "select_provider_rerank",
    ...
  }
```

  前端会自动渲染成下拉选择框，而非文本输入框。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果
<img width="900" height="628" alt="image" src="https://github.com/user-attachments/assets/6ba306e9-8567-4ddd-aab4-b6e074bf4386" />
<img width="883" height="615" alt="image" src="https://github.com/user-attachments/assets/f646cbc2-9dfa-45eb-9458-addbeabdcb57" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Add configuration UI support for selecting embedding and rerank providers via dedicated provider selector types.

New Features:
- Support selecting embedding providers through a dedicated `select_provider_embedding` config schema type rendered as a provider dropdown.
- Support selecting rerank providers through a dedicated `select_provider_rerank` config schema type rendered as a provider dropdown.