### PR TITLE
fix: append /v1 for OpenAI embedding api base

### DIFF
--- a/astrbot/core/provider/sources/openai_embedding_source.py
+++ b/astrbot/core/provider/sources/openai_embedding_source.py
@@ -26,17 +26,17 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         ``https://example.com`` or ``https://example.com/openai``. More specific
         paths (for example ``/v1-beta`` or ``/v1/embeddings``) are preserved as-is.
         """
-        normalized_api_base = api_base.rstrip("/")
-        parsed = urlsplit(normalized_api_base)
-        path_segments = [segment for segment in parsed.path.split("/") if segment]
+        parsed = urlsplit(api_base)
+        normalized_path = parsed.path.rstrip("/") if parsed.path else ""
+        path_segments = [segment for segment in normalized_path.split("/") if segment]
         has_version_segment = any(
             len(segment) > 1 and segment.startswith("v") and segment[1].isdigit()
             for segment in path_segments
         )
         if has_version_segment or len(path_segments) > 1:
-            return normalized_api_base
+            return urlunsplit(parsed._replace(path=normalized_path))
 
-        normalized_path = f"{parsed.path.rstrip('/')}/v1" if parsed.path else "/v1"
+        normalized_path = f"{normalized_path}/v1" if normalized_path else "/v1"
         return urlunsplit(parsed._replace(path=normalized_path))
 
     def __init__(self, provider_config: dict, provider_settings: dict) -> None:

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -611,3 +611,17 @@ async def test_openai_embedding_provider_preserves_versioned_or_specific_paths()
             assert str(provider.client.base_url) == f"{base_url.rstrip('/')}/"
         finally:
             await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding_provider_preserves_query_and_fragment_when_normalizing_path():
+    provider = _make_embedding_provider(
+        {"embedding_api_base": "https://example.com/openai/?next=/foo/#frag/"}
+    )
+    try:
+        assert (
+            str(provider.client.base_url)
+            == "https://example.com/openai/v1?next=/foo/#frag/"
+        )
+    finally:
+        await provider.terminate()


### PR DESCRIPTION
## Summary
- normalize `embedding_api_base` for the OpenAI embedding provider
- append `/v1` automatically when the configured base URL omits it
- add regression tests for both missing and existing `/v1` suffixes

## Problem
When `embedding_api_base` is configured without `/v1`, the OpenAI embedding client uses the raw base URL and requests fail against OpenAI-compatible endpoints that expect the `/v1` prefix.

Closes #6855

## Testing
- uv run pytest tests/test_openai_source.py -q
- uv run ruff format .
- uv run ruff check .

## Summary by Sourcery

Normalize OpenAI embedding API base URL handling and add regression coverage for various base URL configurations.

Bug Fixes:
- Ensure OpenAI embedding provider automatically appends /v1 to root-style embedding_api_base values that omit the version segment.
- Avoid introducing duplicate slashes and preserve versioned or path-specific embedding API base URLs, including query strings and fragments.
- Fall back to the default OpenAI embedding base URL when embedding_api_base is blank in the configuration.

Tests:
- Add unit tests covering normalization of embedding_api_base, including missing or existing /v1, trailing slashes, blank values, versioned paths, and URLs with query/fragment components.