### PR TITLE
fix(subagent): enforce handoff args and provider fallback

### DIFF
--- a/astrbot/core/agent/handoff.py
+++ b/astrbot/core/agent/handoff.py
@@ -39,6 +39,8 @@ class HandoffTool(FunctionTool, Generic[TContext]):
     def default_parameters(self) -> dict:
         return {
             "type": "object",
+            "required": ["input"],
+            "additionalProperties": False,
             "properties": {
                 "input": {
                     "type": "string",

--- a/astrbot/core/astr_agent_tool_exec.py
+++ b/astrbot/core/astr_agent_tool_exec.py
@@ -94,10 +94,14 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
             tool_name=tool_name,
             error_type="invalid_background_task",
             fix_hint=(
-                "`background_task` must be a boolean (`true` or `false`)."
+                "`background_task` must be a boolean (`true` or `false`) or a string "
+                "equivalent such as `\"1\"`/`\"0\"`, `\"yes\"`/`\"no\"`, or "
+                "`\"on\"`/`\"off\"`."
             ),
             action_hint=(
-                "Retry the same handoff with `background_task` as a boolean value."
+                "Retry the same handoff with `background_task` set to a boolean or one "
+                "of the supported string equivalents (`\"true\"`, `\"false\"`, "
+                "`\"1\"`, `\"0\"`, `\"yes\"`, `\"no\"`, `\"on\"`, `\"off\"`)."
             ),
         )
 

--- a/astrbot/core/astr_agent_tool_exec.py
+++ b/astrbot/core/astr_agent_tool_exec.py
@@ -45,6 +45,111 @@ from astrbot.core.utils.string_utils import normalize_and_dedupe_strings
 
 class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
     @classmethod
+    def _build_handoff_error_result(
+        cls,
+        *,
+        tool_name: str,
+        error_type: str,
+        fix_hint: str,
+        action_hint: str,
+    ) -> mcp.types.CallToolResult:
+        guidance = (
+            "[handoff CALL FAILED - IMMEDIATE RETRY REQUIRED]\n"
+            f"error_type: {error_type}\n"
+            f"fix: {fix_hint}\n"
+            f"action: {action_hint}\n"
+            "example:\n"
+            "{\n"
+            '  "input": "Summarize the user request, constraints, and expected output.",\n'
+            '  "background_task": false\n'
+            "}"
+        )
+        return mcp.types.CallToolResult(
+            content=[
+                mcp.types.TextContent(
+                    type="text",
+                    text=f"error: {tool_name} rejected invalid handoff request.\n{guidance}",
+                )
+            ]
+        )
+
+    @classmethod
+    def _parse_background_task_arg(
+        cls,
+        tool_name: str,
+        value: T.Any,
+    ) -> tuple[bool, mcp.types.CallToolResult | None]:
+        if value is None:
+            return False, None
+        if isinstance(value, bool):
+            return value, None
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"true", "1", "yes", "on"}:
+                return True, None
+            if normalized in {"false", "0", "no", "off", ""}:
+                return False, None
+
+        return False, cls._build_handoff_error_result(
+            tool_name=tool_name,
+            error_type="invalid_background_task",
+            fix_hint=(
+                "`background_task` must be a boolean (`true` or `false`)."
+            ),
+            action_hint=(
+                "Retry the same handoff with `background_task` as a boolean value."
+            ),
+        )
+
+    @classmethod
+    def _normalize_handoff_input(
+        cls,
+        tool_name: str,
+        input_value: T.Any,
+    ) -> tuple[str | None, mcp.types.CallToolResult | None]:
+        if not isinstance(input_value, str) or not input_value.strip():
+            return None, cls._build_handoff_error_result(
+                tool_name=tool_name,
+                error_type="missing_or_empty_input",
+                fix_hint=(
+                    "Provide a non-empty `input` string that clearly describes the delegated task."
+                ),
+                action_hint=(
+                    "Retry now with a concise task statement in `input`."
+                ),
+            )
+        return input_value.strip(), None
+
+    @classmethod
+    async def _resolve_handoff_provider_id(
+        cls,
+        tool: HandoffTool,
+        *,
+        ctx: T.Any,
+        umo: str,
+    ) -> str:
+        configured_provider_id = str(getattr(tool, "provider_id", "") or "").strip()
+        if not configured_provider_id:
+            return await ctx.get_current_chat_provider_id(umo)
+
+        provider_mgr = getattr(ctx, "provider_manager", None)
+        if provider_mgr is None or not hasattr(provider_mgr, "get_provider_by_id"):
+            return configured_provider_id
+
+        provider_inst = await provider_mgr.get_provider_by_id(configured_provider_id)
+        if provider_inst is not None:
+            return configured_provider_id
+
+        fallback_provider_id = await ctx.get_current_chat_provider_id(umo)
+        logger.warning(
+            "Subagent %s configured provider `%s` not found, fallback to `%s`.",
+            tool.name,
+            configured_provider_id,
+            fallback_provider_id,
+        )
+        return fallback_provider_id
+
+    @classmethod
     def _collect_image_urls_from_args(cls, image_urls_raw: T.Any) -> list[str]:
         if image_urls_raw is None:
             return []
@@ -130,7 +235,13 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
 
         """
         if isinstance(tool, HandoffTool):
-            is_bg = tool_args.pop("background_task", False)
+            is_bg, bg_error = cls._parse_background_task_arg(
+                tool.name,
+                tool_args.pop("background_task", None),
+            )
+            if bg_error is not None:
+                yield bg_error
+                return
             if is_bg:
                 async for r in cls._execute_handoff_background(
                     tool, run_context, **tool_args
@@ -245,7 +356,14 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
         **tool_args: T.Any,
     ):
         tool_args = dict(tool_args)
-        input_ = tool_args.get("input")
+        input_, input_error = cls._normalize_handoff_input(
+            tool.name,
+            tool_args.get("input"),
+        )
+        if input_error is not None:
+            yield input_error
+            return
+        tool_args["input"] = input_
         if image_urls_prepared:
             prepared_image_urls = tool_args.get("image_urls")
             if isinstance(prepared_image_urls, list):
@@ -272,9 +390,11 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
 
         # Use per-subagent provider override if configured; otherwise fall back
         # to the current/default provider resolution.
-        prov_id = getattr(
-            tool, "provider_id", None
-        ) or await ctx.get_current_chat_provider_id(umo)
+        prov_id = await cls._resolve_handoff_provider_id(
+            tool,
+            ctx=ctx,
+            umo=umo,
+        )
 
         # prepare begin dialogs
         contexts = None

--- a/astrbot/core/astr_agent_tool_exec.py
+++ b/astrbot/core/astr_agent_tool_exec.py
@@ -95,13 +95,13 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
             error_type="invalid_background_task",
             fix_hint=(
                 "`background_task` must be a boolean (`true` or `false`) or a string "
-                "equivalent such as `\"1\"`/`\"0\"`, `\"yes\"`/`\"no\"`, or "
-                "`\"on\"`/`\"off\"`."
+                'equivalent such as `"1"`/`"0"`, `"yes"`/`"no"`, or '
+                '`"on"`/`"off"`.'
             ),
             action_hint=(
                 "Retry the same handoff with `background_task` set to a boolean or one "
-                "of the supported string equivalents (`\"true\"`, `\"false\"`, "
-                "`\"1\"`, `\"0\"`, `\"yes\"`, `\"no\"`, `\"on\"`, `\"off\"`)."
+                'of the supported string equivalents (`"true"`, `"false"`, '
+                '`"1"`, `"0"`, `"yes"`, `"no"`, `"on"`, `"off"`).'
             ),
         )
 
@@ -118,9 +118,7 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
                 fix_hint=(
                     "Provide a non-empty `input` string that clearly describes the delegated task."
                 ),
-                action_hint=(
-                    "Retry now with a concise task statement in `input`."
-                ),
+                action_hint=("Retry now with a concise task statement in `input`."),
             )
         return input_value.strip(), None
 

--- a/tests/unit/test_astr_agent_tool_exec.py
+++ b/tests/unit/test_astr_agent_tool_exec.py
@@ -345,28 +345,6 @@ async def test_collect_handoff_image_urls_filters_extensionless_file_outside_tem
     assert image_urls == []
 
 
-def test_parse_background_task_arg_rejects_invalid_value():
-    is_bg, error = FunctionToolExecutor._parse_background_task_arg(
-        "transfer_to_subagent",
-        "not-a-bool",
-    )
-
-    assert is_bg is False
-    assert error is not None
-    assert isinstance(error, mcp.types.CallToolResult)
-    assert "invalid_background_task" in error.content[0].text
-
-
-def test_parse_background_task_arg_accepts_string_true():
-    is_bg, error = FunctionToolExecutor._parse_background_task_arg(
-        "transfer_to_subagent",
-        "true",
-    )
-
-    assert is_bg is True
-    assert error is None
-
-
 @pytest.mark.asyncio
 async def test_execute_handoff_rejects_empty_input():
     async def _fake_get_current_chat_provider_id(_umo):

--- a/tests/unit/test_astr_agent_tool_exec.py
+++ b/tests/unit/test_astr_agent_tool_exec.py
@@ -343,3 +343,118 @@ async def test_collect_handoff_image_urls_filters_extensionless_file_outside_tem
     )
 
     assert image_urls == []
+
+
+def test_parse_background_task_arg_rejects_invalid_value():
+    is_bg, error = FunctionToolExecutor._parse_background_task_arg(
+        "transfer_to_subagent",
+        "not-a-bool",
+    )
+
+    assert is_bg is False
+    assert error is not None
+    assert isinstance(error, mcp.types.CallToolResult)
+    assert "invalid_background_task" in error.content[0].text
+
+
+def test_parse_background_task_arg_accepts_string_true():
+    is_bg, error = FunctionToolExecutor._parse_background_task_arg(
+        "transfer_to_subagent",
+        "true",
+    )
+
+    assert is_bg is True
+    assert error is None
+
+
+@pytest.mark.asyncio
+async def test_execute_handoff_rejects_empty_input():
+    async def _fake_get_current_chat_provider_id(_umo):
+        return "provider-id"
+
+    async def _fake_tool_loop_agent(**_kwargs):
+        return SimpleNamespace(completion_text="ok")
+
+    context = SimpleNamespace(
+        get_current_chat_provider_id=_fake_get_current_chat_provider_id,
+        tool_loop_agent=_fake_tool_loop_agent,
+        get_config=lambda **_kwargs: {"provider_settings": {}},
+    )
+    event = _DummyEvent([])
+    run_context = ContextWrapper(context=SimpleNamespace(event=event, context=context))
+    tool = SimpleNamespace(
+        name="transfer_to_subagent",
+        provider_id=None,
+        agent=SimpleNamespace(
+            name="subagent",
+            tools=[],
+            instructions="subagent-instructions",
+            begin_dialogs=[],
+            run_hooks=None,
+        ),
+    )
+
+    results = []
+    async for result in FunctionToolExecutor._execute_handoff(
+        tool,
+        run_context,
+        image_urls_prepared=True,
+        input="   ",
+        image_urls=[],
+    ):
+        results.append(result)
+
+    assert len(results) == 1
+    assert isinstance(results[0], mcp.types.CallToolResult)
+    text_content = results[0].content[0]
+    assert isinstance(text_content, mcp.types.TextContent)
+    assert "missing_or_empty_input" in text_content.text
+
+
+@pytest.mark.asyncio
+async def test_execute_handoff_falls_back_to_current_provider_when_configured_missing():
+    captured: dict = {}
+
+    class _DummyProviderManager:
+        async def get_provider_by_id(self, _provider_id: str):
+            return None
+
+    async def _fake_get_current_chat_provider_id(_umo):
+        return "fallback-provider"
+
+    async def _fake_tool_loop_agent(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(completion_text="ok")
+
+    context = SimpleNamespace(
+        provider_manager=_DummyProviderManager(),
+        get_current_chat_provider_id=_fake_get_current_chat_provider_id,
+        tool_loop_agent=_fake_tool_loop_agent,
+        get_config=lambda **_kwargs: {"provider_settings": {}},
+    )
+    event = _DummyEvent([])
+    run_context = ContextWrapper(context=SimpleNamespace(event=event, context=context))
+    tool = SimpleNamespace(
+        name="transfer_to_subagent",
+        provider_id="missing-provider-id",
+        agent=SimpleNamespace(
+            name="subagent",
+            tools=[],
+            instructions="subagent-instructions",
+            begin_dialogs=[],
+            run_hooks=None,
+        ),
+    )
+
+    results = []
+    async for result in FunctionToolExecutor._execute_handoff(
+        tool,
+        run_context,
+        image_urls_prepared=True,
+        input="hello",
+        image_urls=[],
+    ):
+        results.append(result)
+
+    assert len(results) == 1
+    assert captured["chat_provider_id"] == "fallback-provider"

--- a/tests/unit/test_handoff_background_task_arg.py
+++ b/tests/unit/test_handoff_background_task_arg.py
@@ -1,6 +1,11 @@
+from types import SimpleNamespace
+
 import mcp
 import pytest
 
+from astrbot.core.agent.agent import Agent
+from astrbot.core.agent.handoff import HandoffTool
+from astrbot.core.agent.run_context import ContextWrapper
 from astrbot.core.astr_agent_tool_exec import FunctionToolExecutor
 
 
@@ -43,3 +48,57 @@ def test_parse_background_task_arg(value, expected_bool, expect_error):
         assert "invalid_background_task" in text_content.text
     else:
         assert error is None
+
+
+@pytest.mark.asyncio
+async def test_execute_invalid_background_task_early_error(monkeypatch):
+    call_count = {"handoff": 0, "handoff_bg": 0}
+
+    async def _fake_execute_handoff(cls, tool, run_context, **tool_args):
+        call_count["handoff"] += 1
+        yield mcp.types.CallToolResult(
+            content=[mcp.types.TextContent(type="text", text="unexpected")]
+        )
+
+    async def _fake_execute_handoff_bg(cls, tool, run_context, **tool_args):
+        call_count["handoff_bg"] += 1
+        yield mcp.types.CallToolResult(
+            content=[mcp.types.TextContent(type="text", text="unexpected")]
+        )
+
+    monkeypatch.setattr(
+        FunctionToolExecutor,
+        "_execute_handoff",
+        classmethod(_fake_execute_handoff),
+    )
+    monkeypatch.setattr(
+        FunctionToolExecutor,
+        "_execute_handoff_background",
+        classmethod(_fake_execute_handoff_bg),
+    )
+
+    tool = HandoffTool(agent=Agent(name="subagent"))
+    event = SimpleNamespace(
+        unified_msg_origin="webchat:FriendMessage:webchat!user!session",
+        message_obj=SimpleNamespace(message=[]),
+    )
+    run_context = ContextWrapper(
+        context=SimpleNamespace(event=event, context=SimpleNamespace())
+    )
+
+    results = []
+    async for result in FunctionToolExecutor.execute(
+        tool,
+        run_context,
+        input="hello",
+        background_task="not-a-bool",
+    ):
+        results.append(result)
+
+    assert len(results) == 1
+    assert isinstance(results[0], mcp.types.CallToolResult)
+    text_content = results[0].content[0]
+    assert isinstance(text_content, mcp.types.TextContent)
+    assert "invalid_background_task" in text_content.text
+    assert call_count["handoff"] == 0
+    assert call_count["handoff_bg"] == 0

--- a/tests/unit/test_handoff_background_task_arg.py
+++ b/tests/unit/test_handoff_background_task_arg.py
@@ -1,0 +1,45 @@
+import mcp
+import pytest
+
+from astrbot.core.astr_agent_tool_exec import FunctionToolExecutor
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_bool", "expect_error"),
+    [
+        (True, True, False),
+        ("true", True, False),
+        ("1", True, False),
+        ("yes", True, False),
+        ("on", True, False),
+        (" TRUE ", True, False),
+        (False, False, False),
+        ("false", False, False),
+        ("0", False, False),
+        ("no", False, False),
+        ("off", False, False),
+        ("", False, False),
+        (" FALSE ", False, False),
+        (None, False, False),
+        ("not-a-bool", False, True),
+        ("y", False, True),
+        ("t", False, True),
+        (123, False, True),
+        ({}, False, True),
+    ],
+)
+def test_parse_background_task_arg(value, expected_bool, expect_error):
+    is_bg, error = FunctionToolExecutor._parse_background_task_arg(
+        "transfer_to_subagent",
+        value,
+    )
+
+    assert is_bg is expected_bool
+    if expect_error:
+        assert error is not None
+        assert isinstance(error, mcp.types.CallToolResult)
+        text_content = error.content[0]
+        assert isinstance(text_content, mcp.types.TextContent)
+        assert "invalid_background_task" in text_content.text
+    else:
+        assert error is None

--- a/tests/unit/test_handoff_background_task_arg.py
+++ b/tests/unit/test_handoff_background_task_arg.py
@@ -50,6 +50,14 @@ def test_parse_background_task_arg(value, expected_bool, expect_error):
         assert error is None
 
 
+def test_handoff_default_parameters_align_with_background_task_handling():
+    params = HandoffTool(agent=Agent(name="subagent")).parameters
+    assert params["required"] == ["input"]
+    assert params["additionalProperties"] is False
+    assert set(params["properties"]) == {"input", "image_urls", "background_task"}
+    assert params["properties"]["background_task"]["type"] == "boolean"
+
+
 @pytest.mark.asyncio
 async def test_execute_invalid_background_task_early_error(monkeypatch):
     call_count = {"handoff": 0, "handoff_bg": 0}

--- a/tests/unit/test_handoff_background_task_arg.py
+++ b/tests/unit/test_handoff_background_task_arg.py
@@ -9,6 +9,18 @@ from astrbot.core.agent.run_context import ContextWrapper
 from astrbot.core.astr_agent_tool_exec import FunctionToolExecutor
 
 
+def _build_tool_and_run_context():
+    tool = HandoffTool(agent=Agent(name="subagent"))
+    event = SimpleNamespace(
+        unified_msg_origin="webchat:FriendMessage:webchat!user!session",
+        message_obj=SimpleNamespace(message=[]),
+    )
+    run_context = ContextWrapper(
+        context=SimpleNamespace(event=event, context=SimpleNamespace())
+    )
+    return tool, run_context
+
+
 @pytest.mark.parametrize(
     ("value", "expected_bool", "expect_error"),
     [
@@ -85,14 +97,7 @@ async def test_execute_invalid_background_task_early_error(monkeypatch):
         classmethod(_fake_execute_handoff_bg),
     )
 
-    tool = HandoffTool(agent=Agent(name="subagent"))
-    event = SimpleNamespace(
-        unified_msg_origin="webchat:FriendMessage:webchat!user!session",
-        message_obj=SimpleNamespace(message=[]),
-    )
-    run_context = ContextWrapper(
-        context=SimpleNamespace(event=event, context=SimpleNamespace())
-    )
+    tool, run_context = _build_tool_and_run_context()
 
     results = []
     async for result in FunctionToolExecutor.execute(
@@ -110,3 +115,144 @@ async def test_execute_invalid_background_task_early_error(monkeypatch):
     assert "invalid_background_task" in text_content.text
     assert call_count["handoff"] == 0
     assert call_count["handoff_bg"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("background_value", [True, "true"])
+async def test_execute_truthy_background_task_routes_to_background_handoff(
+    monkeypatch,
+    background_value,
+):
+    call_count = {"handoff": 0, "handoff_bg": 0}
+
+    async def _fake_execute_handoff(cls, tool, run_context, **tool_args):
+        call_count["handoff"] += 1
+        yield mcp.types.CallToolResult(
+            content=[mcp.types.TextContent(type="text", text="foreground")]
+        )
+
+    async def _fake_execute_handoff_bg(cls, tool, run_context, **tool_args):
+        call_count["handoff_bg"] += 1
+        yield mcp.types.CallToolResult(
+            content=[mcp.types.TextContent(type="text", text="background")]
+        )
+
+    monkeypatch.setattr(
+        FunctionToolExecutor,
+        "_execute_handoff",
+        classmethod(_fake_execute_handoff),
+    )
+    monkeypatch.setattr(
+        FunctionToolExecutor,
+        "_execute_handoff_background",
+        classmethod(_fake_execute_handoff_bg),
+    )
+
+    tool, run_context = _build_tool_and_run_context()
+
+    results = []
+    async for result in FunctionToolExecutor.execute(
+        tool,
+        run_context,
+        input="hello",
+        background_task=background_value,
+    ):
+        results.append(result)
+
+    assert len(results) == 1
+    assert call_count["handoff"] == 0
+    assert call_count["handoff_bg"] == 1
+    text_content = results[0].content[0]
+    assert isinstance(text_content, mcp.types.TextContent)
+    assert "invalid_background_task" not in text_content.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("background_value", [False, "false", "0"])
+async def test_execute_falsey_background_task_routes_to_foreground_handoff(
+    monkeypatch,
+    background_value,
+):
+    call_count = {"handoff": 0, "handoff_bg": 0}
+
+    async def _fake_execute_handoff(cls, tool, run_context, **tool_args):
+        call_count["handoff"] += 1
+        yield mcp.types.CallToolResult(
+            content=[mcp.types.TextContent(type="text", text="foreground")]
+        )
+
+    async def _fake_execute_handoff_bg(cls, tool, run_context, **tool_args):
+        call_count["handoff_bg"] += 1
+        yield mcp.types.CallToolResult(
+            content=[mcp.types.TextContent(type="text", text="background")]
+        )
+
+    monkeypatch.setattr(
+        FunctionToolExecutor,
+        "_execute_handoff",
+        classmethod(_fake_execute_handoff),
+    )
+    monkeypatch.setattr(
+        FunctionToolExecutor,
+        "_execute_handoff_background",
+        classmethod(_fake_execute_handoff_bg),
+    )
+
+    tool, run_context = _build_tool_and_run_context()
+
+    results = []
+    async for result in FunctionToolExecutor.execute(
+        tool,
+        run_context,
+        input="hello",
+        background_task=background_value,
+    ):
+        results.append(result)
+
+    assert len(results) == 1
+    assert call_count["handoff"] == 1
+    assert call_count["handoff_bg"] == 0
+    text_content = results[0].content[0]
+    assert isinstance(text_content, mcp.types.TextContent)
+    assert "invalid_background_task" not in text_content.text
+
+
+@pytest.mark.asyncio
+async def test_execute_handoff_rejects_empty_input_without_downstream_tool_loop():
+    call_count = {"tool_loop": 0}
+
+    async def _fake_get_current_chat_provider_id(_umo):
+        return "provider-id"
+
+    async def _fake_tool_loop_agent(**_kwargs):
+        call_count["tool_loop"] += 1
+        return SimpleNamespace(completion_text="ok")
+
+    context = SimpleNamespace(
+        get_current_chat_provider_id=_fake_get_current_chat_provider_id,
+        tool_loop_agent=_fake_tool_loop_agent,
+        get_config=lambda **_kwargs: {"provider_settings": {}},
+    )
+    event = SimpleNamespace(
+        unified_msg_origin="webchat:FriendMessage:webchat!user!session",
+        message_obj=SimpleNamespace(message=[]),
+    )
+    run_context = ContextWrapper(context=SimpleNamespace(event=event, context=context))
+    tool = HandoffTool(agent=Agent(name="subagent"))
+
+    results = []
+    async for result in FunctionToolExecutor._execute_handoff(
+        tool,
+        run_context,
+        image_urls_prepared=True,
+        input="   ",
+        image_urls=[],
+    ):
+        results.append(result)
+
+    assert len(results) == 1
+    assert isinstance(results[0], mcp.types.CallToolResult)
+    text_content = results[0].content[0]
+    assert isinstance(text_content, mcp.types.TextContent)
+    assert "missing_or_empty_input" in text_content.text
+    assert call_count["tool_loop"] == 0


### PR DESCRIPTION
### Motivation / 动机

当前 `transfer_to_*` handoff 参数校验和 provider 选择在边界场景下仍可能产生不透明失败：
- `background_task` 输入不规范时，主代理缺少稳定的自纠错指引；
- `input` 为空时可能进入无效委派路径；
- 子代理配置了失效 `provider_id` 时会导致 handoff 失败而非平滑降级。

本 PR 统一 handoff 参数契约并补充 provider fallback，提升可恢复性与可观测性。

### Complement With #5722 / 与 #5722 的互补关系

- [#5722](https://github.com/AstrBotDevs/AstrBot/pull/5722) 关注 SubAgent 编排 runtime 重构（队列/重试/并发/持久化）。
- 本 PR 仅覆盖 handoff 入参校验、错误提示与 provider fallback，不引入新调度能力。
- 与 #5722 的关系：本 PR 提供“入口参数与提供者选择”层面的鲁棒性，作为重构体系外可独立落地的稳定性增强。

### Modifications / 改动点

**Handoff Contract / 参数契约**
- `astrbot/core/agent/handoff.py`
  - 明确默认 schema：`required: ["input"]`
  - `additionalProperties: false`
  - 显式声明 `background_task` 与 `image_urls` 属性，保证 schema 与执行器行为一致

**Validation & Fallback / 校验与回退**
- `astrbot/core/astr_agent_tool_exec.py`
  - `background_task` 解析：支持 `bool` 与常见字符串布尔值；非法值返回结构化错误并给出重试指引
  - `input` 非空校验：空字符串/空白字符串立即拒绝
  - provider fallback：当 subagent 的 `provider_id` 不存在时，回退到当前会话 provider 并记录 warning

**Tests / 测试覆盖**
- `tests/unit/test_astr_agent_tool_exec.py`
  - 覆盖空 `input` 拒绝、缺失 provider 的 fallback 等关键路径
- `tests/unit/test_handoff_background_task_arg.py`
  - 参数化覆盖 `_parse_background_task_arg` 的真值/假值/非法值
  - 覆盖 `execute` 层路由：truthy -> background handoff、falsey -> foreground handoff
  - 覆盖非法 `background_task` 早返回，不触发下游 handoff
  - 覆盖 schema 契约一致性（`background_task` 在 properties 中）

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Test Results / 测试结果

本轮在当前环境执行：

```bash
python3 -m py_compile tests/unit/test_handoff_background_task_arg.py
```

结果：
- `py_compile`: passed

说明：
- 当前容器环境缺少 `deprecated` 依赖，`pytest` 在加载 `tests/conftest.py` 时失败（`ModuleNotFoundError: deprecated`），未在该环境完成完整单测回归。

---

### Checklist / 检查清单

- [ ] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。/ If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了验证步骤和结果**。/ My changes have been well-tested, **and verification steps/results have been provided above**.
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。/ I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 我的更改没有引入恶意代码。/ My changes do not introduce malicious code.
