### PR TITLE
feat: add provider adapter i18n registration support

### DIFF
--- a/astrbot/api/provider/__init__.py
+++ b/astrbot/api/provider/__init__.py
@@ -1,18 +1,18 @@
 from astrbot.core.db.po import Personality
 from astrbot.core.provider import (
-    Provider,
-    STTProvider,
-    STTProvider,
     EmbeddingProvider,
+    Provider,
     RerankProvider,
+    STTProvider,
+    TTSProvider,
 )
-from astrbot.core.provider.register import register_provider_adapter
 from astrbot.core.provider.entities import (
     LLMResponse,
     ProviderMetaData,
     ProviderRequest,
     ProviderType,
 )
+from astrbot.core.provider.register import register_provider_adapter
 
 __all__ = [
     "LLMResponse",
@@ -22,7 +22,7 @@ __all__ = [
     "ProviderRequest",
     "ProviderType",
     "STTProvider",
-    "STTProvider",
+    "TTSProvider",
     "EmbeddingProvider",
     "RerankProvider",
     "register_provider_adapter",

--- a/astrbot/api/provider/__init__.py
+++ b/astrbot/api/provider/__init__.py
@@ -1,5 +1,11 @@
 from astrbot.core.db.po import Personality
-from astrbot.core.provider import Provider, STTProvider, STTProvider, EmbeddingProvider, RerankProvider
+from astrbot.core.provider import (
+    Provider,
+    STTProvider,
+    STTProvider,
+    EmbeddingProvider,
+    RerankProvider,
+)
 from astrbot.core.provider.register import register_provider_adapter
 from astrbot.core.provider.entities import (
     LLMResponse,
@@ -19,5 +25,5 @@ __all__ = [
     "STTProvider",
     "EmbeddingProvider",
     "RerankProvider",
-    "register_provider_adapter"
+    "register_provider_adapter",
 ]

--- a/astrbot/api/provider/__init__.py
+++ b/astrbot/api/provider/__init__.py
@@ -1,5 +1,6 @@
 from astrbot.core.db.po import Personality
-from astrbot.core.provider import Provider, STTProvider
+from astrbot.core.provider import Provider, STTProvider, STTProvider, EmbeddingProvider, RerankProvider
+from astrbot.core.provider.register import register_provider_adapter
 from astrbot.core.provider.entities import (
     LLMResponse,
     ProviderMetaData,
@@ -15,4 +16,8 @@ __all__ = [
     "ProviderRequest",
     "ProviderType",
     "STTProvider",
+    "STTProvider",
+    "EmbeddingProvider",
+    "RerankProvider",
+    "register_provider_adapter"
 ]

--- a/astrbot/core/provider/__init__.py
+++ b/astrbot/core/provider/__init__.py
@@ -1,17 +1,17 @@
 from .entities import ProviderMetaData
 from .provider import (
-    Provider,
-    STTProvider,
-    STTProvider,
     EmbeddingProvider,
+    Provider,
     RerankProvider,
+    STTProvider,
+    TTSProvider,
 )
 
 __all__ = [
     "Provider",
     "ProviderMetaData",
     "STTProvider",
-    "STTProvider",
     "EmbeddingProvider",
     "RerankProvider",
+    "TTSProvider",
 ]

--- a/astrbot/core/provider/__init__.py
+++ b/astrbot/core/provider/__init__.py
@@ -1,4 +1,17 @@
 from .entities import ProviderMetaData
-from .provider import Provider, STTProvider, STTProvider, EmbeddingProvider, RerankProvider
+from .provider import (
+    Provider,
+    STTProvider,
+    STTProvider,
+    EmbeddingProvider,
+    RerankProvider,
+)
 
-__all__ = ["Provider", "ProviderMetaData", "STTProvider", "STTProvider", "EmbeddingProvider", "RerankProvider"]
+__all__ = [
+    "Provider",
+    "ProviderMetaData",
+    "STTProvider",
+    "STTProvider",
+    "EmbeddingProvider",
+    "RerankProvider",
+]

--- a/astrbot/core/provider/__init__.py
+++ b/astrbot/core/provider/__init__.py
@@ -1,4 +1,4 @@
 from .entities import ProviderMetaData
-from .provider import Provider, STTProvider
+from .provider import Provider, STTProvider, STTProvider, EmbeddingProvider, RerankProvider
 
-__all__ = ["Provider", "ProviderMetaData", "STTProvider"]
+__all__ = ["Provider", "ProviderMetaData", "STTProvider", "STTProvider", "EmbeddingProvider", "RerankProvider"]

--- a/astrbot/core/provider/entities.py
+++ b/astrbot/core/provider/entities.py
@@ -58,6 +58,10 @@ class ProviderMetaData(ProviderMeta):
     """the default configuration template of the provider adapter"""
     provider_display_name: str | None = None
     """the display name of the provider shown in the WebUI configuration page; if empty, the type is used"""
+    i18n_resources: dict[str, dict] | None = None
+    """the i18n resources of the provider adapter"""
+    config_metadata: dict | None = None
+    """the config metadata of the provider adapter"""
 
 
 @dataclass

--- a/astrbot/core/provider/register.py
+++ b/astrbot/core/provider/register.py
@@ -17,6 +17,8 @@ def register_provider_adapter(
     provider_type: ProviderType = ProviderType.CHAT_COMPLETION,
     default_config_tmpl: dict | None = None,
     provider_display_name: str | None = None,
+    i18n_resources: dict[str, dict] | None = None,
+    config_metadata: dict | None = None,
 ):
     """用于注册平台适配器的带参装饰器"""
 
@@ -44,6 +46,8 @@ def register_provider_adapter(
             cls_type=cls,
             default_config_tmpl=default_config_tmpl,
             provider_display_name=provider_display_name,
+            i18n_resources=i18n_resources,
+            config_metadata=config_metadata,
         )
         provider_registry.append(pm)
         provider_cls_map[provider_type_name] = pm

--- a/astrbot/dashboard/routes/config.py
+++ b/astrbot/dashboard/routes/config.py
@@ -519,13 +519,30 @@ class ConfigRoute(Route):
                 }
             }
         )
-        config_schema = {
-            "provider": provider_metadata["provider_group"]["metadata"]["provider"]
+        provider_i18n_translations = {}
+        provider_schema = provider_metadata["provider_group"]["metadata"]["provider"]
+        config_schema = {"provider": provider_schema}
+
+        provider_default_tmpl = config_schema["provider"]["config_template"]
+        provider_schema_wrapper = {
+            "provider_group": {"metadata": {"provider": provider_schema}}
         }
+        for provider in provider_registry:
+            if provider.default_config_tmpl:
+                provider_default_tmpl[provider.type] = copy.deepcopy(
+                    provider.default_config_tmpl
+                )
+            if provider.config_metadata:
+                self._inject_provider_metadata_with_i18n(
+                    provider,
+                    provider_schema_wrapper,
+                    provider_i18n_translations,
+                )
         data = {
             "config_schema": config_schema,
             "providers": astrbot_config["provider"],
             "provider_sources": astrbot_config["provider_sources"],
+            "provider_i18n_translations": provider_i18n_translations,
         }
         return Response().ok(data=data).__dict__
 
@@ -1411,6 +1428,33 @@ class ConfigRoute(Route):
                 f"Unexpected error registering logo for platform {platform.name}: {e}",
             )
 
+    def _rewrite_metadata_i18n_keys(
+        self, metadata: dict, i18n_prefix: str, field_path: str = ""
+    ):
+        """Rewrite metadata text fields to dynamic i18n keys recursively."""
+        for field_key, field_value in metadata.items():
+            if not isinstance(field_value, dict):
+                continue
+
+            current_path = f"{field_path}.{field_key}" if field_path else field_key
+            for key in ("description", "hint", "labels", "name"):
+                if key in field_value:
+                    field_value[key] = f"{i18n_prefix}.{current_path}.{key}"
+
+            if "items" in field_value and isinstance(field_value["items"], dict):
+                self._rewrite_metadata_i18n_keys(
+                    field_value["items"], i18n_prefix, current_path
+                )
+
+            if "template_schema" in field_value and isinstance(
+                field_value["template_schema"], dict
+            ):
+                self._rewrite_metadata_i18n_keys(
+                    field_value["template_schema"],
+                    i18n_prefix,
+                    f"{current_path}.template_schema",
+                )
+
     def _inject_platform_metadata_with_i18n(
         self, platform, metadata, platform_i18n_translations: dict
     ):
@@ -1426,13 +1470,31 @@ class ConfigRoute(Route):
                     "platform_group", {}
                 ).setdefault("platform", {})[platform.name] = lang_data
 
