### PR TITLE
fix(telegram): skip empty text in sendMessageDraft to prevent 400 spam

### DIFF
--- a/astrbot/core/platform/sources/telegram/tg_event.py
+++ b/astrbot/core/platform/sources/telegram/tg_event.py
@@ -389,6 +389,9 @@ class TelegramPlatformEvent(AstrMessageEvent):
             message_thread_id: 可选，目标消息线程 ID
             parse_mode: 可选，消息文本的解析模式
         """
+        if not text or not text.strip():
+            return
+
         kwargs: dict[str, Any] = {}
         if message_thread_id:
             kwargs["message_thread_id"] = int(message_thread_id)


### PR DESCRIPTION
## Summary

Fixes #7353

When streaming output is enabled, `markdownify()` can return empty strings for certain inputs (whitespace-only content, formatting-only markdown). The draft sender loop then calls `sendMessageDraft` with empty text, which Telegram rejects with "Text must be non-empty", flooding the log every 0.5s.

## Changes

Added an early return in `_send_message_draft()` when `text` is empty or whitespace-only. This matches WebChat's approach of skipping empty responses (`webchat_event.py` line 200: `if not r: continue`).

## Test plan

- [ ] Enable streaming output, send a message in Telegram private chat
- [ ] Verify no more "sendMessageDraft failed: Text must be non-empty" warnings in log
- [ ] Verify streaming output still displays correctly for normal messages

## Summary by Sourcery

Bug Fixes:
- Prevent Telegram sendMessageDraft calls with empty text that result in repeated 400 errors and log spam during streaming output.