### PR TITLE
feat: add message-level markdown control for QQ Official platform

### DIFF
--- a/astrbot/core/message/message_event_result.py
+++ b/astrbot/core/message/message_event_result.py
@@ -33,6 +33,19 @@ class MessageChain:
     type: str | None = None
     """消息链承载的消息的类型。可选，用于让消息平台区分不同业务场景的消息链。"""
 
+    def derive(self, chain: list[BaseMessageComponent] | None = None) -> "MessageChain":
+        """基于当前消息链创建一个新的 MessageChain，继承元数据（use_t2i_、use_markdown_ 等）。
+
+        Args:
+            chain: 新消息链的组件列表。如果为 None，则使用空列表。
+
+        """
+        new = MessageChain(chain=chain if chain is not None else [])
+        new.use_t2i_ = self.use_t2i_
+        new.use_markdown_ = self.use_markdown_
+        new.type = self.type
+        return new
+
     def message(self, message: str):
         """添加一条文本消息到消息链 `chain` 中。
 

--- a/astrbot/core/message/message_event_result.py
+++ b/astrbot/core/message/message_event_result.py
@@ -27,6 +27,9 @@ class MessageChain:
 
     chain: list[BaseMessageComponent] = field(default_factory=list)
     use_t2i_: bool | None = None  # None 为跟随用户设置
+    use_markdown_: bool | None = (
+        None  # 是否使用 Markdown 发送消息。None 跟随平台默认，True 强制 Markdown，False 强制纯文本。
+    )
     type: str | None = None
     """消息链承载的消息的类型。可选，用于让消息平台区分不同业务场景的消息链。"""
 
@@ -116,6 +119,18 @@ class MessageChain:
 
         """
         self.use_t2i_ = use_t2i
+        return self
+
+    def use_markdown(self, use: bool | None = True):
+        """设置是否使用 Markdown 发送消息。
+
+        仅对支持 Markdown 的平台生效（如 QQ Official），不支持的平台会忽略此字段。
+
+        Args:
+            use: True 强制使用 Markdown，False 强制纯文本，None 跟随平台默认行为。
+
+        """
+        self.use_markdown_ = use
         return self
 
     def get_plain_text(self, with_other_comps_mark: bool = False) -> str:

--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -247,9 +247,9 @@ class RespondStage(Stage):
                     await asyncio.sleep(i)
                     try:
                         if comp.type in need_separately:
-                            await event.send(MessageChain([comp]))
+                            await event.send(result.derive([comp]))
                         else:
-                            await event.send(MessageChain([*header_comps, comp]))
+                            await event.send(result.derive([*header_comps, comp]))
                             header_comps.clear()
                     except Exception as e:
                         logger.error(
@@ -272,7 +272,7 @@ class RespondStage(Stage):
                     modify_raw_chain=True,
                 )
                 for comp in sep_comps:
-                    chain = MessageChain([comp])
+                    chain = result.derive([comp])
                     try:
                         await event.send(chain)
                     except Exception as e:
@@ -280,7 +280,7 @@ class RespondStage(Stage):
                             f"发送消息链失败: chain = {chain}, error = {e}",
                             exc_info=True,
                         )
-                chain = MessageChain(result.chain)
+                chain = result.derive(result.chain)
                 if result.chain and len(result.chain) > 0:
                     try:
                         await event.send(chain)

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -211,12 +211,20 @@ class QQOfficialMessageEvent(AstrMessageEvent):
         ):
             plain_text = plain_text + "\n"
 
-        payload: dict = {
-            # "content": plain_text,
-            "markdown": MarkdownPayload(content=plain_text) if plain_text else None,
-            "msg_type": 2,
-            "msg_id": self.message_obj.message_id,
-        }
+        # 根据消息链的 use_markdown_ 标记决定发送模式
+        use_md = getattr(self.send_buffer, "use_markdown_", None)
+        if use_md is False:
+            payload: dict = {
+                "content": plain_text,
+                "msg_type": 0,
+                "msg_id": self.message_obj.message_id,
+            }
+        else:
+            payload = {
+                "markdown": MarkdownPayload(content=plain_text) if plain_text else None,
+                "msg_type": 2,
+                "msg_id": self.message_obj.message_id,
+            }
 
         if not isinstance(source, botpy.message.Message | botpy.message.DirectMessage):
             payload["msg_seq"] = random.randint(1, 10000)


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
Related Issues: #5845 
QQ Official platform currently always attempts to send messages as Markdown (msg_type=2) with an automatic fallback to plain text on rejection. There is no way for plugins to control this on a per-message basis. Some messages (e.g. structured data, plain notifications) should be sent as plain text directly without the Markdown attempt and fallback overhead. This change gives plugins explicit control over the sending mode, and the field is designed to be reusable by other Markdown-capable platforms in the future.
### Modifications / 改动点
- `astrbot/core/message/message_event_result.py`: Add `use_markdown_: bool | None` field and `use_markdown()` chainable method to MessageChain, following the same pattern as use_t2i_.
- `astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py`: Read `send_buffer.use_markdown_ in _post_send()` to construct plain text payload (msg_type=0, content) when False, otherwise preserve existing Markdown behavior.
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
| `event.plain_result(msg)` | `event.plain_result(msg).use_markdown(False)` |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/6bdd5993-28e2-47db-bd5a-510e58620680" width="400" /> | <img src="https://github.com/user-attachments/assets/4a51351e-40b2-4afa-bb57-51d464095bf4" width="400" /> |
```
# Force plain text (skip Markdown)
yield event.make_result().message("plain text").use_markdown(False)

# Force Markdown (default behavior, explicit)
yield event.make_result().message("**bold**").use_markdown(True)

# Follow platform default (no change needed)
yield event.plain_result("default behavior")
```
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Add message-level control over Markdown usage and preserve message metadata across derived message chains.

New Features:
- Introduce a use_markdown_ flag and chainable use_markdown() API on MessageChain to control Markdown vs plain-text sending per message.
- Enable QQ Official messages to be sent either as Markdown or plain text based on the MessageChain configuration instead of always attempting Markdown first.

Enhancements:
- Add a derive() helper on MessageChain to create new chains that inherit metadata such as use_t2i_, use_markdown_, and type.
- Update response pipeline stages to build derived MessageChains instead of fresh ones so platform-related metadata is preserved when splitting or reusing chains.