### PR TITLE
docs: fix path concatenation error in storage.md

### DIFF
--- a/docs/en/dev/star/guides/storage.md
+++ b/docs/en/dev/star/guides/storage.md
@@ -25,7 +25,8 @@ To keep large file handling consistent, store large files under `data/plugin_dat
 You can fetch the plugin data directory with:
 
 ```py
+from pathlib import Path
 from astrbot.core.utils.astrbot_path import get_astrbot_data_path
 
-plugin_data_path = get_astrbot_data_path() / "plugin_data" / self.name  # self.name is the plugin name; available in v4.9.2 and above. For lower versions, specify the plugin name yourself.
+plugin_data_path = Path(get_astrbot_data_path()) / "plugin_data" / self.name  # self.name is the plugin name; available in v4.9.2 and above. For lower versions, specify the plugin name yourself.
 ```

--- a/docs/zh/dev/star/guides/storage.md
+++ b/docs/zh/dev/star/guides/storage.md
@@ -25,7 +25,8 @@ class Main(star.Star):
 你可以通过以下代码获取插件数据目录：
 
 ```py
+from pathlib import Path
 from astrbot.core.utils.astrbot_path import get_astrbot_data_path
 
-plugin_data_path = get_astrbot_data_path() / "plugin_data" / self.name # self.name 为插件名称，在 v4.9.2 及以上版本可用，低于此版本请自行指定插件名称
+plugin_data_path = Path(get_astrbot_data_path()) / "plugin_data" / self.name # self.name 为插件名称，在 v4.9.2 及以上版本可用，低于此版本请自行指定插件名称
 ```


### PR DESCRIPTION
While developing a new plugin and attempting to import it, I encountered a loading failure. The error occurred because I followed the code example in `docs/zh/dev/star/guides/storage.md` for path concatenation.

The error log is as follows:
```text
Exception: 加载插件「xxxxxx」时出现问题，原因：unsupported operand type(s) for /: 'str' and 'str'。
```

**Reason:**
The `get_astrbot_data_path()` function returns a `str`, but the documentation suggests using the `/` operator for joining paths, which is only supported by `pathlib.Path` objects.

**Changes:**
Updated the documentation example to:
1. Import `pathlib.Path`.
2. Wrap `get_astrbot_data_path()` with `Path()` to ensure compatibility with the `/` operator.

## Summary by Sourcery

Documentation:
- Update English and Chinese storage guides to show wrapping get_astrbot_data_path() with pathlib.Path before using the '/' operator for plugin data paths.