### PR TITLE
fix(platform): prevent qq_official duplicate message consumption (#5848)

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -250,6 +250,7 @@ DEFAULT_CONFIG = {
         },
     },
     "platform": [],
+    "event_bus_dedup_ttl_seconds": 0.5,
     "platform_specific": {
         # 平台特异配置：按平台分类，平台下按功能分组
         "lark": {
@@ -330,6 +331,9 @@ CONFIG_METADATA_2 = {
                         "secret": "",
                         "enable_group_c2c": True,
                         "enable_guild_direct_message": True,
+                        "dedup_message_id_ttl_seconds": 1800.0,
+                        "dedup_content_key_ttl_seconds": 3.0,
+                        "dedup_cleanup_interval_seconds": 1.0,
                     },
                     "QQ 官方机器人(Webhook)": {
                         "id": "default",
@@ -799,6 +803,21 @@ CONFIG_METADATA_2 = {
                         "description": "启用频道私聊",
                         "type": "bool",
                         "hint": "启用后，机器人可以接收到频道的私聊消息。",
+                    },
+                    "dedup_message_id_ttl_seconds": {
+                        "description": "消息 ID 去重窗口（秒）",
+                        "type": "float",
+                        "hint": "QQ 官方适配器中 message_id 去重窗口，默认 1800 秒。",
+                    },
+                    "dedup_content_key_ttl_seconds": {
+                        "description": "内容键去重窗口（秒）",
+                        "type": "float",
+                        "hint": "QQ 官方适配器中 sender+content hash 去重窗口，默认 3 秒。",
+                    },
+                    "dedup_cleanup_interval_seconds": {
+                        "description": "去重缓存清理间隔（秒）",
+                        "type": "float",
+                        "hint": "QQ 官方适配器去重缓存的增量清理间隔，默认 1 秒。",
                     },
                     "ws_reverse_host": {
                         "description": "反向 Websocket 主机",

--- a/astrbot/core/event_bus.py
+++ b/astrbot/core/event_bus.py
@@ -16,65 +16,14 @@ from asyncio import Queue
 from astrbot.core import logger
 from astrbot.core.astrbot_config_mgr import AstrBotConfigManager
 from astrbot.core.message.utils import (
-    build_event_content_dedup_key,
-    build_event_message_id_dedup_key,
+    build_content_dedup_key,
+    build_message_id_dedup_key,
 )
 from astrbot.core.pipeline.scheduler import PipelineScheduler
 from astrbot.core.utils.number_utils import safe_positive_float
 from astrbot.core.utils.ttl_registry import TTLKeyRegistry
 
 from .platform import AstrMessageEvent
-
-
-class EventDeduplicator:
-    """Event deduplicator using TTL-based registry.
-
-    This class handles deduplication of events based on content fingerprint
-    and message ID, with configurable TTL window.
-    """
-
-    def __init__(self, ttl_seconds: float = 0.5) -> None:
-        self._registry = TTLKeyRegistry(ttl_seconds)
-
-    def is_duplicate(self, event: AstrMessageEvent) -> bool:
-        """Check if the event is a duplicate.
-
-        Returns False immediately if TTL is 0 (deduplication disabled).
-        Short-circuits on message_id key to avoid expensive attachment signature computation.
-        """
-        # TTL of 0 means deduplication is disabled
-        if self._registry.ttl_seconds == 0:
-            return False
-
-        # Short-circuit: check message_id first (cheap) before computing full content key (expensive)
-        message_id_key = build_event_message_id_dedup_key(event)
-        if message_id_key is not None:
-            if self._registry.contains(message_id_key):
-                logger.debug(
-                    "Skip duplicate event in event_bus (by message_id): umo=%s, sender=%s",
-                    event.unified_msg_origin,
-                    event.get_sender_id(),
-                )
-                return True
-            # Register message_id key since we'll process the event
-            self._registry.add(message_id_key)
-
-        # Only compute full content key if we get past message_id check
-        content_key = build_event_content_dedup_key(event)
-        if self._registry.contains(content_key):
-            logger.debug(
-                "Skip duplicate event in event_bus (by content): umo=%s, sender=%s",
-                event.unified_msg_origin,
-                event.get_sender_id(),
-            )
-            # If content duplicate, also remove message_id to preserve existing behavior
-            if message_id_key is not None:
-                self._registry.discard(message_id_key)
-            return True
-
-        # Register content key
-        self._registry.add(content_key)
-        return False
 
 
 class EventBus:
@@ -98,18 +47,65 @@ class EventBus:
             ),
             default=0.5,
         )
-        self._deduplicator = EventDeduplicator(ttl_seconds=dedup_ttl_seconds)
+        self._dedup_registry = TTLKeyRegistry(ttl_seconds=dedup_ttl_seconds)
+
+    @staticmethod
+    def _build_event_content_key(event: AstrMessageEvent) -> str:
+        return build_content_dedup_key(
+            platform_id=str(event.get_platform_id() or ""),
+            unified_msg_origin=str(event.unified_msg_origin or ""),
+            sender_id=str(event.get_sender_id() or ""),
+            text=str(event.get_message_str() or ""),
+            components=event.get_messages(),
+        )
+
+    @staticmethod
+    def _build_event_message_id_key(event: AstrMessageEvent) -> str | None:
+        message_id = getattr(event.message_obj, "message_id", "") or getattr(
+            event.message_obj,
+            "id",
+            "",
+        )
+        return build_message_id_dedup_key(
+            platform_id=str(event.get_platform_id() or ""),
+            unified_msg_origin=str(event.unified_msg_origin or ""),
+            message_id=str(message_id or ""),
+        )
+
+    def _is_duplicate(self, event: AstrMessageEvent) -> bool:
+        if self._dedup_registry.ttl_seconds == 0:
+            return False
+
+        message_id_key = self._build_event_message_id_key(event)
+        if message_id_key is not None:
+            if self._dedup_registry.contains(message_id_key):
+                logger.debug(
+                    "Skip duplicate event in event_bus (by message_id): umo=%s, sender=%s",
+                    event.unified_msg_origin,
+                    event.get_sender_id(),
+                )
+                return True
+            self._dedup_registry.add(message_id_key)
+
+        content_key = self._build_event_content_key(event)
+        if self._dedup_registry.contains(content_key):
+            logger.debug(
+                "Skip duplicate event in event_bus (by content): umo=%s, sender=%s",
+                event.unified_msg_origin,
+                event.get_sender_id(),
+            )
+            if message_id_key is not None:
+                self._dedup_registry.discard(message_id_key)
+            return True
+
+        self._dedup_registry.add(content_key)
+        return False
 
     async def dispatch(self) -> None:
         # event_queue 由单一消费者处理；去重结构不是线程安全的，按设计仅在此循环中使用。
         while True:
             event: AstrMessageEvent = await self.event_queue.get()
-            if self._deduplicator.is_duplicate(event):
-                logger.debug(
-                    "Skip duplicate event in event_bus, umo=%s, sender=%s",
-                    event.unified_msg_origin,
-                    event.get_sender_id(),
-                )
+            if self._is_duplicate(event):
                 continue
             conf_info = self.astrbot_config_mgr.get_conf_info(event.unified_msg_origin)
             conf_id = conf_info["id"]

--- a/astrbot/core/event_bus.py
+++ b/astrbot/core/event_bus.py
@@ -11,12 +11,14 @@ class:
 """
 
 import asyncio
-import hashlib
 from asyncio import Queue
 
 from astrbot.core import logger
 from astrbot.core.astrbot_config_mgr import AstrBotConfigManager
-from astrbot.core.message.utils import build_component_dedup_signature
+from astrbot.core.message.utils import (
+    build_event_content_dedup_key,
+    build_event_message_id_dedup_key,
+)
 from astrbot.core.pipeline.scheduler import PipelineScheduler
 from astrbot.core.utils.number_utils import safe_positive_float
 from astrbot.core.utils.ttl_registry import TTLKeyRegistry
@@ -31,52 +33,8 @@ class EventDeduplicator:
     and message ID, with configurable TTL window.
     """
 
-    _MAX_RAW_TEXT_FINGERPRINT_LEN = 256
-
     def __init__(self, ttl_seconds: float = 0.5) -> None:
         self._registry = TTLKeyRegistry(ttl_seconds)
-
-    def _build_attachment_signature(self, event: AstrMessageEvent) -> str:
-        """Build attachment signature for deduplication."""
-        return build_component_dedup_signature(event.get_messages())
-
-    def _build_content_key(self, event: AstrMessageEvent) -> str:
-        """Build content-based deduplication key."""
-        msg_text = (event.get_message_str() or "").strip()
-        if len(msg_text) <= self._MAX_RAW_TEXT_FINGERPRINT_LEN:
-            msg_sig = msg_text
-        else:
-            msg_hash = hashlib.sha1(msg_text.encode("utf-8")).hexdigest()[:16]
-            msg_sig = f"h:{len(msg_text)}:{msg_hash}"
-
-        attach_sig = self._build_attachment_signature(event)
-        return "|".join([
-            "content",
-            event.get_platform_id() or "",
-            event.unified_msg_origin or "",
-            event.get_sender_id() or "",
-            msg_sig,
-            attach_sig,
-        ])
-
-    def _build_message_id_key(self, event: AstrMessageEvent) -> str | None:
-        """Build message ID-based deduplication key.
-
-        Falls back to message_obj.id if message_id is not available.
-        """
-        # Try message_id first
-        message_id = str(getattr(event.message_obj, "message_id", "") or "")
-        # Fallback to id if message_id is not available
-        if not message_id:
-            message_id = str(getattr(event.message_obj, "id", "") or "")
-        if not message_id:
-            return None
-        return "|".join([
-            "message_id",
-            event.get_platform_id() or "",
-            event.unified_msg_origin or "",
-            message_id,
-        ])
 
     def is_duplicate(self, event: AstrMessageEvent) -> bool:
         """Check if the event is a duplicate.
@@ -89,7 +47,7 @@ class EventDeduplicator:
             return False
 
         # Short-circuit: check message_id first (cheap) before computing full content key (expensive)
-        message_id_key = self._build_message_id_key(event)
+        message_id_key = build_event_message_id_dedup_key(event)
         if message_id_key is not None:
             if self._registry.contains(message_id_key):
                 logger.debug(
@@ -102,7 +60,7 @@ class EventDeduplicator:
             self._registry.add(message_id_key)
 
         # Only compute full content key if we get past message_id check
-        content_key = self._build_content_key(event)
+        content_key = build_event_content_dedup_key(event)
         if self._registry.contains(content_key):
             logger.debug(
                 "Skip duplicate event in event_bus (by content): umo=%s, sender=%s",

--- a/astrbot/core/event_bus.py
+++ b/astrbot/core/event_bus.py
@@ -11,13 +11,112 @@ class:
 """
 
 import asyncio
+import hashlib
 from asyncio import Queue
 
 from astrbot.core import logger
 from astrbot.core.astrbot_config_mgr import AstrBotConfigManager
+from astrbot.core.message.utils import build_component_dedup_signature
 from astrbot.core.pipeline.scheduler import PipelineScheduler
+from astrbot.core.utils.number_utils import safe_positive_float
+from astrbot.core.utils.ttl_registry import TTLKeyRegistry
 
 from .platform import AstrMessageEvent
+
+
+class EventDeduplicator:
+    """Event deduplicator using TTL-based registry.
+
+    This class handles deduplication of events based on content fingerprint
+    and message ID, with configurable TTL window.
+    """
+
+    _MAX_RAW_TEXT_FINGERPRINT_LEN = 256
+
+    def __init__(self, ttl_seconds: float = 0.5) -> None:
+        self._registry = TTLKeyRegistry(ttl_seconds)
+
+    def _build_attachment_signature(self, event: AstrMessageEvent) -> str:
+        """Build attachment signature for deduplication."""
+        return build_component_dedup_signature(event.get_messages())
+
+    def _build_content_key(self, event: AstrMessageEvent) -> str:
+        """Build content-based deduplication key."""
+        msg_text = (event.get_message_str() or "").strip()
+        if len(msg_text) <= self._MAX_RAW_TEXT_FINGERPRINT_LEN:
+            msg_sig = msg_text
+        else:
+            msg_hash = hashlib.sha1(msg_text.encode("utf-8")).hexdigest()[:16]
+            msg_sig = f"h:{len(msg_text)}:{msg_hash}"
+
+        attach_sig = self._build_attachment_signature(event)
+        return "|".join([
+            "content",
+            event.get_platform_id() or "",
+            event.unified_msg_origin or "",
+            event.get_sender_id() or "",
+            msg_sig,
+            attach_sig,
+        ])
+
+    def _build_message_id_key(self, event: AstrMessageEvent) -> str | None:
+        """Build message ID-based deduplication key.
+
+        Falls back to message_obj.id if message_id is not available.
+        """
+        # Try message_id first
+        message_id = str(getattr(event.message_obj, "message_id", "") or "")
+        # Fallback to id if message_id is not available
+        if not message_id:
+            message_id = str(getattr(event.message_obj, "id", "") or "")
+        if not message_id:
+            return None
+        return "|".join([
+            "message_id",
+            event.get_platform_id() or "",
+            event.unified_msg_origin or "",
+            message_id,
+        ])
+
+    def is_duplicate(self, event: AstrMessageEvent) -> bool:
+        """Check if the event is a duplicate.
+
+        Returns False immediately if TTL is 0 (deduplication disabled).
+        Short-circuits on message_id key to avoid expensive attachment signature computation.
+        """
+        # TTL of 0 means deduplication is disabled
+        if self._registry.ttl_seconds == 0:
+            return False
+
+        # Short-circuit: check message_id first (cheap) before computing full content key (expensive)
+        message_id_key = self._build_message_id_key(event)
+        if message_id_key is not None:
+            if self._registry.contains(message_id_key):
+                logger.debug(
+                    "Skip duplicate event in event_bus (by message_id): umo=%s, sender=%s",
+                    event.unified_msg_origin,
+                    event.get_sender_id(),
+                )
+                return True
+            # Register message_id key since we'll process the event
+            self._registry.add(message_id_key)
+
+        # Only compute full content key if we get past message_id check
+        content_key = self._build_content_key(event)
+        if self._registry.contains(content_key):
+            logger.debug(
+                "Skip duplicate event in event_bus (by content): umo=%s, sender=%s",
+                event.unified_msg_origin,
+                event.get_sender_id(),
+            )
+            # If content duplicate, also remove message_id to preserve existing behavior
+            if message_id_key is not None:
+                self._registry.discard(message_id_key)
+            return True
+
+        # Register content key
+        self._registry.add(content_key)
+        return False
 
 
 class EventBus:
@@ -33,10 +132,27 @@ class EventBus:
         # abconf uuid -> scheduler
         self.pipeline_scheduler_mapping = pipeline_scheduler_mapping
         self.astrbot_config_mgr = astrbot_config_mgr
+        dedup_ttl_seconds = safe_positive_float(
+            self.astrbot_config_mgr.g(
+                None,
+                "event_bus_dedup_ttl_seconds",
+                0.5,
+            ),
+            default=0.5,
+        )
+        self._deduplicator = EventDeduplicator(ttl_seconds=dedup_ttl_seconds)
 
     async def dispatch(self) -> None:
+        # event_queue 由单一消费者处理；去重结构不是线程安全的，按设计仅在此循环中使用。
         while True:
             event: AstrMessageEvent = await self.event_queue.get()
+            if self._deduplicator.is_duplicate(event):
+                logger.debug(
+                    "Skip duplicate event in event_bus, umo=%s, sender=%s",
+                    event.unified_msg_origin,
+                    event.get_sender_id(),
+                )
+                continue
             conf_info = self.astrbot_config_mgr.get_conf_info(event.unified_msg_origin)
             conf_id = conf_info["id"]
             conf_name = conf_info.get("name") or conf_id

--- a/astrbot/core/event_bus.py
+++ b/astrbot/core/event_bus.py
@@ -15,14 +15,10 @@ from asyncio import Queue
 
 from astrbot.core import logger
 from astrbot.core.astrbot_config_mgr import AstrBotConfigManager
-from astrbot.core.message.utils import (
-    build_content_dedup_key,
-    build_message_id_dedup_key,
-)
 from astrbot.core.pipeline.scheduler import PipelineScheduler
 from astrbot.core.utils.number_utils import safe_positive_float
-from astrbot.core.utils.ttl_registry import TTLKeyRegistry
 
+from .event_dedup import EventDeduplicator
 from .platform import AstrMessageEvent
 
 
@@ -47,65 +43,13 @@ class EventBus:
             ),
             default=0.5,
         )
