### PR TITLE
feat(provider): make Anthropic max_tokens configurable via WebUI

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1113,6 +1113,7 @@ CONFIG_METADATA_2 = {
                         "timeout": 120,
                         "proxy": "",
                         "anth_thinking_config": {"type": "", "budget": 0, "effort": ""},
+                        "max_tokens": 4096,
                     },
                     "Moonshot": {
                         "id": "moonshot",
@@ -2151,6 +2152,11 @@ CONFIG_METADATA_2 = {
                                 "hint": "type 为 'adaptive' 时控制思考深度。默认 'high'。'max' 仅限 Opus 4.6。参见: https://platform.claude.com/docs/en/build-with-claude/effort",
                             },
                         },
+                    },
+                    "max_tokens": {
+                        "description": "最大输出 Token 数",
+                        "type": "int",
+                        "hint": "控制模型单次回复的最大 token 数量。Anthropic 默认 4096。如果回复经常被截断，可以适当调大。",
                     },
                     "minimax-group-id": {
                         "type": "string",

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -2156,7 +2156,8 @@ CONFIG_METADATA_2 = {
                     "max_tokens": {
                         "description": "最大输出 Token 数",
                         "type": "int",
-                        "hint": "控制模型单次回复的最大 token 数量。Anthropic 默认 4096。如果回复经常被截断，可以适当调大。",
+                        "hint": "控制模型单次回复的最大 token 数量。仅对 Anthropic 类型的提供商生效。默认 4096。如果回复经常被截断，可以适当调大。",
+                        "provider_type_filter": ["anthropic_chat_completion"],
                     },
                     "minimax-group-id": {
                         "type": "string",

--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -28,6 +28,9 @@ from ..register import register_provider_adapter
     "anthropic_chat_completion",
     "Anthropic Claude API 提供商适配器",
 )
+DEFAULT_ANTHROPIC_MAX_TOKENS = 4096
+
+
 class ProviderAnthropic(Provider):
     def __init__(
         self,
@@ -209,6 +212,15 @@ class ProviderAnthropic(Provider):
 
         return system_prompt, new_messages
 
+    def _get_max_tokens(self) -> int:
+        """Get max_tokens from provider config with validation."""
+        value = self.provider_config.get("max_tokens", DEFAULT_ANTHROPIC_MAX_TOKENS)
+        try:
+            value = int(value)
+            return max(value, 1)
+        except (TypeError, ValueError):
+            return DEFAULT_ANTHROPIC_MAX_TOKENS
+
     def _extract_usage(self, usage: Usage) -> TokenUsage:
         # https://docs.claude.com/en/docs/build-with-claude/prompt-caching#tracking-cache-performance
         return TokenUsage(
@@ -233,7 +245,7 @@ class ProviderAnthropic(Provider):
         extra_body = self.provider_config.get("custom_extra_body", {})
 
         if "max_tokens" not in payloads:
-            payloads["max_tokens"] = self.provider_config.get("max_tokens", 4096)
+            payloads["max_tokens"] = self._get_max_tokens()
         self._apply_thinking_config(payloads)
 
         try:
@@ -318,7 +330,7 @@ class ProviderAnthropic(Provider):
         reasoning_signature = ""
 
         if "max_tokens" not in payloads:
-            payloads["max_tokens"] = self.provider_config.get("max_tokens", 4096)
+            payloads["max_tokens"] = self._get_max_tokens()
         self._apply_thinking_config(payloads)
 
         async with self.client.messages.stream(

--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -233,7 +233,7 @@ class ProviderAnthropic(Provider):
         extra_body = self.provider_config.get("custom_extra_body", {})
 
         if "max_tokens" not in payloads:
-            payloads["max_tokens"] = 1024
+            payloads["max_tokens"] = self.provider_config.get("max_tokens", 4096)
         self._apply_thinking_config(payloads)
 
         try:
@@ -318,7 +318,7 @@ class ProviderAnthropic(Provider):
         reasoning_signature = ""
 
         if "max_tokens" not in payloads:
-            payloads["max_tokens"] = 1024
+            payloads["max_tokens"] = self.provider_config.get("max_tokens", 4096)
         self._apply_thinking_config(payloads)
 
         async with self.client.messages.stream(

--- a/docs/en/providers/anthropic.md
+++ b/docs/en/providers/anthropic.md
@@ -1,0 +1,26 @@
+# Anthropic
+
+Anthropic is the provider of the Claude series of models. AstrBot natively supports the Anthropic API format.
+
+## Setup
+
+1. Go to [Anthropic Console](https://console.anthropic.com/) to register and get your API Key
+2. In AstrBot Dashboard → Providers, click "Add Provider" and select `Anthropic`
+3. Enter your API Key, click "Get Model List", and select the model you want
+
+## Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| API Key | Anthropic API key | - |
+| API Base | API endpoint. No need to change for official service | `https://api.anthropic.com/v1` |
+| Timeout | Request timeout in seconds | 120 |
+| Proxy | Proxy URL | - |
+| **Max Tokens** | Maximum number of tokens the model can generate per response. Increase if responses are frequently truncated | 4096 |
+| Thinking Config | Thinking configuration. Recommended to set `adaptive` for Opus 4.6+ / Sonnet 4.6+ | - |
+
+### Max Tokens
+
+`max_tokens` controls the maximum number of tokens the model can generate in a single response. When using Agent/tool calling scenarios, model outputs can be lengthy. Consider increasing this value (e.g., 8192 or 16384) based on your needs.
+
+Configure it in AstrBot Dashboard → Providers → click the Anthropic provider → find "Max Output Tokens".

--- a/docs/zh/providers/anthropic.md
+++ b/docs/zh/providers/anthropic.md
@@ -1,0 +1,26 @@
+# Anthropic
+
+Anthropic 是 Claude 系列模型的提供商。AstrBot 原生支持 Anthropic API 格式。
+
+## 接入步骤
+
+1. 前往 [Anthropic Console](https://console.anthropic.com/) 注册账号并获取 API Key
+2. 在 AstrBot 控制台 → 服务提供商页面，点击新增提供商，选择 `Anthropic`
+3. 填入 API Key，点击获取模型列表，选择所需模型
+
+## 配置说明
+
+| 配置项 | 说明 | 默认值 |
+|--------|------|--------|
+| API Key | Anthropic API 密钥 | - |
+| API Base | API 地址，使用官方服务无需修改 | `https://api.anthropic.com/v1` |
+| Timeout | 请求超时时间（秒） | 120 |
+| Proxy | 代理地址 | - |
+| **Max Tokens** | 模型单次回复的最大 token 数量。如果回复经常被截断，可以适当调大 | 4096 |
+| Thinking Config | 思考配置，Opus 4.6+ / Sonnet 4.6+ 推荐设为 `adaptive` | - |
+
+### Max Tokens 说明
+
+`max_tokens` 控制模型单次回复可以生成的最大 token 数量。在使用 Agent/工具调用等场景下，模型输出可能较长，建议根据实际需求调大此值（如 8192 或 16384）。
+
+在 AstrBot 控制台 → 服务提供商 → 点击对应的 Anthropic 提供商 → 找到「最大输出 Token 数」进行配置。


### PR DESCRIPTION
## What
Anthropic provider's `max_tokens` was hardcoded to `1024`, which often causes response truncation for longer outputs (e.g. when using tools/agents).

## Changes
- **`anthropic_source.py`**: Read `max_tokens` from `provider_config` with a sensible default of `4096` (both `_query` and `_query_stream`)
- **`config/default.py`**: Add `max_tokens` field to Anthropic provider template and WebUI schema

## Why 4096 as default?
- The previous `1024` was too small for most real-world use cases
- `4096` is a reasonable default that works well for general chat while avoiding unnecessary token costs
- Users can now easily adjust via WebUI for their specific needs

## Impact
- **Backward compatible**: Existing configs without `max_tokens` will use the new default of `4096`
- **2 files changed, 8 insertions, 2 deletions** — minimal change

## Summary by Sourcery

Make Anthropic provider max_tokens configurable with a higher default while exposing it in the WebUI schema.

New Features:
- Allow configuring Anthropic max_tokens per provider via WebUI configuration.

Enhancements:
- Increase Anthropic provider default max_tokens from 1024 to 4096 to reduce response truncation.
- Read max_tokens from provider configuration in both standard and streaming Anthropic queries instead of using a hardcoded value.

Documentation:
- Document the new Anthropic max_tokens option in the WebUI schema with guidance on usage.