### PR TITLE
fix(google-gemini): skip FunctionCallingConfig when only native tools are present

### DIFF
--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -215,9 +215,7 @@ class ProviderGoogleGenAI(Provider):
             ]
 
         tool_config = None
-        has_func_decl = tool_list and any(
-            t.function_declarations for t in tool_list
-        )
+        has_func_decl = tool_list and any(t.function_declarations for t in tool_list)
         if has_func_decl:
             tool_config = types.ToolConfig(
                 function_calling_config=types.FunctionCallingConfig(


### PR DESCRIPTION
## 问题

开启 Gemini 原生搜索（`google_search`）或 URL 上下文（`url_context`）功能时，如果没有注册任何函数工具，`_prepare_query_config` 仍然会创建 `FunctionCallingConfig`，导致 Gemini API 返回 400 INVALID_ARGUMENT：

```
Function calling config is set without function_declarations.
```

## 原因

`tool_config` 的构建条件 `if tools and tool_list` 过于宽泛。当 `tool_list` 中只有原生工具（`google_search`、`url_context`、`code_execution`）而没有 `function_declarations` 时，也会走进去设置 `FunctionCallingConfig`，但 Gemini API 不允许在没有 `function_declarations` 的情况下设置该配置。

## 修改

在创建 `tool_config` 前，先检查 `tool_list` 里是否真的包含 `function_declarations`，只有在有函数声明时才设置 `FunctionCallingConfig`。

Fixes #7406

## Summary by Sourcery

Bug Fixes:
- Prevent Gemini INVALID_ARGUMENT errors by skipping FunctionCallingConfig when only native tools are configured without any function declarations.