### PR TITLE
fix(tests): update scanUsedIcons tests to include required radio icons

### DIFF
--- a/dashboard/tests/subsetMdiFont.test.mjs
+++ b/dashboard/tests/subsetMdiFont.test.mjs
@@ -83,7 +83,9 @@ test('scanUsedIcons extracts mdi-* icon names from files', () => {
   assert.ok(icons instanceof Set);
   assert.ok(icons.has('mdi-home'));
   assert.ok(icons.has('mdi-close'));
-  assert.equal(icons.size, 2); // mdi-home deduplicated
+  assert.ok(icons.has('mdi-radiobox-blank'));
+  assert.ok(icons.has('mdi-radiobox-marked'));
+  assert.equal(icons.size, 4); // source icons + required radio icons
 
   rmSync(tmp, { recursive: true });
 });
@@ -101,12 +103,26 @@ test('scanUsedIcons excludes utility classes', () => {
   rmSync(tmp, { recursive: true });
 });
 
-test('scanUsedIcons returns empty set when no icons found', () => {
+test('scanUsedIcons includes required radio icons even when no mdi-* icons are found in source', () => {
   const tmp = makeTmpDir();
   writeFileSync(join(tmp, 'A.vue'), '<div>Hello</div>');
 
   const icons = scanUsedIcons(collectFiles(tmp, ['.vue']));
-  assert.equal(icons.size, 0);
+  assert.ok(icons.has('mdi-radiobox-blank'));
+  assert.ok(icons.has('mdi-radiobox-marked'));
+  assert.equal(icons.size, 2);
+
+  rmSync(tmp, { recursive: true });
+});
+
+test('scanUsedIcons deduplicates required radio icons when source already references them', () => {
+  const tmp = makeTmpDir();
+  writeFileSync(join(tmp, 'A.vue'), '<v-icon>mdi-radiobox-marked</v-icon><v-icon>mdi-home</v-icon>');
+
+  const icons = [...scanUsedIcons(collectFiles(tmp, ['.vue']))];
+  assert.equal(icons.filter(icon => icon === 'mdi-radiobox-marked').length, 1);
+  assert.ok(icons.includes('mdi-radiobox-blank'));
+  assert.ok(icons.includes('mdi-home'));
 
   rmSync(tmp, { recursive: true });
 });


### PR DESCRIPTION
### Motivation / 动机

修复 `dashboard/scripts/subset-mdi-font.mjs` 在图标子集化后遗漏 Vuetify `v-radio` 间接依赖图标的问题。

在 fix(ui): include vuetify radiobox icons #6892 中，已通过 `REQUIRED_ICONS` 将 `mdi-radiobox-blank` 和 `mdi-radiobox-marked` 加入 `usedIcons` 的初始化，解决了 Radio 按钮无法正确渲染的问题；但这也改变了 `scanUsedIcons()` 的行为，使其在源码中没有任何 `mdi-*` 图标时也会返回这两个必需图标，导致原有单元测试中关于“返回空集”或“集合大小”的断言不再准确。

本 PR 仅更新对应单元测试，使测试行为与当前实现保持一致，确保测试套件能够准确反映 `REQUIRED_ICONS` 的新逻辑并稳定通过。

### Modifications / 改动点

- 更新 `dashboard/tests/subsetMdiFont.test.mjs`
- 调整 `scanUsedIcons` 相关测试断言，使其适配 `REQUIRED_ICONS` 默认注入的行为
- 将“无图标时返回空集”的旧测试更新为“至少包含两个 Radio 必需图标”
- 更新已有集合大小断言，计入 `mdi-radiobox-blank` 与 `mdi-radiobox-marked`
- 新增去重测试，验证当源码中已包含 `mdi-radiobox-marked` 时不会重复加入

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

已执行以下测试命令：

```bash
node --test --experimental-test-isolation=none dashboard/tests/subsetMdiFont.test.mjs
```
测试结果：
```
text

1..18
# tests 18
# pass 18
# fail 0
```
本次修改后，subsetMdiFont.test.mjs 全部测试通过，测试行为已与 REQUIRED_ICONS 新逻辑保持一致。

Checklist / 检查清单
 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
/ 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

 👀 My changes have been well-tested, and "Verification Steps" and "Screenshots" have been provided above.
/ 我的更改经过了良好的测试，并已在上方提供了“验证步骤”和“运行截图”。

 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in requirements.txt and pyproject.toml.
/ 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 requirements.txt 和 pyproject.toml 文件相应位置。

 😮 My changes do not introduce malicious code.
/ 我的更改没有引入恶意代码。

## Summary by Sourcery

Align scanUsedIcons unit tests with the updated behavior that always includes required Vuetify radio icons.

Tests:
- Update scanUsedIcons extraction tests to expect required radio icons in addition to source-referenced icons.
- Adjust the no-icons-found test to assert that the required radio icons are still present by default.
- Add a new test ensuring required radio icons are not duplicated when already referenced in source files.