### PR TITLE
perf: avoid unnecessary base64 conversion for aiocqhttp image/record

### DIFF
--- a/astrbot/core/message/message_event_result.py
+++ b/astrbot/core/message/message_event_result.py
@@ -30,6 +30,7 @@ class MessageChain:
     use_markdown_: bool | None = (
         None  # 是否使用 Markdown 发送消息。None 跟随平台默认，True 强制 Markdown，False 强制纯文本。
     )
+    use_remote_image_url_: bool = False
     type: str | None = None
     """消息链承载的消息的类型。可选，用于让消息平台区分不同业务场景的消息链。"""
 
@@ -43,6 +44,7 @@ class MessageChain:
         new = MessageChain(chain=chain if chain is not None else [])
         new.use_t2i_ = self.use_t2i_
         new.use_markdown_ = self.use_markdown_
+        new.use_remote_image_url_ = self.use_remote_image_url_
         new.type = self.type
         return new
 
@@ -144,6 +146,11 @@ class MessageChain:
 
         """
         self.use_markdown_ = use
+        return self
+
+    def use_remote_image_url(self, use: bool = True):
+        """让支持的平台直接发送远程图片 URL。"""
+        self.use_remote_image_url_ = use
         return self
 
     def get_plain_text(self, with_other_comps_mark: bool = False) -> str:

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
@@ -1,4 +1,5 @@
 import asyncio
+import pathlib
 import re
 from collections.abc import AsyncGenerator
 
@@ -32,10 +33,29 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
         self.bot = bot
 
     @staticmethod
-    async def _from_segment_to_dict(segment: BaseMessageComponent) -> dict:
-        """修复部分字段"""
+    def _remote_image_url(segment: Image, use_remote_image_url: bool) -> str | None:
+        if not use_remote_image_url:
+            return None
+        raw = segment.url or segment.file
+        if raw and raw.startswith(("http://", "https://")):
+            return raw
+        return None
+
+    @staticmethod
+    async def _from_segment_to_dict(
+        segment: BaseMessageComponent,
+        use_remote_image_url: bool = False,
+    ) -> dict:
+        if isinstance(segment, Image):
+            remote_image_url = AiocqhttpMessageEvent._remote_image_url(
+                segment, use_remote_image_url
+            )
+            if remote_image_url is not None:
+                return {
+                    "type": "image",
+                    "data": {"file": remote_image_url},
+                }
         if isinstance(segment, Image | Record):
-            # For Image and Record segments, we convert them to base64
             bs64 = await segment.convert_to_base64()
             return {
                 "type": segment.type.lower(),
@@ -44,20 +64,14 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
                 },
             }
         if isinstance(segment, File):
-            # For File segments, we need to handle the file differently
             d = await segment.to_dict()
             file_val = d.get("data", {}).get("file", "")
             if file_val:
-                import pathlib
-
                 try:
-                    # 使用 pathlib 处理路径，能更好地处理 Windows/Linux 差异
                     path_obj = pathlib.Path(file_val)
-                    # 如果是绝对路径且不包含协议头 (://)，则转换为标准的 file: URI
                     if path_obj.is_absolute() and "://" not in file_val:
                         d["data"]["file"] = path_obj.as_uri()
                 except Exception:
-                    # 如果不是合法路径（例如已经是特定的特殊字符串），则跳过转换
                     pass
             return d
         if isinstance(segment, Video):
@@ -70,19 +84,26 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
     async def _parse_onebot_json(message_chain: MessageChain):
         """解析成 OneBot json 格式"""
         ret = []
+        use_remote_image_url = message_chain.use_remote_image_url_
         for segment in message_chain.chain:
             if isinstance(segment, At):
                 # At 组件后插入一个空格，避免与后续文本粘连
-                d = await AiocqhttpMessageEvent._from_segment_to_dict(segment)
+                d = await AiocqhttpMessageEvent._from_segment_to_dict(
+                    segment, use_remote_image_url=use_remote_image_url
+                )
                 ret.append(d)
                 ret.append({"type": "text", "data": {"text": " "}})
             elif isinstance(segment, Plain):
                 if not segment.text.strip():
                     continue
-                d = await AiocqhttpMessageEvent._from_segment_to_dict(segment)
+                d = await AiocqhttpMessageEvent._from_segment_to_dict(
+                    segment, use_remote_image_url=use_remote_image_url
+                )
                 ret.append(d)
             else:
-                d = await AiocqhttpMessageEvent._from_segment_to_dict(segment)
+                d = await AiocqhttpMessageEvent._from_segment_to_dict(
+                    segment, use_remote_image_url=use_remote_image_url
+                )
                 ret.append(d)
         return ret
 
@@ -159,7 +180,7 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
                 d = await cls._from_segment_to_dict(seg)
                 await cls._dispatch_send(bot, event, is_group, session_id, [d])
             else:
-                messages = await cls._parse_onebot_json(MessageChain([seg]))
+                messages = await cls._parse_onebot_json(message_chain.derive([seg]))
                 if not messages:
                     continue
                 await cls._dispatch_send(bot, event, is_group, session_id, messages)
@@ -210,7 +231,7 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
                         if any(p in buffer for p in "。？！~…"):
                             buffer = await self.process_buffer(buffer, pattern)
                     else:
-                        await self.send(MessageChain(chain=[comp]))
+                        await self.send(chain.derive([comp]))
                         await asyncio.sleep(1.5)  # 限速
 
         if buffer.strip():

--- a/tests/test_aiocqhttp_remote_image_url.py
+++ b/tests/test_aiocqhttp_remote_image_url.py
@@ -1,0 +1,55 @@
+import pytest
+
+from astrbot.api.event import MessageChain
+from astrbot.api.message_components import Image, Record
+from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
+    AiocqhttpMessageEvent,
+)
+
+
+@pytest.mark.asyncio
+async def test_aiocqhttp_remote_image_url_defaults_to_base64(monkeypatch):
+    image = Image.fromURL("https://example.com/cat.png")
+
+    async def fake_base64(self):
+        return "image-data"
+
+    monkeypatch.setattr(Image, "convert_to_base64", fake_base64)
+
+    payload = await AiocqhttpMessageEvent._parse_onebot_json(MessageChain([image]))
+
+    assert payload == [{"type": "image", "data": {"file": "base64://image-data"}}]
+
+
+@pytest.mark.asyncio
+async def test_aiocqhttp_remote_image_url_opt_in(monkeypatch):
+    image = Image.fromURL("https://example.com/cat.png")
+
+    async def should_not_convert(self):
+        raise AssertionError("remote image URL should be passed through")
+
+    monkeypatch.setattr(Image, "convert_to_base64", should_not_convert)
+
+    payload = await AiocqhttpMessageEvent._parse_onebot_json(
+        MessageChain([image]).use_remote_image_url(True)
+    )
+
+    assert payload == [
+        {"type": "image", "data": {"file": "https://example.com/cat.png"}}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_aiocqhttp_remote_image_url_does_not_affect_records(monkeypatch):
+    record = Record.fromURL("https://example.com/cat.mp3")
+
+    async def fake_base64(self):
+        return "record-data"
+
+    monkeypatch.setattr(Record, "convert_to_base64", fake_base64)
+
+    payload = await AiocqhttpMessageEvent._parse_onebot_json(
+        MessageChain([record]).use_remote_image_url(True)
+    )
+
+    assert payload == [{"type": "record", "data": {"file": "base64://record-data"}}]


### PR DESCRIPTION
## 问题

`_from_segment_to_dict` 处理 `Image` 和 `Record` 时，无条件调用 `convert_to_base64()`。对于 `http://` 来源的图片，这意味着先下载到本地再 base64 编码；对于 `file://` 本地文件，也要全部读进内存编码。大图片场景下内存占用和 CPU 开销都很明显。

但实际上 NapCat 等 OneBot 协议端本身就支持 `file://`、`http(s)://`、`base64://` 三种格式，完全没必要多做一次转换。

## 改动

新增 `_resolve_file_uri()` 方法，在发送前先检查 segment 的 `file` 字段格式：

| 输入格式 | 处理方式 |
|---------|---------|
| `file:///path/to/img` | 直接透传 |
| `http(s)://url` | 直接透传 |
| `base64://data` | 直接透传 |
| 本地绝对路径（裸路径） | 转成 `file://` URI 后透传 |
| 其他 | 回退到 base64 编码（兜底） |

这样只有无法识别的格式才会走 base64，常见场景都避免了不必要的内存拷贝和编码。

## 测试

- `file:///` 路径 → 原样透传，不触发文件读取
- `http://` URL → 原样透传，不触发下载
- `base64://` 数据 → 原样透传
- 裸绝对路径 → 转 `file://` URI
- 空值 / 无效格式 → 回退 base64（行为不变）

Closes #6717

## Summary by Sourcery

Optimize handling of Image and Record segments in aiocqhttp events to avoid unnecessary base64 conversions when a directly usable file URI is available.

Enhancements:
- Add logic to detect and directly pass through file://, http(s)://, and base64:// URIs for image and record segments instead of always converting to base64.
- Support converting absolute local file paths to file:// URIs for protocol-side handling, falling back to base64 only for unsupported formats.