### PR TITLE
fix: prevent floating buttons from jumping during page transitions

### DIFF
--- a/dashboard/src/views/ConfigPage.vue
+++ b/dashboard/src/views/ConfigPage.vue
@@ -44,39 +44,41 @@
       <v-slide-y-transition mode="out-in">
         <div v-if="(selectedConfigID || isSystemConfig) && fetched" :key="configContentKey" class="config-content" style="width: 100%;">
           <!-- 可视化编辑 -->
-          <AstrBotCoreConfigWrapper 
-            :metadata="metadata" 
+          <AstrBotCoreConfigWrapper
+            :metadata="metadata"
             :config_data="config_data"
             :search-keyword="configSearchKeyword"
           />
-
-          <v-tooltip :text="tm('actions.save')" location="left">
-            <template v-slot:activator="{ props }">
-              <v-btn v-bind="props" icon="mdi-content-save" size="x-large" style="position: fixed; right: 52px; bottom: 52px;"
-                color="darkprimary" @click="updateConfig">
-              </v-btn>
-            </template>
-          </v-tooltip>
-
-          <v-tooltip :text="tm('codeEditor.title')" location="left">
-            <template v-slot:activator="{ props }">
-              <v-btn v-bind="props" icon="mdi-code-json" size="x-large" style="position: fixed; right: 52px; bottom: 124px;" color="primary"
-                @click="configToString(); codeEditorDialog = true">
-              </v-btn>
-            </template>
-          </v-tooltip>
-
-          <v-tooltip text="测试当前配置" location="left" v-if="!isSystemConfig">
-            <template v-slot:activator="{ props }">
-              <v-btn v-bind="props" icon="mdi-chat-processing" size="x-large" 
-                style="position: fixed; right: 52px; bottom: 196px;" color="secondary"
-                @click="openTestChat">
-              </v-btn>
-            </template>
-          </v-tooltip>
-
         </div>
       </v-slide-y-transition>
+
+      <!-- 浮动按钮放在 transition 外部 -->
+      <template v-if="(selectedConfigID || isSystemConfig) && fetched">
+        <v-tooltip :text="tm('actions.save')" location="left">
+          <template v-slot:activator="{ props }">
+            <v-btn v-bind="props" icon="mdi-content-save" size="x-large" style="position: fixed; right: 52px; bottom: 52px;"
+              color="darkprimary" @click="updateConfig">
+            </v-btn>
+          </template>
+        </v-tooltip>
+
+        <v-tooltip :text="tm('codeEditor.title')" location="left">
+          <template v-slot:activator="{ props }">
+            <v-btn v-bind="props" icon="mdi-code-json" size="x-large" style="position: fixed; right: 52px; bottom: 124px;" color="primary"
+              @click="configToString(); codeEditorDialog = true">
+            </v-btn>
+          </template>
+        </v-tooltip>
+
+        <v-tooltip text="测试当前配置" location="left" v-if="!isSystemConfig">
+          <template v-slot:activator="{ props }">
+            <v-btn v-bind="props" icon="mdi-chat-processing" size="x-large"
+              style="position: fixed; right: 52px; bottom: 196px;" color="secondary"
+              @click="openTestChat">
+            </v-btn>
+          </template>
+        </v-tooltip>
+      </template>
 
     </div>
   </div>


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
When switching between config sub-pages , the three floating action buttons in the bottom-right corner momentarily jump to the upper part of the page before returning to their correct position. This creates a jarring visual experience for users.

The root cause is that the buttons were placed inside a `v-slide-y-transition` component, causing them to animate along with the page content during transitions.
### Modifications / 改动点
- `dashboard/src/views/ConfigPage.vue`: Move the three floating buttons outside of `v-slide-y-transition` and wrap them in `<template v-if>` to maintain the same visibility condition without being affected by transition animations.
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
| `Before` | `After` |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/7aacf27d-fca5-4e72-a0bf-4d2286ae13a5" width="500" /> | <img src="https://github.com/user-attachments/assets/e3f6eecc-8cce-4d27-a423-735affe426fa" width="500" /> |
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---


### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Prevent floating action buttons from visually jumping during config sub-page transitions by decoupling them from the slide transition animation.