### PR TITLE
fix(t2i): sync active template across all configs

### DIFF
--- a/astrbot/dashboard/routes/t2i.py
+++ b/astrbot/dashboard/routes/t2i.py
@@ -38,12 +38,17 @@ class T2iRoute(Route):
         ]
         self.register_routes()
 
+    async def _reload_all_pipeline_schedulers(self) -> None:
+        """热重载所有配置对应的 pipeline scheduler。"""
+        for conf_id in self.core_lifecycle.astrbot_config_mgr.confs:
+            await self.core_lifecycle.reload_pipeline_scheduler(conf_id)
+
     async def _sync_active_template_to_all_configs(self, name: str) -> None:
         """同步当前激活模板到所有配置文件，并热重载对应流水线。"""
-        for conf_id, config in self.core_lifecycle.astrbot_config_mgr.confs.items():
+        for config in self.core_lifecycle.astrbot_config_mgr.confs.values():
             config["t2i_active_template"] = name
-            config.save_config(config)
-            await self.core_lifecycle.reload_pipeline_scheduler(conf_id)
+            config.save_config()
+        await self._reload_all_pipeline_schedulers()
 
     async def list_templates(self):
         """获取所有T2I模板列表"""
@@ -140,8 +145,7 @@ class T2iRoute(Route):
             # 检查更新的是否为当前激活的模板，如果是，则热重载
             active_template = self.config.get("t2i_active_template", "base")
             if name == active_template:
