### PR TITLE
fix(webchat): migrate webchat data when dashboard username changes

### DIFF
--- a/astrbot/core/db/__init__.py
+++ b/astrbot/core/db/__init__.py
@@ -722,9 +722,16 @@ class BaseDatabase(abc.ABC):
         """Delete a Platform session by its ID."""
         ...
 
+    @abc.abstractmethod
+    async def migrate_user_webchat_data(
+        self, old_username: str, new_username: str
+    ) -> None:
+        """Migrate all webchat user data when username is changed."""
+        ...
+
     # ====
     # ChatUI Project Management
-    # ====
+    # ===="
 
     @abc.abstractmethod
     async def create_chatui_project(

--- a/astrbot/core/db/__init__.py
+++ b/astrbot/core/db/__init__.py
@@ -731,7 +731,7 @@ class BaseDatabase(abc.ABC):
 
     # ====
     # ChatUI Project Management
-    # ===="
+    # ====
 
     @abc.abstractmethod
     async def create_chatui_project(

--- a/astrbot/core/db/sqlite.py
+++ b/astrbot/core/db/sqlite.py
@@ -1616,6 +1616,47 @@ class SQLiteDatabase(BaseDatabase):
                     ),
                 )
 
+    async def migrate_user_webchat_data(
+        self, old_username: str, new_username: str
+    ) -> None:
+        """Migrate all webchat user data when username is changed."""
+        old_fragment = f"!{old_username}!"
+        new_fragment = f"!{new_username}!"
+        async with self.get_db() as session:
+            session: AsyncSession
+            async with session.begin():
+                await session.execute(
+                    update(PlatformSession)
+                    .where(col(PlatformSession.creator) == old_username)
+                    .values(creator=new_username)
+                )
+                await session.execute(
+                    update(ChatUIProject)
+                    .where(col(ChatUIProject.creator) == old_username)
+                    .values(creator=new_username)
+                )
+                await session.execute(
+                    update(ConversationV2)
+                    .where(col(ConversationV2.user_id).like("webchat%"))
+                    .values(
+                        user_id=func.replace(
+                            ConversationV2.user_id, old_fragment, new_fragment
+                        )
+                    )
+                )
+                await session.execute(
+                    update(Preference)
+                    .where(
+                        col(Preference.scope) == "umo",
+                        col(Preference.scope_id).like("webchat%"),
+                    )
+                    .values(
+                        scope_id=func.replace(
+                            Preference.scope_id, old_fragment, new_fragment
+                        )
+                    )
+                )
+
     # ====
     # ChatUI Project Management
     # ====

--- a/astrbot/dashboard/routes/auth.py
+++ b/astrbot/dashboard/routes/auth.py
@@ -6,13 +6,15 @@ from quart import request
 
 from astrbot import logger
 from astrbot.core import DEMO_MODE
+from astrbot.core.db import BaseDatabase
 
 from .route import Response, Route, RouteContext
 
 
 class AuthRoute(Route):
-    def __init__(self, context: RouteContext) -> None:
+    def __init__(self, context: RouteContext, db: BaseDatabase) -> None:
         super().__init__(context)
+        self.db = db
         self.routes = {
             "/auth/login": ("POST", self.login),
             "/auth/account/edit": ("POST", self.edit_account),
@@ -72,8 +74,14 @@ class AuthRoute(Route):
             if confirm_pwd != new_pwd:
                 return Response().error("两次输入的新密码不一致").__dict__
             self.config["dashboard"]["password"] = new_pwd
+
+        old_username = self.config["dashboard"]["username"]
         if new_username:
             self.config["dashboard"]["username"] = new_username
+
+        # Migrate webchat user data before saving config to keep them in sync.
+        if new_username and new_username != old_username:
+            await self.db.migrate_user_webchat_data(old_username, new_username)
 
         self.config.save_config()
 

--- a/astrbot/dashboard/server.py
+++ b/astrbot/dashboard/server.py
@@ -112,7 +112,7 @@ class AstrBotDashboard:
         self.cr = ConfigRoute(self.context, core_lifecycle)
         self.lr = LogRoute(self.context, core_lifecycle.log_broker)
         self.sfr = StaticFileRoute(self.context)
-        self.ar = AuthRoute(self.context)
+        self.ar = AuthRoute(self.context, db)
         self.api_key_route = ApiKeyRoute(self.context, db)
         self.chat_route = ChatRoute(self.context, db, core_lifecycle)
         self.open_api_route = OpenApiRoute(


### PR DESCRIPTION
When dashboard account username is updated, existing webchat records still reference the old username in UMO-like identifiers, causing chat history to appear empty after re-login.

This change:

- adds a database migration contract for username-based webchat data updates

- implements SQLite migration for related user-scoped records

- triggers migration in account edit flow before saving config

- injects database dependency into AuthRoute for migration execution

Closes #7242

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
验证步骤：
1.进行多组会话。
2.修改用户名。
3.检查webui，chat模块下历史聊天记录是否迁移过来。会话记录是否存在。
4.检查“会话数据”页面中，关联webchat的会话记录的会话ID是否迁移正确。
![PixPin_2026-04-01_16-58-05](https://github.com/user-attachments/assets/d4712f09-8397-4b26-9702-cde0598fdf86)


---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure webchat data linked to a dashboard account stays consistent when the account username changes.

Bug Fixes:
- Preserve existing webchat conversations and preferences after a dashboard username change by updating stored identifiers and ownership fields.

Enhancements:
- Introduce a database-agnostic migration contract for username-based webchat data updates and implement it for the SQLite backend.
- Inject the database dependency into the authentication routes so account updates can trigger webchat data migrations atomically.