### PR TITLE
fix: certain APIs return SSE-style string responses by parsing them as JSON and reconstructing a ChatCompletion object

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -462,7 +462,29 @@ class ProviderOpenAIOfficial(Provider):
             stream=False,
             extra_body=extra_body,
         )
-
+        
+        # --- 新增：兼容某些 API 强制返回 SSE 格式的 Bug ---
+        if isinstance(completion, str):
+            logger.warning(f"检测到 API 返回了字符串而非对象，尝试自动修复: {completion[:100]}...")
+            try:
+                # 如果是 data:{...} 格式，去掉 "data:" 并解析 JSON
+                json_str = completion.strip()
+                if json_str.startswith("data:"):
+                    json_str = json_str[5:].strip()
+                
+                # 尝试解析 JSON
+                completion_dict = json.loads(json_str)
+                
+                # 重新构造 ChatCompletion 对象
+                completion = ChatCompletion.construct(**completion_dict)
+                logger.info("成功将字符串响应转换为 ChatCompletion 对象。")
+                
+            except Exception as e:
+                logger.error(f"自动修复失败: {e}")
+                # 如果修复失败，继续抛出原始错误
+                raise Exception(f"API 返回格式错误且无法修复：{type(completion)}: {completion}。")
+        # ---------------------------------------------------
+        
         if not isinstance(completion, ChatCompletion):
             raise Exception(
                 f"API 返回的 completion 类型错误：{type(completion)}: {completion}。",


### PR DESCRIPTION
兼容某些 API 强制返回 SSE 格式的出参，将字符串响应转换为 ChatCompletion 对象

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
兼容某些 API 强制返回 SSE 格式的出参，将字符串响应转换为 ChatCompletion 对象


<img width="1784" height="411" alt="image" src="https://github.com/user-attachments/assets/7170f642-b273-4e8c-a9a5-9750e2daba8e" />

## Summary by Sourcery

Bug Fixes:
- Fix failures when certain APIs return SSE-style string responses by parsing them as JSON and reconstructing a ChatCompletion object.