### PR TITLE
fix: warn when default chat provider is unset

### DIFF
--- a/astrbot/core/core_lifecycle.py
+++ b/astrbot/core/core_lifecycle.py
@@ -59,6 +59,7 @@ class AstrBotCoreLifecycle:
         self.subagent_orchestrator: SubAgentOrchestrator | None = None
         self.cron_manager: CronJobManager | None = None
         self.temp_dir_cleaner: TempDirCleaner | None = None
+        self._default_chat_provider_warning_emitted = False
 
         # 设置代理
         proxy_config = self.astrbot_config.get("http_proxy", "")
@@ -96,6 +97,65 @@ class AstrBotCoreLifecycle:
             )
         except Exception as e:
             logger.error(f"Subagent orchestrator init failed: {e}", exc_info=True)
+
+    @staticmethod
+    def _is_chat_provider_config(
+        provider_config: dict, provider_sources: dict[str, dict]
+    ) -> bool:
+        if provider_config.get("provider_type") == "chat_completion":
+            return True
+
+        provider_source_id = provider_config.get("provider_source_id")
+        if not provider_source_id:
+            return False
+
+        provider_source = provider_sources.get(provider_source_id, {})
+        if provider_source.get("provider_type") == "chat_completion":
+            return True
+
+        provider_source_type = provider_source.get("type", "")
+        return isinstance(provider_source_type, str) and (
+            "chat_completion" in provider_source_type
+        )
+
+    def _warn_about_unset_default_chat_provider(self, config: dict) -> None:
+        if self._default_chat_provider_warning_emitted:
+            return
+
+        provider_settings = config.get("provider_settings", {})
+        default_provider_id = provider_settings.get("default_provider_id", "")
+        if default_provider_id:
+            return
+
+        provider_sources = {
+            source.get("id"): source
+            for source in config.get("provider_sources", [])
+            if isinstance(source, dict) and source.get("id")
+        }
+        enabled_chat_provider_ids: list[str] = []
+        for provider in config.get("provider", []):
+            if not isinstance(provider, dict):
+                continue
+            if not provider.get("enable", True):
+                continue
+            if not self._is_chat_provider_config(provider, provider_sources):
+                continue
+
+            provider_id = provider.get("id")
+            if isinstance(provider_id, str) and provider_id:
+                enabled_chat_provider_ids.append(provider_id)
+
+        if len(enabled_chat_provider_ids) <= 1:
+            return
+
+        self._default_chat_provider_warning_emitted = True
+        logger.warning(
+            "Detected %d enabled chat providers but `provider_settings.default_provider_id` is empty. "
+            "AstrBot will use `%s` as the startup fallback chat provider. "
+            "Set a default chat model in the WebUI configuration page to avoid unexpected provider switching.",
+            len(enabled_chat_provider_ids),
+            enabled_chat_provider_ids[0],
+        )
 
     async def initialize(self) -> None:
         """初始化 AstrBot 核心生命周期管理类.
@@ -202,6 +262,9 @@ class AstrBotCoreLifecycle:
 
         # 根据配置实例化各个 Provider
         await self.provider_manager.initialize()
+        self._warn_about_unset_default_chat_provider(
+            self.astrbot_config_mgr.default_conf
+        )
 
         await self.kb_manager.initialize()
 

--- a/astrbot/core/core_lifecycle.py
+++ b/astrbot/core/core_lifecycle.py
@@ -98,63 +98,36 @@ class AstrBotCoreLifecycle:
         except Exception as e:
             logger.error(f"Subagent orchestrator init failed: {e}", exc_info=True)
 
-    @staticmethod
-    def _is_chat_provider_config(
-        provider_config: dict, provider_sources: dict[str, dict]
-    ) -> bool:
-        if provider_config.get("provider_type") == "chat_completion":
-            return True
-
-        provider_source_id = provider_config.get("provider_source_id")
-        if not provider_source_id:
-            return False
-
-        provider_source = provider_sources.get(provider_source_id, {})
-        if provider_source.get("provider_type") == "chat_completion":
-            return True
-
-        provider_source_type = provider_source.get("type", "")
-        return isinstance(provider_source_type, str) and (
-            "chat_completion" in provider_source_type
-        )
-
-    def _warn_about_unset_default_chat_provider(self, config: dict) -> None:
+    def _warn_about_unset_default_chat_provider(self) -> None:
         if self._default_chat_provider_warning_emitted:
             return
 
-        provider_settings = config.get("provider_settings", {})
-        default_provider_id = provider_settings.get("default_provider_id", "")
+        provider_manager = getattr(self, "provider_manager", None)
+        if provider_manager is None:
+            return
+
+        default_provider_id = provider_manager.provider_settings.get(
+            "default_provider_id", ""
+        )
         if default_provider_id:
             return
 
-        provider_sources = {
-            source.get("id"): source
-            for source in config.get("provider_sources", [])
-            if isinstance(source, dict) and source.get("id")
-        }
-        enabled_chat_provider_ids: list[str] = []
-        for provider in config.get("provider", []):
-            if not isinstance(provider, dict):
-                continue
-            if not provider.get("enable", True):
-                continue
-            if not self._is_chat_provider_config(provider, provider_sources):
-                continue
-
-            provider_id = provider.get("id")
-            if isinstance(provider_id, str) and provider_id:
-                enabled_chat_provider_ids.append(provider_id)
-
-        if len(enabled_chat_provider_ids) <= 1:
+        enabled_chat_providers = provider_manager.provider_insts
+        if len(enabled_chat_providers) <= 1:
             return
+
+        fallback_provider = (
+            provider_manager.curr_provider_inst or enabled_chat_providers[0]
+        )
+        fallback_provider_id = fallback_provider.provider_config.get("id", "unknown")
 
         self._default_chat_provider_warning_emitted = True
         logger.warning(
             "Detected %d enabled chat providers but `provider_settings.default_provider_id` is empty. "
             "AstrBot will use `%s` as the startup fallback chat provider. "
             "Set a default chat model in the WebUI configuration page to avoid unexpected provider switching.",
-            len(enabled_chat_provider_ids),
-            enabled_chat_provider_ids[0],
+            len(enabled_chat_providers),
+            fallback_provider_id,
         )
 
     async def initialize(self) -> None:
@@ -262,9 +235,7 @@ class AstrBotCoreLifecycle:
 
         # 根据配置实例化各个 Provider
         await self.provider_manager.initialize()
-        self._warn_about_unset_default_chat_provider(
-            self.astrbot_config_mgr.default_conf
-        )
+        self._warn_about_unset_default_chat_provider()
 
         await self.kb_manager.initialize()
 

--- a/astrbot/core/core_lifecycle.py
+++ b/astrbot/core/core_lifecycle.py
@@ -113,7 +113,7 @@ class AstrBotCoreLifecycle:
         provider_settings = getattr(pm, "provider_settings", None) or {}
         default_id = provider_settings.get("default_provider_id")
         fallback = pm.curr_provider_inst or providers[0]
-        fallback_id = (fallback.provider_config.get("id") or "unknown")
+        fallback_id = fallback.provider_config.get("id") or "unknown"
 
         if not default_id:
             if len(providers) <= 1:
@@ -128,10 +128,7 @@ class AstrBotCoreLifecycle:
             )
             return
 
-        found = any(
-            (p.provider_config.get("id") == default_id)
-            for p in providers
-        )
+        found = any((p.provider_config.get("id") == default_id) for p in providers)
         if not found:
             self._default_chat_provider_warning_emitted = True
             logger.warning(

--- a/astrbot/core/core_lifecycle.py
+++ b/astrbot/core/core_lifecycle.py
@@ -103,24 +103,44 @@ class AstrBotCoreLifecycle:
             return
 
         pm = getattr(self, "provider_manager", None)
-        if not pm or pm.provider_settings.get("default_provider_id"):
+        if not pm:
             return
 
         providers = pm.provider_insts
-        if len(providers) <= 1:
+        if len(providers) == 0:
             return
 
+        provider_settings = getattr(pm, "provider_settings", None) or {}
+        default_id = provider_settings.get("default_provider_id")
         fallback = pm.curr_provider_inst or providers[0]
-        fallback_id = fallback.provider_config.get("id", "unknown")
+        fallback_id = (fallback.provider_config.get("id") or "unknown")
 
-        self._default_chat_provider_warning_emitted = True
-        logger.warning(
-            "Detected %d enabled chat providers but `provider_settings.default_provider_id` is empty. "
-            "AstrBot will use `%s` as the startup fallback chat provider. "
-            "Set a default chat model in the WebUI configuration page to avoid unexpected provider switching.",
-            len(providers),
-            fallback_id,
+        if not default_id:
+            if len(providers) <= 1:
+                return
+            self._default_chat_provider_warning_emitted = True
+            logger.warning(
+                "Detected %d enabled chat providers but `provider_settings.default_provider_id` is empty. "
+                "AstrBot will use `%s` as the startup fallback chat provider. "
+                "Set a default chat model in the WebUI configuration page to avoid unexpected provider switching.",
+                len(providers),
+                fallback_id,
+            )
+            return
+
+        found = any(
+            (p.provider_config.get("id") == default_id)
+            for p in providers
         )
+        if not found:
+            self._default_chat_provider_warning_emitted = True
+            logger.warning(
+                "Configured `default_provider_id` is `%s` but no enabled provider matches that ID. "
+                "AstrBot will use `%s` as the fallback chat provider. "
+                "Please check the WebUI configuration page.",
+                default_id,
+                fallback_id,
+            )
 
     async def initialize(self) -> None:
         """初始化 AstrBot 核心生命周期管理类.
