### PR TITLE
fix(pipeline): skip waking on empty messages

### DIFF
--- a/astrbot/builtin_stars/session_controller/main.py
+++ b/astrbot/builtin_stars/session_controller/main.py
@@ -91,6 +91,8 @@ class Main(Star):
                         controller: SessionController,
                         event: AstrMessageEvent,
                     ) -> None:
+                        if not event.message_str or not event.message_str.strip():
+                            return
                         event.message_obj.message.insert(
                             0,
                             Comp.At(qq=event.get_self_id(), name=event.get_self_id()),

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -150,13 +150,18 @@ class InternalAgentSubStage(Stage):
             if (enable_streaming := event.get_extra("enable_streaming")) is not None:
                 streaming_response = bool(enable_streaming)
 
+            has_provider_request = event.get_extra("provider_request") is not None
             has_valid_message = bool(event.message_str and event.message_str.strip())
             has_media_content = any(
                 isinstance(comp, Image | File) for comp in event.message_obj.message
             )
 
-            if not has_valid_message and not has_media_content:
-                logger.debug("skip llm request: empty message")
+            if (
+                not has_provider_request
+                and not has_valid_message
+                and not has_media_content
+            ):
+                logger.debug("skip llm request: empty message and no provider_request")
                 return
 
             logger.debug("ready to request llm provider")


### PR DESCRIPTION
Fixes #6000 
我遇到了相同的问题。我的触发词为baka，当我手机私聊输入baka后：
输入1-3个文字，或者删除文字到空，或者进入退出窗口时都会触发一次空信息的回复。
我注意到了 #5797 ,其中[Soulter](https://github.com/Soulter)提到了“应该如果消息是空的的话，不会触发llm吧？”
确实，单纯发送“ ”不会触发，但是：bot有唤醒词（比如baka），只输入唤醒词仍然会触发回答
### Modifications / 改动点
若 is_wake 为 true 但 message_str和 messages 均为空，则调用 stop_event()阻止空消息进入后续管道阶段。此方案保留了事件下发给pipeline的设计，同时防止只发送唤醒词导致的空消息触发

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

改动前，输入bot的唤醒词，并在手机上输入一些字符，会触发一些对空白消息的回复
改动后一切正常:
[16:09:32.922] [Core] [INFO] [core.event_bus:61]: [default] [chatbot1(aiocqhttp)] 1441308506/1441308506: 
[16:09:33.412] [Core] [INFO] [core.event_bus:61]: [default] [chatbot1(aiocqhttp)] 1441308506/1441308506: 
[16:09:34.673] [Core] [INFO] [core.event_bus:61]: [default] [chatbot1(aiocqhttp)] 1441308506/1441308506: 
像这样

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。
