### PR TITLE
fix: remove python-ripgrep dependency, use system rg/grep instead (fixes #7496)

### DIFF
--- a/astrbot/core/computer/booters/local.py
+++ b/astrbot/core/computer/booters/local.py
@@ -9,8 +9,6 @@ import sys
 from dataclasses import dataclass
 from typing import Any
 
-from python_ripgrep import search
-
 from astrbot.api import logger
 from astrbot.core.computer.file_read_utils import (
     detect_text_encoding,
@@ -221,15 +219,57 @@ class LocalFileSystemComponent(FileSystemComponent):
         before_context: int | None = None,
     ) -> dict[str, Any]:
         def _run() -> dict[str, Any]:
-            results = search(
-                patterns=[pattern],
-                paths=[path] if path else None,
-                globs=[glob] if glob else None,
-                after_context=after_context,
-                before_context=before_context,
-                line_number=True,
-            )
-            return {"success": True, "content": _truncate_long_lines("".join(results))}
+            search_path = path if path else "."
+
+            # Try ripgrep first, fallback to grep
+            if shutil.which("rg"):
+                cmd = ["rg", "--line-number", "--color=never"]
+                if glob:
+                    cmd.extend(["--glob", glob])
+                if after_context:
+                    cmd.extend(["--after-context", str(after_context)])
+                if before_context:
+                    cmd.extend(["--before-context", str(before_context)])
+                cmd.extend([pattern, search_path])
+            elif shutil.which("grep"):
+                cmd = ["grep", "-rn", "--color=never"]
+                if after_context:
+                    cmd.extend(["-A", str(after_context)])
+                if before_context:
+                    cmd.extend(["-B", str(before_context)])
+                # grep doesn't support glob directly, use include if available
+                if glob and shutil.which("grep"):
+                    # Try to use --include if grep supports it (GNU grep)
+                    cmd.extend(["--include", glob])
+                cmd.extend([pattern, search_path])
+            else:
+                return {
+                    "success": False,
+                    "error": "Neither ripgrep (rg) nor grep is available on the system",
+                }
+
+            try:
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+                # grep returns exit code 1 when no matches found, which is not an error
+                if result.returncode not in (0, 1):
+                    return {
+                        "success": False,
+                        "error": f"Search command failed with exit code {result.returncode}: {result.stderr}",
+                    }
+                output = result.stdout if result.stdout else ""
+                return {"success": True, "content": _truncate_long_lines(output)}
+            except subprocess.TimeoutExpired:
+                return {
+                    "success": False,
+                    "error": "Search command timed out after 30 seconds",
+                }
+            except Exception as e:
+                return {"success": False, "error": f"Search failed: {str(e)}"}
 
         return await asyncio.to_thread(_run)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ dependencies = [
   "python-socks>=2.8.0",
   "pysocks>=1.7.1",
   "packaging>=24.2",
-  "python-ripgrep==0.0.9",
 ]
 
 [dependency-groups]

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,4 +53,3 @@ shipyard-python-sdk>=0.2.4
 shipyard-neo-sdk>=0.2.0
 packaging>=24.2
 qrcode>=8.2
-python-ripgrep==0.0.9


### PR DESCRIPTION
## Summary


does not support Python 3.13 (requires ), causing AstrBot to fail to start on Python 3.13 environments (see #7496).

This PR removes the dependency and replaces it with direct subprocess calls to system (rg) with automatic fallback to standard .

## Changes

- **local.py**: Remove import, rewrite method
  - Uses to detect or availability
  - Priority: > > error
  - Supports all original parameters: , , , ,
  - Properly handles exit codes (0=success, 1=no matches for grep)
  - 30-second timeout protection

- **requirements.txt**: Remove
- **pyproject.toml**: Remove

## Compatibility

| Python Version | Before | After |
|----------------|--------|-------|
| 3.10-3.12 | ✅ | ✅ |
| 3.13 | ❌ (ModuleNotFoundError) | ✅ |

## Testing

Tested the search functionality logic with:
- available (uses ripgrep)
- not available, available (falls back to grep)
- Neither available (returns proper error message)

## Related

Fixes #7496

---

*This PR is generated by AstrBot*