### PR TITLE
fix: remove unsupported id field from Gemini FunctionResponse

### DIFF
--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -409,8 +409,6 @@ class ProviderGoogleGenAI(Provider):
                         "content": message["content"],
                     },
                 )
-                if part.function_response:
-                    part.function_response.id = message["tool_call_id"]
 
                 parts = [part]
                 append_or_extend(gemini_contents, parts, types.UserContent)


### PR DESCRIPTION
## Summary

Fixes #7357

**Root cause:** Google's Gemini API `FunctionResponse` does not have an `id` field. Setting `part.function_response.id = message["tool_call_id"]` causes a 400 error: `Unknown name 'id' at 'contents[2].parts[0].function_response'`.

**Fix:** Delete the 2 lines that set the unsupported `id` field on `function_response` in `gemini_source.py`.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Bug Fixes:
- Avoid 400 errors from the Gemini API by no longer assigning an id field to FunctionResponse parts, which the API does not support.