### PR TITLE
fix(provider): preserve tool-call pairing after context truncation (#7225)

### DIFF
--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -172,6 +172,48 @@ class Provider(AbstractProvider):
         for idx in reversed(indexs_to_pop):
             context.pop(idx)
 
+        context[:] = self._fix_tool_call_pairs_in_dict_context(context)
+
+    @staticmethod
+    def _fix_tool_call_pairs_in_dict_context(context: list[dict]) -> list[dict]:
+        """Remove orphaned tool call chains from dict-based message history."""
+        if not context:
+            return context
+
+        fixed_context: list[dict] = []
+        pending_assistant: dict | None = None
+        pending_tools: list[dict] = []
+
+        def flush_pending_if_valid() -> None:
+            nonlocal pending_assistant, pending_tools
+            if pending_assistant is not None and pending_tools:
+                fixed_context.append(pending_assistant)
+                fixed_context.extend(pending_tools)
+            pending_assistant = None
+            pending_tools = []
+
+        for message in context:
+            role = message.get("role")
+            if role == "tool":
+                if pending_assistant is not None:
+                    pending_tools.append(message)
+                continue
+
+            if (
+                role == "assistant"
+                and message.get("tool_calls") is not None
+                and len(message.get("tool_calls")) > 0
+            ):
+                flush_pending_if_valid()
+                pending_assistant = message
+                continue
+
+            flush_pending_if_valid()
+            fixed_context.append(message)
+
+        flush_pending_if_valid()
+        return fixed_context
+
     def _ensure_message_to_dicts(
         self,
         messages: list[dict] | list[Message] | None,

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -199,11 +199,7 @@ class Provider(AbstractProvider):
                     pending_tools.append(message)
                 continue
 
-            if (
-                role == "assistant"
-                and message.get("tool_calls") is not None
-                and len(message.get("tool_calls")) > 0
-            ):
+            if role == "assistant" and message.get("tool_calls"):
                 flush_pending_if_valid()
                 pending_assistant = message
                 continue

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -186,7 +186,10 @@ class Provider(AbstractProvider):
 
         def flush_pending_if_valid() -> None:
             nonlocal pending_assistant, pending_tools
-            if pending_assistant is not None and pending_tools:
+            if pending_assistant is not None and Provider._is_complete_tool_chain(
+                pending_assistant,
+                pending_tools,
+            ):
                 fixed_context.append(pending_assistant)
                 fixed_context.extend(pending_tools)
             pending_assistant = None
@@ -209,6 +212,34 @@ class Provider(AbstractProvider):
 
         flush_pending_if_valid()
         return fixed_context
+
+    @staticmethod
+    def _is_complete_tool_chain(
+        assistant_message: dict,
+        tool_messages: list[dict],
+    ) -> bool:
+        """Check whether a dict-based assistant/tool chain is fully paired."""
+        tool_calls = assistant_message.get("tool_calls") or []
+        expected_ids = [
+            tool_call.get("id")
+            for tool_call in tool_calls
+            if tool_call.get("id") is not None
+        ]
+        if not expected_ids or len(expected_ids) != len(tool_calls):
+            return False
+
+        seen_ids: set[str] = set()
+        for tool_message in tool_messages:
+            tool_call_id = tool_message.get("tool_call_id")
+            if (
+                tool_call_id is None
+                or tool_call_id not in expected_ids
+                or tool_call_id in seen_ids
+            ):
+                return False
+            seen_ids.add(tool_call_id)
+
+        return len(seen_ids) == len(expected_ids)
 
     def _ensure_message_to_dicts(
         self,

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -211,6 +211,63 @@ async def test_handle_api_error_context_length_removes_orphaned_tool_messages():
 
 
 @pytest.mark.asyncio
+async def test_fix_tool_call_pairs_in_dict_context_removes_partial_multi_tool_chain():
+    provider = _make_provider()
+    try:
+        full_chain = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "Run multiple tools"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "tool_a", "arguments": "{}"},
+                    },
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "tool_b", "arguments": "{}"},
+                    },
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "name": "tool_a",
+                "content": "result a",
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_2",
+                "name": "tool_b",
+                "content": "result b",
+            },
+            {"role": "assistant", "content": "Final answer"},
+        ]
+
+        assert provider._fix_tool_call_pairs_in_dict_context(full_chain) == full_chain
+
+        missing_assistant = full_chain[:2] + full_chain[3:]
+        assert provider._fix_tool_call_pairs_in_dict_context(missing_assistant) == [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "Run multiple tools"},
+            {"role": "assistant", "content": "Final answer"},
+        ]
+
+        missing_one_tool = full_chain[:-2] + [full_chain[-1]]
+        assert provider._fix_tool_call_pairs_in_dict_context(missing_one_tool) == [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "Run multiple tools"},
+            {"role": "assistant", "content": "Final answer"},
+        ]
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
 async def test_handle_api_error_context_length_preserves_remaining_valid_messages():
     provider = _make_provider()
     try:

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -166,6 +166,87 @@ async def test_handle_api_error_model_not_vlm_after_fallback_raises():
 
 
 @pytest.mark.asyncio