-        self._dedup_registry = TTLKeyRegistry(ttl_seconds=dedup_ttl_seconds)
-
-    @staticmethod
-    def _build_event_content_key(event: AstrMessageEvent) -> str:
-        return build_content_dedup_key(
-            platform_id=str(event.get_platform_id() or ""),
-            unified_msg_origin=str(event.unified_msg_origin or ""),
-            sender_id=str(event.get_sender_id() or ""),
-            text=str(event.get_message_str() or ""),
-            components=event.get_messages(),
-        )
-
-    @staticmethod
-    def _build_event_message_id_key(event: AstrMessageEvent) -> str | None:
-        message_id = getattr(event.message_obj, "message_id", "") or getattr(
-            event.message_obj,
-            "id",
-            "",
-        )
-        return build_message_id_dedup_key(
-            platform_id=str(event.get_platform_id() or ""),
-            unified_msg_origin=str(event.unified_msg_origin or ""),
-            message_id=str(message_id or ""),
-        )
-
-    def _is_duplicate(self, event: AstrMessageEvent) -> bool:
-        if self._dedup_registry.ttl_seconds == 0:
-            return False
-
-        message_id_key = self._build_event_message_id_key(event)
-        if message_id_key is not None:
-            if self._dedup_registry.contains(message_id_key):
-                logger.debug(
-                    "Skip duplicate event in event_bus (by message_id): umo=%s, sender=%s",
-                    event.unified_msg_origin,
-                    event.get_sender_id(),
-                )
-                return True
-            self._dedup_registry.add(message_id_key)
-
-        content_key = self._build_event_content_key(event)
-        if self._dedup_registry.contains(content_key):
-            logger.debug(
-                "Skip duplicate event in event_bus (by content): umo=%s, sender=%s",
-                event.unified_msg_origin,
-                event.get_sender_id(),
-            )
-            if message_id_key is not None:
-                self._dedup_registry.discard(message_id_key)
-            return True
-
-        self._dedup_registry.add(content_key)
-        return False
+        self._deduplicator = EventDeduplicator(ttl_seconds=dedup_ttl_seconds)
 
     async def dispatch(self) -> None:
         # event_queue 由单一消费者处理；去重结构不是线程安全的，按设计仅在此循环中使用。
         while True:
             event: AstrMessageEvent = await self.event_queue.get()
