### PR TITLE
fix: prevent KeyError in Telegram collect_commands when plugin handler not in star_map

### DIFF
--- a/astrbot/core/platform/sources/telegram/tg_adapter.py
+++ b/astrbot/core/platform/sources/telegram/tg_adapter.py
@@ -228,7 +228,10 @@ class TelegramPlatformAdapter(Platform):
 
         for handler_md in star_handlers_registry:
             handler_metadata = handler_md
-            if handler_metadata.handler_module_path not in star_map or not star_map[handler_metadata.handler_module_path].activated:
+            if (
+                handler_metadata.handler_module_path not in star_map
+                or not star_map[handler_metadata.handler_module_path].activated
+            ):
                 continue
             if not handler_metadata.enabled:
                 continue


### PR DESCRIPTION
## Motivation / 动机

When using the [astrbot_plugin_proactive_chat](https://github.com/DBJD-CR/astrbot_plugin_proactive_chat) plugin (and potentially other plugins), the Telegram adapter logs the following error every 5 minutes repeatedly:

\\\
[ERRO] [telegram.tg_adapter:222]: 向 Telegram 注册指令时发生错误: 'data.plugins.astrbot_plugin_proactive_chat.core.message_events'
\\\

The root cause is in \collect_commands()\ inside \	g_adapter.py\. It iterates over \star_handlers_registry\ and accesses \star_map[handler_metadata.handler_module_path]\ directly using \[]\, which raises a \KeyError\ when a plugin registers a handler whose module path is not yet present in \star_map\ (e.g. internal event modules that are scanned but not added to \star_map\).

Confirmed on AstrBot v4.22.3 with \strbot_plugin_proactive_chat\ v1.2.2.

### Modifications / 改动点

- \strbot/core/platform/sources/telegram/tg_adapter.py\ line 231: added a key existence guard before accessing \star_map\.

**Before:**
\\\python
if not star_map[handler_metadata.handler_module_path].activated:
\\\

**After:**
\\\python
if handler_metadata.handler_module_path not in star_map or not star_map[handler_metadata.handler_module_path].activated:
\\\

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

After applying the fix and restarting the container, the repeated error is gone:

\\\
[INFO] [telegram.tg_adapter:170]: Starting Telegram polling...
[INFO] [telegram.tg_adapter:174]: Telegram Platform Adapter is running.
\\\

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] 👀 My changes have been well-tested, and verification has been provided above.
- [x] 🤓 I have ensured that no new dependencies are introduced.
- [x] 😮 My changes do not introduce malicious code.

## Summary by Sourcery

Bug Fixes:
- Avoid KeyError in Telegram adapter command collection when a handler's module path is not present in star_map.