### PR TITLE
fix: surface https backend requirement in dashboard

### DIFF
--- a/astrbot/dashboard/server.py
+++ b/astrbot/dashboard/server.py
@@ -172,7 +172,12 @@ class AstrBotDashboard:
         self.app = cors(
             self.app,
             allow_origin="*",
-            allow_headers=["Authorization", "Content-Type", "X-API-Key"],
+            allow_headers=[
+                "Authorization",
+                "Content-Type",
+                "X-API-Key",
+                "Accept-Language",
+            ],
             allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
         )
 

--- a/dashboard/.env.development
+++ b/dashboard/.env.development
@@ -1,0 +1,3 @@
+# Local development uses the Vite proxy at /api.
+VITE_API_BASE=/api
+VITE_DEV_API_PROXY_TARGET=http://127.0.0.1:6185

--- a/dashboard/.env.production
+++ b/dashboard/.env.production
@@ -1,0 +1,5 @@
+# If deploying to GitHub Pages under a repository subpath, set:
+# VITE_BASE_PATH=/your-repo-name/
+# Set this to your deployed backend origin before publishing, for example:
+# VITE_API_BASE=https://api.example.com
+VITE_API_BASE=

--- a/dashboard/env.d.ts
+++ b/dashboard/env.d.ts
@@ -1,7 +1,10 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+  readonly VITE_API_BASE?: string;
   readonly VITE_ASTRBOT_RELEASE_BASE_URL?: string;
