### PR TITLE
fix: split long telegram final segments

### DIFF
--- a/astrbot/core/platform/sources/telegram/tg_event.py
+++ b/astrbot/core/platform/sources/telegram/tg_event.py
@@ -124,7 +124,9 @@ class TelegramPlatformEvent(AstrMessageEvent):
                     **cast(Any, payload),
                 )
             except (ValueError, BadRequest) as e:
-                logger.warning(f"Failed to convert message to Markdown，using normal text: {e!s}")
+                logger.warning(
+                    f"Failed to convert message to Markdown，using normal text: {e!s}"
+                )
                 await client.send_message(text=chunk, **cast(Any, payload))
 
     @classmethod

--- a/astrbot/core/platform/sources/telegram/tg_event.py
+++ b/astrbot/core/platform/sources/telegram/tg_event.py
@@ -124,7 +124,7 @@ class TelegramPlatformEvent(AstrMessageEvent):
                     **cast(Any, payload),
                 )
             except (ValueError, BadRequest) as e:
-                logger.warning(f"Markdown转换失败，使用普通文本: {e!s}")
+                logger.warning(f"Failed to convert message to Markdown，using normal text: {e!s}")
                 await client.send_message(text=chunk, **cast(Any, payload))
 
     @classmethod

--- a/astrbot/core/platform/sources/telegram/tg_event.py
+++ b/astrbot/core/platform/sources/telegram/tg_event.py
@@ -123,7 +123,7 @@ class TelegramPlatformEvent(AstrMessageEvent):
                     parse_mode="MarkdownV2",
                     **cast(Any, payload),
                 )
-            except Exception as e:
+            except (ValueError, BadRequest) as e:
                 logger.warning(f"Markdown转换失败，使用普通文本: {e!s}")
                 await client.send_message(text=chunk, **cast(Any, payload))
 

--- a/astrbot/core/platform/sources/telegram/tg_event.py
+++ b/astrbot/core/platform/sources/telegram/tg_event.py
@@ -106,6 +106,28 @@ class TelegramPlatformEvent(AstrMessageEvent):
         return chunks
 
     @classmethod
