### PR TITLE
feat: auto-append /v1 to embedding_api_base in OpenAI embedding provider

### DIFF
--- a/astrbot/core/provider/sources/openai_embedding_source.py
+++ b/astrbot/core/provider/sources/openai_embedding_source.py
@@ -24,11 +24,15 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         if proxy:
             logger.info(f"[OpenAI Embedding] {provider_id} Using proxy: {proxy}")
             http_client = httpx.AsyncClient(proxy=proxy)
-        api_base = provider_config.get(
-            "embedding_api_base", "https://api.openai.com/v1"
-        ).strip()
-        if api_base and not api_base.endswith("/v1") and not api_base.endswith("/v1/"):
-            api_base = api_base.rstrip("/") + "/v1"
+        api_base = (
+            provider_config.get("embedding_api_base", "https://api.openai.com/v1")
+            .strip()
+            .rstrip("/")
+            .rstrip("/embeddings")
+        )
+        if api_base and not api_base.endswith("/v1") and not api_base.endswith("/v4"):
+            # /v4 see #5699
+            api_base = api_base + "/v1"
         logger.info(f"[OpenAI Embedding] {provider_id} Using API Base: {api_base}")
         self.client = AsyncOpenAI(
             api_key=provider_config.get("embedding_api_key"),


### PR DESCRIPTION
Fixes #6855

当用户配置 `embedding_api_base` 时未填写 `/v1` 后缀，OpenAI SDK 不会自动补全，导致请求路径错误（如 `https://api.openai.com/embeddings` 而非 `https://api.openai.com/v1/embeddings`）。

### Modifications / 改动点

- 在 `astrbot/core/provider/sources/openai_embedding_source.py` 中，初始化 `api_base` 后增加判断：若 URL 不以 `/v1` 或 `/v1/` 结尾，则自动补全 `/v1`。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

修改前，用户配置 `embedding_api_base` 为 `https://api.openai.com` 时，实际请求路径为 `https://api.openai.com/embeddings`，返回 404。

修改后，自动补全为 `https://api.openai.com/v1`，请求路径正确为 `https://api.openai.com/v1/embeddings`。

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

New Features:
- Automatically append the /v1 suffix to embedding_api_base when it is omitted in the OpenAI embedding provider configuration.