### PR TITLE
fix: keep weixin_oc polling after getupdates timeout

### DIFF
--- a/astrbot/core/platform/sources/weixin_oc/weixin_oc_adapter.py
+++ b/astrbot/core/platform/sources/weixin_oc/weixin_oc_adapter.py
@@ -734,18 +734,25 @@ class WeixinOCAdapter(Platform):
         )
 
     async def _poll_inbound_updates(self) -> None:
-        data = await self.client.request_json(
-            "POST",
-            "ilink/bot/getupdates",
-            payload={
-                "base_info": {
-                    "channel_version": "astrbot",
+        try:
+            data = await self.client.request_json(
+                "POST",
+                "ilink/bot/getupdates",
+                payload={
+                    "base_info": {
+                        "channel_version": "astrbot",
+                    },
+                    "get_updates_buf": self._sync_buf,
                 },
-                "get_updates_buf": self._sync_buf,
-            },
-            token_required=True,
-            timeout_ms=self.long_poll_timeout_ms,
-        )
+                token_required=True,
+                timeout_ms=self.long_poll_timeout_ms,
+            )
+        except asyncio.TimeoutError:
+            logger.debug(
+                "weixin_oc(%s): inbound getupdates long-poll timeout",
+                self.meta().id,
+            )
+            return
         ret = int(data.get("ret") or 0)
         errcode = data.get("errcode", 0)
         if ret != 0 and ret is not None:
@@ -895,13 +902,7 @@ class WeixinOCAdapter(Platform):
                         await asyncio.sleep(self.qr_poll_interval)
                     continue
 
-                try:
-                    await self._poll_inbound_updates()
-                except asyncio.TimeoutError:
-                    logger.debug(
-                        "weixin_oc(%s): inbound getupdates long-poll timeout",
-                        self.meta().id,
-                    )
+                await self._poll_inbound_updates()
         except asyncio.CancelledError:
             raise
         except Exception as e:

--- a/tests/test_weixin_oc_adapter.py
+++ b/tests/test_weixin_oc_adapter.py
@@ -21,16 +21,45 @@ async def test_run_continues_after_inbound_long_poll_timeout():
 
     call_count = 0
 
-    async def fake_poll_inbound_updates():
+    async def fake_request_json(*args, **kwargs):
         nonlocal call_count
         call_count += 1
         if call_count == 1:
             raise asyncio.TimeoutError()
         adapter._shutdown_event.set()
+        return {"msgs": []}
 
-    adapter._poll_inbound_updates = fake_poll_inbound_updates  # type: ignore[method-assign]
+    adapter.client.request_json = fake_request_json  # type: ignore[method-assign]
 
     await adapter.run()
 
     assert call_count == 2
+    adapter.client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_stops_on_non_timeout_inbound_error():
+    adapter = WeixinOCAdapter(
+        platform_config={
+            "id": "weixin_main",
+            "type": "weixin_oc",
+            "weixin_oc_token": "test-token",
+        },
+        platform_settings={},
+        event_queue=asyncio.Queue(),
+    )
+    adapter.client.close = AsyncMock()
+
+    call_count = 0
+
+    async def fake_request_json(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        raise RuntimeError("boom")
+
+    adapter.client.request_json = fake_request_json  # type: ignore[method-assign]
+
+    await adapter.run()
+
+    assert call_count == 1
     adapter.client.close.assert_awaited_once()


### PR DESCRIPTION
Fixes #6901.

### Modifications / 改动点

This PR prevents `weixin_oc` from exiting when the inbound `ilink/bot/getupdates` long-poll hits a normal `asyncio.TimeoutError`.

- handle the timeout at the `getupdates` request boundary inside `WeixinOCAdapter._poll_inbound_updates()`
- keep other inbound processing failures on the existing fatal path, so the fix does not mask unrelated errors
- add regression tests for both the timeout case and the non-timeout error case

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```text
make pr-test-full
924 passed, 5 warnings in 50.40s
Smoke test passed
Dashboard build passed

.venv/bin/pytest tests/test_weixin_oc_adapter.py
2 passed in 0.98s
```

---

### Checklist / 检查清单

- [x] This PR is a bugfix for issue #6901 and does not add a new feature.
- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 I have ensured that no new dependencies are introduced.
- [x] 😮 My changes do not introduce malicious code.

## Summary by Sourcery

Handle Weixin OC inbound long-poll timeouts without stopping the adapter loop.

Bug Fixes:
- Prevent the Weixin OC adapter from exiting when ilink/bot/getupdates long-polling hits a normal asyncio.TimeoutError.

Tests:
- Add regression tests to ensure the adapter continues running after a long-poll timeout and still stops on non-timeout inbound errors.