### PR TITLE
fix: satisfy Google Gemini's function_response requirements to avoid 400 Invalid argument errors

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -839,6 +839,9 @@ class ProviderOpenAIOfficial(Provider):
 
     def _finally_convert_payload(self, payloads: dict) -> None:
         """Finally convert the payload. Such as think part conversion, tool inject."""
+        model = payloads.get("model", "").lower()
+        is_gemini = "gemini" in model
+
         for message in payloads.get("messages", []):
             if message.get("role") == "assistant" and isinstance(
                 message.get("content"), list
@@ -854,6 +857,18 @@ class ProviderOpenAIOfficial(Provider):
                 # reasoning key is "reasoning_content"
                 if reasoning_content:
                     message["reasoning_content"] = reasoning_content
+
+            # Gemini 的 function_response 要求 google.protobuf.Struct（即 JSON 对象），
+            # 纯文本会触发 400 Invalid argument，需要包一层 JSON。
+            if is_gemini and message.get("role") == "tool":
+                content = message.get("content", "")
+                if isinstance(content, str):
+                    try:
+                        json.loads(content)
+                    except (json.JSONDecodeError, ValueError):
+                        message["content"] = json.dumps(
+                            {"result": content}, ensure_ascii=False
+                        )
 
     async def _handle_api_error(
         self,


### PR DESCRIPTION
## Summary

Gemini API 的 `function_response` 要求 `google.protobuf.Struct`（即 JSON 对象），但当工具（如内置知识库）返回纯文本结果时，框架直接把字符串传给 API，导致 400 Invalid argument。

在 `_finally_convert_payload` 中检测 Gemini 模型的 tool 消息，如果 content 不是合法 JSON，自动包装成 `{"result": content}` 后再发送。已有的 JSON 格式内容不受影响。

## Changes

- `openai_source.py`: `_finally_convert_payload()` 增加 Gemini tool content JSON 包装逻辑

## Test

1. 配置 Gemini 模型（如 gemini-3.1-pro-preview）通过 OpenAI 兼容接口
2. 启用内置知识库或任何返回纯文本的工具
3. 发送触发工具调用的消息
4. 验证不再出现 400 Invalid argument 错误

Fixes #7134

## Summary by Sourcery

Bug Fixes:
- Wrap plain-text tool message content as a JSON object for Gemini models to satisfy function_response requirements and avoid 400 Invalid argument errors.