### PR TITLE
fix: 新增临时额外文本块

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -189,13 +189,13 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
         if request.prompt is not None:
             m = await request.assemble_context()
             messages.append(Message.model_validate(m))
-            if request.transient_extra_user_content_parts:
-                extra_msg = Message(
-                    role="user",
-                    content=request.transient_extra_user_content_parts,
-                )
-                extra_msg._no_save = True
-                messages.append(extra_msg)
+        if request.transient_extra_user_content_parts:
+            extra_msg = Message(
+                role="user",
+                content=request.transient_extra_user_content_parts,
+            )
+            extra_msg._no_save = True
+            messages.append(extra_msg)
         if request.system_prompt:
             messages.insert(
                 0,

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -187,7 +187,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 m._no_save = True
             messages.append(m)
         if request.prompt is not None:
-            extra_user_content_parts = copy.deepcopy(request.extra_user_content_parts)
+            extra_user_content_parts = request.extra_user_content_parts
             request.extra_user_content_parts = []
             try:
                 m = await request.assemble_context()

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -187,8 +187,20 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 m._no_save = True
             messages.append(m)
         if request.prompt is not None:
-            m = await request.assemble_context()
+            extra_user_content_parts = copy.deepcopy(request.extra_user_content_parts)
+            request.extra_user_content_parts = []
+            try:
+                m = await request.assemble_context()
+            finally:
+                request.extra_user_content_parts = extra_user_content_parts
             messages.append(Message.model_validate(m))
+            if extra_user_content_parts:
+                extra_msg = Message(
+                    role="user",
+                    content=extra_user_content_parts,
+                )
+                extra_msg._no_save = True
+                messages.append(extra_msg)
         if request.system_prompt:
             messages.insert(
                 0,
@@ -207,7 +219,6 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             "contexts": self.run_context.messages,  # list[Message]
             "func_tool": self.req.func_tool,
             "session_id": self.req.session_id,
-            "extra_user_content_parts": self.req.extra_user_content_parts,  # list[ContentPart]
         }
         if include_model:
             # For primary provider we keep explicit model selection if provided.

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -187,17 +187,12 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 m._no_save = True
             messages.append(m)
         if request.prompt is not None:
-            extra_user_content_parts = request.extra_user_content_parts
-            request.extra_user_content_parts = []
-            try:
-                m = await request.assemble_context()
-            finally:
-                request.extra_user_content_parts = extra_user_content_parts
+            m = await request.assemble_context()
             messages.append(Message.model_validate(m))
-            if extra_user_content_parts:
+            if request.transient_extra_user_content_parts:
                 extra_msg = Message(
                     role="user",
-                    content=extra_user_content_parts,
+                    content=request.transient_extra_user_content_parts,
                 )
                 extra_msg._no_save = True
                 messages.append(extra_msg)

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -486,7 +486,7 @@ async def _ensure_img_caption(
             plugin_context,
         )
         if caption:
-            req.extra_user_content_parts.append(
+            req.transient_extra_user_content_parts.append(
                 TextPart(text=f"<image_caption>{caption}</image_caption>")
             )
             req.image_urls = []
@@ -495,7 +495,7 @@ async def _ensure_img_caption(
 
 
 def _append_quoted_image_attachment(req: ProviderRequest, image_path: str) -> None:
-    req.extra_user_content_parts.append(
+    req.transient_extra_user_content_parts.append(
         TextPart(text=f"[Image Attachment in quoted message: path {image_path}]")
     )
 
@@ -570,7 +570,7 @@ async def _process_quote_message(
 
     quoted_content = "\n".join(content_parts)
     quoted_text = f"<Quoted Message>\n{quoted_content}\n</Quoted Message>"
-    req.extra_user_content_parts.append(TextPart(text=quoted_text))
+    req.transient_extra_user_content_parts.append(TextPart(text=quoted_text))
 
 
 def _append_system_reminders(
@@ -614,7 +614,7 @@ def _append_system_reminders(
         system_content = (
             "<system_reminder>" + "\n".join(system_parts) + "</system_reminder>"
         )
-        req.extra_user_content_parts.append(TextPart(text=system_content))
+        req.transient_extra_user_content_parts.append(TextPart(text=system_content))
 
 
 async def _decorate_llm_request(
@@ -1027,13 +1027,13 @@ async def build_main_agent(
                 if isinstance(comp, Image):
                     image_path = await comp.convert_to_file_path()
                     req.image_urls.append(image_path)
-                    req.extra_user_content_parts.append(
+                    req.transient_extra_user_content_parts.append(
                         TextPart(text=f"[Image Attachment: path {image_path}]")
                     )
                 elif isinstance(comp, File):
                     file_path = await comp.get_file()
                     file_name = comp.name or os.path.basename(file_path)
-                    req.extra_user_content_parts.append(
+                    req.transient_extra_user_content_parts.append(
                         TextPart(
                             text=f"[File Attachment: name {file_name}, path {file_path}]"
                         )
@@ -1058,7 +1058,7 @@ async def build_main_agent(
                         elif isinstance(reply_comp, File):
                             file_path = await reply_comp.get_file()
                             file_name = reply_comp.name or os.path.basename(file_path)
-                            req.extra_user_content_parts.append(
+                            req.transient_extra_user_content_parts.append(
                                 TextPart(
                                     text=(
                                         f"[File Attachment in quoted message: "
@@ -1130,7 +1130,9 @@ async def build_main_agent(
             logger.error("Error occurred while applying file extract: %s", exc)
 
     if not req.prompt and not req.image_urls:
-        if not event.get_group_id() and req.extra_user_content_parts:
+        if not event.get_group_id() and (
+            req.extra_user_content_parts or req.transient_extra_user_content_parts
+        ):
             req.prompt = "<attachment>"
         else:
             return None

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -486,7 +486,7 @@ async def _ensure_img_caption(
             plugin_context,
         )
         if caption:
-            req.transient_extra_user_content_parts.append(
+            req.extra_user_content_parts.append(
                 TextPart(text=f"<image_caption>{caption}</image_caption>")
             )
             req.image_urls = []
@@ -495,7 +495,7 @@ async def _ensure_img_caption(
 
 
 def _append_quoted_image_attachment(req: ProviderRequest, image_path: str) -> None:
-    req.transient_extra_user_content_parts.append(
+    req.extra_user_content_parts.append(
         TextPart(text=f"[Image Attachment in quoted message: path {image_path}]")
     )
 
@@ -570,7 +570,7 @@ async def _process_quote_message(
 
     quoted_content = "\n".join(content_parts)
     quoted_text = f"<Quoted Message>\n{quoted_content}\n</Quoted Message>"
-    req.transient_extra_user_content_parts.append(TextPart(text=quoted_text))
+    req.extra_user_content_parts.append(TextPart(text=quoted_text))
 
 
 def _append_system_reminders(
@@ -614,7 +614,7 @@ def _append_system_reminders(
         system_content = (
             "<system_reminder>" + "\n".join(system_parts) + "</system_reminder>"
         )
-        req.transient_extra_user_content_parts.append(TextPart(text=system_content))
+        req.extra_user_content_parts.append(TextPart(text=system_content))
 
 
 async def _decorate_llm_request(
@@ -1027,13 +1027,13 @@ async def build_main_agent(
                 if isinstance(comp, Image):
                     image_path = await comp.convert_to_file_path()
                     req.image_urls.append(image_path)
-                    req.transient_extra_user_content_parts.append(
+                    req.extra_user_content_parts.append(
                         TextPart(text=f"[Image Attachment: path {image_path}]")
                     )
                 elif isinstance(comp, File):
                     file_path = await comp.get_file()
                     file_name = comp.name or os.path.basename(file_path)
-                    req.transient_extra_user_content_parts.append(
+                    req.extra_user_content_parts.append(
                         TextPart(
                             text=f"[File Attachment: name {file_name}, path {file_path}]"
                         )
@@ -1058,7 +1058,7 @@ async def build_main_agent(
                         elif isinstance(reply_comp, File):
                             file_path = await reply_comp.get_file()
                             file_name = reply_comp.name or os.path.basename(file_path)
-                            req.transient_extra_user_content_parts.append(
+                            req.extra_user_content_parts.append(
                                 TextPart(
                                     text=(
                                         f"[File Attachment in quoted message: "
@@ -1130,9 +1130,7 @@ async def build_main_agent(
             logger.error("Error occurred while applying file extract: %s", exc)
 
     if not req.prompt and not req.image_urls:
-        if not event.get_group_id() and (
-            req.extra_user_content_parts or req.transient_extra_user_content_parts
-        ):
+        if not event.get_group_id() and req.extra_user_content_parts:
             req.prompt = "<attachment>"
         else:
             return None

--- a/astrbot/core/provider/entities.py
+++ b/astrbot/core/provider/entities.py
@@ -95,6 +95,8 @@ class ProviderRequest:
     """图片 URL 列表"""
     extra_user_content_parts: list[ContentPart] = field(default_factory=list)
     """额外的用户消息内容部分列表，用于在用户消息后添加额外的内容块（如系统提醒、指令等）。支持 dict 或 ContentPart 对象"""
+    transient_extra_user_content_parts: list[ContentPart] = field(default_factory=list)
+    """仅当前请求可见的额外用户消息内容部分列表，不应进入持久化消息历史。"""
     func_tool: ToolSet | None = None
     """可用的函数工具"""
     contexts: list[dict] = field(default_factory=list)

--- a/astrbot/core/provider/entities.py
+++ b/astrbot/core/provider/entities.py
@@ -96,7 +96,7 @@ class ProviderRequest:
     extra_user_content_parts: list[ContentPart] = field(default_factory=list)
     """额外的用户消息内容部分列表，用于在用户消息后添加额外的内容块（如系统提醒、指令等）。支持 dict 或 ContentPart 对象"""
     transient_extra_user_content_parts: list[ContentPart] = field(default_factory=list)
-    """仅当前请求可见的额外用户消息内容部分列表，不应进入持久化消息历史。"""
+    """仅在构建当前轮最新用户消息时追加的临时内容块，不参与持久化消息历史。"""
     func_tool: ToolSet | None = None
     """可用的函数工具"""
     contexts: list[dict] = field(default_factory=list)

--- a/astrbot/core/provider/entities.py
+++ b/astrbot/core/provider/entities.py
@@ -94,9 +94,9 @@ class ProviderRequest:
     image_urls: list[str] = field(default_factory=list)
     """图片 URL 列表"""
     extra_user_content_parts: list[ContentPart] = field(default_factory=list)
-    """额外的用户消息内容部分列表，用于在用户消息后添加额外的内容块（如系统提醒、指令等）。支持 dict 或 ContentPart 对象"""
+    """正式用户消息的一部分，会和 prompt、image_urls 一起组成当前轮用户消息，并进入消息记录。适用于应长期保留的补充信息，例如消息发送时间、发送人等。"""
     transient_extra_user_content_parts: list[ContentPart] = field(default_factory=list)
-    """仅在构建当前轮最新用户消息时追加的临时内容块，不参与持久化消息历史。"""
+    """仅当前轮临时追加的用户内容块，会出现在正式用户消息之后，但不会进入消息记录。适用于只影响当前轮的补充信息，例如增强检索结果、当前语境的相似对话参考等。"""
     func_tool: ToolSet | None = None
     """可用的函数工具"""
     contexts: list[dict] = field(default_factory=list)


### PR DESCRIPTION
## 摘要
- 新增 `transient_extra_user_content_parts`，用于承载仅在组装当前轮最新用户消息时出现、且不会进入消息记录的临时内容块
- 保留现有 `extra_user_content_parts` 的生产和消费逻辑不变，不改动框架内原有写入点
- 这是一个小修复，不需要 schema 变更、数据迁移或删除现有记录即可上线

## 问题说明
当前 `extra_user_content_parts` 会进入正常消息记录。

但第三方插件有可能需要给“当前这一次请求”附加临时文本块，这类内容不应该被持久化到消息历史。
如果误用 `extra_user_content_parts` 来承载这类临时内容，就会把它们写入历史，并在后续轮次中继续被带入上下文。
这不仅是错误实现，还会持续浪费 token 和存储空间。

## 修改说明
本次修复采用增量方式处理：
- 新增 `transient_extra_user_content_parts`
- 不修改现有 `extra_user_content_parts` 的既有语义
- 不改动框架内原有 `extra_user_content_parts.append(...)` 的调用点

运行时仅在组装消息时额外处理这个新字段：
- `transient_extra_user_content_parts` 会被拼成一条临时的最新 `user` 消息
- 这条消息会标记为 `_no_save`
- 除了这一步之外，不额外让其他逻辑消费它

这样可以保证：
- 插件仍然可以为当前请求追加临时内容块
- 这些临时内容只出现在本轮最新用户消息中
- 它们不会进入持久化消息历史
- 现有框架内的 `extra_user_content_parts` 行为保持不变

## 测试
- `uv run ruff check astrbot/core/provider/entities.py`
- `uv run ruff check astrbot/core/agent/runners/tool_loop_agent_runner.py`
- `uv run ruff check astrbot/core/astr_main_agent.py`

## 补充说明
这是一个不需要删除数据的小修复。
这个补丁不会主动清理已经被污染的旧历史记录，只提供一种正确的“临时额外内容块”承载方式，供后续插件使用。

## Summary by Sourcery

Introduce transient user content blocks for per-request context without affecting persisted message history.

New Features:
- Add a transient_extra_user_content_parts field on ProviderRequest to carry temporary user content blocks that only affect the current turn.

Enhancements:
- Assemble transient_extra_user_content_parts into a separate, non-persisted user message when building the LLM message list.
- Clarify the semantics of extra_user_content_parts in ProviderRequest to describe their persistence in message history.