### PR TITLE
feat: install plugin using metadata name and validate importable identifiers

### DIFF
--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -1242,7 +1242,10 @@ class PluginManager:
                 _, repo_name, _ = self.updator.parse_github_url(repo_url)
                 repo_name = self.updator.format_name(repo_name)
                 plugin_path = os.path.join(self.plugin_store_path, repo_name)
-                plugin_path_exists = os.path.exists(plugin_path)
+                if os.path.exists(plugin_path):
+                    raise Exception(
+                        f"安装失败：目录 {os.path.basename(plugin_path)} 已存在。"
+                    )
                 plugin_path = await self.updator.install(repo_url, proxy)
 
                 # reload the plugin
@@ -1252,10 +1255,6 @@ class PluginManager:
                     self.plugin_store_path,
                     metadata_dir_name,
                 )
-                if plugin_path_exists:
-                    raise Exception(
-                        f"安装失败：目录 {os.path.basename(plugin_path)} 已存在。"
-                    )
                 if target_plugin_path != plugin_path and os.path.exists(
                     target_plugin_path
                 ):


### PR DESCRIPTION
## What changed
- Plugin installation now reads `metadata.yaml` name after unzip.
- Plugin directory is renamed based on metadata name before loading.
- Installation fails fast when target directory already exists (no overwrite/replace).
- Added import-safe validation for `metadata.yaml` name:
  - must be a Python identifier
  - cannot contain path separators
  - cannot be a Python keyword

## Why
- Avoid ambiguous names from zip filename.
- Prevent importlib failures during plugin load.
- Make duplicate-install behavior explicit.

## Summary by Sourcery

Use plugin metadata to determine and validate plugin directory names during installation, and fail installation when conflicting plugin directories already exist.

New Features:
- Derive plugin directory names from the name field in metadata.yaml instead of the archive or repository name.
- Validate plugin names from metadata.yaml as import-safe Python identifiers without path separators or keywords before installation.

Bug Fixes:
- Prevent installing or overwriting plugins when the resolved plugin directory already exists for both GitHub and zip-based installations.

Enhancements:
- Normalize plugin names read from metadata.yaml before using them as directory names.