### PR TITLE
fix: support both old and new Bailian Rerank API response formats

### DIFF
--- a/astrbot/core/provider/sources/bailian_rerank_source.py
+++ b/astrbot/core/provider/sources/bailian_rerank_source.py
@@ -143,7 +143,7 @@ class BailianRerankProvider(RerankProvider):
             )
 
         # 兼容旧版 API (output.results) 和新版 compatible API (results)
-        results = data.get("output", {}).get("results") or data.get("results", [])
+        results = (data.get("output") or {}).get("results") or data.get("results") or []
         if not results:
             logger.warning(f"百炼 Rerank 返回空结果: {data}")
             return []


### PR DESCRIPTION
## Summary

commit 971bcbad 要求 qwen3-rerank 使用新版 compatible API (`/compatible-api/v1/reranks`)，但没有更新响应解析逻辑。新 API 返回 `data.results`，而解析器只检查旧路径 `data.output.results`，导致 qwen3-rerank 始终返回空结果。

改为同时兼容两种格式：优先检查 `output.results`（旧 API），回退到 `results`（新 API）。

## Changes

- `bailian_rerank_source.py`: `_parse_results()` 兼容新旧两种响应格式

## Test

1. 配置阿里云百炼 qwen3-rerank 模型
2. 使用新版 API `https://dashscope.aliyuncs.com/compatible-api/v1/reranks`
3. 点击测试，验证能正确返回重排序结果

Fixes #7161

## Summary by Sourcery

Bug Fixes:
- Ensure Bailian Rerank results are correctly parsed when using the new compatible API response structure that returns data.results instead of data.output.results.