+    async def _send_text_chunks(
+        cls,
+        client: ExtBot,
+        text: str,
+        payload: dict[str, Any],
+    ) -> None:
+        """按 Telegram 限制切分文本后逐段发送。"""
+        for chunk in cls._split_message(text):
+            try:
+                markdown_text = telegramify_markdown.markdownify(
+                    chunk,
+                )
+                await client.send_message(
+                    text=markdown_text,
+                    parse_mode="MarkdownV2",
+                    **cast(Any, payload),
+                )
+            except Exception as e:
+                logger.warning(f"Markdown转换失败，使用普通文本: {e!s}")
+                await client.send_message(text=chunk, **cast(Any, payload))
+
+    @classmethod
     async def _send_chat_action(
         cls,
         client: ExtBot,
@@ -283,22 +305,7 @@ class TelegramPlatformEvent(AstrMessageEvent):
                 if at_user_id and not at_flag:
                     i.text = f"@{at_user_id} {i.text}"
                     at_flag = True
-                chunks = cls._split_message(i.text)
-                for chunk in chunks:
-                    try:
-                        md_text = telegramify_markdown.markdownify(
-                            chunk,
-                        )
-                        await client.send_message(
-                            text=md_text,
-                            parse_mode="MarkdownV2",
-                            **cast(Any, payload),
-                        )
-                    except Exception as e:
-                        logger.warning(
-                            f"MarkdownV2 send failed: {e}. Using plain text instead.",
-                        )
-                        await client.send_message(text=chunk, **cast(Any, payload))
+                await cls._send_text_chunks(client, i.text, payload)
             elif isinstance(i, Image):
                 image_path = await i.convert_to_file_path()
                 if _is_gif(image_path):
@@ -479,18 +486,7 @@ class TelegramPlatformEvent(AstrMessageEvent):
 
     async def _send_final_segment(self, delta: str, payload: dict[str, Any]) -> None:
         """将累积文本作为 MarkdownV2 真实消息发送，失败时回退到纯文本。"""
-        try:
-            markdown_text = telegramify_markdown.markdownify(
-                delta,
-            )
-            await self.client.send_message(
-                text=markdown_text,
-                parse_mode="MarkdownV2",
-                **cast(Any, payload),
-            )
-        except Exception as e:
-            logger.warning(f"Markdown转换失败，使用普通文本: {e!s}")
-            await self.client.send_message(text=delta, **cast(Any, payload))
+        await self._send_text_chunks(self.client, delta, payload)
 
     async def send_streaming(self, generator, use_fallback: bool = False):
         message_thread_id = None

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -14,6 +14,7 @@ from tests.fixtures.helpers import (
 from tests.fixtures.mocks.telegram import create_mock_telegram_modules
 
 _TELEGRAM_PLATFORM_ADAPTER = None
+_TELEGRAM_PLATFORM_EVENT = None
 
 
 def _load_telegram_adapter():
@@ -35,9 +36,37 @@ def _load_telegram_adapter():
     }
     with patch.dict(sys.modules, patched_modules):
         sys.modules.pop("astrbot.core.platform.sources.telegram.tg_adapter", None)
-        module = importlib.import_module("astrbot.core.platform.sources.telegram.tg_adapter")
+        module = importlib.import_module(
+            "astrbot.core.platform.sources.telegram.tg_adapter"
+        )
         _TELEGRAM_PLATFORM_ADAPTER = module.TelegramPlatformAdapter
         return _TELEGRAM_PLATFORM_ADAPTER
+
+
+def _load_telegram_platform_event():
+    global _TELEGRAM_PLATFORM_EVENT
+    if _TELEGRAM_PLATFORM_EVENT is not None:
+        return _TELEGRAM_PLATFORM_EVENT
+
+    mocks = create_mock_telegram_modules()
+    patched_modules = {
+        "telegram": mocks["telegram"],
+        "telegram.constants": mocks["telegram"].constants,
+        "telegram.error": mocks["telegram"].error,
+        "telegram.ext": mocks["telegram.ext"],
+        "telegramify_markdown": mocks["telegramify_markdown"],
+        "apscheduler": mocks["apscheduler"],
+        "apscheduler.schedulers": mocks["apscheduler"].schedulers,
+        "apscheduler.schedulers.asyncio": mocks["apscheduler"].schedulers.asyncio,
+        "apscheduler.schedulers.background": mocks["apscheduler"].schedulers.background,
+    }
+    with patch.dict(sys.modules, patched_modules):
+        sys.modules.pop("astrbot.core.platform.sources.telegram.tg_event", None)
+        module = importlib.import_module(
+            "astrbot.core.platform.sources.telegram.tg_event"
+        )
+        _TELEGRAM_PLATFORM_EVENT = module.TelegramPlatformEvent
+        return _TELEGRAM_PLATFORM_EVENT
 
 
 def _build_context() -> MagicMock:
@@ -71,8 +100,7 @@ async def test_telegram_document_caption_populates_message_text_and_plain():
     assert result.message_str == "@alice 请总结这份文档"
     assert any(isinstance(component, Comp.File) for component in result.message)
     assert any(
-        isinstance(component, Comp.Plain)
-        and component.text == "@alice 请总结这份文档"
+        isinstance(component, Comp.Plain) and component.text == "@alice 请总结这份文档"
         for component in result.message
     )
     assert any(
@@ -140,3 +168,47 @@ async def test_telegram_voice_message_creates_record_component(tmp_path):
     assert result.message[0].file == str(wav_path)
     assert result.message[0].path == str(wav_path)
     assert result.message[0].url == str(wav_path)
+
+
+@pytest.mark.asyncio
+async def test_telegram_final_segment_splits_long_markdown_messages():
+    TelegramPlatformEvent = _load_telegram_platform_event()
+    client = MagicMock()
+    client.send_message = AsyncMock()
+    event = TelegramPlatformEvent("msg", MagicMock(), MagicMock(), "session", client)
+
+    delta = "A" * (TelegramPlatformEvent.MAX_MESSAGE_LENGTH + 32)
+    payload = {"chat_id": "123456"}
+
+    await event._send_final_segment(delta, payload)
+
+    assert client.send_message.await_count == 2
+    first_call = client.send_message.await_args_list[0].kwargs
+    second_call = client.send_message.await_args_list[1].kwargs
+    assert len(first_call["text"]) == TelegramPlatformEvent.MAX_MESSAGE_LENGTH
+    assert len(second_call["text"]) == 32
+    assert first_call["parse_mode"] == "MarkdownV2"
+    assert second_call["parse_mode"] == "MarkdownV2"
+
+
+@pytest.mark.asyncio
+async def test_telegram_final_segment_splits_long_plaintext_when_markdown_fails():
+    TelegramPlatformEvent = _load_telegram_platform_event()
+    client = MagicMock()
+    client.send_message = AsyncMock()
+    event = TelegramPlatformEvent("msg", MagicMock(), MagicMock(), "session", client)
+    markdownify = event._send_final_segment.__func__.__globals__["telegramify_markdown"]
+
+    delta = "B" * (TelegramPlatformEvent.MAX_MESSAGE_LENGTH + 18)
+    payload = {"chat_id": "123456"}
+
+    with patch.object(markdownify, "markdownify", side_effect=Exception("boom")):
+        await event._send_final_segment(delta, payload)
+
+    assert client.send_message.await_count == 2
+    first_call = client.send_message.await_args_list[0].kwargs
+    second_call = client.send_message.await_args_list[1].kwargs
+    assert len(first_call["text"]) == TelegramPlatformEvent.MAX_MESSAGE_LENGTH
+    assert len(second_call["text"]) == 18
+    assert "parse_mode" not in first_call
+    assert "parse_mode" not in second_call

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -15,6 +15,36 @@ from tests.fixtures.mocks.telegram import create_mock_telegram_modules
 
 _TELEGRAM_PLATFORM_ADAPTER = None
 _TELEGRAM_PLATFORM_EVENT = None
+_TELEGRAM_MODULES: dict[str, object] = {}
+
+
+def _build_telegram_patched_modules():
+    mocks = create_mock_telegram_modules()
+    return {
+        "telegram": mocks["telegram"],
+        "telegram.constants": mocks["telegram"].constants,
+        "telegram.error": mocks["telegram"].error,
+        "telegram.ext": mocks["telegram.ext"],
+        "telegramify_markdown": mocks["telegramify_markdown"],
+        "apscheduler": mocks["apscheduler"],
+        "apscheduler.schedulers": mocks["apscheduler"].schedulers,
+        "apscheduler.schedulers.asyncio": mocks["apscheduler"].schedulers.asyncio,
+        "apscheduler.schedulers.background": mocks["apscheduler"].schedulers.background,
+    }
+
+
+def _load_telegram_module(module_name: str):
+    module = _TELEGRAM_MODULES.get(module_name)
+    if module is not None:
+        return module
+
+    with patch.dict(sys.modules, _build_telegram_patched_modules()):
+        sys.modules.pop(module_name, None)
+        module = importlib.import_module(module_name)
+
+    sys.modules[module_name] = module
+    _TELEGRAM_MODULES[module_name] = module
+    return module
 
 
 def _load_telegram_adapter():
@@ -22,25 +52,9 @@ def _load_telegram_adapter():
     if _TELEGRAM_PLATFORM_ADAPTER is not None:
         return _TELEGRAM_PLATFORM_ADAPTER
 
-    mocks = create_mock_telegram_modules()
-    patched_modules = {
-        "telegram": mocks["telegram"],
-        "telegram.constants": mocks["telegram"].constants,
-        "telegram.error": mocks["telegram"].error,
-        "telegram.ext": mocks["telegram.ext"],
-        "telegramify_markdown": mocks["telegramify_markdown"],
-        "apscheduler": mocks["apscheduler"],
-        "apscheduler.schedulers": mocks["apscheduler"].schedulers,
-        "apscheduler.schedulers.asyncio": mocks["apscheduler"].schedulers.asyncio,
-        "apscheduler.schedulers.background": mocks["apscheduler"].schedulers.background,
-    }
-    with patch.dict(sys.modules, patched_modules):
-        sys.modules.pop("astrbot.core.platform.sources.telegram.tg_adapter", None)
-        module = importlib.import_module(
-            "astrbot.core.platform.sources.telegram.tg_adapter"
-        )
-        _TELEGRAM_PLATFORM_ADAPTER = module.TelegramPlatformAdapter
-        return _TELEGRAM_PLATFORM_ADAPTER
+    module = _load_telegram_module("astrbot.core.platform.sources.telegram.tg_adapter")
+    _TELEGRAM_PLATFORM_ADAPTER = module.TelegramPlatformAdapter
+    return _TELEGRAM_PLATFORM_ADAPTER
 
 
 def _load_telegram_platform_event():
@@ -48,25 +62,9 @@ def _load_telegram_platform_event():
     if _TELEGRAM_PLATFORM_EVENT is not None:
         return _TELEGRAM_PLATFORM_EVENT
 
-    mocks = create_mock_telegram_modules()
-    patched_modules = {
-        "telegram": mocks["telegram"],
-        "telegram.constants": mocks["telegram"].constants,
-        "telegram.error": mocks["telegram"].error,
-        "telegram.ext": mocks["telegram.ext"],
-        "telegramify_markdown": mocks["telegramify_markdown"],
-        "apscheduler": mocks["apscheduler"],
-        "apscheduler.schedulers": mocks["apscheduler"].schedulers,
-        "apscheduler.schedulers.asyncio": mocks["apscheduler"].schedulers.asyncio,
-        "apscheduler.schedulers.background": mocks["apscheduler"].schedulers.background,
-    }
-    with patch.dict(sys.modules, patched_modules):
-        sys.modules.pop("astrbot.core.platform.sources.telegram.tg_event", None)
-        module = importlib.import_module(
-            "astrbot.core.platform.sources.telegram.tg_event"
-        )
-        _TELEGRAM_PLATFORM_EVENT = module.TelegramPlatformEvent
-        return _TELEGRAM_PLATFORM_EVENT
+    module = _load_telegram_module("astrbot.core.platform.sources.telegram.tg_event")
+    _TELEGRAM_PLATFORM_EVENT = module.TelegramPlatformEvent
+    return _TELEGRAM_PLATFORM_EVENT
 
 
 def _build_context() -> MagicMock:
@@ -197,12 +195,14 @@ async def test_telegram_final_segment_splits_long_plaintext_when_markdown_fails(
     client = MagicMock()
     client.send_message = AsyncMock()
     event = TelegramPlatformEvent("msg", MagicMock(), MagicMock(), "session", client)
-    markdownify = event._send_final_segment.__func__.__globals__["telegramify_markdown"]
 
     delta = "B" * (TelegramPlatformEvent.MAX_MESSAGE_LENGTH + 18)
     payload = {"chat_id": "123456"}
 
-    with patch.object(markdownify, "markdownify", side_effect=Exception("boom")):
+    with patch(
+        "astrbot.core.platform.sources.telegram.tg_event.telegramify_markdown.markdownify",
+        side_effect=Exception("boom"),
+    ):
         await event._send_final_segment(delta, payload)
 
     assert client.send_message.await_count == 2


### PR DESCRIPTION
## Summary

- add a shared helper to split Telegram text by the 4096-character limit before sending
- reuse the helper for regular plain text sends and streaming final segments
- add regression tests for both Markdown and plain-text fallback paths

## Problem

Telegram streaming replies could fail with `Message is too long` when the final accumulated segment exceeded Telegram's single-message limit.

The regular plain-text send path already split long messages, but `_send_final_segment()` still tried to send the whole final reply as one message. That made long streaming replies fail even though the adapter already had splitting logic available.

## Testing

- `ruff check astrbot/core/platform/sources/telegram/tg_event.py tests/test_telegram_adapter.py`
- `ruff format --check astrbot/core/platform/sources/telegram/tg_event.py tests/test_telegram_adapter.py`
- `pytest tests/test_telegram_adapter.py -q`

## Summary by Sourcery

Ensure Telegram text messages, including streaming final replies, are split according to Telegram’s length limit using a shared sending helper.

Bug Fixes:
- Prevent Telegram streaming final segments from failing when the accumulated reply exceeds the single-message length limit by splitting into multiple messages.

Enhancements:
- Introduce a shared helper to send long Telegram text messages with MarkdownV2 formatting and plain-text fallback, reused by both regular sends and streaming final segments.

Tests:
- Add regression tests to verify long Markdown-formatted final segments are split correctly and that plain-text fallback also splits correctly when Markdown conversion fails.