-            for field_key, field_value in platform_items_to_inject.items():
-                for key in ("description", "hint", "labels"):
-                    if key in field_value:
-                        field_value[key] = f"{i18n_prefix}.{field_key}.{key}"
+            self._rewrite_metadata_i18n_keys(platform_items_to_inject, i18n_prefix)
 
         metadata["platform_group"]["metadata"]["platform"]["items"].update(
             platform_items_to_inject
+        )
+
+    def _inject_provider_metadata_with_i18n(
+        self, provider, metadata, provider_i18n_translations: dict
+    ):
+        """Inject provider config metadata and rewrite dynamic i18n keys."""
+        metadata["provider_group"]["metadata"]["provider"].setdefault("items", {})
+        provider_items_to_inject = copy.deepcopy(provider.config_metadata)
+
+        if provider.i18n_resources:
+            i18n_prefix = f"provider_group.provider.{provider.type}"
+
+            for lang, lang_data in provider.i18n_resources.items():
+                provider_i18n_translations.setdefault(lang, {}).setdefault(
+                    "provider_group", {}
+                ).setdefault("provider", {})[provider.type] = lang_data
+
+            self._rewrite_metadata_i18n_keys(provider_items_to_inject, i18n_prefix)
+
+        metadata["provider_group"]["metadata"]["provider"]["items"].update(
+            provider_items_to_inject
         )
 
     async def _get_astrbot_config(self):
