### PR TITLE
feat(persona): 为 Persona 增加 Subagent 选择功能，允许指定人格可调用的 Subagent 范围

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -4,6 +4,7 @@ import asyncio
 import copy
 import datetime
 import json
+import logging
 import os
 import platform
 import zoneinfo
@@ -446,14 +447,10 @@ async def _ensure_persona_and_skills(
         else:
             # 只允许指向归一化白名单中的 subagents 的 handoff
             for tool in so.handoffs:
-                short_name = (
-                    (getattr(tool, "name", None) or "")
-                    .replace("transfer_to_", "")
-                    .strip()
-                )
-                if (
-                    short_name in normalized_subagents
-                ):  # normalized_subagents 可能是空集合则禁用所有 handoffs
+                agent = getattr(tool, "agent", None)
+                agent_name = getattr(agent, "name", None) if agent else None
+                logging.info(f"Agent {agent_name}")
+                if agent_name and agent_name.strip() in normalized_subagents:
                     req.func_tool.add_tool(tool)
 
         # check duplicates

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -448,8 +448,10 @@ async def _ensure_persona_and_skills(
             for tool in so.handoffs:
                 agent = getattr(tool, "agent", None)
                 agent_name = getattr(agent, "name", None) if agent else None
-                if agent_name and agent_name.strip() in normalized_subagents:
-                    req.func_tool.add_tool(tool)
+                if agent_name is not None:
+                    name_norm = str(agent_name).strip()
+                    if name_norm and name_norm in normalized_subagents:
+                        req.func_tool.add_tool(tool)
 
         # check duplicates
         if remove_dup:

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -387,21 +387,21 @@ async def _ensure_persona_and_skills(
         assigned_tools: set[str] = set()
         agents = orch_cfg.get("agents", [])
 
-        # 1. 提取白名单
+        # 1. 提取白名单（归一化 subagents 名称）
         sub_agents_cfg = (persona or {}).get("subagents")
-        persona_subagents = (
+        normalized_subagents = (
             {str(name).strip() for name in sub_agents_cfg if str(name).strip()}
             if sub_agents_cfg is not None
             else None
         )
 
-        # 2. 过滤 agents
-        if persona_subagents is not None:
+        # 2. 过滤 agents（使用归一化后的名称）
+        if normalized_subagents is not None:
             agents = [
                 agent
                 for agent in agents
                 if isinstance(agent, dict)
-                and str(agent.get("name", "")).strip() in persona_subagents
+                and str(agent.get("name", "")).strip() in normalized_subagents
             ]
         if isinstance(agents, list):
             for a in agents:
@@ -438,15 +438,22 @@ async def _ensure_persona_and_skills(
             req.func_tool = ToolSet()
 
         # add subagent handoff tools
-        # 如果 sub_agents_cfg 为 None 或空列表，则默认放行所有 handoffs
-        if not sub_agents_cfg:
+        # 如果 normalized_subagents 为 None 则默认放行所有 handoffs,空集合禁用所有handoffs
+        if normalized_subagents is None:
+            # 不配置 subagents 时，默认放行所有 handoffs
             for tool in so.handoffs:
                 req.func_tool.add_tool(tool)
         else:
+            # 只允许指向归一化白名单中的 subagents 的 handoff
             for tool in so.handoffs:
-                # 去掉 "transfer_to_" 前缀再匹配
-                short_name = tool.name.replace("transfer_to_", "")
-                if short_name in sub_agents_cfg:
+                short_name = (
+                    (getattr(tool, "name", None) or "")
+                    .replace("transfer_to_", "")
+                    .strip()
+                )
+                if (
+                    short_name in normalized_subagents
+                ):  # normalized_subagents 可能是空集合则禁用所有 handoffs
                     req.func_tool.add_tool(tool)
 
         # check duplicates

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -4,7 +4,6 @@ import asyncio
 import copy
 import datetime
 import json
-import logging
 import os
 import platform
 import zoneinfo
@@ -449,7 +448,6 @@ async def _ensure_persona_and_skills(
             for tool in so.handoffs:
                 agent = getattr(tool, "agent", None)
                 agent_name = getattr(agent, "name", None) if agent else None
-                logging.info(f"Agent {agent_name}")
                 if agent_name and agent_name.strip() in normalized_subagents:
                     req.func_tool.add_tool(tool)
 

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -386,6 +386,23 @@ async def _ensure_persona_and_skills(
 
         assigned_tools: set[str] = set()
         agents = orch_cfg.get("agents", [])
+
+        # 1. 提取白名单
+        sub_agents_cfg = (persona or {}).get("subagents")
+        persona_subagents = (
+            {str(name).strip() for name in sub_agents_cfg if str(name).strip()}
+            if sub_agents_cfg is not None
+            else None
+        )
+
+        # 2. 过滤 agents
+        if persona_subagents is not None:
+            agents = [
+                agent
+                for agent in agents
+                if isinstance(agent, dict)
+                and str(agent.get("name", "")).strip() in persona_subagents
+            ]
         if isinstance(agents, list):
             for a in agents:
                 if not isinstance(a, dict):
@@ -421,8 +438,16 @@ async def _ensure_persona_and_skills(
             req.func_tool = ToolSet()
 
         # add subagent handoff tools
-        for tool in so.handoffs:
-            req.func_tool.add_tool(tool)
+        # 如果 sub_agents_cfg 为 None 或空列表，则默认放行所有 handoffs
+        if not sub_agents_cfg:
+            for tool in so.handoffs:
+                req.func_tool.add_tool(tool)
+        else:
+            for tool in so.handoffs:
+                # 去掉 "transfer_to_" 前缀再匹配
+                short_name = tool.name.replace("transfer_to_", "")
+                if short_name in sub_agents_cfg:
+                    req.func_tool.add_tool(tool)
 
         # check duplicates
         if remove_dup:

--- a/astrbot/core/db/__init__.py
+++ b/astrbot/core/db/__init__.py
@@ -314,6 +314,7 @@ class BaseDatabase(abc.ABC):
         begin_dialogs: list[str] | None = None,
         tools: list[str] | None = None,
         skills: list[str] | None = None,
+        subagents: list[str] | None = None,
         custom_error_message: str | None = None,
         folder_id: str | None = None,
         sort_order: int = 0,
@@ -326,6 +327,7 @@ class BaseDatabase(abc.ABC):
             begin_dialogs: Optional list of initial dialog strings
             tools: Optional list of tool names (None means all tools, [] means no tools)
             skills: Optional list of skill names (None means all skills, [] means no skills)
+            subagents: Optional list of subagent names (None means all subagents, [] means no subagents)
             custom_error_message: Optional persona-level fallback error message
             folder_id: Optional folder ID to place the persona in (None means root)
             sort_order: Sort order within the folder (default 0)
@@ -350,6 +352,7 @@ class BaseDatabase(abc.ABC):
         begin_dialogs: list[str] | None = None,
         tools: list[str] | None = None,
         skills: list[str] | None = None,
+        subagents: list[str] | None = None,
         custom_error_message: str | None = None,
     ) -> Persona | None:
         """Update a persona's system prompt or begin dialogs."""

--- a/astrbot/core/db/po.py
+++ b/astrbot/core/db/po.py
@@ -126,6 +126,8 @@ class Persona(TimestampMixin, SQLModel, table=True):
     """None means use ALL tools for default, empty list means no tools, otherwise a list of tool names."""
     skills: list | None = Field(default=None, sa_type=JSON)
     """None means use ALL skills for default, empty list means no skills, otherwise a list of skill names."""
+    subagents: list | None = Field(default=None, sa_type=JSON)
+    """None means use ALL subagents for default, empty list means no subagents, otherwise a list of subagents names."""
     custom_error_message: str | None = Field(default=None, sa_type=Text)
     """Optional custom error message sent to end users when the agent request fails."""
     folder_id: str | None = Field(default=None, max_length=36)
@@ -474,6 +476,8 @@ class Personality(TypedDict):
     """工具列表。None 表示使用所有工具，空列表表示不使用任何工具"""
     skills: list[str] | None
     """Skills 列表。None 表示使用所有 Skills，空列表表示不使用任何 Skills"""
+    subagents: list[str] | None
+    """Subagents 列表。None 表示使用所有 Subagents，空列表表示不使用任何 Subagents"""
     custom_error_message: str | None
     """可选的人格自定义报错回复信息。配置后将优先发送给最终用户。"""
 

--- a/astrbot/core/db/sqlite.py
+++ b/astrbot/core/db/sqlite.py
@@ -55,9 +55,10 @@ class SQLiteDatabase(BaseDatabase):
             await conn.execute(text("PRAGMA temp_store=MEMORY"))
             await conn.execute(text("PRAGMA mmap_size=134217728"))
             await conn.execute(text("PRAGMA optimize"))
-            # 确保 personas 表有 folder_id、sort_order、skills 列（前向兼容）
+            # 确保 personas 表有 folder_id、sort_order、skills、subagents 列（前向兼容）
             await self._ensure_persona_folder_columns(conn)
             await self._ensure_persona_skills_column(conn)
+            await self._ensure_persona_subagents_column(conn)
             await self._ensure_persona_custom_error_message_column(conn)
             await conn.commit()
 
@@ -92,6 +93,18 @@ class SQLiteDatabase(BaseDatabase):
 
         if "skills" not in columns:
             await conn.execute(text("ALTER TABLE personas ADD COLUMN skills JSON"))
+
+    async def _ensure_persona_subagents_column(self, conn) -> None:
+        """确保 personas 表有 subagents 列。
+
+        这是为了支持旧版数据库的平滑升级。新版数据库通过 SQLModel
+        的 metadata.create_all 自动创建这些列。
+        """
+        result = await conn.execute(text("PRAGMA table_info(personas)"))
+        columns = {row[1] for row in result.fetchall()}
+
+        if "subagents" not in columns:
+            await conn.execute(text("ALTER TABLE personas ADD COLUMN subagents JSON"))
 
     async def _ensure_persona_custom_error_message_column(self, conn) -> None:
         """确保 personas 表有 custom_error_message 列。"""
@@ -686,6 +699,7 @@ class SQLiteDatabase(BaseDatabase):
         begin_dialogs=None,
         tools=None,
         skills=None,
+        subagents=None,
         custom_error_message=None,
         folder_id=None,
         sort_order=0,
@@ -700,6 +714,7 @@ class SQLiteDatabase(BaseDatabase):
                     begin_dialogs=begin_dialogs or [],
                     tools=tools,
                     skills=skills,
+                    subagents=subagents,
                     custom_error_message=custom_error_message,
                     folder_id=folder_id,
                     sort_order=sort_order,
@@ -732,6 +747,7 @@ class SQLiteDatabase(BaseDatabase):
         begin_dialogs=None,
         tools=NOT_GIVEN,
         skills=NOT_GIVEN,
+        subagents=NOT_GIVEN,
         custom_error_message=NOT_GIVEN,
     ):
         """Update a persona's system prompt or begin dialogs."""
@@ -748,6 +764,8 @@ class SQLiteDatabase(BaseDatabase):
                     values["tools"] = tools
                 if skills is not NOT_GIVEN:
                     values["skills"] = skills
+                if subagents is not NOT_GIVEN:
+                    values["subagents"] = subagents
                 if custom_error_message is not NOT_GIVEN:
                     values["custom_error_message"] = custom_error_message
                 if not values:

--- a/astrbot/core/persona_mgr.py
+++ b/astrbot/core/persona_mgr.py
@@ -13,6 +13,7 @@ DEFAULT_PERSONALITY = Personality(
     mood_imitation_dialogs=[],
     tools=None,
     skills=None,
+    subagents=None,
     custom_error_message=None,
     _begin_dialogs_processed=[],
     _mood_imitation_dialogs_processed="",

--- a/astrbot/core/persona_mgr.py
+++ b/astrbot/core/persona_mgr.py
@@ -141,6 +141,7 @@ class PersonaManager:
         begin_dialogs: list[str] | None = None,
         tools: list[str] | None | object = NOT_GIVEN,
         skills: list[str] | None | object = NOT_GIVEN,
+        subagents: list[str] | None | object = NOT_GIVEN,
         custom_error_message: str | None | object = NOT_GIVEN,
     ):
         """更新指定 persona 的信息。tools 参数为 None 时表示使用所有工具，空列表表示不使用任何工具"""
@@ -152,6 +153,8 @@ class PersonaManager:
             update_kwargs["tools"] = tools
         if skills is not NOT_GIVEN:
             update_kwargs["skills"] = skills
+        if subagents is not NOT_GIVEN:
+            update_kwargs["subagents"] = subagents
         if custom_error_message is not NOT_GIVEN:
             update_kwargs["custom_error_message"] = custom_error_message
 
@@ -319,6 +322,7 @@ class PersonaManager:
         begin_dialogs: list[str] | None = None,
         tools: list[str] | None = None,
         skills: list[str] | None = None,
+        subagents: list[str] | None = None,
         custom_error_message: str | None = None,
         folder_id: str | None = None,
         sort_order: int = 0,
@@ -331,6 +335,7 @@ class PersonaManager:
             begin_dialogs: 预设对话列表
             tools: 工具列表，None 表示使用所有工具，空列表表示不使用任何工具
             skills: Skills 列表，None 表示使用所有 Skills，空列表表示不使用任何 Skills
+            subagents: Subagents 列表，None 表示使用所有 Subagents，空列表表示不使用任何 Subagents
             folder_id: 所属文件夹 ID，None 表示根目录
             sort_order: 排序顺序
         """
@@ -342,6 +347,7 @@ class PersonaManager:
             begin_dialogs,
             tools=tools,
             skills=skills,
+            subagents=subagents,
             custom_error_message=custom_error_message,
             folder_id=folder_id,
             sort_order=sort_order,
@@ -369,6 +375,7 @@ class PersonaManager:
                 "mood_imitation_dialogs": [],  # deprecated
                 "tools": persona.tools,
                 "skills": persona.skills,
+                "subagents": persona.subagents,
                 "custom_error_message": persona.custom_error_message,
             }
             for persona in self.personas
@@ -426,6 +433,7 @@ class PersonaManager:
             begin_dialogs=selected_default_persona["begin_dialogs"],
             tools=selected_default_persona["tools"] or None,
             skills=selected_default_persona["skills"] or None,
+            subagents=selected_default_persona["subagents"] or None,
             custom_error_message=selected_default_persona["custom_error_message"],
         )
 

--- a/astrbot/dashboard/routes/persona.py
+++ b/astrbot/dashboard/routes/persona.py
@@ -58,6 +58,7 @@ class PersonaRoute(Route):
                             "begin_dialogs": persona.begin_dialogs or [],
                             "tools": persona.tools,
                             "skills": persona.skills,
+                            "subagents": persona.subagents,
                             "custom_error_message": persona.custom_error_message,
                             "folder_id": persona.folder_id,
                             "sort_order": persona.sort_order,
@@ -99,6 +100,7 @@ class PersonaRoute(Route):
                         "begin_dialogs": persona.begin_dialogs or [],
                         "tools": persona.tools,
                         "skills": persona.skills,
+                        "subagents": persona.subagents,
                         "custom_error_message": persona.custom_error_message,
                         "folder_id": persona.folder_id,
                         "sort_order": persona.sort_order,
@@ -125,6 +127,7 @@ class PersonaRoute(Route):
             begin_dialogs = data.get("begin_dialogs", [])
             tools = data.get("tools")
             skills = data.get("skills")
+            subagents = data.get("subagents")
             custom_error_message = data.get("custom_error_message")
             folder_id = data.get("folder_id")  # None 表示根目录
             sort_order = data.get("sort_order", 0)
@@ -154,6 +157,7 @@ class PersonaRoute(Route):
                 begin_dialogs=begin_dialogs if begin_dialogs else None,
                 tools=tools if tools else None,
                 skills=skills if skills else None,
+                subagents=subagents if subagents else None,
                 custom_error_message=custom_error_message,
                 folder_id=folder_id,
                 sort_order=sort_order,
@@ -170,6 +174,7 @@ class PersonaRoute(Route):
                             "begin_dialogs": persona.begin_dialogs or [],
                             "tools": persona.tools or [],
                             "skills": persona.skills or [],
+                            "subagents": persona.subagents or [],
                             "custom_error_message": persona.custom_error_message,
                             "folder_id": persona.folder_id,
                             "sort_order": persona.sort_order,
@@ -201,6 +206,8 @@ class PersonaRoute(Route):
             tools = data.get("tools")
             has_skills = "skills" in data
             skills = data.get("skills")
+            has_subagents = "subagents" in data
+            subagents = data.get("subagents")
             has_custom_error_message = "custom_error_message" in data
             custom_error_message = data.get("custom_error_message")
 
@@ -232,6 +239,8 @@ class PersonaRoute(Route):
                 update_kwargs["tools"] = tools
             if has_skills:
                 update_kwargs["skills"] = skills
+            if has_subagents:
+                update_kwargs["subagents"] = subagents
             if has_custom_error_message:
                 update_kwargs["custom_error_message"] = custom_error_message
 

--- a/dashboard/src/components/shared/PersonaForm.vue
+++ b/dashboard/src/components/shared/PersonaForm.vue
@@ -265,6 +265,101 @@
                             </v-expansion-panel-text>
                         </v-expansion-panel>
 
+                        <!-- Subagents 选择面板 -->
+                        <v-expansion-panel value="subagents">
+                            <v-expansion-panel-title>
+                                <v-icon class="mr-2">mdi-vector-link</v-icon>
+                                {{ tm('form.subagents') }}
+                                <v-chip v-if="Array.isArray(personaForm.subagents) && personaForm.subagents.length > 0"
+                                    size="small" color="primary" variant="tonal" class="ml-2">
+                                    {{ personaForm.subagents.length }}
+                                </v-chip>
+                            </v-expansion-panel-title>
+
+                            <v-expansion-panel-text>
+                                <div class="mb-3">
+                                    <p class="text-body-2 text-medium-emphasis">
+                                        {{ tm('form.subagentsHelp') }}
+                                    </p>
+                                </div>
+
+                                <v-radio-group class="mt-2" v-model="subagentSelectValue" hide-details="true">
+                                    <v-radio :label="tm('form.subagentsAllAvailable')" value="0"></v-radio>
+                                    <v-radio :label="tm('form.subagentsSelectSpecific')" value="1"></v-radio>
+                                </v-radio-group>
+
+                                <div v-if="subagentSelectValue === '1'" class="mt-3 selected-config-area">
+                                    <v-text-field v-model="subagentSearch" :label="tm('form.searchSubagents')"
+                                        prepend-inner-icon="mdi-magnify" variant="outlined" density="compact"
+                                        hide-details clearable class="mb-3" />
+
+                                    <div v-if="filteredSubagents.length > 0" class="subagents-selection">
+                                        <v-virtual-scroll :items="filteredSubagents" height="240" item-height="48">
+                                            <template v-slot:default="{ item }">
+                                                <v-list-item :key="item.name" density="comfortable"
+                                                    @click="toggleSubagent(item.name)">
+                                                    <template v-slot:prepend>
+                                                        <v-checkbox-btn :model-value="isSubagentSelected(item.name)"
+                                                            @click.stop="toggleSubagent(item.name)" />
+                                                    </template>
+                                                    <v-list-item-title>
+                                                        {{ item.name }}
+                                                    </v-list-item-title>
+                                                    <v-list-item-subtitle v-if="item.public_description">
+                                                        {{ truncateText(item.public_description, 100) }}
+                                                    </v-list-item-subtitle>
+                                                </v-list-item>
+                                            </template>
+                                        </v-virtual-scroll>
+                                    </div>
+
+                                    <div v-else-if="!loadingSubagents && availableSubagents.length === 0"
+                                        class="text-center pa-4">
+                                        <v-icon size="48" color="grey-lighten-2"
+                                            class="mb-2">mdi-lightning-bolt</v-icon>
+                                        <p class="text-body-2 text-medium-emphasis">{{ tm('form.noSubagentsAvailable') }}
+                                        </p>
+                                    </div>
+
+                                    <div v-else-if="!loadingSubagents && filteredSubagents.length === 0"
+                                        class="text-center pa-4">
+                                        <v-icon size="48" color="grey-lighten-2" class="mb-2">mdi-magnify</v-icon>
+                                        <p class="text-body-2 text-medium-emphasis">{{ tm('form.noSubagentsFound') }}
+                                        </p>
+                                    </div>
+
+                                    <div v-if="loadingSubagents" class="text-center pa-4">
+                                        <v-progress-circular indeterminate color="primary" />
+                                        <p class="text-body-2 text-medium-emphasis mt-2">{{ tm('form.loadingSubagents') }}
+                                        </p>
+                                    </div>
+
+                                    <div class="mt-4">
+                                        <h4 class="text-subtitle-2 mb-2">
+                                            {{ tm('form.selectedSubagents') }}
+                                            <span v-if="personaForm.subagents === null" class="text-success">
+                                                ({{ tm('form.allSelected') }})
+                                            </span>
+                                            <span v-else-if="Array.isArray(personaForm.subagents)">
+                                                ({{ personaForm.subagents.length }})
+                                            </span>
+                                        </h4>
+                                        <div v-if="Array.isArray(personaForm.subagents) && personaForm.subagents.length > 0"
+                                            class="d-flex flex-wrap ga-1" style="max-height: 100px; overflow-y: auto;">
+                                            <v-chip v-for="subagentName in personaForm.subagents" :key="subagentName"
+                                                size="small" color="primary" variant="tonal" closable
+                                                @click:close="removeSubagent(subagentName)">
+                                                {{ subagentName }}
+                                            </v-chip>
+                                        </div>
+                                        <div v-else class="text-body-2 text-medium-emphasis">
+                                            {{ tm('form.noSubagentsSelected') }}
+                                        </div>
+                                    </div>
+                                </div>
+                            </v-expansion-panel-text>
+                        </v-expansion-panel>
+
                         <!-- 预设对话面板 -->
                         <v-expansion-panel value="dialogs">
                             <v-expansion-panel-title>
@@ -367,6 +462,9 @@ export default {
             loadingTools: false,
             availableSkills: [],
             loadingSkills: false,
+            subagentMainEnable:false,
+            availableSubagents: [],
+            loadingSubagents: false,
             existingPersonaIds: [], // 已存在的人格ID列表
             personaForm: {
                 persona_id: '',
@@ -375,6 +473,7 @@ export default {
                 begin_dialogs: [],
                 tools: [],
                 skills: [],
+                subagents: [],
                 folder_id: null
             },
             personaIdRules: [
@@ -388,7 +487,9 @@ export default {
             ],
             toolSearch: '',
             skillSearch: '',
-            skillSelectValue: '0'
+            skillSelectValue: '0',
+            subagentSearch: '',
+            subagentSelectValue: '0'
         }
     },
 
@@ -422,6 +523,16 @@ export default {
                 (skill.description && skill.description.toLowerCase().includes(search))
             );
         },
+        filteredSubagents() {
+            if (!this.subagentSearch) {
+                return this.availableSubagents;
+            }
+            const search = this.subagentSearch.toLowerCase();
+            return this.availableSubagents.filter(subagent =>
+                subagent.name.toLowerCase().includes(search) ||
+                (subagent.public_description && subagent.public_description.toLowerCase().includes(search))
+            );
+        },
         folderDisplayName() {
             // 优先使用传入的文件夹名称
             if (this.currentFolderName) {
@@ -450,6 +561,7 @@ export default {
                 this.loadMcpServers();
                 this.loadTools();
                 this.loadSkills();
+                this.loadSubagents();
             }
         },
         editingPersona: {
@@ -484,6 +596,15 @@ export default {
                     this.personaForm.skills = [];
                 }
             }
+        },
+        subagentSelectValue(newValue) {
+            if (newValue === '0') {
+                this.personaForm.subagents = null;
+            } else if (newValue === '1') {
+                if (this.personaForm.subagents === null) {
+                    this.personaForm.subagents = [];
+                }
+            }
         }
     },
 
@@ -496,10 +617,12 @@ export default {
                 begin_dialogs: [],
                 tools: [],
                 skills: [],
+                subagents: [],
                 folder_id: this.currentFolderId
             };
             this.toolSelectValue = '0';
             this.skillSelectValue = '0';
+            this.subagentSelectValue = '0'
             this.expandedPanels = this.getDefaultExpandedPanels();
         },
 
@@ -511,11 +634,13 @@ export default {
                 begin_dialogs: [...(persona.begin_dialogs || [])],
                 tools: persona.tools === null ? null : [...(persona.tools || [])],
                 skills: persona.skills === null ? null : [...(persona.skills || [])],
+                subagents: persona.subagents === null ? null : [...(persona.subagents || [])],
                 folder_id: persona.folder_id
             };
             // 根据 tools 的值设置 toolSelectValue
             this.toolSelectValue = persona.tools === null ? '0' : '1';
             this.skillSelectValue = persona.skills === null ? '0' : '1';
+            this.subagentSelectValue = persona.subagents === null ? '0' : '1';
             this.expandedPanels = this.getDefaultExpandedPanels();
         },
 
@@ -578,6 +703,32 @@ export default {
                 this.availableSkills = [];
             } finally {
                 this.loadingSkills = false;
+            }
+        },
+
+        async loadSubagents(){
+            this.loadingSubagents = true;
+            try {
+                const response = await axios.get('/api/subagent/config');
+                if (response.data.status === 'ok') {
+                    const payload = response.data.data || [];
+                    this.subagentMainEnable = payload.main_enable;
+                    if (this.subagentMainEnable){
+                        if (Array.isArray(payload)) {
+                            this.availableSubagents = payload.filter(subagent => subagent.enabled !== false);
+                        } else {
+                            const subagents = payload.agents || [];
+                            this.availableSubagents = subagents.filter(subagent => subagent.enabled !== false);
+                        }
+                    }
+                } else {
+                    this.$emit('error', response.data.message || 'Failed to load subagents');
+                }
+            } catch (error) {
+                this.$emit('error', error.response?.data?.message || 'Failed to load subagents');
+                this.availableSubagents = [];
+            } finally {
+                this.loadingSubagents = false;
             }
         },
 
@@ -779,6 +930,38 @@ export default {
             }
         },
 
+        toggleSubagent(subagentName) {
+            if (this.personaForm.subagents === null) {
+                this.personaForm.subagents = this.availableSubagents.map(subagent => subagent.name)
+                    .filter(name => name !== subagentName);
+                this.subagentSelectValue = '1';
+            } else if (Array.isArray(this.personaForm.subagents)) {
+                const index = this.personaForm.subagents.indexOf(subagentName);
+                if (index !== -1) {
+                    this.personaForm.subagents.splice(index, 1);
+                } else {
+                    this.personaForm.subagents.push(subagentName);
+                }
+            } else {
+                this.personaForm.subagents = [subagentName];
+                this.subagentSelectValue = '1';
+            }
+        },
+
+        removeSubagent(subagentName) {
+            if (this.personaForm.subagents === null) {
+                this.personaForm.subagents = this.availableSubagents.map(subagent => subagent.name)
+                    .filter(name => name !== subagentName);
+                this.subagentSelectValue = '1';
+            } else if (Array.isArray(this.personaForm.subagents)) {
+                const index = this.personaForm.subagents.indexOf(subagentName);
+                if (index !== -1) {
+                    this.personaForm.subagents.splice(index, 1);
+                }
+            }
+        },
+
+
         truncateText(text, maxLength) {
             if (!text) return '';
             return text.length > maxLength ? text.substring(0, maxLength) + '...' : text;
@@ -805,6 +988,13 @@ export default {
                 return true;
             }
             return Array.isArray(this.personaForm.skills) && this.personaForm.skills.includes(skillName);
+        },
+
+        isSubagentSelected(subagentName) {
+            if (this.personaForm.subagents === null) {
+                return true;
+            }
+            return Array.isArray(this.personaForm.subagents) && this.personaForm.subagents.includes(subagentName);
         },
 
         isServerSelected(server) {
@@ -864,6 +1054,11 @@ export default {
     overflow-y: auto;
 }
 
+.subagents-selection {
+    max-height: 300px;
+    overflow-y: auto;
+}
+
 .v-virtual-scroll {
     padding-bottom: 16px;
 }
@@ -893,7 +1088,8 @@ export default {
     }
 
     .tools-selection,
-    .skills-selection {
+    .skills-selection,
+    .subagents-selection{
         max-height: 38vh;
     }
 

--- a/dashboard/src/components/shared/PersonaForm.vue
+++ b/dashboard/src/components/shared/PersonaForm.vue
@@ -462,7 +462,6 @@ export default {
             loadingTools: false,
             availableSkills: [],
             loadingSkills: false,
-            subagentMainEnable:false,
             availableSubagents: [],
             loadingSubagents: false,
             existingPersonaIds: [], // 已存在的人格ID列表

--- a/dashboard/src/components/shared/PersonaForm.vue
+++ b/dashboard/src/components/shared/PersonaForm.vue
@@ -712,15 +712,8 @@ export default {
                 const response = await axios.get('/api/subagent/config');
                 if (response.data.status === 'ok') {
                     const payload = response.data.data || [];
-                    this.subagentMainEnable = payload.main_enable;
-                    if (this.subagentMainEnable){
-                        if (Array.isArray(payload)) {
-                            this.availableSubagents = payload.filter(subagent => subagent.enabled !== false);
-                        } else {
-                            const subagents = payload.agents || [];
-                            this.availableSubagents = subagents.filter(subagent => subagent.enabled !== false);
-                        }
-                    }
+                    const subagents = payload.agents || [];
+                    this.availableSubagents = subagents.filter(subagent => subagent.enabled !== false);
                 } else {
                     this.$emit('error', response.data.message || 'Failed to load subagents');
                 }

--- a/dashboard/src/i18n/locales/en-US/features/persona.json
+++ b/dashboard/src/i18n/locales/en-US/features/persona.json
@@ -52,6 +52,17 @@
     "allSkillsAvailable": "Use all available Skills",
     "noSkillsSelected": "No skills selected",
     "skillsRuntimeNoneWarning": "Computer Use runtime is set to None; Skills may not run correctly because no runtime is enabled.",
+    "subagents": "Subagents Selection",
+    "subagentsHelp": "Select available Subagents for this persona. Subagents can participate as auxiliary agents in task execution.",
+    "subagentsAllAvailable": "Use all Subagents by default",
+    "subagentsSelectSpecific": "Select specific Subagents",
+    "searchSubagents": "Search Subagents",
+    "selectedSubagents": "Selected Subagents",
+    "noSubagentsAvailable": "No Subagents available",
+    "noSubagentsFound": "No matching Subagents found",
+    "loadingSubagents": "Loading Subagents...",
+    "allSubagentsAvailable": "Use all available Subagents",
+    "noSubagentsSelected": "No Subagents selected",
     "createInFolder": "Will be created in \"{folder}\"",
     "rootFolder": "All Personas"
   },
@@ -88,6 +99,7 @@
     "personasTitle": "Personas",
     "toolsCount": "tools",
     "skillsCount": "skills",
+    "subagentsCount": "subagents",
     "contextMenu": {
       "moveTo": "Move to..."
     },

--- a/dashboard/src/i18n/locales/ru-RU/features/persona.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/persona.json
@@ -52,6 +52,17 @@
         "allSkillsAvailable": "Использовать все доступные навыки",
         "noSkillsSelected": "Навыки не выбраны",
         "skillsRuntimeNoneWarning": "Среда выполнения Computer Use не задана. Навыки могут не работать, так как нет активного окружения.",
+        "subagents": "Выбор Subagents",
+        "subagentsHelp": "Выберите доступных Subagents для этого персонажа. Subagents могут участвовать в выполнении задач в качестве вспомогательных агентов.",
+        "subagentsAllAvailable": "По умолчанию использовать всех Subagents",
+        "subagentsSelectSpecific": "Выбрать конкретных Subagents",
+        "searchSubagents": "Поиск Subagents",
+        "selectedSubagents": "Выбранные Subagents",
+        "noSubagentsAvailable": "Нет доступных Subagents",
+        "noSubagentsFound": "Совпадающие Subagents не найдены",
+        "loadingSubagents": "Загрузка Subagents...",
+        "allSubagentsAvailable": "Использовать всех доступных Subagents",
+        "noSubagentsSelected": "Не выбрано ни одного Subagents",
         "createInFolder": "Будет создан в папке «{folder}»",
         "rootFolder": "Все персонажи"
     },
@@ -88,6 +99,7 @@
         "personasTitle": "Персонаж",
         "toolsCount": "инстр.",
         "skillsCount": "навыков",
+        "subagentsCount": "subagents",
         "contextMenu": {
             "moveTo": "Переместить в..."
         },

--- a/dashboard/src/i18n/locales/zh-CN/features/persona.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/persona.json
@@ -52,6 +52,17 @@
     "allSkillsAvailable": "使用所有可用 Skills",
     "noSkillsSelected": "未选择任何 Skills",
     "skillsRuntimeNoneWarning": "Computer Use 运行环境为无，Skills 可能无法正确被 Agent 运行，因为没有启用运行环境。",
+    "subagents": "Subagents 选择",
+    "subagentsHelp": "为这个人格选择可用的 Subagents。Subagents 可以作为辅助代理参与任务执行。",
+    "subagentsAllAvailable": "默认使用全部 Subagents",
+    "subagentsSelectSpecific": "选择指定 Subagents",
+    "searchSubagents": "搜索 Subagents",
+    "selectedSubagents": "已选择的 Subagents",
+    "noSubagentsAvailable": "暂无可用 Subagents",
+    "noSubagentsFound": "未找到匹配的 Subagents",
+    "loadingSubagents": "正在加载 Subagents...",
+    "allSubagentsAvailable": "使用所有可用 Subagents",
+    "noSubagentsSelected": "未选择任何 Subagents",
     "createInFolder": "将在「{folder}」中创建",
     "rootFolder": "全部人格"
   },
@@ -88,6 +99,7 @@
     "personasTitle": "人格",
     "toolsCount": "个工具",
     "skillsCount": "个 Skills",
+    "subagentsCount": "个 Subagents",
     "contextMenu": {
       "moveTo": "移动到..."
     },

--- a/dashboard/src/views/persona/PersonaCard.vue
+++ b/dashboard/src/views/persona/PersonaCard.vue
@@ -58,11 +58,11 @@
                     {{ persona.skills.length }} {{ tm('persona.skillsCount') }}
                 </v-chip>
                 <v-chip v-if="persona.subagents === null" size="small" color="success" variant="tonal"
-                    prepend-icon="mdi-lightning-bolt">
+                    prepend-icon="mdi-vector-link">
                     {{ tm('form.allSubagentsAvailable') }}
                 </v-chip>
                 <v-chip v-else-if="persona.subagents && persona.subagents.length > 0" size="small" color="primary"
-                    variant="tonal" prepend-icon="mdi-lightning-bolt">
+                    variant="tonal" prepend-icon="mdi-vector-link">
                     {{ persona.subagents.length }} {{ tm('persona.subagentsCount') }}
                 </v-chip>
             </div>

--- a/dashboard/src/views/persona/PersonaCard.vue
+++ b/dashboard/src/views/persona/PersonaCard.vue
@@ -57,6 +57,14 @@
                     variant="tonal" prepend-icon="mdi-lightning-bolt">
                     {{ persona.skills.length }} {{ tm('persona.skillsCount') }}
                 </v-chip>
+                <v-chip v-if="persona.subagents === null" size="small" color="success" variant="tonal"
+                    prepend-icon="mdi-lightning-bolt">
+                    {{ tm('form.allSubagentsAvailable') }}
+                </v-chip>
+                <v-chip v-else-if="persona.subagents && persona.subagents.length > 0" size="small" color="primary"
+                    variant="tonal" prepend-icon="mdi-lightning-bolt">
+                    {{ persona.subagents.length }} {{ tm('persona.subagentsCount') }}
+                </v-chip>
             </div>
 
             <div class="mt-3 text-caption text-medium-emphasis">
@@ -83,6 +91,7 @@ interface Persona {
     begin_dialogs?: string[] | null;
     tools?: string[] | null;
     skills?: string[] | null;
+    subagents?: string[] | null;
     created_at?: string;
     updated_at?: string;
     folder_id?: string | null;

--- a/dashboard/src/views/persona/PersonaManager.vue
+++ b/dashboard/src/views/persona/PersonaManager.vue
@@ -191,6 +191,25 @@
                         </div>
                     </div>
 
+                    <div class="mb-4">
+                        <h4 class="text-h6 mb-2">{{ tm('form.subagents') }}</h4>
+                        <div v-if="viewingPersona.subagents === null" class="text-body-2 text-medium-emphasis">
+                            <v-chip size="small" color="success" variant="tonal" prepend-icon="mdi-check-all">
+                                {{ tm('form.allSubagentsAvailable') }}
+                            </v-chip>
+                        </div>
+                        <div v-else-if="viewingPersona.subagents && viewingPersona.subagents.length > 0"
+                            class="d-flex flex-wrap ga-1">
+                            <v-chip v-for="subagentName in viewingPersona.subagents" :key="subagentName" size="small"
+                                color="primary" variant="tonal">
+                                {{ subagentName }}
+                            </v-chip>
+                        </div>
+                        <div v-else class="text-body-2 text-medium-emphasis">
+                            {{ tm('form.noSubagentsSelected') }}
+                        </div>
+                    </div>
+
                     <div class="text-caption text-medium-emphasis">
                         <div>{{ tm('labels.createdAt') }}: {{ formatDate(viewingPersona.created_at) }}</div>
                         <div v-if="viewingPersona.updated_at">{{ tm('labels.updatedAt') }}:
@@ -290,6 +309,7 @@ interface Persona {
     begin_dialogs?: string[] | null;
     tools?: string[] | null;
     skills?: string[] | null;
+    subagents?: string[] | null;
     created_at?: string;
     updated_at?: string;
     folder_id?: string | null;


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
增加 Subagent 选择功能，类似Skill选择，允许指定人格可调用的 Subagent 范围，从而避免无限制调用所有已配置并启用 Subagent，降低权限风险

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
- 在 Persona 数据库模型中新增 subagents 字段，支持选择特定 Subagents
- 在仪表板人格表单中添加 Subagents 选择面板，支持搜索和批量选择
- 在人格卡片和详情页中显示 Subagents 配置状态和数量
- 在核心代理逻辑中根据人格配置过滤可用的 Subagents
- 更新所有相关 API 接口以支持 subagents 字段的增删改查
- 添加多语言支持（中文、英文、俄文）的 Subagents 相关文本
- 确保数据库迁移兼容性，自动添加 subagents 列到现有表

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/e24edbce-144a-49c1-a014-5053af36bc7f" />

#### 观察persona_toolset

- 测试人格1，只能调用testagent1
<img width="2282" height="888" alt="image" src="https://github.com/user-attachments/assets/42857933-93d8-4d65-a7bd-51e003e0ccea" />

- 测试人格2，只能调用testagent2
<img width="1348" height="906" alt="image" src="https://github.com/user-attachments/assets/ec70272a-e5aa-4c3b-b85d-4ebb703d8f02" />

- 测试人格3，能调用所有subagents
<img width="1519" height="1150" alt="image" src="https://github.com/user-attachments/assets/e9a4f78b-5ff0-4455-bae9-161480ae7d50" />


<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Add persona-level configuration for allowed subagents and integrate it through the backend, database, and dashboard UI.

New Features:
- Allow personas to specify which subagents they can call, with support for using all or none.

Enhancements:
- Filter available agents and handoff tools at runtime based on persona subagent configuration to limit cross-agent calls.
- Extend persona APIs, database models, and migrations to persist subagent allowlists and expose them via v3 persona data.
- Update dashboard persona forms, cards, and details views to manage and display subagent configuration, including search and multi-select UI and i18n labels.