### PR TITLE
fix: align deerflow runner with deerflow 2.0

### DIFF
--- a/astrbot/builtin_stars/builtin_commands/commands/conversation.py
+++ b/astrbot/builtin_stars/builtin_commands/commands/conversation.py
@@ -24,67 +24,60 @@ async def _cleanup_deerflow_thread_if_present(
     context: star.Context,
     umo: str,
 ) -> None:
-    thread_id = await sp.get_async(
-        scope="umo",
-        scope_id=umo,
-        key=DEERFLOW_THREAD_ID_KEY,
-        default="",
-    )
-    if not thread_id:
-        return
-
-    cfg = context.get_config(umo=umo)
-    provider_id = cfg["provider_settings"].get(
-        DEERFLOW_AGENT_RUNNER_PROVIDER_ID_KEY,
-        "",
-    )
-    if not provider_id:
-        return
-
-    provider_config = next(
-        (
-            provider
-            for provider in context.provider_manager.providers_config
-            if provider.get("id") == provider_id
-        ),
-        None,
-    )
-    if not provider_config:
-        logger.warning(
-            "Failed to resolve DeerFlow provider config for remote thread cleanup: provider_id=%s",
-            provider_id,
-        )
-        return
-
-    merged_provider_config = context.provider_manager.get_merged_provider_config(
-        provider_config,
-    )
-    client = DeerFlowAPIClient(
-        api_base=merged_provider_config.get(
-            "deerflow_api_base",
-            "http://127.0.0.1:2026",
-        ),
-        api_key=merged_provider_config.get("deerflow_api_key", ""),
-        auth_header=merged_provider_config.get("deerflow_auth_header", ""),
-        proxy=merged_provider_config.get("proxy", ""),
-    )
     try:
-        await client.delete_thread(thread_id)
+        thread_id = await sp.get_async(
+            scope="umo",
+            scope_id=umo,
+            key=DEERFLOW_THREAD_ID_KEY,
+            default="",
+        )
+        if not thread_id:
+            return
+
+        cfg = context.get_config(umo=umo)
+        provider_id = cfg["provider_settings"].get(
+            DEERFLOW_AGENT_RUNNER_PROVIDER_ID_KEY,
+            "",
+        )
+        if not provider_id:
+            return
+
+        merged_provider_config = context.provider_manager.get_provider_config_by_id(
+            provider_id,
+            merged=True,
+        )
+        if not merged_provider_config:
+            logger.warning(
+                "Failed to resolve DeerFlow provider config for remote thread cleanup: provider_id=%s",
+                provider_id,
+            )
+            return
+
+        client = DeerFlowAPIClient(
+            api_base=merged_provider_config.get(
+                "deerflow_api_base",
+                "http://127.0.0.1:2026",
+            ),
+            api_key=merged_provider_config.get("deerflow_api_key", ""),
+            auth_header=merged_provider_config.get("deerflow_auth_header", ""),
+            proxy=merged_provider_config.get("proxy", ""),
+        )
+        try:
+            await client.delete_thread(thread_id)
+        finally:
+            try:
+                await client.close()
+            except Exception as e:
+                logger.warning(
+                    "Failed to close DeerFlow API client after thread cleanup: %s",
+                    e,
+                )
     except Exception as e:
         logger.warning(
-            "Failed to delete DeerFlow thread %s for session %s: %s",
-            thread_id,
+            "Failed to clean up DeerFlow thread for session %s: %s",
             umo,
             e,
         )
