### PR TITLE
fix: auto-append /v1 to embedding API base URL

### DIFF
--- a/astrbot/core/provider/sources/openai_embedding_source.py
+++ b/astrbot/core/provider/sources/openai_embedding_source.py
@@ -27,10 +27,10 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         api_base = provider_config.get(
             "embedding_api_base", "https://api.openai.com/v1"
         ).strip()
-        # Auto-append /v1 for OpenAI-compatible APIs
+        # Auto-append /v1 for OpenAI-compatible APIs when no path is specified
         api_base = api_base.rstrip("/")
-        if not api_base.endswith("/v1"):
-            api_base = api_base + "/v1"
+        if not api_base.endswith("/v1") and api_base.count("/") == 2:
+            api_base += "/v1"
         logger.info(f"[OpenAI Embedding] {provider_id} Using API Base: {api_base}")
         self.client = AsyncOpenAI(
             api_key=provider_config.get("embedding_api_key"),


### PR DESCRIPTION
## Summary
- Auto-append `/v1` to custom embedding API base URL when not present

## Problem
When users configure a custom embedding API base URL without the `/v1` path (e.g., `https://api.siliconflow.cn`), API calls fail with "Not Found" error because OpenAI-compatible APIs require the `/v1` prefix.

## Fix
Added URL normalization after retrieving `embedding_api_base`:
```python
api_base = api_base.rstrip("/")
if not api_base.endswith("/v1"):
    api_base = api_base + "/v1"
```

This ensures:
- `https://api.siliconflow.cn` → `https://api.siliconflow.cn/v1`
- `https://api.openai.com/v1` → unchanged
- `https://api.siliconflow.cn/v1/` → `https://api.siliconflow.cn/v1`

Closes #6855

## Summary by Sourcery

Bug Fixes:
- Fix failures when a custom embedding API base URL omits the /v1 path by normalizing the URL to include it.