+async def test_handle_api_error_context_length_removes_orphaned_tool_messages():
+    provider = _make_provider()
+    try:
+        payloads = {
+            "messages": [
+                {"role": "system", "content": "system"},
+                {"role": "user", "content": "Run tool"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "search", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "content": "Tool result", "tool_call_id": "call_1"},
+                {"role": "assistant", "content": "Final answer"},
+            ]
+        }
+        context_query = payloads["messages"]
+
+        success, *_rest = await provider._handle_api_error(
+            Exception("maximum context length exceeded"),
+            payloads=payloads,
+            context_query=context_query,
+            func_tool=None,
+            chosen_key="test-key",
+            available_api_keys=["test-key"],
+            retry_cnt=0,
+            max_retries=10,
+        )
+
+        assert success is False
+        assert payloads["messages"] == [
+            {"role": "system", "content": "system"},
+            {"role": "assistant", "content": "Final answer"},
+        ]
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_handle_api_error_context_length_preserves_remaining_valid_messages():
+    provider = _make_provider()
+    try:
+        payloads = {
+            "messages": [
+                {"role": "system", "content": "system"},
+                {"role": "user", "content": "old question"},
+                {"role": "assistant", "content": "old answer"},
+                {"role": "user", "content": "new question"},
+                {"role": "assistant", "content": "new answer"},
+            ]
+        }
+        context_query = payloads["messages"]
+
+        success, *_rest = await provider._handle_api_error(
+            Exception("maximum context length exceeded"),
+            payloads=payloads,
+            context_query=context_query,
+            func_tool=None,
+            chosen_key="test-key",
+            available_api_keys=["test-key"],
+            retry_cnt=0,
+            max_retries=10,
+        )
+
+        assert success is False
+        assert payloads["messages"] == [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "new question"},
+            {"role": "assistant", "content": "new answer"},
+        ]
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
 async def test_handle_api_error_content_moderated_with_unserializable_body():
     provider = _make_provider({"image_moderation_error_patterns": ["blocked"]})
     try:


### PR DESCRIPTION
## Summary

# Review summary for issue #7225

## Branch

`fix/7225-tool-call-truncation`

## Changed files

- astrbot/core/provider/provider.py
- tests/test_openai_source.py

## Commit

```
Subject: fix(provider): clean orphaned tool messages after truncation
Author: LehaoLin <linlehao@cuhk.edu.cn>
Date: Tue Mar 31 22:16:35 2026 +0800
```

## Issue

- Issue number: #7225
- Issue URL: https://github.com/AstrBotDevs/AstrBot/issues/7225
- Origin: https://github.com/Yaohua-Leo/AstrBot.git
- Upstream: https://github.com/AstrBotDevs/AstrBot.git

## Executed

- Command: `python -m pytest tests/test_openai_source.py -k "context_length or content_moderated_removes_images"`
  Purpose: Try the smallest repository-native OpenAI provider test slice from the existing global Python environment.