-            if self._is_duplicate(event):
+            if self._deduplicator.is_duplicate(event):
                 continue
             conf_info = self.astrbot_config_mgr.get_conf_info(event.unified_msg_origin)
             conf_id = conf_info["id"]

--- a/astrbot/core/event_dedup.py
+++ b/astrbot/core/event_dedup.py
@@ -1,0 +1,65 @@
+from astrbot.core import logger
+from astrbot.core.message.utils import (
+    build_content_dedup_key,
+    build_message_id_dedup_key,
+)
+from astrbot.core.utils.ttl_registry import TTLKeyRegistry
+
+from .platform import AstrMessageEvent
+
+
+class EventDeduplicator:
+    def __init__(self, ttl_seconds: float = 0.5) -> None:
+        self._registry = TTLKeyRegistry(ttl_seconds=ttl_seconds)
+
+    def is_duplicate(self, event: AstrMessageEvent) -> bool:
+        if self._registry.ttl_seconds == 0:
+            return False
+
+        message_id_key = self._build_message_id_key(event)
+        if message_id_key is not None:
+            if self._registry.contains(message_id_key):
+                logger.debug(
+                    "Skip duplicate event in event_bus (by message_id): umo=%s, sender=%s",
+                    event.unified_msg_origin,
+                    event.get_sender_id(),
+                )
+                return True
+            self._registry.add(message_id_key)
+
+        content_key = self._build_content_key(event)
+        if self._registry.contains(content_key):
+            logger.debug(
+                "Skip duplicate event in event_bus (by content): umo=%s, sender=%s",
+                event.unified_msg_origin,
+                event.get_sender_id(),
+            )
+            if message_id_key is not None:
+                self._registry.discard(message_id_key)
+            return True
+
+        self._registry.add(content_key)
+        return False
+
+    @staticmethod
+    def _build_content_key(event: AstrMessageEvent) -> str:
+        return build_content_dedup_key(
+            platform_id=str(event.get_platform_id() or ""),
+            unified_msg_origin=str(event.unified_msg_origin or ""),
+            sender_id=str(event.get_sender_id() or ""),
+            text=str(event.get_message_str() or ""),
+            components=event.get_messages(),
+        )
+
+    @staticmethod
+    def _build_message_id_key(event: AstrMessageEvent) -> str | None:
+        message_id = getattr(event.message_obj, "message_id", "") or getattr(
+            event.message_obj,
+            "id",
+            "",
+        )
+        return build_message_id_dedup_key(
+            platform_id=str(event.get_platform_id() or ""),
+            unified_msg_origin=str(event.unified_msg_origin or ""),
+            message_id=str(message_id or ""),
+        )

