### PR TITLE
fix: qq_offical cron job send_message_to_user tool call failed

### DIFF
--- a/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
@@ -238,6 +238,9 @@ class QQOfficialPlatformAdapter(Platform):
                 )
 
         elif session.message_type == MessageType.FRIEND_MESSAGE:
+            # 参考 https://bot.q.qq.com/wiki/develop/pythonsdk/api/message/post_message.html
+            # msg_id 缺失时认为是主动推送，而似乎至少在私聊上主动推送是没有被限制的，这里直接移除 msg_id 可以避免越权或 msg_id 不可用的bug
+            payload.pop("msg_id", None)
             payload["msg_seq"] = random.randint(1, 10000)
             if image_base64:
                 media = await QQOfficialMessageEvent.upload_group_and_c2c_image(
@@ -268,9 +271,6 @@ class QQOfficialPlatformAdapter(Platform):
                 if media:
                     payload["media"] = media
                     payload["msg_type"] = 7
-                    # QQ API rejects msg_id for media (video/file) messages sent
-                    # via the proactive tool-call path; remove it to avoid 越权 error.
-                    payload.pop("msg_id", None)
             if file_source:
                 media = await QQOfficialMessageEvent.upload_group_and_c2c_media(
                     send_helper,  # type: ignore
@@ -282,7 +282,6 @@ class QQOfficialPlatformAdapter(Platform):
                 if media:
                     payload["media"] = media
                     payload["msg_type"] = 7
-                    payload.pop("msg_id", None)
 
             ret = await QQOfficialMessageEvent.post_c2c_message(
                 send_helper,  # type: ignore


### PR DESCRIPTION
Remove msg_id from payload to prevent errors with proactive tool-call path and avoid permission issues.

fixed: #6599


<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
修复了 #6599 （这是我第一次提PR，且我对原本的运行机制没有进行过学习研究，如果可能引入问题请拒绝该PR🙏）

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
在qq_offical适配器中私聊消息直接移除了msg_id字段以避免越权或 msg_id 不可用的问题

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

只做了简单测试，修改后带图片和纯文本的消息都能够正常回应，10分钟后的定时任务能正常响应

```
[2026-03-19 13:10:57.518] [Core] [INFO] [runners.tool_loop_agent_runner:657]: Agent 使用工具: ['create_future_task']

[2026-03-19 13:10:57.519] [Core] [INFO] [runners.tool_loop_agent_runner:703]: 使用工具：create_future_task，参数：{'run_at': '2026-03-19T13:12:00+08:00', 'note': '2分钟后（13:12）连续调用2次send_message_to_user工具测试定时任务的消息发送功能。\n\n执行步骤：\n1. 调用send_message_to_user工具，发送消息："定时任务测试消息1：时间 2026-03-19 13:12:00"\n2. 等待短暂间隔后，再次调用send_message_to_user工具，发送消息："定时任务测试消息2：连续调用测试"\n\n记录执行结果和可能的错误信息，用于分析定时任务中send_message_to_user工具的问题。', 'name': '定时任务send_message_to_user工具测试', 'run_once': True}

[2026-03-19 13:10:57.751] [Core] [INFO] [runners.tool_loop_agent_runner:881]: Tool `create_future_task` Result: Scheduled future task 7286088a-6b26-49c6-a607-c07584bef173 (定时任务send_message_to_user工具测试) one-time at 2026-03-19 13:12:00+08:00.

[2026-03-19 13:11:06.949] [Core] [INFO] [result_decorate.stage:189]: 流式输出已启用，跳过结果装饰阶段

[2026-03-19 13:12:14.642] [Core] [INFO] [runners.tool_loop_agent_runner:657]: Agent 使用工具: ['send_message_to_user']

[2026-03-19 13:12:14.642] [Core] [INFO] [runners.tool_loop_agent_runner:703]: 使用工具：send_message_to_user，参数：{'messages': [{'type': 'plain', 'text': '定时任务测试消息1：时间 2026-03-19 13:12:00'}]}

[2026-03-19 13:12:16.509] [Core] [INFO] [runners.tool_loop_agent_runner:881]: Tool `send_message_to_user` Result: Message sent to session QQ:FriendMessage:1F92E5124D83FC64DFE2A0EC30FA5EA1

[2026-03-19 13:12:21.148] [Core] [INFO] [runners.tool_loop_agent_runner:657]: Agent 使用工具: ['send_message_to_user']

[2026-03-19 13:12:21.148] [Core] [INFO] [runners.tool_loop_agent_runner:703]: 使用工具：send_message_to_user，参数：{'messages': [{'type': 'plain', 'text': '定时任务测试消息2：连续调用测试'}]}

[2026-03-19 13:12:22.276] [Core] [INFO] [runners.tool_loop_agent_runner:881]: Tool `send_message_to_user` Result: Message sent to session QQ:FriendMessage:1F92E5124D83FC64DFE2A0EC30FA5EA1

[2026-03-19 13:12:57.437] [Core] [INFO] [core.event_bus:66]: [default] [QQ(qq_official)] 1F92E5124D83FC64DFE2A0EC30FA5EA1: [At:qq_official] 测试成功了，再测试10分钟后连续调用2次send_message_to_user工具 

[2026-03-19 13:12:57.588] [Core] [INFO] [respond.stage:184]: Prepare to send - /1F92E5124D83FC64DFE2A0EC30FA5EA1: 

[2026-03-19 13:12:57.588] [Core] [INFO] [respond.stage:200]: 应用流式输出(QQ)

[2026-03-19 13:13:10.395] [Core] [INFO] [runners.tool_loop_agent_runner:657]: Agent 使用工具: ['create_future_task']

[2026-03-19 13:13:10.395] [Core] [INFO] [runners.tool_loop_agent_runner:703]: 使用工具：create_future_task，参数：{'run_at': '2026-03-19T13:22:00+08:00', 'note': '10分钟后（13:22）连续调用2次send_message_to_user工具进行进一步测试。\n\n执行步骤：\n1. 调用send_message_to_user工具，发送消息："10分钟后测试消息1：时间 2026-03-19 13:22:00"\n2. 再次调用send_message_to_user工具，发送消息："10分钟后测试消息2：连续调用验证"\n\n测试定时任务环境下send_message_to_user工具的稳定性和可靠性。', 'name': '10分钟后send_message_to_user工具测试', 'run_once': True}

[2026-03-19 13:13:11.337] [Core] [INFO] [runners.tool_loop_agent_runner:881]: Tool `create_future_task` Result: Scheduled future task 215da7c4-d975-4033-9a6c-beaeaa2fee97 (10分钟后send_message_to_user工具测试) one-time at 2026-03-19 13:22:00+08:00.

[2026-03-19 13:13:21.409] [Core] [INFO] [runners.tool_loop_agent_runner:657]: Agent 使用工具: ['send_message_to_user']

[2026-03-19 13:13:21.409] [Core] [INFO] [runners.tool_loop_agent_runner:703]: 使用工具：send_message_to_user，参数：{'messages': [{'type': 'plain', 'text': '那尔ちゃん，定时任务已经设置好了。\n\n**任务详情：**\n- **任务ID**: 215da7c4-d975-4033-9a6c-beaeaa2fee97\n- **执行时间**: 10分钟后（2026-03-19 13:22:00 CST）\n- **执行内容**: 连续调用2次send_message_to_user工具\n- **任务类型**: 一次性执行\n\n（轻声）这次的测试是为了验证定时任务环境下消息发送功能的稳定性。我会在13:22准时执行测试，然后向你汇报结果。'}]}

[2026-03-19 13:13:22.805] [Core] [INFO] [runners.tool_loop_agent_runner:881]: Tool `send_message_to_user` Result: Message sent to session QQ:FriendMessage:1F92E5124D83FC64DFE2A0EC30FA5EA1

[2026-03-19 13:13:29.923] [Core] [INFO] [result_decorate.stage:189]: 流式输出已启用，跳过结果装饰阶段

[2026-03-19 13:22:06.505] [Core] [INFO] [runners.tool_loop_agent_runner:657]: Agent 使用工具: ['send_message_to_user']

[2026-03-19 13:22:06.505] [Core] [INFO] [runners.tool_loop_agent_runner:703]: 使用工具：send_message_to_user，参数：{'messages': [{'type': 'plain', 'text': '10分钟后测试消息1：时间 2026-03-19 13:22:00'}]}

[2026-03-19 13:22:07.562] [Core] [INFO] [runners.tool_loop_agent_runner:881]: Tool `send_message_to_user` Result: Message sent to session QQ:FriendMessage:1F92E5124D83FC64DFE2A0EC30FA5EA1

[2026-03-19 13:22:11.225] [Core] [INFO] [runners.tool_loop_agent_runner:657]: Agent 使用工具: ['send_message_to_user']

[2026-03-19 13:22:11.225] [Core] [INFO] [runners.tool_loop_agent_runner:703]: 使用工具：send_message_to_user，参数：{'messages': [{'type': 'plain', 'text': '10分钟后测试消息2：连续调用验证'}]}

[2026-03-19 13:22:12.316] [Core] [INFO] [runners.tool_loop_agent_runner:881]: Tool `send_message_to_user` Result: Message sent to session QQ:FriendMessage:1F92E5124D83FC64DFE2A0EC30FA5EA1

[2026-03-19 13:34:52.634] [Core] [INFO] [core.event_bus:66]: [default] [QQ(qq_official)] 1F92E5124D83FC64DFE2A0EC30FA5EA1: [At:qq_official] 讲个笑话吧？ 

[2026-03-19 13:34:52.786] [Core] [INFO] [respond.stage:184]: Prepare to send - /1F92E5124D83FC64DFE2A0EC30FA5EA1: 

[2026-03-19 13:34:52.786] [Core] [INFO] [respond.stage:200]: 应用流式输出(QQ)

[2026-03-19 13:35:02.841] [Core] [INFO] [result_decorate.stage:189]: 流式输出已启用，跳过结果装饰阶段

[2026-03-19 13:41:10.105] [Core] [INFO] [core.event_bus:66]: [default] [QQ(qq_official)] 1F92E5124D83FC64DFE2A0EC30FA5EA1: [At:qq_official] 检查一下这张图片的尺寸和大小 [图片] 

[2026-03-19 13:41:10.484] [Core] [INFO] [respond.stage:184]: Prepare to send - /1F92E5124D83FC64DFE2A0EC30FA5EA1: 

[2026-03-19 13:41:10.484] [Core] [INFO] [respond.stage:200]: 应用流式输出(QQ)

[2026-03-19 13:41:19.810] [Core] [INFO] [runners.tool_loop_agent_runner:657]: Agent 使用工具: ['get_file_info']

[2026-03-19 13:41:19.810] [Core] [INFO] [runners.tool_loop_agent_runner:703]: 使用工具：get_file_info，参数：{'path': '/AstrBot/data/temp/io_temp_img_1773898870_f420cbcb.jpg'}

[2026-03-19 13:41:20.079] [Core] [INFO] [runners.tool_loop_agent_runner:881]: Tool `get_file_info` Result: size: 215284
created: Thu Mar 19 2026 05:41:10 GMT+0000 (Coordinated Universal Time)
modified: Thu Mar 19 2026 05:41:10 GMT+0000 (Coordinated Universal Time)
accessed: Thu Mar 19 2026 05:41:10 GMT+0000 (Coordinated Universal Time)
isDirectory: false
isFile: true
permissions: 644

[2026-03-19 13:41:25.610] [Core] [INFO] [runners.tool_loop_agent_runner:657]: Agent 使用工具: ['astrbot_execute_shell']

[2026-03-19 13:41:25.611] [Core] [INFO] [runners.tool_loop_agent_runner:703]: 使用工具：astrbot_execute_shell，参数：{'command': 'which identify 2>/dev/null || echo "identify command not found"'}

[2026-03-19 13:41:25.856] [Core] [INFO] [runners.tool_loop_agent_runner:881]: Tool `astrbot_execute_shell` Result: {"stdout": "identify command not found\n", "stderr": "", "exit_code": 0}

[2026-03-19 13:41:46.592] [Core] [INFO] [runners.tool_loop_agent_runner:657]: Agent 使用工具: ['astrbot_execute_python']

[2026-03-19 13:41:46.593] [Core] [INFO] [runners.tool_loop_agent_runner:703]: 使用工具：astrbot_execute_python，参数：{'code': 'import sys\nimport struct\nimport os\n\ndef get_jpeg_size(file_path):\n    """读取JPEG图片的尺寸"""\n    try:\n        # 尝试使用PIL\n        from PIL import Image\n        with Image.open(file_path) as img:\n            return img.size  # (width, height)\n    except ImportError:\n        # 如果没有PIL，尝试解析JPEG文件头\n        with open(file_path, \'rb\') as f:\n            # 检查JPEG起始标记\n            if f.read(2) != b\'\\xff\\xd8\':\n                return None\n            \n            while True:\n                marker = f.read(2)\n                if not marker or len(marker) < 2:\n                    break\n                    \n                if marker[0] != 0xFF:\n                    break\n                    \n                marker_type = marker[1]\n                \n                # 如果是SOF标记（Start Of Frame），包含尺寸信息\n                if 0xC0 <= marker_type <= 0xCF and marker_type != 0xC4 and marker_type != 0xC8:\n                    # 读取长度\n                    length_bytes = f.read(2)\n                    if len(length_bytes) < 2:\n                        break\n                    length = struct.unpack(\'>H\', length_bytes)[0]\n                    \n                    # 跳过精度和图像高度/宽度\n                    f.read(1)  # 精度\n                    height_bytes = f.read(2)\n                    width_bytes = f.read(2)\n                    \n                    if len(height_bytes) < 2 or len(width_bytes) < 2:\n                        break\n                        \n                    height = struct.unpack(\'>H\', height_bytes)[0]\n                    width = struct.unpack(\'>H\', width_bytes)[0]\n                    return (width, height)\n                \n                # 读取该标记的长度并跳过\n                length_bytes = f.read(2)\n                if len(length_bytes) < 2:\n                    break\n                length = struct.unpack(\'>H\', length_bytes)[0]\n                f.seek(length - 2, 1)\n    \n    return None\n\nfile_path = \'/AstrBot/data/temp/io_temp_img_1773898870_f420cbcb.jpg\'\nsize = get_jpeg_size(file_path)\nif size:\n    print(f"图片尺寸: {size[0]} x {size[1]} 像素")\nelse:\n    print("无法读取图片尺寸")'}

[2026-03-19 13:41:47.636] [Core] [INFO] [runners.tool_loop_agent_runner:881]: Tool `astrbot_execute_python` Result: 图片尺寸: 873 x 1920 像素

[2026-03-19 13:41:55.760] [Core] [INFO] [result_decorate.stage:189]: 流式输出已启用，跳过结果装饰阶段
```

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Adjust QQ Official private message sending to avoid msg_id-related errors in proactive tool-call scenarios.

Bug Fixes:
- Prevent send_message_to_user failures in QQ Official friend messages by omitting msg_id so proactive messages are accepted by the API.

Enhancements:
- Unify handling of QQ Official private messages so all friend-message payloads drop msg_id and rely on msg_seq and media fields as appropriate.