### PR TITLE
fix(dashboard): restore plugin card changelog and author

### DIFF
--- a/dashboard/src/components/shared/ExtensionCard.vue
+++ b/dashboard/src/components/shared/ExtensionCard.vue
@@ -326,6 +326,30 @@ const viewChangelog = () => {
               </div>
 
               <div
+                v-if="!marketMode && extension.author"
+                class="extension-author-row"
+              >
+                <v-icon
+                  icon="mdi-account"
+                  size="x-small"
+                  class="extension-author-row__icon"
+                ></v-icon>
+                <a
+                  v-if="extension.social_link"
+                  :href="extension.social_link"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="extension-author-row__link"
+                  @click.stop
+                >
+                  {{ extension.author }}
+                </a>
+                <span v-else class="extension-author-row__text">
+                  {{ extension.author }}
+                </span>
+              </div>
+
+              <div
                 class="extension-desc"
                 :class="{ 'text-caption': $vuetify.display.xs }"
               >
@@ -408,6 +432,14 @@ const viewChangelog = () => {
             <v-list-item-title>{{ tm("buttons.viewInfo") }}</v-list-item-title>
           </v-list-item>
 
+          <v-list-item
+            class="styled-menu-item"
+            prepend-icon="mdi-text-box-search-outline"
+            @click="viewChangelog"
+          >
+            <v-list-item-title>{{ tm("pluginChangelog.menuTitle") }}</v-list-item-title>
+          </v-list-item>
+
           <v-list-item class="styled-menu-item" prepend-icon="mdi-update" @click="updateExtension">
             <v-list-item-title>{{
               extension.has_update
@@ -463,6 +495,39 @@ const viewChangelog = () => {
 
 .extension-chip-group {
   gap: 8px;
+}
+
+.extension-author-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 8px;
+  color: rgb(var(--v-theme-primary));
+  min-width: 0;
+}
+
+.extension-author-row__icon {
+  color: rgba(var(--v-theme-on-surface), 0.5);
+  flex-shrink: 0;
+}
+
+.extension-author-row__link,
+.extension-author-row__text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.extension-author-row__link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.extension-author-row__link:hover {
+  text-decoration: underline;
 }
 
 .extension-desc {

--- a/dashboard/src/components/shared/ExtensionCard.vue
+++ b/dashboard/src/components/shared/ExtensionCard.vue
@@ -126,6 +126,22 @@ const viewChangelog = () => {
   emit("view-changelog", props.extension);
 };
 
+const safeSocialLink = computed(() => {
+  const socialLink = props.extension?.social_link;
+  if (typeof socialLink !== "string" || !socialLink.trim().length) {
+    return "";
+  }
+
+  try {
+    const parsed = new URL(socialLink);
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+      ? parsed.href
+      : "";
+  } catch {
+    return "";
+  }
+});
+
 </script>
 
 <template>
@@ -335,16 +351,19 @@ const viewChangelog = () => {
                   class="extension-author-row__icon"
                 ></v-icon>
                 <a
-                  v-if="extension.social_link"
-                  :href="extension.social_link"
+                  v-if="safeSocialLink"
+                  :href="safeSocialLink"
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="extension-author-row__link"
+                  class="extension-author-row__link text-subtitle-2 font-weight-medium"
                   @click.stop
                 >
                   {{ extension.author }}
                 </a>
-                <span v-else class="extension-author-row__text">
+                <span
+                  v-else
+                  class="extension-author-row__text text-subtitle-2 font-weight-medium"
+                >
                   {{ extension.author }}
                 </span>
               </div>
@@ -517,12 +536,14 @@ const viewChangelog = () => {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 0.95rem;
-  font-weight: 500;
+}
+
+.extension-author-row__link,
+.extension-author-row__text {
+  color: rgb(var(--v-theme-primary));
 }
 
 .extension-author-row__link {
-  color: inherit;
   text-decoration: none;
 }
 


### PR DESCRIPTION
## Summary
- restore a manual changelog entry in installed plugin cards by wiring the existing `view-changelog` flow back into the installed-card action menu
- restore author display in installed plugin cards, keeping `social_link` clickable when available
- keep the change scoped to installed cards so market-mode behavior is unchanged

## Testing
- `cd dashboard && pnpm install --frozen-lockfile`
- `cd dashboard && pnpm run typecheck`
- `cd dashboard && pnpm run lint -- src/components/shared/ExtensionCard.vue` *(fails because of existing repository-wide ESLint/parser configuration issues, not this patch specifically)*

Fixes #6639

## Summary by Sourcery

Restore installed plugin card metadata and actions in the dashboard UI.

New Features:
- Show plugin author information on installed extension cards, linking to the social profile when available.
- Add a changelog menu action back to the installed extension card action menu to open the plugin changelog.

Enhancements:
- Style the author row in installed extension cards for consistent layout, truncation, and hover behavior while keeping market-mode cards unchanged.