### PR TITLE
fix: improve number input UX in config renderer

### DIFF
--- a/dashboard/src/components/shared/ConfigItemRenderer.vue
+++ b/dashboard/src/components/shared/ConfigItemRenderer.vue
@@ -148,6 +148,7 @@
         v-if="itemMeta?.slider"
         :model-value="toNumber(numericTemp ?? modelValue)"
         @update:model-value="val => { numericTemp = val; emitUpdate(toNumber(val)) }"
+        @end="numericTemp = null"
         :min="itemMeta?.slider?.min ?? 0"
         :max="itemMeta?.slider?.max ?? 100"
         :step="itemMeta?.slider?.step ?? 1"
@@ -159,7 +160,7 @@
       <v-text-field
         :model-value="numericTemp ?? modelValue"
         @update:model-value="val => (numericTemp = val)"
-        @blur="e => { emitUpdate(toNumber(e.target.value)); numericTemp = null }"
+        @blur="() => { emitUpdate(toNumber(numericTemp)); numericTemp = null }"
         density="compact"
         variant="outlined"
         class="config-field"
@@ -363,12 +364,12 @@ function getSpecialSubtype(value) {
   font-size: 14px;
 }
 
-:deep(input[type='number']::-webkit-inner-spin-button),
-:deep(input[type='number']::-webkit-outer-spin-button) {
+:deep(.config-field input[type='number']::-webkit-inner-spin-button),
+:deep(.config-field input[type='number']::-webkit-outer-spin-button) {
   -webkit-appearance: none;
 }
 
-:deep(input[type='number']) {
+:deep(.config-field input[type='number']) {
   -moz-appearance: textfield;
 }
 </style>


### PR DESCRIPTION
数字输入框体验较差
原生上下箭头按钮基本无用；输入过程中（如 0.、-、1e）每次按键都会触发parseFloat 强制转换。总之就是怪怪的

### Modifications / 改动点

ConfigItemRenderer.vue：将数字类型转换推迟到失焦（blur）时执行；用本地 numericTemp ref 在输入过程中实时同步slider；通过 CSS 隐藏原生数字输入框的上下箭头
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Improve numeric configuration input UX by deferring numeric parsing and syncing the slider with in-progress text input, while hiding native number input spin buttons.

Enhancements:
- Defer conversion of text input to numeric values until the input field loses focus to avoid disruptive parsing during typing.
- Keep the slider value in sync with the temporary numeric text input state for smoother interaction between the slider and text field.
- Hide native number input spin buttons via CSS for a cleaner numeric input appearance.