@@ -226,6 +246,7 @@ class AstrBotCoreLifecycle:
         await self.plugin_manager.reload()
 
         # 根据配置实例化各个 Provider
+        self._default_chat_provider_warning_emitted = False
         await self.provider_manager.initialize()
         self._warn_about_unset_default_chat_provider()
 

--- a/astrbot/core/core_lifecycle.py
+++ b/astrbot/core/core_lifecycle.py
@@ -102,32 +102,24 @@ class AstrBotCoreLifecycle:
         if self._default_chat_provider_warning_emitted:
             return
 
-        provider_manager = getattr(self, "provider_manager", None)
-        if provider_manager is None:
+        pm = getattr(self, "provider_manager", None)
+        if not pm or pm.provider_settings.get("default_provider_id"):
             return
 
-        default_provider_id = provider_manager.provider_settings.get(
-            "default_provider_id", ""
-        )
-        if default_provider_id:
+        providers = pm.provider_insts
+        if len(providers) <= 1:
             return
 
-        enabled_chat_providers = provider_manager.provider_insts
-        if len(enabled_chat_providers) <= 1:
-            return
-
-        fallback_provider = (
-            provider_manager.curr_provider_inst or enabled_chat_providers[0]
-        )
-        fallback_provider_id = fallback_provider.provider_config.get("id", "unknown")
+        fallback = pm.curr_provider_inst or providers[0]
+        fallback_id = fallback.provider_config.get("id", "unknown")
 
         self._default_chat_provider_warning_emitted = True
         logger.warning(
             "Detected %d enabled chat providers but `provider_settings.default_provider_id` is empty. "
             "AstrBot will use `%s` as the startup fallback chat provider. "
             "Set a default chat model in the WebUI configuration page to avoid unexpected provider switching.",
-            len(enabled_chat_providers),
-            fallback_provider_id,
+            len(providers),
+            fallback_id,
         )
 
     async def initialize(self) -> None:

