### PR TITLE
perf(ltm): pre-caption images outside session lock to unblock subsequent messages

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -477,6 +477,52 @@ async def _request_img_caption(
     return llm_resp.completion_text
 
 
+_PRE_CAPTION_RESULT_KEY = "_pre_caption_result"
+
+
+async def pre_caption_images(
+    event: AstrMessageEvent,
+    plugin_context: Context,
+) -> None:
+    """在 session lock 外提前完成图片描述，结果写入 event extra。
+
+    由 pipeline 在获取 session lock 之前调用，避免图片描述慢速 LLM
+    调用占用 session lock，阻塞后续消息处理。
+    """
+    cfg = plugin_context.get_config(umo=event.unified_msg_origin).get(
+        "provider_settings", {}
+    )
+    img_cap_prov_id: str = cfg.get("default_image_caption_provider_id") or ""
+    if not img_cap_prov_id:
+        return
+
+    image_components = [
+        comp for comp in event.message_obj.message if isinstance(comp, Image)
+    ]
+    if not image_components:
+        return
+
+    try:
+        image_urls = []
+        for comp in image_components:
+            path = await comp.convert_to_file_path()
+            compressed = await _compress_image_for_provider(path, cfg)
+            if _is_generated_compressed_image_path(path, compressed):
+                event.track_temporary_local_file(compressed)
+            image_urls.append(compressed)
+
+        caption = await _request_img_caption(
+            img_cap_prov_id,
+            cfg,
+            image_urls,
+            plugin_context,
+        )
+        event.set_extra(_PRE_CAPTION_RESULT_KEY, caption or "")
+    except Exception as exc:  # noqa: BLE001
+        logger.error("预处理图片描述失败: %s", exc)
+        event.set_extra(_PRE_CAPTION_RESULT_KEY, None)
+
+
 async def _ensure_img_caption(
     event: AstrMessageEvent,
     req: ProviderRequest,
@@ -484,6 +530,15 @@ async def _ensure_img_caption(
     plugin_context: Context,
     image_caption_provider: str,
 ) -> None:
+    pre_caption = event.get_extra(_PRE_CAPTION_RESULT_KEY)
+    if pre_caption is not None:
+        if pre_caption:
+            req.extra_user_content_parts.append(
+                TextPart(text=f"<image_caption>{pre_caption}</image_caption>")
+            )
+        req.image_urls = []
+        return
+
     try:
         compressed_urls = []
         for url in req.image_urls:

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -483,15 +483,13 @@ _PRE_CAPTION_RESULT_KEY = "_pre_caption_result"
 async def pre_caption_images(
     event: AstrMessageEvent,
     plugin_context: Context,
+    cfg: dict,
 ) -> None:
     """在 session lock 外提前完成图片描述，结果写入 event extra。
 
     由 pipeline 在获取 session lock 之前调用，避免图片描述慢速 LLM
     调用占用 session lock，阻塞后续消息处理。
     """
-    cfg = plugin_context.get_config(umo=event.unified_msg_origin).get(
-        "provider_settings", {}
-    )
     img_cap_prov_id: str = cfg.get("default_image_caption_provider_id") or ""
     if not img_cap_prov_id:
         return
@@ -519,7 +517,7 @@ async def pre_caption_images(
         )
         event.set_extra(_PRE_CAPTION_RESULT_KEY, caption or "")
     except Exception as exc:  # noqa: BLE001
-        logger.error("预处理图片描述失败: %s", exc)
+        logger.error("预处理图片描述失败: %s", exc, exc_info=True)
         event.set_extra(_PRE_CAPTION_RESULT_KEY, None)
 
 
@@ -530,12 +528,14 @@ async def _ensure_img_caption(
     plugin_context: Context,
     image_caption_provider: str,
 ) -> None:
+    if event.get_extra("_skip_img_caption"):
+        return
+
     pre_caption = event.get_extra(_PRE_CAPTION_RESULT_KEY)
-    if pre_caption is not None:
-        if pre_caption:
-            req.extra_user_content_parts.append(
-                TextPart(text=f"<image_caption>{pre_caption}</image_caption>")
-            )
+    if pre_caption:
+        req.extra_user_content_parts.append(
+            TextPart(text=f"<image_caption>{pre_caption}</image_caption>")
+        )
         req.image_urls = []
         return
 

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -103,6 +103,7 @@ DEFAULT_CONFIG = {
         "fallback_chat_models": [],
         "default_image_caption_provider_id": "",
         "image_caption_prompt": "Please describe the image using Chinese.",
+        "image_caption_wait_for_context_order": True,
         "provider_pool": ["*"],  # "*" 表示使用所有可用的提供者
         "wake_prefix": "",
         "web_search": False,
@@ -2978,6 +2979,11 @@ CONFIG_METADATA_3 = {
                         "type": "string",
                         "_special": "select_provider",
                         "hint": "留空代表不使用，可用于非多模态模型",
+                    },
+                    "provider_settings.image_caption_wait_for_context_order": {
+                        "description": "图片转述时等待上下文顺序",
+                        "type": "bool",
+                        "hint": "开启后，同一会话中图片转述完成前，后续消息将等待，以保证上下文顺序正确；关闭后，后续消息立即响应，但上下文中图片描述可能在后续消息之后。",
                     },
                     "provider_stt_settings.enable": {
                         "description": "启用语音转文本",

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -12,6 +12,7 @@ from astrbot.core.astr_main_agent import (
     MainAgentBuildConfig,
     MainAgentBuildResult,
     build_main_agent,
+    pre_caption_images,
 )
 from astrbot.core.message.components import File, Image
 from astrbot.core.message.message_event_result import (
@@ -185,6 +186,11 @@ class InternalAgentSubStage(Stage):
             except Exception:
                 logger.warning("send_typing failed", exc_info=True)
             await call_event_hook(event, EventType.OnWaitingLLMRequestEvent)
+
+            if not event.get_extra("provider_request"):
+                await pre_caption_images(
+                    event, self.ctx.plugin_manager.context
+                )
 
             async with session_lock_manager.acquire_lock(event.unified_msg_origin):
                 logger.debug("acquired session lock for llm request")

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -188,9 +188,12 @@ class InternalAgentSubStage(Stage):
             await call_event_hook(event, EventType.OnWaitingLLMRequestEvent)
 
             if not event.get_extra("provider_request"):
-                await pre_caption_images(
-                    event, self.ctx.plugin_manager.context
-                )
+                plugin_context = self.ctx.plugin_manager.context
+                cfg = plugin_context.get_config(
+                    umo=event.unified_msg_origin
+                ).get("provider_settings", {})
+                if cfg.get("image_caption_wait_for_context_order", True):
+                    await pre_caption_images(event, plugin_context)
 
             async with session_lock_manager.acquire_lock(event.unified_msg_origin):
                 logger.debug("acquired session lock for llm request")

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -189,11 +189,13 @@ class InternalAgentSubStage(Stage):
 
             if not event.get_extra("provider_request"):
                 plugin_context = self.ctx.plugin_manager.context
-                cfg = plugin_context.get_config(
-                    umo=event.unified_msg_origin
-                ).get("provider_settings", {})
+                cfg = plugin_context.get_config(umo=event.unified_msg_origin).get(
+                    "provider_settings", {}
+                )
                 if cfg.get("image_caption_wait_for_context_order", True):
-                    await pre_caption_images(event, plugin_context)
+                    await pre_caption_images(event, plugin_context, cfg)
+                else:
+                    event.set_extra("_skip_img_caption", True)
 
             async with session_lock_manager.acquire_lock(event.unified_msg_origin):
                 logger.debug("acquired session lock for llm request")

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -51,6 +51,10 @@
         },
         "image_caption_prompt": {
           "description": "Image Caption Prompt"
+        },
+        "image_caption_wait_for_context_order": {
+          "description": "Wait for Context Order on Image Caption",
+          "hint": "When enabled, subsequent messages in the same session will wait until image captioning completes, ensuring correct context order. When disabled, subsequent messages respond immediately but the image description may appear after them in context."
         }
       },
       "provider_stt_settings": {

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -51,6 +51,10 @@
         },
         "image_caption_prompt": {
           "description": "图片转述提示词"
+        },
+        "image_caption_wait_for_context_order": {
+          "description": "图片转述时等待上下文顺序",
+          "hint": "开启后，同一会话中图片转述完成前，后续消息将等待，以保证上下文顺序正确；关闭后，后续消息立即响应，但上下文中图片描述可能在后续消息之后。"
         }
       },
       "provider_stt_settings": {


### PR DESCRIPTION
开启图片转述功能后，若用户发送图片后紧接着发送文字消息 ，文字消息会被阻塞，必须等待图片转述完全 结束后才能得到回复。
小模型调用的时候延迟尤其明显。
根本原因：图片转述的 LLM 调用在 session_lock 内执行，占用锁期间同 session 的后续消息无法进入处理流程。


- This is NOT a breaking change. / 这不是一个破坏性变更。

### Modifications / 改动点
- astrbot/core/astr_main_agent.py：新增 pre_caption_images() 函数，在获取 session lock 之前完成图片下载、压缩、转述，结果写入 event extra；_ensure_img_caption() 优先读取预处理结果，避免在 lock 内重复调用小模型。
- astrbot/core/pipeline/process_stage/method/agent_sub_ stages/internal.py：在 session_lock_manager.acquire_lock() 之前调用 pre_caption_images()，根据配置决定是否等待。
- astrbot/core/config/default.py：新增配置项 provider_s ettings.image_caption_wait_for_context_order（默认
True），位于”默认图片转述模型“下方。
- 开启（默认）：后续消息等待图片转述完成后再处理，上 下文顺序正确（图片描述在后续消息之前）。也就是现在的行为。
- 关闭：后续消息立即响应，图片转述并发执行，但上下文 中图片描述可能出现在后续消息之后。

- dashboard/src/i18n/：新增 zh-CN 和 en-US 翻译。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
改后并关闭：
$+ΛʀƊ∪$τ: 03-31 16:54:48
[图片]

$+ΛʀƊ∪$τ: 03-31 16:54:53
黑

Baka！: 03-31 16:54:58
什么黑？我的蝴蝶结是蓝的！

Baka！: 03-31 16:55:02
这个帽子比我的翅膀还大！他这样能看到路吗？

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Allow image captioning to run before acquiring the session lock so that slow caption LLMs no longer block subsequent messages in the same session.

New Features:
- Add a configurable option to choose whether later messages wait for image captioning to preserve context order or are processed immediately with captioning running concurrently.

Bug Fixes:
- Prevent text messages from being blocked behind slow image captioning when image transcription is enabled in a session.

Enhancements:
- Pre-process and cache image captions outside the session lock and reuse them during request handling to avoid redundant caption LLM calls.
- Expose the new image caption ordering option in the dashboard configuration metadata with localized labels.