### PR TITLE
fix(discord): prevent 10062 Unknown interaction error by deferring slash commands immediately

### DIFF
--- a/astrbot/core/platform/sources/discord/discord_platform_adapter.py
+++ b/astrbot/core/platform/sources/discord/discord_platform_adapter.py
@@ -444,8 +444,10 @@ class DiscordPlatformAdapter(Platform):
                 followup_webhook = ctx.followup
             except asyncio.TimeoutError:
                 logger.warning(f"[Discord] Defer command '{cmd_name}' timeout. Network might be too slow.")
+                return
             except Exception as e:
                 logger.warning(f"[Discord] Failed to defer command '{cmd_name}': {e}")
+                return
 
             # 将平台特定的前缀'/'剥离，以适配通用的CommandFilter
             logger.debug(f"[Discord] Callback triggered: {cmd_name}")

--- a/astrbot/core/platform/sources/discord/discord_platform_adapter.py
+++ b/astrbot/core/platform/sources/discord/discord_platform_adapter.py
@@ -436,6 +436,17 @@ class DiscordPlatformAdapter(Platform):
         async def dynamic_callback(
             ctx: discord.ApplicationContext, params: str | None = None
         ) -> None:
+            # 1. 嘗試立即响应，防止超时 (移到最前面)
+            followup_webhook = None
+            try:
+                # 設定 2.5 秒超時，避免卡死整個 event loop
+                await asyncio.wait_for(ctx.defer(), timeout=2.5)
+                followup_webhook = ctx.followup
+            except asyncio.TimeoutError:
+                logger.warning(f"[Discord] Defer command '{cmd_name}' timeout. Network might be too slow.")
+            except Exception as e:
+                logger.warning(f"[Discord] Failed to defer command '{cmd_name}': {e}")
+
             # 将平台特定的前缀'/'剥离，以适配通用的CommandFilter
             logger.debug(f"[Discord] Callback triggered: {cmd_name}")
             logger.debug(f"[Discord] Callback context: {ctx}")
@@ -449,14 +460,6 @@ class DiscordPlatformAdapter(Platform):
                 f"Raw params: '{params}'. "
                 f"Built command string: '{message_str_for_filter}'",
             )
-
-            # 尝试立即响应，防止超时
-            followup_webhook = None
-            try:
-                await ctx.defer()
-                followup_webhook = ctx.followup
-            except Exception as e:
-                logger.warning(f"[Discord] Failed to defer command '{cmd_name}': {e}")
 
             # 2. 构建 AstrBotMessage
             channel = ctx.channel

--- a/astrbot/core/platform/sources/discord/discord_platform_adapter.py
+++ b/astrbot/core/platform/sources/discord/discord_platform_adapter.py
@@ -443,7 +443,9 @@ class DiscordPlatformAdapter(Platform):
                 await asyncio.wait_for(ctx.defer(), timeout=2.5)
                 followup_webhook = ctx.followup
             except asyncio.TimeoutError:
-                logger.warning(f"[Discord] Defer command '{cmd_name}' timeout. Network might be too slow.")
+                logger.warning(
+                    f"[Discord] Defer command '{cmd_name}' timeout. Network might be too slow."
+                )
                 return
             except Exception as e:
                 logger.warning(f"[Discord] Failed to defer command '{cmd_name}': {e}")


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
## 問題描述 (Description)
這個 PR 修復了在使用 Discord 平台適配器時，使用者觸發斜線指令經常遇到 `404 Not Found (error code: 10062): Unknown interaction` 的問題。

對應issue：https://github.com/AstrBotDevs/AstrBot/issues/7458#issue-4244174251
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### 原因分析 (Problem)
Discord 官方嚴格要求機器人必須在收到互動（Interaction）指令的 **3 秒內** 做出回應。
在原本的程式碼中，`dynamic_callback` 會先進行多次 `logger.debug` 呼叫、變數建立與字串拼接，最後才執行 `await ctx.defer()`。如果機器人伺服器到 Discord API 的網路有延遲（或使用了 proxy），發送 `defer()` 的 HTTP 請求很容易就會超過這 3 秒的死線，導致指令觸發失敗。

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
#### 解決方案 (Solution)
1. 將 `await ctx.defer()` 區塊移到 `dynamic_callback` 函式的最開頭，確保機器人收到指令的瞬間能用最快速度向 Discord 註冊「正在處理中」。
2. 使用 `asyncio.wait_for(..., timeout=2.5)` 對 `defer()` 加上超時保護，避免網路連線卡死時導致整個事件迴圈（Event Loop）阻塞。
#### 程式碼變動 (Code Changes / Diff)
```python
# astrbot/core/platform/sources/discord/discord_platform_adapter.py
# 在 _create_dynamic_callback 中：
        async def dynamic_callback(
            ctx: discord.ApplicationContext, params: str | None = None
        ) -> None:
           # 1. 嘗試立即响应，防止超时 (移到最前面)
           followup_webhook = None
           try:
               # 設定 2.5 秒超時，避免卡死整個 event loop
               await asyncio.wait_for(ctx.defer(), timeout=2.5)
               followup_webhook = ctx.followup
           except asyncio.TimeoutError:
               logger.warning(f"[Discord] Defer command '{cmd_name}' timeout. Network might be too slow.")
           except Exception as e:
               logger.warning(f"[Discord] Failed to defer command '{cmd_name}': {e}")
            # 将平台特定的前缀'/'剥离，以适配通用的CommandFilter
            logger.debug(f"[Discord] Callback triggered: {cmd_name}")
            # ... 下方為原本的程式碼 ...
```

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

```
[2026-04-12 13:59:46.152] [Core] [DBUG] [discord.discord_platform_adapter:450]: [Discord] Callback triggered: help
[2026-04-12 13:59:46.153] [Core] [DBUG] [discord.discord_platform_adapter:451]: [Discord] Callback context: <discord.commands.context.ApplicationContext object at 0x7f845a57e120>
[2026-04-12 13:59:46.153] [Core] [DBUG] [discord.discord_platform_adapter:452]: [Discord] Callback params: None
[2026-04-12 13:59:46.153] [Core] [DBUG] [discord.discord_platform_adapter:457]: [Discord] Slash command 'help' triggered. Raw params: 'None'. Built command string: 'help'
[2026-04-12 13:59:46.154] [Core] [INFO] [core.event_bus:61]: [default] [discord(discord)] yuanqiuye/xxx: help 
[2026-04-12 13:59:46.154] [Core] [DBUG] [waking_check.stage:157]: enabled_plugins_name: ['*']
[2026-04-12 13:59:46.160] [Core] [DBUG] [method.star_request:44]: plugin -> session_controller - handle_session_control_agent
[2026-04-12 13:59:46.160] [Core] [DBUG] [method.star_request:44]: plugin -> session_controller - handle_empty_mention
[2026-04-12 13:59:46.160] [Core] [DBUG] [method.star_request:44]: plugin -> astrbot - on_message
[2026-04-12 13:59:46.161] [Core] [DBUG] [method.star_request:44]: plugin -> builtin_commands - help
[2026-04-12 13:59:47.715] [Core] [INFO] [respond.stage:184]: Prepare to send - yuanqiuye/xxx: AstrBot v4.22.3(WebUI: v4.22.3)
```
<img width="575" height="967" alt="image" src="https://github.com/user-attachments/assets/5a0bc123-eaff-4c6f-a577-6584082497bb" />






### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。