### PR TITLE
fix(webui): keep account dialog content scrollable

### DIFF
--- a/dashboard/src/layouts/full/vertical-header/VerticalHeader.vue
+++ b/dashboard/src/layouts/full/vertical-header/VerticalHeader.vue
@@ -932,6 +932,7 @@ onMounted(async () => {
 }
 
 .account-dialog__content {
+  flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
 }


### PR DESCRIPTION
## Summary
- keep the account dialog content scrollable on smaller windows
- prevent the confirm-password and action area from being pushed out of view during forced first-login password changes
- limit the fix to dialog layout only without changing account edit validation logic

Fixes #6628

## Testing
- git diff --check
- frontend build/lint not run locally in this environment (dashboard dependencies/pnpm unavailable)

## Summary by Sourcery

Ensure the account dialog layout remains scrollable and usable on smaller viewports without altering validation behavior.

Enhancements:
- Constrain the account dialog card height and layout to fit within the viewport while keeping critical actions visible.
- Make the account dialog content area independently scrollable to prevent form fields and buttons from being pushed out of view on small screens.