### PR TITLE
fix(qqofficial): convert non-WAV audio to PCM WAV before Tencent Silk encoding

### DIFF
--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -22,7 +22,10 @@ from astrbot.api.message_components import File, Image, Plain, Record, Video
 from astrbot.api.platform import AstrBotMessage, PlatformMetadata
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
 from astrbot.core.utils.io import download_image_by_url, file_to_base64
-from astrbot.core.utils.tencent_record_helper import wav_to_tencent_silk
+from astrbot.core.utils.tencent_record_helper import (
+    convert_to_pcm_wav,
+    wav_to_tencent_silk,
+)
 
 
 def _patch_qq_botpy_formdata() -> None:
@@ -602,22 +605,41 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                 image_base64 = image_base64.removeprefix("base64://")
             elif isinstance(i, Record):
                 if i.file:
-                    record_wav_path = await i.convert_to_file_path()  # wav 路径
+                    record_wav_path = await i.convert_to_file_path()  # 可能不是wav
                     temp_dir = get_astrbot_temp_path()
                     record_tecent_silk_path = os.path.join(
                         temp_dir,
                         f"qqofficial_{uuid.uuid4()}.silk",
                     )
-                    try:
-                        duration = await wav_to_tencent_silk(
-                            record_wav_path,
-                            record_tecent_silk_path,
+                    # 检查是否为 WAV 文件，非 WAV 需要先转换
+                    ext = os.path.splitext(record_wav_path)[1].lower()
+                    if ext != ".wav":
+                        temp_wav_path = os.path.join(
+                            temp_dir,
+                            f"qqofficial_{uuid.uuid4()}.wav",
                         )
-                        if duration > 0:
-                            record_file_path = record_tecent_silk_path
+                        try:
+                            record_wav_path = await convert_to_pcm_wav(
+                                record_wav_path,
+                                temp_wav_path,
+                            )
+                        except Exception as e:
+                            logger.error(f"转换音频为WAV格式时出错: {e}")
+                            record_file_path = None
+                            record_wav_path = None
+                    try:
+                        if record_wav_path:
+                            duration = await wav_to_tencent_silk(
+                                record_wav_path,
+                                record_tecent_silk_path,
+                            )
+                            if duration > 0:
+                                record_file_path = record_tecent_silk_path
+                            else:
+                                record_file_path = None
+                                logger.error("转换音频格式时出错：音频时长不大于0")
                         else:
                             record_file_path = None
-                            logger.error("转换音频格式时出错：音频时长不大于0")
                     except Exception as e:
                         logger.error(f"处理语音时出错: {e}")
                         record_file_path = None


### PR DESCRIPTION
## Summary
Fixes #6853: After upgrading from 4.19.5 to 4.20+, sending voice or audio files to the QQ bot produces no response.

## Root Cause
When a `Record` message arrives, `convert_to_file_path()` may return a non-WAV file (MP3, etc.), but `wav_to_tencent_silk()` calls `wave.open()` which requires RIFF WAV format. The `convert_to_pcm_wav()` helper exists but was never called for incoming `Record` messages in `_parse_to_qqofficial()`.

## Fix
Check the file extension of the Record audio path. If not `.wav`, call `convert_to_pcm_wav()` to convert to PCM 16bit WAV at 24000Hz mono before passing to `wav_to_tencent_silk()`. Also import `convert_to_pcm_wav` from `tencent_record_helper`.

## Testing
- Verified `convert_to_pcm_wav` is used correctly (same pattern as `audio_to_tencent_silk_base64` and whisper STT providers)
- No regressions to existing WAV file path

Closes #6853

## Summary by Sourcery

Bug Fixes:
- Fix QQ official voice message handling when incoming Record audio is not already in WAV format by converting it to PCM WAV before Silk encoding and adding error handling for conversion and duration validation.