### PR TITLE
fix: pop_record() preserves tool_calls/tool pairing to prevent 400 error on context overflow

### DIFF
--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -162,7 +162,7 @@ class Provider(AbstractProvider):
         raise NotImplementedError()
 
     async def pop_record(self, context: list) -> None:
-        """Pop earliest non-system records while preserving tool-call pairing."""
+        """弹出最早的非 system 记录，同时保持 tool_calls 与 tool 配对完整。"""
 
         def _has_tool_calls(message: dict) -> bool:
             return bool(message.get("tool_calls"))
@@ -199,8 +199,35 @@ class Provider(AbstractProvider):
             del context[start_idx : end_idx + 1]
             return removed_count
 
+        def _peek_earliest_unit_count() -> int:
+            start_idx = _first_non_system_index()
+            if start_idx is None:
+                return 0
+
+            record = context[start_idx]
+            role = record.get("role")
+            end_idx = start_idx
+            if role == "assistant" and _has_tool_calls(record):
+                while end_idx + 1 < len(context) and (
+                    context[end_idx + 1].get("role") == "tool"
+                ):
+                    end_idx += 1
+            elif role == "tool":
+                while end_idx + 1 < len(context) and (
+                    context[end_idx + 1].get("role") == "tool"
+                ):
+                    end_idx += 1
+            return end_idx - start_idx + 1
+
         removed = 0
         while removed < 2:
+            next_unit_count = _peek_earliest_unit_count()
+            if next_unit_count == 0:
+                break
+            # Keep behavior close to the old "pop around 2 records" strategy,
+            # while still preserving tool-call atomicity.
+            if removed > 0 and removed + next_unit_count > 3:
+                break
             removed_now = _pop_earliest_unit()
             if removed_now == 0:
                 break

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -187,8 +187,13 @@ class Provider(AbstractProvider):
                     return idx, end_idx
             return None
 
+        # Removal policy: try to remove around TARGET_RECORDS messages,
+        # but allow up to MAX_RECORDS to keep tool-call/message units atomic.
+        TARGET_RECORDS = 2
+        MAX_RECORDS = 3
+
         removed = 0
-        while removed < 2:
+        while removed < TARGET_RECORDS:
             next_unit = _next_unit_bounds()
             if next_unit is None:
                 break
@@ -196,7 +201,7 @@ class Provider(AbstractProvider):
             next_unit_count = end_idx - start_idx + 1
             # Keep behavior close to the old "pop around 2 records" strategy,
             # while still preserving tool-call atomicity.
-            if removed > 0 and removed + next_unit_count > 3:
+            if removed > 0 and removed + next_unit_count > MAX_RECORDS:
                 break
             del context[start_idx : end_idx + 1]
             removed += next_unit_count

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -162,19 +162,44 @@ class Provider(AbstractProvider):
         raise NotImplementedError()
 
     async def pop_record(self, context: list) -> None:
-        """弹出 context 第一条非系统提示词对话记录"""
-        poped = 0
-        indexs_to_pop = []
-        for idx, record in enumerate(context):
-            if record["role"] == "system":
-                continue
-            indexs_to_pop.append(idx)
-            poped += 1
-            if poped == 2:
-                break
+        """弹出最早的非 system 记录，同时保持 tool_calls 与 tool 配对完整。"""
 
