### PR TITLE
fix: set packaged Windows runtime build env for pip native builds

### DIFF
--- a/astrbot/core/utils/pip_installer.py
+++ b/astrbot/core/utils/pip_installer.py
@@ -240,48 +240,79 @@ def _run_pip_main_streaming(pip_main, args: list[str]) -> tuple[int, list[str]]:
     return result_code, stream.lines
 
 
+@contextlib.contextmanager
+def _temporary_environ(updates: Mapping[str, str]):
+    if not updates:
+        yield
+        return
+
+    missing = object()
+    previous_values = {key: os.environ.get(key, missing) for key in updates}
+
+    try:
+        os.environ.update(updates)
+        yield
+    finally:
+        for key, previous_value in previous_values.items():
+            if previous_value is missing:
+                os.environ.pop(key, None)
+            else:
+                assert isinstance(previous_value, str)
+                os.environ[key] = previous_value
+
+
 def _run_pip_main_with_temporary_environ(
     pip_main,
     args: list[str],
-    env_updates: dict[str, str] | None = None,
 ) -> tuple[int, list[str]]:
-    # os.environ is process-wide; serialize temporary mutations around the
-    # in-process pip invocation, including reading the existing environment for
-    # packaged runtime build-path prepends, and keep the mutation window inside
-    # the worker.
+    # os.environ is process-wide; serialize reading current INCLUDE/LIB values
+    # together with the temporary mutation window around the in-process pip
+    # invocation.
     with _PIP_IN_PROCESS_ENV_LOCK:
-        if env_updates is None:
-            env_updates = _build_packaged_windows_runtime_build_env(base_env=os.environ)
+        env_updates = _build_packaged_windows_runtime_build_env(base_env=os.environ)
         if not env_updates:
             return _run_pip_main_streaming(pip_main, args)
 
-        missing = object()
-        previous_values = {key: os.environ.get(key, missing) for key in env_updates}
-
-        try:
-            os.environ.update(env_updates)
+        with _temporary_environ(env_updates):
             return _run_pip_main_streaming(pip_main, args)
-        finally:
-            for key, previous_value in previous_values.items():
-                if previous_value is missing:
-                    os.environ.pop(key, None)
-                elif isinstance(previous_value, str):
-                    os.environ[key] = previous_value
 
 
 def _normalize_windows_native_build_path(path: str) -> str:
+    """Normalize a Windows path returned by native APIs or sys.executable.
+
+    Extended UNC prefixes are converted back to the standard ``\\server`` form,
+    other extended prefixes are stripped, and the remaining path is normalized.
+    """
     normalized = path.replace("/", "\\")
 
+    # Extended UNC: \\?\UNC\server\share\... -> \\server\share\...
     for prefix in _WINDOWS_UNC_PATH_PREFIXES:
         if normalized.startswith(prefix):
             return ntpath.normpath(f"\\\\{normalized[len(prefix) :]}")
 
+    # Other extended prefixes are stripped before normalizing the path.
     for prefix in _WINDOWS_EXTENDED_PATH_PREFIXES:
         if normalized.startswith(prefix):
             normalized = normalized[len(prefix) :]
             break
 
     return ntpath.normpath(normalized)
+
+
+def _get_case_insensitive_env_value(
+    env: Mapping[str, str],
+    upper_to_key: Mapping[str, str],
+    name: str,
+) -> str | None:
+    direct = env.get(name)
+    if direct is not None:
+        return direct
+
+    existing_key = upper_to_key.get(name.upper())
+    if existing_key is not None:
+        return env.get(existing_key)
+
+    return None
 
 
 def _build_packaged_windows_runtime_build_env(
@@ -291,8 +322,7 @@ def _build_packaged_windows_runtime_build_env(
     if sys.platform != "win32" or not is_packaged_desktop_runtime():
         return {}
 
-    if base_env is None:
-        base_env = os.environ
+    base_env = os.environ if base_env is None else base_env
 
     runtime_executable = _normalize_windows_native_build_path(sys.executable)
     runtime_dir = ntpath.dirname(runtime_executable)
@@ -310,23 +340,16 @@ def _build_packaged_windows_runtime_build_env(
         return {}
 
     upper_to_key = {key.upper(): key for key in base_env}
-
-    def _prepend(name: str, path: str) -> str:
-        existing = base_env.get(name)
-        if existing is None:
-            existing_key = upper_to_key.get(name.upper())
-            if existing_key is not None:
-                existing = base_env.get(existing_key)
-        if existing:
-            return f"{path};{existing}"
-        return path
-
     env_updates: dict[str, str] = {}
 
     if include_exists:
-        env_updates["INCLUDE"] = _prepend("INCLUDE", include_dir)
+        existing = _get_case_insensitive_env_value(base_env, upper_to_key, "INCLUDE")
+        env_updates["INCLUDE"] = (
+            f"{include_dir};{existing}" if existing else include_dir
+        )
     if libs_exists:
-        env_updates["LIB"] = _prepend("LIB", libs_dir)
+        existing = _get_case_insensitive_env_value(base_env, upper_to_key, "LIB")
+        env_updates["LIB"] = f"{libs_dir};{existing}" if existing else libs_dir
 
     return env_updates
 

--- a/tests/test_pip_installer.py
+++ b/tests/test_pip_installer.py
@@ -331,6 +331,23 @@ def test_normalize_windows_native_build_path_variants(path, expected):
     assert pip_installer_module._normalize_windows_native_build_path(path) == expected
 
 
+def test_temporary_environ_restores_previous_values(monkeypatch):
+    monkeypatch.setenv("INCLUDE", EXISTING_WINDOWS_INCLUDE_DIR)
+    monkeypatch.delenv("LIB", raising=False)
+
+    with pip_installer_module._temporary_environ(
+        {
+            "INCLUDE": WINDOWS_RUNTIME_INCLUDE_DIR,
+            "LIB": WINDOWS_RUNTIME_LIBS_DIR,
+        }
+    ):
+        assert pip_installer_module.os.environ["INCLUDE"] == WINDOWS_RUNTIME_INCLUDE_DIR
+        assert pip_installer_module.os.environ["LIB"] == WINDOWS_RUNTIME_LIBS_DIR
+
+    assert pip_installer_module.os.environ["INCLUDE"] == EXISTING_WINDOWS_INCLUDE_DIR
+    assert "LIB" not in pip_installer_module.os.environ
+
+
 def test_build_packaged_windows_runtime_build_env_uses_base_env_snapshot(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary
- normalize packaged Windows runtime paths before native-extension builds
- inject packaged runtime include/lib directories into the in-process pip environment on Windows desktop builds
- add a regression test covering packaged desktop runtime env injection

## Verification
- uv run pytest tests/test_pip_installer.py

## Summary by Sourcery

Adjust in-process pip installation to respect packaged Windows desktop runtimes and ensure native builds see the correct include/lib paths while keeping the process environment consistent.

Bug Fixes:
- Normalize Windows runtime and UNC paths before deriving native build include/lib directories for pip installations.
- Inject packaged Windows runtime include and lib directories into the in-process pip environment on Windows desktop builds only when those directories exist, without affecting non-Windows or non-packaged runs.
- Ensure temporary modification of INCLUDE and LIB during in-process pip runs is thread-safe and restores original environment values afterward.

Tests:
- Add comprehensive tests covering Windows path normalization, temporary environment handling, runtime build env construction, and pip in-process env injection behavior across packaged/non-packaged and Windows/non-Windows scenarios.