### PR TITLE
fix: filter Gemini thinking parts from user-facing message chain

### DIFF
--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -241,15 +241,10 @@ class ProviderGoogleGenAI(Provider):
                 thinking_config = types.ThinkingConfig(
                     thinking_budget=thinking_budget,
                 )
-        elif model_name in [
-            "gemini-3-pro",
-            "gemini-3-pro-preview",
-            "gemini-3-flash",
-            "gemini-3-flash-preview",
-            "gemini-3-flash-lite",
-            "gemini-3-flash-lite-preview",
-        ]:
-            # The thinkingLevel parameter, recommended for Gemini 3 models and onwards
+        elif any(model_name.startswith(p) for p in ("gemini-3-", "gemini-3.")):
+            # The thinkingLevel parameter, recommended for Gemini 3 models and onwards.
+            # Use prefix match so new variants (3.1, 3-flash-lite-preview, etc.) are
+            # covered without needing to keep an exhaustive list up to date.
             # Gemini 2.5 series models don't support thinkingLevel; use thinkingBudget instead.
             thinking_level = self.provider_config.get("gm_thinking_config", {}).get(
                 "level", "HIGH"
@@ -517,7 +512,11 @@ class ProviderGoogleGenAI(Provider):
         ):
             chain.append(Comp.Plain("这是图片"))
         for part in result_parts:
-            if part.text:
+            # Skip thinking parts — their text is already captured via
+            # _extract_reasoning_content above.  Including them here would
+            # leak the model's internal reasoning into the user-facing message,
+            # which also causes duplicate/triple replies on some platforms.
+            if part.text and not part.thought:
                 chain.append(Comp.Plain(part.text))
 
             if (


### PR DESCRIPTION
## Problem

When using Gemini 3 series models (e.g. gemini-3-pro, gemini-3-flash), the bot sends duplicate or triple replies for a single user message. Only one API request is made (confirmed via Google AI Studio), but the response text appears multiple times in chat.

## Root Cause

Gemini 3 models with thinking enabled return response parts that include both thinking (`part.thought=True`) and actual text parts. In `_process_content_parts`, the loop that builds the user-facing message chain didn't filter out thinking parts:

```python
for part in result_parts:
    if part.text:  # includes thinking parts!
        chain.append(Comp.Plain(part.text))
```

This leaked the model's internal reasoning into the message chain. Since thinking text often mirrors the actual response, the user sees what appears to be the same content repeated. On platforms that split long messages by sentence (e.g. aiocqhttp with realtime segmenting), this turns into multiple separate replies.

The streaming path was unaffected because `chunk.text` (the SDK's convenience property) already skips thinking parts internally. But non-streaming requests and the final-chunk processing in streaming both go through `_process_content_parts`.

## Fix

1. **Filter thinking parts from chain**: Add `and not part.thought` check when building the chain. Reasoning text is already captured separately via `_extract_reasoning_content`.

2. **Use prefix matching for Gemini 3 model names**: The hardcoded model name list (`gemini-3-pro`, `gemini-3-flash`, etc.) missed variants like `gemini-3.1-pro-preview`. Switched to prefix matching (`gemini-3-` / `gemini-3.`) so new model variants get proper `thinkingLevel` config automatically.

Fixes #7183

## Summary by Sourcery

Prevent Gemini 3 model reasoning content from leaking into user-facing messages and ensure thinking configuration applies consistently across current and future Gemini 3 variants.

Bug Fixes:
- Exclude Gemini 3 thinking parts from the constructed user-facing message chain to stop duplicate or repeated replies.

Enhancements:
- Apply Gemini 3 thinking configuration based on model name prefixes rather than a hardcoded list so new model variants are automatically supported.