-        for idx in reversed(indexs_to_pop):
-            context.pop(idx)
+        def _has_tool_calls(message: dict) -> bool:
+            return bool(message.get("tool_calls"))
+
+        def _next_unit_bounds() -> tuple[int, int] | None:
+            for idx, record in enumerate(context):
+                if record.get("role") != "system":
+                    end_idx = idx
+                    role = record.get("role")
+                    if role == "assistant" and _has_tool_calls(record):
+                        # Keep assistant(tool_calls) and following tool messages atomic.
+                        while end_idx + 1 < len(context) and (
+                            context[end_idx + 1].get("role") == "tool"
+                        ):
+                            end_idx += 1
+                    elif role == "tool":
+                        # Remove leading orphan tool messages together.
+                        while end_idx + 1 < len(context) and (
+                            context[end_idx + 1].get("role") == "tool"
+                        ):
+                            end_idx += 1
+                    return idx, end_idx
+            return None
+
+        removed = 0
+        while removed < 2:
+            next_unit = _next_unit_bounds()
+            if next_unit is None:
+                break
+            start_idx, end_idx = next_unit
+            next_unit_count = end_idx - start_idx + 1
+            # Keep behavior close to the old "pop around 2 records" strategy,
+            # while still preserving tool-call atomicity.
+            if removed > 0 and removed + next_unit_count > 3:
+                break
+            del context[start_idx : end_idx + 1]
+            removed += next_unit_count
 
     def _ensure_message_to_dicts(
         self,

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -162,19 +162,49 @@ class Provider(AbstractProvider):
         raise NotImplementedError()
 
     async def pop_record(self, context: list) -> None:
-        """弹出 context 第一条非系统提示词对话记录"""
-        poped = 0
-        indexs_to_pop = []
-        for idx, record in enumerate(context):
-            if record["role"] == "system":
-                continue
-            indexs_to_pop.append(idx)
-            poped += 1
-            if poped == 2:
-                break
+        """Pop earliest non-system records while preserving tool-call pairing."""
 
-        for idx in reversed(indexs_to_pop):
-            context.pop(idx)
+        def _has_tool_calls(message: dict) -> bool:
+            return bool(message.get("tool_calls"))
+
+        def _first_non_system_index() -> int | None:
+            for idx, record in enumerate(context):
+                if record.get("role") != "system":
+                    return idx
+            return None
+
+        def _pop_earliest_unit() -> int:
+            start_idx = _first_non_system_index()
+            if start_idx is None:
+                return 0
+
+            record = context[start_idx]
+            role = record.get("role")
+            end_idx = start_idx
+
+            if role == "assistant" and _has_tool_calls(record):
+                # Keep assistant(tool_calls) and following tool messages atomic.
+                while end_idx + 1 < len(context) and (
+                    context[end_idx + 1].get("role") == "tool"
+                ):
+                    end_idx += 1
+            elif role == "tool":
+                # Remove leading orphan tool messages together.
+                while end_idx + 1 < len(context) and (
+                    context[end_idx + 1].get("role") == "tool"
+                ):
+                    end_idx += 1
+
+            removed_count = end_idx - start_idx + 1
+            del context[start_idx : end_idx + 1]
+            return removed_count
+
+        removed = 0
+        while removed < 2:
+            removed_now = _pop_earliest_unit()
+            if removed_now == 0:
+                break
+            removed += removed_now
 
     def _ensure_message_to_dicts(
         self,

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -1,4 +1,6 @@
+from pathlib import Path
 from types import SimpleNamespace
+from urllib.parse import urlparse, urlunparse
 
 import pytest
 from openai.types.chat.chat_completion import ChatCompletion
@@ -240,6 +242,112 @@ async def test_openai_payload_keeps_reasoning_content_in_assistant_history():
             {"type": "text", "text": "final answer"}
         ]
         assert assistant_message["reasoning_content"] == "step 1"
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_pop_record_removes_assistant_tool_calls_with_following_tools_atomically():
+    provider = _make_provider()
+    try:
+        context = [
+            {"role": "system", "content": "system"},
+            {"role": "assistant", "tool_calls": [{"id": "call_1"}], "content": None},
+            {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+            {"role": "user", "content": "keep me"},
+        ]
+
+        await provider.pop_record(context)
+
+        assert context == [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "keep me"},
+        ]
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_pop_record_removes_leading_orphan_tool_messages():
+    provider = _make_provider()
+    try:
+        context = [
+            {"role": "system", "content": "system"},
+            {"role": "tool", "tool_call_id": "call_1", "content": "orphan"},
+            {"role": "user", "content": "old user"},
+            {"role": "assistant", "content": "old assistant"},
+            {"role": "user", "content": "new user"},
+        ]
+
+        await provider.pop_record(context)
+
+        assert context == [
+            {"role": "system", "content": "system"},
+            {"role": "assistant", "content": "old assistant"},
+            {"role": "user", "content": "new user"},
+        ]
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_pop_record_normal_messages_no_regression():
+    provider = _make_provider()
+    try:
+        context = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "user1"},
+            {"role": "assistant", "content": "assistant1"},
+            {"role": "user", "content": "user2"},
+            {"role": "assistant", "content": "assistant2"},
+        ]
+
+        await provider.pop_record(context)
+
+        assert context == [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "user2"},
+            {"role": "assistant", "content": "assistant2"},
+        ]
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_pop_record_assistant_with_multiple_tool_calls():
+    provider = _make_provider()
+    try:
+        context = [
+            {"role": "system", "content": "system"},
+            {
+                "role": "assistant",
+                "tool_calls": [{"id": "call_1"}, {"id": "call_2"}],
+                "content": None,
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "result1"},
+            {"role": "tool", "tool_call_id": "call_2", "content": "result2"},
+            {"role": "user", "content": "keep me"},
+        ]
+
+        await provider.pop_record(context)
+
+        assert context == [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "keep me"},
+        ]
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_pop_record_only_system_messages():
+    provider = _make_provider()
+    try:
+        context = [{"role": "system", "content": "system"}]
+
+        await provider.pop_record(context)
+
+        assert context == [{"role": "system", "content": "system"}]
     finally:
         await provider.terminate()
 