@@ -1487,14 +1549,22 @@ class ConfigRoute(Route):
         provider_default_tmpl = metadata["provider_group"]["metadata"]["provider"][
             "config_template"
         ]
+        provider_i18n_translations = {}
         for provider in provider_registry:
             if provider.default_config_tmpl:
-                provider_default_tmpl[provider.type] = provider.default_config_tmpl
+                provider_default_tmpl[provider.type] = copy.deepcopy(
+                    provider.default_config_tmpl
+                )
+            if provider.config_metadata:
+                self._inject_provider_metadata_with_i18n(
+                    provider, metadata, provider_i18n_translations
+                )
 
         return {
             "metadata": metadata,
             "config": config,
             "platform_i18n_translations": platform_i18n_translations,
+            "provider_i18n_translations": provider_i18n_translations,
         }
 
     async def _get_plugin_config(self, plugin_name: str):

--- a/dashboard/src/composables/useProviderSources.ts
+++ b/dashboard/src/composables/useProviderSources.ts
@@ -1,8 +1,9 @@
-import { ref, computed, onMounted, nextTick, watch } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue'
 import axios from 'axios'
 import { getProviderIcon } from '@/utils/providerUtils'
 import { askForConfirmation as askForConfirmationDialog, useConfirmDialog } from '@/utils/confirmDialog'
 import { normalizeTextInput } from '@/utils/inputValue'