--- a/tests/unit/test_core_lifecycle.py
+++ b/tests/unit/test_core_lifecycle.py
@@ -262,93 +262,78 @@ class TestAstrBotCoreLifecycleErrorHandling:
 class TestAstrBotCoreLifecycleDefaultChatProviderWarning:
     """Tests for startup warning when default chat provider is unset."""
 
+    @staticmethod
+    def _make_provider(provider_id: str):
+        provider = MagicMock()
+        provider.provider_config = {"id": provider_id}
+        return provider
+
     def test_warns_for_multiple_enabled_chat_providers_without_default(
         self, mock_log_broker, mock_db
     ):
         lifecycle = AstrBotCoreLifecycle(mock_log_broker, mock_db)
-        config = {
-            "provider_settings": {"default_provider_id": ""},
-            "provider_sources": [
-                {"id": "openai_source", "provider_type": "chat_completion"}
-            ],
-            "provider": [
-                {
-                    "id": "openai_source/model-a",
-                    "provider_source_id": "openai_source",
-                    "enable": True,
-                },
-                {
-                    "id": "agent_runner_provider",
-                    "provider_type": "agent_runner",
-                    "enable": True,
-                },
-                {
-                    "id": "openai_source/model-b",
-                    "provider_source_id": "openai_source",
-                    "enable": True,
-                },
-            ],
-        }
+        provider_a = self._make_provider("openai_source/model-a")
+        provider_b = self._make_provider("openai_source/model-b")
+        lifecycle.provider_manager = MagicMock(
+            provider_settings={"default_provider_id": ""},
+            provider_insts=[provider_a, provider_b],
+            curr_provider_inst=provider_b,
+        )
 
         with patch("astrbot.core.core_lifecycle.logger") as mock_logger:
-            lifecycle._warn_about_unset_default_chat_provider(config)
+            lifecycle._warn_about_unset_default_chat_provider()
 
         mock_logger.warning.assert_called_once()
         assert mock_logger.warning.call_args[0][1] == 2
-        assert mock_logger.warning.call_args[0][2] == "openai_source/model-a"
+        assert mock_logger.warning.call_args[0][2] == "openai_source/model-b"
 
     def test_warns_only_once_per_lifecycle(self, mock_log_broker, mock_db):
         lifecycle = AstrBotCoreLifecycle(mock_log_broker, mock_db)
-        config = {
-            "provider_settings": {"default_provider_id": ""},
-            "provider_sources": [
-                {"id": "openai_source", "provider_type": "chat_completion"}
+        lifecycle.provider_manager = MagicMock(
+            provider_settings={"default_provider_id": ""},
+            provider_insts=[
+                self._make_provider("openai_source/model-a"),
+                self._make_provider("openai_source/model-b"),
             ],
-            "provider": [
-                {
-                    "id": "openai_source/model-a",
-                    "provider_source_id": "openai_source",
-                    "enable": True,
-                },
-                {
-                    "id": "openai_source/model-b",
-                    "provider_source_id": "openai_source",
-                    "enable": True,
-                },
-            ],
-        }
+            curr_provider_inst=self._make_provider("openai_source/model-a"),
+        )
 
         with patch("astrbot.core.core_lifecycle.logger") as mock_logger:
-            lifecycle._warn_about_unset_default_chat_provider(config)
-            lifecycle._warn_about_unset_default_chat_provider(config)
+            lifecycle._warn_about_unset_default_chat_provider()
+            lifecycle._warn_about_unset_default_chat_provider()
 
         mock_logger.warning.assert_called_once()
+
+    def test_does_not_warn_with_single_enabled_chat_provider_without_default(
+        self, mock_log_broker, mock_db
+    ):
+        lifecycle = AstrBotCoreLifecycle(mock_log_broker, mock_db)
+        lifecycle.provider_manager = MagicMock(
+            provider_settings={"default_provider_id": ""},
+            provider_insts=[self._make_provider("openai_source/model-a")],
+            curr_provider_inst=self._make_provider("openai_source/model-a"),
+        )
+
+        with patch("astrbot.core.core_lifecycle.logger") as mock_logger:
+            lifecycle._warn_about_unset_default_chat_provider()
+
+        mock_logger.warning.assert_not_called()
 
     def test_does_not_warn_when_default_chat_provider_is_set(
         self, mock_log_broker, mock_db
     ):
         lifecycle = AstrBotCoreLifecycle(mock_log_broker, mock_db)
-        config = {
-            "provider_settings": {"default_provider_id": "openai_source/model-a"},
-            "provider_sources": [
-                {"id": "openai_source", "provider_type": "chat_completion"}
+        lifecycle.provider_manager = MagicMock(
+            provider_settings={"default_provider_id": "openai_source/model-a"},
+            provider_insts=[
+                self._make_provider("openai_source/model-a"),
+                self._make_provider("openai_source/model-b"),
             ],
-            "provider": [
-                {
-                    "id": "openai_source/model-a",
-                    "provider_source_id": "openai_source",
-                    "enable": True,
-                },
-                {
-                    "id": "openai_source/model-b",
-                    "provider_source_id": "openai_source",
-                    "enable": True,
-                },
-            ],
-        }
+            curr_provider_inst=self._make_provider("openai_source/model-a"),
+        )
 
         with patch("astrbot.core.core_lifecycle.logger") as mock_logger:
-            lifecycle._warn_about_unset_default_chat_provider(config)
+            lifecycle._warn_about_unset_default_chat_provider()
 
         mock_logger.warning.assert_not_called()
 

--- a/tests/unit/test_core_lifecycle.py
+++ b/tests/unit/test_core_lifecycle.py
@@ -337,6 +337,45 @@ class TestAstrBotCoreLifecycleDefaultChatProviderWarning:
 
         mock_logger.warning.assert_not_called()
 
+    def test_warns_and_fallbacks_to_first_provider_when_curr_provider_inst_is_none(
+        self, mock_log_broker, mock_db
+    ):
+        lifecycle = AstrBotCoreLifecycle(mock_log_broker, mock_db)
+        provider_a = self._make_provider("openai_source/model-a")
+        provider_b = self._make_provider("openai_source/model-b")
+        lifecycle.provider_manager = MagicMock(
+            provider_settings={"default_provider_id": ""},
+            provider_insts=[provider_a, provider_b],
+            curr_provider_inst=None,
+        )
+
+        with patch("astrbot.core.core_lifecycle.logger") as mock_logger:
+            lifecycle._warn_about_unset_default_chat_provider()
+
+        mock_logger.warning.assert_called_once()
+        assert mock_logger.warning.call_args[0][1] == 2
+        assert mock_logger.warning.call_args[0][2] == "openai_source/model-a"
+
+    def test_warns_when_default_provider_id_does_not_match_any_enabled_provider(
+        self, mock_log_broker, mock_db
+    ):
+        lifecycle = AstrBotCoreLifecycle(mock_log_broker, mock_db)
+        lifecycle.provider_manager = MagicMock(
+            provider_settings={"default_provider_id": "non-existent-id"},
+            provider_insts=[
+                self._make_provider("openai_source/model-a"),
+                self._make_provider("openai_source/model-b"),
+            ],
+            curr_provider_inst=self._make_provider("openai_source/model-b"),
+        )
+
+        with patch("astrbot.core.core_lifecycle.logger") as mock_logger:
+            lifecycle._warn_about_unset_default_chat_provider()
+
+        mock_logger.warning.assert_called_once()
+        assert mock_logger.warning.call_args[0][1] == "non-existent-id"
+        assert mock_logger.warning.call_args[0][2] == "openai_source/model-b"
+
 
 class TestAstrBotCoreLifecycleInitialize:
     """Tests for AstrBotCoreLifecycle.initialize method."""

--- a/tests/unit/test_core_lifecycle.py
+++ b/tests/unit/test_core_lifecycle.py
@@ -259,6 +259,100 @@ class TestAstrBotCoreLifecycleErrorHandling:
         )
 
 
+class TestAstrBotCoreLifecycleDefaultChatProviderWarning:
+    """Tests for startup warning when default chat provider is unset."""
+
+    def test_warns_for_multiple_enabled_chat_providers_without_default(
+        self, mock_log_broker, mock_db
+    ):
+        lifecycle = AstrBotCoreLifecycle(mock_log_broker, mock_db)
+        config = {
+            "provider_settings": {"default_provider_id": ""},
+            "provider_sources": [
+                {"id": "openai_source", "provider_type": "chat_completion"}
+            ],
+            "provider": [
+                {
+                    "id": "openai_source/model-a",
+                    "provider_source_id": "openai_source",
+                    "enable": True,
+                },
+                {
+                    "id": "agent_runner_provider",
+                    "provider_type": "agent_runner",
+                    "enable": True,
+                },
+                {
+                    "id": "openai_source/model-b",
+                    "provider_source_id": "openai_source",
+                    "enable": True,
+                },
+            ],
+        }
+
+        with patch("astrbot.core.core_lifecycle.logger") as mock_logger:
+            lifecycle._warn_about_unset_default_chat_provider(config)
+
+        mock_logger.warning.assert_called_once()
+        assert mock_logger.warning.call_args[0][1] == 2
+        assert mock_logger.warning.call_args[0][2] == "openai_source/model-a"
+
+    def test_warns_only_once_per_lifecycle(self, mock_log_broker, mock_db):
+        lifecycle = AstrBotCoreLifecycle(mock_log_broker, mock_db)
+        config = {
+            "provider_settings": {"default_provider_id": ""},
+            "provider_sources": [
+                {"id": "openai_source", "provider_type": "chat_completion"}
+            ],
+            "provider": [
+                {
+                    "id": "openai_source/model-a",
+                    "provider_source_id": "openai_source",
+                    "enable": True,
+                },
+                {
+                    "id": "openai_source/model-b",
+                    "provider_source_id": "openai_source",
+                    "enable": True,
+                },
+            ],
+        }
+
+        with patch("astrbot.core.core_lifecycle.logger") as mock_logger:
+            lifecycle._warn_about_unset_default_chat_provider(config)
+            lifecycle._warn_about_unset_default_chat_provider(config)
+
+        mock_logger.warning.assert_called_once()
+
+    def test_does_not_warn_when_default_chat_provider_is_set(
+        self, mock_log_broker, mock_db
+    ):
+        lifecycle = AstrBotCoreLifecycle(mock_log_broker, mock_db)
+        config = {
+            "provider_settings": {"default_provider_id": "openai_source/model-a"},
+            "provider_sources": [
+                {"id": "openai_source", "provider_type": "chat_completion"}
+            ],
+            "provider": [
+                {
+                    "id": "openai_source/model-a",
+                    "provider_source_id": "openai_source",
+                    "enable": True,
+                },
+                {
+                    "id": "openai_source/model-b",
+                    "provider_source_id": "openai_source",
+                    "enable": True,
+                },
+            ],
+        }
+
+        with patch("astrbot.core.core_lifecycle.logger") as mock_logger:
+            lifecycle._warn_about_unset_default_chat_provider(config)
+
+        mock_logger.warning.assert_not_called()
+
+
 class TestAstrBotCoreLifecycleInitialize:
     """Tests for AstrBotCoreLifecycle.initialize method."""
 


### PR DESCRIPTION
### Description

When multiple chat providers are enabled but `provider_settings.default_provider_id` is left empty, AstrBot silently falls back to a startup-selected chat provider. After users add more providers later, they may unknowingly talk to a different model without any clear hint.

This PR adds a startup warning so the configuration risk is visible and users are guided to set a default chat model in the WebUI.

### Solution

- Add a startup-only warning check after provider initialization
- Warn only when multiple enabled chat providers are detected and `default_provider_id` is empty
- Use `ProviderManager`'s actual runtime state so the warning shows the real fallback provider id
- Emit the warning only once per lifecycle
- Add unit tests for warning emission, one-time behavior, the single-provider case, and the configured-default case

### Modified Files

- `astrbot/core/core_lifecycle.py`
- `tests/unit/test_core_lifecycle.py`

- [x] This is NOT a breaking change.

### Test Results

Verification steps:

```bash
uv run pytest tests/unit/test_core_lifecycle.py -q
uv run ruff format .
uv run ruff check .
```

Result:

- `24 passed` for `tests/unit/test_core_lifecycle.py`
- `ruff format .` passed
- `ruff check .` passed

---

### Checklist

- [x] If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] My changes have been well-tested, and verification steps have been provided above.
- [x] I have ensured that no new dependencies are introduced, or any new dependencies have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] My changes do not introduce malicious code.

## Summary by Sourcery

Add a startup warning when multiple chat providers are enabled but no default chat provider is configured, using the current provider manager state to highlight the active fallback provider.

New Features:
- Introduce a lifecycle warning that alerts users when multiple chat providers are enabled without a configured default, indicating which provider will be used as the fallback.

Tests:
- Add unit tests covering warning emission, one-time warning behavior per lifecycle, the single-provider scenario, and the configured-default scenario.