@@ -782,9 +890,8 @@ async def test_prepare_chat_payload_materializes_context_file_uri_image_urls(tmp
 async def test_file_uri_to_path_preserves_windows_drive_letter():
     provider = _make_provider()
     try:
-        assert provider._file_uri_to_path("file:///C:/tmp/quoted-image.png") == (
-            "C:/tmp/quoted-image.png"
-        )
+        resolved = provider._file_uri_to_path("file:///C:/tmp/quoted-image.png")
+        assert Path(resolved) == Path("C:/tmp/quoted-image.png")
     finally:
         await provider.terminate()
 
@@ -793,9 +900,8 @@ async def test_file_uri_to_path_preserves_windows_drive_letter():
 async def test_file_uri_to_path_preserves_windows_netloc_drive_letter():
     provider = _make_provider()
     try:
-        assert provider._file_uri_to_path("file://C:/tmp/quoted-image.png") == (
-            "C:/tmp/quoted-image.png"
-        )
+        resolved = provider._file_uri_to_path("file://C:/tmp/quoted-image.png")
+        assert Path(resolved) == Path("C:/tmp/quoted-image.png")
     finally:
         await provider.terminate()
 
@@ -804,9 +910,8 @@ async def test_file_uri_to_path_preserves_windows_netloc_drive_letter():
 async def test_file_uri_to_path_preserves_remote_netloc_as_unc_path():
     provider = _make_provider()
     try:
-        assert provider._file_uri_to_path("file://server/share/quoted-image.png") == (
-            "//server/share/quoted-image.png"
-        )
+        resolved = provider._file_uri_to_path("file://server/share/quoted-image.png")
+        assert Path(resolved) == Path("//server/share/quoted-image.png")
     finally:
         await provider.terminate()
 
@@ -977,7 +1082,10 @@ async def test_prepare_chat_payload_materializes_context_localhost_file_uri_imag
         image_path = tmp_path / "quoted-image.png"
         PILImage.new("RGBA", (1, 1), (255, 0, 0, 255)).save(image_path)
 
-        localhost_uri = f"file://localhost{image_path.as_posix()}"
+        parsed_local_uri = urlparse(image_path.as_uri())
+        localhost_uri = urlunparse(
+            ("file", "localhost", parsed_local_uri.path, "", "", "")
+        )
         payloads, _ = await provider._prepare_chat_payload(
             prompt=None,
             contexts=[

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -245,6 +245,50 @@ async def test_openai_payload_keeps_reasoning_content_in_assistant_history():
 
 
 @pytest.mark.asyncio
+async def test_pop_record_removes_assistant_tool_calls_with_following_tools_atomically():
+    provider = _make_provider()
+    try:
+        context = [
+            {"role": "system", "content": "system"},
+            {"role": "assistant", "tool_calls": [{"id": "call_1"}], "content": None},
+            {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+            {"role": "user", "content": "keep me"},
+        ]
+
+        await provider.pop_record(context)
+
+        assert context == [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "keep me"},
+        ]
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_pop_record_removes_leading_orphan_tool_messages():
+    provider = _make_provider()
+    try:
+        context = [
+            {"role": "system", "content": "system"},
+            {"role": "tool", "tool_call_id": "call_1", "content": "orphan"},
+            {"role": "user", "content": "old user"},
+            {"role": "assistant", "content": "old assistant"},
+            {"role": "user", "content": "new user"},
+        ]
+
+        await provider.pop_record(context)
+
+        assert context == [
+            {"role": "system", "content": "system"},
+            {"role": "assistant", "content": "old assistant"},
+            {"role": "user", "content": "new user"},
+        ]
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
 async def test_groq_payload_drops_reasoning_content_from_assistant_history():
     provider = _make_groq_provider()
     try:

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -289,6 +289,68 @@ async def test_pop_record_removes_leading_orphan_tool_messages():
 
 
 @pytest.mark.asyncio
+async def test_pop_record_normal_messages_no_regression():
+    provider = _make_provider()
+    try:
+        context = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "user1"},
+            {"role": "assistant", "content": "assistant1"},
+            {"role": "user", "content": "user2"},
+            {"role": "assistant", "content": "assistant2"},
+        ]
+
+        await provider.pop_record(context)
+
+        assert context == [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "user2"},
+            {"role": "assistant", "content": "assistant2"},
+        ]
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_pop_record_assistant_with_multiple_tool_calls():
+    provider = _make_provider()
+    try:
+        context = [
+            {"role": "system", "content": "system"},
+            {
+                "role": "assistant",
+                "tool_calls": [{"id": "call_1"}, {"id": "call_2"}],
+                "content": None,
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "result1"},
+            {"role": "tool", "tool_call_id": "call_2", "content": "result2"},
+            {"role": "user", "content": "keep me"},
+        ]
+
+        await provider.pop_record(context)
+
+        assert context == [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "keep me"},
+        ]
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_pop_record_only_system_messages():
+    provider = _make_provider()
+    try:
+        context = [{"role": "system", "content": "system"}]
+
+        await provider.pop_record(context)
+
+        assert context == [{"role": "system", "content": "system"}]
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
 async def test_groq_payload_drops_reasoning_content_from_assistant_history():
     provider = _make_groq_provider()
     try:

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -1,4 +1,6 @@
 from types import SimpleNamespace
