### PR TITLE
feat(ci): introduce unified CI Required Gate workflow

### DIFF
--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -25,12 +25,11 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    - name: Install uv
-      shell: bash
-      run: |
-        set -euo pipefail
-        python -m pip install --upgrade pip
-        python -m pip install "uv==${{ inputs.uv-version }}"
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v7.6.0
+      with:
+        version: ${{ inputs.uv-version }}
+        enable-cache: "true"
 
     - name: Sync dependencies
       if: ${{ inputs.sync-deps == 'true' }}

--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -36,4 +36,12 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        uv sync ${{ inputs.sync-args }}
+        sync_args_raw="${{ inputs.sync-args }}"
+        if [[ -z "$sync_args_raw" ]]; then
+          uv sync
+          exit 0
+        fi
+
+        # Split configured sync arguments into an array to avoid glob expansion.
+        read -r -a sync_args <<< "$sync_args_raw"
+        uv sync "${sync_args[@]}"

--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: Python version to install.
     required: false
     default: "3.12"
+  uv-version:
+    description: uv version to install.
+    required: false
+    default: "0.10.12"
   sync-deps:
     description: Whether to run dependency sync via uv.
     required: false
@@ -26,7 +30,7 @@ runs:
       run: |
         set -euo pipefail
         python -m pip install --upgrade pip
-        python -m pip install uv
+        python -m pip install "uv==${{ inputs.uv-version }}"
 
     - name: Sync dependencies
       if: ${{ inputs.sync-deps == 'true' }}

