### PR TITLE
perf: Set `content` to None when the OpenAI message content list is empty

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -604,8 +604,9 @@ class ProviderOpenAIOfficial(Provider):
                         reasoning_content += str(part.get("think"))
                     else:
                         new_content.append(part)
-                message["content"] = new_content
-                # reasoning key is "reasoning_content"
+                # Some providers (Grok, etc.) reject empty content lists.
+                # When all parts were think blocks, fall back to None.
+                message["content"] = new_content or None
                 if reasoning_content:
                     message["reasoning_content"] = reasoning_content
 


### PR DESCRIPTION
## 问题

从 DeepSeek（带 reasoning）切换到 Grok 后，历史消息中的 assistant 消息 content 变成空列表 `[]`，Grok 拒绝请求：

```
Invalid request content: Each message must have at least one content element.
```

## 根因

`_finally_convert_payload` 在处理 assistant 消息时，把 `think` 类型的 content part 提取到 `reasoning_content`，剩下的放进 `new_content`。如果所有 part 都是 think 类型（DeepSeek 纯思考的消息），`new_content` 就是 `[]`。

Grok 和其他一些 provider 不接受空 content list，直接 400。

## 修复

```python
# 修复前
message["content"] = new_content

# 修复后
message["content"] = new_content or None
```

空列表回退到 `None`。OpenAI 兼容 API 普遍接受 `null` content 的 assistant 消息（只要有 `reasoning_content` 或 `tool_calls`）。

这是一个核心层面的修复，不是给某个 provider 打补丁，所以切换到任何不支持空 content 的 provider 都不会再出问题。

## 复现

1. 用 DeepSeek（开启 reasoning）对话，触发工具调用（产生 reasoning_content + 空 content）
2. 切换到 Grok 系列模型
3. 继续对话 → 400 错误

修复后 step 3 正常返回。

Fixes #6447

## Summary by Sourcery

Bug Fixes:
- Avoid 400 errors from providers like Grok by ensuring assistant messages never send an empty content list when they contain only reasoning content.