### PR TITLE
fix: preserve inbound qqofficial msg anchor for proactive sends

### DIFF
--- a/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
@@ -131,7 +131,8 @@ class QQOfficialPlatformAdapter(Platform):
 
         self.client.set_platform(self)
 
-        self._session_last_message_id: dict[str, str] = {}
+        self._session_last_inbound_message_id: dict[str, str] = {}
+        self._session_last_outbound_message_id: dict[str, str] = {}
         self._session_scene: dict[str, str] = {}
 
         self.test_mode = os.environ.get("TEST_MODE", "off") == "on"
@@ -167,10 +168,10 @@ class QQOfficialPlatformAdapter(Platform):
         ):
             return
 
-        msg_id = self._session_last_message_id.get(session.session_id)
+        msg_id = self._session_last_inbound_message_id.get(session.session_id)
         if not msg_id:
             logger.warning(
-                "[QQOfficial] No cached msg_id for session: %s, skip send_by_session",
+                "[QQOfficial] No cached inbound msg_id for session: %s, skip send_by_session",
                 session.session_id,
             )
             return
@@ -298,13 +299,25 @@ class QQOfficialPlatformAdapter(Platform):
 
         sent_message_id = self._extract_message_id(ret)
         if sent_message_id:
-            self.remember_session_message_id(session.session_id, sent_message_id)
+            self.remember_session_sent_message_id(session.session_id, sent_message_id)
         await super().send_by_session(session, message_chain)
 
-    def remember_session_message_id(self, session_id: str, message_id: str) -> None:
+    def remember_session_inbound_message_id(
+        self, session_id: str, message_id: str
+    ) -> None:
         if not session_id or not message_id:
             return
-        self._session_last_message_id[session_id] = message_id
+        self._session_last_inbound_message_id[session_id] = message_id
+
+    def remember_session_message_id(self, session_id: str, message_id: str) -> None:
+        self.remember_session_inbound_message_id(session_id, message_id)
+
+    def remember_session_sent_message_id(
+        self, session_id: str, message_id: str
+    ) -> None:
+        if not session_id or not message_id:
+            return
+        self._session_last_outbound_message_id[session_id] = message_id
 
     def remember_session_scene(self, session_id: str, scene: str) -> None:
         if not session_id or not scene:


### PR DESCRIPTION
修复了 `qq_official` 在主动私聊发送场景下 `msg_id` 锚点被错误覆盖的问题。

此前，适配器会在一次主动发送成功后，将机器人自己发出的消息返回 `id` 写回会话缓存，并在下一次主动发送时继续把它当作 `msg_id` 使用。在 QQ Official C2C 场景下，这会导致后续主动发送出现如下报错：

- `请求参数msg_id无效或越权`

本次修改保证主动发送始终使用“最近一次用户入站消息”的 `msg_id` 作为发送锚点，而不会被机器人自己的出站消息 `id` 覆盖。

### Modifications / 改动点

- 修改了 [astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py](/Users/game-netease/work/20260501/AstrBot/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py)
- 将会话消息缓存拆分为两类：
  - 用户入站消息 `msg_id`
  - 机器人主动发送后的返回 `id`
- 主动发送时仅使用入站消息 `msg_id` 作为发送锚点
- 主动发送成功后，不再用机器人自己的出站消息 `id` 覆盖入站锚点

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

验证步骤：

1. 使用真实 `qq_official` 机器人配置启动 AstrBot。
2. 先从 QQ 私聊向机器人发送一条消息，建立有效的入站 `msg_id`。
3. 通过 AstrBot 的真实 `send_by_session` 链路触发一次主动发送。
4. 在没有新的入站消息情况下，再次触发一次主动发送。
5. 确认两次主动消息均成功送达，且日志中未再出现 `msg_id` 越权报错。

验证结果：

- QQ 私聊入站消息接收正常。
- 第一次主动发送成功。
- 在没有新入站消息的情况下，第二次主动发送仍然成功。
- QQ 侧实际收到了两条主动消息。
- 整个验证过程中未再出现 `botpy.errors.ServerError: 请求参数msg_id无效或越权`。

示例日志：

```text
[default] [qq-official-test(qq_official)] 5CDE98807986347C3CE73A719F2A62DF: [At:qq_official] 11
{"status":"ok","message":null,"data":{}}
{"status":"ok","message":null,"data":{}}

## Summary by Sourcery

Bug Fixes:
- Prevent QQ Official C2C proactive sends from failing due to overwritten msg_id anchors by separating inbound and outbound message IDs in session cache.