### PR TITLE
feat: add NVIDIA rerank provider support

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1789,6 +1789,19 @@ CONFIG_METADATA_2 = {
                         "return_documents": False,
                         "instruct": "",
                     },
+                    "Nvidia Rerank": {
+                        "id": "nvidia_rerank",
+                        "type": "nvidia_rerank",
+                        "provider": "nvidia",
+                        "provider_type": "rerank",
+                        "enable": True,
+                        "nvidia_rerank_api_key": "",
+                        "nvidia_rerank_api_base": "https://ai.api.nvidia.com/v1/retrieval",
+                        "nvidia_rerank_model": "nv-rerank-qa-mistral-4b:1",
+                        "nvidia_rerank_model_endpoint": "/reranking",
+                        "timeout": 20,
+                        "nvidia_rerank_truncate": "",
+                    },
                     "Xinference STT": {
                         "id": "xinference_stt",
                         "type": "xinference_stt",
@@ -1851,6 +1864,34 @@ CONFIG_METADATA_2 = {
                         "description": "模型未运行时自动启动",
                         "type": "bool",
                         "hint": "如果模型当前未在 Xinference 服务中运行，是否尝试自动启动它。在生产环境中建议关闭。",
+                    },
+                    "nvidia_rerank_api_base": {
+                        "description": "API Base URL",
+                        "type": "string",
+                    },
+                    "nvidia_rerank_api_key": {
+                        "description": "API Key",
+                        "type": "string",
+                    },
+                    "nvidia_rerank_model": {
+                        "description": "重排序模型名称",
+                        "type": "string",
+                        "hint": "请参照NVIDIA Docs中模型名称填写。",
+                    },
+                    "nvidia_rerank_model_endpoint": {
+                        "description": "自定义模型端点",
+                        "type": "string",
+                        "hint": "自定义URL末尾端点，默认为 /reranking",
+                    },
+                    "nvidia_rerank_truncate": {
+                        "description": "文本截断策略",
+                        "type": "string",
+                        "hint": "当输入文本过长时，是否截断输入以适应模型的最大上下文长度。",
+                        "options": [
+                            "",
+                            "NONE",
+                            "END",
+                        ],
                     },
                     "modalities": {
                         "description": "模型能力",

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1789,7 +1789,7 @@ CONFIG_METADATA_2 = {
                         "return_documents": False,
                         "instruct": "",
                     },
-                    "Nvidia Rerank": {
+                    "NVIDIA Rerank": {
                         "id": "nvidia_rerank",
                         "type": "nvidia_rerank",
                         "provider": "nvidia",

--- a/astrbot/core/provider/manager.py
+++ b/astrbot/core/provider/manager.py
@@ -471,6 +471,10 @@ class ProviderManager:
                 from .sources.bailian_rerank_source import (
                     BailianRerankProvider as BailianRerankProvider,
                 )
+            case "nvidia_rerank":
+                from .sources.nvidia_rerank_source import (
+                    NvidiaRerankProvider as NvidiaRerankProvider,
+                )
 
     def get_merged_provider_config(self, provider_config: dict) -> dict:
         """获取 provider 配置和 provider_source 配置合并后的结果

--- a/astrbot/core/provider/sources/nvidia_rerank_source.py
+++ b/astrbot/core/provider/sources/nvidia_rerank_source.py
@@ -8,19 +8,22 @@ from ..register import register_provider_adapter
 
 
 @register_provider_adapter(
-    "nvidia_rerank",
-    "NVIDIA Rerank 适配器",
-    provider_type=ProviderType.RERANK
+    "nvidia_rerank", "NVIDIA Rerank 适配器", provider_type=ProviderType.RERANK
 )
 class NvidiaRerankProvider(RerankProvider):
-
     def __init__(self, provider_config: dict, provider_settings: dict) -> None:
         super().__init__(provider_config, provider_settings)
         self.api_key = provider_config.get("nvidia_rerank_api_key", "")
-        self.base_url = provider_config.get("nvidia_rerank_api_base", "https://ai.api.nvidia.com/v1/retrieval").rstrip("/")
+        self.base_url = provider_config.get(
+            "nvidia_rerank_api_base", "https://ai.api.nvidia.com/v1/retrieval"
+        ).rstrip("/")
         self.timeout = provider_config.get("timeout", 20)
-        self.model = provider_config.get("nvidia_rerank_model", "nv-rerank-qa-mistral-4b:1")
-        self.model_endpoint = provider_config.get("nvidia_rerank_model_endpoint", "/reranking")
+        self.model = provider_config.get(
+            "nvidia_rerank_model", "nv-rerank-qa-mistral-4b:1"
+        )
+        self.model_endpoint = provider_config.get(
+            "nvidia_rerank_model_endpoint", "/reranking"
+        )
         self.truncate = provider_config.get("nvidia_rerank_truncate", "")
 
         headers = {
@@ -68,7 +71,9 @@ class NvidiaRerankProvider(RerankProvider):
             payload["truncate"] = self.truncate
         return payload
 
-    def _parse_results(self, response_data: dict, top_n: int | None) -> list[RerankResult]:
+    def _parse_results(
+        self, response_data: dict, top_n: int | None
+    ) -> list[RerankResult]:
         """解析响应数据"""
         results = response_data.get("rankings", [])
         if not results:
@@ -80,9 +85,13 @@ class NvidiaRerankProvider(RerankProvider):
             try:
                 index = item.get("index", idx)
                 score = item.get("relevance_score", item.get("logit", 0.0))
-                rerank_results.append(RerankResult(index=index, relevance_score=float(score)))
+                rerank_results.append(
+                    RerankResult(index=index, relevance_score=float(score))
+                )
             except Exception as e:
-                logger.warning(f"[NVIDIA Rerank] Result parsing error: {e}, Data={item}")
+                logger.warning(
+                    f"[NVIDIA Rerank] Result parsing error: {e}, Data={item}"
+                )
 
         rerank_results.sort(key=lambda x: x.relevance_score, reverse=True)
 
@@ -107,7 +116,9 @@ class NvidiaRerankProvider(RerankProvider):
             return []
 
         if not documents or not query.strip():
-            logger.warning("[NVIDIA Rerank] Input data is invalid, query or documents are empty")
+            logger.warning(
+                "[NVIDIA Rerank] Input data is invalid, query or documents are empty"
+            )
             return []
 
         try:
@@ -119,7 +130,9 @@ class NvidiaRerankProvider(RerankProvider):
                 logger.debug(f"[NVIDIA Rerank] API Response: {response_data}")
 
                 if response.status != 200:
-                    error_detail = response_data.get("detail", response_data.get("message", "Unknown Error"))
+                    error_detail = response_data.get(
+                        "detail", response_data.get("message", "Unknown Error")
+                    )
                     raise Exception(f"HTTP {response.status} - {error_detail}")
 
                 results = self._parse_results(response_data, top_n)

--- a/astrbot/core/provider/sources/nvidia_rerank_source.py
+++ b/astrbot/core/provider/sources/nvidia_rerank_source.py
@@ -1,0 +1,139 @@
+import aiohttp
+
+from astrbot import logger
+
+from ..entities import ProviderType, RerankResult
+from ..provider import RerankProvider
+from ..register import register_provider_adapter
+
+
+@register_provider_adapter(
+    "nvidia_rerank",
+    "NVIDIA Rerank 适配器",
+    provider_type=ProviderType.RERANK
+)
+class NvidiaRerankProvider(RerankProvider):
+
+    def __init__(self, provider_config: dict, provider_settings: dict) -> None:
+        super().__init__(provider_config, provider_settings)
+        self.api_key = provider_config.get("nvidia_rerank_api_key", "")
+        self.base_url = provider_config.get("nvidia_rerank_api_base", "https://ai.api.nvidia.com/v1/retrieval").rstrip("/")
+        self.timeout = provider_config.get("timeout", 20)
+        self.model = provider_config.get("nvidia_rerank_model", "nv-rerank-qa-mistral-4b:1")
+        self.model_endpoint = provider_config.get("nvidia_rerank_model_endpoint", "/reranking")
+        self.truncate = provider_config.get("nvidia_rerank_truncate", "")
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+        self.client = aiohttp.ClientSession(
+            headers=headers, timeout=aiohttp.ClientTimeout(total=self.timeout)
+        )
+
+        self.set_model(self.model)
+
+    def _get_endpoint(self) -> str:
+        """
+        构建完整API URL。
+
+        根据 Nvidia Rerank API 文档来看，当前URL存在不同模型格式不一致的问题。
+        这里针对模型名做一个基础判断用以适配，后续要等Nvidia统一API格式后再做调整。
+
+        例：
+        模型： nv-rerank-qa-mistral-4b:1
+        URL: .../v1/retrieval/nvidia/reranking
+
+        模型： nvidia/llama-nemotron-rerank-1b-v2
+        URL: .../v1/retrieval/nvidia/llama-nemotron-rerank-1b-v2/reranking
+        """
+
+        model_path = "nvidia"
+        logger.debug(f"[NVIDIA Rerank] Building endpoint for model: {self.model}")
+        if "/" in self.model:
+            model_path = self.model.strip("/")
+        endpoint = self.model_endpoint.lstrip("/")
+        return f"{self.base_url}/{model_path}/{endpoint}"
+
+    def _build_payload(self, query: str, documents: list[str]) -> dict:
+        """构建请求载荷"""
+        payload = {
+            "model": self.model,
+            "query": {"text": query},
+            "passages": [{"text": doc} for doc in documents],
+        }
+        if self.truncate:
+            payload["truncate"] = self.truncate
+        return payload
+
+    def _parse_results(self, response_data: dict, top_n: int | None) -> list[RerankResult]:
+        """解析响应数据"""
+        results = response_data.get("rankings", [])
+        if not results:
+            logger.warning(f"[NVIDIA Rerank] Empty response: {response_data}")
+            return []
+
+        rerank_results = []
+        for idx, item in enumerate(results):
+            try:
+                index = item.get("index", idx)
+                score = item.get("relevance_score", item.get("logit", 0.0))
+                rerank_results.append(RerankResult(index=index, relevance_score=float(score)))
+            except Exception as e:
+                logger.warning(f"[NVIDIA Rerank] Result parsing error: {e}, Data={item}")
+
+        rerank_results.sort(key=lambda x: x.relevance_score, reverse=True)
+
+        if top_n is not None and top_n > 0:
+            return rerank_results[:top_n]
+        return rerank_results
+
+    def _log_usage(self, data: dict) -> None:
+        usage = data.get("usage", {})
+        total_tokens = usage.get("total_tokens", 0)
+        if total_tokens > 0:
+            logger.debug(f"[NVIDIA Rerank] Token Usage: {total_tokens}")
+
+    async def rerank(
+        self,
+        query: str,
+        documents: list[str],
+        top_n: int | None = None,
+    ) -> list[RerankResult]:
+        if not self.client or self.client.closed:
+            logger.error("[NVIDIA Rerank] Client session not initialized or closed")
+            return []
+
+        if not documents or not query.strip():
+            logger.warning("[NVIDIA Rerank] Input data is invalid, query or documents are empty")
+            return []
+
+        try:
+            payload = self._build_payload(query, documents)
+            request_url = self._get_endpoint()
+
+            async with self.client.post(request_url, json=payload) as response:
+                response_data = await response.json()
+                logger.debug(f"[NVIDIA Rerank] API Response: {response_data}")
+
+                if response.status != 200:
+                    error_detail = response_data.get("detail", response_data.get("message", "Unknown Error"))
+                    raise Exception(f"HTTP {response.status} - {error_detail}")
+
+                results = self._parse_results(response_data, top_n)
+                self._log_usage(response_data)
+                return results
+
+        except aiohttp.ClientError as e:
+            logger.error(f"[NVIDIA Rerank] Network error: {e}")
+            raise Exception(f"Network error: {e}") from e
+        except Exception as e:
+            logger.error(f"[NVIDIA Rerank] Error: {e}")
+            raise Exception(f"Rerank error: {e}") from e
+
+    async def terminate(self) -> None:
+        if self.client and not self.client.closed:
+            await self.client.close()
+            self.client = None

--- a/astrbot/core/provider/sources/nvidia_rerank_source.py
+++ b/astrbot/core/provider/sources/nvidia_rerank_source.py
@@ -26,17 +26,20 @@ class NvidiaRerankProvider(RerankProvider):
         )
         self.truncate = provider_config.get("nvidia_rerank_truncate", "")
 
-        headers = {
-            "Authorization": f"Bearer {self.api_key}",
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-        }
-
-        self.client = aiohttp.ClientSession(
-            headers=headers, timeout=aiohttp.ClientTimeout(total=self.timeout)
-        )
-
+        self.client = None
         self.set_model(self.model)
+
+    async def _get_client(self):
+        if self.client is None or self.client.closed:
+            headers = {
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            }
+            self.client = aiohttp.ClientSession(
+                headers=headers, timeout=aiohttp.ClientTimeout(total=self.timeout)
+            )
+        return self.client
 
     def _get_endpoint(self) -> str:
         """
@@ -111,7 +114,8 @@ class NvidiaRerankProvider(RerankProvider):
         documents: list[str],
         top_n: int | None = None,
     ) -> list[RerankResult]:
-        if not self.client or self.client.closed:
+        client = await self._get_client()
+        if not client or client.closed:
             logger.error("[NVIDIA Rerank] Client session not initialized or closed")
             return []
 
@@ -125,7 +129,7 @@ class NvidiaRerankProvider(RerankProvider):
             payload = self._build_payload(query, documents)
             request_url = self._get_endpoint()
 
-            async with self.client.post(request_url, json=payload) as response:
+            async with client.post(request_url, json=payload) as response:
                 response_data = await response.json()
                 logger.debug(f"[NVIDIA Rerank] API Response: {response_data}")
 

--- a/astrbot/core/provider/sources/nvidia_rerank_source.py
+++ b/astrbot/core/provider/sources/nvidia_rerank_source.py
@@ -56,7 +56,7 @@ class NvidiaRerankProvider(RerankProvider):
         model_path = "nvidia"
         logger.debug(f"[NVIDIA Rerank] Building endpoint for model: {self.model}")
         if "/" in self.model:
-            model_path = self.model.strip("/")
+            model_path = self.model.strip("/").replace(".", "_")
         endpoint = self.model_endpoint.lstrip("/")
         return f"{self.base_url}/{model_path}/{endpoint}"
 

--- a/astrbot/core/provider/sources/nvidia_rerank_source.py
+++ b/astrbot/core/provider/sources/nvidia_rerank_source.py
@@ -130,15 +130,22 @@ class NvidiaRerankProvider(RerankProvider):
             request_url = self._get_endpoint()
 
             async with client.post(request_url, json=payload) as response:
-                response_data = await response.json()
-                logger.debug(f"[NVIDIA Rerank] API Response: {response_data}")
-
                 if response.status != 200:
-                    error_detail = response_data.get(
-                        "detail", response_data.get("message", "Unknown Error")
-                    )
+                    try:
+                        response_data = await response.json()
+                        error_detail = response_data.get(
+                            "detail", response_data.get("message", "Unknown Error")
+                        )
+
+                    except Exception:
+                        error_detail = await response.text()
+                        response_data = {"message": error_detail}
+
+                    logger.error(f"[NVIDIA Rerank] API Error Response: {response_data}")
                     raise Exception(f"HTTP {response.status} - {error_detail}")
 
+                response_data = await response.json()
+                logger.debug(f"[NVIDIA Rerank] API Response: {response_data}")
                 results = self._parse_results(response_data, top_n)
                 self._log_usage(response_data)
                 return results

--- a/astrbot/core/provider/sources/nvidia_rerank_source.py
+++ b/astrbot/core/provider/sources/nvidia_rerank_source.py
@@ -59,6 +59,7 @@ class NvidiaRerankProvider(RerankProvider):
         model_path = "nvidia"
         logger.debug(f"[NVIDIA Rerank] Building endpoint for model: {self.model}")
         if "/" in self.model:
+            """遵循NVIDIA API的URL规则，替换模型名中特殊字符"""
             model_path = self.model.strip("/").replace(".", "_")
         endpoint = self.model_endpoint.lstrip("/")
         return f"{self.base_url}/{model_path}/{endpoint}"

--- a/dashboard/src/components/provider/AddNewProvider.vue
+++ b/dashboard/src/components/provider/AddNewProvider.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-dialog v-model="showDialog" max-width="1100px" min-height="95%">
+    <v-dialog v-model="showDialog" max-width="1000px" >
         <v-card :title="tm('dialogs.addProvider.title')">
             <v-card-text style="overflow-y: auto;">
                 <v-tabs v-model="activeProviderTab" grow>
@@ -73,6 +73,8 @@
 import { useModuleI18n } from '@/i18n/composables';
 import { getProviderIcon, getProviderDescription } from '@/utils/providerUtils';
 
+const AVAILABLE_PROVIDER_TABS = ['agent_runner', 'speech_to_text', 'text_to_speech', 'embedding', 'rerank'];
+
 export default {
     name: 'AddNewProvider',
     props: {
@@ -83,6 +85,10 @@ export default {
         metadata: {
             type: Object,
             default: () => ({})
+        },
+        currentProviderType: {
+            type: String,
+            default: 'agent_runner'
         }
     },
     emits: ['update:show', 'select-template'],
@@ -92,7 +98,7 @@ export default {
     },
     data() {
         return {
-            activeProviderTab: 'chat_completion'
+            activeProviderTab: 'agent_runner'
         };
     },
     computed: {
@@ -105,7 +111,25 @@ export default {
             }
         },
     },
+    watch: {
+        show(value) {
+            if (value) {
+                this.syncActiveProviderTab();
+            }
+        },
+        currentProviderType() {
+            if (this.showDialog) {
+                this.syncActiveProviderTab();
+            }
+        }
+    },
     methods: {
+        syncActiveProviderTab() {
+            this.activeProviderTab = AVAILABLE_PROVIDER_TABS.includes(this.currentProviderType)
+                ? this.currentProviderType
+                : 'agent_runner';
+        },
+
         closeDialog() {
             this.showDialog = false;
         },

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -1092,6 +1092,24 @@
         "description": "Custom rerank task description",
         "hint": "Only effective for qwen3-rerank models. Recommended to write in English."
       },
+      "nvidia_rerank_api_base": {
+          "description": "API Base URL"
+      },
+      "nvidia_rerank_api_key": {
+          "description": "API Key"
+      },
+      "nvidia_rerank_model": {
+          "description": "Rerank Model Name",
+          "hint": "Please refer to the NVIDIA Docs for the model name."
+      },
+      "nvidia_rerank_model_endpoint": {
+          "description": "Custom Model Endpoint",
+          "hint": "Custom URL suffix endpoint, defaults to /reranking."
+      },
+      "nvidia_rerank_truncate": {
+          "description": "Text Truncation Strategy",
+          "hint": "Whether to truncate the input to fit the model's maximum context length when the input text is too long."
+      },
       "launch_model_if_not_running": {
         "description": "Auto-start model if not running",
         "hint": "If the model is not running in Xinference, attempt to start it automatically. Recommended to disable in production."

--- a/dashboard/src/i18n/locales/ru-RU/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/config-metadata.json
@@ -1093,6 +1093,24 @@
                 "description": "Описание задачи для Rerank",
                 "hint": "Эффективно только для моделей qwen3-rerank. Рекомендуется писать на английском."
             },
+            "nvidia_rerank_api_base": {
+                "description": "Базовый URL API"
+            },
+            "nvidia_rerank_api_key": {
+                "description": "API-ключ"
+            },
+            "nvidia_rerank_model": {
+                "description": "Название модели Rerank",
+                "hint": "Укажите название модели в соответствии с документацией NVIDIA."
+            },
+            "nvidia_rerank_model_endpoint": {
+                "description": "Пользовательский endpoint модели",
+                "hint": "Пользовательский суффикс URL endpoint, по умолчанию /reranking."
+            },
+            "nvidia_rerank_truncate": {
+                "description": "Стратегия усечения текста",
+                "hint": "Определяет, следует ли усекать входной текст, если он слишком длинный и не помещается в максимальную длину контекста модели."
+            },
             "launch_model_if_not_running": {
                 "description": "Автозапуск модели",
                 "hint": "Если модель не запущена в Xinference, попытаться запустить её автоматически. Рекомендуется отключать в продакшене."

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -1094,6 +1094,24 @@
         "description": "自定义排序任务类型说明",
         "hint": "仅在使用 qwen3-rerank 模型时生效。建议使用英文撰写。"
       },
+      "nvidia_rerank_api_base": {
+          "description": "API Base URL"
+      },
+      "nvidia_rerank_api_key": {
+          "description": "API Key"
+      },
+      "nvidia_rerank_model": {
+          "description": "重排序模型名称",
+          "hint": "请参照NVIDIA Docs中模型名称填写。"
+      },
+      "nvidia_rerank_model_endpoint": {
+          "description": "自定义模型端点",
+          "hint": "自定义URL末尾端点，默认为 /reranking"
+      },
+      "nvidia_rerank_truncate": {
+          "description": "文本截断策略",
+          "hint": "当输入文本过长时，是否截断输入以适应模型的最大上下文长度。"
+      },
       "launch_model_if_not_running": {
         "description": "模型未运行时自动启动",
         "hint": "如果模型当前未在 Xinference 服务中运行，是否尝试自动启动它。在生产环境中建议关闭。"

--- a/dashboard/src/utils/providerUtils.js
+++ b/dashboard/src/utils/providerUtils.js
@@ -40,7 +40,10 @@ export function getProviderIcon(type) {
     'aihubmix': 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/aihubmix-color.svg',
     'openrouter': 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/openrouter.svg',
     "tokenpony": "https://tokenpony.cn/tokenpony-web/logo.png",
-    "compshare": "https://compshare.cn/favicon.ico"
+    "compshare": "https://compshare.cn/favicon.ico",
+    "xinference": "https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/xinference-color.svg",
+    "bailian": "https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/bailian-color.svg",
+    "volcengine": 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/volcengine-color.svg',
   };
   return icons[type] || '';
 }

--- a/dashboard/src/views/ProviderPage.vue
+++ b/dashboard/src/views/ProviderPage.vue
@@ -163,6 +163,7 @@
 
     <!-- 添加提供商对话框 -->
     <AddNewProvider v-model:show="showAddProviderDialog" :metadata="configSchema"
+      :current-provider-type="selectedProviderType"
       @select-template="selectProviderTemplate" />
 
     <!-- 手动添加模型对话框 -->


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

Issues #7195 的代码实现。对NVIDIA NIM平台的Rerank模型API的适配

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

 - 增加 NVIDIA Rerank API 请求逻辑 
   - astrbot/core/provider/sources/nvidia_rerank_source.py 
   - astrbot/core/provider/manager.py
 - 针对 NVIDIA Rerank 增加WebUI上的配置支持以及多语言支持( zh-CN & en-US )
   - astrbot/core/config/default.py
   - dashboard/src/i18n/locales/en-US/features/config-metadata.json
   - dashboard/src/i18n/locales/zh-CN/features/config-metadata.json

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

已经过本地搭建使用测试

#### WebUI配置界面

<img width="796" height="557" alt="image" src="https://github.com/user-attachments/assets/a950182a-4aaf-4b6a-957c-241d70e2a156" />


#### 可用性测试

<img width="384" height="236" alt="image" src="https://github.com/user-attachments/assets/20600144-3172-4db0-a2cb-9078de49312a" />

#### 知识库检索

<img width="865" height="433" alt="image" src="https://github.com/user-attachments/assets/9801d84a-cfa1-4122-b926-8eee5427b536" />

#### 日志记录

<img width="898" height="155" alt="image" src="https://github.com/user-attachments/assets/19f1f9e0-7de9-40c4-a87b-99251448fddb" />


---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Add support for NVIDIA NIM-based rerank models as a configurable provider and wire it into the provider management system.

New Features:
- Introduce an NVIDIA rerank provider adapter that calls the NVIDIA NIM retrieval/reranking API.
- Expose NVIDIA rerank provider configuration (API base, key, model, endpoint, truncate policy) in the default provider templates and Web UI metadata with i18n support.