- Command: `.venv\Scripts\python.exe -m pytest tests/test_openai_source.py -k "context_length or content_moderated_removes_images"`
  Purpose: Re-run the same repository-native slice in a repo-local Python 3.12 virtualenv after installing `requirements.txt`, `pytest`, and `pytest-asyncio`.
- Command: `.venv\Scripts\python.exe -m pytest tests/test_openai_source.py::test_handle_api_error_context_length_removes_orphaned_tool_messages`
  Purpose: Validate the issue-specific regression where emergency truncation used to leave an orphaned `tool` message.
- Command: `.venv\Scripts\python.exe -m pytest tests/test_openai_source.py::test_handle_api_error_context_length_preserves_remaining_valid_messages`
  Purpose: Check the nearby boundary case that valid non-tool messages still survive emergency truncation.
- Command: `.venv\Scripts\python.exe -m pytest tests/test_openai_source.py`
  Purpose: Run the full OpenAI provider test module to catch adjacent regressions in error-handling branches.
- Command: `.venv\Scripts\python.exe -m ruff check astrbot/core/provider/provider.py tests/test_openai_source.py`
  Purpose: Run static checks on the changed implementation and regression tests.

## Results

- Command: `python -m pytest tests/test_openai_source.py -k "context_length or content_moderated_removes_images"`
  Status: failed then fixed
  Summary: The first attempt failed before test collection because the global Python environment was missing `sqlalchemy`. I created a repo-local Python 3.12 `.venv`, installed the runtime requirements plus pytest tooling, and reran the equivalent repository-native check successfully.
- Command: `.venv\Scripts\python.exe -m pytest tests/test_openai_source.py -k "context_length or content_moderated_removes_images"`
  Status: passed
  Summary: Three selected tests passed, covering the new maximum-context regression cases plus one pre-existing content-moderation check.
- Command: `.venv\Scripts\python.exe -m pytest tests/test_openai_source.py::test_handle_api_error_context_length_removes_orphaned_tool_messages`
  Status: passed
  Summary: Confirmed that after `pop_record()` removes the earliest user/assistant(tool_calls) pair, orphaned `tool` messages are now removed from the dict-based context before retry.
- Command: `.venv\Scripts\python.exe -m pytest tests/test_openai_source.py::test_handle_api_error_context_length_preserves_remaining_valid_messages`
  Status: passed
  Summary: Confirmed that emergency truncation still preserves unrelated valid messages after the oldest conversation turn is removed.
- Command: `.venv\Scripts\python.exe -m pytest tests/test_openai_source.py`
  Status: passed
  Summary: All 16 tests in `tests/test_openai_source.py` passed.
- Command: `.venv\Scripts\python.exe -m ruff check astrbot/core/provider/provider.py tests/test_openai_source.py`
  Status: passed
  Summary: Ruff reported no lint errors in the changed files.

## Not run

- Command or area: Full repository test suite
  Reason: The fix is isolated to the OpenAI provider emergency truncation path, so I kept validation focused on the smallest relevant built-in module instead of running the entire suite.
- Command or area: End-to-end chat flow against a real OpenAI-compatible provider
  Reason: This workspace does not have a test-specific remote provider session configured for safe reproducible E2E verification.

## Residual risk

- Risk: The regression coverage is strong for dict-based `maximum context length` retries in `ProviderOpenAIOfficial`, but it does not exercise a live multi-round agent conversation end to end.
- Follow-up: If maintainers want extra confidence, run one manual agent session that forces context trimming and confirms the retry path no longer sends a lone `tool` message.

## Changes

- astrbot/core/provider/provider.py
- tests/test_openai_source.py

## Testing

### Executed

- Command: `python -m pytest tests/test_openai_source.py -k "context_length or content_moderated_removes_images"`
  Purpose: Try the smallest repository-native OpenAI provider test slice from the existing global Python environment.
