### PR TITLE
fix(dashboard): update aiocqhttp tutorial links to new docs path

### DIFF
--- a/dashboard/src/components/platform/AddNewPlatform.vue
+++ b/dashboard/src/components/platform/AddNewPlatform.vue
@@ -259,7 +259,7 @@
       <v-card-text class="py-4">
         <p>{{ tm('dialog.securityWarning.aiocqhttpTokenMissing') }}</p>
         <span><a
-            href="https://docs.astrbot.app/deploy/platform/aiocqhttp/napcat.html#%E9%99%84%E5%BD%95-%E5%A2%9E%E5%BC%BA%E8%BF%9E%E6%8E%A5%E5%AE%89%E5%85%A8%E6%80%A7"
+            href="https://docs.astrbot.app/platform/aiocqhttp.html"
             target="_blank">{{ tm('dialog.securityWarning.learnMore') }}</a></span>
       </v-card-text>
       <v-card-actions class="px-4 pb-4">

--- a/dashboard/src/utils/platformUtils.js
+++ b/dashboard/src/utils/platformUtils.js
@@ -50,7 +50,7 @@ export function getTutorialLink(platformType) {
   const tutorialMap = {
     "qq_official_webhook": "https://docs.astrbot.app/platform/qqofficial/webhook.html",
     "qq_official": "https://docs.astrbot.app/platform/qqofficial/websockets.html",
-    "aiocqhttp": "https://docs.astrbot.app/platform/aiocqhttp/napcat.html",
+    "aiocqhttp": "https://docs.astrbot.app/platform/aiocqhttp.html",
     "wecom": "https://docs.astrbot.app/platform/wecom.html",
     "weixin_oc": "https://docs.astrbot.app/platform/weixin_oc.html",
     "wecom_ai_bot": "https://docs.astrbot.app/platform/wecom_ai_bot.html",


### PR DESCRIPTION
## Summary

Fix OneBot (`aiocqhttp`) tutorial links in Dashboard that still point to the old `napcat` path.

- Update `dashboard/src/utils/platformUtils.js`
  - `aiocqhttp` tutorial URL: `.../platform/aiocqhttp/napcat.html` -> `.../platform/aiocqhttp.html`
- Update `dashboard/src/components/platform/AddNewPlatform.vue`
  - Security warning "learn more" URL: `.../deploy/platform/aiocqhttp/napcat.html#...` -> `.../platform/aiocqhttp.html`

## Why

The docs page has been migrated to:

- https://docs.astrbot.app/platform/aiocqhttp.html

The old links can lead to wrong pages / stale routes.

## Related Issue

Closes #7037

## Test

- Verified by code search that no old `aiocqhttp/napcat.html` or `deploy/platform/aiocqhttp` links remain in repo.

## Summary by Sourcery

Update dashboard links to point OneBot (aiocqhttp) users to the new documentation URL.

Bug Fixes:
- Correct aiocqhttp tutorial link in the platform tutorial mapping to use the new docs path.
- Update the aiocqhttp security warning "learn more" link to the current documentation page.