### PR TITLE
Fix Telegram polling recovery after repeated network errors

### DIFF
--- a/astrbot/core/platform/sources/telegram/tg_adapter.py
+++ b/astrbot/core/platform/sources/telegram/tg_adapter.py
@@ -3,12 +3,13 @@ import os
 import re
 import sys
 import uuid
+from contextlib import suppress
 from typing import cast
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from telegram import BotCommand, Update
 from telegram.constants import ChatType
-from telegram.error import Forbidden, InvalidToken
+from telegram.error import Forbidden, InvalidToken, NetworkError
 from telegram.ext import ApplicationBuilder, ContextTypes, ExtBot, filters
 from telegram.ext import MessageHandler as TelegramMessageHandler
 
@@ -66,6 +67,7 @@ class TelegramPlatformAdapter(Platform):
             file_base_url = "https://api.telegram.org/file/bot"
 
         self.base_url = base_url
+        self.file_base_url = file_base_url
 
         self.enable_command_register = self.config.get(
             "telegram_command_register",
@@ -77,23 +79,12 @@ class TelegramPlatformAdapter(Platform):
         )
         self.last_command_hash = None
 
-        self.application = (
-            ApplicationBuilder()
-            .token(self.config["telegram_token"])
-            .base_url(base_url)
-            .base_file_url(file_base_url)
-            .build()
-        )
-        message_handler = TelegramMessageHandler(
-            filters=filters.ALL,  # receive all messages
-            callback=self.message_handler,
-        )
-        self.application.add_handler(message_handler)
-        self.client = self.application.bot
-        logger.debug(f"Telegram base url: {self.client.base_url}")
-
         self.scheduler = AsyncIOScheduler()
         self._terminating = False
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._polling_recovery_requested = asyncio.Event()
+        self._consecutive_polling_failures = 0
+        self._last_polling_failure_at = 0.0
         raw_delay = self.config.get("telegram_polling_restart_delay", 5.0)
         try:
             delay = float(raw_delay)
@@ -113,6 +104,9 @@ class TelegramPlatformAdapter(Platform):
             )
             delay = 0.1
         self._polling_restart_delay = delay
+        self._polling_recovery_threshold = 3
+        self._polling_failure_window = 60.0
+        self._build_application()
 
         # Media group handling
         # Cache structure: {media_group_id: {"created_at": datetime, "items": [(update, context), ...]}}
@@ -123,6 +117,78 @@ class TelegramPlatformAdapter(Platform):
         self.media_group_max_wait = self.config.get(
             "telegram_media_group_max_wait", 10.0
         )  # max seconds - hard cap to prevent indefinite delay