-    finally:
-        try:
-            await client.close()
-        except Exception as e:
-            logger.warning(
-                "Failed to close DeerFlow API client after thread cleanup: %s",
-                e,
-            )
 
 
 async def _clear_third_party_agent_runner_state(

--- a/astrbot/builtin_stars/builtin_commands/commands/conversation.py
+++ b/astrbot/builtin_stars/builtin_commands/commands/conversation.py
@@ -1,9 +1,12 @@
 from astrbot.api import sp, star
 from astrbot.api.event import AstrMessageEvent, MessageEventResult
+from astrbot.core import logger
 from astrbot.core.agent.runners.deerflow.constants import (
+    DEERFLOW_AGENT_RUNNER_PROVIDER_ID_KEY,
     DEERFLOW_PROVIDER_TYPE,
     DEERFLOW_THREAD_ID_KEY,
 )
+from astrbot.core.agent.runners.deerflow.deerflow_api_client import DeerFlowAPIClient
 from astrbot.core.utils.active_event_registry import active_event_registry
 
 from .utils.rst_scene import RstScene
@@ -15,6 +18,92 @@ THIRD_PARTY_AGENT_RUNNER_KEY = {
     DEERFLOW_PROVIDER_TYPE: DEERFLOW_THREAD_ID_KEY,
 }
 THIRD_PARTY_AGENT_RUNNER_STR = ", ".join(THIRD_PARTY_AGENT_RUNNER_KEY.keys())
+
+
+async def _cleanup_deerflow_thread_if_present(
+    context: star.Context,
+    umo: str,
+) -> None:
+    thread_id = await sp.get_async(
+        scope="umo",
+        scope_id=umo,
+        key=DEERFLOW_THREAD_ID_KEY,
+        default="",
+    )
+    if not thread_id:
+        return
+
+    cfg = context.get_config(umo=umo)
+    provider_id = cfg["provider_settings"].get(
+        DEERFLOW_AGENT_RUNNER_PROVIDER_ID_KEY,
+        "",
+    )
+    if not provider_id:
+        return
+
+    provider_config = next(
+        (
+            provider
+            for provider in context.provider_manager.providers_config
+            if provider.get("id") == provider_id
+        ),
+        None,
+    )
+    if not provider_config:
+        logger.warning(
+            "Failed to resolve DeerFlow provider config for remote thread cleanup: provider_id=%s",
+            provider_id,
+        )
+        return
+
+    merged_provider_config = context.provider_manager.get_merged_provider_config(
+        provider_config,
+    )
+    client = DeerFlowAPIClient(
+        api_base=merged_provider_config.get(
+            "deerflow_api_base",
+            "http://127.0.0.1:2026",
+        ),
+        api_key=merged_provider_config.get("deerflow_api_key", ""),
+        auth_header=merged_provider_config.get("deerflow_auth_header", ""),
+        proxy=merged_provider_config.get("proxy", ""),
+    )
+    try:
+        await client.delete_thread(thread_id)
+    except Exception as e:
+        logger.warning(
+            "Failed to delete DeerFlow thread %s for session %s: %s",
+            thread_id,
+            umo,
+            e,
+        )
+    finally:
+        try:
+            await client.close()
+        except Exception as e:
+            logger.warning(
+                "Failed to close DeerFlow API client after thread cleanup: %s",
+                e,
+            )
+
+
+async def _clear_third_party_agent_runner_state(
+    context: star.Context,
+    umo: str,
+    agent_runner_type: str,
+) -> None:
+    session_key = THIRD_PARTY_AGENT_RUNNER_KEY.get(agent_runner_type)
+    if not session_key:
+        return
+
+    if agent_runner_type == DEERFLOW_PROVIDER_TYPE:
+        await _cleanup_deerflow_thread_if_present(context, umo)
+
+    await sp.remove_async(
+        scope="umo",
+        scope_id=umo,
+        key=session_key,
+    )
 
 
 class ConversationCommands:
@@ -65,10 +154,10 @@ class ConversationCommands:
         agent_runner_type = cfg["provider_settings"]["agent_runner_type"]
         if agent_runner_type in THIRD_PARTY_AGENT_RUNNER_KEY:
             active_event_registry.stop_all(umo, exclude=message)
-            await sp.remove_async(
-                scope="umo",
-                scope_id=umo,
-                key=THIRD_PARTY_AGENT_RUNNER_KEY[agent_runner_type],
+            await _clear_third_party_agent_runner_state(
+                self.context,
+                umo,
+                agent_runner_type,
             )
             message.set_result(
                 MessageEventResult().message("✅ Conversation reset successfully.")
@@ -139,10 +228,10 @@ class ConversationCommands:
         agent_runner_type = cfg["provider_settings"]["agent_runner_type"]
         if agent_runner_type in THIRD_PARTY_AGENT_RUNNER_KEY:
             active_event_registry.stop_all(message.unified_msg_origin, exclude=message)
-            await sp.remove_async(
-                scope="umo",
-                scope_id=message.unified_msg_origin,
-                key=THIRD_PARTY_AGENT_RUNNER_KEY[agent_runner_type],
+            await _clear_third_party_agent_runner_state(
+                self.context,
+                message.unified_msg_origin,
+                agent_runner_type,
             )
             message.set_result(
                 MessageEventResult().message("✅ New conversation created.")

--- a/astrbot/core/agent/runners/deerflow/deerflow_agent_runner.py
+++ b/astrbot/core/agent/runners/deerflow/deerflow_agent_runner.py
@@ -410,18 +410,20 @@ class DeerFlowAgentRunner(BaseAgentRunner[TContext]):
         )
         return messages
 
-    def _build_runtime_context(self, thread_id: str) -> dict[str, T.Any]:
-        runtime_context: dict[str, T.Any] = {
+    def _build_runtime_configurable(self, thread_id: str) -> dict[str, T.Any]:
+        runtime_configurable: dict[str, T.Any] = {
             "thread_id": thread_id,
             "thinking_enabled": self.thinking_enabled,
             "is_plan_mode": self.plan_mode,
             "subagent_enabled": self.subagent_enabled,
         }
         if self.subagent_enabled:
-            runtime_context["max_concurrent_subagents"] = self.max_concurrent_subagents
+            runtime_configurable["max_concurrent_subagents"] = (
+                self.max_concurrent_subagents
+            )
         if self.model_name:
-            runtime_context["model_name"] = self.model_name
-        return runtime_context
+            runtime_configurable["model_name"] = self.model_name
+        return runtime_configurable
 
     def _build_payload(
         self,
@@ -430,16 +432,19 @@ class DeerFlowAgentRunner(BaseAgentRunner[TContext]):
         image_urls: list[str],
         system_prompt: str | None,
     ) -> dict[str, T.Any]:
+        runtime_configurable = self._build_runtime_configurable(thread_id)
         return {
             "assistant_id": self.assistant_id,
             "input": {
                 "messages": self._build_messages(prompt, image_urls, system_prompt),
             },
             "stream_mode": ["values", "messages-tuple", "custom"],
-            # LangGraph 0.6+ prefers context instead of configurable.
-            "context": self._build_runtime_context(thread_id),
+            # DeerFlow 2.0 consumes runtime overrides from config.configurable.
+            # Keep the legacy context mirror for older compat paths.
+            "context": dict(runtime_configurable),
             "config": {
                 "recursion_limit": self.recursion_limit,
+                "configurable": runtime_configurable,
             },
         }
 

--- a/astrbot/core/agent/runners/deerflow/deerflow_api_client.py
+++ b/astrbot/core/agent/runners/deerflow/deerflow_api_client.py
@@ -10,6 +10,33 @@ from astrbot.core import logger
 SSE_MAX_BUFFER_CHARS = 1_048_576
 
 
+class DeerFlowAPIError(Exception):
+    def __init__(
+        self,
+        *,
+        operation: str,
+        status: int,
+        body: str,
+        url: str,
+        thread_id: str | None = None,
+    ) -> None:
+        self.operation = operation
+        self.status = status
+        self.body = body
+        self.url = url
+        self.thread_id = thread_id
+
+        message = (
+            f"DeerFlow {operation} failed: status={status}, url={url}, body={body}"
+        )
+        if thread_id is not None:
+            message = (
+                f"DeerFlow {operation} failed: thread_id={thread_id}, "
+                f"status={status}, url={url}, body={body}"
+            )
+        super().__init__(message)
+
+
 def _normalize_sse_newlines(text: str) -> str:
     """Normalize CRLF/CR to LF so SSE block splitting works reliably."""
     return text.replace("\r\n", "\n").replace("\r", "\n")
@@ -152,8 +179,11 @@ class DeerFlowAPIClient:
         ) as resp:
             if resp.status not in (200, 201):
                 text = await resp.text()
-                raise Exception(
-                    f"DeerFlow create thread failed: {resp.status}. {text}",
+                raise DeerFlowAPIError(
+                    operation="create thread",
+                    status=resp.status,
+                    body=text,
+                    url=url,
                 )
             return await resp.json()
 
@@ -168,8 +198,12 @@ class DeerFlowAPIClient:
         ) as resp:
             if resp.status not in (200, 202, 204, 404):
                 text = await resp.text()
-                raise Exception(
-                    f"DeerFlow delete thread failed: {resp.status}. {text}",
+                raise DeerFlowAPIError(
+                    operation="delete thread",
+                    status=resp.status,
+                    body=text,
+                    url=url,
+                    thread_id=thread_id,
                 )
 
     async def stream_run(
@@ -215,8 +249,12 @@ class DeerFlowAPIClient:
         ) as resp:
             if resp.status != 200:
                 text = await resp.text()
-                raise Exception(
-                    f"DeerFlow runs/stream request failed: {resp.status}. {text}",
+                raise DeerFlowAPIError(
+                    operation="runs/stream request",
+                    status=resp.status,
+                    body=text,
+                    url=url,
+                    thread_id=thread_id,
                 )
             async for event in _stream_sse(resp):
                 yield event

--- a/astrbot/core/agent/runners/deerflow/deerflow_api_client.py
+++ b/astrbot/core/agent/runners/deerflow/deerflow_api_client.py
@@ -157,6 +157,21 @@ class DeerFlowAPIClient:
                 )
             return await resp.json()
 
+    async def delete_thread(self, thread_id: str, timeout: float = 20) -> None:
+        session = self._get_session()
+        url = f"{self.api_base}/api/threads/{thread_id}"
+        async with session.delete(
+            url,
+            headers=self.headers,
+            timeout=timeout,
+            proxy=self.proxy,
+        ) as resp:
+            if resp.status not in (200, 202, 204, 404):
+                text = await resp.text()
+                raise Exception(
+                    f"DeerFlow delete thread failed: {resp.status}. {text}",
+                )
+
     async def stream_run(
         self,
         thread_id: str,

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -2671,12 +2671,12 @@ CONFIG_METADATA_2 = {
                     "deerflow_assistant_id": {
                         "description": "Assistant ID",
                         "type": "string",
-                        "hint": "LangGraph assistant_id，默认为 lead_agent。",
+                        "hint": "DeerFlow 2.0 LangGraph assistant_id，默认为 lead_agent。",
                     },
                     "deerflow_model_name": {
                         "description": "模型名称覆盖",
                         "type": "string",
-                        "hint": "可选。覆盖 DeerFlow 默认模型（对应 runtime context 的 model_name）。",
+                        "hint": "可选。覆盖 DeerFlow 默认模型（对应运行时 configurable 的 model_name）。",
                     },
                     "deerflow_thinking_enabled": {
                         "description": "启用思考模式",
@@ -2685,17 +2685,17 @@ CONFIG_METADATA_2 = {
                     "deerflow_plan_mode": {
                         "description": "启用计划模式",
                         "type": "bool",
-                        "hint": "对应 DeerFlow 的 is_plan_mode。",
+                        "hint": "对应 DeerFlow 2.0 运行时 configurable 的 is_plan_mode。",
                     },
                     "deerflow_subagent_enabled": {
                         "description": "启用子智能体",
                         "type": "bool",
-                        "hint": "对应 DeerFlow 的 subagent_enabled。",
+                        "hint": "对应 DeerFlow 2.0 运行时 configurable 的 subagent_enabled。",
                     },
                     "deerflow_max_concurrent_subagents": {
                         "description": "子智能体最大并发数",
                         "type": "int",
-                        "hint": "对应 DeerFlow 的 max_concurrent_subagents。仅在启用子智能体时生效，默认 3。",
+                        "hint": "对应 DeerFlow 2.0 运行时 configurable 的 max_concurrent_subagents。仅在启用子智能体时生效，默认 3。",
                     },
                     "deerflow_recursion_limit": {
                         "description": "递归深度上限",

--- a/astrbot/core/provider/manager.py
+++ b/astrbot/core/provider/manager.py
@@ -505,6 +505,26 @@ class ProviderManager:
                 pc = merged_config
         return pc
 
+    def get_provider_config_by_id(
+        self,
+        provider_id: str,
+        *,
+        merged: bool = False,
+    ) -> dict | None:
+        """Get a provider config by id.
+
+        Args:
+            provider_id: Provider id to resolve.
+            merged: Whether to merge provider_source config into the provider config.
+        """
+        for provider_config in self.providers_config:
+            if provider_config.get("id") != provider_id:
+                continue
+            if merged:
+                return self.get_merged_provider_config(provider_config)
+            return copy.deepcopy(provider_config)
+        return None
+
     def _resolve_env_key_list(self, provider_config: dict) -> dict:
         keys = provider_config.get("key", [])
         if not isinstance(keys, list):

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -1604,26 +1604,26 @@
       },
       "deerflow_assistant_id": {
         "description": "Assistant ID",
-        "hint": "LangGraph assistant_id，默认为 lead_agent。"
+        "hint": "DeerFlow 2.0 LangGraph assistant_id，默认为 lead_agent。"
       },
       "deerflow_model_name": {
         "description": "模型名称覆盖",
-        "hint": "可选。覆盖 DeerFlow 默认模型（对应 runtime context 的 model_name）。"
+        "hint": "可选。覆盖 DeerFlow 默认模型（对应运行时 configurable 的 model_name）。"
       },
       "deerflow_thinking_enabled": {
         "description": "启用思考模式"
       },
       "deerflow_plan_mode": {
         "description": "启用计划模式",
-        "hint": "对应 DeerFlow 的 is_plan_mode。"
+        "hint": "对应 DeerFlow 2.0 运行时 configurable 的 is_plan_mode。"
       },
       "deerflow_subagent_enabled": {
         "description": "启用子智能体",
-        "hint": "对应 DeerFlow 的 subagent_enabled。"
+        "hint": "对应 DeerFlow 2.0 运行时 configurable 的 subagent_enabled。"
       },
       "deerflow_max_concurrent_subagents": {
         "description": "子智能体最大并发数",
-        "hint": "对应 DeerFlow 的 max_concurrent_subagents。仅在启用子智能体时生效，默认 3。"
+        "hint": "对应 DeerFlow 2.0 运行时 configurable 的 max_concurrent_subagents。仅在启用子智能体时生效，默认 3。"
       },
       "deerflow_recursion_limit": {
         "description": "递归深度上限",

--- a/docs/zh/providers/agent-runners/deerflow.md
+++ b/docs/zh/providers/agent-runners/deerflow.md
@@ -2,6 +2,8 @@
 
 在 v4.19.2 及之后，AstrBot 支持接入 [DeerFlow](https://github.com/bytedance/deer-flow) Agent Runner。
 
+当前适配面向 DeerFlow **2.0 `main` 分支**。DeerFlow 官方已将原始 Deep Research 框架迁移到 `main-1.x` 分支持续维护，因此如果你使用的是 2.0，请以 `main` 分支文档和后端 API 为准。
+
 ## 预备工作：部署 DeerFlow
 
 如果你还没有部署 DeerFlow，请先参考 DeerFlow 官方文档完成安装和启动：
@@ -25,12 +27,12 @@
 - `API Base URL`：DeerFlow API 网关地址，默认为 `http://127.0.0.1:2026`
 - `DeerFlow API Key`：可选。若你的 DeerFlow 网关使用 Bearer 鉴权，可在此填写
 - `Authorization Header`：可选。自定义 Authorization 请求头，优先级高于 `DeerFlow API Key`
-- `Assistant ID`：对应 LangGraph 的 `assistant_id`，默认为 `lead_agent`
+- `Assistant ID`：对应 DeerFlow 2.0 LangGraph 的 `assistant_id`，默认为 `lead_agent`
 - `模型名称覆盖`：可选。覆盖 DeerFlow 默认模型
 - `启用思考模式`：是否启用 DeerFlow 的思考模式
-- `启用计划模式`：对应 DeerFlow 的 `is_plan_mode`
-- `启用子智能体`：对应 DeerFlow 的 `subagent_enabled`
-- `子智能体最大并发数`：对应 `max_concurrent_subagents`，仅在启用子智能体时生效，默认 `3`
+- `启用计划模式`：对应 DeerFlow 2.0 运行时 `config.configurable.is_plan_mode`
+- `启用子智能体`：对应 DeerFlow 2.0 运行时 `config.configurable.subagent_enabled`
+- `子智能体最大并发数`：对应 DeerFlow 2.0 运行时 `config.configurable.max_concurrent_subagents`，仅在启用子智能体时生效，默认 `3`
 - `递归深度上限`：对应 LangGraph 的 `recursion_limit`，默认 `1000`
 
 填写完成后点击「保存」。
@@ -38,6 +40,7 @@
 > [!TIP]
 > - 如果 DeerFlow 侧已经配置了默认模型，可以将 `模型名称覆盖` 留空。
 > - 只有在 DeerFlow 侧已经启用了相应能力时，才建议开启 `计划模式` 或 `子智能体` 相关选项。
+> - AstrBot 会同时发送 DeerFlow 2.0 推荐的 `config.configurable` 运行时参数，并保留兼容字段，便于对接上游近期版本。
 
 ## 选择 Agent 执行器
 
@@ -51,3 +54,4 @@
 - `API Base URL` 是否能从 AstrBot 所在环境访问
 - 鉴权配置是否填写正确
 - `Assistant ID` 是否与 DeerFlow 中实际可用的 assistant 一致
+- 如果通过 `/reset`、`/new`、`/del` 重置 DeerFlow 会话，AstrBot 会尝试同步清理 DeerFlow 远端 thread；若 DeerFlow 网关不可达，则只会清理 AstrBot 本地会话标识

--- a/tests/test_conversation_commands.py
+++ b/tests/test_conversation_commands.py
@@ -2,7 +2,9 @@ from types import SimpleNamespace
 
 import pytest
 
-from astrbot.builtin_stars.builtin_commands.commands import conversation as conversation_module
+from astrbot.builtin_stars.builtin_commands.commands import (
+    conversation as conversation_module,
+)
 
 
 @pytest.mark.asyncio
@@ -33,16 +35,15 @@ async def test_clear_third_party_agent_runner_state_deletes_deerflow_thread_befo
             "provider_settings": {"deerflow_agent_runner_provider_id": "deerflow-runner"}
         },
         provider_manager=SimpleNamespace(
-            providers_config=[
-                {
-                    "id": "deerflow-runner",
-                    "deerflow_api_base": "http://127.0.0.1:2026",
-                    "deerflow_api_key": "token",
-                    "deerflow_auth_header": "",
-                    "proxy": "",
-                }
-            ],
-            get_merged_provider_config=lambda config: config,
+            get_provider_config_by_id=lambda provider_id, merged=False: {
+                "id": provider_id,
+                "deerflow_api_base": "http://127.0.0.1:2026",
+                "deerflow_api_key": "token",
+                "deerflow_auth_header": "",
+                "proxy": "",
+            }
+            if merged
+            else {"id": provider_id},
         ),
     )
 
@@ -97,16 +98,15 @@ async def test_clear_third_party_agent_runner_state_removes_local_state_when_dee
             "provider_settings": {"deerflow_agent_runner_provider_id": "deerflow-runner"}
         },
         provider_manager=SimpleNamespace(
-            providers_config=[
-                {
-                    "id": "deerflow-runner",
-                    "deerflow_api_base": "http://127.0.0.1:2026",
-                    "deerflow_api_key": "",
-                    "deerflow_auth_header": "",
-                    "proxy": "",
-                }
-            ],
-            get_merged_provider_config=lambda config: config,
+            get_provider_config_by_id=lambda provider_id, merged=False: {
+                "id": provider_id,
+                "deerflow_api_base": "http://127.0.0.1:2026",
+                "deerflow_api_key": "",
+                "deerflow_auth_header": "",
+                "proxy": "",
+            }
+            if merged
+            else {"id": provider_id},
         ),
     )
 
@@ -124,5 +124,58 @@ async def test_clear_third_party_agent_runner_state_removes_local_state_when_dee
         "remove",
         "umo",
         "umo-2",
+        conversation_module.DEERFLOW_THREAD_ID_KEY,
+    ) in calls
+
+
+@pytest.mark.asyncio
+async def test_clear_third_party_agent_runner_state_removes_local_state_when_deerflow_client_init_fails(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls: list[object] = []
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            _ = kwargs
+            raise RuntimeError("invalid deerflow config")
+
+    async def fake_get_async(*args, **kwargs):
+        _ = args, kwargs
+        return "thread-789"
+
+    async def fake_remove_async(*args, **kwargs):
+        calls.append(("remove", kwargs["scope"], kwargs["scope_id"], kwargs["key"]))
+
+    context = SimpleNamespace(
+        get_config=lambda **kwargs: {
+            "provider_settings": {"deerflow_agent_runner_provider_id": "deerflow-runner"}
+        },
+        provider_manager=SimpleNamespace(
+            get_provider_config_by_id=lambda provider_id, merged=False: {
+                "id": provider_id,
+                "deerflow_api_base": "http://127.0.0.1:2026",
+                "deerflow_api_key": "",
+                "deerflow_auth_header": "",
+                "proxy": "",
+            }
+            if merged
+            else {"id": provider_id},
+        ),
+    )
+
+    monkeypatch.setattr(conversation_module, "DeerFlowAPIClient", FakeClient)
+    monkeypatch.setattr(conversation_module.sp, "get_async", fake_get_async)
+    monkeypatch.setattr(conversation_module.sp, "remove_async", fake_remove_async)
+
+    await conversation_module._clear_third_party_agent_runner_state(
+        context,
+        "umo-3",
+        conversation_module.DEERFLOW_PROVIDER_TYPE,
+    )
+
+    assert (
+        "remove",
+        "umo",
+        "umo-3",
         conversation_module.DEERFLOW_THREAD_ID_KEY,
     ) in calls

--- a/tests/test_conversation_commands.py
+++ b/tests/test_conversation_commands.py
@@ -1,0 +1,128 @@
+from types import SimpleNamespace
+
+import pytest
+
+from astrbot.builtin_stars.builtin_commands.commands import conversation as conversation_module
+
+
+@pytest.mark.asyncio
+async def test_clear_third_party_agent_runner_state_deletes_deerflow_thread_before_local_state(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls: list[object] = []
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            calls.append(("init", kwargs))
+
+        async def delete_thread(self, thread_id: str, timeout: float = 20):
+            calls.append(("delete", thread_id, timeout))
+
+        async def close(self):
+            calls.append(("close",))
+
+    async def fake_get_async(*args, **kwargs):
+        _ = args, kwargs
+        return "thread-123"
+
+    async def fake_remove_async(*args, **kwargs):
+        calls.append(("remove", kwargs["scope"], kwargs["scope_id"], kwargs["key"]))
+
+    context = SimpleNamespace(
+        get_config=lambda **kwargs: {
+            "provider_settings": {"deerflow_agent_runner_provider_id": "deerflow-runner"}
+        },
+        provider_manager=SimpleNamespace(
+            providers_config=[
+                {
+                    "id": "deerflow-runner",
+                    "deerflow_api_base": "http://127.0.0.1:2026",
+                    "deerflow_api_key": "token",
+                    "deerflow_auth_header": "",
+                    "proxy": "",
+                }
+            ],
+            get_merged_provider_config=lambda config: config,
+        ),
+    )
+
+    monkeypatch.setattr(conversation_module, "DeerFlowAPIClient", FakeClient)
+    monkeypatch.setattr(conversation_module.sp, "get_async", fake_get_async)
+    monkeypatch.setattr(conversation_module.sp, "remove_async", fake_remove_async)
+
+    await conversation_module._clear_third_party_agent_runner_state(
+        context,
+        "umo-1",
+        conversation_module.DEERFLOW_PROVIDER_TYPE,
+    )
+
+    assert ("delete", "thread-123", 20) in calls
+    assert (
+        "remove",
+        "umo",
+        "umo-1",
+        conversation_module.DEERFLOW_THREAD_ID_KEY,
+    ) in calls
+    assert calls.index(("delete", "thread-123", 20)) < calls.index(
+        ("remove", "umo", "umo-1", conversation_module.DEERFLOW_THREAD_ID_KEY)
+    )
+
+
+@pytest.mark.asyncio
+async def test_clear_third_party_agent_runner_state_removes_local_state_when_deerflow_cleanup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls: list[object] = []
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            _ = kwargs
+
+        async def delete_thread(self, thread_id: str, timeout: float = 20):
+            _ = thread_id, timeout
+            raise RuntimeError("gateway down")
+
+        async def close(self):
+            calls.append(("close",))
+
+    async def fake_get_async(*args, **kwargs):
+        _ = args, kwargs
+        return "thread-456"
+
+    async def fake_remove_async(*args, **kwargs):
+        calls.append(("remove", kwargs["scope"], kwargs["scope_id"], kwargs["key"]))
+
+    context = SimpleNamespace(
+        get_config=lambda **kwargs: {
+            "provider_settings": {"deerflow_agent_runner_provider_id": "deerflow-runner"}
+        },
+        provider_manager=SimpleNamespace(
+            providers_config=[
+                {
+                    "id": "deerflow-runner",
+                    "deerflow_api_base": "http://127.0.0.1:2026",
+                    "deerflow_api_key": "",
+                    "deerflow_auth_header": "",
+                    "proxy": "",
+                }
+            ],
+            get_merged_provider_config=lambda config: config,
+        ),
+    )
+
+    monkeypatch.setattr(conversation_module, "DeerFlowAPIClient", FakeClient)
+    monkeypatch.setattr(conversation_module.sp, "get_async", fake_get_async)
+    monkeypatch.setattr(conversation_module.sp, "remove_async", fake_remove_async)
+
+    await conversation_module._clear_third_party_agent_runner_state(
+        context,
+        "umo-2",
+        conversation_module.DEERFLOW_PROVIDER_TYPE,
+    )
+
+    assert (
+        "remove",
+        "umo",
+        "umo-2",
+        conversation_module.DEERFLOW_THREAD_ID_KEY,
+    ) in calls

--- a/tests/test_deerflow_agent_runner.py
+++ b/tests/test_deerflow_agent_runner.py
@@ -1,0 +1,36 @@
+from astrbot.core.agent.runners.deerflow.deerflow_agent_runner import (
+    DeerFlowAgentRunner,
+)
+
+
+def test_build_payload_includes_configurable_runtime_overrides_and_legacy_context():
+    runner = DeerFlowAgentRunner()
+    runner.assistant_id = "lead_agent"
+    runner.thinking_enabled = True
+    runner.plan_mode = True
+    runner.subagent_enabled = True
+    runner.max_concurrent_subagents = 5
+    runner.model_name = "gpt-4.1"
+    runner.recursion_limit = 321
+
+    payload = runner._build_payload(
+        thread_id="thread-123",
+        prompt="hello deerflow",
+        image_urls=[],
+        system_prompt=None,
+    )
+
+    expected_runtime = {
+        "thread_id": "thread-123",
+        "thinking_enabled": True,
+        "is_plan_mode": True,
+        "subagent_enabled": True,
+        "max_concurrent_subagents": 5,
+        "model_name": "gpt-4.1",
+    }
+
+    assert payload["assistant_id"] == "lead_agent"
+    assert payload["stream_mode"] == ["values", "messages-tuple", "custom"]
+    assert payload["config"]["recursion_limit"] == 321
+    assert payload["config"]["configurable"] == expected_runtime
+    assert payload["context"] == expected_runtime

--- a/tests/test_deerflow_api_client.py
+++ b/tests/test_deerflow_api_client.py
@@ -1,0 +1,50 @@
+import pytest
+
+from astrbot.core.agent.runners.deerflow.deerflow_api_client import (
+    DeerFlowAPIClient,
+    DeerFlowAPIError,
+)
+
+
+class _FakeDeleteResponse:
+    def __init__(self, status: int, body: str):
+        self.status = status
+        self._body = body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        _ = exc_type, exc, tb
+
+    async def text(self) -> str:
+        return self._body
+
+
+class _FakeSession:
+    def __init__(self, response: _FakeDeleteResponse):
+        self.closed = False
+        self._response = response
+
+    def delete(self, *args, **kwargs):
+        _ = args, kwargs
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_delete_thread_raises_api_error_with_thread_context():
+    client = DeerFlowAPIClient(api_base="http://127.0.0.1:2026")
+    client._session = _FakeSession(
+        _FakeDeleteResponse(status=500, body="thread cleanup failed"),
+    )
+
+    try:
+        with pytest.raises(DeerFlowAPIError) as exc_info:
+            await client.delete_thread("thread-123")
+    finally:
+        client._closed = True
+
+    assert exc_info.value.status == 500
+    assert exc_info.value.thread_id == "thread-123"
+    assert "/api/threads/thread-123" in str(exc_info.value)
+    assert "thread cleanup failed" in str(exc_info.value)


### PR DESCRIPTION
## Summary

This PR aligns AstrBot's DeerFlow integration with the current DeerFlow 2.0 runtime contract on the `main` branch.

Previously AstrBot only sent runtime overrides through the legacy top-level `context` field and only cleared its local session marker when users reset or recreated a DeerFlow conversation. That still worked against DeerFlow's compatibility layer, but it diverged from the 2.0 contract and could leave remote DeerFlow threads, uploads, and artifacts behind after `/reset`, `/new`, and `/del`.

This change updates the DeerFlow runner to send runtime overrides through `config.configurable` while preserving the legacy `context` mirror for compatibility. It also adds thread deletion support in the DeerFlow API client and uses it when AstrBot clears DeerFlow-backed conversations, falling back to local cleanup if the gateway is unavailable. The user-facing config hints and docs are updated to describe DeerFlow 2.0 semantics, and regression tests cover both the new payload shape and the remote cleanup behavior.

## Testing

- `uv run ruff format .`
- `uv run ruff check .`
- `uv run pytest tests/test_deerflow_agent_runner.py tests/test_conversation_commands.py -q`

## Summary by Sourcery

Align DeerFlow agent runner and conversation handling with DeerFlow 2.0 runtime semantics and remote thread lifecycle management.

New Features:
- Support remote DeerFlow thread deletion when AstrBot conversations backed by DeerFlow are reset or recreated.
- Expose a provider-manager helper to resolve provider configuration by id with optional merging of source config.

Bug Fixes:
- Ensure DeerFlow runtime overrides are sent via the 2.0-compatible config.configurable payload while preserving the legacy context mirror.

Enhancements:
- Introduce structured DeerFlowAPIError exceptions and improve error handling for thread creation, deletion, and streaming requests.
- Refine DeerFlow configuration hints and provider documentation to reflect DeerFlow 2.0 runtime fields and behavior.

Documentation:
- Update DeerFlow provider docs to document 2.0 main-branch compatibility, runtime configuration semantics, and conversation reset cleanup behavior.

Tests:
- Add tests covering DeerFlow payload shape, DeerFlow API client error propagation for thread deletion, and conversation command cleanup behavior when DeerFlow cleanup succeeds or fails.