### PR TITLE
Feat(webui): improve code block readability in dark mode（iss#6963)

### DIFF
--- a/dashboard/src/scss/_override.scss
+++ b/dashboard/src/scss/_override.scss
@@ -37,7 +37,7 @@ html {
 
 pre, code, .markdown pre, .markdown code, .release-notes pre, .release-notes code {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, "Roboto Mono", "Helvetica Neue", monospace;
-  color: #111827;
+  color: var(--astrbot-code-color);
 }
 
 

--- a/dashboard/src/scss/_variables.scss
+++ b/dashboard/src/scss/_variables.scss
@@ -11,10 +11,12 @@ $font-size-root: 1rem;
 $border-radius-root: 8px;
 $cjk-sans-fallback: 'PingFang SC', 'Hiragino Sans GB', 'Noto Sans CJK SC', 'Microsoft YaHei' !default;
 $cjk-mono-fallback: 'PingFang SC', 'PingFang TC', 'Hiragino Sans GB', 'Noto Sans CJK SC', 'Microsoft YaHei' !default;
+$code-text-color: #111827 !default;
 
 :root {
   --astrbot-font-cjk-sans: #{$cjk-sans-fallback};
   --astrbot-font-cjk-mono: #{$cjk-mono-fallback};
+  --astrbot-code-color: #{$code-text-color};
 }
 
 $body-font-family: 'Roboto', $cjk-sans-fallback, sans-serif !default;


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点
- 在override.css中增加全局样式，增强了暗色模式下代码块中文字的可读性。
- 关联 Issue: [#6963](https://github.com/AstrBotDevs/AstrBot/issues/6963)
Fixes #6963
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
<img width="707" height="158" alt="image" src="https://github.com/user-attachments/assets/05bc8f07-0335-47fb-a418-5024b899b388" />

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Enhancements:
- Unify and customize monospace font styling and text color for code blocks across markdown and release notes to enhance readability in dark mode.