### PR TITLE
[Draft] feat: add EXTRA_PROMPT.md instruction to local mode system prompt

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -361,11 +361,16 @@ def _build_local_mode_prompt() -> str:
         if system_name.lower() == "windows"
         else "The runtime shell is Unix-like. Use POSIX-compatible shell commands."
     )
-    return (
-        "You have access to the host local environment and can execute shell commands and Python code. "
-        f"Current operating system: {system_name}. "
-        f"{shell_hint}"
-    )
+    lines = [
+        "You have access to the host local environment and can execute shell commands and Python code.",
+        f"Current operating system: {system_name}.",
+        shell_hint,
+        "",
+        "You can write and modify the EXTRA_PROMPT.md file in the current workspace",
+        "to customize your own system prompt instructions. This file will be automatically",
+        "loaded and applied to your system prompt in subsequent conversations.",
+    ]
+    return " ".join(lines)
 
 
 async def _ensure_persona_and_skills(


### PR DESCRIPTION
## Summary

When using  mode, the agent's system prompt now includes instructions about the  file.

This allows users to customize the system prompt by creating/modifying  in their workspace, which will be automatically loaded and applied in subsequent conversations.

## Changes

- Modified  in 
- Added instructions about EXTRA_PROMPT.md customization capability

## Usage

1. Use AstrBot with  mode
2. Create or edit  in the workspace
3. The custom instructions will be loaded into system prompt automatically

---

*This PR is generated by AstrBot*