### PR TITLE
Fix(kb_helper):数据库选择的提供商消失,导致的数据库不显示问题

### DIFF
--- a/astrbot/core/knowledge_base/kb_helper.py
+++ b/astrbot/core/knowledge_base/kb_helper.py
@@ -201,7 +201,7 @@ class KBHelper:
                     top_n: int | None = None,
                 ):
                     raise ValueError(
-                        f"无法找到 ID 为 {self.rerank_provider_id} 的 Embedding Provider"
+                        f"无法找到 ID 为 {self.rerank_provider_id} 的 Rerank Provider"
                     )
 
             rp: RerankProvider = TempRerankProvider({}, {}, self.kb.rerank_provider_id)


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

fixes #7218
修理了数据库选择的提供商消失，导致的数据库不显示问题

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

在AstrBot\astrbot\core\knowledge_base\kb_helper.py的文件给get_ep和get_rp添加了临时占位的提供商,该提供商实现的方法被调用将抛出报错,通过这样的方法将报错延迟到实际调用时,防止数据库在初始化时报错导致的数据库不显示。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

这是一个两个提供商都被删除的数据库,正常显示了

<img width="1919" height="881" alt="42e5cf1fee440dc8f33d0b02a6acc8cb" src="https://github.com/user-attachments/assets/1f6cb4ca-6554-4501-a1a1-43541fb576dd" />

使用占位提供商的后台日志

<img width="1733" height="755" alt="00af5e1bfb63c70b652af9d2899259f0" src="https://github.com/user-attachments/assets/e6296690-ff04-4c98-b1f2-2826f133ea4e" />

测试截图

<img width="1891" height="616" alt="image" src="https://github.com/user-attachments/assets/0a045644-8ded-43e0-843b-f7438b813c2b" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ X ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

没有新功能

- [ X ] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

有进行测试

- [ X ] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

没有引入

- [ X ] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

没有恶意代码

## Summary by Sourcery

Bug Fixes:
- Prevent knowledge bases from failing to display when their configured embedding or rerank providers are missing by logging and substituting temporary placeholder providers instead of raising initialization-time errors.