### PR TITLE
fix(web_searcher): use readability_lxml instead of readability import

### DIFF
--- a/astrbot/builtin_stars/web_searcher/main.py
+++ b/astrbot/builtin_stars/web_searcher/main.py
@@ -5,7 +5,7 @@ import uuid
 
 import aiohttp
 from bs4 import BeautifulSoup
-from readability import Document
+from readability_lxml import Document
 
 from astrbot.api import AstrBotConfig, llm_tool, logger, sp, star
 from astrbot.api.event import AstrMessageEvent, filter


### PR DESCRIPTION
## Bug Description
ModuleNotFoundError: No module named 'lxml.html' — plugin web_searcher fails to load.

## Root Cause
pyproject.toml specifies dependency `readability-lxml>=0.8.4.1`, but the code imports:

```python
from readability import Document
```

The `readability-lxml` package installs as `readability_lxml` (underscore), not `readability`. The missing `lxml.html` is provided by `readability_lxml`.

## Fix
Change import to:

```python
from readability_lxml import Document
```

## Testing
This aligns the import with the dependency declared in pyproject.toml.

## Summary by Sourcery

Bug Fixes:
- Replace the incorrect readability import with readability_lxml in the web_searcher plugin to resolve ModuleNotFoundError for lxml.html.