--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -1,0 +1,36 @@
+name: Setup Python and uv
+description: Set up Python, install uv, and optionally sync dependencies.
+inputs:
+  python-version:
+    description: Python version to install.
+    required: false
+    default: "3.12"
+  sync-deps:
+    description: Whether to run dependency sync via uv.
+    required: false
+    default: "false"
+  sync-args:
+    description: Extra arguments passed to `uv sync`.
+    required: false
+    default: ""
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install uv
+      shell: bash
+      run: |
+        set -euo pipefail
+        python -m pip install --upgrade pip
+        python -m pip install uv
+
+    - name: Sync dependencies
+      if: ${{ inputs.sync-deps == 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        uv sync ${{ inputs.sync-args }}

--- a/.github/workflows/ci-required-gate.yml
+++ b/.github/workflows/ci-required-gate.yml
@@ -53,9 +53,11 @@ jobs:
 
           docs_only=true
           dashboard_changed=false
+          has_changed_files=false
 
           while IFS= read -r f; do
             [[ -z "$f" ]] && continue
+            has_changed_files=true
 
             if [[ "$f" == dashboard/* ]]; then
               dashboard_changed=true
@@ -65,6 +67,11 @@ jobs:
               docs_only=false
             fi
           done <<< "$changed_files"
+
+          # Empty diff can happen in edge cases; fail closed to avoid skipping core checks.
+          if [[ "$has_changed_files" == "false" ]]; then
+            docs_only=false
+          fi
 
           echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
           echo "dashboard_changed=$dashboard_changed" >> "$GITHUB_OUTPUT"
@@ -143,6 +150,16 @@ jobs:
           trap cleanup EXIT
 
           for _ in {1..60}; do
+            if ! kill -0 "$app_pid" 2>/dev/null; then
+              app_exit=0
+              wait "$app_pid" || app_exit=$?
+              if [[ "$app_exit" -eq 0 ]]; then
+                app_exit=1
+              fi
+              echo "Application exited early with status $app_exit"
+              exit "$app_exit"
+            fi
+
             if curl -sf http://localhost:6185 >/dev/null 2>&1; then
               exit 0
             fi

--- a/.github/workflows/ci-required-gate.yml
+++ b/.github/workflows/ci-required-gate.yml
@@ -189,13 +189,35 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
-            echo "One or more required jobs failed or were cancelled"
+          declare -A results=(
+            [changes]="${{ needs.changes.result }}"
+            [lint]="${{ needs.lint.result }}"
+            [test]="${{ needs.test.result }}"
+            [smoke]="${{ needs.smoke.result }}"
+            [dashboard]="${{ needs.dashboard.result }}"
+          )
+
+          has_blocking=false
+          for job in "${!results[@]}"; do
+            case "${results[$job]}" in
+              failure|cancelled)
+                echo "::error::${job}=${results[$job]} (blocking)"
+                has_blocking=true
+                ;;
+              skipped)
+                echo "::notice::${job}=skipped (expected for conditional paths)"
+                ;;
+            esac
+          done
+
+          if [[ "$has_blocking" == "true" ]]; then
+            echo "One or more required jobs failed or were cancelled."
             exit 1
           fi
 
       - name: Print job summary
         run: |
+          echo "skipped results are expected for docs-only/dashboard-unchanged paths."
           echo "changes=${{ needs.changes.result }}"
           echo "lint=${{ needs.lint.result }}"
           echo "test=${{ needs.test.result }}"

--- a/.github/workflows/ci-required-gate.yml
+++ b/.github/workflows/ci-required-gate.yml
@@ -177,18 +177,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4.4.0
+        with:
+          version: 10.28.2
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24.13.0'
+          node-version: '22.x'
+          cache: 'pnpm'
+          cache-dependency-path: dashboard/pnpm-lock.yaml
 
       - name: Build dashboard
         run: |
-          cd dashboard
-          npm install pnpm -g
-          pnpm install
-          pnpm i --save-dev @types/markdown-it
-          pnpm run build
+          pnpm --dir dashboard install --frozen-lockfile
+          pnpm --dir dashboard run build
 
   gate:
     name: CI Required Gate

--- a/.github/workflows/ci-required-gate.yml
+++ b/.github/workflows/ci-required-gate.yml
@@ -1,0 +1,214 @@
+name: CI Required Gate
+
+on:
+  pull_request:
+    branches: [master, dev]
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-required-gate-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Detect Change Scope
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.detect.outputs.docs_only }}
+      dashboard_changed: ${{ steps.detect.outputs.dashboard_changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed files
+        id: detect
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base_sha="${{ github.event.pull_request.base.sha }}"
+            head_sha="${{ github.event.pull_request.head.sha }}"
+          else
+            base_sha="${{ github.event.before }}"
+            head_sha="${{ github.sha }}"
+          fi
+
+          if [[ -z "$base_sha" || "$base_sha" == "0000000000000000000000000000000000000000" ]]; then
+            base_sha="$(git rev-parse "${head_sha}^" 2>/dev/null || true)"
+          fi
+
+          if [[ -z "$base_sha" ]]; then
+            changed_files="$(git ls-tree -r --name-only "$head_sha")"
+          else
+            changed_files="$(git diff --name-only "$base_sha" "$head_sha")"
+          fi
+
+          docs_only=true
+          dashboard_changed=false
+
+          while IFS= read -r f; do
+            [[ -z "$f" ]] && continue
+
+            if [[ "$f" == dashboard/* ]]; then
+              dashboard_changed=true
+            fi
+
+            if [[ ! "$f" =~ ^docs/ && ! "$f" =~ ^README.*\.md$ && ! "$f" =~ ^changelogs/ ]]; then
+              docs_only=false
+            fi
+          done <<< "$changed_files"
+
+          echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
+          echo "dashboard_changed=$dashboard_changed" >> "$GITHUB_OUTPUT"
+
+  lint:
+    name: Lint (Ruff)
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install uv
+
+      - name: Sync dependencies
+        run: uv sync --group dev
+
+      - name: Ruff format check
+        run: uv run ruff format --check .
+
+      - name: Ruff lint check
+        run: uv run ruff check .
+
+  test:
+    name: Unit Tests
+    needs: [changes, lint]
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install uv
+
+      - name: Run pytest suite
+        run: bash ./scripts/run_pytests_ci.sh ./tests
+
+  smoke:
+    name: Smoke Test
+    needs: [changes, lint]
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install uv
+
+      - name: Sync dependencies
+        run: uv sync --group dev
+
+      - name: Startup smoke test
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run main.py &
+          app_pid=$!
+
+          cleanup() {
+            kill "$app_pid" 2>/dev/null || true
+            wait "$app_pid" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          for _ in {1..60}; do
+            if curl -sf http://localhost:6185 >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "Application failed to start within 60 seconds"
+          exit 1
+
+  dashboard:
+    name: Dashboard Build
+    needs: changes
+    if: needs.changes.outputs.dashboard_changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 18
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.13.0'
+
+      - name: Build dashboard
+        run: |
+          cd dashboard
+          npm install pnpm -g
+          pnpm install
+          pnpm i --save-dev @types/markdown-it
+          pnpm run build
+
+  gate:
+    name: CI Required Gate
+    if: always()
+    needs: [changes, lint, test, smoke, dashboard]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check upstream job results
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs failed or were cancelled"
+            exit 1
+          fi
+
+      - name: Print job summary
+        run: |
+          echo "changes=${{ needs.changes.result }}"
+          echo "lint=${{ needs.lint.result }}"
+          echo "test=${{ needs.test.result }}"
+          echo "smoke=${{ needs.smoke.result }}"
+          echo "dashboard=${{ needs.dashboard.result }}"

--- a/.github/workflows/ci-required-gate.yml
+++ b/.github/workflows/ci-required-gate.yml
@@ -61,7 +61,7 @@ jobs:
               dashboard_changed=true
             fi
 
-            if [[ ! "$f" =~ ^docs/ && ! "$f" =~ ^README.*\.md$ && ! "$f" =~ ^changelogs/ ]]; then
+            if [[ ! "$f" =~ ^docs/ && ! "$f" =~ ^docs-[^/]+/ && ! "$f" =~ ^README.*\.md$ && ! "$f" =~ ^changelogs/ ]]; then
               docs_only=false
             fi
           done <<< "$changed_files"
@@ -187,7 +187,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24.13.0'
+          node-version: '24'
           cache: 'pnpm'
           cache-dependency-path: dashboard/pnpm-lock.yaml
 

--- a/.github/workflows/ci-required-gate.yml
+++ b/.github/workflows/ci-required-gate.yml
@@ -118,8 +118,10 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install uv
 
-      - name: Run pytest suite
-        run: bash ./scripts/run_pytests_ci.sh ./tests
+      - name: Run pytest suite (script performs uv sync --dev)
+        run: |
+          # scripts/run_pytests_ci.sh includes dependency sync (`uv sync --dev`) before pytest.
+          bash ./scripts/run_pytests_ci.sh ./tests
 
   smoke:
     name: Smoke Test
@@ -185,7 +187,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22.x'
+          node-version: '24.13.0'
           cache: 'pnpm'
           cache-dependency-path: dashboard/pnpm-lock.yaml
 

--- a/.github/workflows/ci-required-gate.yml
+++ b/.github/workflows/ci-required-gate.yml
@@ -79,18 +79,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up Python and uv
+        uses: ./.github/actions/setup-python-uv
         with:
           python-version: '3.12'
-
-      - name: Install uv
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install uv
-
-      - name: Sync dependencies
-        run: uv sync --group dev
+          sync-deps: 'true'
+          sync-args: '--group dev'
 
       - name: Ruff format check
         run: uv run ruff format --check .
@@ -108,15 +102,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up Python and uv
+        uses: ./.github/actions/setup-python-uv
         with:
           python-version: '3.12'
-
-      - name: Install uv
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install uv
 
       - name: Run pytest suite (script performs uv sync --dev)
         run: |
@@ -133,18 +122,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up Python and uv
+        uses: ./.github/actions/setup-python-uv
         with:
           python-version: '3.12'
-
-      - name: Install uv
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install uv
-
-      - name: Sync dependencies
-        run: uv sync --group dev
+          sync-deps: 'true'
+          sync-args: '--group dev'
 
       - name: Startup smoke test
         shell: bash


### PR DESCRIPTION
## Motivation / 修改目的

当前 AstrBot 的 CI 检查分散在多个 workflow 中（format / unit tests / smoke / dashboard 等），但缺少一个统一、可直接被分支保护规则要求的“单一门禁信号”。

本 PR 的目标是引入 **`CI Required Gate`**：

- 把关键质量检查串成一条可聚合的主链路；
- 在 PR 审核阶段提供稳定、可判定的通过/失败结论；
- 兼顾效率（docs-only 快速路径）与稳定性（lint + tests + smoke + 条件 dashboard build）。

---

## Overall Design / 整体思路

引入新的 workflow：

- `.github/workflows/ci-required-gate.yml`

核心逻辑：

1. 先做变更范围探测（`changes` job）。
2. 根据变更范围决定执行路径（docs-only 快速通过 / 常规质量链路 / dashboard 条件构建）。
3. 最终由 `gate` job 聚合所有上游结果，输出单一门禁状态 `CI Required Gate`。

该设计与“分散检查 + 人工拼接判断”相比，降低 reviewer 决策成本，并且更适合后续分支规则直接配置 Required Check。

---

## Modifications / 改动项详解

### 1) Workflow 触发策略

```yaml
on:
  pull_request:
    branches: [master, dev]
  push:
    branches: [master]
  workflow_dispatch:
```

设置说明：

- `pull_request` 覆盖 `master` 与 `dev`，解决不同目标分支下检查覆盖不一致的问题。
- `push master` 让主分支持续接受同构验证（便于基线监控）。
- `workflow_dispatch` 便于手动复验。

预期实践：

- PR 合并门禁依赖 `pull_request` 结果。
- `push master` 用于持续观测主分支健康度。

可行性：

- 仅新增 workflow，不破坏现有发布/安全/文档流程。

---

### 2) 并发控制

```yaml
concurrency:
  group: ci-required-gate-${{ github.event.pull_request.number || github.sha }}
  cancel-in-progress: true
```

设置说明：

- 同一个 PR 的新提交会取消旧流水线。

预期实践：

- reviewer 只需关注最新一次 CI 结果。
- 节省 runner 时间，减少排队。

可行性：

- 与现有 GitHub Actions 机制兼容，属于低风险优化。

---

### 3) `changes` 变更范围探测

`changes` job 通过 `base..head` diff 计算两个输出：

- `docs_only`
- `dashboard_changed`

并包含边界处理：

- `github.event.before` 为空或全 0（首推/特殊场景）时回退到 `HEAD^`；
- 仍不可用时使用当前树文件列表兜底。

预期实践：

- docs-only PR 不再跑完整 Python 流水线，提升反馈速度。
- 仅 dashboard 相关变更才执行 dashboard build。

可行性：

- 全部基于 Git 原生命令与 bash，无额外 action 依赖。

---

### 4) `lint` 质量门

执行：

- `uv sync --group dev`
- `uv run ruff format --check .`
- `uv run ruff check .`

触发条件：`docs_only != true`

预期实践：

- 代码风格与静态问题前置拦截。

可行性：

- 与仓库现有 Ruff/uv 规范一致。

---

### 5) `test` 单元测试门

执行：

- `bash ./scripts/run_pytests_ci.sh ./tests`

触发条件：`docs_only != true`

预期实践：

- 复用仓库既有 CI 测试入口，减少重复逻辑。

可行性：

- 直接复用现有脚本，维护成本低。

---

### 6) `smoke` 启动可用性门

执行：

- `uv run main.py` 启动应用；
- 轮询 `http://localhost:6185` 最长 60 秒；
- `trap` 保证进程清理。

触发条件：`docs_only != true`

预期实践：

- 防止“单测通过但应用无法启动”的回归。

可行性：

- 与现有 smoke_test 思路一致，风险可控。

---

### 7) `dashboard` 条件构建门

执行：

- Node `24.13.0`
- `pnpm install`
- `pnpm run build`

触发条件：`dashboard_changed == true`

预期实践：

- 避免非 dashboard PR 承担前端构建成本。

可行性：

- 与当前 dashboard CI 构建链路一致。

---

### 8) `gate` 聚合门（核心）

```yaml
if: always()
needs: [changes, lint, test, smoke, dashboard]
```

判定规则：

- 上游任一 job `failure/cancelled` -> `gate` 失败；
- 否则通过；
- 同时输出各 job 结果摘要，便于排障。

预期实践：

- 在分支保护规则中仅需要求一个 Required Check：`CI Required Gate`。
- reviewer 决策路径从“看多个 workflow”收敛到“看一个门禁 + 失败明细”。

可行性：

- 已在多个高并发仓库证明有效，且本次实现不改业务代码。

---

## Scope Boundary / 变更边界

本 PR **只新增**：

- `.github/workflows/ci-required-gate.yml`

未修改任何业务代码、测试代码、依赖文件或其它 workflow。

---

## Validation / 验证

本地验证：

- `python3` + `pyyaml` 解析 workflow 文件，确认 YAML 结构合法。

```bash
python3 - <<'PY'
import yaml
yaml.safe_load(open('.github/workflows/ci-required-gate.yml', 'r', encoding='utf-8'))
print('yaml_ok')
PY
```

结果：`yaml_ok`

---

## Practical Rollout Plan / 建议落地方式

1. 先合并该 workflow，观察 3-7 天执行稳定性与耗时。
2. 在分支规则中将 `CI Required Gate` 设为 required check。
3. 再逐步评估是否收敛/调整已有分散 CI（避免重复计算）。

---

- [x] This is NOT a breaking change.

## Summary by Sourcery

Introduce a unified "CI Required Gate" GitHub Actions workflow that aggregates key quality checks into a single required status for PRs and master pushes.

CI:
- Add a new `CI Required Gate` workflow that orchestrates change detection, linting, tests, smoke checks, and conditional dashboard builds into a single gate job.
- Add a concurrency policy so only the latest run per PR or commit is active, cancelling in-progress runs for older revisions.
- Introduce a change-scope detection job to shortcut docs-only changes and to trigger dashboard builds only when dashboard files change.
- Add a composite `setup-python-uv` GitHub Action to standardize Python and uv setup and optional dependency syncing across CI jobs.