### PR TITLE
fix: use UMO-bound config for group_icl_enable in on_message

### DIFF
--- a/astrbot/builtin_stars/astrbot/main.py
+++ b/astrbot/builtin_stars/astrbot/main.py
@@ -36,9 +36,9 @@ class Main(star.Star):
         if self.ltm_enabled(event) and self.ltm and has_image_or_plain:
             need_active = await self.ltm.need_active_reply(event)
 
-            group_icl_enable = self.context.get_config(
-                umo=event.unified_msg_origin
-            )["provider_ltm_settings"]["group_icl_enable"]
+            group_icl_enable = self.context.get_config(umo=event.unified_msg_origin)[
+                "provider_ltm_settings"
+            ]["group_icl_enable"]
             if group_icl_enable:
                 """记录对话"""
                 try:


### PR DESCRIPTION
Fixes #7305

`on_message()` currently reads `group_icl_enable` from the default config via `self.context.get_config()`.
When a platform instance is bound to a non-default profile, this can disable group context recording even though `ltm_enabled()` correctly reads the UMO-bound config.

This patch makes `on_message()` read `group_icl_enable` with the same `umo=event.unified_msg_origin` lookup path used by `ltm_enabled()`.

Greetings, saschabuehrle

## Summary by Sourcery

Bug Fixes:
- Fix reading of group_icl_enable in on_message to respect UMO-bound configuration instead of always using the default profile.