### PR TITLE
fix(webui): keep account password dialog accessible on small viewports

### DIFF
--- a/dashboard/src/layouts/full/vertical-header/VerticalHeader.vue
+++ b/dashboard/src/layouts/full/vertical-header/VerticalHeader.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from 'vue';
+import type { VForm } from 'vuetify/components';
 import { useCustomizerStore } from '@/stores/customizer';
 import axios from 'axios';
 import Logo from '@/components/shared/Logo.vue';
@@ -95,6 +96,7 @@ const releasesHeader = computed(() => [
 ]);
 // Form validation
 const formValid = ref(true);
+const accountFormRef = ref<VForm | null>(null);
 const passwordRules = computed(() => [
   (v: string) => !!v || t('core.header.accountDialog.validation.passwordRequired'),
   (v: string) => v.length >= 8 || t('core.header.accountDialog.validation.passwordMinLength')
@@ -217,10 +219,16 @@ const isPreRelease = (version: string) => {
 };
 
 // 账户修改
-function accountEdit() {
-  accountEditStatus.value.loading = true;
+async function accountEdit() {
   accountEditStatus.value.error = false;
   accountEditStatus.value.success = false;
+
+  const { valid } = await accountFormRef.value?.validate() ?? { valid: false };
+  if (!valid) {
+    return;
+  }
+
+  accountEditStatus.value.loading = true;
 
   const passwordHash = password.value ? md5(password.value) : '';
   const newPasswordHash = newPassword.value ? md5(newPassword.value) : '';
@@ -824,7 +832,7 @@ onMounted(async () => {
     <!-- 账户对话框 -->
     <v-dialog v-model="dialog" persistent :max-width="$vuetify.display.xs ? '90%' : '500'">
       <v-card class="account-dialog">
-        <v-card-text class="py-6">
+        <v-card-text class="account-dialog__content py-6">
           <div class="d-flex flex-column align-center mb-6">
             <logo :title="t('core.header.logoTitle')" :subtitle="t('core.header.accountDialog.title')"></logo>
           </div>
@@ -840,7 +848,7 @@ onMounted(async () => {
             {{ accountEditStatus.message }}
           </v-alert>
 
-          <v-form v-model="formValid" @submit.prevent="accountEdit">
+          <v-form ref="accountFormRef" v-model="formValid" @submit.prevent="accountEdit">
             <v-text-field v-model="password" :append-inner-icon="showPassword ? 'mdi-eye-off' : 'mdi-eye'"
               :type="showPassword ? 'text' : 'password'" :label="t('core.header.accountDialog.form.currentPassword')"
               variant="outlined" required clearable @click:append-inner="showPassword = !showPassword"
@@ -914,6 +922,16 @@ onMounted(async () => {
   /* Adds indentation to unordered lists */
   margin-top: 8px;
   margin-bottom: 8px;
+}
+
+.account-dialog {
+  max-height: min(720px, calc(100vh - 32px));
+  display: flex;
+  flex-direction: column;
+}
+
+.account-dialog__content {
+  overflow-y: auto;
 }
 
 .account-dialog .v-card-text {

--- a/dashboard/src/layouts/full/vertical-header/VerticalHeader.vue
+++ b/dashboard/src/layouts/full/vertical-header/VerticalHeader.vue
@@ -97,13 +97,14 @@ const releasesHeader = computed(() => [
 // Form validation
 const formValid = ref(true);
 const accountFormRef = ref<VForm | null>(null);
+const isPasswordChangeAttempted = computed(() => !!newPassword.value || !!confirmPassword.value);
 const passwordRules = computed(() => [
-  (v: string) => !!v || t('core.header.accountDialog.validation.passwordRequired'),
-  (v: string) => v.length >= 8 || t('core.header.accountDialog.validation.passwordMinLength')
+  (v: string) => !isPasswordChangeAttempted.value || !!v || t('core.header.accountDialog.validation.passwordRequired'),
+  (v: string) => !v || v.length >= 8 || t('core.header.accountDialog.validation.passwordMinLength')
 ]);
 const confirmPasswordRules = computed(() => [
-  (v: string) => !newPassword.value || !!v || t('core.header.accountDialog.validation.passwordRequired'),
-  (v: string) => !newPassword.value || v === newPassword.value || t('core.header.accountDialog.validation.passwordMatch')
+  (v: string) => !isPasswordChangeAttempted.value || !!v || t('core.header.accountDialog.validation.passwordRequired'),
+  (v: string) => !isPasswordChangeAttempted.value || v === newPassword.value || t('core.header.accountDialog.validation.passwordMatch')
 ]);
 const usernameRules = computed(() => [
   (v: string) => !v || v.length >= 3 || t('core.header.accountDialog.validation.usernameMinLength')
@@ -223,7 +224,12 @@ async function accountEdit() {
   accountEditStatus.value.error = false;
   accountEditStatus.value.success = false;
 
-  const { valid } = await accountFormRef.value?.validate() ?? { valid: false };
+  if (!accountFormRef.value) {
+    console.error('Account form reference is not available.');
+    return;
+  }
+
+  const { valid } = await accountFormRef.value.validate();
   if (!valid) {
     return;
   }

--- a/dashboard/src/layouts/full/vertical-header/VerticalHeader.vue
+++ b/dashboard/src/layouts/full/vertical-header/VerticalHeader.vue
@@ -221,6 +221,10 @@ const isPreRelease = (version: string) => {
 
 // 账户修改
 async function accountEdit() {
+  if (accountEditStatus.value.loading) {
+    return;
+  }
+
   accountEditStatus.value.error = false;
   accountEditStatus.value.success = false;
 
@@ -229,12 +233,13 @@ async function accountEdit() {
     return;
   }
 
+  accountEditStatus.value.loading = true;
+
   const { valid } = await accountFormRef.value.validate();
   if (!valid) {
+    accountEditStatus.value.loading = false;
     return;
   }
-
-  accountEditStatus.value.loading = true;
 
   const passwordHash = password.value ? md5(password.value) : '';
   const newPasswordHash = newPassword.value ? md5(newPassword.value) : '';


### PR DESCRIPTION
## Summary
- keep the account/password dialog usable on constrained viewports by making the content area scrollable
- validate the account form before submit so empty or mismatched confirm-password input is blocked on the frontend
- preserve the existing backend validation and successful password-change flow

## Testing
- `pnpm --dir dashboard install --frozen-lockfile`
- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard lint` *(fails due to existing repository-wide ESLint/parser configuration issues, not this patch specifically)*

Fixes #6628

## Summary by Sourcery

Improve the account password dialog usability and validation in the dashboard header.

New Features:
- Validate the account password form on the frontend before submitting to the backend.

Enhancements:
- Make the account password dialog content scrollable and constrain its height so it remains usable on small viewports.