### PR TITLE
Fix: 修复 MiniMax API tool_call 参数 JSON 解析失败导致 KeyError

### DIFF
--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -418,19 +418,40 @@ class ProviderAnthropic(Provider):
                     if event.index in tool_use_buffer:
                         # 解析完整的工具调用
                         tool_info = tool_use_buffer[event.index]
+                        parsed_ok = False
+
                         try:
                             if "input_json" in tool_info:
                                 tool_info["input"] = json.loads(tool_info["input_json"])
+                            else:
+                                tool_info["input"] = {}
+                            parsed_ok = True
 
-                            # 添加到最终结果
-                            final_tool_calls.append(
-                                {
-                                    "id": tool_info["id"],
-                                    "name": tool_info["name"],
-                                    "input": tool_info["input"],
-                                },
+                        except json.JSONDecodeError as e:
+                            raw_json = tool_info.get("input_json", "")
+                            logger.warning(
+                                f"工具调用参数 JSON 解析失败: {e}。"
+                                f"len={len(raw_json)}; head={raw_json[:120]!r}; tail={raw_json[-120:]!r}"
                             )
+                            # Fallback：尝试补全可能截断的尾部
+                            for suffix in ["}", "]", '"}', '"]']:
+                                if raw_json and not raw_json.rstrip().endswith(suffix):
+                                    try:
+                                        tool_info["input"] = json.loads(raw_json + suffix)
+                                        parsed_ok = True
+                                        logger.info(
+                                            f"工具调用参数 JSON 解析成功 (fallback，修复后缀 '{suffix}')"
+                                        )
+                                        break
+                                    except json.JSONDecodeError:
+                                        pass
 
+                        if parsed_ok:
+                            final_tool_calls.append({
+                                "id": tool_info["id"],
+                                "name": tool_info["name"],
+                                "input": tool_info["input"],
+                            })
                             yield LLMResponse(
                                 role="tool",
                                 completion_text="",
@@ -441,12 +462,12 @@ class ProviderAnthropic(Provider):
                                 usage=usage,
                                 id=id,
                             )
-                        except json.JSONDecodeError:
-                            # JSON 解析失败，跳过这个工具调用
-                            logger.warning(f"工具调用参数 JSON 解析失败: {tool_info}")
+                        else:
+                            logger.warning(
+                                f"工具调用参数 JSON 解析最终失败，跳过工具调用: {tool_info['name']}"
+                            )
 
-                        # 清理缓冲区
-                        del tool_use_buffer[event.index]
+                        tool_use_buffer.pop(event.index, None)
 
                 elif event.type == "message_delta":
                     if event.usage:


### PR DESCRIPTION
## Fix: 修复 MiniMax API tool_call 参数 JSON 解析失败导致 KeyError
Fixed #6755 
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
### 问题
`sources/anthropic_source.py` 中，`content_block_stop` 处理工具调用时：
1. 若 `json.loads(input_json)` 失败，原始代码只 warn 不处理，`input` 留在空 `{}`
2. `del tool_use_buffer[event.index]` 在 fallback 路径可能触发 KeyError
3. 日志信息不足，无法判断截断发生在 JSON 哪个位置

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- 使用 `parsed_ok` 标志分离成功/失败路径，统一在 `if parsed_ok` 块内执行 `final_tool_calls.append` 和 `yield`
- Fallback 阶段尝试补全常见截断后缀（`}` , `]` , `"}` , `"]`）
- 改用 `tool_use_buffer.pop(event.index, None)` 替代 `del`，避免 KeyError
- 日志同时输出原始 JSON 的前 120 字符和后 120 字符，便于定位截断位置

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<img width="1814" height="1016" alt="截图 2026-03-22 01-43-56" src="https://github.com/user-attachments/assets/ba473db0-4fc1-48fd-8291-c95f3418520b" />
<img width="716" height="285" alt="截图 2026-03-22 01-47-30" src="https://github.com/user-attachments/assets/2ca78b22-88d4-4d7d-a225-3046416f7523" />
<img width="3438" height="1931" alt="截图 2026-03-22 01-47-55" src="https://github.com/user-attachments/assets/5f47f97f-3ea2-4633-a55d-ea4f0bc31043" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml` .
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Handle MiniMax tool_call JSON parsing failures in the Anthropic streaming source to avoid crashes and improve fallbacks and logging.

Bug Fixes:
- Prevent KeyError when cleaning up tool_use_buffer entries after failed tool_call parsing.
- Ensure tool_call entries with missing or invalid input_json are safely handled without breaking the stream.

Enhancements:
- Add fallback logic to recover from truncated tool_call JSON payloads by attempting common suffix completions.
- Improve logging for tool_call JSON parse failures by including truncated head/tail content for easier debugging.