### PR TITLE
feat: implement retry mechanism for QQ Official API file uploads

### DIFF
--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -52,7 +52,7 @@ def _patch_qq_botpy_formdata() -> None:
 
 _patch_qq_botpy_formdata()
 
-# Retry decorator for QQ Official API transient errors (HTTP 500/504, 429)
+# Retry decorator for QQ Official API transient errors (HTTP 500/504)
 _qqofficial_retry = retry(
     retry=retry_if_exception_type(
         (
@@ -564,7 +564,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                     ttl=result.get("ttl", 0),
                 )
         except (botpy.errors.ServerError, botpy.errors.SequenceNumberError):
-            logger.error(f"上传媒体文件失败，已重试3次: {file_source}")
+            logger.error(f"上传媒体文件失败，共尝试3次后放弃: {file_source}")
         except Exception as e:
             logger.error(f"上传请求错误: {e}")
 

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import logging
 import os
 import random
 import uuid
@@ -15,6 +16,13 @@ from botpy import Client
 from botpy.http import Route
 from botpy.types import message
 from botpy.types.message import MarkdownPayload, Media
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent, MessageChain
@@ -43,6 +51,20 @@ def _patch_qq_botpy_formdata() -> None:
 
 
 _patch_qq_botpy_formdata()
+
+# Retry decorator for QQ Official API transient errors (HTTP 500/504, 429)
+_qqofficial_retry = retry(
+    retry=retry_if_exception_type(
+        (
+            botpy.errors.ServerError,
+            botpy.errors.SequenceNumberError,
+        )
+    ),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    before_sleep=before_sleep_log(logger, logging.WARNING),
+    reraise=True,
+)
 
 
 class QQOfficialMessageEvent(AstrMessageEvent):
@@ -453,21 +475,26 @@ class QQOfficialMessageEvent(AstrMessageEvent):
             "srv_send_msg": False,
         }
 
-        result = None
-        if "openid" in kwargs:
-            payload["openid"] = kwargs["openid"]
-            route = Route("POST", "/v2/users/{openid}/files", openid=kwargs["openid"])
-            result = await self.bot.api._http.request(route, json=payload)
-        elif "group_openid" in kwargs:
-            payload["group_openid"] = kwargs["group_openid"]
-            route = Route(
-                "POST",
-                "/v2/groups/{group_openid}/files",
-                group_openid=kwargs["group_openid"],
-            )
-            result = await self.bot.api._http.request(route, json=payload)
-        else:
-            raise ValueError("Invalid upload parameters")
+        @_qqofficial_retry
+        async def _do_upload():
+            if "openid" in kwargs:
+                payload["openid"] = kwargs["openid"]
+                route = Route(
+                    "POST", "/v2/users/{openid}/files", openid=kwargs["openid"]
+                )
+                return await self.bot.api._http.request(route, json=payload)
+            elif "group_openid" in kwargs:
+                payload["group_openid"] = kwargs["group_openid"]
+                route = Route(
+                    "POST",
+                    "/v2/groups/{group_openid}/files",
+                    group_openid=kwargs["group_openid"],
+                )
+                return await self.bot.api._http.request(route, json=payload)
+            else:
+                raise ValueError("Invalid upload parameters")
+
+        result = await _do_upload()
 
         if not isinstance(result, dict):
             raise RuntimeError(
@@ -490,7 +517,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
     ) -> Media | None:
         """上传媒体文件"""
         # 构建基础payload
-        payload = {"file_type": file_type, "srv_send_msg": srv_send_msg}
+        payload: dict = {"file_type": file_type, "srv_send_msg": srv_send_msg}
         if file_name:
             payload["file_name"] = file_name
 
@@ -519,9 +546,12 @@ class QQOfficialMessageEvent(AstrMessageEvent):
         else:
             return None
 
+        @_qqofficial_retry
+        async def _do_upload():
+            return await self.bot.api._http.request(route, json=payload)
+
         try:
-            # 使用底层HTTP请求
-            result = await self.bot.api._http.request(route, json=payload)
+            result = await _do_upload()
 
             if result:
                 if not isinstance(result, dict):
@@ -533,6 +563,8 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                     file_info=result["file_info"],
                     ttl=result.get("ttl", 0),
                 )
+        except (botpy.errors.ServerError, botpy.errors.SequenceNumberError):
+            logger.error(f"上传媒体文件失败，已重试3次: {file_source}")
         except Exception as e:
             logger.error(f"上传请求错误: {e}")
 


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
Related Issue: #7257 
The QQ Official API's file upload endpoints (`/v2/users/{openid}/files` and `/v2/groups/{group_openid}/files`) can occasionally return transient server errors (`ServerError` HTTP 500/504). Without retry logic, these transient failures silently drop media uploads, causing messages to send without their intended attachments. This PR wraps both upload call sites with a `tenacity`-based retry decorator so that recoverable errors are retried automatically before surfacing to the user.
### Modifications / 改动点
- `astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py`: Added a module-level `_qqofficial_retry` decorator (3 attempts, exponential back-off 1–10 s, logs warnings between retries) and applied it to both `_do_upload()` inner functions in `_upload_file_for_message()` and `upload_media()`. Also catches `ServerError`/`SequenceNumberError` after exhausted retries to log a clear error message instead of swallowing it silently.
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
After the feature was implemented, I have been running it for over a week without any media upload errors.
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Add a retry mechanism around QQ Official API file upload requests to improve reliability of media uploads under transient server errors.

New Features:
- Introduce a shared retry decorator for QQ Official API upload calls with bounded exponential backoff and logging.

Enhancements:
- Wrap user and group file upload paths in the QQ Official message handler with the shared retry logic and clearer error logging on repeated failures.