### PR TITLE
fix(embedding): use removesuffix instead of rstrip to prevent over-trimming URLs

### DIFF
--- a/astrbot/core/provider/sources/openai_embedding_source.py
+++ b/astrbot/core/provider/sources/openai_embedding_source.py
@@ -27,8 +27,8 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         api_base = (
             provider_config.get("embedding_api_base", "https://api.openai.com/v1")
             .strip()
-            .rstrip("/")
-            .rstrip("/embeddings")
+            .removesuffix("/")
+            .removesuffix("/embeddings")
         )
         if api_base and not api_base.endswith("/v1") and not api_base.endswith("/v4"):
             # /v4 see #5699


### PR DESCRIPTION
## 动机

修复 #7025

之前在 #6863 中提交的修复使用了 `rstrip()` 方法来移除 URL 末尾的 `/embeddings` 路径，但 `rstrip()` 是字符集操作而非字符串移除操作，会误删 URL 末尾属于该字符集的任意字符。

### 问题表现

当 API Base URL 以 `/embeddings` 字符集中的字符结尾时（如 `siliconflow.cn` 的 `n`），该字符会被误删：

- 输入：`https://api.siliconflow.cn`
- 错误结果：`https://api.siliconflow.c/v1`（`n` 被删掉）
- 正确结果：`https://api.siliconflow.cn/v1`

### 修复方案

将 `rstrip()` 改为 `removesuffix()`，后者只在字符串以指定后缀结尾时才移除，避免误删字符。

### Modifications / 改动点

- 将 `astrbot/core/provider/sources/openai_embedding_source.py` 中的 `.rstrip("/")` 和 `.rstrip("/embeddings")` 改为 `.removesuffix("/")` 和 `.removesuffix("/embeddings")`

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

本地测试日志：
```
[OpenAI Embedding] openai_embedding Using API Base: https://api.siliconflow.cn/v1
```

URL 中的 `n` 不再被误删。

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Fix incorrect removal of trailing characters from embedding API base URLs by replacing character-based stripping with suffix-based removal.