### PR TITLE
fix(provider): restore parameter transparency in core LLM provider adapters

### DIFF
--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -515,8 +515,7 @@ class ProviderAnthropic(Provider):
 
         model = model or self.get_model()
 
-        payloads = {"messages": new_messages, "model": model}
-        payloads.update(kwargs)
+        payloads = {**kwargs, "messages": new_messages, "model": model}
 
         # Anthropic has a different way of handling system prompts
         if system_prompt:
@@ -572,8 +571,7 @@ class ProviderAnthropic(Provider):
 
         model = model or self.get_model()
 
-        payloads = {"messages": new_messages, "model": model}
-        payloads.update(kwargs)
+        payloads = {**kwargs, "messages": new_messages, "model": model}
 
         # Anthropic has a different way of handling system prompts
         if system_prompt:

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -757,8 +757,7 @@ class ProviderGoogleGenAI(Provider):
 
         model = model or self.get_model()
 
-        payloads = {"messages": context_query, "model": model}
-        payloads.update(kwargs)
+        payloads = {**kwargs, "messages": context_query, "model": model}
 
         retry = 10
         keys = self.api_keys.copy()
@@ -813,8 +812,7 @@ class ProviderGoogleGenAI(Provider):
 
         model = model or self.get_model()
 
-        payloads = {"messages": context_query, "model": model}
-        payloads.update(kwargs)
+        payloads = {**kwargs, "messages": context_query, "model": model}
 
         retry = 10
         keys = self.api_keys.copy()

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -619,8 +619,7 @@ class ProviderOpenAIOfficial(Provider):
                     context_query.extend(tcr.to_openai_messages())
 
         model = model or self.get_model()
-        payloads = {"messages": context_query, "model": model}
-        payloads.update(kwargs)
+        payloads = {**kwargs, "messages": context_query, "model": model}
 
         self._finally_convert_payload(payloads)
 


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

核心对话适配器（OpenAI, Anthropic, Gemini）在准备请求 Payload 时未对 kwargs 进行合并，导致插件层传入的自定义参数（如 max_tokens, temperature, timeout 等）失效，回退到提供商的保守默认值。本次修复确保了各主流模型适配器对请求参数的完整透传。

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->



---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Restore propagation of caller-supplied kwargs (e.g., runtime parameters) into chat request payloads for OpenAI, Anthropic, and Gemini providers so they no longer fall back to provider defaults.