### PR TITLE
fix: allow multiple skills in a single zip archive

### DIFF
--- a/astrbot/core/skills/skill_manager.py
+++ b/astrbot/core/skills/skill_manager.py
@@ -541,7 +541,7 @@ class SkillManager:
         *,
         overwrite: bool = True,
         skill_name_hint: str | None = None,
-    ) -> str:  
+    ) -> str:
         zip_path_obj = Path(zip_path)
         if not zip_path_obj.exists():
             raise FileNotFoundError(f"Zip file not found: {zip_path}")
@@ -588,18 +588,23 @@ class SkillManager:
                 top_dirs = {PurePosixPath(n).parts[0] for n in file_names if n.strip()}
                 conflict_dirs: list[str] = []
                 for src_dir_name in top_dirs:
-                    if (f"{src_dir_name}/SKILL.md" not in file_names and f"{src_dir_name}/skill.md" not in file_names):
+                    if (
+                        f"{src_dir_name}/SKILL.md" not in file_names
+                        and f"{src_dir_name}/skill.md" not in file_names
+                    ):
                         continue
-                    
+
                     candidate_name = _normalize_skill_name(src_dir_name)
-                    if not candidate_name or not _SKILL_NAME_RE.fullmatch(candidate_name):
-                        continue 
-                        
+                    if not candidate_name or not _SKILL_NAME_RE.fullmatch(
+                        candidate_name
+                    ):
+                        continue
+
                     if archive_skill_name and len(top_dirs) == 1:
                         target_name = archive_skill_name
                     else:
                         target_name = candidate_name
-                        
+
                     dest_dir = Path(self.skills_root) / target_name
                     if dest_dir.exists():
                         conflict_dirs.append(str(dest_dir))
@@ -610,7 +615,6 @@ class SkillManager:
                         "overwrite=False. No skills were installed. Conflicting "
                         f"paths: {', '.join(conflict_dirs)}"
                     )
-
 
             with tempfile.TemporaryDirectory(dir=get_astrbot_temp_path()) as tmp_dir:
                 for member in zf.infolist():
@@ -626,61 +630,70 @@ class SkillManager:
                     if not archive_hint or not _SKILL_NAME_RE.fullmatch(archive_hint):
                         raise ValueError("Invalid skill name.")
                     skill_name = archive_hint
-                    
+
                     src_dir = Path(tmp_dir)
                     normalized_path = _normalize_skill_markdown_path(src_dir)
                     if normalized_path is None:
-                        raise ValueError("SKILL.md not found in the root of the zip archive.")
-                    
+                        raise ValueError(
+                            "SKILL.md not found in the root of the zip archive."
+                        )
+
                     dest_dir = Path(self.skills_root) / skill_name
                     if dest_dir.exists() and overwrite:
                         shutil.rmtree(dest_dir)
                     elif dest_dir.exists() and not overwrite:
-                         raise FileExistsError(f"Skill {skill_name} already exists.")
-                    
+                        raise FileExistsError(f"Skill {skill_name} already exists.")
+
                     shutil.move(str(src_dir), str(dest_dir))
                     self.set_skill_active(skill_name, True)
                     installed_skills.append(skill_name)
-                    
+
                 else:
-                    top_dirs = {PurePosixPath(n).parts[0] for n in file_names if n.strip()}
-                    
+                    top_dirs = {
+                        PurePosixPath(n).parts[0] for n in file_names if n.strip()
+                    }
+
                     for archive_root_name in top_dirs:
-                        archive_root_name_normalized = _normalize_skill_name(archive_root_name)
-                        
+                        archive_root_name_normalized = _normalize_skill_name(
+                            archive_root_name
+                        )
+
                         if (
                             f"{archive_root_name}/SKILL.md" not in file_names
                             and f"{archive_root_name}/skill.md" not in file_names
                         ):
                             continue
-                            
-                        if archive_root_name in {".", "..", ""} or not _SKILL_NAME_RE.fullmatch(
-                            archive_root_name_normalized
+
+                        if archive_root_name in {".", "..", ""} or not (
+                            _SKILL_NAME_RE.fullmatch(archive_root_name_normalized)
                         ):
                             continue
-                            
-      
+
                         if archive_skill_name and len(top_dirs) == 1:
                             skill_name = archive_skill_name
                         else:
                             skill_name = archive_root_name_normalized
-                        
+
                         src_dir = Path(tmp_dir) / archive_root_name
                         normalized_path = _normalize_skill_markdown_path(src_dir)
                         if normalized_path is None:
                             continue
-                            
+
                         dest_dir = Path(self.skills_root) / skill_name
                         if dest_dir.exists():
                             if not overwrite:
-                                raise FileExistsError(f"Skill {skill_name} already exists.") 
+                                raise FileExistsError(
+                                    f"Skill {skill_name} already exists."
+                                )
                             shutil.rmtree(dest_dir)
-                            
+
                         shutil.move(str(src_dir), str(dest_dir))
                         self.set_skill_active(skill_name, True)
                         installed_skills.append(skill_name)
 
         if not installed_skills:
-            raise ValueError("No valid SKILL.md found in any folder of the zip archive.")
+            raise ValueError(
+                "No valid SKILL.md found in any folder of the zip archive."
+            )
 
-        return installed_skills[0]
+        return ", ".join(installed_skills)


### PR DESCRIPTION
### Motivation / 动机

The Web UI explicitly states that users can import zip archives containing multiple skills ("支持压缩包内含多个 skills 文件夹"). However, the current backend logic in `install_skill_from_zip` within `skill_manager.py` enforces a strict check: `if len(top_dirs) != 1:`. This raises a `Zip archive must contain a single top-level folder.` error if users upload multiple skills in parallel. Furthermore, wrapping them in a root folder bypasses this check but fails with `SKILL.md not found`, as the code does not iterate through subdirectories. This PR fixes the discrepancy between the frontend prompt and the backend logic.

### Modifications / 改动点

- Removed the strict single-folder validation (`len(top_dirs) != 1`) in `astrbot/core/skills/skill_manager.py`.
- Refactored `install_skill_from_zip` to iterate through all top-level directories in the archive. 
- It now correctly extracts, identifies, and registers each valid skill folder containing a `SKILL.md` (or `skill.md`), aligning backend behavior with frontend documentation while strictly preserving existing Zip Slip security checks.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果
<img width="2264" height="1156" alt="ffdb08ca62c169108f8b984301c43e54" src="https://github.com/user-attachments/assets/fd23f491-3839-4680-9b55-5b8992fd9461" />

Locally tested with a zip file containing 12 individual skill folders. 
Result: All 12 skills were successfully parsed, moved to the `data/skills/` directory, and registered as active in the system without triggering the previous ValueError exceptions.

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。(N/A - This is a bug fix)

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Allow installing multiple skills from a single zip archive while preserving existing validation and security checks.

Bug Fixes:
- Fix skill installation failures when uploading zip archives containing multiple top-level skill folders.
- Ensure root-mode zip installations correctly validate the presence of SKILL.md at the archive root and use a validated skill name.

Enhancements:
- Support installing and activating all valid skill folders within a zip archive in one operation, skipping invalid or malformed entries and collecting their names in the return value.
- Improve error reporting by raising a clear error when no valid SKILL.md is found in any folder and by including the skill name in file-exists errors.