### PR TITLE
fix: Follow-up logic persists after `/stop` trigger.

### DIFF
--- a/astrbot/core/pipeline/process_stage/follow_up.py
+++ b/astrbot/core/pipeline/process_stage/follow_up.py
@@ -172,6 +172,9 @@ def try_capture_follow_up(event: AstrMessageEvent) -> FollowUpCapture | None:
     if not active_sender_id or active_sender_id != sender_id:
         return None
 
+    if runner_event.get_extra("agent_stop_requested"):
+        return None
+
     ticket = runner.follow_up(message_text=_event_follow_up_text(event))
     if not ticket:
         return None


### PR DESCRIPTION
## 问题

`/stop` 设置 `agent_stop_requested` 标记，但 runner 要等当前工具调用超时后才从 `_ACTIVE_AGENT_RUNNERS` 注销。在此窗口期内（可达 30 秒），用户发的新消息被 `try_capture_follow_up()` 当作 follow-up 吞掉，而非作为新会话处理。

时间线：
1. 用户发 `/stop` → 设置 `agent_stop_requested=True`
2. runner 仍在 `_ACTIVE_AGENT_RUNNERS` 中（工具还在跑）
3. 用户发新消息 → `try_capture_follow_up()` 找到 runner → 按 follow-up 处理 ❌

## 修复

在 `try_capture_follow_up()` 中，捕获 follow-up 之前检查 `agent_stop_requested` 标记。一旦用户请求停止，就不再把后续消息注入到正在终止的 agent 上下文中。

Runner 生命周期（注册/注销）不受影响，仍然在 `finally` 块中正常清理。

Fixes #6626

## Summary by Sourcery

Bug Fixes:
- Avoid capturing new user messages as follow-ups when an agent has received a stop request but its runner has not yet been fully cleaned up.