### PR TITLE
修复 ObjectEditor中因索引错位导致误报"键名已存在"的 bug

### DIFF
--- a/dashboard/src/components/shared/ObjectEditor.vue
+++ b/dashboard/src/components/shared/ObjectEditor.vue
@@ -28,7 +28,7 @@
       <v-card-text class="pa-4" style="max-height: 400px; overflow-y: auto;">
         <!-- Regular key-value pairs (non-template) -->
         <div v-if="nonTemplatePairs.length > 0">
-          <div v-for="(pair, index) in nonTemplatePairs" :key="index" class="key-value-pair">
+          <div v-for="pair in nonTemplatePairs" :key="pair._id" class="key-value-pair">
             <v-row no-gutters align="center" class="mb-2">
               <v-col cols="4">
                 <v-text-field
@@ -222,9 +222,11 @@
 <script setup>
 import { ref, computed, watch } from 'vue'
 import { useI18n, useModuleI18n } from '@/i18n/composables'
+import { useToast } from '@/utils/toast'
 
 const { t } = useI18n()
 const { tm, getRaw } = useModuleI18n('features/config-metadata')
+const { warning: toastWarning } = useToast()
 
 const props = defineProps({
   modelValue: {
@@ -259,6 +261,7 @@ const localKeyValuePairs = ref([])
 const originalKeyValuePairs = ref([])
 const newKey = ref('')
 const newValueType = ref('string')
+const nextPairId = ref(0)
 
 // Template schema support
 const templateSchema = computed(() => {
@@ -285,12 +288,26 @@ watch(() => props.modelValue, (newValue) => {
   // The dialog-based editing handles internal updates
 }, { immediate: true })
 
+function createPair({ key, value, type, slider, template, jsonError = '', _originalKey }) {
+  return {
+    _id: nextPairId.value++,
+    key,
+    value,
+    type,
+    slider,
+    template,
+    jsonError,
+    _originalKey
+  }
+}
+
 function initializeLocalKeyValuePairs() {
   localKeyValuePairs.value = []
+  nextPairId.value = 0
   for (const [key, value] of Object.entries(props.modelValue)) {
     let _type = (typeof value) === 'object' ? 'json':(typeof value)
-    let _value = _type === 'json'?JSON.stringify(value):value
-    
+    let _value = _type === 'json' ? JSON.stringify(value) : value
+
     // Check if this key has a template schema
     const template = templateSchema.value[key]
     if (template) {
@@ -301,20 +318,20 @@ function initializeLocalKeyValuePairs() {
         _value = template.default !== undefined ? template.default : _value
       }
     }
-    
-    localKeyValuePairs.value.push({
-      key: key,
+
+    localKeyValuePairs.value.push(createPair({
+      key,
       value: _value,
       type: _type,
       slider: template?.slider,
-      template: template
-    })
+      template
+    }))
   }
 }
 
 function openDialog() {
   initializeLocalKeyValuePairs()
-  originalKeyValuePairs.value = JSON.parse(JSON.stringify(localKeyValuePairs.value)) // Deep copy
+  originalKeyValuePairs.value = localKeyValuePairs.value.map(pair => ({ ...pair }))
   newKey.value = ''
   newValueType.value = 'string'
   dialog.value = true
@@ -325,7 +342,7 @@ function addKeyValuePair() {
   if (key !== '') {
     const isKeyExists = localKeyValuePairs.value.some(pair => pair.key === key)
     if (isKeyExists) {
-      alert(t('core.common.objectEditor.keyExists'))
+      toastWarning(t('core.common.objectEditor.keyExists'))
       return
     }
 
@@ -338,18 +355,18 @@ function addKeyValuePair() {
         defaultValue = false
         break
       case 'json':
-        defaultValue = "{}"
+        defaultValue = '{}'
         break
       default: // string
-        defaultValue = ""
+        defaultValue = ''
         break
     }
 
-    localKeyValuePairs.value.push({
-      key: key,
+    localKeyValuePairs.value.push(createPair({
+      key,
       value: defaultValue,
       type: newValueType.value
-    })
+    }))
     newKey.value = ''
   }
 }
@@ -377,7 +394,7 @@ function onKeyBlur(pair) {
 
   const isKeyExists = localKeyValuePairs.value.some(p => p !== pair && p.key === newKey)
   if (isKeyExists) {
-    alert(t('core.common.objectEditor.keyExists'))
+    toastWarning(t('core.common.objectEditor.keyExists'))
     pair.key = originalKey
     return
   }
@@ -412,20 +429,20 @@ function getTemplateValue(templateKey) {
 function updateTemplateValue(templateKey, newValue) {
   const existingIndex = localKeyValuePairs.value.findIndex(pair => pair.key === templateKey)
   const template = templateSchema.value[templateKey]
-  
+
   if (existingIndex >= 0) {
     // 更新现有值
     localKeyValuePairs.value[existingIndex].value = newValue
   } else {
     // 添加新字段
-    let valueType = template?.type || 'string'
-    localKeyValuePairs.value.push({
+    const valueType = template?.type || 'string'
+    localKeyValuePairs.value.push(createPair({
       key: templateKey,
       value: newValue,
       type: valueType,
       slider: template?.slider,
-      template: template
-    })
+      template
+    }))
   }
 }
 
@@ -446,10 +463,10 @@ function getDefaultValueForType(type) {
     case 'boolean':
       return false
     case 'json':
-      return "{}"
+      return '{}'
     case 'string':
     default:
-      return ""
+      return ''
   }
 }
 
@@ -473,7 +490,7 @@ function confirmDialog() {
       case 'bool':
       case 'boolean':
         // 布尔值通常由 v-switch 正确处理，但为保险起见可以显式转换
-        // 注意：在 JavaScript 中，只有严格的 false, 0, "", null, undefined, NaN 会被转换为 false
+        // 注意：在 JavaScript 中，只有严格的 false, 0, '', null, undefined, NaN 会被转换为 false
         // 这里直接赋值 pair.value 应该是安全的，因为 v-model 绑定的就是布尔值
         // convertedValue = Boolean(pair.value)
         break
@@ -494,7 +511,7 @@ function confirmDialog() {
 
 function cancelDialog() {
   // Reset to original state
-  localKeyValuePairs.value = JSON.parse(JSON.stringify(originalKeyValuePairs.value))
+  localKeyValuePairs.value = originalKeyValuePairs.value.map(pair => ({ ...pair }))
   dialog.value = false
 }
 
@@ -521,3 +538,4 @@ function getTemplateTitle(template, templateKey) {
   opacity: 0.8;
 }
 </style>
+


### PR DESCRIPTION
修复 ObjectEditor 组件中，选中自定义请求体参数的 key输入框后点击其他位置会误弹"键名已存在"提示的 bug。

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
 nonTemplatePairs 是 localKeyValuePairs过滤模板字段后的子数组，v-for 的 index与原始数组索引不对应。updateKey用错误的索引去原始数组查找originalKey，导致误判键名重复。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
原来的问题：
<img width="2936" height="1686" alt="image" src="https://github.com/user-attachments/assets/061ca286-4fed-4c5d-9e7a-1fb757330391" />
改后解决了此问题
验证步骤：
打开模型提供商配置，点击自定义请求体参数的"修改"按钮
点击已有 key 的输入框（如frequency_penalty），使其获得焦点
不做任何修改，点击对话框外的空白区域或切换桌面
预期结果：不再弹出"键名已存在"提示而是正常退出
---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Fix key rename handling in ObjectEditor to avoid false "key already exists" warnings when blurring key fields.

Bug Fixes:
- Preserve and compare the original key on focus to prevent spurious duplicate-key alerts when a key input loses focus without changes.

Enhancements:
- Simplify key update logic in ObjectEditor by operating on the key-value pair object directly instead of relying on list indices.