### PR TITLE
fix: register javascript mime types for dashboard assets

### DIFF
--- a/astrbot/dashboard/server.py
+++ b/astrbot/dashboard/server.py
@@ -1,6 +1,7 @@
 import asyncio
 import hashlib
 import logging
+import mimetypes
 import os
 import socket
 from datetime import datetime
@@ -44,6 +45,13 @@ class _AddrWithPort(Protocol):
 APP: Quart
 
 
+def _ensure_static_asset_mime_types() -> None:
+    # Override platform-specific mappings so module scripts are always served
+    # with a JavaScript MIME type, especially on Windows hosts.
+    mimetypes.add_type("application/javascript", ".js")
+    mimetypes.add_type("application/javascript", ".mjs")
+
+
 def _parse_env_bool(value: str | None, default: bool) -> bool:
     if value is None:
         return default
@@ -68,6 +76,7 @@ class AstrBotDashboard:
         self.core_lifecycle = core_lifecycle
         self.config = core_lifecycle.astrbot_config
         self.db = db
+        _ensure_static_asset_mime_types()
 
         # Path priority:
         # 1. Explicit webui_dir argument

--- a/tests/test_dashboard_static_mime.py
+++ b/tests/test_dashboard_static_mime.py
@@ -1,0 +1,17 @@
+import mimetypes
+
+from astrbot.dashboard.server import _ensure_static_asset_mime_types
+
+
+def test_ensure_static_asset_mime_types_registers_javascript_types(monkeypatch):
+    calls = []
+
+    def fake_add_type(mime_type: str, extension: str, strict: bool = True):
+        calls.append((mime_type, extension, strict))
+
+    monkeypatch.setattr(mimetypes, "add_type", fake_add_type)
+
+    _ensure_static_asset_mime_types()
+
+    assert ("application/javascript", ".js", True) in calls
+    assert ("application/javascript", ".mjs", True) in calls


### PR DESCRIPTION
## Summary
- register explicit `.js` and `.mjs` MIME mappings before Quart serves dashboard static assets
- avoid Windows host MIME associations returning `text/plain` for module scripts and causing a blank WebUI
- add a small regression test for the MIME registration helper

Fixes #6253

## Testing
- `uv run --group dev pytest tests/test_dashboard_static_mime.py -q`

## Summary by Sourcery

Register correct JavaScript MIME types for dashboard static assets to ensure the WebUI loads correctly across platforms.

Bug Fixes:
- Force .js and .mjs dashboard assets to be served with a JavaScript MIME type to avoid incorrect text/plain responses on some platforms.

Tests:
- Add a regression test verifying that JavaScript MIME types are registered for .js and .mjs dashboard assets.