+import { mergeDynamicTranslations } from '@/i18n/composables'
 
 export interface UseProviderSourcesOptions {
   defaultTab?: string
@@ -43,6 +44,16 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
 
   async function askForConfirmation(message: string) {
     return askForConfirmationDialog(message, confirmDialog)
+  }
+
+  function applyProviderDynamicI18n(providerI18nTranslations?: Record<string, any>) {
+    if (providerI18nTranslations && typeof providerI18nTranslations === 'object') {
+      mergeDynamicTranslations('features.config-metadata', providerI18nTranslations)
+    }
+  }
+
+  function handleLocaleChange() {
+    void loadProviderTemplate()
   }
 
   // ===== State =====
@@ -628,6 +639,7 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
     try {
       const response = await axios.get('/api/config/provider/template')
       if (response.data.status === 'ok') {
+        applyProviderDynamicI18n(response.data.data.provider_i18n_translations)
         configSchema.value = response.data.data.config_schema || {}
         if (configSchema.value.provider?.config_template) {
           providerTemplates.value = configSchema.value.provider.config_template
@@ -645,7 +657,12 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
   }
 
   onMounted(async () => {
+    window.addEventListener('astrbot-locale-changed', handleLocaleChange)
     await loadProviderTemplate()
+  })
+
+  onBeforeUnmount(() => {
+    window.removeEventListener('astrbot-locale-changed', handleLocaleChange)
   })
 
   return {


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

此项更改为 Provider 适配器增加了动态 i18n 注册支持，与现有的平台适配器机制保持一致。
在此更改之前，register_provider_adapter 无法声明 i18n_resources 或 config_metadata，因此 Provider 适配器缺少完整的后端到前端 i18n 注册路径。这导致自定义 Provider 配置字段无法参与到平台适配器所使用的同一套已翻译的 WebUI 表单流程中。

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

`astrbot/core/provider/entities.py`
在 ProviderMetaData 中添加了 i18n_resources 和 config_metadata，使 Provider 适配器注册能够通过后端注册层携带自定义的 i18n 负载和配置元数据。

`astrbot/core/provider/register.py`
扩展了 register_provider_adapter(...) 以接受 i18n_resources 和 config_metadata，并将其持久化到 ProviderMetaData 中。这保持了旧注册的兼容性，同时启用了 Provider 端的 i18n 注册功能。

`astrbot/dashboard/routes/config.py`
添加了 Provider 元数据注入和动态 i18n 响应支持。
为 description / hint / labels / name 实现了递归的元数据 i18n 键重写，包括嵌套的 items 和 template_schema。
添加了使用 provider_group.provider.{provider.type}.* 的 Provider 端键路径生成。
扩展了 /api/config/get 和 /api/config/provider/template 两个接口，使其返回 provider_i18n_translations。
将 Provider 适配器的 config_metadata 注入到 Provider 架构生成中。

`dashboard/src/composables/useProviderSources.ts`
通过 mergeDynamicTranslations('features.config-metadata', ...) 添加了动态 Provider i18n 合并逻辑。
将 Provider 翻译加载路径集中到共享的组合式函数中，使 Provider 页面和 Provider 配置对话框都能受益于相同的动态 i18n 行为。
添加了语言切换重新加载处理，以便在切换语言时刷新 Provider 适配器的翻译。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<img width="1569" height="777" alt="image" src="https://github.com/user-attachments/assets/49da3b3c-deee-4bee-a94b-e674a56a4a5a" />
<img width="1916" height="875" alt="image" src="https://github.com/user-attachments/assets/16330454-3f3c-4bff-96f3-1c4ae683f2fe" />
<img width="1901" height="863" alt="image" src="https://github.com/user-attachments/assets/14406381-fd6d-45a5-b880-4e2ddffe0310" />
<img width="1895" height="707" alt="image" src="https://github.com/user-attachments/assets/29c102fa-f8da-4ebd-b864-6e1e298be3bf" />

测试插件代码(节选)

```python
from astrbot.api.provider import register_provider_adapter
from astrbot.api.provider import ProviderType
from astrbot.api.provider import EmbeddingProvider

DEFAULT_MODEL_NAME = "paraphrase-multilingual-MiniLM-L12-v2"
STEMBEDDING_PROVIDER_TEMPLATE = {
    "id": "STEmbedding",
    "type": "STEmbedding",
    "provider": "Local",
    "STEmbedding_path": DEFAULT_MODEL_NAME,
    "STEmbedding_torch_load_weights_only": "auto",
    "provider_type": "embedding",
    "enable": True,
    "embedding_dimensions": 384,
}
STEMBEDDING_PROVIDER_CONFIG_METADATA = {
    "STEmbedding_path": {
        "type": "string",
        "description": "",
        "hint": "",
    },
    "STEmbedding_torch_load_weights_only": {
        "type": "string",
        "description": "",
        "hint": "",
    },
}
STEMBEDDING_PROVIDER_I18N_RESOURCES = {
    "zh-CN": {
        "name": "STEmbedding",
        "STEmbedding_path": {
            "description": "Sentence Transformers 模型路径",
            "hint": "支持相对路径和绝对路径。相对路径会基于 AstrBot 的数据目录解析。",
        },
        "STEmbedding_torch_load_weights_only": {
            "description": "PyTorch torch.load 的 weights_only 行为",
            "hint": "可选 auto、true、false。PyTorch 2.6+ 默认更严格，旧模型遇到加载失败时可尝试 false，但只建议用于可信模型。",
        },
    },
    "en-US": {
        "name": "STEmbedding",
        "STEmbedding_path": {
            "description": "Sentence Transformers model path",
            "hint": "Supports both relative and absolute paths. Relative paths are resolved from the AstrBot data directory.",
        },
        "STEmbedding_torch_load_weights_only": {
            "description": "PyTorch torch.load weights_only behavior",
            "hint": "Available values: auto, true, false. PyTorch 2.6+ is stricter by default. If an older model fails to load, you can try false, but only for trusted models.",
        },
    },
    "ru-RU": {
        "name": "STEmbedding",
        "STEmbedding_path": {
            "description": "Путь к модели Sentence Transformers",
            "hint": "Поддерживаются относительные и абсолютные пути. Относительные пути вычисляются относительно каталога данных AstrBot.",
        },
        "STEmbedding_torch_load_weights_only": {
            "description": "Поведение параметра weights_only в PyTorch torch.load",
            "hint": "Допустимые значения: auto, true, false. В PyTorch 2.6+ загрузка по умолчанию стала строже. Если старая модель не загружается, можно попробовать false, но только для доверенных моделей.",
        },
    },
}

def register_STEmbeddingProvider():
    try:
        register_provider_adapter(
            "STEmbedding",
            "Sentence Transformers Embedding Provider",
            provider_type=ProviderType.EMBEDDING,
            provider_display_name="STEmbedding",
            default_config_tmpl=STEMBEDDING_PROVIDER_TEMPLATE.copy(),
            config_metadata={
                key: value.copy()
                for key, value in STEMBEDDING_PROVIDER_CONFIG_METADATA.items()
            },
            i18n_resources=STEMBEDDING_PROVIDER_I18N_RESOURCES,
        )(STEmbeddingProvider)
        logger.info("[STEmbedding] Provider 已注册")
    except ValueError:
        logger.info("[STEmbedding] Provider 已存在，跳过注册")
```
---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [ x ] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

有进行测试

- [ x ] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

没有引入新库

- [ x ] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

没有引入

## Summary by Sourcery

Add dynamic i18n registration and metadata support for provider adapters and expose provider adapter types and registration utilities through the public API.

New Features:
- Allow provider adapters to register i18n resources and configuration metadata via the ProviderMetaData model and register_provider_adapter decorator.
- Return provider-specific i18n translations alongside configuration schemas from backend config endpoints for use in the Web UI.
- Enable the frontend provider configuration UI to merge and reload dynamic provider i18n translations when templates are fetched or the locale changes.
- Expose additional provider adapter base classes and the provider adapter registration helper through the astrbot.api.provider package.

Enhancements:
- Refactor platform metadata i18n key rewriting into a reusable helper and reuse it for provider metadata to support nested schemas.