### PR TITLE
fix: retry qq_official startup after gateway timeout

### DIFF
--- a/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
@@ -11,6 +11,7 @@ from typing import Any, cast
 import botpy
 import botpy.message
 from botpy import Client
+from botpy.client import ConnectionSession, Robot, Token
 
 from astrbot import logger
 from astrbot.api.event import MessageChain
@@ -34,9 +35,42 @@ for handler in logging.root.handlers[:]:
 
 
 # QQ 机器人官方框架
+class QQOfficialGatewayUnavailableError(RuntimeError):
+    """botpy returned no usable gateway metadata during startup."""
+
+
 class botClient(Client):
     def set_platform(self, platform: QQOfficialPlatformAdapter) -> None:
         self.platform = platform
+
+    async def _bot_login(self, token: Token) -> None:
+        user = await self.http.login(token)
+
+        # botpy may return None here after a transient /gateway/bot timeout.
+        self._ws_ap = await self.api.get_ws_url()
+        session_limit = (
+            self._ws_ap.get("session_start_limit")
+            if isinstance(self._ws_ap, dict)
+            else None
+        )
+        max_concurrency = (
+            session_limit.get("max_concurrency")
+            if isinstance(session_limit, dict)
+            else None
+        )
+        if not isinstance(max_concurrency, int):
+            raise QQOfficialGatewayUnavailableError(
+                "gateway metadata unavailable during qq_official startup"
+            )
+
+        self._connection = ConnectionSession(
+            max_async=max_concurrency,
+            connect=self.bot_connect,
+            dispatch=self.ws_dispatch,
+            loop=self.loop,
+            api=self.api,
+        )
+        self._connection.state.robot = Robot(user)
 
     # 收到群消息
     async def on_group_at_message_create(
@@ -144,14 +178,17 @@ class QQOfficialPlatformAdapter(Platform):
 
     @staticmethod
     def _should_retry_startup_error(error: Exception) -> bool:
-        if isinstance(error, (asyncio.TimeoutError, ConnectionError, OSError)):
-            return True
-        if isinstance(error, TypeError):
-            error_msg = str(error)
-            return "NoneType" in error_msg and "subscriptable" in error_msg
-        return False
+        return isinstance(
+            error,
+            (
+                asyncio.TimeoutError,
+                ConnectionError,
+                OSError,
+                QQOfficialGatewayUnavailableError,
+            ),
+        )
 
-    async def _close_client(self) -> None:
+    async def _restart_client(self) -> None:
         try:
             await self.client.close()
         except asyncio.CancelledError:
@@ -162,10 +199,17 @@ class QQOfficialPlatformAdapter(Platform):
                 self.meta().id,
                 e,
             )
-
-    async def _recreate_client(self) -> None:
-        await self._close_client()
         self.client = self._create_client()
+
+    async def _sleep_until_retry_or_shutdown(self) -> bool:
+        try:
+            await asyncio.wait_for(
+                self._shutdown_event.wait(),
+                timeout=self.STARTUP_RETRY_DELAY_SECONDS,
+            )
+            return False
+        except asyncio.TimeoutError:
+            return True
 
     async def send_by_session(
         self,
@@ -557,22 +601,34 @@ class QQOfficialPlatformAdapter(Platform):
                         e,
                     )
 
-                await self._recreate_client()
-
-                try:
-                    await asyncio.wait_for(
-                        self._shutdown_event.wait(),
-                        timeout=self.STARTUP_RETRY_DELAY_SECONDS,
-                    )
-                except asyncio.TimeoutError:
-                    continue
+                await self._restart_client()
+                if not await self._sleep_until_retry_or_shutdown():
+                    break
         finally:
-            await self._close_client()
+            try:
+                await self.client.close()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.warning(
+                    "qq_official(%s): close client failed during shutdown: %s",
+                    self.meta().id,
+                    e,
+                )
 
     def get_client(self) -> botClient:
         return self.client
 
     async def terminate(self) -> None:
         self._shutdown_event.set()
-        await self._close_client()
+        try:
+            await self.client.close()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(
+                "qq_official(%s): close client failed during shutdown: %s",
+                self.meta().id,
+                e,
+            )
         logger.info("QQ 官方机器人接口 适配器已被优雅地关闭")

--- a/tests/test_qqofficial_platform_adapter.py
+++ b/tests/test_qqofficial_platform_adapter.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from astrbot.core.platform.sources.qqofficial.qqofficial_platform_adapter import (
+    QQOfficialGatewayUnavailableError,
     QQOfficialPlatformAdapter,
 )
 
@@ -23,7 +24,9 @@ def _platform_config() -> dict:
 async def test_qqofficial_run_retries_after_gateway_timeout(monkeypatch):
     first_client = SimpleNamespace(
         start=AsyncMock(
-            side_effect=TypeError("'NoneType' object is not subscriptable")
+            side_effect=QQOfficialGatewayUnavailableError(
+                "gateway metadata unavailable during qq_official startup"
+            )
         ),
         close=AsyncMock(),
     )
@@ -75,6 +78,21 @@ async def test_qqofficial_run_reraises_non_retryable_error(monkeypatch):
 
     client.start.assert_awaited_once_with(appid="appid", secret="secret")
     client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_qqofficial_bot_login_raises_gateway_error_when_metadata_missing():
+    adapter = QQOfficialPlatformAdapter(_platform_config(), {}, asyncio.Queue())
+    adapter.client.http = SimpleNamespace(login=AsyncMock(return_value=SimpleNamespace()))
+    adapter.client.api = SimpleNamespace(get_ws_url=AsyncMock(return_value=None))
+
+    with pytest.raises(
+        QQOfficialGatewayUnavailableError,
+        match="gateway metadata unavailable",
+    ):
+        await adapter.client._bot_login(SimpleNamespace())
+
+    await adapter.terminate()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- retry qq_official startup when otpy crashes after a transient /gateway/bot timeout
- recreate the QQ official client between retry attempts and stop cleanly on shutdown
- add regression tests for retryable startup failures, non-retryable errors, and CancelledError

## Testing
- uv run --group dev pytest tests/test_qqofficial_platform_adapter.py -q
- uv run --group dev ruff check astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py tests/test_qqofficial_platform_adapter.py

Closes #6858

## Summary by Sourcery

Add retry and graceful shutdown logic to the QQ official platform adapter startup flow to handle transient gateway failures.

Bug Fixes:
- Retry QQ official client startup on transient timeout and connection-related failures instead of exiting.
- Ensure the QQ official client is always closed and recreated cleanly during recovery and on adapter termination.
- Propagate non-retryable errors and cancellation correctly from the QQ official adapter run loop.

Tests:
- Add regression tests covering retryable startup failures, non-retryable startup errors, and CancelledError propagation for the QQ official adapter.