### PR TITLE
fix: pass tool_call_timeout to shell.exec for configurable shell timeout

### DIFF
--- a/astrbot/core/computer/tools/shell.py
+++ b/astrbot/core/computer/tools/shell.py
@@ -58,7 +58,11 @@ class ExecuteShellTool(FunctionTool):
                 context.context.event.unified_msg_origin,
             )
         try:
-            result = await sb.shell.exec(command, background=background, env=env)
+            # 从上下文获取工具调用超时时间配置，传递给 shell.exec
+            timeout = context.tool_call_timeout
+            result = await sb.shell.exec(
+                command, background=background, env=env, timeout=timeout
+            )
             return json.dumps(result)
         except Exception as e:
             return f"Error executing command: {str(e)}"


### PR DESCRIPTION
### PR 描述（Draft）

---

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

**修复了 `astrbot_execute_shell` 工具的超时时间配置功能，使得用户可以通过管理面板中的"工具调用超时时间（秒）"设置来控制 shell 执行的超时时间。**

**问题描述**：
- 之前 `ExecuteShellTool` 调用 `shell.exec()` 时，没有传递 `timeout` 参数，导致始终使用接口默认的 30 秒超时
- 用户即使将 `tool_call_timeout` 设置为 600 秒，shell 执行仍然是 30 秒就超时

**修复方案**：
- 从 `context.tool_call_timeout` 获取配置的超时时间
- 将 `tool_call_timeout` 传递给 `shell.exec()` 的 `timeout` 参数

**修改文件**：
- `astrbot/core/computer/tools/shell.py`

```diff
--- a/astrbot/core/computer/tools/shell.py
+++ b/astrbot/core/computer/tools/shell.py
@@ -58,7 +58,11 @@ class ExecuteShellTool(FunctionTool):
                 context.context.event.unified_msg_origin,
             )
         try:
-            result = await sb.shell.exec(command, background=background, env=env)
+            # 从上下文获取工具调用超时时间配置，传递给 shell.exec
+            timeout = context.tool_call_timeout
+            result = await sb.shell.exec(
+                command, background=background, env=env, timeout=timeout
+            )
             return json.dumps(result)
         except Exception as e:
             return f"Error executing command: {str(e)}"
```

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

**注意：这是一个 Draft PR，目前代码尚未经过实际测试。**

测试步骤建议：
1. 在管理面板中设置 `tool_call_timeout` 为较大值（如 600）
2. 使用 `astrbot_execute_shell` 工具执行一个耗时较长的命令
3. 验证 shell 执行是否能在 30 秒后继续运行，直到达到配置的超时时间

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
- [ ] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [ ] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 My changes do not introduce malicious code.

---

**状态：Draft PR - 待测试**

## Summary by Sourcery

Bug Fixes:
- Ensure astrbot_execute_shell uses the context-provided tool_call_timeout value when invoking shell.exec so long-running commands respect the configured timeout.