### PR TITLE
fix(ltm): Retain per-user contexts when enabling dialogue isolation

### DIFF
--- a/astrbot/builtin_stars/astrbot/long_term_memory.py
+++ b/astrbot/builtin_stars/astrbot/long_term_memory.py
@@ -43,6 +43,7 @@ class LongTermMemory:
         ar_possibility = active_reply["possibility_reply"]
         ar_prompt = active_reply.get("prompt", "")
         ar_whitelist = active_reply.get("whitelist", [])
+        unique_session = cfg.get("platform_settings", {}).get("unique_session", False)
         ret = {
             "max_cnt": max_cnt,
             "image_caption": image_caption,
@@ -53,6 +54,7 @@ class LongTermMemory:
             "ar_possibility": ar_possibility,
             "ar_prompt": ar_prompt,
             "ar_whitelist": ar_whitelist,
+            "unique_session": unique_session,
         }
         return ret
 
@@ -156,7 +158,6 @@ class LongTermMemory:
         chats_str = "\n---\n".join(self.session_chats[event.unified_msg_origin])
 
         cfg = self.cfg(event)
-        unique_session = cfg.get("platform_settings", {}).get("unique_session", False)
         if cfg["enable_active_reply"]:
             prompt = req.prompt
             req.prompt = (
@@ -165,7 +166,7 @@ class LongTermMemory:
                 "Please react to it. Only output your response and do not output any other information. "
                 "You MUST use the SAME language as the chatroom is using."
             )
-            if not unique_session:
+            if not cfg["unique_session"]:
                 req.contexts = []  # 清空上下文，当使用了主动回复，所有聊天记录都在一个prompt中。
         else:
             req.system_prompt += (


### PR DESCRIPTION
开启群聊上下文感知的主动回复时，on_req_llm 会无条件执行 req.contexts = []， 导致对话隔离（unique_session）维护的 per-user 对话历史被清空，对话隔离无效

### Modifications / 改动点
`astrbot/builtin_stars/astrbot/long_term_memory.py`： 仅在 unique_session 未开启时清空 req.contexts。开启时保留 per-user contexts，使其与群聊上下文背景并存。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

逻辑错误，无报错日志。可通过在 on_req_llm 执行前后打印 req.contexts 验证：unique_session 开启时执行后 contexts 不再被清空
---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Ensure unique_session conversation contexts are not cleared when active reply is enabled, so per-user dialog isolation remains effective.