### PR TITLE
fix(core): apply session plugin disable rules to hooks and tools

### DIFF
--- a/astrbot/core/astr_agent_tool_exec.py
+++ b/astrbot/core/astr_agent_tool_exec.py
@@ -30,6 +30,8 @@ from astrbot.core.message.message_event_result import (
 from astrbot.core.platform.message_session import MessageSession
 from astrbot.core.provider.entites import ProviderRequest
 from astrbot.core.provider.register import llm_tools
+from astrbot.core.star.session_plugin_manager import SessionPluginManager
+from astrbot.core.star.star import star_map
 from astrbot.core.tools.computer_tools import (
     CuaKeyboardTypeTool,
     CuaMouseClickTool,
@@ -52,6 +54,26 @@ from astrbot.core.utils.string_utils import normalize_and_dedupe_strings
 
 
 class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
+    @classmethod
+    def _tool_enabled_for_session(
+        cls,
+        tool: FunctionTool,
+        session_config: dict | None,
+    ) -> bool:
+        mp = tool.handler_module_path
+        if not mp:
+            return True
+
+        plugin = star_map.get(mp)
+        if not plugin:
+            return True
+
+        return SessionPluginManager.is_plugin_enabled_for_session_config(
+            plugin.name,
+            session_config,
+            reserved=plugin.reserved,
+        )
+
     @classmethod
     def _collect_image_urls_from_args(cls, image_urls_raw: T.Any) -> list[str]:
         if image_urls_raw is None:
@@ -241,7 +263,7 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
         return {}
 
     @classmethod
-    def _build_handoff_toolset(
+    async def _build_handoff_toolset(
         cls,
         run_context: ContextWrapper[AstrAgentContext],
         tools: list[str | FunctionTool] | None,
@@ -249,6 +271,9 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
         ctx = run_context.context.context
         event = run_context.context.event
         cfg = ctx.get_config(umo=event.unified_msg_origin)
+        session_config = await SessionPluginManager.get_session_plugin_config(
+            event.unified_msg_origin
+        )
         provider_settings = cfg.get("provider_settings", {})
         runtime = str(provider_settings.get("computer_use_runtime", "local"))
         tool_mgr = (
@@ -269,7 +294,10 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
             for registered_tool in llm_tools.func_list:
                 if isinstance(registered_tool, HandoffTool):
                     continue
-                if registered_tool.active:
+                if registered_tool.active and cls._tool_enabled_for_session(
+                    registered_tool,
+                    session_config,
+                ):
                     toolset.add_tool(registered_tool)
             for runtime_tool in runtime_computer_tools.values():
                 toolset.add_tool(runtime_tool)
@@ -282,14 +310,19 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
         for tool_name_or_obj in tools:
             if isinstance(tool_name_or_obj, str):
                 registered_tool = llm_tools.get_func(tool_name_or_obj)
-                if registered_tool and registered_tool.active:
+                if (
+                    registered_tool
+                    and registered_tool.active
+                    and cls._tool_enabled_for_session(registered_tool, session_config)
+                ):
                     toolset.add_tool(registered_tool)
                     continue
                 runtime_tool = runtime_computer_tools.get(tool_name_or_obj)
                 if runtime_tool:
                     toolset.add_tool(runtime_tool)
             elif isinstance(tool_name_or_obj, FunctionTool):
-                toolset.add_tool(tool_name_or_obj)
+                if cls._tool_enabled_for_session(tool_name_or_obj, session_config):
+                    toolset.add_tool(tool_name_or_obj)
         return None if toolset.empty() else toolset
 
     @classmethod
@@ -321,7 +354,7 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
         tool_args["image_urls"] = image_urls
 
         # Build handoff toolset from registered tools plus runtime computer tools.
-        toolset = cls._build_handoff_toolset(run_context, tool.agent.tools)
+        toolset = await cls._build_handoff_toolset(run_context, tool.agent.tools)
 
         ctx = run_context.context.context
         event = run_context.context.event

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -44,8 +44,8 @@ from astrbot.core.skills.skill_manager import (
     build_skills_prompt,
 )
 from astrbot.core.star.context import Context
-from astrbot.core.star.star import star_registry
 from astrbot.core.star.session_plugin_manager import SessionPluginManager
+from astrbot.core.star.star import star_registry
 from astrbot.core.star.star_handler import star_map
 from astrbot.core.tools.computer_tools import (
     AnnotateExecutionTool,

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -899,136 +899,6 @@ async def _decorate_llm_request(
     _apply_workspace_extra_prompt(event, req)
 
 
-def _modalities_fix(provider: Provider, req: ProviderRequest) -> None:
-    if req.image_urls:
-        provider_cfg = provider.provider_config.get("modalities", ["image"])
-        if "image" not in provider_cfg:
-            logger.debug(
-                "Provider %s does not support image, using placeholder.", provider
-            )
-            image_count = len(req.image_urls)
-            placeholder = " ".join(["[Image]"] * image_count)
-            if req.prompt:
-                req.prompt = f"{placeholder} {req.prompt}"
-            else:
-                req.prompt = placeholder
-            req.image_urls = []
-    if req.audio_urls:
-        provider_cfg = provider.provider_config.get("modalities", ["audio"])
-        if "audio" not in provider_cfg:
-            logger.debug(
-                "Provider %s does not support audio, using placeholder.", provider
-            )
-            audio_count = len(req.audio_urls)
-            placeholder = " ".join(["[Audio]"] * audio_count)
-            if req.prompt:
-                req.prompt = f"{placeholder} {req.prompt}"
-            else:
-                req.prompt = placeholder
-            req.audio_urls = []
-    if req.func_tool:
-        provider_cfg = provider.provider_config.get("modalities", ["tool_use"])
-        if "tool_use" not in provider_cfg:
-            logger.debug(
-                "Provider %s does not support tool_use, clearing tools.", provider
-            )
-            req.func_tool = None
-
-
-def _sanitize_context_by_modalities(
-    config: MainAgentBuildConfig,
-    provider: Provider,
-    req: ProviderRequest,
-) -> None:
-    if not config.sanitize_context_by_modalities:
-        return
-    if not isinstance(req.contexts, list) or not req.contexts:
-        return
-    modalities = provider.provider_config.get("modalities", None)
-    if not modalities or not isinstance(modalities, list):
-        return
-    supports_image = bool("image" in modalities)
-    supports_audio = bool("audio" in modalities)
-    supports_tool_use = bool("tool_use" in modalities)
-    if supports_image and supports_audio and supports_tool_use:
-        return
-
-    sanitized_contexts: list[dict] = []
-    removed_image_blocks = 0
-    removed_audio_blocks = 0
-    removed_tool_messages = 0
-    removed_tool_calls = 0
-
-    for msg in req.contexts:
-        if not isinstance(msg, dict):
-            continue
-        role = msg.get("role")
-        if not role:
-            continue
-
-        new_msg = msg
-        if not supports_tool_use:
-            if role == "tool":
-                removed_tool_messages += 1
-                continue
-            if role == "assistant" and "tool_calls" in new_msg:
-                if "tool_calls" in new_msg:
-                    removed_tool_calls += 1
-                new_msg.pop("tool_calls", None)
-                new_msg.pop("tool_call_id", None)
-
-        if not supports_image or not supports_audio:
-            content = new_msg.get("content")
-            if isinstance(content, list):
-                filtered_parts: list = []
-                removed_any_multimodal = False
-                for part in content:
-                    if isinstance(part, dict):
-                        part_type = str(part.get("type", "")).lower()
-                        if not supports_image and part_type in {"image_url", "image"}:
-                            removed_any_multimodal = True
-                            removed_image_blocks += 1
-                            continue
-                        if not supports_audio and part_type in {
-                            "audio_url",
-                            "input_audio",
-                        }:
-                            removed_any_multimodal = True
-                            removed_audio_blocks += 1
-                            continue
-                    filtered_parts.append(part)
-                if removed_any_multimodal:
-                    new_msg["content"] = filtered_parts
-
-        if role == "assistant":
-            content = new_msg.get("content")
-            has_tool_calls = bool(new_msg.get("tool_calls"))
-            if not has_tool_calls:
-                if not content:
-                    continue
-                if isinstance(content, str) and not content.strip():
-                    continue
-
-        sanitized_contexts.append(new_msg)
-
-    if (
-        removed_image_blocks
-        or removed_audio_blocks
-        or removed_tool_messages
-        or removed_tool_calls
-    ):
-        logger.debug(
-            "sanitize_context_by_modalities applied: "
-            "removed_image_blocks=%s, removed_audio_blocks=%s, "
-            "removed_tool_messages=%s, removed_tool_calls=%s",
-            removed_image_blocks,
-            removed_audio_blocks,
-            removed_tool_messages,
-            removed_tool_calls,
-        )
-    req.contexts = sanitized_contexts
-
-
 async def _plugin_tool_fix(event: AstrMessageEvent, req: ProviderRequest) -> None:
     """根据事件中的插件设置，过滤请求中的工具列表。
 
@@ -1519,10 +1389,8 @@ async def build_main_agent(
     if not req.session_id:
         req.session_id = event.unified_msg_origin
 
-    _modalities_fix(provider, req)
     await _plugin_tool_fix(event, req)
     await _apply_web_search_tools(event, req, plugin_context)
-    _sanitize_context_by_modalities(config, provider, req)
 
     if config.llm_safety_mode:
         _apply_llm_safety_mode(config, req)

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -45,6 +45,7 @@ from astrbot.core.skills.skill_manager import (
 )
 from astrbot.core.star.context import Context
 from astrbot.core.star.star import star_registry
+from astrbot.core.star.session_plugin_manager import SessionPluginManager
 from astrbot.core.star.star_handler import star_map
 from astrbot.core.tools.computer_tools import (
     AnnotateExecutionTool,
@@ -898,33 +899,179 @@ async def _decorate_llm_request(
     _apply_workspace_extra_prompt(event, req)
 
 
-def _plugin_tool_fix(event: AstrMessageEvent, req: ProviderRequest) -> None:
+def _modalities_fix(provider: Provider, req: ProviderRequest) -> None:
+    if req.image_urls:
+        provider_cfg = provider.provider_config.get("modalities", ["image"])
+        if "image" not in provider_cfg:
+            logger.debug(
+                "Provider %s does not support image, using placeholder.", provider
+            )
+            image_count = len(req.image_urls)
+            placeholder = " ".join(["[Image]"] * image_count)
+            if req.prompt:
+                req.prompt = f"{placeholder} {req.prompt}"
+            else:
+                req.prompt = placeholder
+            req.image_urls = []
+    if req.audio_urls:
+        provider_cfg = provider.provider_config.get("modalities", ["audio"])
+        if "audio" not in provider_cfg:
+            logger.debug(
+                "Provider %s does not support audio, using placeholder.", provider
+            )
+            audio_count = len(req.audio_urls)
+            placeholder = " ".join(["[Audio]"] * audio_count)
+            if req.prompt:
+                req.prompt = f"{placeholder} {req.prompt}"
+            else:
+                req.prompt = placeholder
+            req.audio_urls = []
+    if req.func_tool:
+        provider_cfg = provider.provider_config.get("modalities", ["tool_use"])
+        if "tool_use" not in provider_cfg:
+            logger.debug(
+                "Provider %s does not support tool_use, clearing tools.", provider
+            )
+            req.func_tool = None
+
+
+def _sanitize_context_by_modalities(
+    config: MainAgentBuildConfig,
+    provider: Provider,
+    req: ProviderRequest,
+) -> None:
+    if not config.sanitize_context_by_modalities:
+        return
+    if not isinstance(req.contexts, list) or not req.contexts:
+        return
+    modalities = provider.provider_config.get("modalities", None)
+    if not modalities or not isinstance(modalities, list):
+        return
+    supports_image = bool("image" in modalities)
+    supports_audio = bool("audio" in modalities)
+    supports_tool_use = bool("tool_use" in modalities)
+    if supports_image and supports_audio and supports_tool_use:
+        return
+
+    sanitized_contexts: list[dict] = []
+    removed_image_blocks = 0
+    removed_audio_blocks = 0
+    removed_tool_messages = 0
+    removed_tool_calls = 0
+
+    for msg in req.contexts:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        if not role:
+            continue
+
+        new_msg = msg
+        if not supports_tool_use:
+            if role == "tool":
+                removed_tool_messages += 1
+                continue
+            if role == "assistant" and "tool_calls" in new_msg:
+                if "tool_calls" in new_msg:
+                    removed_tool_calls += 1
+                new_msg.pop("tool_calls", None)
+                new_msg.pop("tool_call_id", None)
+
+        if not supports_image or not supports_audio:
+            content = new_msg.get("content")
+            if isinstance(content, list):
+                filtered_parts: list = []
+                removed_any_multimodal = False
+                for part in content:
+                    if isinstance(part, dict):
+                        part_type = str(part.get("type", "")).lower()
+                        if not supports_image and part_type in {"image_url", "image"}:
+                            removed_any_multimodal = True
+                            removed_image_blocks += 1
+                            continue
+                        if not supports_audio and part_type in {
+                            "audio_url",
+                            "input_audio",
+                        }:
+                            removed_any_multimodal = True
+                            removed_audio_blocks += 1
+                            continue
+                    filtered_parts.append(part)
+                if removed_any_multimodal:
+                    new_msg["content"] = filtered_parts
+
+        if role == "assistant":
+            content = new_msg.get("content")
+            has_tool_calls = bool(new_msg.get("tool_calls"))
+            if not has_tool_calls:
+                if not content:
+                    continue
+                if isinstance(content, str) and not content.strip():
+                    continue
+
+        sanitized_contexts.append(new_msg)
+
+    if (
+        removed_image_blocks
+        or removed_audio_blocks
+        or removed_tool_messages
+        or removed_tool_calls
+    ):
+        logger.debug(
+            "sanitize_context_by_modalities applied: "
+            "removed_image_blocks=%s, removed_audio_blocks=%s, "
+            "removed_tool_messages=%s, removed_tool_calls=%s",
+            removed_image_blocks,
+            removed_audio_blocks,
+            removed_tool_messages,
+            removed_tool_calls,
+        )
+    req.contexts = sanitized_contexts
+
+
+async def _plugin_tool_fix(event: AstrMessageEvent, req: ProviderRequest) -> None:
     """根据事件中的插件设置，过滤请求中的工具列表。
 
     注意：没有 handler_module_path 的工具（如 MCP 工具）会被保留，
     因为它们不属于任何插件，不应被插件过滤逻辑影响。
     """
-    if event.plugins_name is not None and req.func_tool:
-        new_tool_set = ToolSet()
-        for tool in req.func_tool.tools:
-            if isinstance(tool, MCPTool):
-                # 保留 MCP 工具
-                new_tool_set.add_tool(tool)
-                continue
-            mp = tool.handler_module_path
-            if not mp:
-                # 没有 plugin 归属信息的工具（如 subagent transfer_to_*）
-                # 不应受到会话插件过滤影响。
-                new_tool_set.add_tool(tool)
-                continue
-            plugin = star_map.get(mp)
-            if not plugin:
-                # 无法解析插件归属时，保守保留工具，避免误过滤。
-                new_tool_set.add_tool(tool)
-                continue
-            if plugin.name in event.plugins_name or plugin.reserved:
-                new_tool_set.add_tool(tool)
-        req.func_tool = new_tool_set
+    if not req.func_tool:
+        return
+
+    session_config = await SessionPluginManager.get_session_plugin_config(
+        event.unified_msg_origin
+    )
+    new_tool_set = ToolSet()
+    for tool in req.func_tool.tools:
+        if isinstance(tool, MCPTool):
+            # 保留 MCP 工具
+            new_tool_set.add_tool(tool)
+            continue
+        mp = tool.handler_module_path
+        if not mp:
+            # 没有 plugin 归属信息的工具（如 subagent transfer_to_*）
+            # 不应受到会话插件过滤影响。
+            new_tool_set.add_tool(tool)
+            continue
+        plugin = star_map.get(mp)
+        if not plugin:
+            # 无法解析插件归属时，保守保留工具，避免误过滤。
+            new_tool_set.add_tool(tool)
+            continue
+        if (
+            event.plugins_name is not None
+            and not plugin.reserved
+            and plugin.name not in event.plugins_name
+        ):
+            continue
+        if not SessionPluginManager.is_plugin_enabled_for_session_config(
+            plugin.name,
+            session_config,
+            reserved=plugin.reserved,
+        ):
+            continue
+        new_tool_set.add_tool(tool)
+    req.func_tool = new_tool_set
 
 
 async def _handle_webchat(
@@ -1372,8 +1519,10 @@ async def build_main_agent(
     if not req.session_id:
         req.session_id = event.unified_msg_origin
 
-    _plugin_tool_fix(event, req)
+    _modalities_fix(provider, req)
+    await _plugin_tool_fix(event, req)
     await _apply_web_search_tools(event, req, plugin_context)
+    _sanitize_context_by_modalities(config, provider, req)
 
     if config.llm_safety_mode:
         _apply_llm_safety_mode(config, req)

--- a/astrbot/core/pipeline/context_utils.py
+++ b/astrbot/core/pipeline/context_utils.py
@@ -5,9 +5,9 @@ import typing as T
 from astrbot import logger
 from astrbot.core.message.message_event_result import CommandResult, MessageEventResult
 from astrbot.core.platform.astr_message_event import AstrMessageEvent
+from astrbot.core.star.session_plugin_manager import SessionPluginManager
 from astrbot.core.star.star import star_map
 from astrbot.core.star.star_handler import EventType, star_handlers_registry
-from astrbot.core.star.session_plugin_manager import SessionPluginManager
 
 
 async def call_handler(

--- a/astrbot/core/pipeline/context_utils.py
+++ b/astrbot/core/pipeline/context_utils.py
@@ -7,6 +7,7 @@ from astrbot.core.message.message_event_result import CommandResult, MessageEven
 from astrbot.core.platform.astr_message_event import AstrMessageEvent
 from astrbot.core.star.star import star_map
 from astrbot.core.star.star_handler import EventType, star_handlers_registry
+from astrbot.core.star.session_plugin_manager import SessionPluginManager
 
 
 async def call_handler(
@@ -89,11 +90,24 @@ async def call_event_hook(
         hook_type,
         plugins_name=event.plugins_name,
     )
+    session_config = await SessionPluginManager.get_session_plugin_config(
+        event.unified_msg_origin
+    )
     for handler in handlers:
+        plugin = star_map.get(handler.handler_module_path)
+        if plugin and not SessionPluginManager.is_plugin_enabled_for_session_config(
+            plugin.name,
+            session_config,
+            reserved=plugin.reserved,
+        ):
+            logger.debug(
+                f"插件 {plugin.name} 在会话 {event.unified_msg_origin} 中被禁用，跳过 hook {handler.handler_name}",
+            )
+            continue
         try:
             assert inspect.iscoroutinefunction(handler.handler)
             logger.debug(
-                f"hook({hook_type.name}) -> {star_map[handler.handler_module_path].name} - {handler.handler_name}",
+                f"hook({hook_type.name}) -> {plugin.name if plugin else handler.handler_module_path} - {handler.handler_name}",
             )
             await handler.handler(event, *args, **kwargs)
         except BaseException:
@@ -101,7 +115,7 @@ async def call_event_hook(
 
         if event.is_stopped():
             logger.info(
-                f"{star_map[handler.handler_module_path].name} - {handler.handler_name} 终止了事件传播。",
+                f"{plugin.name if plugin else handler.handler_module_path} - {handler.handler_name} 终止了事件传播。",
             )
             return True
 

--- a/astrbot/core/star/session_plugin_manager.py
+++ b/astrbot/core/star/session_plugin_manager.py
@@ -60,7 +60,9 @@ class SessionPluginManager:
             bool: True表示启用，False表示禁用
 
         """
-        session_config = await SessionPluginManager.get_session_plugin_config(session_id)
+        session_config = await SessionPluginManager.get_session_plugin_config(
+            session_id
+        )
         return SessionPluginManager.is_plugin_enabled_for_session_config(
             plugin_name,
             session_config,
@@ -87,7 +89,9 @@ class SessionPluginManager:
         session_id = event.unified_msg_origin
         filtered_handlers = []
 
-        session_config = await SessionPluginManager.get_session_plugin_config(session_id)
+        session_config = await SessionPluginManager.get_session_plugin_config(
+            session_id
+        )
 
         for handler in handlers:
             # 获取处理器对应的插件

--- a/astrbot/core/star/session_plugin_manager.py
+++ b/astrbot/core/star/session_plugin_manager.py
@@ -8,9 +8,47 @@ class SessionPluginManager:
     """管理会话级别的插件启停状态"""
 
     @staticmethod
+    async def get_session_plugin_config(session_id: str) -> dict:
+        """获取指定会话的插件配置。"""
+        session_plugin_config = await sp.get_async(
+            scope="umo",
+            scope_id=session_id,
+            key="session_plugin_config",
+            default={},
+        )
+        return session_plugin_config.get(session_id, {})
+
+    @staticmethod
+    def is_plugin_enabled_for_session_config(
+        plugin_name: str | None,
+        session_config: dict | None,
+        *,
+        reserved: bool = False,
+    ) -> bool:
+        """检查插件是否在指定会话配置中启用。"""
+        if reserved or not plugin_name:
+            return True
+
+        if not session_config:
+            return True
+
+        enabled_plugins = session_config.get("enabled_plugins", [])
+        disabled_plugins = session_config.get("disabled_plugins", [])
+
+        if plugin_name in disabled_plugins:
+            return False
+
+        if plugin_name in enabled_plugins:
+            return True
+
+        return True
+
+    @staticmethod
     async def is_plugin_enabled_for_session(
         session_id: str,
         plugin_name: str,
+        *,
+        reserved: bool = False,
     ) -> bool:
         """检查插件是否在指定会话中启用
 
@@ -22,28 +60,12 @@ class SessionPluginManager:
             bool: True表示启用，False表示禁用
 
         """
-        # 获取会话插件配置
-        session_plugin_config = await sp.get_async(
-            scope="umo",
-            scope_id=session_id,
-            key="session_plugin_config",
-            default={},
+        session_config = await SessionPluginManager.get_session_plugin_config(session_id)
+        return SessionPluginManager.is_plugin_enabled_for_session_config(
+            plugin_name,
+            session_config,
+            reserved=reserved,
         )
-        session_config = session_plugin_config.get(session_id, {})
-
-        enabled_plugins = session_config.get("enabled_plugins", [])
-        disabled_plugins = session_config.get("disabled_plugins", [])
-
-        # 如果插件在禁用列表中，返回False
-        if plugin_name in disabled_plugins:
-            return False
-
-        # 如果插件在启用列表中，返回True
-        if plugin_name in enabled_plugins:
-            return True
-
-        # 如果都没有配置，默认为启用（兼容性考虑）
-        return True
 
     @staticmethod
     async def filter_handlers_by_session(
@@ -65,14 +87,7 @@ class SessionPluginManager:
         session_id = event.unified_msg_origin
         filtered_handlers = []
 
-        session_plugin_config = await sp.get_async(
-            scope="umo",
-            scope_id=session_id,
-            key="session_plugin_config",
-            default={},
-        )
-        session_config = session_plugin_config.get(session_id, {})
-        disabled_plugins = session_config.get("disabled_plugins", [])
+        session_config = await SessionPluginManager.get_session_plugin_config(session_id)
 
         for handler in handlers:
             # 获取处理器对应的插件
@@ -91,7 +106,11 @@ class SessionPluginManager:
                 continue
 
             # 检查插件是否在当前会话中启用
-            if plugin.name in disabled_plugins:
+            if not SessionPluginManager.is_plugin_enabled_for_session_config(
+                plugin.name,
+                session_config,
+                reserved=plugin.reserved,
+            ):
                 logger.debug(
                     f"插件 {plugin.name} 在会话 {session_id} 中被禁用，跳过处理器 {handler.handler_name}",
                 )

--- a/tests/unit/test_astr_agent_tool_exec.py
+++ b/tests/unit/test_astr_agent_tool_exec.py
@@ -1,9 +1,11 @@
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import mcp
 import pytest
 
 from astrbot.core.agent.run_context import ContextWrapper
+from astrbot.core.agent.tool import FunctionTool
 from astrbot.core.astr_agent_tool_exec import FunctionToolExecutor
 from astrbot.core.message.components import Image
 
@@ -270,6 +272,44 @@ async def test_collect_handoff_image_urls_filters_extensionless_missing_event_fi
     )
 
     assert image_urls == []
+
+
+@pytest.mark.asyncio
+async def test_build_handoff_toolset_filters_session_disabled_plugin_tool():
+    plugin_tool = FunctionTool(
+        name="memorix_tool",
+        description="memorix tool",
+        parameters={"type": "object", "properties": {}},
+        handler_module_path="test_plugin",
+        active=True,
+    )
+    run_context = ContextWrapper(
+        context=SimpleNamespace(
+            event=_DummyEvent([]),
+            context=SimpleNamespace(
+                get_config=lambda **_kwargs: {"provider_settings": {"computer_use_runtime": "none"}}
+            ),
+        )
+    )
+
+    with patch(
+        "astrbot.core.astr_agent_tool_exec.SessionPluginManager.get_session_plugin_config",
+        new=AsyncMock(return_value={"disabled_plugins": ["astrbot_plugin_memorix"]}),
+    ) as mock_get_config, patch(
+        "astrbot.core.astr_agent_tool_exec.llm_tools"
+    ) as mock_llm_tools, patch(
+        "astrbot.core.astr_agent_tool_exec.star_map"
+    ) as mock_star_map:
+        mock_llm_tools.func_list = [plugin_tool]
+        mock_plugin = MagicMock()
+        mock_plugin.name = "astrbot_plugin_memorix"
+        mock_plugin.reserved = False
+        mock_star_map.get.return_value = mock_plugin
+
+        toolset = await FunctionToolExecutor._build_handoff_toolset(run_context, None)
+
+    mock_get_config.assert_awaited_once()
+    assert toolset is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_astr_main_agent.py
+++ b/tests/unit/test_astr_main_agent.py
@@ -844,17 +844,23 @@ class TestDecorateLlmRequest:
 class TestPluginToolFix:
     """Tests for _plugin_tool_fix function."""
 
-    def test_plugin_tool_fix_none_plugins(self, mock_event):
+    @pytest.mark.asyncio
+    async def test_plugin_tool_fix_none_plugins(self, mock_event):
         """Test plugin tool fix when no plugins specified."""
         module = ama
         req = ProviderRequest(func_tool=ToolSet())
         mock_event.plugins_name = None
 
-        module._plugin_tool_fix(mock_event, req)
+        with patch(
+            "astrbot.core.astr_main_agent.SessionPluginManager.get_session_plugin_config",
+            new=AsyncMock(return_value={}),
+        ):
+            await module._plugin_tool_fix(mock_event, req)
 
         assert req.func_tool is not None
 
-    def test_plugin_tool_fix_filters_by_plugin(self, mock_event):
+    @pytest.mark.asyncio
+    async def test_plugin_tool_fix_filters_by_plugin(self, mock_event):
         """Test plugin tool fix filters tools by enabled plugins."""
         module = ama
         mcp_tool = MagicMock(spec=MCPTool)
@@ -878,12 +884,17 @@ class TestPluginToolFix:
             mock_plugin.reserved = False
             mock_star_map.get.return_value = mock_plugin
 
-            module._plugin_tool_fix(mock_event, req)
+            with patch(
+                "astrbot.core.astr_main_agent.SessionPluginManager.get_session_plugin_config",
+                new=AsyncMock(return_value={}),
+            ):
+                await module._plugin_tool_fix(mock_event, req)
 
         assert "mcp_tool" in req.func_tool.names()
         assert "plugin_tool" in req.func_tool.names()
 
-    def test_plugin_tool_fix_mcp_preserved(self, mock_event):
+    @pytest.mark.asyncio
+    async def test_plugin_tool_fix_mcp_preserved(self, mock_event):
         """Test that MCP tools are always preserved."""
         module = ama
         mcp_tool = MagicMock(spec=MCPTool)
@@ -897,11 +908,18 @@ class TestPluginToolFix:
         mock_event.plugins_name = ["other_plugin"]
 
         with patch("astrbot.core.astr_main_agent.star_map"):
-            module._plugin_tool_fix(mock_event, req)
+            with patch(
+                "astrbot.core.astr_main_agent.SessionPluginManager.get_session_plugin_config",
+                new=AsyncMock(return_value={}),
+            ):
+                await module._plugin_tool_fix(mock_event, req)
 
         assert "mcp_tool" in req.func_tool.names()
 
-    def test_plugin_tool_fix_preserves_tools_without_plugin_origin(self, mock_event):
+    @pytest.mark.asyncio
+    async def test_plugin_tool_fix_preserves_tools_without_plugin_origin(
+        self, mock_event
+    ):
         """Tools without handler_module_path should not be filtered out."""
         module = ama
         handoff_tool = FunctionTool(
@@ -919,9 +937,43 @@ class TestPluginToolFix:
         mock_event.plugins_name = ["other_plugin"]
 
         with patch("astrbot.core.astr_main_agent.star_map"):
-            module._plugin_tool_fix(mock_event, req)
+            with patch(
+                "astrbot.core.astr_main_agent.SessionPluginManager.get_session_plugin_config",
+                new=AsyncMock(return_value={}),
+            ):
+                await module._plugin_tool_fix(mock_event, req)
 
         assert "transfer_to_demo_agent" in req.func_tool.names()
+
+    @pytest.mark.asyncio
+    async def test_plugin_tool_fix_filters_session_disabled_plugin(self, mock_event):
+        """Session-disabled plugin tools should not enter the request toolset."""
+        module = ama
+        plugin_tool = FunctionTool(
+            name="memorix_search",
+            description="memorix tool",
+            parameters={"type": "object", "properties": {}},
+            handler_module_path="test_plugin",
+            active=True,
+        )
+        req = ProviderRequest(func_tool=ToolSet([plugin_tool]))
+        mock_event.plugins_name = ["*"]
+
+        with patch("astrbot.core.astr_main_agent.star_map") as mock_star_map:
+            mock_plugin = MagicMock()
+            mock_plugin.name = "astrbot_plugin_memorix"
+            mock_plugin.reserved = False
+            mock_star_map.get.return_value = mock_plugin
+
+            with patch(
+                "astrbot.core.astr_main_agent.SessionPluginManager.get_session_plugin_config",
+                new=AsyncMock(
+                    return_value={"disabled_plugins": ["astrbot_plugin_memorix"]}
+                ),
+            ):
+                await module._plugin_tool_fix(mock_event, req)
+
+        assert "memorix_search" not in req.func_tool.names()
 
 
 class TestBuildMainAgent:

--- a/tests/unit/test_context_utils.py
+++ b/tests/unit/test_context_utils.py
@@ -1,0 +1,38 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from astrbot.core.pipeline.context_utils import call_event_hook
+from astrbot.core.star.star_handler import EventType
+
+
+@pytest.mark.asyncio
+async def test_call_event_hook_skips_session_disabled_plugin():
+    event = MagicMock()
+    event.plugins_name = ["*"]
+    event.unified_msg_origin = "test_platform:private:session123"
+    event.is_stopped.return_value = False
+
+    handler = MagicMock()
+    handler.handler_name = "on_llm_request"
+    handler.handler_module_path = "test_plugin"
+    handler.handler = AsyncMock()
+
+    with patch(
+        "astrbot.core.pipeline.context_utils.star_handlers_registry.get_handlers_by_event_type",
+        return_value=[handler],
+    ), patch(
+        "astrbot.core.pipeline.context_utils.star_map"
+    ) as mock_star_map, patch(
+        "astrbot.core.pipeline.context_utils.SessionPluginManager.get_session_plugin_config",
+        new=AsyncMock(return_value={"disabled_plugins": ["astrbot_plugin_memorix"]}),
+    ):
+        mock_plugin = MagicMock()
+        mock_plugin.name = "astrbot_plugin_memorix"
+        mock_plugin.reserved = False
+        mock_star_map.get.return_value = mock_plugin
+
+        stopped = await call_event_hook(event, EventType.OnLLMRequestEvent)
+
+    assert stopped is False
+    handler.handler.assert_not_awaited()


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
Fixes #8097 
修复会话级自定义规则中“已禁用插件但插件仍可在目标会话继续生效”的问题。

此前会话级插件禁用只作用于消息处理器过滤，无法覆盖插件的 LLM Hook 与工具调用链路，导致某些插件即使在目标会话中被禁用，仍可能通过 `OnLLMRequestEvent`、主 Agent 工具集或 handoff/subagent 工具集继续执行实际功能。

本次修改将会话级插件禁用规则统一补齐到 Hook 和 Tool 两条执行链路中，确保“会话中禁用插件”不仅拦截消息 handler，也能真正阻止该插件在当前会话中的后续 LLM 相关能力生效。
### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
本次改动主要补齐了会话级插件禁用在 Hook 与 Tool 路径上的过滤逻辑，并增加了对应单元测试覆盖。

核心改动包括：

- 在 `astrbot/core/star/session_plugin_manager.py` 中抽出会话级插件配置读取与统一启用判断逻辑，作为公共过滤入口，避免不同链路各自实现、行为不一致。
- 在 `astrbot/core/pipeline/context_utils.py` 中为 `call_event_hook()` 增加会话级插件过滤，确保被当前会话禁用的插件不会继续执行 `OnLLMRequestEvent` 等 Hook。
- 在 `astrbot/core/astr_main_agent.py` 中增强主 Agent 工具集过滤逻辑，使插件工具在进入请求工具集前，除了原有插件集合判断外，还会校验当前会话是否已禁用该插件。
- 在 `astrbot/core/astr_agent_tool_exec.py` 中为 handoff/subagent 工具集构建过程增加同样的会话级过滤，避免被禁用插件的工具继续进入子 Agent 可用工具集。
- 在测试侧补充和更新了单元测试，覆盖：
  - 会话禁用插件后 Hook 不再执行
  - 会话禁用插件后主 Agent 工具集会过滤对应插件工具
  - 会话禁用插件后 handoff/subagent 工具集同样会过滤对应插件工具
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
修改前：
```text
[2026-04-04 23:42:31.249] [Core] [INFO] [core.event_bus:61]: [default] [平台-账号(适配器)] 用户/<USER_ID>: [引用消息(...)] [At:<BOT_ID>] 呜呜 这么冷漠
[2026-04-04 23:42:31.250] [Core] [DBUG] [waking_check.stage:157]: enabled_plugins_name: ['*']
[2026-04-04 23:42:31.258] [Core] [DBUG] [star.session_plugin_manager:95]: 插件 astrbot_plugin_memorix 在会话 平台:GroupMessage:<SESSION_ID> 中被禁用，跳过处理器 on_all_messages
[2026-04-04 23:42:31.325] [Core] [DBUG] [agent_sub_stages.internal:167]: ready to request llm provider
[2026-04-04 23:42:31.327] [Core] [DBUG] [agent_sub_stages.internal:190]: acquired session lock for llm request
[2026-04-04 23:42:31.343] [Core] [DBUG] [pipeline.context_utils:95]: hook(OnLLMRequestEvent) -> astrbot_plugin_memorix - on_llm_request
[2026-04-04 23:42:31.344] [Plug] [DBUG] [memorix.app_context:166]: runtime cache hit: scope=<PLATFORM_SCOPE>
[2026-04-04 23:42:31.344] [Plug] [INFO] [retrieval.dual_path:237]: 执行检索: query='呜呜 这么冷漠...', strategy=dual_path
[2026-04-04 23:42:33.178] [Plug] [DBUG] [retrieval.dual_path:1027]: 未识别到实体，跳过PPR重排序
[2026-04-04 23:42:33.180] [Plug] [INFO] [retrieval.dual_path:250]: 检索完成: 返回 10 条结果
[2026-04-04 23:42:33.181] [Plug] [DBUG] [retrieval.threshold:214]: 百分位数阈值: 0.253 (percentile=75.0)
[2026-04-04 23:42:33.182] [Plug] [DBUG] [retrieval.threshold:235]: 标准差阈值: 0.233 (mean=0.247, std=0.009)
[2026-04-04 23:42:33.182] [Plug] [DBUG] [retrieval.threshold:265]: 跳变检测阈值: 0.236 (gap=-0.000, idx=8)
[2026-04-04 23:42:33.183] [Plug] [INFO] [retrieval.threshold:148]: 过滤完成: 10 -> 3 (threshold=0.254)
```
修改后：
```
[2026-04-05 00:40:35.773] [Core] [INFO] [core.event_bus:61]: [default] [平台(适配器)] 用户/<USER_ID>: 吃了吗
[2026-04-05 00:40:35.776] [Core] [DBUG] [waking_check.stage:157]: enabled_plugins_name: ['*']
[2026-04-05 00:40:35.787] [Core] [DBUG] [star.session_plugin_manager:114]: 插件 astrbot_plugin_memorix 在会话 平台:FriendMessage:<SESSION_ID> 中被禁用，跳过处理器 on_all_messages
[2026-04-05 00:40:35.790] [Core] [DBUG] [method.star_request:44]: plugin -> session_controller - handle_session_control_agent
[2026-04-05 00:40:35.790] [Core] [DBUG] [method.star_request:44]: plugin -> session_controller - handle_empty_mention
[2026-04-05 00:40:35.790] [Core] [DBUG] [method.star_request:44]: plugin -> astrbot - on_message
[2026-04-05 00:40:35.792] [Core] [DBUG] [agent_sub_stages.internal:167]: ready to request llm provider
[2026-04-05 00:40:36.709] [Core] [DBUG] [agent_sub_stages.internal:190]: acquired session lock for llm request
[2026-04-05 00:40:36.725] [Core] [DBUG] [core.astr_main_agent_resources:463]: [知识库] 使用全局配置，知识库数量: 0
[2026-04-05 00:40:36.725] [Core] [DBUG] [core.astr_main_agent:766]: Provider <astrbot.core.provider.sources.openai_source.ProviderOpenAIOfficial object at 0xXXXXXXXX> does not support tool_use, clearing tools.
[2026-04-05 00:40:36.728] [Core] [DBUG] [pipeline.context_utils:103]: 插件 astrbot_plugin_memorix 在会话 平台:FriendMessage:<SESSION_ID> 中被禁用，跳过 hook on_llm_request
[2026-04-05 00:40:36.728] [Core] [DBUG] [pipeline.context_utils:109]: hook(OnLLMRequestEvent) -> astrbot - decorate_llm_req
```
---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Apply session-level plugin disable rules consistently to hooks and tool execution paths so disabled plugins cannot affect LLM behavior in a session.

Enhancements:
- Centralize session plugin configuration lookup and enablement checks in SessionPluginManager for reuse across handlers, hooks, and tools.
- Filter main agent request toolsets and handoff/subagent toolsets using session plugin disable rules while keeping reserved, MCP, and non-plugin tools unaffected.

Tests:
- Extend and convert relevant tool filtering tests to async and add coverage ensuring session-disabled plugins are skipped in hooks, main agent tools, and handoff/subagent toolsets.