### PR TITLE
fix(lark): support thread/reply-chain context isolation and reply_in_thread

### DIFF
--- a/astrbot/core/platform/sources/lark/lark_adapter.py
+++ b/astrbot/core/platform/sources/lark/lark_adapter.py
@@ -470,11 +470,17 @@ class LarkPlatformAdapter(Platform):
         if session.message_type == MessageType.GROUP_MESSAGE:
             id_type = "chat_id"
             receive_id = session.session_id
-            if "%" in receive_id:
+            # 从 session_id 中提取真实的 chat_id（去除 %thread% / %root% 后缀）
+            if "%thread%" in receive_id or "%root%" in receive_id:
+                receive_id = receive_id.split("%")[0]
+            elif "%" in receive_id:
                 receive_id = receive_id.split("%")[1]
         else:
             id_type = "open_id"
             receive_id = session.session_id
+            # 单聊也需要去除 %thread% / %root% 后缀
+            if "%thread%" in receive_id or "%root%" in receive_id:
+                receive_id = receive_id.split("%")[0]
 
         # 复用 LarkMessageEvent 中的通用发送逻辑
         await LarkMessageEvent.send_message_chain(
@@ -580,20 +586,40 @@ class LarkPlatformAdapter(Platform):
             user_id=event.event.sender.sender_id.open_id,
             nickname=event.event.sender.sender_id.open_id[:8],
         )
+        # 构建 session_id：按话题/回复链隔离上下文
         if abm.type == MessageType.GROUP_MESSAGE:
-            abm.session_id = abm.group_id
+            base_id = abm.group_id or ""
+            if message.thread_id:
+                # 话题群中的消息，按 thread_id 隔离
+                abm.session_id = f"{base_id}%thread%{message.thread_id}"
+            elif message.root_id:
+                # 群聊中的回复链，按 root_id 隔离
+                abm.session_id = f"{base_id}%root%{message.root_id}"
+            else:
+                abm.session_id = base_id
         else:
-            abm.session_id = abm.sender.user_id
+            base_id = abm.sender.user_id
+            if message.thread_id:
+                abm.session_id = f"{base_id}%thread%{message.thread_id}"
+            elif message.root_id:
+                # 单聊中的回复链，按 root_id 隔离
+                abm.session_id = f"{base_id}%root%{message.root_id}"
+            else:
+                abm.session_id = base_id
 
-        await self.handle_msg(abm)
+        # 判断消息是否在话题/回复链中
+        # 仅在需要创建话题时标记（已在话题中的消息回复自然在话题内，无需 reply_in_thread）
+        _is_in_thread = bool(message.root_id) and not bool(message.thread_id)
+        await self.handle_msg(abm, is_in_thread=_is_in_thread)
 
-    async def handle_msg(self, abm: AstrBotMessage) -> None:
+    async def handle_msg(self, abm: AstrBotMessage, is_in_thread: bool = False) -> None:
         event = LarkMessageEvent(
             message_str=abm.message_str,
             message_obj=abm,
             platform_meta=self.meta(),
             session_id=abm.session_id,
             bot=self.lark_api,
+            is_in_thread=is_in_thread,
         )
 
         self._event_queue.put_nowait(event)

--- a/astrbot/core/platform/sources/lark/lark_event.py
+++ b/astrbot/core/platform/sources/lark/lark_event.py
@@ -48,9 +48,11 @@ class LarkMessageEvent(AstrMessageEvent):
         platform_meta,
         session_id,
         bot: lark.Client,
+        is_in_thread: bool = False,
     ) -> None:
         super().__init__(message_str, message_obj, platform_meta, session_id)
         self.bot = bot
+        self.is_in_thread = is_in_thread
 
     @staticmethod
     async def _send_im_message(
@@ -61,6 +63,7 @@ class LarkMessageEvent(AstrMessageEvent):
         reply_message_id: str | None = None,
         receive_id: str | None = None,
         receive_id_type: str | None = None,
+        reply_in_thread: bool = False,
     ) -> bool:
         """发送飞书 IM 消息的通用辅助函数
 
@@ -71,6 +74,7 @@ class LarkMessageEvent(AstrMessageEvent):
             reply_message_id: 回复的消息ID（用于回复消息）
             receive_id: 接收者ID（用于主动发送）
             receive_id_type: 接收者ID类型（用于主动发送）
+            reply_in_thread: 是否在话题中回复
 
         Returns:
             是否发送成功
@@ -88,7 +92,7 @@ class LarkMessageEvent(AstrMessageEvent):
                     .content(content)
                     .msg_type(msg_type)
                     .uuid(str(uuid.uuid4()))
-                    .reply_in_thread(False)
+                    .reply_in_thread(reply_in_thread)
                     .build()
                 )
                 .build()
@@ -287,6 +291,7 @@ class LarkMessageEvent(AstrMessageEvent):
         reply_message_id: str | None = None,
         receive_id: str | None = None,
         receive_id_type: str | None = None,
+        reply_in_thread: bool = False,
     ) -> None:
         """通用的消息链发送方法
 
