### PR TITLE
feat(provider/vllm_rerank): add configurable rerank_api_suffix option

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1827,7 +1827,7 @@ CONFIG_METADATA_2 = {
                     "rerank_api_base": {
                         "description": "重排序模型 API Base URL",
                         "type": "string",
-                        "hint": "与 rerank_api_suffix 配合使用来确定最终请求路径。",
+                        "hint": "最终请求路径由 Base URL 和路径后缀拼接而成（默认为 /v1/rerank）。",
                     },
                     "rerank_api_suffix": {
                         "description": "API URL 路径后缀",

--- a/astrbot/core/provider/sources/vllm_rerank_source.py
+++ b/astrbot/core/provider/sources/vllm_rerank_source.py
@@ -21,6 +21,8 @@ class VLLMRerankProvider(RerankProvider):
         self.base_url = provider_config.get("rerank_api_base", "http://127.0.0.1:8000")
         self.base_url = self.base_url.rstrip("/")
         self.api_suffix = provider_config.get("rerank_api_suffix", "/v1/rerank")
+        if self.api_suffix is None:
+            self.api_suffix = "/v1/rerank"
         if self.api_suffix and not self.api_suffix.startswith("/"):
             self.api_suffix = "/" + self.api_suffix
         self.timeout = provider_config.get("timeout", 20)

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -1075,7 +1075,7 @@
       },
       "rerank_api_base": {
         "description": "Rerank Model API Base URL",
-        "hint": "Combined with rerank_api_suffix to form the full request URL."
+        "hint": "The full request URL is formed by combining the Base URL and a path suffix (defaults to /v1/rerank)."
       },
       "rerank_api_suffix": {
         "description": "API URL path suffix",

--- a/dashboard/src/i18n/locales/ru-RU/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/config-metadata.json
@@ -1076,7 +1076,11 @@
             },
             "rerank_api_base": {
                 "description": "Base URL API модели Rerank",
-                "hint": "AstrBot добавляет /v1/rerank к URL запроса."
+                "hint": "Полный URL запроса формируется путём добавления суффикса к Base URL (по умолчанию /v1/rerank)."
+            },
+            "rerank_api_suffix": {
+                "description": "Суффикс пути API",
+                "hint": "Суффикс пути, добавляемый к base_url, например /v1/rerank. Оставьте пустым, чтобы не добавлять."
             },
             "rerank_api_key": {
                 "description": "API Key",

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -1077,7 +1077,7 @@
       },
       "rerank_api_base": {
         "description": "重排序模型 API Base URL",
-        "hint": "与 rerank_api_suffix 配合使用来确定最终请求路径。"
+        "hint": "最终请求路径由 Base URL 和路径后缀拼接而成（默认为 /v1/rerank）。"
       },
       "rerank_api_suffix": {
         "description": "API URL 路径后缀",


### PR DESCRIPTION
## Summary

Add `rerank_api_suffix` config option to the VLLM Rerank provider so users can control the API URL path suffix instead of having `/v1/rerank` hardcoded.

**Changes:**
- `vllm_rerank_source.py`: Add `rerank_api_suffix` config with leading-slash normalization
- `default.py`: Add `rerank_api_suffix` to vLLM Rerank config template and schema
- `config-metadata.json` (zh-CN/en-US): Update i18n hints

**Behaviour:**
- Default: `/v1/rerank` — preserves existing behaviour for existing configs
- Set to empty string to disable auto-append when base_url already contains full path
- Handles suffix without leading `/` by auto-adding one

## Issue

Fixes #7238

## Test Plan

- [x] Codex CLI review: passed
- [ ] CI: pending

## Summary by Sourcery

Make the vLLM rerank provider’s API endpoint path configurable instead of hardcoding the /v1/rerank suffix.

New Features:
- Add a rerank_api_suffix configuration option to control the path suffix appended to the vLLM rerank API base URL.

Enhancements:
- Normalize and compose the rerank API URL from base and suffix to support more flexible deployments.

Documentation:
- Update configuration metadata and i18n hints to describe the new rerank_api_suffix option and its interaction with rerank_api_base.