+  readonly VITE_BASE_PATH?: string;
+  readonly VITE_DEV_API_PROXY_TARGET?: string;
 }
 
 interface ImportMeta {

--- a/dashboard/src/components/chat/LiveMode.vue
+++ b/dashboard/src/components/chat/LiveMode.vue
@@ -96,7 +96,7 @@
 </template>
 
 <script setup lang="ts">
-import axios from "axios";
+import { resolveWebSocketUrl } from "@/utils/request";
 import { ref, computed, onBeforeUnmount, watch } from "vue";
 import { useVADRecording } from "@/composables/useVADRecording";
 import SiriOrb from "./LiveOrb.vue";
@@ -331,28 +331,7 @@ function connectWebSocket(): Promise<void> {
       return;
     }
 
-    let wsBase = "";
-    const apiBase = axios.defaults.baseURL || "";
-
-    if (apiBase) {
-      if (apiBase.startsWith("https://")) {
-        wsBase = apiBase.replace("https://", "wss://");
-      } else if (apiBase.startsWith("http://")) {
-        wsBase = apiBase.replace("http://", "ws://");
-      } else {
-        const protocol =
-          window.location.protocol === "https:" ? "wss://" : "ws://";
-        wsBase = protocol + apiBase;
-      }
-      wsBase = wsBase.replace(/\/+$/, "");
-    } else {
-      const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-      wsBase = `${protocol}//${window.location.host}`;
-    }
-
-    const wsUrl = `${wsBase}/api/live_chat/ws?token=${encodeURIComponent(
-      token,
-    )}`;
+    const wsUrl = resolveWebSocketUrl("/api/live_chat/ws", { token });
 
     ws = new WebSocket(wsUrl);
 

--- a/dashboard/src/components/platform/AddNewPlatform.vue
+++ b/dashboard/src/components/platform/AddNewPlatform.vue
@@ -559,6 +559,7 @@
 
 <script>
 import axios from 'axios';
+import { resolveApiUrl } from '@/utils/request';
 import { useModuleI18n } from '@/i18n/composables';
 import { getPlatformIcon, getPlatformDescription, getTutorialLink } from '@/utils/platformUtils';
 import AstrBotConfig from '@/components/shared/AstrBotConfig.vue';
@@ -780,7 +781,7 @@ export default {
       // Check for plugin-provided logo_token first
       const template = this.platformTemplates?.[platformType];
       if (template && template.logo_token) {
-        return `/api/file/${template.logo_token}`;
+        return resolveApiUrl(`/api/file/${template.logo_token}`);
       }
       return getPlatformIcon(platformType);
     },

--- a/dashboard/src/components/shared/BackupDialog.vue
+++ b/dashboard/src/components/shared/BackupDialog.vue
@@ -681,6 +681,7 @@
 <script setup>
 import { ref, computed, watch } from 'vue'
 import axios from 'axios'
+import { resolveApiUrl } from '@/utils/request'
 import { useI18n } from '@/i18n/composables'
 import { askForConfirmation, useConfirmDialog } from '@/utils/confirmDialog'
 import { restartAstrBot as restartAstrBotRuntime } from '@/utils/restartAstrBot'
@@ -1115,7 +1116,7 @@ const downloadBackup = (filename) => {
     }
     
     // 直接使用浏览器下载，这样可以看到原生下载进度条
-    const downloadUrl = `/api/backup/download?filename=${encodeURIComponent(filename)}&token=${encodeURIComponent(token)}`
+    const downloadUrl = resolveApiUrl(`/api/backup/download?filename=${encodeURIComponent(filename)}&token=${encodeURIComponent(token)}`)
     
     // 创建隐藏的 a 标签触发下载
     const link = document.createElement('a')

--- a/dashboard/src/components/shared/ConsoleDisplayer.vue
+++ b/dashboard/src/components/shared/ConsoleDisplayer.vue
@@ -2,6 +2,7 @@
 import { useCommonStore } from '@/stores/common';
 import axios from 'axios';
 import { EventSourcePolyfill } from 'event-source-polyfill';
+import { resolveApiUrl } from '@/utils/request';
 </script>
 
 <template>
@@ -120,7 +121,7 @@ export default {
       
       const token = localStorage.getItem('token');
 
-      this.eventSource = new EventSourcePolyfill('/api/live-log', {
+      this.eventSource = new EventSourcePolyfill(resolveApiUrl('/api/live-log'), {
         headers: {
             'Authorization': token ? `Bearer ${token}` : ''
         },

--- a/dashboard/src/components/shared/TraceDisplayer.vue
+++ b/dashboard/src/components/shared/TraceDisplayer.vue
@@ -1,6 +1,7 @@
 <script setup>
 import axios from 'axios';
 import { EventSourcePolyfill } from 'event-source-polyfill';
+import { resolveApiUrl } from '@/utils/request';
 </script>
 
 <template>
@@ -203,7 +204,7 @@ export default {
 
       const token = localStorage.getItem('token');
 
-      this.eventSource = new EventSourcePolyfill('/api/live-log', {
+      this.eventSource = new EventSourcePolyfill(resolveApiUrl('/api/live-log'), {
         headers: {
           Authorization: token ? `Bearer ${token}` : ''
         },

--- a/dashboard/src/composables/useMessages.ts
+++ b/dashboard/src/composables/useMessages.ts
@@ -1,5 +1,6 @@
 import { ref, reactive, type Ref } from 'vue';
 import axios from 'axios';
+import { resolveWebSocketUrl } from '@/utils/request';
 import { useToast } from '@/utils/toast';
 
 // 工具调用信息
@@ -162,11 +163,7 @@ export function useMessages(
         if (!token) {
             throw new Error('Missing authentication token');
         }
-        const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-        const wsUrl = new URL('/api/unified_chat/ws', window.location.href);
-        wsUrl.protocol = protocol;
-        wsUrl.searchParams.set('token', token);
-        return wsUrl.toString();
+        return resolveWebSocketUrl('/api/unified_chat/ws', { token });
     }
 
     function closeChatWebSocket() {

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -10,7 +10,13 @@ import VueApexCharts from "vue3-apexcharts";
 
 import print from "vue3-print-nb";
 import { loader } from "@guolao/vue-monaco-editor";
-import axios from "axios";
+import {
+  getApiBaseUrl,
+  getApiBaseUrlValidationError,
+  resolveApiUrl,
+  resolvePublicUrl,
+  setApiBaseUrl,
+} from "@/utils/request";
 import { waitForRouterReadyInBackground } from "./utils/routerReadiness.mjs";
 import { LIGHT_THEME_NAME, DARK_THEME_NAME } from "@/theme/constants";
 
@@ -18,7 +24,9 @@ import { LIGHT_THEME_NAME, DARK_THEME_NAME } from "@/theme/constants";
 async function loadAppConfig() {
   try {
     // 加上时间戳防止浏览器缓存 config.json
-    const response = await fetch(`/config.json?t=${new Date().getTime()}`);
+    const configUrl = new URL(resolvePublicUrl("config.json"));
+    configUrl.searchParams.set("t", `${Date.now()}`);
+    const response = await fetch(configUrl.toString());
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
@@ -64,10 +72,12 @@ async function initApp() {
   const config = await loadAppConfig();
   const configApiUrl = config.apiBaseUrl || "";
   const presets = config.presets || [];
+  const envApiUrl = import.meta.env.VITE_API_BASE || "";
 
   // 优先使用 localStorage 中的配置，其次是 config.json，最后是空字符串
   const localApiUrl = localStorage.getItem("apiBaseUrl");
-  const apiBaseUrl = localApiUrl !== null ? localApiUrl : configApiUrl;
+  const apiBaseUrl =
+    localApiUrl !== null ? localApiUrl : configApiUrl || envApiUrl;
 
   if (apiBaseUrl) {
     console.log(
@@ -75,20 +85,13 @@ async function initApp() {
     );
   }
 
-  // 配置 Axios 全局 Base URL
-  axios.defaults.baseURL = apiBaseUrl;
-
-  axios.interceptors.request.use((config) => {
-    const token = localStorage.getItem("token");
-    if (token) {
-      config.headers["Authorization"] = `Bearer ${token}`;
-    }
-    const locale = localStorage.getItem("astrbot-locale");
-    if (locale) {
-      config.headers["Accept-Language"] = locale;
-    }
-    return config;
-  });
+  const apiBaseUrlValidationError = getApiBaseUrlValidationError(apiBaseUrl);
+  if (apiBaseUrlValidationError) {
+    console.warn(apiBaseUrlValidationError);
+    setApiBaseUrl("");
+  } else {
+    setApiBaseUrl(apiBaseUrl);
+  }
 
   // Keep fetch() calls consistent with axios by automatically attaching the JWT.
   // Some parts of the UI use fetch directly; without this, those requests will 401.
@@ -97,20 +100,9 @@ async function initApp() {
   window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
     let url = input;
 
-    // 动态获取当前的 Base URL (可能已被 Store 修改)
-    const currentBaseUrl = axios.defaults.baseURL;
-
     // 如果是字符串路径且以 /api 开头，并且配置了 Base URL，则拼接
-    if (
-      typeof input === "string" &&
-      input.startsWith("/api") &&
-      currentBaseUrl
-    ) {
-      // 移除 apiBaseUrl 尾部的斜杠
-      const cleanBase = currentBaseUrl.replace(/\/+$/, "");
-      // 移除 input 开头的斜杠
-      const cleanPath = input.replace(/^\/+/, "");
-      url = `${cleanBase}/${cleanPath}`;
+    if (typeof input === "string" && input.startsWith("/api")) {
+      url = resolveApiUrl(input, getApiBaseUrl());
     }
 
     const token = localStorage.getItem("token");
@@ -118,7 +110,7 @@ async function initApp() {
     const headers = new Headers(
       init?.headers ||
         (typeof input !== "string" && "headers" in input
-          ? (input ).headers
+          ? input.headers
           : undefined),
     );
     if (token && !headers.has("Authorization")) {
@@ -153,6 +145,7 @@ async function initApp() {
       const { useApiStore } = await import("@/stores/api");
       const apiStore = useApiStore(pinia);
       apiStore.setPresets(presets);
+      apiStore.init();
 
       app.use(print);
       app.use(VueApexCharts);
@@ -174,6 +167,7 @@ async function initApp() {
       const { useApiStore } = await import("@/stores/api");
       const apiStore = useApiStore(pinia);
       apiStore.setPresets(presets);
+      apiStore.init();
 
       app.use(print);
       app.use(VueApexCharts);

--- a/dashboard/src/stores/api.ts
+++ b/dashboard/src/stores/api.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import axios from "axios";
+import { getApiBaseUrl, setApiBaseUrl } from "@/utils/request";
 
 export type ApiPreset = {
   name: string;
@@ -10,7 +10,7 @@ export const useApiStore = defineStore({
   id: "api",
   state: () => ({
     // 优先从 localStorage 读取用户手动设置的地址
-    apiBaseUrl: localStorage.getItem("apiBaseUrl") || "",
+    apiBaseUrl: getApiBaseUrl() || localStorage.getItem("apiBaseUrl") || "",
     configPresets: [] as ApiPreset[],
     customPresets: JSON.parse(
       localStorage.getItem("customPresets") || "[]",
@@ -53,8 +53,7 @@ export const useApiStore = defineStore({
         localStorage.removeItem("apiBaseUrl");
       }
 
-      // 立即更新 axios 配置
-      axios.defaults.baseURL = cleanUrl;
+      setApiBaseUrl(cleanUrl);
     },
 
     /**
@@ -63,7 +62,7 @@ export const useApiStore = defineStore({
      */
     init() {
       if (this.apiBaseUrl) {
-        axios.defaults.baseURL = this.apiBaseUrl;
+        this.apiBaseUrl = setApiBaseUrl(this.apiBaseUrl);
       }
     },
   },

--- a/dashboard/src/utils/request.ts
+++ b/dashboard/src/utils/request.ts
@@ -1,0 +1,237 @@
+import axios, { type InternalAxiosRequestConfig } from "axios";
+
+const ABSOLUTE_URL_PATTERN = /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//;
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+let interceptorsConfigured = false;
+
+function isAbsoluteUrl(value: string): boolean {
+  return ABSOLUTE_URL_PATTERN.test(value);
+}
+
+function stripTrailingSlashes(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function ensureLeadingSlash(value: string): string {
+  if (!value) {
+    return "/";
+  }
+  return value.startsWith("/") ? value : `/${value}`;
+}
+
+function stripLeadingApiPrefix(path: string): string {
+  const normalizedPath = ensureLeadingSlash(path);
+  const strippedPath = normalizedPath.replace(/^\/api(?=\/|$)/, "");
+  return strippedPath || "/";
+}
+
+function baseEndsWithApi(baseUrl: string): boolean {
+  if (!baseUrl) {
+    return false;
+  }
+
+  if (isAbsoluteUrl(baseUrl)) {
+    try {
+      return new URL(baseUrl).pathname.replace(/\/+$/, "").endsWith("/api");
+    } catch {
+      return baseUrl.replace(/\/+$/, "").endsWith("/api");
+    }
+  }
+
+  return stripTrailingSlashes(baseUrl).endsWith("/api");
+}
+
+function normalizePathForBase(path: string, baseUrl = ""): string {
+  if (!path) {
+    return "/";
+  }
+
+  if (isAbsoluteUrl(path)) {
+    return path;
+  }
+
+  const normalizedPath = ensureLeadingSlash(path);
+  if (baseEndsWithApi(baseUrl)) {
+    return stripLeadingApiPrefix(normalizedPath);
+  }
+  return normalizedPath;
+}
+
+function joinBaseAndPath(baseUrl: string, path: string): string {
+  const cleanBase = stripTrailingSlashes(baseUrl);
+  const cleanPath = path.replace(/^\/+/, "");
+  return `${cleanBase}/${cleanPath}`;
+}
+
+function normalizeBaseUrl(baseUrl: string | null | undefined): string {
+  return stripTrailingSlashes(baseUrl?.trim() || "");
+}
+
+function shouldUseDevProxyBase(baseUrl: string): boolean {
+  if (!import.meta.env.DEV || !isAbsoluteUrl(baseUrl)) {
+    return false;
+  }
+
+  try {
+    const parsedUrl = new URL(baseUrl);
+    const proxyTarget = import.meta.env.VITE_DEV_API_PROXY_TARGET?.trim();
+    const normalizedPathname = parsedUrl.pathname.replace(/\/+$/, "") || "/";
+    const isLoopbackHost = LOOPBACK_HOSTS.has(parsedUrl.hostname);
+    const targetsProxyPath =
+      normalizedPathname === "/" || normalizedPathname === "/api";
+
+    if (proxyTarget) {
+      const proxyUrl = new URL(proxyTarget);
+      const sameOriginAsProxyTarget =
+        parsedUrl.protocol === proxyUrl.protocol &&
+        parsedUrl.hostname === proxyUrl.hostname &&
+        parsedUrl.port === proxyUrl.port;
+
+      if (sameOriginAsProxyTarget && targetsProxyPath) {
+        return true;
+      }
+    }
+
+    return isLoopbackHost && targetsProxyPath;
+  } catch {
+    return false;
+  }
+}
+
+function ensureAxiosInterceptors(): void {
+  if (interceptorsConfigured) {
+    return;
+  }
+
+  axios.interceptors.request.use((config: InternalAxiosRequestConfig) => {
+    const normalizedBaseUrl = normalizeConfiguredApiBaseUrl(
+      config.baseURL ?? axios.defaults.baseURL,
+    );
+
+    config.baseURL = normalizedBaseUrl;
+
+    if (typeof config.url === "string") {
+      config.url = normalizePathForBase(config.url, normalizedBaseUrl);
+    }
+
+    const token = localStorage.getItem("token");
+    if (token) {
+      config.headers.set("Authorization", `Bearer ${token}`);
+    }
+
+    const locale = localStorage.getItem("astrbot-locale");
+    if (locale) {
+      config.headers.set("Accept-Language", locale);
+    }
+
+    return config;
+  });
+
+  interceptorsConfigured = true;
+}
+
+export function normalizeConfiguredApiBaseUrl(
+  baseUrl: string | null | undefined,
+): string {
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+
+  if (!normalizedBaseUrl) {
+    return "";
+  }
+
+  if (shouldUseDevProxyBase(normalizedBaseUrl)) {
+    return "/api";
+  }
+
+  return normalizedBaseUrl;
+}
+
+export function getApiBaseUrl(): string {
+  return normalizeConfiguredApiBaseUrl(axios.defaults.baseURL);
+}
+
+export function getApiBaseUrlValidationError(
+  baseUrl: string | null | undefined,
+): string | null {
+  const normalizedBaseUrl = normalizeConfiguredApiBaseUrl(baseUrl);
+
+  if (!normalizedBaseUrl || !isAbsoluteUrl(normalizedBaseUrl)) {
+    return null;
+  }
+
+  if (window.location.protocol !== "https:") {
+    return null;
+  }
+
+  try {
+    const parsedUrl = new URL(normalizedBaseUrl);
+    if (parsedUrl.protocol !== "http:") {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+
+  return "This dashboard is served over HTTPS, so the browser will block an HTTP backend. Put AstrBot behind an HTTPS reverse proxy or tunnel (for example Nginx, Caddy, or Cloudflare Tunnel), then use that HTTPS URL here.";
+}
+
+export function setApiBaseUrl(baseUrl: string | null | undefined): string {
+  const normalizedBaseUrl = normalizeConfiguredApiBaseUrl(baseUrl);
+  axios.defaults.baseURL = normalizedBaseUrl;
+  return normalizedBaseUrl;
+}
+
+export function resolveApiUrl(
+  path: string,
+  baseUrl: string | null | undefined = getApiBaseUrl(),
+): string {
+  const normalizedBaseUrl = normalizeConfiguredApiBaseUrl(baseUrl);
+  const normalizedPath = normalizePathForBase(path, normalizedBaseUrl);
+
+  if (isAbsoluteUrl(normalizedPath)) {
+    return normalizedPath;
+  }
+
+  if (!normalizedBaseUrl) {
+    return normalizedPath;
+  }
+
+  return joinBaseAndPath(normalizedBaseUrl, normalizedPath);
+}
+
+export function resolvePublicUrl(path: string): string {
+  const base = import.meta.env.BASE_URL || "/";
+  const cleanBase = base.endsWith("/") ? base : `${base}/`;
+  return new URL(
+    path.replace(/^\/+/, ""),
+    window.location.origin + cleanBase,
+  ).toString();
+}
+
+export function resolveWebSocketUrl(
+  path: string,
+  queryParams?: Record<string, string>,
+): string {
+  const resolvedApiUrl = resolveApiUrl(path);
+  const url = new URL(resolvedApiUrl, window.location.href);
+
+  if (url.protocol === "https:") {
+    url.protocol = "wss:";
+  } else if (url.protocol === "http:") {
+    url.protocol = "ws:";
+  }
+
+  if (queryParams) {
+    Object.entries(queryParams).forEach(([key, value]) => {
+      url.searchParams.set(key, value);
+    });
+  }
+
+  return url.toString();
+}
+
+setApiBaseUrl(import.meta.env.VITE_API_BASE);
+ensureAxiosInterceptors();
+
+export default axios;
+export * from "axios";

--- a/dashboard/src/views/PlatformPage.vue
+++ b/dashboard/src/views/PlatformPage.vue
@@ -310,6 +310,7 @@
 
 <script>
 import axios from 'axios';
+import { resolveApiUrl } from '@/utils/request';
 import AstrBotConfig from '@/components/shared/AstrBotConfig.vue';
 import WaitingForRestart from '@/components/shared/WaitingForRestart.vue';
 import ConsoleDisplayer from '@/components/shared/ConsoleDisplayer.vue';
@@ -441,7 +442,7 @@ export default {
       const template = this.metadata['platform_group']?.metadata?.platform?.config_template?.[platform_id];
       if (template && template.logo_token) {
           // 通过文件服务访问插件提供的 logo
-        return `/api/file/${template.logo_token}`;
+        return resolveApiUrl(`/api/file/${template.logo_token}`);
       }
       return getPlatformIcon(platform_id);
     },
@@ -666,7 +667,7 @@ export default {
       if (callbackBase) {
         return `${callbackBase.replace(/\/$/, '')}/api/platform/webhook/${webhookUuid}`;
       }
-      return `/api/platform/webhook/${webhookUuid}`;
+      return resolveApiUrl(`/api/platform/webhook/${webhookUuid}`);
     },
 
     openWebhookDialog(webhookUuid) {

--- a/dashboard/src/views/Settings.vue
+++ b/dashboard/src/views/Settings.vue
@@ -3,10 +3,7 @@
     <!-- Proxy Settings -->
     <!-- <div class="text-h6 mb-2">{{ tm('network.title') }}</div> -->
 
-    <v-list
-      lines="two"
-      subheader
-    >
+    <v-list lines="two" subheader>
       <v-list-subheader>{{ tm("network.title") }}</v-list-subheader>
 
       <v-list-item
@@ -148,23 +145,15 @@
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  <v-icon size="18">
-                    mdi-help-circle-outline
-                  </v-icon>
+                  <v-icon size="18"> mdi-help-circle-outline </v-icon>
                 </v-btn>
               </template>
               <span>{{ tm("apiKey.docsLink") }}</span>
             </v-tooltip>
           </div>
         </template>
-        <v-row
-          class="mt-2"
-          dense
-        >
-          <v-col
-            cols="12"
-            md="4"
-          >
+        <v-row class="mt-2" dense>
+          <v-col cols="12" md="4">
             <v-text-field
               v-model="newApiKeyName"
               :label="tm('apiKey.name')"
@@ -173,10 +162,7 @@
               hide-details
             />
           </v-col>
-          <v-col
-            cols="12"
-            md="3"
-          >
+          <v-col cols="12" md="3">
             <v-select
               v-model="newApiKeyExpiresInDays"
               :items="apiKeyExpiryOptions"
@@ -186,31 +172,18 @@
               hide-details
             />
           </v-col>
-          <v-col
-            v-if="newApiKeyExpiresInDays === 'permanent'"
-            cols="12"
-          >
-            <v-alert
-              type="warning"
-              variant="tonal"
-              density="comfortable"
-            >
+          <v-col v-if="newApiKeyExpiresInDays === 'permanent'" cols="12">
+            <v-alert type="warning" variant="tonal" density="comfortable">
               {{ tm("apiKey.permanentWarning") }}
             </v-alert>
           </v-col>
-          <v-col
-            cols="12"
-            md="5"
-            class="d-flex align-center"
-          >
+          <v-col cols="12" md="5" class="d-flex align-center">
             <v-btn
               color="primary"
               :loading="apiKeyCreating"
               @click="createApiKey"
             >
-              <v-icon class="mr-2">
-                mdi-key-plus
-              </v-icon>
+              <v-icon class="mr-2"> mdi-key-plus </v-icon>
               {{ tm("apiKey.create") }}
             </v-btn>
           </v-col>
@@ -219,10 +192,7 @@
             <div class="text-caption text-medium-emphasis mb-1">
               {{ tm("apiKey.scopes") }}
             </div>
-            <v-chip-group
-              v-model="newApiKeyScopes"
-              multiple
-            >
+            <v-chip-group v-model="newApiKeyScopes" multiple>
               <v-chip
                 v-for="scope in availableScopes"
                 :key="scope.value"
@@ -239,14 +209,8 @@
             </v-chip-group>
           </v-col>
 
-          <v-col
-            v-if="createdApiKeyPlaintext"
-            cols="12"
-          >
-            <v-alert
-              type="warning"
-              variant="tonal"
-            >
+          <v-col v-if="createdApiKeyPlaintext" cols="12">
+            <v-alert type="warning" variant="tonal">
               <div class="d-flex align-center justify-space-between flex-wrap">
                 <span>{{ tm("apiKey.plaintextHint") }}</span>
                 <v-btn
@@ -255,9 +219,8 @@
                   color="primary"
                   @click="copyCreatedApiKey"
                 >
-                  <v-icon class="mr-1">
-                    mdi-content-copy
-                  </v-icon>{{ tm("apiKey.copy") }}
+                  <v-icon class="mr-1"> mdi-content-copy </v-icon
+                  >{{ tm("apiKey.copy") }}
                 </v-btn>
               </div>
               <code style="word-break: break-all">{{
@@ -280,10 +243,7 @@
                 </tr>
               </thead>
               <tbody>
-                <tr
-                  v-for="item in apiKeys"
-                  :key="item.key_id"
-                >
+                <tr v-for="item in apiKeys" :key="item.key_id">
                   <td>{{ item.name }}</td>
                   <td>
                     <code>{{ item.key_prefix }}</code>
@@ -328,10 +288,7 @@
                   </td>
                 </tr>
                 <tr v-if="apiKeys.length === 0">
-                  <td
-                    colspan="7"
-                    class="text-center text-medium-emphasis"
-                  >
+                  <td colspan="7" class="text-center text-medium-emphasis">
                     {{ tm("apiKey.empty") }}
                   </td>
                 </tr>
@@ -345,11 +302,7 @@
         :subtitle="tm('system.migration.subtitle')"
         :title="tm('system.migration.title')"
       >
-        <v-btn
-          style="margin-top: 16px"
-          color="primary"
-          @click="startMigration"
-        >
+        <v-btn style="margin-top: 16px" color="primary" @click="startMigration">
           {{ tm("system.migration.button") }}
         </v-btn>
       </v-list-item>
@@ -371,14 +324,8 @@
       >
         <template #append />
 
-        <v-row
-          class="mt-2"
-          dense
-        >
-          <v-col
-            cols="12"
-            md="4"
-          >
+        <v-row class="mt-2" dense>
+          <v-col cols="12" md="4">
             <v-text-field
               v-model="primaryColor"
               :label="tm('style.color.primary')"
@@ -400,10 +347,7 @@
               </template>
             </v-text-field>
           </v-col>
-          <v-col
-            cols="12"
-            md="4"
-          >
+          <v-col cols="12" md="4">
             <v-text-field
               v-model="secondaryColor"
               :label="tm('style.color.secondary')"
@@ -425,18 +369,9 @@
               </template>
             </v-text-field>
           </v-col>
-          <v-col
-            cols="12"
-            md="4"
-          >
-            <v-btn
-              color="primary"
-              block
-              @click="applyThemeColors"
-            >
-              <v-icon start>
-                mdi-pencil-ruler
-              </v-icon>
+          <v-col cols="12" md="4">
+            <v-btn color="primary" block @click="applyThemeColors">
+              <v-icon start> mdi-pencil-ruler </v-icon>
               {{ t("core.common.save") }}
             </v-btn>
           </v-col>
@@ -473,10 +408,7 @@
         </div>
       </v-list-item>
 
-      <v-list-item
-        :subtitle="tm('reset.subtitle')"
-        :title="tm('reset.title')"
-      >
+      <v-list-item :subtitle="tm('reset.subtitle')" :title="tm('reset.title')">
         <div class="d-flex align-center mt-2">
           <v-btn
             color="error"
@@ -541,6 +473,7 @@ import WaitingForRestart from "@/components/shared/WaitingForRestart.vue";
 import MigrationDialog from "@/components/shared/MigrationDialog.vue";
 import BackupDialog from "@/components/shared/BackupDialog.vue";
 import axios from "axios";
+import { getApiBaseUrlValidationError } from "@/utils/request";
 import { useI18n, useModuleI18n } from "@/i18n/composables";
 import { useToast } from "@/utils/toast";
 
@@ -595,6 +528,12 @@ const isCustomPreset = (name) => {
 };
 
 const saveApiUrl = () => {
+  const validationError = getApiBaseUrlValidationError(apiBaseUrl.value);
+  if (validationError) {
+    toastStore.error(validationError);
+    return;
+  }
+
   apiStore.setApiBaseUrl(apiBaseUrl.value);
   window.location.reload();
 };
@@ -651,8 +590,10 @@ const autoThemeSwitcher = computed({
   get: () => customizer.autoSwitchTheme,
   set: (value) => {
     customizer.SET_AUTO_SYNC(value);
-    if (value) { customizer.APPLY_SYSTEM_THEME() }
-  }
+    if (value) {
+      customizer.APPLY_SYSTEM_THEME();
+    }
+  },
 });
 
 const wfr = ref(null);

--- a/dashboard/src/views/WelcomePage.vue
+++ b/dashboard/src/views/WelcomePage.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="welcome-page">
-    <v-container
-      fluid
-      class="pa-0"
-    >
+    <v-container fluid class="pa-0">
       <v-row class="px-4 py-3 pb-6">
         <v-col cols="12">
           <h1 class="text-h1 font-weight-bold mb-2 d-flex align-center">
@@ -17,11 +14,7 @@
 
       <v-row class="px-4">
         <v-col cols="12">
-          <v-card
-            class="welcome-card pa-6"
-            elevation="0"
-            border
-          >
+          <v-card class="welcome-card pa-6" elevation="0" border>
             <div class="mb-4 text-h3 font-weight-bold">
               {{ tm("onboard.title") }}
             </div>
@@ -52,7 +45,7 @@
                   <p class="text-body-2 text-medium-emphasis mb-3">
                     {{
                       tm("onboard.step0Desc") ||
-                        "配置 AstrBot 的后端 API 地址。"
+                      "配置 AstrBot 的后端 API 地址。"
                     }}
                   </p>
                   <div class="d-flex align-center">
@@ -185,19 +178,12 @@
 
       <v-row class="px-4 mt-4">
         <v-col cols="12">
-          <v-card
-            class="welcome-card pa-6"
-            elevation="0"
-            border
-          >
+          <v-card class="welcome-card pa-6" elevation="0" border>
             <div class="mb-4 text-h3 font-weight-bold">
               {{ tm("resources.title") }}
             </div>
             <v-row>
-              <v-col
-                cols="12"
-                sm="4"
-              >
+              <v-col cols="12" sm="4">
                 <!-- GitHub Card -->
                 <v-card
                   variant="outlined"
@@ -206,12 +192,7 @@
                   target="_blank"
                 >
                   <div class="d-flex align-center mb-3">
-                    <v-icon
-                      size="32"
-                      class="mr-3"
-                    >
-                      mdi-github
-                    </v-icon>
+                    <v-icon size="32" class="mr-3"> mdi-github </v-icon>
                     <span class="text-h6 font-weight-bold">GitHub</span>
                   </div>
                   <p class="text-body-2 text-medium-emphasis mb-0">
@@ -220,10 +201,7 @@
                 </v-card>
               </v-col>
 
-              <v-col
-                cols="12"
-                sm="4"
-              >
+              <v-col cols="12" sm="4">
                 <!-- Docs Card -->
                 <v-card
                   variant="outlined"
@@ -232,10 +210,7 @@
                   target="_blank"
                 >
                   <div class="d-flex align-center mb-3">
-                    <v-icon
-                      size="32"
-                      class="mr-3"
-                    >
+                    <v-icon size="32" class="mr-3">
                       mdi-book-open-variant
                     </v-icon>
                     <span class="text-h6 font-weight-bold">{{
@@ -248,10 +223,7 @@
                 </v-card>
               </v-col>
 
-              <v-col
-                cols="12"
-                sm="4"
-              >
+              <v-col cols="12" sm="4">
                 <!-- Afdian Card -->
                 <v-card
                   variant="outlined"
@@ -260,12 +232,7 @@
                   target="_blank"
                 >
                   <div class="d-flex align-center mb-3">
-                    <v-icon
-                      size="32"
-                      class="mr-3"
-                    >
-                      mdi-hand-heart
-                    </v-icon>
+                    <v-icon size="32" class="mr-3"> mdi-hand-heart </v-icon>
                     <span class="text-h6 font-weight-bold">{{
                       tm("resources.afdianTitle")
                     }}</span>
@@ -280,16 +247,9 @@
         </v-col>
       </v-row>
 
-      <v-row
-        v-if="showAnnouncement"
-        class="px-4 mb-4"
-      >
+      <v-row v-if="showAnnouncement" class="px-4 mb-4">
         <v-col cols="12">
-          <v-card
-            class="welcome-card pa-6"
-            elevation="0"
-            border
-          >
+          <v-card class="welcome-card pa-6" elevation="0" border>
             <div class="mb-4 text-h3 font-weight-bold">
               {{ tm("announcement.title") }}
             </div>
@@ -315,7 +275,11 @@
 
 <script setup lang="ts">
 import { computed, ref, watch, onMounted } from "vue";
-import axios from "axios";
+import axios, {
+  getApiBaseUrlValidationError,
+  normalizeConfiguredApiBaseUrl,
+  setApiBaseUrl,
+} from "@/utils/request";
 import AddNewPlatform from "@/components/platform/AddNewPlatform.vue";
 import ProviderConfigDialog from "@/components/chat/ProviderConfigDialog.vue";
 import { useI18n, useModuleI18n } from "@/i18n/composables";
@@ -457,32 +421,34 @@ async function loadPlatformConfigBase() {
 
 async function checkAndSaveBackend() {
   checkingBackend.value = true;
-  try {
-    // try to connect
-    const url = apiBaseUrl.value.replace(/\/+$/, "");
-    // temp set axios base url to check
-    const originalBase = axios.defaults.baseURL;
-    axios.defaults.baseURL = url;
+  const originalBase = axios.defaults.baseURL;
+  const normalizedUrl = normalizeConfiguredApiBaseUrl(apiBaseUrl.value);
+  const validationError = getApiBaseUrlValidationError(normalizedUrl);
 
+  if (validationError) {
+    backendStepState.value = "pending";
+    showError(validationError);
+    checkingBackend.value = false;
+    return;
+  }
+
+  try {
+    setApiBaseUrl(normalizedUrl);
     await axios.get("/api/stat/version");
 
-    // if success, save
-    apiStore.setApiBaseUrl(url);
+    apiStore.setApiBaseUrl(normalizedUrl);
+    apiBaseUrl.value = normalizedUrl;
     backendStepState.value = "completed";
     showSuccess("Connected to AstrBot Backend successfully!");
 
-    // load subsequent data
     await loadPlatformConfigBase();
     if ((platformConfigData.value.platform || []).length > 0) {
       platformStepState.value = "completed";
     }
-  } catch (e) {
-    showError("Failed to connect to backend: " + e);
+  } catch (error) {
+    setApiBaseUrl(originalBase);
     backendStepState.value = "pending";
-    // restore if failed (though user might want to try another)
-    // but here we just keep the axios instance dirty or reset?
-    // actually apiStore.init() logic should be used but simpler:
-    // we don't reset axios defaults here because the user might be trying to correct it.
+    showError(`Failed to connect to backend: ${error}`);
   } finally {
     checkingBackend.value = false;
   }

--- a/dashboard/src/views/authentication/auth/LoginPage.vue
+++ b/dashboard/src/views/authentication/auth/LoginPage.vue
@@ -7,6 +7,8 @@ import { useApiStore } from "@/stores/api";
 import { useRouter } from "vue-router";
 import { useCustomizerStore } from "@/stores/customizer";
 import { useModuleI18n } from "@/i18n/composables";
+import { useToast } from "@/utils/toast";
+import { getApiBaseUrlValidationError } from "@/utils/request";
 
 const cardVisible = ref(false);
 const router = useRouter();
@@ -14,6 +16,7 @@ const authStore = useAuthStore();
 const apiStore = useApiStore();
 const customizer = useCustomizerStore();
 const { tm: t } = useModuleI18n("features/auth");
+const toast = useToast();
 
 const serverConfigDialog = ref(false);
 const apiUrl = ref(apiStore.apiBaseUrl);
@@ -23,6 +26,12 @@ const newPresetName = ref("");
 const newPresetUrl = ref("");
 
 function saveApiUrl() {
+  const validationError = getApiBaseUrlValidationError(apiUrl.value);
+  if (validationError) {
+    toast.error(validationError);
+    return;
+  }
+
   apiStore.setApiBaseUrl(apiUrl.value);
   serverConfigDialog.value = false;
   window.location.reload();
@@ -64,17 +73,14 @@ onMounted(() => {
 
 <template>
   <div class="login-page-container">
-    <v-card
-      class="login-card"
-      elevation="1"
-    >
+    <v-card class="login-card" elevation="1">
       <v-card-title>
         <div class="d-flex justify-space-between align-center w-100">
           <img
             width="80"
             src="@/assets/images/icon-no-shadow.svg"
             alt="AstrBot Logo"
-          >
+          />
           <div class="d-flex align-center gap-1">
             <LanguageSwitcher />
             <v-divider
@@ -94,16 +100,10 @@ onMounted(() => {
               size="small"
               @click="serverConfigDialog = true"
             >
-              <v-icon
-                size="18"
-                :color="'rgb(var(--v-theme-primary))'"
-              >
+              <v-icon size="18" :color="'rgb(var(--v-theme-primary))'">
                 mdi-server
               </v-icon>
-              <v-tooltip
-                activator="parent"
-                location="top"
-              >
+              <v-tooltip activator="parent" location="top">
                 {{ t("serverConfig.tooltip") }}
               </v-tooltip>
             </v-btn>
@@ -115,31 +115,27 @@ onMounted(() => {
               size="small"
               @click="toggleTheme"
             >
-              <v-icon
-                size="18"
-                :color="'rgb(var(--v-theme-primary))'"
-              >
-                {{ customizer.isDarkTheme ? 'mdi-weather-night' : 'mdi-white-balance-sunny' }}
+              <v-icon size="18" :color="'rgb(var(--v-theme-primary))'">
+                {{
+                  customizer.isDarkTheme
+                    ? "mdi-weather-night"
+                    : "mdi-white-balance-sunny"
+                }}
               </v-icon>
-              <v-tooltip
-                activator="parent"
-                location="top"
-              >
-                {{ customizer.isDarkTheme ? t('theme.switchToLight') : t('theme.switchToDark') }}
+              <v-tooltip activator="parent" location="top">
+                {{
+                  customizer.isDarkTheme
+                    ? t("theme.switchToLight")
+                    : t("theme.switchToDark")
+                }}
               </v-tooltip>
             </v-btn>
           </div>
         </div>
-        <div
-          class="ml-2"
-          style="font-size: 26px"
-        >
+        <div class="ml-2" style="font-size: 26px">
           {{ t("logo.title") }}
         </div>
-        <div
-          class="mt-2 ml-2"
-          style="font-size: 14px; color: grey"
-        >
+        <div class="mt-2 ml-2" style="font-size: 14px; color: grey">
           {{ t("logo.subtitle") }}
         </div>
       </v-card-title>
@@ -148,10 +144,7 @@ onMounted(() => {
       </v-card-text>
     </v-card>
 
-    <v-dialog
-      v-model="serverConfigDialog"
-      max-width="450"
-    >
+    <v-dialog v-model="serverConfigDialog" max-width="450">
       <v-card>
         <v-card-title>{{ t("serverConfig.title") }}</v-card-title>
         <v-card-text>
@@ -162,7 +155,7 @@ onMounted(() => {
           <div
             v-if="
               (apiStore.presets && apiStore.presets.length > 0) ||
-                apiStore.customPresets
+              apiStore.customPresets
             "
             class="mb-4"
           >
@@ -243,22 +236,11 @@ onMounted(() => {
         </v-card-text>
         <v-card-actions>
           <v-spacer />
-          <v-btn
-            variant="text"
-            @click="serverConfigDialog = false"
-          >
-            {{
-              t("serverConfig.cancel")
-            }}
+          <v-btn variant="text" @click="serverConfigDialog = false">
+            {{ t("serverConfig.cancel") }}
           </v-btn>
-          <v-btn
-            color="primary"
-            variant="flat"
-            @click="saveApiUrl"
-          >
-            {{
-              t("serverConfig.save")
-            }}
+          <v-btn color="primary" variant="flat" @click="saveApiUrl">
+            {{ t("serverConfig.save") }}
           </v-btn>
         </v-card-actions>
       </v-card>

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath, URL } from 'url';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import vuetify from 'vite-plugin-vuetify';
 import webfontDl from 'vite-plugin-webfont-dl';
@@ -17,54 +17,57 @@ function mdiSubset() {
 }
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command }) => ({
-   base: command === 'build'
-    ? process.env.BASE_PATH || '/'
-    : '/',
+export default defineConfig(({ command, mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const basePath = env.VITE_BASE_PATH || process.env.BASE_PATH || '/';
 
-  plugins: [
-    // Only run MDI subsetting during production builds, skip in dev server
-    ...(command === 'build' ? [mdiSubset()] : []),
-    vue({
-      template: {
-        compilerOptions: {
-          isCustomElement: (tag) => ["v-list-recognize-title"].includes(tag),
+  return {
+    base: command === 'build' ? basePath : '/',
+
+    plugins: [
+      // Only run MDI subsetting during production builds, skip in dev server
+      ...(command === 'build' ? [mdiSubset()] : []),
+      vue({
+        template: {
+          compilerOptions: {
+            isCustomElement: (tag) => ["v-list-recognize-title"].includes(tag),
+          },
         },
+      }),
+      vuetify({
+        autoImport: true
+      }),
+      webfontDl()
+    ],
+    resolve: {
+      alias: {
+        mermaid: "mermaid/dist/mermaid.js",
+        "@": fileURLToPath(new URL("./src", import.meta.url)),
       },
-    }),
-    vuetify({
-      autoImport: true
-    }),
-    webfontDl()
-  ],
-  resolve: {
-    alias: {
-      mermaid: "mermaid/dist/mermaid.js",
-      "@": fileURLToPath(new URL("./src", import.meta.url)),
     },
-  },
-  css: {
-    preprocessorOptions: {
-      scss: {},
+    css: {
+      preprocessorOptions: {
+        scss: {},
+      },
     },
-  },
-  build: {
-    sourcemap: false,
-    chunkSizeWarningLimit: 1024 * 1024, // Set the limit to 1 MB
-  },
-  optimizeDeps: {
-    exclude: ["vuetify"],
-    entries: ["./src/**/*.vue"],
-  },
-  server: {
-    host: "::",
-    port: 3000,
-    proxy: {
-      "/api": {
-        target: "http://127.0.0.1:6185/",
-        changeOrigin: true,
-        ws: true
+    build: {
+      sourcemap: false,
+      chunkSizeWarningLimit: 1024 * 1024, // Set the limit to 1 MB
+    },
+    optimizeDeps: {
+      exclude: ["vuetify"],
+      entries: ["./src/**/*.vue"],
+    },
+    server: {
+      host: "::",
+      port: 3000,
+      proxy: {
+        "/api": {
+          target: env.VITE_DEV_API_PROXY_TARGET || "http://127.0.0.1:6185",
+          changeOrigin: true,
+          ws: true
+        }
       }
     }
-  }
-}));
+  };
+});


### PR DESCRIPTION
### Motivation
- Users deploying the dashboard to GitHub Pages saw opaque `AxiosError: Network Error` failures because an HTTP backend is blocked by browser mixed-content when the page is served over HTTPS.  
- Avoid applying an insecure (HTTP) backend URL on app bootstrap when the dashboard is served via HTTPS, and give an actionable message to users instead of leaving the client in a broken state.  
- Prevent saving backend URLs that will be blocked by the browser so users cannot accidentally persist a non-working configuration from multiple UI entry points.

### Description
- Add `getApiBaseUrlValidationError` and related base normalization helpers to `dashboard/src/utils/request.ts` to detect and return an actionable validation message for the HTTPS-page + HTTP-backend mixed-content case.  
- Change app bootstrap in `dashboard/src/main.ts` to run the validation and avoid applying stored HTTP backends when the dashboard is served over `https:`, using `setApiBaseUrl` only when valid.  
- Validate backend URLs before saving in the welcome flow, settings page, and login server dialog by wiring those UIs to the new validation function (`dashboard/src/views/WelcomePage.vue`, `dashboard/src/views/Settings.vue`, `dashboard/src/views/authentication/auth/LoginPage.vue`), and show an explicit error instead of attempting the request.  
- Keep axios/fetch URL normalization and the centralized request helpers in place so resolved API/WS URLs continue to be generated consistently across the dashboard.

### Testing
- Ran `git diff --check` and it reported no issues.  
- Ran `ruff format .` which completed successfully.  
- Ran `ruff check .` which failed due to pre-existing repository-wide Ruff violations unrelated to this change.  
- Ran `cd dashboard && bunx prettier --check src/utils/request.ts src/main.ts src/views/WelcomePage.vue src/views/Settings.vue src/views/authentication/auth/LoginPage.vue` which passed formatting checks.  
- Attempted a production build with `cd dashboard && bunx vite build --debug` which entered the build pipeline and produced Vite transform logs but did not finish within the environment time window (timed out in this session).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb9b5116f4833084d2cee05477de59)

## Summary by Sourcery

Enforce safe, normalized backend URL handling across the dashboard and surface clear validation errors when insecure HTTP backends are configured from an HTTPS-served UI.

Bug Fixes:
- Prevent configuring an HTTP backend when the dashboard is served over HTTPS by validating and rejecting mixed-content API base URLs during app bootstrap and from URL entry points.

Enhancements:
- Introduce a centralized request utility module to normalize API base URLs, attach auth and locale headers, and consistently resolve HTTP and WebSocket endpoints for axios, fetch, SSE, and download links.
- Update dashboard entry points (welcome flow, settings, login, live mode, messaging, platform pages, backup, logs, and traces) to use the new URL resolution helpers instead of manually constructing paths and WebSocket URLs.
- Allow dashboard API base URL, base path, and dev proxy target to be configured via Vite env vars including VITE_API_BASE, VITE_BASE_PATH, and VITE_DEV_API_PROXY_TARGET.
- Initialize the API store from the normalized global axios base URL and ensure it re-applies the configured base URL on startup.

Build:
- Adjust Vite configuration to derive the base path and dev API proxy target from environment variables and to centralize base path selection for build and dev server.

Chores:
- Expand CORS allow_headers in the backend dashboard server to include Accept-Language so localized requests are accepted.