@@ -296,6 +301,7 @@ class LarkMessageEvent(AstrMessageEvent):
             reply_message_id: 回复的消息ID（用于回复消息）
             receive_id: 接收者ID（用于主动发送）
             receive_id_type: 接收者ID类型，如 'open_id', 'chat_id'（用于主动发送）
+            reply_in_thread: 是否在话题中回复
         """
         if lark_client.im is None:
             logger.error("[Lark] API Client im 模块未初始化")
@@ -337,22 +343,26 @@ class LarkMessageEvent(AstrMessageEvent):
                     reply_message_id=reply_message_id,
                     receive_id=receive_id,
                     receive_id_type=receive_id_type,
+                    reply_in_thread=reply_in_thread,
                 )
 
         # 发送附件
         for file_comp in file_components:
             await LarkMessageEvent._send_file_message(
-                file_comp, lark_client, reply_message_id, receive_id, receive_id_type
+                file_comp, lark_client, reply_message_id, receive_id, receive_id_type,
+                reply_in_thread=reply_in_thread,
             )
 
         for audio_comp in audio_components:
             await LarkMessageEvent._send_audio_message(
-                audio_comp, lark_client, reply_message_id, receive_id, receive_id_type
+                audio_comp, lark_client, reply_message_id, receive_id, receive_id_type,
+                reply_in_thread=reply_in_thread,
             )
 
         for media_comp in media_components:
             await LarkMessageEvent._send_media_message(
-                media_comp, lark_client, reply_message_id, receive_id, receive_id_type
+                media_comp, lark_client, reply_message_id, receive_id, receive_id_type,
+                reply_in_thread=reply_in_thread,
             )
 
     async def send(self, message: MessageChain) -> None:
@@ -361,6 +371,7 @@ class LarkMessageEvent(AstrMessageEvent):
             message,
             self.bot,
             reply_message_id=self.message_obj.message_id,
+            reply_in_thread=self.is_in_thread,
         )
         await super().send(message)
 
@@ -371,6 +382,7 @@ class LarkMessageEvent(AstrMessageEvent):
         reply_message_id: str | None = None,
         receive_id: str | None = None,
         receive_id_type: str | None = None,
+        reply_in_thread: bool = False,
     ) -> None:
         """发送文件消息
 
@@ -396,6 +408,7 @@ class LarkMessageEvent(AstrMessageEvent):
             reply_message_id=reply_message_id,
             receive_id=receive_id,
             receive_id_type=receive_id_type,
+            reply_in_thread=reply_in_thread,
         )
 
     @staticmethod
@@ -405,6 +418,7 @@ class LarkMessageEvent(AstrMessageEvent):
         reply_message_id: str | None = None,
         receive_id: str | None = None,
         receive_id_type: str | None = None,
+        reply_in_thread: bool = False,
     ) -> None:
         """发送音频消息
 
@@ -469,6 +483,7 @@ class LarkMessageEvent(AstrMessageEvent):
             reply_message_id=reply_message_id,
             receive_id=receive_id,
             receive_id_type=receive_id_type,
+            reply_in_thread=reply_in_thread,
         )
 
     @staticmethod
@@ -478,6 +493,7 @@ class LarkMessageEvent(AstrMessageEvent):
         reply_message_id: str | None = None,
         receive_id: str | None = None,
         receive_id_type: str | None = None,
+        reply_in_thread: bool = False,
     ) -> None:
         """发送视频消息
 
@@ -542,6 +558,7 @@ class LarkMessageEvent(AstrMessageEvent):
             reply_message_id=reply_message_id,
             receive_id=receive_id,
             receive_id_type=receive_id_type,