-                for conf_id in self.core_lifecycle.astrbot_config_mgr.confs:
-                    await self.core_lifecycle.reload_pipeline_scheduler(conf_id)
+                await self._reload_all_pipeline_schedulers()
                 message = f"模板 '{name}' 已更新并重新加载。"
             else:
                 message = f"模板 '{name}' 已更新。"

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -497,6 +497,157 @@ async def test_t2i_set_active_template_syncs_all_configs(
 
 
 @pytest.mark.asyncio
+async def test_t2i_reset_default_template_syncs_all_configs(
+    app: Quart,
+    authenticated_header: dict,
+    core_lifecycle_td: AstrBotCoreLifecycle,
+):
+    test_client = app.test_client()
+    template_name = f"reset_tpl_{uuid.uuid4().hex[:8]}"
+    created_conf_ids: list[str] = []
+
+    try:
+        for name in ("reset-a", "reset-b"):
+            response = await test_client.post(
+                "/api/config/abconf/new",
+                json={"name": name},
+                headers=authenticated_header,
+            )
+            assert response.status_code == 200
+            data = await response.get_json()
+            assert data["status"] == "ok"
+            created_conf_ids.append(data["data"]["conf_id"])
+
+        response = await test_client.post(
+            "/api/t2i/templates/create",
+            json={
+                "name": template_name,
+                "content": "<html><body>{{ content }} reset</body></html>",
+            },
+            headers=authenticated_header,
+        )
+        assert response.status_code == 201
+        data = await response.get_json()
+        assert data["status"] == "ok"
+
+        response = await test_client.post(
+            "/api/t2i/templates/set_active",
+            json={"name": template_name},
+            headers=authenticated_header,
+        )
+        assert response.status_code == 200
+
+        response = await test_client.post(
+            "/api/t2i/templates/reset_default",
+            headers=authenticated_header,
+        )
+        assert response.status_code == 200
+        data = await response.get_json()
+        assert data["status"] == "ok"
+
+        conf_ids = set(core_lifecycle_td.astrbot_config_mgr.confs.keys())
+        assert "default" in conf_ids
+        for conf_id in conf_ids:
+            conf = core_lifecycle_td.astrbot_config_mgr.confs[conf_id]
+            assert conf.get("t2i_active_template") == "base"
+            assert conf_id in core_lifecycle_td.pipeline_scheduler_mapping
+    finally:
+        await test_client.post(
+            "/api/t2i/templates/set_active",
+            json={"name": "base"},
+            headers=authenticated_header,
+        )
+        await test_client.delete(
+            f"/api/t2i/templates/{template_name}",
+            headers=authenticated_header,
+        )
+        for conf_id in created_conf_ids:
+            await test_client.post(
+                "/api/config/abconf/delete",
+                json={"id": conf_id},
+                headers=authenticated_header,
+            )
+
+
+@pytest.mark.asyncio
+async def test_t2i_update_active_template_reloads_all_schedulers(
+    app: Quart,
+    authenticated_header: dict,
+    core_lifecycle_td: AstrBotCoreLifecycle,
+):
+    test_client = app.test_client()
+    template_name = f"update_tpl_{uuid.uuid4().hex[:8]}"
+    created_conf_ids: list[str] = []
+
+    try:
+        for name in ("update-a", "update-b"):
+            response = await test_client.post(
+                "/api/config/abconf/new",
+                json={"name": name},
+                headers=authenticated_header,
+            )
+            assert response.status_code == 200
+            data = await response.get_json()
+            assert data["status"] == "ok"
+            created_conf_ids.append(data["data"]["conf_id"])
+
+        response = await test_client.post(
+            "/api/t2i/templates/create",
+            json={
+                "name": template_name,
+                "content": "<html><body>{{ content }} v1</body></html>",
+            },
+            headers=authenticated_header,
+        )
+        assert response.status_code == 201
+
+        response = await test_client.post(
+            "/api/t2i/templates/set_active",
+            json={"name": template_name},
+            headers=authenticated_header,
+        )
+        assert response.status_code == 200
+
+        conf_ids = list(core_lifecycle_td.astrbot_config_mgr.confs.keys())
+        old_schedulers = {
+            conf_id: core_lifecycle_td.pipeline_scheduler_mapping[conf_id]
+            for conf_id in conf_ids
+        }
+
+        response = await test_client.put(
+            f"/api/t2i/templates/{template_name}",
+            json={"content": "<html><body>{{ content }} v2</body></html>"},
+            headers=authenticated_header,
+        )
+        assert response.status_code == 200
+        data = await response.get_json()
+        assert data["status"] == "ok"
+
+        for conf_id in conf_ids:
+            assert conf_id in core_lifecycle_td.pipeline_scheduler_mapping
+            assert (
+                core_lifecycle_td.pipeline_scheduler_mapping[conf_id]
+                is not old_schedulers[conf_id]
+            )
+    finally:
+        await test_client.post(
+            "/api/t2i/templates/set_active",
+            json={"name": "base"},
+            headers=authenticated_header,
+        )
+        await test_client.delete(
+            f"/api/t2i/templates/{template_name}",
+            headers=authenticated_header,
+        )
+        for conf_id in created_conf_ids:
+            await test_client.post(
+                "/api/config/abconf/delete",
+                json={"id": conf_id},
+                headers=authenticated_header,
+            )
+
+
+@pytest.mark.asyncio
 async def test_check_update(
     app: Quart,
     authenticated_header: dict,


### PR DESCRIPTION
apply template activation and reset to every config profile instead of only the default one, and reload each pipeline scheduler so changes take effect consistently in multi-config setups

add a dashboard test that creates extra configs and verifies active template updates and scheduler reload coverage across all config ids

fix of #6748

### Modifications / 改动点

在同步t2i模板时同步到所有配置文件，并添加对应测试

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<img width="483" height="146" alt="image" src="https://github.com/user-attachments/assets/da5ef628-3eb9-4ed1-87a4-70e2b1fac057" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Synchronize the active T2I template and corresponding pipeline scheduler reloads across all configuration profiles instead of only the default, and add coverage to ensure the behavior in multi-config setups.

Bug Fixes:
- Ensure updating or resetting the active T2I template applies to every config profile and reloads each pipeline scheduler so template changes take effect consistently.

Tests:
- Add a dashboard test that creates additional configs and verifies active T2I template propagation and scheduler reload mapping for all configuration IDs.