- Command: `.venv\Scripts\python.exe -m pytest tests/test_openai_source.py -k "context_length or content_moderated_removes_images"`
  Purpose: Re-run the same repository-native slice in a repo-local Python 3.12 virtualenv after installing `requirements.txt`, `pytest`, and `pytest-asyncio`.
- Command: `.venv\Scripts\python.exe -m pytest tests/test_openai_source.py::test_handle_api_error_context_length_removes_orphaned_tool_messages`
  Purpose: Validate the issue-specific regression where emergency truncation used to leave an orphaned `tool` message.
- Command: `.venv\Scripts\python.exe -m pytest tests/test_openai_source.py::test_handle_api_error_context_length_preserves_remaining_valid_messages`
  Purpose: Check the nearby boundary case that valid non-tool messages still survive emergency truncation.
- Command: `.venv\Scripts\python.exe -m pytest tests/test_openai_source.py`
  Purpose: Run the full OpenAI provider test module to catch adjacent regressions in error-handling branches.
- Command: `.venv\Scripts\python.exe -m ruff check astrbot/core/provider/provider.py tests/test_openai_source.py`
  Purpose: Run static checks on the changed implementation and regression tests.

### Results

- Command: `python -m pytest tests/test_openai_source.py -k "context_length or content_moderated_removes_images"`
  Status: failed then fixed
  Summary: The first attempt failed before test collection because the global Python environment was missing `sqlalchemy`. I created a repo-local Python 3.12 `.venv`, installed the runtime requirements plus pytest tooling, and reran the equivalent repository-native check successfully.
- Command: `.venv\Scripts\python.exe -m pytest tests/test_openai_source.py -k "context_length or content_moderated_removes_images"`
  Status: passed
  Summary: Three selected tests passed, covering the new maximum-context regression cases plus one pre-existing content-moderation check.
- Command: `.venv\Scripts\python.exe -m pytest tests/test_openai_source.py::test_handle_api_error_context_length_removes_orphaned_tool_messages`
  Status: passed
  Summary: Confirmed that after `pop_record()` removes the earliest user/assistant(tool_calls) pair, orphaned `tool` messages are now removed from the dict-based context before retry.
- Command: `.venv\Scripts\python.exe -m pytest tests/test_openai_source.py::test_handle_api_error_context_length_preserves_remaining_valid_messages`
  Status: passed
  Summary: Confirmed that emergency truncation still preserves unrelated valid messages after the oldest conversation turn is removed.
- Command: `.venv\Scripts\python.exe -m pytest tests/test_openai_source.py`
  Status: passed
  Summary: All 16 tests in `tests/test_openai_source.py` passed.
- Command: `.venv\Scripts\python.exe -m ruff check astrbot/core/provider/provider.py tests/test_openai_source.py`
  Status: passed
  Summary: Ruff reported no lint errors in the changed files.

### Not run

- Command or area: Full repository test suite
  Reason: The fix is isolated to the OpenAI provider emergency truncation path, so I kept validation focused on the smallest relevant built-in module instead of running the entire suite.
- Command or area: End-to-end chat flow against a real OpenAI-compatible provider
  Reason: This workspace does not have a test-specific remote provider session configured for safe reproducible E2E verification.

### Residual risk

- Risk: The regression coverage is strong for dict-based `maximum context length` retries in `ProviderOpenAIOfficial`, but it does not exercise a live multi-round agent conversation end to end.
- Follow-up: If maintainers want extra confidence, run one manual agent session that forces context trimming and confirms the retry path no longer sends a lone `tool` message.

## Summary by Sourcery

Ensure OpenAI provider context truncation maintains valid conversation structure when handling maximum context length errors.

Bug Fixes:
- Remove orphaned tool messages left behind after truncating the earliest user/assistant(tool_calls) pair in dict-based message histories.
- Preserve remaining non-tool messages when emergency context trimming occurs on maximum context length errors.

Tests:
- Add regression tests covering removal of orphaned tool messages and preservation of valid messages after context-length-based truncation in the OpenAI provider.