--- a/astrbot/core/message/utils.py
+++ b/astrbot/core/message/utils.py
@@ -1,0 +1,42 @@
+"""Message utilities for deduplication and component handling."""
+
+import hashlib
+from typing import Iterable
+
+from astrbot.core.message.components import BaseMessageComponent, File, Image
+
+
+def build_component_dedup_signature(
+    components: Iterable[BaseMessageComponent],
+) -> str:
+    """Build a deduplication signature from message components.
+
+    This function extracts unique identifiers from Image and File components
+    and creates a hash-based signature for deduplication purposes.
+
+    Args:
+        components: An iterable of message components to analyze.
+
+    Returns:
+        A SHA1 hash (16 hex characters) representing the component signatures,
+        or an empty string if no valid components are found.
+    """
+    parts: list[str] = []
+    for component in components:
+        if isinstance(component, Image):
+            # Image can have url, file, or file_unique
+            ref = component.url or component.file or component.file_unique or ""
+            if ref:
+                parts.append(f"img:{ref}")
+        elif isinstance(component, File):
+            # File can have url, file (via property), or name
+            ref = component.url or component.file or component.name or ""
+            if ref:
+                parts.append(f"file:{ref}")
+        # Future component types can be added here
+
+    if not parts:
+        return ""
+
+    payload = "|".join(parts)
+    return hashlib.sha1(payload.encode("utf-8")).hexdigest()[:16]

--- a/astrbot/core/message/utils.py
+++ b/astrbot/core/message/utils.py
@@ -1,9 +1,16 @@
 """Message utilities for deduplication and component handling."""
 
 import hashlib
