### PR TITLE
feat: context aware prompt

### DIFF
--- a/astrbot/builtin_stars/astrbot/long_term_memory.py
+++ b/astrbot/builtin_stars/astrbot/long_term_memory.py
@@ -41,6 +41,10 @@ class LongTermMemory:
             "context_prompt",
             "You are now in a chatroom. The chat history is as follows: \n",
         )
+        active_reply_suffix_prompt = cfg["provider_ltm_settings"].get(
+            "active_reply_suffix_prompt",
+            "Please react to it. Only output your response and do not output any other information. You MUST use the SAME language as the chatroom is using.",
+        )
         active_reply = cfg["provider_ltm_settings"]["active_reply"]
         enable_active_reply = active_reply.get("enable", False)
         ar_method = active_reply["method"]
@@ -50,6 +54,7 @@ class LongTermMemory:
         ret = {
             "max_cnt": max_cnt,
             "context_prompt": context_prompt,
+            "active_reply_suffix_prompt": active_reply_suffix_prompt,
             "image_caption": image_caption,
             "image_caption_prompt": image_caption_prompt,
             "image_caption_provider_id": image_caption_provider_id,
@@ -166,8 +171,7 @@ class LongTermMemory:
             req.prompt = (
                 f"{cfg['context_prompt']}{chats_str}"
                 f"\nNow, a new message is coming: `{prompt}`. "
-                "Please react to it. Only output your response and do not output any other information. "
-                "You MUST use the SAME language as the chatroom is using."
+                f"{cfg['active_reply_suffix_prompt']}"
             )
             req.contexts = []  # 清空上下文，当使用了主动回复，所有聊天记录都在一个prompt中。
         else:

--- a/astrbot/builtin_stars/astrbot/long_term_memory.py
+++ b/astrbot/builtin_stars/astrbot/long_term_memory.py
@@ -37,6 +37,10 @@ class LongTermMemory:
         image_caption = cfg["provider_ltm_settings"]["image_caption"] and bool(
             image_caption_provider_id
         )
+        context_prompt = cfg["provider_ltm_settings"].get(
+            "context_prompt",
+            "You are now in a chatroom. The chat history is as follows: \n",
+        )
         active_reply = cfg["provider_ltm_settings"]["active_reply"]
         enable_active_reply = active_reply.get("enable", False)
         ar_method = active_reply["method"]
@@ -45,6 +49,7 @@ class LongTermMemory:
         ar_whitelist = active_reply.get("whitelist", [])
         ret = {
             "max_cnt": max_cnt,
+            "context_prompt": context_prompt,
             "image_caption": image_caption,
             "image_caption_prompt": image_caption_prompt,
             "image_caption_provider_id": image_caption_provider_id,
@@ -159,16 +164,14 @@ class LongTermMemory:
         if cfg["enable_active_reply"]:
             prompt = req.prompt
             req.prompt = (
-                f"You are now in a chatroom. The chat history is as follows:\n{chats_str}"
+                f"{cfg['context_prompt']}{chats_str}"
                 f"\nNow, a new message is coming: `{prompt}`. "
                 "Please react to it. Only output your response and do not output any other information. "
                 "You MUST use the SAME language as the chatroom is using."
             )
             req.contexts = []  # 清空上下文，当使用了主动回复，所有聊天记录都在一个prompt中。
         else:
-            req.system_prompt += (
-                "You are now in a chatroom. The chat history is as follows: \n"
-            )
+            req.system_prompt += cfg["context_prompt"]
             req.system_prompt += chats_str
 
     async def after_req_llm(

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -210,6 +210,7 @@ DEFAULT_CONFIG = {
         "group_icl_enable": False,
         "group_message_max_cnt": 300,
         "context_prompt": "You are now in a chatroom. The chat history is as follows: \n",
+        "active_reply_suffix_prompt": "Please react to it. Only output your response and do not output any other information. You MUST use the SAME language as the chatroom is using.",
         "image_caption": False,
         "image_caption_provider_id": "",
         "active_reply": {
@@ -3913,6 +3914,12 @@ CONFIG_METADATA_3 = {
                         "type": "list",
                         "items": {"type": "string"},
                         "hint": "为空时不启用白名单过滤。使用 /sid 获取 ID。",
+                        "condition": {
+                            "provider_ltm_settings.active_reply.enable": True,
+                        },
+                        "provider_ltm_settings.active_reply_suffix_prompt": {
+                        "description": "主动回复后缀提示词",
+                        "type": "text",
                         "condition": {
                             "provider_ltm_settings.active_reply.enable": True,
                         },

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -3917,7 +3917,8 @@ CONFIG_METADATA_3 = {
                         "condition": {
                             "provider_ltm_settings.active_reply.enable": True,
                         },
-                        "provider_ltm_settings.active_reply_suffix_prompt": {
+                    },
+                    "provider_ltm_settings.active_reply_suffix_prompt": {
                         "description": "主动回复后缀提示词",
                         "type": "text",
                         "condition": {

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -209,6 +209,7 @@ DEFAULT_CONFIG = {
     "provider_ltm_settings": {
         "group_icl_enable": False,
         "group_message_max_cnt": 300,
+        "context_prompt": "You are now in a chatroom. The chat history is as follows: \n",
         "image_caption": False,
         "image_caption_provider_id": "",
         "active_reply": {
@@ -3867,6 +3868,10 @@ CONFIG_METADATA_3 = {
                     "provider_ltm_settings.group_message_max_cnt": {
                         "description": "最大消息数量",
                         "type": "int",
+                    },
+                    "provider_ltm_settings.context_prompt": {
+                        "description": "上下文感知提示词",
+                        "type": "text",
                     },
                     "provider_ltm_settings.image_caption": {
                         "description": "自动理解图片",

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -936,6 +936,12 @@
         "group_message_max_cnt": {
           "description": "Maximum Message Count"
         },
+        "context_prompt": {
+          "description": "Context Awareness Prompt"
+        },
+        "active_reply_suffix_prompt": {
+          "description": "Active Reply Suffix Prompt"
+        },
         "image_caption": {
           "description": "Auto-understand Images",
           "hint": "Requires setting a group chat image caption model."

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -938,6 +938,12 @@
         "group_message_max_cnt": {
           "description": "最大消息数量"
         },
+        "context_prompt": {
+          "description": "上下文感知提示词"
+        },
+        "active_reply_suffix_prompt": {
+          "description": "主动回复后缀提示词"
+        },
         "image_caption": {
           "description": "自动理解图片",
           "hint": "需要设置群聊图片转述模型。"


### PR DESCRIPTION
群聊上下文感知功能的提示词此前均为硬编码，用户无法根据自己的 Bot 人格或语言风格进行调整。
### Modifications / 改动点
- astrbot/core/config/default.py：在 provider_ltm_settings 下新增两个可配置字段：
- context_prompt：上下文感知提示词（引导 LLM 理解聊天记录的前缀，普通模式与主动回复模式均生效）
- active_reply_suffix_prompt：主动回复后缀提示词（主动回复模式下追加在消息末尾的指令，仅主动回复启用时在
Dashboard 中显示）
- astrbot/builtin_stars/astrbot/long_term_memory.py：从 配置读取上述字段，替换原有硬编码字符串
- dashboard/src/i18n/locales/zh-CNen-US/features/confi g-metadata.json：新增对应 i18n 翻译

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Make group chat long-term memory prompts configurable and expose them in the provider settings UI.

New Features:
- Add configurable context prompt for group chat history used in both normal and active reply modes.
- Add configurable active-reply suffix prompt appended to messages when active reply is enabled.

Enhancements:
- Replace hard-coded long-term memory prompts with values loaded from provider_ltm_settings, with sensible defaults.
- Extend provider configuration metadata to surface the new prompt fields in the dashboard only when active reply is enabled.

Documentation:
- Add i18n entries for the new context and active-reply prompt configuration fields in both Chinese and English locales.