### PR TITLE
Introduce centralized request utilities, configurable API base, and Vite env handling

### DIFF
--- a/dashboard/.env.development
+++ b/dashboard/.env.development
@@ -1,0 +1,3 @@
+# Local development uses the Vite proxy at /api.
+VITE_API_BASE=/api
+VITE_DEV_API_PROXY_TARGET=http://127.0.0.1:6185

--- a/dashboard/.env.production
+++ b/dashboard/.env.production
@@ -1,0 +1,5 @@
+# If deploying to GitHub Pages under a repository subpath, set:
+# VITE_BASE_PATH=/your-repo-name/
+# Set this to your deployed backend origin before publishing, for example:
+# VITE_API_BASE=https://api.example.com
+VITE_API_BASE=

--- a/dashboard/env.d.ts
+++ b/dashboard/env.d.ts
@@ -1,7 +1,10 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+  readonly VITE_API_BASE?: string;
   readonly VITE_ASTRBOT_RELEASE_BASE_URL?: string;
+  readonly VITE_BASE_PATH?: string;
+  readonly VITE_DEV_API_PROXY_TARGET?: string;
 }
 
 interface ImportMeta {

--- a/dashboard/src/components/chat/ConfigSelector.vue
+++ b/dashboard/src/components/chat/ConfigSelector.vue
@@ -111,7 +111,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue';
-import axios from 'axios';
+import axios from '@/utils/request';
 import { useToast } from '@/utils/toast';
 import { useModuleI18n } from '@/i18n/composables';
 import {

--- a/dashboard/src/components/chat/LiveMode.vue
+++ b/dashboard/src/components/chat/LiveMode.vue
@@ -96,7 +96,7 @@
 </template>
 
 <script setup lang="ts">
-import axios from "axios";
+import { resolveWebSocketUrl } from "@/utils/request";
 import { ref, computed, onBeforeUnmount, watch } from "vue";
 import { useVADRecording } from "@/composables/useVADRecording";
 import SiriOrb from "./LiveOrb.vue";
@@ -331,28 +331,7 @@ function connectWebSocket(): Promise<void> {
       return;
     }
 
-    let wsBase = "";
-    const apiBase = axios.defaults.baseURL || "";
-
-    if (apiBase) {
-      if (apiBase.startsWith("https://")) {
-        wsBase = apiBase.replace("https://", "wss://");
-      } else if (apiBase.startsWith("http://")) {
-        wsBase = apiBase.replace("http://", "ws://");
-      } else {
-        const protocol =
-          window.location.protocol === "https:" ? "wss://" : "ws://";
-        wsBase = protocol + apiBase;
-      }
-      wsBase = wsBase.replace(/\/+$/, "");
-    } else {
-      const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-      wsBase = `${protocol}//${window.location.host}`;
-    }
-
-    const wsUrl = `${wsBase}/api/live_chat/ws?token=${encodeURIComponent(
-      token,
-    )}`;
+    const wsUrl = resolveWebSocketUrl("/api/live_chat/ws", { token });
 
     ws = new WebSocket(wsUrl);
 

--- a/dashboard/src/components/chat/MessageList.vue
+++ b/dashboard/src/components/chat/MessageList.vue
@@ -403,7 +403,7 @@ import {
 import "markstream-vue/index.css";
 import "katex/dist/katex.min.css";
 import "highlight.js/styles/github.css";
-import axios from "axios";
+import axios from "@/utils/request";
 import { useToast } from "@/utils/toast";
 import ReasoningBlock from "./message_list_comps/ReasoningBlock.vue";
 import MessagePartsRenderer from "./message_list_comps/MessagePartsRenderer.vue";

--- a/dashboard/src/components/chat/ProviderConfigDialog.vue
+++ b/dashboard/src/components/chat/ProviderConfigDialog.vue
@@ -251,7 +251,7 @@ import ProviderModelsPanel from '@/components/provider/ProviderModelsPanel.vue'
 import ProviderSourcesPanel from '@/components/provider/ProviderSourcesPanel.vue'
 import { useProviderSources } from '@/composables/useProviderSources'
 import { getProviderIcon } from '@/utils/providerUtils'
-import axios from 'axios'
+import axios from '@/utils/request'
 
 const props = defineProps({
   modelValue: {

--- a/dashboard/src/components/chat/ProviderModelMenu.vue
+++ b/dashboard/src/components/chat/ProviderModelMenu.vue
@@ -117,7 +117,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue';
 import { useDisplay } from 'vuetify';
-import axios from 'axios';
+import axios from '@/utils/request';
 
 interface ModelMetadata {
     modalities?: { input?: string[] };

--- a/dashboard/src/components/chat/StandaloneChat.vue
+++ b/dashboard/src/components/chat/StandaloneChat.vue
@@ -87,7 +87,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onBeforeUnmount, nextTick } from "vue";
-import axios from "axios";
+import axios from "@/utils/request";
 import { useCustomizerStore } from "@/stores/customizer";
 import { useI18n, useModuleI18n } from "@/i18n/composables";
 import MessageList from "@/components/chat/MessageList.vue";

--- a/dashboard/src/components/extension/McpServersSection.vue
+++ b/dashboard/src/components/extension/McpServersSection.vue
@@ -412,7 +412,7 @@
 </template>
 
 <script>
-import axios from 'axios';
+import axios from '@/utils/request';
 import { VueMonacoEditor } from '@guolao/vue-monaco-editor';
 import ItemCard from '@/components/shared/ItemCard.vue';
 import { useI18n, useModuleI18n } from '@/i18n/composables';

--- a/dashboard/src/components/extension/SkillsSection.vue
+++ b/dashboard/src/components/extension/SkillsSection.vue
@@ -713,7 +713,7 @@
 </template>
 
 <script>
-import axios from "axios";
+import axios from "@/utils/request";
 import { computed, onMounted, reactive, ref, watch } from "vue";
 import ItemCard from "@/components/shared/ItemCard.vue";
 import { useI18n, useModuleI18n } from "@/i18n/composables";

--- a/dashboard/src/components/extension/componentPanel/composables/useCommandActions.ts
+++ b/dashboard/src/components/extension/componentPanel/composables/useCommandActions.ts
@@ -2,7 +2,7 @@
  * 指令操作方法 Composable
  */
 import { reactive } from 'vue';
-import axios from 'axios';
+import axios from '@/utils/request';
 import type { CommandItem, RenameDialogState, DetailsDialogState, TypeInfo, StatusInfo } from '../types';
 
 export function useCommandActions(

--- a/dashboard/src/components/extension/componentPanel/composables/useComponentData.ts
+++ b/dashboard/src/components/extension/componentPanel/composables/useComponentData.ts
@@ -2,7 +2,7 @@
  * 指令数据管理 Composable
  */
 import { ref, reactive } from 'vue';
-import axios from 'axios';
+import axios from '@/utils/request';
 import type { CommandItem, CommandSummary, SnackbarState, ToolItem } from '../types';
 
 export function useComponentData() {

--- a/dashboard/src/components/extension/componentPanel/index.vue
+++ b/dashboard/src/components/extension/componentPanel/index.vue
@@ -13,7 +13,7 @@
  * - components/DetailsDialog.vue: 详情对话框
  */
 import { computed, onActivated, onMounted, ref, watch} from 'vue';
-import axios from 'axios';
+import axios from '@/utils/request';
 import { useModuleI18n } from '@/i18n/composables';
 import { normalizeTextInput } from '@/utils/inputValue';
 

--- a/dashboard/src/components/platform/AddNewPlatform.vue
+++ b/dashboard/src/components/platform/AddNewPlatform.vue
@@ -558,7 +558,8 @@
 
 
 <script>
-import axios from 'axios';
+import axios from '@/utils/request';
+import { resolveApiUrl } from '@/utils/request';
 import { useModuleI18n } from '@/i18n/composables';
 import { getPlatformIcon, getPlatformDescription, getTutorialLink } from '@/utils/platformUtils';
 import AstrBotConfig from '@/components/shared/AstrBotConfig.vue';
@@ -780,7 +781,7 @@ export default {
       // Check for plugin-provided logo_token first
       const template = this.platformTemplates?.[platformType];
       if (template && template.logo_token) {
-        return `/api/file/${template.logo_token}`;
+        return resolveApiUrl(`/api/file/${template.logo_token}`);
       }
       return getPlatformIcon(platformType);
     },

--- a/dashboard/src/components/shared/AstrBotConfig.vue
+++ b/dashboard/src/components/shared/AstrBotConfig.vue
@@ -4,7 +4,7 @@ import { ref, computed } from 'vue'
 import ConfigItemRenderer from './ConfigItemRenderer.vue'
 import TemplateListEditor from './TemplateListEditor.vue'
 import { useI18n, useModuleI18n } from '@/i18n/composables'
-import axios from 'axios'
+import axios from '@/utils/request'
 import { useToast } from '@/utils/toast'
 
 const props = defineProps({

--- a/dashboard/src/components/shared/BackupDialog.vue
+++ b/dashboard/src/components/shared/BackupDialog.vue
@@ -680,7 +680,8 @@
 
 <script setup>
 import { ref, computed, watch } from 'vue'
-import axios from 'axios'
+import axios from '@/utils/request'
+import { resolveApiUrl } from '@/utils/request'
 import { useI18n } from '@/i18n/composables'
 import { askForConfirmation, useConfirmDialog } from '@/utils/confirmDialog'
 import { restartAstrBot as restartAstrBotRuntime } from '@/utils/restartAstrBot'
@@ -1115,7 +1116,7 @@ const downloadBackup = (filename) => {
     }
     
     // 直接使用浏览器下载，这样可以看到原生下载进度条
-    const downloadUrl = `/api/backup/download?filename=${encodeURIComponent(filename)}&token=${encodeURIComponent(token)}`
+    const downloadUrl = resolveApiUrl(`/api/backup/download?filename=${encodeURIComponent(filename)}&token=${encodeURIComponent(token)}`)
     
     // 创建隐藏的 a 标签触发下载
     const link = document.createElement('a')

--- a/dashboard/src/components/shared/ChangelogDialog.vue
+++ b/dashboard/src/components/shared/ChangelogDialog.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, watch, computed } from 'vue';
 import { useI18n } from '@/i18n/composables';
-import axios from 'axios';
+import axios from '@/utils/request';
 import { MarkdownRender, enableKatex, enableMermaid } from 'markstream-vue';
 import 'markstream-vue/index.css';
 import 'katex/dist/katex.min.css';

--- a/dashboard/src/components/shared/ConsoleDisplayer.vue
+++ b/dashboard/src/components/shared/ConsoleDisplayer.vue
@@ -1,7 +1,8 @@
 <script setup>
 import { useCommonStore } from '@/stores/common';
-import axios from 'axios';
+import axios from '@/utils/request';
 import { EventSourcePolyfill } from 'event-source-polyfill';
+import { resolveApiUrl } from '@/utils/request';
 </script>
 
 <template>
@@ -120,7 +121,7 @@ export default {
       
       const token = localStorage.getItem('token');
 
-      this.eventSource = new EventSourcePolyfill('/api/live-log', {
+      this.eventSource = new EventSourcePolyfill(resolveApiUrl('/api/live-log'), {
         headers: {
             'Authorization': token ? `Bearer ${token}` : ''
         },

--- a/dashboard/src/components/shared/FileConfigItem.vue
+++ b/dashboard/src/components/shared/FileConfigItem.vue
@@ -141,7 +141,7 @@
 
 <script setup>
 import { computed, ref, watch } from 'vue'
-import axios from 'axios'
+import axios from '@/utils/request'
 import { useToast } from '@/utils/toast'
 import { useModuleI18n } from '@/i18n/composables'
 

--- a/dashboard/src/components/shared/KnowledgeBaseSelector.vue
+++ b/dashboard/src/components/shared/KnowledgeBaseSelector.vue
@@ -158,7 +158,7 @@
 
 <script setup>
 import { ref, watch } from 'vue'
-import axios from 'axios'
+import axios from '@/utils/request'
 import { useRouter } from 'vue-router'
 import { useModuleI18n } from '@/i18n/composables'
 

--- a/dashboard/src/components/shared/MigrationDialog.vue
+++ b/dashboard/src/components/shared/MigrationDialog.vue
@@ -207,7 +207,7 @@
 
 <script setup>
 import { ref, computed, watch } from 'vue'
-import axios from 'axios'
+import axios from '@/utils/request'
 import { useI18n } from '@/i18n/composables'
 import { restartAstrBot as restartAstrBotRuntime } from '@/utils/restartAstrBot'
 import ConsoleDisplayer from './ConsoleDisplayer.vue'

--- a/dashboard/src/components/shared/PersonaForm.vue
+++ b/dashboard/src/components/shared/PersonaForm.vue
@@ -582,7 +582,7 @@
 </template>
 
 <script>
-import axios from 'axios';
+import axios from '@/utils/request';
 import { useModuleI18n } from '@/i18n/composables';
 import {
     askForConfirmation as askForConfirmationDialog,

--- a/dashboard/src/components/shared/PersonaQuickPreview.vue
+++ b/dashboard/src/components/shared/PersonaQuickPreview.vue
@@ -135,7 +135,7 @@
 
 <script setup>
 import { computed, ref, watch, onMounted, onBeforeUnmount } from 'vue'
-import axios from 'axios'
+import axios from '@/utils/request'
 import { useModuleI18n } from '@/i18n/composables'
 
 const props = defineProps({

--- a/dashboard/src/components/shared/PersonaSelector.vue
+++ b/dashboard/src/components/shared/PersonaSelector.vue
@@ -32,7 +32,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
-import axios from 'axios'
+import axios from '@/utils/request'
 import BaseFolderItemSelector from '@/components/folder/BaseFolderItemSelector.vue'
 import PersonaForm from './PersonaForm.vue'
 import { useI18n, useModuleI18n } from '@/i18n/composables'

--- a/dashboard/src/components/shared/PluginSetSelector.vue
+++ b/dashboard/src/components/shared/PluginSetSelector.vue
@@ -159,7 +159,7 @@
 
 <script setup>
 import { ref, computed, watch } from 'vue'
-import axios from 'axios'
+import axios from '@/utils/request'
 import { useModuleI18n } from '@/i18n/composables'
 
 const props = defineProps({

--- a/dashboard/src/components/shared/ProviderSelector.vue
+++ b/dashboard/src/components/shared/ProviderSelector.vue
@@ -244,7 +244,7 @@
 
 <script setup>
 import { computed, ref, watch } from 'vue'
-import axios from 'axios'
+import axios from '@/utils/request'
 import { useModuleI18n } from '@/i18n/composables'
 import ProviderPage from '@/views/ProviderPage.vue'
 

--- a/dashboard/src/components/shared/ProxySelector.vue
+++ b/dashboard/src/components/shared/ProxySelector.vue
@@ -89,7 +89,7 @@
 
 
 <script>
-import axios from 'axios';
+import axios from '@/utils/request';
 import { useModuleI18n } from '@/i18n/composables';
 
 export default {

--- a/dashboard/src/components/shared/ReadmeDialog.vue
+++ b/dashboard/src/components/shared/ReadmeDialog.vue
@@ -2,7 +2,7 @@
 import { ref, watch, computed, onUnmounted } from "vue";
 import MarkdownIt from "markdown-it";
 import hljs from "highlight.js";
-import axios from "axios";
+import axios from "@/utils/request";
 import DOMPurify from "dompurify";
 import "highlight.js/styles/github-dark.css";
 import { useI18n } from "@/i18n/composables";

--- a/dashboard/src/components/shared/T2ITemplateEditor.vue
+++ b/dashboard/src/components/shared/T2ITemplateEditor.vue
@@ -336,7 +336,7 @@
 import { ref, computed, nextTick, watch } from 'vue'
 import { VueMonacoEditor } from '@guolao/vue-monaco-editor'
 import { useI18n, useModuleI18n } from '@/i18n/composables'
-import axios from 'axios'
+import axios from '@/utils/request'
 
 const { t } = useI18n()
 const { tm } = useModuleI18n('core.shared')

--- a/dashboard/src/components/shared/TraceDisplayer.vue
+++ b/dashboard/src/components/shared/TraceDisplayer.vue
@@ -1,6 +1,7 @@
 <script setup>
-import axios from 'axios';
+import axios from '@/utils/request';
 import { EventSourcePolyfill } from 'event-source-polyfill';
+import { resolveApiUrl } from '@/utils/request';
 </script>
 
 <template>
@@ -203,7 +204,7 @@ export default {
 
       const token = localStorage.getItem('token');
 
-      this.eventSource = new EventSourcePolyfill('/api/live-log', {
+      this.eventSource = new EventSourcePolyfill(resolveApiUrl('/api/live-log'), {
         headers: {
           Authorization: token ? `Bearer ${token}` : ''
         },

--- a/dashboard/src/components/shared/WaitingForRestart.vue
+++ b/dashboard/src/components/shared/WaitingForRestart.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script>
-import axios from 'axios'
+import axios from '@/utils/request'
 import { useCommonStore } from '@/stores/common';
 import { useI18n } from '@/i18n/composables';
 

--- a/dashboard/src/composables/useConversations.ts
+++ b/dashboard/src/composables/useConversations.ts
@@ -1,5 +1,5 @@
 import { ref, computed } from 'vue';
-import axios from 'axios';
+import axios from '@/utils/request';
 import { useRouter } from 'vue-router';
 
 export interface Conversation {

--- a/dashboard/src/composables/useMediaHandling.ts
+++ b/dashboard/src/composables/useMediaHandling.ts
@@ -1,5 +1,5 @@
 import { ref, computed } from 'vue';
-import axios from 'axios';
+import axios from '@/utils/request';
 
 export interface StagedFileInfo {
     attachment_id: string;

--- a/dashboard/src/composables/useMessages.ts
+++ b/dashboard/src/composables/useMessages.ts
@@ -1,5 +1,6 @@
 import { ref, reactive, type Ref } from 'vue';
-import axios from 'axios';
+import axios from '@/utils/request';
+import { resolveWebSocketUrl } from '@/utils/request';
 import { useToast } from '@/utils/toast';
 
 // 工具调用信息
@@ -162,11 +163,7 @@ export function useMessages(
         if (!token) {
             throw new Error('Missing authentication token');
         }
-        const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-        const wsUrl = new URL('/api/unified_chat/ws', window.location.href);
-        wsUrl.protocol = protocol;
-        wsUrl.searchParams.set('token', token);
-        return wsUrl.toString();
+        return resolveWebSocketUrl('/api/unified_chat/ws', { token });
     }
 
     function closeChatWebSocket() {

--- a/dashboard/src/composables/useProjects.ts
+++ b/dashboard/src/composables/useProjects.ts
@@ -1,5 +1,5 @@
 import { ref } from 'vue';
-import axios from 'axios';
+import axios from '@/utils/request';
 import type { Project } from '@/components/chat/ProjectList.vue';
 
 export function useProjects() {

--- a/dashboard/src/composables/useProviderSources.ts
+++ b/dashboard/src/composables/useProviderSources.ts
@@ -1,5 +1,5 @@
 import { ref, computed, onMounted, nextTick, watch } from 'vue'
-import axios from 'axios'
+import axios from '@/utils/request'
 import { getProviderIcon } from '@/utils/providerUtils'
 import { askForConfirmation as askForConfirmationDialog, useConfirmDialog } from '@/utils/confirmDialog'
 import { normalizeTextInput } from '@/utils/inputValue'

--- a/dashboard/src/composables/useRecording.ts
+++ b/dashboard/src/composables/useRecording.ts
@@ -1,5 +1,5 @@
 import { ref } from 'vue';
-import axios from 'axios';
+import axios from '@/utils/request';
 
 export function useRecording() {
     const isRecording = ref(false);

--- a/dashboard/src/composables/useSessions.ts
+++ b/dashboard/src/composables/useSessions.ts
@@ -1,5 +1,5 @@
 import { ref, computed } from 'vue';
-import axios from 'axios';
+import axios from '@/utils/request';
 import { useRouter } from 'vue-router';
 import { buildWebchatUmoDetails, getStoredSelectedChatConfigId } from '@/utils/chatConfigBinding';
 

--- a/dashboard/src/composables/useVADRecording.ts
+++ b/dashboard/src/composables/useVADRecording.ts
@@ -1,5 +1,5 @@
 import { ref, onBeforeUnmount } from 'vue';
-import axios from 'axios';
+import axios from '@/utils/request';
 
 interface VADOptions {
     onSpeechStart?: () => void;

--- a/dashboard/src/layouts/full/FullLayout.vue
+++ b/dashboard/src/layouts/full/FullLayout.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { RouterView, useRoute } from 'vue-router';
 import { ref, onMounted, computed } from 'vue';
-import axios from 'axios';
+import axios from '@/utils/request';
 import VerticalSidebarVue from './vertical-sidebar/VerticalSidebar.vue';
 import VerticalHeaderVue from './vertical-header/VerticalHeader.vue';
 import MigrationDialog from '@/components/shared/MigrationDialog.vue';

--- a/dashboard/src/layouts/full/vertical-header/VerticalHeader.vue
+++ b/dashboard/src/layouts/full/vertical-header/VerticalHeader.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from "vue";
 import { useCustomizerStore } from "@/stores/customizer";
-import axios from "axios";
+import axios from "@/utils/request";
 import Logo from "@/components/shared/Logo.vue";
 import { hashDashboardPassword } from "@/utils/passwordHash";
 import { useAuthStore } from "@/stores/auth";

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -10,7 +10,12 @@ import VueApexCharts from "vue3-apexcharts";
 
 import print from "vue3-print-nb";
 import { loader } from "@guolao/vue-monaco-editor";
-import axios from "axios";
+import {
+  getApiBaseUrl,
+  resolveApiUrl,
+  resolvePublicUrl,
+  setApiBaseUrl,
+} from "@/utils/request";
 import { waitForRouterReadyInBackground } from "./utils/routerReadiness.mjs";
 import { LIGHT_THEME_NAME, DARK_THEME_NAME } from "@/theme/constants";
 
@@ -18,7 +23,9 @@ import { LIGHT_THEME_NAME, DARK_THEME_NAME } from "@/theme/constants";
 async function loadAppConfig() {
   try {
     // 加上时间戳防止浏览器缓存 config.json
-    const response = await fetch(`/config.json?t=${new Date().getTime()}`);
+    const configUrl = new URL(resolvePublicUrl("config.json"));
+    configUrl.searchParams.set("t", `${Date.now()}`);
+    const response = await fetch(configUrl.toString());
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
@@ -64,10 +71,12 @@ async function initApp() {
   const config = await loadAppConfig();
   const configApiUrl = config.apiBaseUrl || "";
   const presets = config.presets || [];
+  const envApiUrl = import.meta.env.VITE_API_BASE || "";
 
   // 优先使用 localStorage 中的配置，其次是 config.json，最后是空字符串
   const localApiUrl = localStorage.getItem("apiBaseUrl");
-  const apiBaseUrl = localApiUrl !== null ? localApiUrl : configApiUrl;
+  const apiBaseUrl =
+    localApiUrl !== null ? localApiUrl : configApiUrl || envApiUrl;
 
   if (apiBaseUrl) {
     console.log(
@@ -75,20 +84,7 @@ async function initApp() {
     );
   }
 
-  // 配置 Axios 全局 Base URL
-  axios.defaults.baseURL = apiBaseUrl;
-
-  axios.interceptors.request.use((config) => {
-    const token = localStorage.getItem("token");
-    if (token) {
-      config.headers["Authorization"] = `Bearer ${token}`;
-    }
-    const locale = localStorage.getItem("astrbot-locale");
-    if (locale) {
-      config.headers["Accept-Language"] = locale;
-    }
-    return config;
-  });
+  setApiBaseUrl(apiBaseUrl);
 
   // Keep fetch() calls consistent with axios by automatically attaching the JWT.
   // Some parts of the UI use fetch directly; without this, those requests will 401.
@@ -97,20 +93,9 @@ async function initApp() {
   window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
     let url = input;
 
-    // 动态获取当前的 Base URL (可能已被 Store 修改)
-    const currentBaseUrl = axios.defaults.baseURL;
-
     // 如果是字符串路径且以 /api 开头，并且配置了 Base URL，则拼接
-    if (
-      typeof input === "string" &&
-      input.startsWith("/api") &&
-      currentBaseUrl
-    ) {
-      // 移除 apiBaseUrl 尾部的斜杠
-      const cleanBase = currentBaseUrl.replace(/\/+$/, "");
-      // 移除 input 开头的斜杠
-      const cleanPath = input.replace(/^\/+/, "");
-      url = `${cleanBase}/${cleanPath}`;
+    if (typeof input === "string" && input.startsWith("/api")) {
+      url = resolveApiUrl(input, getApiBaseUrl());
     }
 
     const token = localStorage.getItem("token");
@@ -153,6 +138,7 @@ async function initApp() {
       const { useApiStore } = await import("@/stores/api");
       const apiStore = useApiStore(pinia);
       apiStore.setPresets(presets);
+      apiStore.init();
 
       app.use(print);
       app.use(VueApexCharts);
@@ -174,6 +160,7 @@ async function initApp() {
       const { useApiStore } = await import("@/stores/api");
       const apiStore = useApiStore(pinia);
       apiStore.setPresets(presets);
+      apiStore.init();
 
       app.use(print);
       app.use(VueApexCharts);

--- a/dashboard/src/stores/api.ts
+++ b/dashboard/src/stores/api.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import axios from "axios";
+import { getApiBaseUrl, setApiBaseUrl } from "@/utils/request";
 
 export type ApiPreset = {
   name: string;
@@ -10,7 +10,7 @@ export const useApiStore = defineStore({
   id: "api",
   state: () => ({
     // 优先从 localStorage 读取用户手动设置的地址
-    apiBaseUrl: localStorage.getItem("apiBaseUrl") || "",
+    apiBaseUrl: getApiBaseUrl() || localStorage.getItem("apiBaseUrl") || "",
     configPresets: [] as ApiPreset[],
     customPresets: JSON.parse(
       localStorage.getItem("customPresets") || "[]",
@@ -53,8 +53,7 @@ export const useApiStore = defineStore({
         localStorage.removeItem("apiBaseUrl");
       }
 
-      // 立即更新 axios 配置
-      axios.defaults.baseURL = cleanUrl;
+      setApiBaseUrl(cleanUrl);
     },
 
     /**
@@ -63,7 +62,7 @@ export const useApiStore = defineStore({
      */
     init() {
       if (this.apiBaseUrl) {
-        axios.defaults.baseURL = this.apiBaseUrl;
+        this.apiBaseUrl = setApiBaseUrl(this.apiBaseUrl);
       }
     },
   },

--- a/dashboard/src/stores/auth.ts
+++ b/dashboard/src/stores/auth.ts
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 import { router } from "@/router";
-import axios from "axios";
+import axios from "@/utils/request";
 
 export const useAuthStore = defineStore({
   id: "auth",

--- a/dashboard/src/stores/common.js
+++ b/dashboard/src/stores/common.js
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia';
-import axios from 'axios';
+import axios from '@/utils/request';
 
 export const useCommonStore = defineStore({
   id: 'common',

--- a/dashboard/src/stores/personaStore.ts
+++ b/dashboard/src/stores/personaStore.ts
@@ -2,7 +2,7 @@
  * Persona 文件夹管理 Store
  */
 import { defineStore } from 'pinia';
-import axios from 'axios';
+import axios from '@/utils/request';
 
 // 类型定义
 export interface PersonaFolder {

--- a/dashboard/src/utils/request.ts
+++ b/dashboard/src/utils/request.ts
@@ -1,0 +1,151 @@
+import axios, { type InternalAxiosRequestConfig } from "axios";
+
+const ABSOLUTE_URL_PATTERN = /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//;
+
+function isAbsoluteUrl(value: string): boolean {
+  return ABSOLUTE_URL_PATTERN.test(value);
+}
+
+function stripTrailingSlashes(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function ensureLeadingSlash(value: string): string {
+  if (!value) {
+    return "/";
+  }
+  return value.startsWith("/") ? value : `/${value}`;
+}
+
+function stripLeadingApiPrefix(path: string): string {
+  const normalizedPath = ensureLeadingSlash(path);
+  const strippedPath = normalizedPath.replace(/^\/api(?=\/|$)/, "");
+  return strippedPath || "/";
+}
+
+function baseEndsWithApi(baseUrl: string): boolean {
+  if (!baseUrl) {
+    return false;
+  }
+
+  if (isAbsoluteUrl(baseUrl)) {
+    try {
+      return new URL(baseUrl).pathname.replace(/\/+$/, "").endsWith("/api");
+    } catch {
+      return baseUrl.replace(/\/+$/, "").endsWith("/api");
+    }
+  }
+
+  return stripTrailingSlashes(baseUrl).endsWith("/api");
+}
+
+function normalizePathForBase(path: string, baseUrl = ""): string {
+  if (!path) {
+    return "/";
+  }
+
+  if (isAbsoluteUrl(path)) {
+    return path;
+  }
+
+  const normalizedPath = ensureLeadingSlash(path);
+  if (baseEndsWithApi(baseUrl)) {
+    return stripLeadingApiPrefix(normalizedPath);
+  }
+  return normalizedPath;
+}
+
+function joinBaseAndPath(baseUrl: string, path: string): string {
+  const cleanBase = stripTrailingSlashes(baseUrl);
+  const cleanPath = path.replace(/^\/+/, "");
+  return `${cleanBase}/${cleanPath}`;
+}
+
+function normalizeBaseUrl(baseUrl: string | null | undefined): string {
+  return stripTrailingSlashes(baseUrl?.trim() || "");
+}
+
+export function getApiBaseUrl(): string {
+  return normalizeBaseUrl(service.defaults.baseURL);
+}
+
+export function setApiBaseUrl(baseUrl: string | null | undefined): string {
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+  service.defaults.baseURL = normalizedBaseUrl;
+  return normalizedBaseUrl;
+}
+
+export function resolveApiUrl(
+  path: string,
+  baseUrl: string | null | undefined = getApiBaseUrl(),
+): string {
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+  const normalizedPath = normalizePathForBase(path, normalizedBaseUrl);
+
+  if (isAbsoluteUrl(normalizedPath)) {
+    return normalizedPath;
+  }
+
+  if (!normalizedBaseUrl) {
+    return normalizedPath;
+  }
+
+  return joinBaseAndPath(normalizedBaseUrl, normalizedPath);
+}
+
+export function resolvePublicUrl(path: string): string {
+  const base = import.meta.env.BASE_URL || "/";
+  const cleanBase = base.endsWith("/") ? base : `${base}/`;
+  return new URL(path.replace(/^\/+/, ""), window.location.origin + cleanBase)
+    .toString();
+}
+
+export function resolveWebSocketUrl(
+  path: string,
+  queryParams?: Record<string, string>,
+): string {
+  const resolvedApiUrl = resolveApiUrl(path);
+  const url = new URL(resolvedApiUrl, window.location.href);
+
+  if (url.protocol === "https:") {
+    url.protocol = "wss:";
+  } else if (url.protocol === "http:") {
+    url.protocol = "ws:";
+  }
+
+  if (queryParams) {
+    Object.entries(queryParams).forEach(([key, value]) => {
+      url.searchParams.set(key, value);
+    });
+  }
+
+  return url.toString();
+}
+
+const service = axios.create({
+  baseURL: normalizeBaseUrl(import.meta.env.VITE_API_BASE),
+  timeout: 10000,
+});
+
+service.interceptors.request.use((config: InternalAxiosRequestConfig) => {
+  const normalizedBaseUrl = normalizeBaseUrl(config.baseURL ?? service.defaults.baseURL);
+
+  if (typeof config.url === "string") {
+    config.url = normalizePathForBase(config.url, normalizedBaseUrl);
+  }
+
+  const token = localStorage.getItem("token");
+  if (token) {
+    config.headers.set("Authorization", `Bearer ${token}`);
+  }
+
+  const locale = localStorage.getItem("astrbot-locale");
+  if (locale) {
+    config.headers.set("Accept-Language", locale);
+  }
+
+  return config;
+});
+
+export default service;
+export * from "axios";

--- a/dashboard/src/utils/restartAstrBot.ts
+++ b/dashboard/src/utils/restartAstrBot.ts
@@ -1,4 +1,4 @@
-import axios from 'axios'
+import axios from '@/utils/request'
 import { getDesktopRuntimeInfo } from '@/utils/desktopRuntime'
 
 type WaitingForRestartRef = {

--- a/dashboard/src/views/ConfigPage.vue
+++ b/dashboard/src/views/ConfigPage.vue
@@ -361,7 +361,7 @@
 
 
 <script>
-import axios from 'axios';
+import axios from '@/utils/request';
 import AstrBotCoreConfigWrapper from '@/components/config/AstrBotCoreConfigWrapper.vue';
 import WaitingForRestart from '@/components/shared/WaitingForRestart.vue';
 import StandaloneChat from '@/components/chat/StandaloneChat.vue';

--- a/dashboard/src/views/ConsolePage.vue
+++ b/dashboard/src/views/ConsolePage.vue
@@ -1,7 +1,7 @@
 <script setup>
 import ConsoleDisplayer from '@/components/shared/ConsoleDisplayer.vue';
 import { useModuleI18n } from '@/i18n/composables';
-import axios from 'axios';
+import axios from '@/utils/request';
 
 const { tm } = useModuleI18n('features/console');
 </script>

--- a/dashboard/src/views/ConversationPage.vue
+++ b/dashboard/src/views/ConversationPage.vue
@@ -589,7 +589,7 @@
 </template>
 
 <script>
-import axios from 'axios';
+import axios from '@/utils/request';
 import { debounce } from 'lodash';
 import { VueMonacoEditor } from '@guolao/vue-monaco-editor';
 import { useCommonStore } from '@/stores/common';

--- a/dashboard/src/views/CronJobPage.vue
+++ b/dashboard/src/views/CronJobPage.vue
@@ -244,7 +244,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
-import axios from 'axios'
+import axios from '@/utils/request'
 import { useModuleI18n } from '@/i18n/composables'
 
 const { tm } = useModuleI18n('features/cron')

--- a/dashboard/src/views/PlatformPage.vue
+++ b/dashboard/src/views/PlatformPage.vue
@@ -309,7 +309,8 @@
 </template>
 
 <script>
-import axios from 'axios';
+import axios from '@/utils/request';
+import { resolveApiUrl } from '@/utils/request';
 import AstrBotConfig from '@/components/shared/AstrBotConfig.vue';
 import WaitingForRestart from '@/components/shared/WaitingForRestart.vue';
 import ConsoleDisplayer from '@/components/shared/ConsoleDisplayer.vue';
@@ -441,7 +442,7 @@ export default {
       const template = this.metadata['platform_group']?.metadata?.platform?.config_template?.[platform_id];
       if (template && template.logo_token) {
           // 通过文件服务访问插件提供的 logo
-        return `/api/file/${template.logo_token}`;
+        return resolveApiUrl(`/api/file/${template.logo_token}`);
       }
       return getPlatformIcon(platform_id);
     },
@@ -666,7 +667,7 @@ export default {
       if (callbackBase) {
         return `${callbackBase.replace(/\/$/, '')}/api/platform/webhook/${webhookUuid}`;
       }
-      return `/api/platform/webhook/${webhookUuid}`;
+      return resolveApiUrl(`/api/platform/webhook/${webhookUuid}`);
     },
 
     openWebhookDialog(webhookUuid) {

--- a/dashboard/src/views/ProviderPage.vue
+++ b/dashboard/src/views/ProviderPage.vue
@@ -470,7 +470,7 @@
 <script setup>
 import { ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import axios from 'axios'
+import axios from '@/utils/request'
 import { useModuleI18n } from '@/i18n/composables'
 import AstrBotConfig from '@/components/shared/AstrBotConfig.vue'
 import ItemCard from '@/components/shared/ItemCard.vue'

--- a/dashboard/src/views/SessionManagementPage.vue
+++ b/dashboard/src/views/SessionManagementPage.vue
@@ -1166,7 +1166,7 @@
 </template>
 
 <script>
-import axios from 'axios'
+import axios from '@/utils/request'
 import { useI18n, useModuleI18n } from '@/i18n/composables'
 import {
   askForConfirmation as askForConfirmationDialog,

--- a/dashboard/src/views/Settings.vue
+++ b/dashboard/src/views/Settings.vue
@@ -540,7 +540,7 @@ import SidebarCustomizer from "@/components/shared/SidebarCustomizer.vue";
 import WaitingForRestart from "@/components/shared/WaitingForRestart.vue";
 import MigrationDialog from "@/components/shared/MigrationDialog.vue";
 import BackupDialog from "@/components/shared/BackupDialog.vue";
-import axios from "axios";
+import axios from "@/utils/request";
 import { useI18n, useModuleI18n } from "@/i18n/composables";
 import { useToast } from "@/utils/toast";
 

--- a/dashboard/src/views/SubAgentPage.vue
+++ b/dashboard/src/views/SubAgentPage.vue
@@ -332,7 +332,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
-import axios from 'axios'
+import axios from '@/utils/request'
 import ProviderSelector from '@/components/shared/ProviderSelector.vue'
 import PersonaSelector from '@/components/shared/PersonaSelector.vue'
 import PersonaQuickPreview from '@/components/shared/PersonaQuickPreview.vue'

--- a/dashboard/src/views/TracePage.vue
+++ b/dashboard/src/views/TracePage.vue
@@ -2,7 +2,7 @@
 import TraceDisplayer from '@/components/shared/TraceDisplayer.vue';
 import { useModuleI18n } from '@/i18n/composables';
 import { ref, onMounted } from 'vue';
-import axios from 'axios';
+import axios from '@/utils/request';
 
 const { tm } = useModuleI18n('features/trace');
 

--- a/dashboard/src/views/WelcomePage.vue
+++ b/dashboard/src/views/WelcomePage.vue
@@ -315,7 +315,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch, onMounted } from "vue";
-import axios from "axios";
+import axios from "@/utils/request";
 import AddNewPlatform from "@/components/platform/AddNewPlatform.vue";
 import ProviderConfigDialog from "@/components/chat/ProviderConfigDialog.vue";
 import { useI18n, useModuleI18n } from "@/i18n/composables";

--- a/dashboard/src/views/alkaid/KnowledgeBase.vue
+++ b/dashboard/src/views/alkaid/KnowledgeBase.vue
@@ -825,7 +825,7 @@
 </template>
 
 <script>
-import axios from 'axios';
+import axios from '@/utils/request';
 import ConsoleDisplayer from '@/components/shared/ConsoleDisplayer.vue';
 import { useModuleI18n } from '@/i18n/composables';
 import { normalizeTextInput } from '@/utils/inputValue';

--- a/dashboard/src/views/alkaid/LongTermMemory.vue
+++ b/dashboard/src/views/alkaid/LongTermMemory.vue
@@ -467,7 +467,7 @@
 </template>
 
 <script>
-import axios from 'axios';
+import axios from '@/utils/request';
 import * as d3 from 'd3';
 import { useModuleI18n } from '@/i18n/composables';
 import { normalizeTextInput } from '@/utils/inputValue';

--- a/dashboard/src/views/dashboards/default/DefaultDashboard.vue
+++ b/dashboard/src/views/dashboards/default/DefaultDashboard.vue
@@ -102,7 +102,7 @@ import RunningTime from './components/RunningTime.vue';
 import MemoryUsage from './components/MemoryUsage.vue';
 import MessageStat from './components/MessageStat.vue';
 import PlatformStat from './components/PlatformStat.vue';
-import axios from 'axios';
+import axios from '@/utils/request';
 import { useModuleI18n } from '@/i18n/composables';
 
 export default {

--- a/dashboard/src/views/dashboards/default/components/MessageStat.vue
+++ b/dashboard/src/views/dashboards/default/components/MessageStat.vue
@@ -105,7 +105,7 @@
 </template>
 
 <script>
-import axios from 'axios';
+import axios from '@/utils/request';
 import {useCustomizerStore} from "@/stores/customizer";
 import { useModuleI18n } from '@/i18n/composables';
 

--- a/dashboard/src/views/extension/useExtensionPage.js
+++ b/dashboard/src/views/extension/useExtensionPage.js
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios from "@/utils/request";
 import { useCommonStore } from "@/stores/common";
 import { useI18n, useModuleI18n } from "@/i18n/composables";
 import { getPlatformDisplayName } from "@/utils/platformUtils";

--- a/dashboard/src/views/knowledge-base/DocumentDetail.vue
+++ b/dashboard/src/views/knowledge-base/DocumentDetail.vue
@@ -342,7 +342,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
-import axios from 'axios'
+import axios from '@/utils/request'
 import { useModuleI18n } from '@/i18n/composables'
 import { askForConfirmation, useConfirmDialog } from '@/utils/confirmDialog'
 

--- a/dashboard/src/views/knowledge-base/KBDetail.vue
+++ b/dashboard/src/views/knowledge-base/KBDetail.vue
@@ -255,7 +255,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
-import axios from 'axios'
+import axios from '@/utils/request'
 import { useModuleI18n } from '@/i18n/composables'
 import DocumentsTab from './components/DocumentsTab.vue'
 import RetrievalTab from './components/RetrievalTab.vue'

--- a/dashboard/src/views/knowledge-base/KBList.vue
+++ b/dashboard/src/views/knowledge-base/KBList.vue
@@ -378,7 +378,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
-import axios from 'axios'
+import axios from '@/utils/request'
 import { useModuleI18n } from '@/i18n/composables'
 
 const { tm: t } = useModuleI18n('features/knowledge-base/index')

--- a/dashboard/src/views/knowledge-base/components/DocumentsTab.vue
+++ b/dashboard/src/views/knowledge-base/components/DocumentsTab.vue
@@ -496,7 +496,7 @@
 import TavilyKeyDialog from './TavilyKeyDialog.vue'
 import { ref, onMounted, onUnmounted, computed } from 'vue'
 import { useRouter } from 'vue-router'
-import axios from 'axios'
+import axios from '@/utils/request'
 import { useModuleI18n } from '@/i18n/composables'
 
 const { tm: t } = useModuleI18n('features/knowledge-base/detail')

--- a/dashboard/src/views/knowledge-base/components/RetrievalTab.vue
+++ b/dashboard/src/views/knowledge-base/components/RetrievalTab.vue
@@ -236,7 +236,7 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
-import axios from 'axios'
+import axios from '@/utils/request'
 import { useModuleI18n } from '@/i18n/composables'
 
 const { tm: t } = useModuleI18n('features/knowledge-base/detail')

--- a/dashboard/src/views/knowledge-base/components/SettingsTab.vue
+++ b/dashboard/src/views/knowledge-base/components/SettingsTab.vue
@@ -217,7 +217,7 @@
 
 <script setup lang="ts">
 import { ref, watch, onMounted } from 'vue'
-import axios from 'axios'
+import axios from '@/utils/request'
 import { useModuleI18n } from '@/i18n/composables'
 
 const { tm: t } = useModuleI18n('features/knowledge-base/detail')

--- a/dashboard/src/views/knowledge-base/components/TavilyKeyDialog.vue
+++ b/dashboard/src/views/knowledge-base/components/TavilyKeyDialog.vue
@@ -50,7 +50,7 @@
 
 <script setup lang="ts">
 import { ref, watch } from 'vue'
-import axios from 'axios'
+import axios from '@/utils/request'
 
 const props = defineProps<{
   modelValue: boolean

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath, URL } from 'url';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import vuetify from 'vite-plugin-vuetify';
 import webfontDl from 'vite-plugin-webfont-dl';
@@ -17,54 +17,57 @@ function mdiSubset() {
 }
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command }) => ({
-   base: command === 'build'
-    ? process.env.BASE_PATH || '/'
-    : '/',
+export default defineConfig(({ command, mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const basePath = env.VITE_BASE_PATH || process.env.BASE_PATH || '/';
 
-  plugins: [
-    // Only run MDI subsetting during production builds, skip in dev server
-    ...(command === 'build' ? [mdiSubset()] : []),
-    vue({
-      template: {
-        compilerOptions: {
-          isCustomElement: (tag) => ["v-list-recognize-title"].includes(tag),
+  return {
+    base: command === 'build' ? basePath : '/',
+
+    plugins: [
+      // Only run MDI subsetting during production builds, skip in dev server
+      ...(command === 'build' ? [mdiSubset()] : []),
+      vue({
+        template: {
+          compilerOptions: {
+            isCustomElement: (tag) => ["v-list-recognize-title"].includes(tag),
+          },
         },
+      }),
+      vuetify({
+        autoImport: true
+      }),
+      webfontDl()
+    ],
+    resolve: {
+      alias: {
+        mermaid: "mermaid/dist/mermaid.js",
+        "@": fileURLToPath(new URL("./src", import.meta.url)),
       },
-    }),
-    vuetify({
-      autoImport: true
-    }),
-    webfontDl()
-  ],
-  resolve: {
-    alias: {
-      mermaid: "mermaid/dist/mermaid.js",
-      "@": fileURLToPath(new URL("./src", import.meta.url)),
     },
-  },
-  css: {
-    preprocessorOptions: {
-      scss: {},
+    css: {
+      preprocessorOptions: {
+        scss: {},
+      },
     },
-  },
-  build: {
-    sourcemap: false,
-    chunkSizeWarningLimit: 1024 * 1024, // Set the limit to 1 MB
-  },
-  optimizeDeps: {
-    exclude: ["vuetify"],
-    entries: ["./src/**/*.vue"],
-  },
-  server: {
-    host: "::",
-    port: 3000,
-    proxy: {
-      "/api": {
-        target: "http://127.0.0.1:6185/",
-        changeOrigin: true,
-        ws: true
+    build: {
+      sourcemap: false,
+      chunkSizeWarningLimit: 1024 * 1024, // Set the limit to 1 MB
+    },
+    optimizeDeps: {
+      exclude: ["vuetify"],
+      entries: ["./src/**/*.vue"],
+    },
+    server: {
+      host: "::",
+      port: 3000,
+      proxy: {
+        "/api": {
+          target: env.VITE_DEV_API_PROXY_TARGET || "http://127.0.0.1:6185",
+          changeOrigin: true,
+          ws: true
+        }
       }
     }
-  }
-}));
+  };
+});


### PR DESCRIPTION
### Motivation

- Centralize HTTP/WebSocket URL resolution and Axios configuration so the frontend can reliably resolve API, SSE and WebSocket endpoints across different deployment scenarios and honor runtime/configured API base URL.
- Make Vite build/dev behavior configurable via environment variables (`VITE_BASE_PATH`, `VITE_API_BASE`, `VITE_DEV_API_PROXY_TARGET`) and prevent ad-hoc URL manipulations scattered across the codebase.
- Ensure requests automatically include JWT and Accept-Language headers and unify fetch/axios behavior when an API base is set.

### Description

- Add `dashboard/src/utils/request.ts` that exports a configured Axios instance with helpers: `getApiBaseUrl`, `setApiBaseUrl`, `resolveApiUrl`, `resolveWebSocketUrl`, and `resolvePublicUrl`, and request interceptor attaching `Authorization` and `Accept-Language` headers.
- Add `.env.development` and `.env.production` templates and extend `env.d.ts` to include new Vite environment variables (`VITE_API_BASE`, `VITE_BASE_PATH`, `VITE_DEV_API_PROXY_TARGET`).
- Replace many imports of the raw `axios` with the new `@/utils/request` service across numerous components, composables and stores to standardize request behavior.
- Use `resolveApiUrl` / `resolveWebSocketUrl` / `resolvePublicUrl` in places that build URLs dynamically (file downloads, SSE endpoints, WebSocket connections, webhook URLs, file assets) to correctly respect the configured API base and deployment base path.
- Refactor `main.ts` to load `config.json` via `resolvePublicUrl`, derive the effective API base from `localStorage`, `config.json` and `import.meta.env`, call `setApiBaseUrl`, patch `window.fetch` to attach auth and language headers and resolve `/api` paths, and initialize the `api` Pinia store.
- Update `stores/api.ts` to persist and apply API base via the new utilities and call `setApiBaseUrl` where needed.
- Update `vite.config.ts` to load environment variables at config time (`loadEnv`), support `VITE_BASE_PATH`, and use `VITE_DEV_API_PROXY_TARGET` for the dev server proxy target.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb9b5116f4833084d2cee05477de59)

## Summary by Sourcery

Centralize frontend API base URL handling and request behavior while making Vite’s base path and dev proxy configurable via environment variables.

New Features:
- Introduce a shared HTTP request utility module that encapsulates Axios configuration, API base URL management, and URL resolution helpers for API, WebSocket, and public asset endpoints.

Enhancements:
- Refine application bootstrap to derive the effective API base URL from local storage, config.json, and environment variables, and to initialize the API store accordingly.
- Standardize Axios usage across components, composables, and stores by replacing direct axios imports with the shared request service and using URL helpers wherever dynamic API, SSE, WebSocket, and download URLs are built.
- Ensure fetch-based API calls align with Axios behavior by resolving /api paths through the centralized URL helper and automatically attaching authentication and localization headers.

Build:
- Update Vite configuration to load environment variables at config time, support a configurable base path, and allow overriding the dev server API proxy target via an env variable.