-from typing import Iterable
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 from astrbot.core.message.components import BaseMessageComponent, File, Image
+
+if TYPE_CHECKING:
+    from astrbot.core.platform import AstrMessageEvent
+
+
+_MAX_RAW_TEXT_FINGERPRINT_LEN = 256
 
 
 def build_component_dedup_signature(
@@ -40,3 +47,56 @@ def build_component_dedup_signature(
 
     payload = "|".join(parts)
     return hashlib.sha1(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def build_sender_content_dedup_key(content: str, sender_id: str) -> str | None:
+    """Build a sender+content hash key for short-window deduplication."""
+    if not (content and sender_id):
+        return None
+    content_hash = hashlib.sha1(content.encode("utf-8")).hexdigest()[:16]
+    return f"{sender_id}:{content_hash}"
+
+
+def build_event_content_dedup_key(event: "AstrMessageEvent") -> str:
+    """Build a content fingerprint key for EventBus deduplication."""
+    msg_text = str(event.get_message_str() or "").strip()
+    if len(msg_text) <= _MAX_RAW_TEXT_FINGERPRINT_LEN:
+        msg_sig = msg_text
+    else:
+        msg_hash = hashlib.sha1(msg_text.encode("utf-8")).hexdigest()[:16]
+        msg_sig = f"h:{len(msg_text)}:{msg_hash}"
+
+    attach_sig = build_component_dedup_signature(event.get_messages())
+    platform_id = str(event.get_platform_id() or "")
+    unified_msg_origin = str(event.unified_msg_origin or "")
+    sender_id = str(event.get_sender_id() or "")
+    return "|".join(
+        [
+            "content",
+            platform_id,
+            unified_msg_origin,
+            sender_id,
+            msg_sig,
+            attach_sig,
+        ]
+    )
+
+
+def build_event_message_id_dedup_key(event: "AstrMessageEvent") -> str | None:
+    """Build a message_id fingerprint key for EventBus deduplication."""
+    message_id = str(getattr(event.message_obj, "message_id", "") or "")
+    if not message_id:
+        message_id = str(getattr(event.message_obj, "id", "") or "")
+    if not message_id:
+        return None
+
+    platform_id = str(event.get_platform_id() or "")
+    unified_msg_origin = str(event.unified_msg_origin or "")
+    return "|".join(
+        [
+            "message_id",
+            platform_id,
+            unified_msg_origin,
+            message_id,
+        ]
+    )

--- a/astrbot/core/message/utils.py
+++ b/astrbot/core/message/utils.py
@@ -2,13 +2,8 @@
 
 import hashlib
 from collections.abc import Iterable
-from typing import TYPE_CHECKING
 
 from astrbot.core.message.components import BaseMessageComponent, File, Image
-
-if TYPE_CHECKING:
-    from astrbot.core.platform import AstrMessageEvent
-
 
 _MAX_RAW_TEXT_FINGERPRINT_LEN = 256
 
@@ -57,46 +52,50 @@ def build_sender_content_dedup_key(content: str, sender_id: str) -> str | None:
     return f"{sender_id}:{content_hash}"
 
 
-def build_event_content_dedup_key(event: "AstrMessageEvent") -> str:
-    """Build a content fingerprint key for EventBus deduplication."""
-    msg_text = str(event.get_message_str() or "").strip()
+def build_content_dedup_key(
+    *,
+    platform_id: str,
+    unified_msg_origin: str,
+    sender_id: str,
+    text: str,
+    components: Iterable[BaseMessageComponent],
+) -> str:
+    """Build a content fingerprint key for event deduplication."""
+    msg_text = str(text or "").strip()
     if len(msg_text) <= _MAX_RAW_TEXT_FINGERPRINT_LEN:
         msg_sig = msg_text
     else:
         msg_hash = hashlib.sha1(msg_text.encode("utf-8")).hexdigest()[:16]
         msg_sig = f"h:{len(msg_text)}:{msg_hash}"
 
-    attach_sig = build_component_dedup_signature(event.get_messages())
-    platform_id = str(event.get_platform_id() or "")
-    unified_msg_origin = str(event.unified_msg_origin or "")
-    sender_id = str(event.get_sender_id() or "")
+    attach_sig = build_component_dedup_signature(components)
     return "|".join(
         [
             "content",
-            platform_id,
-            unified_msg_origin,
-            sender_id,
+            str(platform_id or ""),
+            str(unified_msg_origin or ""),
+            str(sender_id or ""),
             msg_sig,
             attach_sig,
         ]
     )
 
 
-def build_event_message_id_dedup_key(event: "AstrMessageEvent") -> str | None:
-    """Build a message_id fingerprint key for EventBus deduplication."""
-    message_id = str(getattr(event.message_obj, "message_id", "") or "")
-    if not message_id:
-        message_id = str(getattr(event.message_obj, "id", "") or "")
-    if not message_id:
+def build_message_id_dedup_key(
+    *,
+    platform_id: str,
+    unified_msg_origin: str,
+    message_id: str,
+) -> str | None:
+    """Build a message_id fingerprint key for event deduplication."""
+    normalized_message_id = str(message_id or "")
+    if not normalized_message_id:
         return None
-
-    platform_id = str(event.get_platform_id() or "")
-    unified_msg_origin = str(event.unified_msg_origin or "")
     return "|".join(
         [
             "message_id",
-            platform_id,
-            unified_msg_origin,
-            message_id,
+            str(platform_id or ""),
+            str(unified_msg_origin or ""),
+            normalized_message_id,
         ]
     )

--- a/astrbot/core/platform/manager.py
+++ b/astrbot/core/platform/manager.py
@@ -122,6 +122,15 @@ class PlatformManager:
                     )
                     return
 
+            # 防御式处理：避免同一平台 ID 被重复加载导致消息重复消费。
+            if platform_id in self._inst_map:
+                logger.warning(
+                    "平台 %s(%s) 已存在实例，先终止旧实例再重载。",
+                    platform_config["type"],
+                    platform_id,
+                )
+                await self.terminate_platform(platform_id)
+
             logger.info(
                 f"载入 {platform_config['type']}({platform_config['id']}) 平台适配器 ...",
             )

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import logging
 import os
 import random
@@ -24,6 +23,7 @@ from astrbot.api.platform import (
     PlatformMetadata,
 )
 from astrbot.core.message.components import BaseMessageComponent
+from astrbot.core.message.utils import build_sender_content_dedup_key
 from astrbot.core.platform.astr_message_event import MessageSesion
 from astrbot.core.utils.number_utils import safe_positive_float
 from astrbot.core.utils.ttl_registry import TTLKeyRegistry
@@ -73,13 +73,22 @@ def _extract_sender_id(message) -> str:
     Returns:
         The sender ID as a string, or empty string if not found.
     """
-    if hasattr(message, "author") and hasattr(message.author, "user_openid"):
-        return str(message.author.user_openid)
-    if hasattr(message, "author") and hasattr(message.author, "member_openid"):
-        return str(message.author.member_openid)
-    if hasattr(message, "author") and hasattr(message.author, "id"):
-        return str(message.author.id)
-    return ""
+    author = getattr(message, "author", None)
+    if not author:
+        return ""
+
+    sender_id = (
+        getattr(author, "user_openid", None)
+        or getattr(author, "member_openid", None)
+        or getattr(author, "id", None)
+    )
+    if sender_id is None:
+        return ""
+
+    sender_id_str = str(sender_id).strip()
+    if not sender_id_str:
+        return ""
+    return sender_id_str
 
 
 class MessageDeduplicator:
@@ -100,10 +109,7 @@ class MessageDeduplicator:
         self._lock = asyncio.Lock()
 
     def _build_content_key(self, content: str, sender_id: str) -> str | None:
-        if not (content and sender_id):
-            return None
-        content_hash = hashlib.sha1(content.encode("utf-8")).hexdigest()[:16]
-        return f"{sender_id}:{content_hash}"
+        return build_sender_content_dedup_key(content, sender_id)
 
     async def is_duplicate(
         self,
@@ -112,24 +118,35 @@ class MessageDeduplicator:
         sender_id: str = "",
     ) -> bool:
         async with self._lock:
-            # Bypass deduplication if TTL is 0 (disabled)
-            if self._message_ids.ttl_seconds == 0:
+            id_dedup_enabled = self._message_ids.ttl_seconds > 0 and bool(message_id)
+            content_dedup_enabled = self._content_keys.ttl_seconds > 0
+
+            if not id_dedup_enabled and not content_dedup_enabled:
                 return False
 
             # 1) ID-based dedup
-            if self._message_ids.contains(message_id):
-                logger.debug(
-                    "[QQOfficial] Duplicate message detected (by ID): %s...",
-                    message_id[:50],
-                )
-                return True
+            if id_dedup_enabled:
+                if self._message_ids.contains(message_id):
+                    logger.debug(
+                        "[QQOfficial] Duplicate message detected (by ID): %s...",
+                        message_id[:50],
+                    )
+                    return True
 
-            self._message_ids.add(message_id)
+                self._message_ids.add(message_id)
 
             # 2) Content-based dedup
+            if not content_dedup_enabled:
+                logger.debug(
+                    "[QQOfficial] New message registered: %s...", message_id[:50]
+                )
+                return False
+
             content_key = self._build_content_key(content, sender_id)
             if content_key is None:
-                logger.debug("[QQOfficial] New message registered: %s...", message_id[:50])
+                logger.debug(
+                    "[QQOfficial] New message registered: %s...", message_id[:50]
+                )
                 return False
 
             if self._content_keys.contains(content_key):
@@ -138,7 +155,8 @@ class MessageDeduplicator:
                     content_key,
                 )
                 # Preserve existing behavior: do not keep message_id on content duplicates
-                self._message_ids.discard(message_id)
+                if id_dedup_enabled:
+                    self._message_ids.discard(message_id)
                 return True
 
             self._content_keys.add(content_key)
@@ -159,21 +177,9 @@ class botClient(Client):
     def is_shutting_down(self) -> bool:
         return self._shutting_down or self.is_closed()
 
-    def _get_sender_id(self, message) -> str:
-        """Extract sender ID from different message types.
-
-        Delegates to the centralized _extract_sender_id function to avoid
-        precedence drift.
-        """
-        return _extract_sender_id(message)
-
-    def _extract_dedup_key(self, message) -> tuple[str, str]:
-        sender_id = self._get_sender_id(message)
-        content = getattr(message, "content", "") or ""
-        return sender_id, content
-
     async def _should_drop_message(self, message) -> bool:
-        sender_id, content = self._extract_dedup_key(message)
+        sender_id = _extract_sender_id(message)
+        content = getattr(message, "content", "") or ""
         return await self.platform._is_duplicate_message(message.id, content, sender_id)
 
     # 收到群消息
@@ -674,11 +680,12 @@ class QQOfficialPlatformAdapter(Platform):
             message,
             botpy.message.C2CMessage,
         ):
+            sender_user_id = _extract_sender_id(message)
             if isinstance(message, botpy.message.GroupMessage):
-                abm.sender = MessageMember(message.author.member_openid, "")
+                abm.sender = MessageMember(sender_user_id, "")
                 abm.group_id = message.group_openid
             else:
-                abm.sender = MessageMember(message.author.user_openid, "")
+                abm.sender = MessageMember(sender_user_id, "")
             # Parse face messages to readable text
             abm.message_str = QQOfficialPlatformAdapter._parse_face_message(
                 message.content.strip()

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
@@ -5,6 +5,7 @@ import logging
 import os
 import random
 import time
+from types import SimpleNamespace
 from typing import Any, cast
 
 import botpy
@@ -108,8 +109,50 @@ class MessageDeduplicator:
         )
         self._lock = asyncio.Lock()
 
-    def _build_content_key(self, content: str, sender_id: str) -> str | None:
-        return build_sender_content_dedup_key(content, sender_id)
+    def _id_dedup_enabled(self, message_id: str) -> bool:
+        return self._message_ids.ttl_seconds > 0 and bool(message_id)
+
+    def _content_dedup_enabled(self) -> bool:
+        return self._content_keys.ttl_seconds > 0
+
+    def _register_message_id(self, message_id: str) -> bool:
+        """Return True if duplicate by ID, False otherwise (and register)."""
+        if self._message_ids.contains(message_id):
+            logger.debug(
+                "[QQOfficial] Duplicate message detected (by ID): %s...",
+                message_id[:50],
+            )
+            return True
+
+        self._message_ids.add(message_id)
+        return False
+
+    def _register_content(
+        self,
+        message_id: str,
+        content: str,
+        sender_id: str,
+        id_dedup_enabled: bool,
+    ) -> bool:
+        """Return True if duplicate by content, False otherwise (and register)."""
+        content_key = build_sender_content_dedup_key(content, sender_id)
+        if content_key is None:
+            logger.debug("[QQOfficial] New message registered: %s...", message_id[:50])
+            return False
+
+        if self._content_keys.contains(content_key):
+            logger.debug(
+                "[QQOfficial] Duplicate message detected (by content): %s",
+                content_key,
+            )
+            # Preserve existing behavior: do not keep message_id on content duplicates
+            if id_dedup_enabled:
+                self._message_ids.discard(message_id)
+            return True
+
+        self._content_keys.add(content_key)
+        logger.debug("[QQOfficial] New message registered: %s...", message_id[:50])
+        return False
 
     async def is_duplicate(
         self,
@@ -118,22 +161,14 @@ class MessageDeduplicator:
         sender_id: str = "",
     ) -> bool:
         async with self._lock:
-            id_dedup_enabled = self._message_ids.ttl_seconds > 0 and bool(message_id)
-            content_dedup_enabled = self._content_keys.ttl_seconds > 0
+            id_dedup_enabled = self._id_dedup_enabled(message_id)
+            content_dedup_enabled = self._content_dedup_enabled()
 
             if not id_dedup_enabled and not content_dedup_enabled:
                 return False
 
-            # 1) ID-based dedup
-            if id_dedup_enabled:
-                if self._message_ids.contains(message_id):
-                    logger.debug(
-                        "[QQOfficial] Duplicate message detected (by ID): %s...",
-                        message_id[:50],
-                    )
-                    return True
-
-                self._message_ids.add(message_id)
+            if id_dedup_enabled and self._register_message_id(message_id):
+                return True
 
             # 2) Content-based dedup
             if not content_dedup_enabled:
@@ -142,26 +177,12 @@ class MessageDeduplicator:
                 )
                 return False
 
-            content_key = self._build_content_key(content, sender_id)
-            if content_key is None:
-                logger.debug(
-                    "[QQOfficial] New message registered: %s...", message_id[:50]
-                )
-                return False
-
-            if self._content_keys.contains(content_key):
-                logger.debug(
-                    "[QQOfficial] Duplicate message detected (by content): %s",
-                    content_key,
-                )
-                # Preserve existing behavior: do not keep message_id on content duplicates
-                if id_dedup_enabled:
-                    self._message_ids.discard(message_id)
-                return True
-
-            self._content_keys.add(content_key)
-            logger.debug("[QQOfficial] New message registered: %s...", message_id[:50])
-            return False
+            return self._register_content(
+                message_id=message_id,
+                content=content,
+                sender_id=sender_id,
+                id_dedup_enabled=id_dedup_enabled,
+            )
 
 
 class botClient(Client):
@@ -334,9 +355,11 @@ class QQOfficialPlatformAdapter(Platform):
     async def should_handle_raw_message(self, message: Any) -> bool:
         """Return False if the raw incoming message should be dropped."""
         sender_id = _extract_sender_id(message)
-        content = getattr(message, "content", "") or ""
+        message_id = str(getattr(message, "id", "") or "")
+        raw_content = getattr(message, "content", "")
+        content = str(raw_content or "")
         is_duplicate = await self._deduplicator.is_duplicate(
-            message.id,
+            message_id,
             content,
             sender_id,
         )
@@ -383,7 +406,7 @@ class QQOfficialPlatformAdapter(Platform):
 
         payload: dict[str, Any] = {"content": plain_text, "msg_id": msg_id}
         ret: Any = None
-        send_helper = self.client
+        send_helper = SimpleNamespace(bot=self.client)
 
         if session.message_type == MessageType.GROUP_MESSAGE:
             scene = self._session_scene.get(session.session_id)

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
@@ -331,10 +331,16 @@ class QQOfficialPlatformAdapter(Platform):
             cleanup_interval_seconds=cleanup_interval_seconds,
         )
 
-    async def _is_duplicate_message(
-        self, message_id: str, content: str = "", sender_id: str = ""
-    ) -> bool:
-        return await self._deduplicator.is_duplicate(message_id, content, sender_id)
+    async def should_handle_raw_message(self, message: Any) -> bool:
+        """Return False if the raw incoming message should be dropped."""
+        sender_id = _extract_sender_id(message)
+        content = getattr(message, "content", "") or ""
+        is_duplicate = await self._deduplicator.is_duplicate(
+            message.id,
+            content,
+            sender_id,
+        )
+        return not is_duplicate
 
     async def send_by_session(
         self,

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import os
 import random
 import time
-import uuid
-from pathlib import Path
-from types import SimpleNamespace
 from typing import Any, cast
 
 import botpy
@@ -27,11 +25,13 @@ from astrbot.api.platform import (
 )
 from astrbot.core.message.components import BaseMessageComponent
 from astrbot.core.platform.astr_message_event import MessageSesion
-from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
-from astrbot.core.utils.io import download_file
+from astrbot.core.utils.number_utils import safe_positive_float
+from astrbot.core.utils.ttl_registry import TTLKeyRegistry
 
 from ...register import register_platform_adapter
 from .qqofficial_message_event import QQOfficialMessageEvent
+
+# pyright: reportUnreachable=false
 
 # remove logger handler
 for handler in logging.root.handlers[:]:
@@ -56,6 +56,96 @@ class ManagedBotWebSocket(BotWebSocket):
 
 
 # QQ 机器人官方框架
+def _extract_sender_id(message) -> str:
+    """Extract sender ID from a QQ message object.
+
+    This is the central location for sender ID extraction logic to avoid
+    precedence drift between different code paths.
+
+    The precedence order is:
+    1. author.user_openid
+    2. author.member_openid
+    3. author.id
+
+    Args:
+        message: The message object with an author attribute.
+
+    Returns:
+        The sender ID as a string, or empty string if not found.
+    """
+    if hasattr(message, "author") and hasattr(message.author, "user_openid"):
+        return str(message.author.user_openid)
+    if hasattr(message, "author") and hasattr(message.author, "member_openid"):
+        return str(message.author.member_openid)
+    if hasattr(message, "author") and hasattr(message.author, "id"):
+        return str(message.author.id)
+    return ""
+
+
+class MessageDeduplicator:
+    def __init__(
+        self,
+        message_id_ttl_seconds: float = 30 * 60,
+        content_key_ttl_seconds: float = 3.0,
+        cleanup_interval_seconds: float = 1.0,
+    ) -> None:
+        self._message_ids = TTLKeyRegistry(
+            ttl_seconds=message_id_ttl_seconds,
+            cleanup_interval_seconds=cleanup_interval_seconds,
+        )
+        self._content_keys = TTLKeyRegistry(
+            ttl_seconds=content_key_ttl_seconds,
+            cleanup_interval_seconds=cleanup_interval_seconds,
+        )
+        self._lock = asyncio.Lock()
+
+    def _build_content_key(self, content: str, sender_id: str) -> str | None:
+        if not (content and sender_id):
+            return None
+        content_hash = hashlib.sha1(content.encode("utf-8")).hexdigest()[:16]
+        return f"{sender_id}:{content_hash}"
+
+    async def is_duplicate(
+        self,
+        message_id: str,
+        content: str = "",
+        sender_id: str = "",
+    ) -> bool:
+        async with self._lock:
+            # Bypass deduplication if TTL is 0 (disabled)
+            if self._message_ids.ttl_seconds == 0:
+                return False
+
+            # 1) ID-based dedup
+            if self._message_ids.contains(message_id):
+                logger.debug(
+                    "[QQOfficial] Duplicate message detected (by ID): %s...",
+                    message_id[:50],
+                )
+                return True
+
+            self._message_ids.add(message_id)
+
+            # 2) Content-based dedup
+            content_key = self._build_content_key(content, sender_id)
+            if content_key is None:
+                logger.debug("[QQOfficial] New message registered: %s...", message_id[:50])
+                return False
+
+            if self._content_keys.contains(content_key):
+                logger.debug(
+                    "[QQOfficial] Duplicate message detected (by content): %s",
+                    content_key,
+                )
+                # Preserve existing behavior: do not keep message_id on content duplicates
+                self._message_ids.discard(message_id)
+                return True
+
+            self._content_keys.add(content_key)
+            logger.debug("[QQOfficial] New message registered: %s...", message_id[:50])
+            return False
+
+
 class botClient(Client):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -69,10 +159,29 @@ class botClient(Client):
     def is_shutting_down(self) -> bool:
         return self._shutting_down or self.is_closed()
 
+    def _get_sender_id(self, message) -> str:
+        """Extract sender ID from different message types.
+
+        Delegates to the centralized _extract_sender_id function to avoid
+        precedence drift.
+        """
+        return _extract_sender_id(message)
+
+    def _extract_dedup_key(self, message) -> tuple[str, str]:
+        sender_id = self._get_sender_id(message)
+        content = getattr(message, "content", "") or ""
+        return sender_id, content
+
+    async def _should_drop_message(self, message) -> bool:
+        sender_id, content = self._extract_dedup_key(message)
+        return await self.platform._is_duplicate_message(message.id, content, sender_id)
+
     # 收到群消息
     async def on_group_at_message_create(
         self, message: botpy.message.GroupMessage
     ) -> None:
+        if await self._should_drop_message(message):
+            return
         abm = await QQOfficialPlatformAdapter._parse_from_qqofficial(
             message,
             MessageType.GROUP_MESSAGE,
@@ -84,6 +193,8 @@ class botClient(Client):
 
     # 收到频道消息
     async def on_at_message_create(self, message: botpy.message.Message) -> None:
+        if await self._should_drop_message(message):
+            return
         abm = await QQOfficialPlatformAdapter._parse_from_qqofficial(
             message,
             MessageType.GROUP_MESSAGE,
@@ -97,6 +208,8 @@ class botClient(Client):
     async def on_direct_message_create(
         self, message: botpy.message.DirectMessage
     ) -> None:
+        if await self._should_drop_message(message):
+            return
         abm = await QQOfficialPlatformAdapter._parse_from_qqofficial(
             message,
             MessageType.FRIEND_MESSAGE,
@@ -107,6 +220,8 @@ class botClient(Client):
 
     # 收到 C2C 消息
     async def on_c2c_message_create(self, message: botpy.message.C2CMessage) -> None:
+        if await self._should_drop_message(message):
+            return
         abm = await QQOfficialPlatformAdapter._parse_from_qqofficial(
             message,
             MessageType.FRIEND_MESSAGE,
@@ -191,6 +306,30 @@ class QQOfficialPlatformAdapter(Platform):
 
         self.test_mode = os.environ.get("TEST_MODE", "off") == "on"
 
+        message_id_ttl_seconds = safe_positive_float(
+            platform_config.get("dedup_message_id_ttl_seconds"),
+            30 * 60,
+        )
+        content_key_ttl_seconds = safe_positive_float(
+            platform_config.get("dedup_content_key_ttl_seconds"),
+            3.0,
+        )
+        cleanup_interval_seconds = safe_positive_float(
+            platform_config.get("dedup_cleanup_interval_seconds"),
+            1.0,
+        )
+
+        self._deduplicator = MessageDeduplicator(
+            message_id_ttl_seconds=message_id_ttl_seconds,
+            content_key_ttl_seconds=content_key_ttl_seconds,
+            cleanup_interval_seconds=cleanup_interval_seconds,
+        )
+
+    async def _is_duplicate_message(
+        self, message_id: str, content: str = "", sender_id: str = ""
+    ) -> bool:
+        return await self._deduplicator.is_duplicate(message_id, content, sender_id)
+
     async def send_by_session(
         self,
         session: MessageSesion,
@@ -232,7 +371,7 @@ class QQOfficialPlatformAdapter(Platform):
 
         payload: dict[str, Any] = {"content": plain_text, "msg_id": msg_id}
         ret: Any = None
-        send_helper = SimpleNamespace(bot=self.client)
+        send_helper = self.client
 
         if session.message_type == MessageType.GROUP_MESSAGE:
             scene = self._session_scene.get(session.session_id)
@@ -529,6 +668,7 @@ class QQOfficialPlatformAdapter(Platform):
         abm.message_id = message.id
         # abm.tag = "qq_official"
         msg: list[BaseMessageComponent] = []
+        message = cast(Any, message)
 
         if isinstance(message, botpy.message.GroupMessage) or isinstance(
             message,
@@ -572,8 +712,9 @@ class QQOfficialPlatformAdapter(Platform):
             )
             abm.message = msg
             abm.message_str = plain_content
+            sender_user_id = _extract_sender_id(message)
             abm.sender = MessageMember(
-                str(message.author.id),
+                sender_user_id,
                 str(message.author.username),
             )
             msg.append(At(qq="qq_official"))

--- a/astrbot/core/utils/number_utils.py
+++ b/astrbot/core/utils/number_utils.py
@@ -1,0 +1,26 @@
+import math
+
+
+def safe_positive_float(value: object, default: float) -> float:
+    """Parse a value to a positive float.
+
+    Args:
+        value: The value to parse (int, float, str, or other).
+        default: Default value to return if parsing fails or value is not positive.
+
+    Returns:
+        The parsed positive float, or the default value.
+        Note: 0 is considered a valid value to allow disabling via config (e.g., TTL=0 disables dedup).
+    """
+    if not isinstance(value, (int, float, str)):
+        return default
+
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+
+    # Allow 0 to pass through (for disabling via config), but reject negative values
+    if not math.isfinite(parsed) or parsed < 0:
+        return default
+    return parsed

--- a/astrbot/core/utils/ttl_registry.py
+++ b/astrbot/core/utils/ttl_registry.py
@@ -1,0 +1,134 @@
+"""TTL-based key registry for deduplication.
+
+This module provides a reusable TTL (time-to-live) key registry that can be used
+for message/event deduplication across different components.
+"""
+
+import time
+from typing import Hashable, Sequence
+
+
+class TTLKeyRegistry:
+    """A TTL-based registry for tracking seen keys.
+
+    This utility handles time-based expiration of keys, making it suitable for
+    deduplication scenarios where old entries should be automatically cleaned up.
+    Supports optional cleanup interval throttling to avoid per-access full scans.
+
+    Example:
+        registry = TTLKeyRegistry(ttl_seconds=0.5)
+        if registry.seen("some_key"):
+            # Key was seen within TTL window
+            pass
+        else:
+            # New key, register it
+            pass
+    """
+
+    def __init__(
+        self,
+        ttl_seconds: float,
+        cleanup_interval_seconds: float = 0.0,
+    ) -> None:
+        """Initialize the registry.
+
+        Args:
+            ttl_seconds: Time-to-live in seconds for each key. Keys older than
+                        this will be considered expired and cleaned up on next access.
+            cleanup_interval_seconds: Minimum interval between cleanup operations.
+                                      If 0 (default), cleanup runs on every access.
+                                      If > 0, cleanup is throttled to this interval.
+        """
+        self._ttl_seconds = ttl_seconds
+        self._cleanup_interval_seconds = cleanup_interval_seconds
+        self._last_cleanup_at: float = 0.0
+        self._seen: dict[Hashable, float] = {}
+
+    @property
+    def ttl_seconds(self) -> float:
+        """Return the TTL seconds value."""
+        return self._ttl_seconds
+
+    def _clean_expired(self) -> None:
+        """Remove expired entries from the registry, with interval throttling."""
+        # Short-circuit: if TTL is disabled (<=0), skip all cleanup logic
+        if self._ttl_seconds <= 0:
+            return
+
+        now = time.monotonic()
+
+        # Apply cleanup interval throttling if configured
+        if self._cleanup_interval_seconds > 0:
+            if self._last_cleanup_at > 0:
+                if now - self._last_cleanup_at < self._cleanup_interval_seconds:
+                    return
+            self._last_cleanup_at = now
+
+        expire_before = now - self._ttl_seconds
+        for key, ts in list(self._seen.items()):
+            if ts < expire_before:
+                del self._seen[key]
+
+    def contains(self, key: Hashable) -> bool:
+        """Check if a key exists in the registry (without registering).
+
+        Args:
+            key: The key to check.
+
+        Returns:
+            True if the key exists and is not expired, False otherwise.
+        """
+        self._clean_expired()
+        return key in self._seen
+
+    def add(self, key: Hashable) -> None:
+        """Register a key with current timestamp.
+
+        Args:
+            key: The key to add.
+        """
+        self._seen[key] = time.monotonic()
+
+    def discard(self, key: Hashable) -> None:
+        """Remove a key from the registry.
+
+        Args:
+            key: The key to remove.
+        """
+        self._seen.pop(key, None)
+
+    def seen(self, key: Hashable) -> bool:
+        """Check if a key has been seen within the TTL window.
+
+        If not seen, registers the key with current timestamp.
+
+        Args:
+            key: The key to check.
+
+        Returns:
+            True if the key was already seen within TTL window, False otherwise.
+        """
+        self._clean_expired()
+        if key in self._seen:
+            return True
+        self._seen[key] = time.monotonic()
+        return False
+
+    def seen_many(self, keys: Sequence[Hashable]) -> bool:
+        """Check if any of the keys have been seen within the TTL window.
+
+        If none are seen, registers all keys with current timestamp.
+
+        Args:
+            keys: The sequence of keys to check.
+
+        Returns:
+            True if any key was already seen within TTL window, False otherwise.
+        """
+        self._clean_expired()
+        now = time.monotonic()
+        if any(k in self._seen for k in keys):
+            return True
+        for k in keys:
+            self._seen[k] = now
+        return False

--- a/astrbot/core/utils/ttl_registry.py
+++ b/astrbot/core/utils/ttl_registry.py
@@ -5,7 +5,7 @@ for message/event deduplication across different components.
 """
 
 import time
-from typing import Hashable, Sequence
+from collections.abc import Hashable, Sequence
 
 
 class TTLKeyRegistry:
@@ -14,6 +14,12 @@ class TTLKeyRegistry:
     This utility handles time-based expiration of keys, making it suitable for
     deduplication scenarios where old entries should be automatically cleaned up.
     Supports optional cleanup interval throttling to avoid per-access full scans.
+
+    Concurrency note:
+        This class is not thread-safe and does not provide internal locking.
+        It is designed for single-consumer/single-thread usage patterns.
+        If shared across concurrent tasks/threads, callers must provide
+        external synchronization.
 
     Example:
         registry = TTLKeyRegistry(ttl_seconds=0.5)


### PR DESCRIPTION
Fixes #5848

---
在 `qq_official` 场景下，消息可能被重复消费，导致同一输入触发多次回复，严重时会造成接口异常/封禁风险。  
从 issue 日志看，重复事件会在短时间内连续进入处理链，且在运行一段时间后有“递增-回落-再递增”的趋势。  
本 PR 的目标是从**平台入口、事件总线、平台实例管理**三个层面同时消除重复消费，并避免过度去重误拦截正常消息。
### Modifications / 改动点
本次核心修改文件如下：
- `astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py`
- `astrbot/core/event_bus.py`
- `astrbot/core/platform/manager.py`
- `astrbot/core/config/default.py`
- `astrbot/core/utils/ttl_registry.py`
- `astrbot/core/utils/number_utils.py`
- `astrbot/core/message/utils.py`
主要改动说明：
1. **QQ Official 入口去重（平台层）**
   - 新增 `MessageDeduplicator`，拆分两类去重：
     - `message_id` 长窗口去重（默认 `1800s`）
     - `sender_id + content_hash` 短窗口去重（默认 `3s`）
   - `group/channel/direct/c2c` 四类入口回调统一前置判重，命中即丢弃重复消息。
   - 统一 sender_id 提取优先级（`user_openid > member_openid > id`），减少不同回调路径导致的判重漂移。
2. **EventBus 全局去重兜底（调度前）**
   - 在 `dispatch` 前新增 `EventDeduplicator`：
     - 先按 `message_id` 快速短路判重；
     - 再按内容指纹判重（平台、来源、发送者、文本、附件签名）。
   - 新增可配置项 `event_bus_dedup_ttl_seconds`（默认 `0.5s`，支持 `0` 关闭）。
3. **平台实例防重复加载（实例管理层）**
   - `PlatformManager.load_platform` 中增加防御逻辑：
     - 若同 `platform_id` 实例已存在，先终止旧实例再加载新实例。
   - 避免同 ID 多实例并发消费导致“一条消息被处理多次”。
4. **通用基础能力抽离**
   - 新增 `TTLKeyRegistry`（TTL 去重注册表，使用 `time.monotonic()`，支持清理节流）。
   - 新增 `safe_positive_float`（配置解析安全化，允许 `0` 作为禁用值）。
   - 新增消息组件签名工具，将附件特征纳入去重指纹，降低误判。
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
### Screenshots or Test Results / 运行截图或测试结果
**Verification Steps / 验证步骤：**
## **一、改动前**
1. 使用 `qq_official` 适配器启动，保持默认去重配置：
   -打开`启用消息列表单聊`功能和`启用频道私聊`功能
<img width="624" height="188" alt="bug3" src="https://github.com/user-attachments/assets/dcf03be3-7f39-42bd-a89c-817b5ef8ecbf" />

2. 在短时间内重复发送相同消息：
   - 触发多次回复
  - **由下图可见发送`1`和 `2`两条消息后日志里却收到2条`1`和2条 `2`一共四条消息**
<img width="576" height="536" alt="bug" src="https://github.com/user-attachments/assets/7e8ca390-57e3-4a4a-bc4d-ecb03f10a5e5" />
<img width="1527" height="638" alt="bug2" src="https://github.com/user-attachments/assets/337463dd-fa99-44cc-b498-a16104bd3d05" />

## **一、改动后**
1. 使用 `qq_official` 适配器启动，保持默认去重配置：
   -打开`启用消息列表单聊`功能和`启用频道私聊`功能
2. 在短时间内重复发送相同消息：
** 可以看见消息并没有重复消费，测试了3分钟一切正常**
![debug2](https://github.com/user-attachments/assets/39244d74-2aa7-4756-9907-2a622d96c4fa)
![debug4](https://github.com/user-attachments/assets/9c0405e5-2b74-45f4-9389-27db12f9e94d)


---
### Checklist / 检查清单
- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.  
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。  
  （本 PR 为 bugfix，无新增功能）
- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.  
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。
- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.  
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 My changes do not introduce malicious code.  
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Improve cross-layer message deduplication to prevent repeated consumption, especially for qq_official, and add reusable TTL-based utilities and configuration to support it.

Bug Fixes:
- Prevent duplicate handling of qq_official messages by adding platform-level and event-bus-level deduplication based on message IDs and sender/content fingerprints.
- Avoid multiple active instances of the same platform ID consuming messages in parallel by terminating existing instances before reloading.

Enhancements:
- Introduce a reusable TTLKeyRegistry and message fingerprint utilities for content- and attachment-based deduplication across components.
- Add a safe_positive_float helper and wire new deduplication-related timeouts into configuration with sensible defaults.