### PR TITLE
fix: handle GPT-5 empty content response gracefully

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -889,11 +889,23 @@ class ProviderOpenAIOfficial(Provider):
             and not has_reasoning_output
             and not llm_response.tools_call_args
         ):
-            logger.error(f"OpenAI completion has no usable output: {completion}.")
-            raise EmptyModelOutputError(
-                "OpenAI completion has no usable output. "
-                f"response_id={completion.id}, finish_reason={choice.finish_reason}"
-            )
+            # Some models (e.g. GPT-5 series) complete normally but put all
+            # tokens into internal reasoning, leaving content/reasoning_content
+            # both None.  When finish_reason is "stop" this is not an error.
+            if choice.finish_reason == "stop":
+                logger.warning(
+                    f"OpenAI completion returned no visible content "
+                    f"(response_id={completion.id}, model={completion.model}). "
+                    f"The model may have used internal reasoning only."
+                )
+                if not llm_response.result_chain:
+                    llm_response.result_chain = MessageChain().message("")
+            else:
+                logger.error(f"OpenAI completion has no usable output: {completion}.")
+                raise EmptyModelOutputError(
+                    "OpenAI completion has no usable output. "
+                    f"response_id={completion.id}, finish_reason={choice.finish_reason}"
+                )
 
         llm_response.raw_completion = completion
         llm_response.id = completion.id

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -894,9 +894,11 @@ class ProviderOpenAIOfficial(Provider):
             # both None.  When finish_reason is "stop" this is not an error.
             if choice.finish_reason == "stop":
                 logger.warning(
-                    f"OpenAI completion returned no visible content "
-                    f"(response_id={completion.id}, model={completion.model}). "
-                    f"The model may have used internal reasoning only."
+                    "OpenAI completion returned no visible content "
+                    f"(response_id={completion.id}, model={completion.model}, "
+                    f"choice_index={choice.index}, finish_reason={choice.finish_reason}, "
+                    "marker=internal_reasoning_only). "
+                    "The model may have used internal reasoning only."
                 )
                 if not llm_response.result_chain:
                     llm_response.result_chain = MessageChain().message("")

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -1142,6 +1142,7 @@ async def test_query_injects_reasoning_effort_none_for_ollama(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_parse_openai_completion_raises_empty_model_output_error():
+    """Empty output with non-stop finish_reason should raise."""
     provider = _make_provider()
     try:
         completion = ChatCompletion.model_validate(
@@ -1159,7 +1160,7 @@ async def test_parse_openai_completion_raises_empty_model_output_error():
                             "refusal": None,
                             "tool_calls": None,
                         },
-                        "finish_reason": "stop",
+                        "finish_reason": "length",
                     }
                 ],
                 "usage": {
@@ -1172,6 +1173,44 @@ async def test_parse_openai_completion_raises_empty_model_output_error():
 
         with pytest.raises(EmptyModelOutputError):
             await provider._parse_openai_completion(completion, tools=None)
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_parse_openai_completion_empty_content_finish_stop_no_error():
+    """Empty output with finish_reason=stop should return gracefully (GPT-5 etc.)."""
+    provider = _make_provider()
+    try:
+        completion = ChatCompletion.model_validate(
+            {
+                "id": "chatcmpl-empty-stop",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "gpt-5.4",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "refusal": None,
+                            "tool_calls": None,
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 13,
+                    "completion_tokens": 18,
+                    "total_tokens": 31,
+                },
+            }
+        )
+
+        resp = await provider._parse_openai_completion(completion, tools=None)
+        assert resp.role == "assistant"
+        assert resp.result_chain is not None
     finally:
         await provider.terminate()
 


### PR DESCRIPTION
Fixes #7409

## 问题

GPT-5 系列模型（gpt-5.3-codex、gpt-5.4）通过 Chat Completions API 返回的响应中 `content=None`、`reasoning_content=None`，但 `finish_reason="stop"` 且有 `completion_tokens > 0`。这些模型将 token 用于内部推理，不会在常规字段中暴露内容。

之前所有空输出响应都会触发 `EmptyModelOutputError`，导致重试循环反复失败。

## 修复

当 `finish_reason == "stop"` 时，空输出不再视为错误。改为记录 warning 并返回空 result chain，避免无意义的重试。只有 `finish_reason` 非 `"stop"`（异常终止）时才抛出 `EmptyModelOutputError`。

## 改动

- `openai_source.py`: 在空输出检查中区分正常完成（`finish_reason="stop"`）和异常情况

## Summary by Sourcery

Handle OpenAI chat completions that have empty content but a normal stop finish_reason without treating them as errors.

Bug Fixes:
- Avoid raising EmptyModelOutputError when GPT-5-style models return empty content with finish_reason=stop by treating these responses as successful but contentless completions.

Tests:
- Add tests ensuring empty outputs with non-stop finish_reason still raise EmptyModelOutputError and that empty outputs with finish_reason=stop are handled gracefully and produce an assistant response.