+
+    def _build_application(self) -> None:
+        self.application = (
+            ApplicationBuilder()
+            .token(self.config["telegram_token"])
+            .base_url(self.base_url)
+            .base_file_url(self.file_base_url)
+            .build()
+        )
+        message_handler = TelegramMessageHandler(
+            filters=filters.ALL,
+            callback=self.message_handler,
+        )
+        self.application.add_handler(message_handler)
+        self.client = self.application.bot
+        logger.debug(f"Telegram base url: {self.client.base_url}")
+
+    async def _start_application(self) -> None:
+        await self.application.initialize()
+        await self.application.start()
+
+        if self.enable_command_register:
+            await self.register_commands()
+
+    async def _shutdown_application(
+        self,
+        *,
+        delete_commands: bool,
+    ) -> None:
+        updater = self.application.updater
+        if updater is not None:
+            with suppress(Exception):
+                await updater.stop()
+
+        with suppress(Exception):
+            await self.application.stop()
+
+        if delete_commands and self.enable_command_register:
+            with suppress(Exception):
+                await self.client.delete_my_commands()
+
+        shutdown = getattr(self.application, "shutdown", None)
+        if shutdown is not None:
+            with suppress(Exception):
+                await shutdown()
+
+    async def _recreate_application(self) -> None:
+        logger.warning(
+            "Telegram polling hit repeated network errors; rebuilding the "
+            "Telegram application and HTTP client.",
+        )
+        await self._shutdown_application(delete_commands=False)
+        self._build_application()
+        await self._start_application()
+        self._consecutive_polling_failures = 0
+        self._last_polling_failure_at = 0.0
+        self._polling_recovery_requested.clear()
+
+    def _start_command_scheduler(self) -> None:
+        if not self.enable_command_refresh or not self.enable_command_register:
+            return
+        if self.scheduler.running:
+            return
+
+        self.scheduler.add_job(
+            self.register_commands,
+            "interval",
+            seconds=self.config.get("telegram_command_register_interval", 300),
+            id="telegram_command_register",
+            misfire_grace_time=60,
+        )
+        self.scheduler.start()
 
     @override
     async def send_by_session(
@@ -145,21 +211,9 @@ class TelegramPlatformAdapter(Platform):
 
     @override
     async def run(self) -> None:
-        await self.application.initialize()
-        await self.application.start()
-
-        if self.enable_command_register:
-            await self.register_commands()
-
-        if self.enable_command_refresh and self.enable_command_register:
-            self.scheduler.add_job(
-                self.register_commands,
-                "interval",
-                seconds=self.config.get("telegram_command_register_interval", 300),
-                id="telegram_command_register",
-                misfire_grace_time=60,
-            )
-            self.scheduler.start()
+        self._loop = asyncio.get_running_loop()
+        await self._start_application()
+        self._start_command_scheduler()
 
         if not self.application.updater:
             logger.error("Telegram Updater is not initialized. Cannot start polling.")
@@ -167,19 +221,34 @@ class TelegramPlatformAdapter(Platform):
 
         while not self._terminating:
             try:
+                self._polling_recovery_requested.clear()
+                updater = self.application.updater
+                if updater is None:
+                    logger.error(
+                        "Telegram Updater is not initialized. Cannot start polling."
+                    )
+                    return
                 logger.info("Starting Telegram polling...")
-                await self.application.updater.start_polling(
+                await updater.start_polling(
                     error_callback=self._on_polling_error
                 )
                 logger.info("Telegram Platform Adapter is running.")
-                while self.application.updater.running and not self._terminating:  # noqa: ASYNC110
+                while updater.running and not self._terminating:  # noqa: ASYNC110
+                    if self._polling_recovery_requested.is_set():
+                        await self._recreate_application()
+                        break
                     await asyncio.sleep(1)
+                else:
+                    if not self._terminating:
+                        logger.warning(
+                            "Telegram polling loop exited unexpectedly, "
+                            f"retrying in {self._polling_restart_delay}s."
+                        )
+                    continue
 
                 if not self._terminating:
-                    logger.warning(
-                        "Telegram polling loop exited unexpectedly, "
-                        f"retrying in {self._polling_restart_delay}s."
-                    )
+                    logger.info("Telegram polling restarted with a fresh client.")
+                    continue
             except asyncio.CancelledError:
                 raise
             except (Forbidden, InvalidToken) as e:
@@ -202,6 +271,28 @@ class TelegramPlatformAdapter(Platform):
             f"Telegram polling request failed: {type(error).__name__}: {error!s}",
             exc_info=error,
         )
+        if not isinstance(error, NetworkError):
+            return
+
+        if self._loop is None:
+            return
+
+        now = self._loop.time()
+        if now - self._last_polling_failure_at > self._polling_failure_window:
+            self._consecutive_polling_failures = 0
+        self._last_polling_failure_at = now
+        self._consecutive_polling_failures += 1
+
+        if self._consecutive_polling_failures < self._polling_recovery_threshold:
+            return
+
+        logger.warning(
+            "Telegram polling encountered %s network failures within %.1fs; "
+            "scheduling client rebuild.",
+            self._consecutive_polling_failures,
+            self._polling_failure_window,
+        )
+        self._loop.call_soon_threadsafe(self._polling_recovery_requested.set)
 
     async def register_commands(self) -> None:
         """收集所有注册的指令并注册到 Telegram"""
@@ -634,15 +725,8 @@ class TelegramPlatformAdapter(Platform):
             self._terminating = True
             if self.scheduler.running:
                 self.scheduler.shutdown()
-
-            await self.application.stop()
-
-            if self.enable_command_register:
-                await self.client.delete_my_commands()
-
-            # 保险起见先判断是否存在updater对象
-            if self.application.updater is not None:
-                await self.application.updater.stop()
+            self._polling_recovery_requested.set()
+            await self._shutdown_application(delete_commands=True)
 
             logger.info("Telegram adapter has been closed.")
         except Exception as e:

--- a/astrbot/core/platform/sources/telegram/tg_event.py
+++ b/astrbot/core/platform/sources/telegram/tg_event.py
@@ -106,6 +106,28 @@ class TelegramPlatformEvent(AstrMessageEvent):
         return chunks
 
     @classmethod
+    async def _send_text_chunks(
+        cls,
+        client: ExtBot,
+        text: str,
+        payload: dict[str, Any],
+    ) -> None:
+        """按 Telegram 限制切分文本后逐段发送。"""
+        for chunk in cls._split_message(text):
+            try:
+                markdown_text = telegramify_markdown.markdownify(
+                    chunk,
+                )
+                await client.send_message(
+                    text=markdown_text,
+                    parse_mode="MarkdownV2",
+                    **cast(Any, payload),
+                )
+            except Exception as e:
+                logger.warning(f"Markdown转换失败，使用普通文本: {e!s}")
+                await client.send_message(text=chunk, **cast(Any, payload))
+
+    @classmethod
     async def _send_chat_action(
         cls,
         client: ExtBot,
@@ -283,22 +305,7 @@ class TelegramPlatformEvent(AstrMessageEvent):
                 if at_user_id and not at_flag:
                     i.text = f"@{at_user_id} {i.text}"
                     at_flag = True
-                chunks = cls._split_message(i.text)
-                for chunk in chunks:
-                    try:
-                        md_text = telegramify_markdown.markdownify(
-                            chunk,
-                        )
-                        await client.send_message(
-                            text=md_text,
-                            parse_mode="MarkdownV2",
-                            **cast(Any, payload),
-                        )
-                    except Exception as e:
-                        logger.warning(
-                            f"MarkdownV2 send failed: {e}. Using plain text instead.",
-                        )
-                        await client.send_message(text=chunk, **cast(Any, payload))
+                await cls._send_text_chunks(client, i.text, payload)
             elif isinstance(i, Image):
                 image_path = await i.convert_to_file_path()
                 if _is_gif(image_path):
@@ -479,18 +486,7 @@ class TelegramPlatformEvent(AstrMessageEvent):
 
     async def _send_final_segment(self, delta: str, payload: dict[str, Any]) -> None:
         """将累积文本作为 MarkdownV2 真实消息发送，失败时回退到纯文本。"""
-        try:
-            markdown_text = telegramify_markdown.markdownify(
-                delta,
-            )
-            await self.client.send_message(
-                text=markdown_text,
-                parse_mode="MarkdownV2",
-                **cast(Any, payload),
-            )
-        except Exception as e:
-            logger.warning(f"Markdown转换失败，使用普通文本: {e!s}")
-            await self.client.send_message(text=delta, **cast(Any, payload))
+        await self._send_text_chunks(self.client, delta, payload)
 
     async def send_streaming(self, generator, use_fallback: bool = False):
         message_thread_id = None

--- a/tests/fixtures/mocks/telegram.py
+++ b/tests/fixtures/mocks/telegram.py
@@ -28,6 +28,9 @@ def create_mock_telegram_modules():
     mock_telegram.constants.ChatAction.UPLOAD_PHOTO = "upload_photo"
     mock_telegram.error = MagicMock()
     mock_telegram.error.BadRequest = Exception
+    mock_telegram.error.Forbidden = Exception
+    mock_telegram.error.InvalidToken = Exception
+    mock_telegram.error.NetworkError = Exception
     mock_telegram.ReactionTypeCustomEmoji = MagicMock
     mock_telegram.ReactionTypeEmoji = MagicMock
 
@@ -126,10 +129,12 @@ class MockTelegramBuilder:
         app.initialize = AsyncMock()
         app.start = AsyncMock()
         app.stop = AsyncMock()
+        app.shutdown = AsyncMock()
         app.add_handler = MagicMock()
         app.updater = MagicMock()
         app.updater.start_polling = MagicMock(return_value=NoopAwaitable())
         app.updater.stop = AsyncMock()
+        app.updater.running = False
         return app
 
     @staticmethod

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -14,6 +14,7 @@ from tests.fixtures.helpers import (
 from tests.fixtures.mocks.telegram import create_mock_telegram_modules
 
 _TELEGRAM_PLATFORM_ADAPTER = None
+_TELEGRAM_PLATFORM_EVENT = None
 
 
 def _load_telegram_adapter():
@@ -35,9 +36,37 @@ def _load_telegram_adapter():
     }
     with patch.dict(sys.modules, patched_modules):
         sys.modules.pop("astrbot.core.platform.sources.telegram.tg_adapter", None)
-        module = importlib.import_module("astrbot.core.platform.sources.telegram.tg_adapter")
+        module = importlib.import_module(
+            "astrbot.core.platform.sources.telegram.tg_adapter"
+        )
         _TELEGRAM_PLATFORM_ADAPTER = module.TelegramPlatformAdapter
         return _TELEGRAM_PLATFORM_ADAPTER
+
+
+def _load_telegram_platform_event():
+    global _TELEGRAM_PLATFORM_EVENT
+    if _TELEGRAM_PLATFORM_EVENT is not None:
+        return _TELEGRAM_PLATFORM_EVENT
+
+    mocks = create_mock_telegram_modules()
+    patched_modules = {
+        "telegram": mocks["telegram"],
+        "telegram.constants": mocks["telegram"].constants,
+        "telegram.error": mocks["telegram"].error,
+        "telegram.ext": mocks["telegram.ext"],
+        "telegramify_markdown": mocks["telegramify_markdown"],
+        "apscheduler": mocks["apscheduler"],
+        "apscheduler.schedulers": mocks["apscheduler"].schedulers,
+        "apscheduler.schedulers.asyncio": mocks["apscheduler"].schedulers.asyncio,
+        "apscheduler.schedulers.background": mocks["apscheduler"].schedulers.background,
+    }
+    with patch.dict(sys.modules, patched_modules):
+        sys.modules.pop("astrbot.core.platform.sources.telegram.tg_event", None)
+        module = importlib.import_module(
+            "astrbot.core.platform.sources.telegram.tg_event"
+        )
+        _TELEGRAM_PLATFORM_EVENT = module.TelegramPlatformEvent
+        return _TELEGRAM_PLATFORM_EVENT
 
 
 def _build_context() -> MagicMock:
@@ -71,8 +100,7 @@ async def test_telegram_document_caption_populates_message_text_and_plain():
     assert result.message_str == "@alice 请总结这份文档"
     assert any(isinstance(component, Comp.File) for component in result.message)
     assert any(
-        isinstance(component, Comp.Plain)
-        and component.text == "@alice 请总结这份文档"
+        isinstance(component, Comp.Plain) and component.text == "@alice 请总结这份文档"
         for component in result.message
     )
     assert any(
@@ -140,3 +168,47 @@ async def test_telegram_voice_message_creates_record_component(tmp_path):
     assert result.message[0].file == str(wav_path)
     assert result.message[0].path == str(wav_path)
     assert result.message[0].url == str(wav_path)
+
+
+@pytest.mark.asyncio
+async def test_telegram_final_segment_splits_long_markdown_messages():
+    TelegramPlatformEvent = _load_telegram_platform_event()
+    client = MagicMock()
+    client.send_message = AsyncMock()
+    event = TelegramPlatformEvent("msg", MagicMock(), MagicMock(), "session", client)
+
+    delta = "A" * (TelegramPlatformEvent.MAX_MESSAGE_LENGTH + 32)
+    payload = {"chat_id": "123456"}
+
+    await event._send_final_segment(delta, payload)
+
+    assert client.send_message.await_count == 2
+    first_call = client.send_message.await_args_list[0].kwargs
+    second_call = client.send_message.await_args_list[1].kwargs
+    assert len(first_call["text"]) == TelegramPlatformEvent.MAX_MESSAGE_LENGTH
+    assert len(second_call["text"]) == 32
+    assert first_call["parse_mode"] == "MarkdownV2"
+    assert second_call["parse_mode"] == "MarkdownV2"
+
+
+@pytest.mark.asyncio
+async def test_telegram_final_segment_splits_long_plaintext_when_markdown_fails():
+    TelegramPlatformEvent = _load_telegram_platform_event()
+    client = MagicMock()
+    client.send_message = AsyncMock()
+    event = TelegramPlatformEvent("msg", MagicMock(), MagicMock(), "session", client)
+    markdownify = event._send_final_segment.__func__.__globals__["telegramify_markdown"]
+
+    delta = "B" * (TelegramPlatformEvent.MAX_MESSAGE_LENGTH + 18)
+    payload = {"chat_id": "123456"}
+
+    with patch.object(markdownify, "markdownify", side_effect=Exception("boom")):
+        await event._send_final_segment(delta, payload)
+
+    assert client.send_message.await_count == 2
+    first_call = client.send_message.await_args_list[0].kwargs
+    second_call = client.send_message.await_args_list[1].kwargs
+    assert len(first_call["text"]) == TelegramPlatformEvent.MAX_MESSAGE_LENGTH
+    assert len(second_call["text"]) == 18
+    assert "parse_mode" not in first_call
+    assert "parse_mode" not in second_call

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -7,11 +7,15 @@ import pytest
 
 import astrbot.api.message_components as Comp
 from tests.fixtures.helpers import (
+    NoopAwaitable,
     create_mock_file,
     create_mock_update,
     make_platform_config,
 )
-from tests.fixtures.mocks.telegram import create_mock_telegram_modules
+from tests.fixtures.mocks.telegram import (
+    MockTelegramBuilder,
+    create_mock_telegram_modules,
+)
 
 _TELEGRAM_PLATFORM_ADAPTER = None
 _TELEGRAM_PLATFORM_EVENT = None
@@ -212,3 +216,84 @@ async def test_telegram_final_segment_splits_long_plaintext_when_markdown_fails(
     assert len(second_call["text"]) == 18
     assert "parse_mode" not in first_call
     assert "parse_mode" not in second_call
+
+
+@pytest.mark.asyncio
+async def test_telegram_polling_error_requests_rebuild_after_threshold():
+    TelegramPlatformAdapter = _load_telegram_adapter()
+    adapter = TelegramPlatformAdapter(
+        make_platform_config("telegram"),
+        {},
+        asyncio.Queue(),
+    )
+    adapter._loop = asyncio.get_running_loop()
+
+    assert not adapter._polling_recovery_requested.is_set()
+
+    for _ in range(adapter._polling_recovery_threshold):
+        adapter._on_polling_error(Exception("proxy disconnected"))
+
+    await asyncio.sleep(0)
+
+    assert adapter._polling_recovery_requested.is_set()
+
+
+@pytest.mark.asyncio
+async def test_telegram_run_rebuilds_application_after_repeated_polling_errors():
+    TelegramPlatformAdapter = _load_telegram_adapter()
+    module_globals = TelegramPlatformAdapter.__init__.__globals__
+    app_one = MockTelegramBuilder.create_application()
+    app_one.updater.running = True
+    app_two = MockTelegramBuilder.create_application()
+    app_two.updater.running = True
+    created_apps = [app_one, app_two]
+
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.base_url.return_value = builder
+    builder.base_file_url.return_value = builder
+    builder.build.side_effect = created_apps
+
+    adapter = None
+
+    def start_polling_side_effect(*args, **kwargs):
+        nonlocal adapter
+        error_callback = kwargs["error_callback"]
+        assert adapter is not None
+
+        async def _emit_errors():
+            await asyncio.sleep(0)
+            for _ in range(adapter._polling_recovery_threshold):
+                error_callback(Exception("proxy disconnected"))
+
+        asyncio.create_task(_emit_errors())
+        return NoopAwaitable()
+
+    app_one.updater.start_polling.side_effect = start_polling_side_effect
+
+    async def second_start_polling(*args, **kwargs):
+        assert adapter is not None
+        adapter._terminating = True
+
+    app_two.updater.start_polling.side_effect = second_start_polling
+
+    with patch.dict(
+        module_globals,
+        {
+            "ApplicationBuilder": MagicMock(return_value=builder),
+            "AsyncIOScheduler": MagicMock(return_value=MockTelegramBuilder.create_scheduler()),
+        },
+    ):
+        adapter = TelegramPlatformAdapter(
+            make_platform_config("telegram"),
+            {},
+            asyncio.Queue(),
+        )
+        await adapter.run()
+
+    assert builder.build.call_count == 2
+    app_one.updater.stop.assert_awaited()
+    app_one.stop.assert_awaited()
+    app_one.shutdown.assert_awaited()
+    app_two.initialize.assert_awaited()
+    app_two.start.assert_awaited()

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -15,6 +15,36 @@ from tests.fixtures.mocks.telegram import create_mock_telegram_modules
 
 _TELEGRAM_PLATFORM_ADAPTER = None
 _TELEGRAM_PLATFORM_EVENT = None
+_TELEGRAM_MODULES: dict[str, object] = {}
+
+
+def _build_telegram_patched_modules():
+    mocks = create_mock_telegram_modules()
+    return {
+        "telegram": mocks["telegram"],
+        "telegram.constants": mocks["telegram"].constants,
+        "telegram.error": mocks["telegram"].error,
+        "telegram.ext": mocks["telegram.ext"],
+        "telegramify_markdown": mocks["telegramify_markdown"],
+        "apscheduler": mocks["apscheduler"],
+        "apscheduler.schedulers": mocks["apscheduler"].schedulers,
+        "apscheduler.schedulers.asyncio": mocks["apscheduler"].schedulers.asyncio,
+        "apscheduler.schedulers.background": mocks["apscheduler"].schedulers.background,
+    }
+
+
+def _load_telegram_module(module_name: str):
+    module = _TELEGRAM_MODULES.get(module_name)
+    if module is not None:
+        return module
+
+    with patch.dict(sys.modules, _build_telegram_patched_modules()):
+        sys.modules.pop(module_name, None)
+        module = importlib.import_module(module_name)
+
+    sys.modules[module_name] = module
+    _TELEGRAM_MODULES[module_name] = module
+    return module
 
 
 def _load_telegram_adapter():
@@ -22,25 +52,9 @@ def _load_telegram_adapter():
     if _TELEGRAM_PLATFORM_ADAPTER is not None:
         return _TELEGRAM_PLATFORM_ADAPTER
 
-    mocks = create_mock_telegram_modules()
-    patched_modules = {
-        "telegram": mocks["telegram"],
-        "telegram.constants": mocks["telegram"].constants,
-        "telegram.error": mocks["telegram"].error,
-        "telegram.ext": mocks["telegram.ext"],
-        "telegramify_markdown": mocks["telegramify_markdown"],
-        "apscheduler": mocks["apscheduler"],
-        "apscheduler.schedulers": mocks["apscheduler"].schedulers,
-        "apscheduler.schedulers.asyncio": mocks["apscheduler"].schedulers.asyncio,
-        "apscheduler.schedulers.background": mocks["apscheduler"].schedulers.background,
-    }
-    with patch.dict(sys.modules, patched_modules):
-        sys.modules.pop("astrbot.core.platform.sources.telegram.tg_adapter", None)
-        module = importlib.import_module(
-            "astrbot.core.platform.sources.telegram.tg_adapter"
-        )
-        _TELEGRAM_PLATFORM_ADAPTER = module.TelegramPlatformAdapter
-        return _TELEGRAM_PLATFORM_ADAPTER
+    module = _load_telegram_module("astrbot.core.platform.sources.telegram.tg_adapter")
+    _TELEGRAM_PLATFORM_ADAPTER = module.TelegramPlatformAdapter
+    return _TELEGRAM_PLATFORM_ADAPTER
 
 
 def _load_telegram_platform_event():
@@ -48,25 +62,9 @@ def _load_telegram_platform_event():
     if _TELEGRAM_PLATFORM_EVENT is not None:
         return _TELEGRAM_PLATFORM_EVENT
 
-    mocks = create_mock_telegram_modules()
-    patched_modules = {
-        "telegram": mocks["telegram"],
-        "telegram.constants": mocks["telegram"].constants,
-        "telegram.error": mocks["telegram"].error,
-        "telegram.ext": mocks["telegram.ext"],
-        "telegramify_markdown": mocks["telegramify_markdown"],
-        "apscheduler": mocks["apscheduler"],
-        "apscheduler.schedulers": mocks["apscheduler"].schedulers,
-        "apscheduler.schedulers.asyncio": mocks["apscheduler"].schedulers.asyncio,
-        "apscheduler.schedulers.background": mocks["apscheduler"].schedulers.background,
-    }
-    with patch.dict(sys.modules, patched_modules):
-        sys.modules.pop("astrbot.core.platform.sources.telegram.tg_event", None)
-        module = importlib.import_module(
-            "astrbot.core.platform.sources.telegram.tg_event"
-        )
-        _TELEGRAM_PLATFORM_EVENT = module.TelegramPlatformEvent
-        return _TELEGRAM_PLATFORM_EVENT
+    module = _load_telegram_module("astrbot.core.platform.sources.telegram.tg_event")
+    _TELEGRAM_PLATFORM_EVENT = module.TelegramPlatformEvent
+    return _TELEGRAM_PLATFORM_EVENT
 
 
 def _build_context() -> MagicMock:
@@ -197,12 +195,14 @@ async def test_telegram_final_segment_splits_long_plaintext_when_markdown_fails(
     client = MagicMock()
     client.send_message = AsyncMock()
     event = TelegramPlatformEvent("msg", MagicMock(), MagicMock(), "session", client)
-    markdownify = event._send_final_segment.__func__.__globals__["telegramify_markdown"]
 
     delta = "B" * (TelegramPlatformEvent.MAX_MESSAGE_LENGTH + 18)
     payload = {"chat_id": "123456"}
 
-    with patch.object(markdownify, "markdownify", side_effect=Exception("boom")):
+    with patch(
+        "astrbot.core.platform.sources.telegram.tg_event.telegramify_markdown.markdownify",
+        side_effect=Exception("boom"),
+    ):
         await event._send_final_segment(delta, payload)
 
     assert client.send_message.await_count == 2


### PR DESCRIPTION
## Summary
- rebuild the Telegram Application/Updater/HTTP client after repeated polling `NetworkError`s
- keep command registration scheduling intact across client rebuilds
- add regression tests covering recovery threshold handling and application recreation

## Testing
- `.venv/bin/python -m pytest -q tests/test_telegram_adapter.py`
- `.venv/bin/python -m ruff check astrbot/core/platform/sources/telegram/tg_adapter.py tests/test_telegram_adapter.py tests/fixtures/mocks/telegram.py`

## Summary by Sourcery

Improve Telegram adapter resilience to polling network errors and standardize Telegram text sending behavior under message length and Markdown constraints.

Bug Fixes:
- Rebuild the Telegram application and HTTP client after repeated NetworkError polling failures within a time window, while preserving command registration scheduling.
- Ensure termination shuts down the Telegram application and updater safely and always cleans up commands.
- Fix handling of long final streaming segments by splitting and sending them in chunks within Telegram’s message length limit, with a plaintext fallback when Markdown conversion fails.

Enhancements:
- Refactor Telegram application lifecycle management into dedicated build, start, shutdown, and recreate helpers with centralized command scheduler control.
- Unify text chunking and Markdown/plaintext fallback logic into a reusable helper used by both normal sends and streaming final segments.
- Extend Telegram test fixtures and module loading helpers to support multiple application rebuilds and error types, enabling more robust adapter tests.

Tests:
- Add regression tests for polling error recovery threshold handling and application recreation after repeated polling failures.
- Add tests verifying that long messages and final streaming segments are split into multiple Telegram messages and fall back to plaintext when Markdown formatting fails.