### PR TITLE
revert: "fix(provider): restore parameter transparency in core LLM provider adapters"

### DIFF
--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -515,7 +515,7 @@ class ProviderAnthropic(Provider):
 
         model = model or self.get_model()
 
-        payloads = {**kwargs, "messages": new_messages, "model": model}
+        payloads = {"messages": new_messages, "model": model}
 
         # Anthropic has a different way of handling system prompts
         if system_prompt:
@@ -571,7 +571,7 @@ class ProviderAnthropic(Provider):
 
         model = model or self.get_model()
 
-        payloads = {**kwargs, "messages": new_messages, "model": model}
+        payloads = {"messages": new_messages, "model": model}
 
         # Anthropic has a different way of handling system prompts
         if system_prompt:

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -757,7 +757,7 @@ class ProviderGoogleGenAI(Provider):
 
         model = model or self.get_model()
 
-        payloads = {**kwargs, "messages": context_query, "model": model}
+        payloads = {"messages": context_query, "model": model}
 
         retry = 10
         keys = self.api_keys.copy()
@@ -812,7 +812,7 @@ class ProviderGoogleGenAI(Provider):
 
         model = model or self.get_model()
 
-        payloads = {**kwargs, "messages": context_query, "model": model}
+        payloads = {"messages": context_query, "model": model}
 
         retry = 10
         keys = self.api_keys.copy()

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -812,7 +812,8 @@ class ProviderOpenAIOfficial(Provider):
             context_query = await self._materialize_context_image_parts(context_query)
 
         model = model or self.get_model()
-        payloads = {**kwargs, "messages": context_query, "model": model}
+
+        payloads = {"messages": context_query, "model": model}
 
         self._finally_convert_payload(payloads)
 


### PR DESCRIPTION
Reverts AstrBotDevs/AstrBot#6934

## Summary by Sourcery

Enhancements:
- Limit Anthropic, Gemini, and OpenAI chat payloads back to explicit message and model fields instead of transparently passing through extra parameters.