### PR TITLE
fix(webui): align extension page snackbars

### DIFF
--- a/dashboard/src/views/ExtensionPage.vue
+++ b/dashboard/src/views/ExtensionPage.vue
@@ -385,6 +385,7 @@ const {
   <v-snackbar
     :timeout="2000"
     elevation="24"
+    location="top center"
     :color="snack_success"
     v-model="snack_show"
   >


### PR DESCRIPTION
## Summary
- align the Extension page snackbar position with the app's shared toast convention
- show install/update/uninstall result messages at top center instead of the default bottom position
- keep the fix limited to the local Extension page snackbar without changing existing install logic

Fixes #6022

## Testing
- git diff --check
- frontend build/lint not run locally in this environment (dashboard dependencies/pnpm unavailable)

## Summary by Sourcery

Enhancements:
- Update the extension page snackbar to display at the top center to match global toast positioning.