### PR TITLE
fix: disabled web search tools still being injected into LLM requests

### DIFF
--- a/astrbot/builtin_stars/web_searcher/main.py
+++ b/astrbot/builtin_stars/web_searcher/main.py
@@ -564,24 +564,23 @@ class Main(star.Star):
             return
 
         func_tool_mgr = self.context.get_llm_tool_manager()
+
+        def _try_add(tool_name: str) -> None:
+            """Only add a tool if it exists and hasn't been deactivated by the admin."""
+            t = func_tool_mgr.get_func(tool_name)
+            if t and t.active:
+                tool_set.add_tool(t)
+
         if provider == "default":
-            web_search_t = func_tool_mgr.get_func("web_search")
-            fetch_url_t = func_tool_mgr.get_func("fetch_url")
-            if web_search_t:
-                tool_set.add_tool(web_search_t)
-            if fetch_url_t:
-                tool_set.add_tool(fetch_url_t)
+            _try_add("web_search")
+            _try_add("fetch_url")
             tool_set.remove_tool("web_search_tavily")
             tool_set.remove_tool("tavily_extract_web_page")
             tool_set.remove_tool("AIsearch")
             tool_set.remove_tool("web_search_bocha")
         elif provider == "tavily":
-            web_search_tavily = func_tool_mgr.get_func("web_search_tavily")
-            tavily_extract_web_page = func_tool_mgr.get_func("tavily_extract_web_page")
-            if web_search_tavily:
-                tool_set.add_tool(web_search_tavily)
-            if tavily_extract_web_page:
-                tool_set.add_tool(tavily_extract_web_page)
+            _try_add("web_search_tavily")
+            _try_add("tavily_extract_web_page")
             tool_set.remove_tool("web_search")
             tool_set.remove_tool("fetch_url")
             tool_set.remove_tool("AIsearch")
@@ -592,7 +591,8 @@ class Main(star.Star):
                 aisearch_tool = func_tool_mgr.get_func("AIsearch")
                 if not aisearch_tool:
                     raise ValueError("Cannot get Baidu AI Search MCP tool.")
-                tool_set.add_tool(aisearch_tool)
+                if aisearch_tool.active:
+                    tool_set.add_tool(aisearch_tool)
                 tool_set.remove_tool("web_search")
                 tool_set.remove_tool("fetch_url")
                 tool_set.remove_tool("web_search_tavily")
@@ -601,9 +601,7 @@ class Main(star.Star):
             except Exception as e:
                 logger.error(f"Cannot Initialize Baidu AI Search MCP Server: {e}")
         elif provider == "bocha":
-            web_search_bocha = func_tool_mgr.get_func("web_search_bocha")
-            if web_search_bocha:
-                tool_set.add_tool(web_search_bocha)
+            _try_add("web_search_bocha")
             tool_set.remove_tool("web_search")
             tool_set.remove_tool("fetch_url")
             tool_set.remove_tool("AIsearch")


### PR DESCRIPTION
## Problem

When a user deactivates `web_search_tavily` (or any other web search tool) through the admin behavior config panel, the tool still gets added to LLM requests. The model can then call the "disabled" tool as if nothing happened.

Root cause: `edit_web_search_tools` filter fetches tools via `func_tool_mgr.get_func()` which returns the tool object regardless of its `active` status, then calls `tool_set.add_tool()` unconditionally. This bypasses the admin deactivation that sets `tool.active = False`.

## Fix

Add an `active` check before adding any web search tool. Extracted a `_try_add` helper that wraps the get-and-check pattern to keep the provider branches clean:

```python
def _try_add(tool_name: str) -> None:
    t = func_tool_mgr.get_func(tool_name)
    if t and t.active:
        tool_set.add_tool(t)
```

This is consistent with how `astr_main_agent.py` already filters inactive tools during persona setup (line 362: `if not tool.active: persona_toolset.remove_tool(tool.name)`).

All four provider branches (default, tavily, baidu_ai_search, bocha) are covered.

## How to test

1. Set web search provider to `tavily` and enable web search
2. Deactivate `web_search_tavily` in admin behavior config
3. Send a message that would trigger web search
4. Model should NOT attempt to call `web_search_tavily`

Fixes #6506

## Summary by Sourcery

Ensure only active web search tools are injected into LLM toolsets based on the selected provider.

Bug Fixes:
- Prevent deactivated web search tools from being added to LLM requests when the provider is changed in the admin behavior config.

Enhancements:
- Introduce a helper to conditionally add web search tools and apply consistent active-status checks across all web search providers.