+from pathlib import Path
+from urllib.parse import urlparse, urlunparse
 
 import pytest
 from openai.types.chat.chat_completion import ChatCompletion
@@ -888,9 +890,8 @@ async def test_prepare_chat_payload_materializes_context_file_uri_image_urls(tmp
 async def test_file_uri_to_path_preserves_windows_drive_letter():
     provider = _make_provider()
     try:
-        assert provider._file_uri_to_path("file:///C:/tmp/quoted-image.png") == (
-            "C:/tmp/quoted-image.png"
-        )
+        resolved = provider._file_uri_to_path("file:///C:/tmp/quoted-image.png")
+        assert Path(resolved) == Path("C:/tmp/quoted-image.png")
     finally:
         await provider.terminate()
 
@@ -899,9 +900,8 @@ async def test_file_uri_to_path_preserves_windows_drive_letter():
 async def test_file_uri_to_path_preserves_windows_netloc_drive_letter():
     provider = _make_provider()
     try:
-        assert provider._file_uri_to_path("file://C:/tmp/quoted-image.png") == (
-            "C:/tmp/quoted-image.png"
-        )
+        resolved = provider._file_uri_to_path("file://C:/tmp/quoted-image.png")
+        assert Path(resolved) == Path("C:/tmp/quoted-image.png")
     finally:
         await provider.terminate()
 
@@ -910,9 +910,8 @@ async def test_file_uri_to_path_preserves_windows_netloc_drive_letter():
 async def test_file_uri_to_path_preserves_remote_netloc_as_unc_path():
     provider = _make_provider()
     try:
-        assert provider._file_uri_to_path("file://server/share/quoted-image.png") == (
-            "//server/share/quoted-image.png"
-        )
+        resolved = provider._file_uri_to_path("file://server/share/quoted-image.png")
+        assert Path(resolved) == Path("//server/share/quoted-image.png")
     finally:
         await provider.terminate()
 
@@ -1083,7 +1082,10 @@ async def test_prepare_chat_payload_materializes_context_localhost_file_uri_imag
         image_path = tmp_path / "quoted-image.png"
         PILImage.new("RGBA", (1, 1), (255, 0, 0, 255)).save(image_path)
 
-        localhost_uri = f"file://localhost{image_path.as_posix()}"
+        parsed_local_uri = urlparse(image_path.as_uri())
+        localhost_uri = urlunparse(
+            ("file", "localhost", parsed_local_uri.path, "", "", "")
+        )
         payloads, _ = await provider._prepare_chat_payload(
             prompt=None,
             contexts=[


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
### Motivation / 动机

当对话上下文超过模型 token 上限时，`Provider.pop_record()` 会触发应急截断（#7225）。原实现固定从头部盲删 2 条非 system 消息，不检查 `assistant(tool_calls)` 与 `tool` 回复的配对关系，可能导致孤立 `tool` 消息残留，使 OpenAI 兼容 API 返回 400 错误（`Messages with role 'tool' must be a response to a preceding message with 'tool_calls'`）。

此前 `ContextTruncator.fix_messages()` 已在常规截断路径（#5416 / #5417）中解决了同类问题，但 `pop_record()` 走的是另一条独立路径，未经过该修复。

此外，`test_file_uri_to_path` 系列测试在 Windows 上构造 localhost file URI 的方式存在缺陷：通过字符串拼接 `file://localhost{as_posix()}` 生成 `file://localhostC:/...`，缺少 localhost 后的 `/`，导致 URI 无效。本 PR 一并修复。
### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- **`astrbot/core/provider/provider.py`**：重写 `Provider.pop_record()`
  - 引入 `_pop_earliest_unit()`：将 `assistant(tool_calls)` 及其后续连续 `tool` 消息作为原子单位整体删除
  - 引入 `_peek_earliest_unit_count()`：预判下一个待删单元大小，当累计删除数即将超过 3 时提前停止，避免过度截断
  - 处理头部孤立 `tool` 消息：将连续的孤立 `tool` 消息作为一个单位整体清除

- **`tests/test_openai_source.py`**：新增 5 个单元测试覆盖 `pop_record()` 的核心场景
  - `test_pop_record_removes_assistant_tool_calls_with_following_tools_atomically`：基本 tool 链原子删除
  - `test_pop_record_removes_leading_orphan_tool_messages`：孤立 tool 消息清理
  - `test_pop_record_normal_messages_no_regression`：普通对话无回归
  - `test_pop_record_assistant_with_multiple_tool_calls`：多 tool_calls 配对
  - `test_pop_record_only_system_messages`：仅含 system 消息的边界情况

- **`tests/test_openai_source.py`**：修复 Windows localhost file URI 测试构造
  - 使用 `urlparse`/`urlunparse` 基于 `Path.as_uri()` 规范构造 URI，替代字符串拼接，确保生成 `file://localhost/C:/...` 格式

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

```
$ ruff format .
All checks passed!

$ ruff check .
All checks passed!
```
新增测试覆盖的场景（本地验证）：

| 测试 | 输入 | 预期输出 | 结果 |
|------|------|---------|------|
| tool 链原子删除 | `system → assistant(tc) → tool → user` | `system → user` | ✅ Pass |
| 孤立 tool 清理 | `system → tool(orphan) → user → assistant → user` | `system → assistant → user` | ✅ Pass |
| 普通对话回归 | `system → u1 → a1 → u2 → a2` | `system → u2 → a2` | ✅ Pass |
| 多 tool_calls | `system → assistant(tc1,tc2) → tool1 → tool2 → user` | `system → user` | ✅ Pass |
| 仅 system | `system` | `system`（不变） | ✅ Pass |
---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Adjust context truncation logic to preserve assistant tool_call and tool message pairing while keeping truncation bounded, and update tests including Windows file URI handling.

Bug Fixes:
- Ensure emergency context truncation via pop_record removes assistant tool_calls and their corresponding tool messages atomically to prevent invalid tool-only histories and API 400 errors.
- Fix Windows localhost file URI construction and path resolution tests to validate using normalized Path comparisons instead of string literals.

Tests:
- Add unit tests covering pop_record behavior with tool_call chains, orphan tool messages, normal conversations, multiple tool_calls, and system-only contexts.
- Adjust file URI to path tests on Windows to assert normalized Path equality for local and UNC-style file URIs.