### PR TITLE
Fix LLM always choosing FileDownloadTool instead of FileUploadTool

### DIFF
--- a/astrbot/core/computer/tools/fs.py
+++ b/astrbot/core/computer/tools/fs.py
@@ -80,14 +80,19 @@ from .permissions import check_admin_permission
 @dataclass
 class FileUploadTool(FunctionTool):
     name: str = "astrbot_upload_file"
-    description: str = "Upload a local file to the sandbox. The file must exist on the local filesystem."
+    description: str = (
+        "Transfer a file FROM the host machine INTO the sandbox so that sandbox "
+        "code can access it. Use this when the user sends/attaches a file and you "
+        "need to process it inside the sandbox. The local_path must point to an "
+        "existing file on the host filesystem."
+    )
     parameters: dict = field(
         default_factory=lambda: {
             "type": "object",
             "properties": {
                 "local_path": {
                     "type": "string",
-                    "description": "The local file path to upload. This must be an absolute path to an existing file on the local filesystem.",
+                    "description": "Absolute path to the file on the host filesystem that will be copied into the sandbox.",
                 },
                 # "remote_path": {
                 #     "type": "string",
@@ -140,14 +145,18 @@ class FileUploadTool(FunctionTool):
 @dataclass
 class FileDownloadTool(FunctionTool):
     name: str = "astrbot_download_file"
-    description: str = "Download a file from the sandbox. Only call this when user explicitly need you to download a file."
+    description: str = (
+        "Transfer a file FROM the sandbox OUT to the host and optionally send it "
+        "to the user. Use this ONLY when the user asks to retrieve/export a file "
+        "that was created or modified inside the sandbox."
+    )
     parameters: dict = field(
         default_factory=lambda: {
             "type": "object",
             "properties": {
                 "remote_path": {
                     "type": "string",
-                    "description": "The path of the file in the sandbox to download.",
+                    "description": "Path of the file inside the sandbox to copy out to the host.",
                 },
                 "also_send_to_user": {
                     "type": "boolean",


### PR DESCRIPTION
## Problem

When a user attaches a file and asks the bot to process it in the sandbox, every tested model (Gemini 3, GPT-5.2, Claude Sonnet 4.5, Kimi K2.5) consistently calls `FileDownloadTool` instead of `FileUploadTool`. The sandbox then can't find the file.

The root cause isn't model capability — it's the tool descriptions. "Upload" and "download" are ambiguous from the LLM's perspective because it doesn't inherently know which side is "local" vs "remote". When a user sends a file, the LLM interprets "I need to get this file" → "download".

## Fix

Rewrite tool descriptions with explicit directional language that leaves no room for misinterpretation:

**FileUploadTool** (before → after):
```
- "Upload a local file to the sandbox."
+ "Transfer a file FROM the host machine INTO the sandbox so that
+  sandbox code can access it. Use this when the user sends/attaches
+  a file and you need to process it inside the sandbox."
```

**FileDownloadTool** (before → after):
```
- "Download a file from the sandbox."
+ "Transfer a file FROM the sandbox OUT to the host and optionally
+  send it to the user. Use this ONLY when the user asks to
+  retrieve/export a file that was created or modified inside the sandbox."
```

Parameter descriptions also updated with the same directional clarity.

## Why this works

The key changes that help LLMs pick the right tool:
1. **"FROM ... INTO"** / **"FROM ... OUT"** — explicit direction, no ambiguity
2. **"when the user sends/attaches a file"** — matches the exact trigger scenario
3. **"ONLY when"** on download — discourages default selection

Fixes #6497

## Summary by Sourcery

Clarify file transfer tool semantics so LLMs choose upload vs download correctly when handling sandbox files.

Enhancements:
- Refine FileUploadTool description and parameter docs to explicitly describe transferring files from the host into the sandbox when processing user-attached files.
- Refine FileDownloadTool description and parameter docs to explicitly describe transferring files from the sandbox out to the host only when the user requests retrieval or export.