### PR TITLE
fix: fallbfix: fallback for streaming tool_call args lost when proxy omits index fieldck for streaming tool_call args lost when proxy omits inde…

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -712,6 +712,9 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
 
                 valid_params = {}  # 参数过滤：只传递函数实际需要的参数
 
+                if func_tool_args is None:
+                    func_tool_args = {}
+
                 # 获取实际的 handler 函数
                 if func_tool.handler:
                     logger.debug(

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -33,6 +33,78 @@ from astrbot.core.utils.string_utils import normalize_and_dedupe_strings
 from ..register import register_provider_adapter
 
 
+class _StreamToolCallFallback:
+    """Fallback accumulator for streaming tool_call data.
+
+    Some OpenAI-compatible proxies (e.g. Gemini) return tool_call chunks
+    without the required ``index`` field, causing the openai SDK's
+    ``ChatCompletionStreamState`` to reject them. This class manually
+    collects tool_call data from such rejected chunks so the arguments
+    can be restored after the stream completes.
+    """
+
+    def __init__(self) -> None:
+        self._calls: dict[int, dict[str, str]] = {}
+
+    def collect_from_chunk(self, chunk: ChatCompletionChunk) -> None:
+        if not chunk.choices:
+            return
+        delta = chunk.choices[0].delta
+        if not delta or not hasattr(delta, "tool_calls") or not delta.tool_calls:
+            return
+        for tc in delta.tool_calls:
+            idx = getattr(tc, "index", None) or 0
+            if idx not in self._calls:
+                self._calls[idx] = {"id": "", "name": "", "arguments": ""}
+            if getattr(tc, "id", None):
+                self._calls[idx]["id"] = tc.id
+            if hasattr(tc, "function") and tc.function:
+                if getattr(tc.function, "name", None):
+                    self._calls[idx]["name"] = tc.function.name
+                if getattr(tc.function, "arguments", None):
+                    self._calls[idx]["arguments"] += tc.function.arguments
+
+    def apply_to(self, response: "LLMResponse") -> None:
+        if not self._calls:
+            return
+
+        # Case 1: tool_calls were parsed but args are empty — fill them in
+        if response.tools_call_args:
+            for i, args in enumerate(response.tools_call_args):
+                if (args is None or args == {}) and i in self._calls:
+                    parsed = self._parse_args(self._calls[i]["arguments"])
+                    if parsed is not None:
+                        response.tools_call_args[i] = parsed
+                        logger.info(
+                            f"Stream fallback: restored args for {self._calls[i]['name']}"
+                        )
+            return
+
+        # Case 2: no tool_calls were parsed at all — rebuild from fallback
+        for idx in sorted(self._calls):
+            fb = self._calls[idx]
+            if not fb["name"] or not fb["arguments"]:
+                continue
+            parsed = self._parse_args(fb["arguments"])
+            if parsed is None:
+                parsed = {}
+            response.tools_call_args = response.tools_call_args or []
+            response.tools_call_name = response.tools_call_name or []
+            response.tools_call_ids = response.tools_call_ids or []
+            response.tools_call_args.append(parsed)
+            response.tools_call_name.append(fb["name"])
+            response.tools_call_ids.append(fb["id"] or f"fallback_{idx}")
+            response.role = "tool"
+            logger.info(f"Stream fallback: rebuilt tool_call {fb['name']}({parsed})")
+
+    @staticmethod
+    def _parse_args(raw: str) -> dict | None:
+        try:
+            return json.loads(raw)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return None
+
+
 @register_provider_adapter(
     "openai_chat_completion",
     "OpenAI API Chat Completion 提供商适配器",
@@ -305,12 +377,14 @@ class ProviderOpenAIOfficial(Provider):
         llm_response = LLMResponse("assistant", is_chunk=True)
 
         state = ChatCompletionStreamState()
+        fallback_tc = _StreamToolCallFallback()
 
         async for chunk in stream:
             try:
                 state.handle_chunk(chunk)
             except Exception as e:
                 logger.warning("Saving chunk state error: " + str(e))
+                fallback_tc.collect_from_chunk(chunk)
             if not chunk.choices:
                 continue
             choice = chunk.choices[0]
@@ -342,6 +416,7 @@ class ProviderOpenAIOfficial(Provider):
 
         final_completion = state.get_final_completion()
         llm_response = await self._parse_openai_completion(final_completion, tools)
+        fallback_tc.apply_to(llm_response)
 
         yield llm_response
 
@@ -517,9 +592,14 @@ class ProviderOpenAIOfficial(Provider):
                     ):
                         # workaround for #1454
                         if isinstance(tool_call.function.arguments, str):
-                            args = json.loads(tool_call.function.arguments)
+                            try:
+                                args = json.loads(tool_call.function.arguments)
+                            except (json.JSONDecodeError, TypeError):
+                                args = {}
                         else:
                             args = tool_call.function.arguments
+                        if args is None:
+                            args = {}
                         args_ls.append(args)
                         func_name_ls.append(tool_call.function.name)
                         tool_call_ids.append(tool_call.id)


### PR DESCRIPTION
Fixes #6661

  ## Motivation

  When using Gemini models through OpenAI-compatible proxy services, streaming tool_call chunks are missing the required
   `index` field. The openai SDK's `ChatCompletionStreamState.handle_chunk()` rejects these chunks, silently dropping
  tool_call arguments. This causes `AttributeError: 'NoneType' object has no attribute 'items'` crashes in tool
  execution.

  ### Modifications / 改动点

  **Files modified:**
  - `astrbot/core/provider/sources/openai_source.py`
    - Add `_StreamToolCallFallback` class: manually accumulates tool_call data from rejected stream chunks and restores
  args after parsing
    - Add `try/except` around `json.loads` in `_parse_openai_completion` for robustness
  - `astrbot/core/agent/runners/tool_loop_agent_runner.py`
    - Add `None` guard for `func_tool_args` to prevent crash

  - [x] This is NOT a breaking change. / 这不是一个破坏性变更。

  ### Screenshots or Test Results / 运行截图或测试结果

  **Before fix:** tool_call args are None, crashes with AttributeError
  [WARN] Saving chunk state error: Expected list delta entry to have an index key
  [INFO] 使用工具：memory_save，参数：None
  AttributeError: 'NoneType' object has no attribute 'items'

  **After fix:** fallback restores args from rejected chunks
  [INFO] Stream fallback: restored args for memory_save
  [INFO] 使用工具：memory_save，参数：{'content': '用户喜欢吃火锅', 'tags': 'preference,food'}

  Zero impact on standard OpenAI/DeepSeek providers — fallback only activates when `handle_chunk()` throws.

  ### Checklist / 检查清单

  - [x] 😊 Discussed via Issue #6661
  - [x] 👀 Tested with Gemini-3.1-Pro via OpenAI-compatible proxy, verified DeepSeek unaffected
  - [x] 🤓 No new dependencies introduced
  - [x] 😮 No malicious code

## Summary by Sourcery

Add a streaming tool call fallback for OpenAI-compatible proxies that omit tool_call indices and harden tool-call argument handling to prevent crashes.

Bug Fixes:
- Recover and reconstruct tool_call arguments from rejected streaming chunks when proxies omit the required index field.
- Prevent crashes in tool execution when parsed tool_call arguments are missing or invalid by defaulting to empty argument objects.

Enhancements:
- Improve robustness of JSON parsing for tool_call arguments in OpenAI completion parsing by safely handling malformed payloads.