+            reply_in_thread=reply_in_thread,
         )
 
     async def react(self, emoji: str) -> None:
@@ -633,6 +650,7 @@ class LarkMessageEvent(AstrMessageEvent):
         reply_message_id: str | None = None,
         receive_id: str | None = None,
         receive_id_type: str | None = None,
+        reply_in_thread: bool = False,
     ) -> bool:
         """将卡片实体作为 interactive 消息发送。"""
         content = json.dumps(
@@ -646,6 +664,7 @@ class LarkMessageEvent(AstrMessageEvent):
             reply_message_id=reply_message_id,
             receive_id=receive_id,
             receive_id_type=receive_id_type,
+            reply_in_thread=reply_in_thread,
         )
 
     async def _update_streaming_text(
@@ -747,6 +766,12 @@ class LarkMessageEvent(AstrMessageEvent):
         使用解耦发送循环，LLM token 到达时只更新 buffer 并唤醒发送协程，
         发送频率由网络 RTT 自然限流。
         """
+        # 话题内消息不支持流式卡片，回退到普通回复
+        if self.is_in_thread:
+            logger.info("[Lark] 话题内消息，回退到非流式发送（reply_in_thread）")
+            await self._fallback_send_streaming(generator, use_fallback)
+            return
+
         # Step 1: 创建流式卡片实体
         card_id = await self._create_streaming_card()
         if not card_id:
@@ -758,6 +783,7 @@ class LarkMessageEvent(AstrMessageEvent):
         sent = await self._send_card_message(
             card_id,
             reply_message_id=self.message_obj.message_id,
+            reply_in_thread=self.is_in_thread,
         )
         if not sent:
             logger.error("[Lark] 发送流式卡片消息失败，回退到非流式发送")


### PR DESCRIPTION
## Summary

This PR adds proper thread and reply-chain support for the Lark (Feishu) platform adapter.

### Problem

- All messages in a group shared the same `session_id`, so conversations in different threads/reply-chains were mixed together.
- The bot always replied in the main chat even when the user messaged from within a thread or reply chain.
- `reply_in_thread` was hardcoded to `False`, preventing thread-aware replies.

### Changes

**`lark_adapter.py`**
- Build `session_id` with `%thread%{thread_id}` or `%root%{root_id}` suffix to isolate conversation context per thread/reply chain (both group and DM).
- Extract the real `chat_id` / `open_id` from `session_id` by stripping the `%thread%` / `%root%` suffix when sending active messages.
- Determine `is_in_thread` based on whether a thread needs to be **created** (`root_id` present but no `thread_id`), not whether the message is already in a thread.

**`lark_event.py`**
- Add `is_in_thread` attribute and `reply_in_thread` parameter through all send methods.
- When `reply_in_thread=True`, pass it to the Lark API `ReplyMessageRequestBody` so the reply creates/continues a thread.
- Fall back to non-streaming send when `is_in_thread=True`, because CardKit streaming cards do not support `reply_in_thread`.

### Key Design Decision

| Scenario | `thread_id` | `reply_in_thread` | Streaming |
|----------|-------------|-------------------|-----------|
| Message already in an existing thread | ✅ present | `False` (reply stays in thread naturally) | ✅ Works |
| Message in a reply chain, no thread yet | ❌ absent, `root_id` present | `True` (creates thread) | ❌ Falls back to non-streaming |
| Regular message (no thread/reply) | ❌ absent | `False` | ✅ Works |

### Testing

Tested in both group chat threads and reply chains on Feishu. Verified:
- Session isolation works correctly per thread/reply chain
- Streaming output works in existing threads
- Non-streaming fallback works when creating new threads
- Active message sending correctly extracts chat_id from suffixed session_id

## Summary by Sourcery

Add proper thread and reply-chain awareness to the Lark adapter so sessions and replies are isolated per thread and behave correctly in group and DM conversations.

Bug Fixes:
- Ensure Lark group and DM conversations no longer share context across different threads or reply chains by deriving distinct session IDs.
- Fix Lark replies being sent to the main chat instead of staying within or creating the appropriate thread or reply chain.
- Prevent use of streaming card responses when replying in thread contexts that do not support them, falling back to non-streaming sends instead.

Enhancements:
- Propagate an explicit thread-context flag through the Lark event and messaging pipeline to control reply_in_thread behavior for all message types (text, files, audio, media, cards).