### PR TITLE
fix: routing not displayed when session id includes `:`

### DIFF
--- a/dashboard/src/components/platform/AddNewPlatform.vue
+++ b/dashboard/src/components/platform/AddNewPlatform.vue
@@ -860,17 +860,15 @@ export default {
         // 过滤出属于该平台的路由，并保持顺序
         const routes = [];
         for (const [umop, confId] of Object.entries(routingTable)) {
-          if (this.isUmopMatchPlatform(umop, platformId)) {
-            const parsedUmop = this.parseUmop(umop);
-            if (parsedUmop) {
-              routes.push({
-                umop: umop,
-                originalUmop: umop, // 保存原始 UMOP 用于更新时查找
-                messageType: parsedUmop.messageType === '' || parsedUmop.messageType === '*' ? '*' : parsedUmop.messageType,
-                sessionId: parsedUmop.sessionId === '' || parsedUmop.sessionId === '*' ? '*' : parsedUmop.sessionId,
-                configId: confId
-              });
-            }
+          const parsedUmop = this.parseUmop(umop);
+          if (this.isParsedUmopMatchPlatform(parsedUmop, platformId)) {
+            routes.push({
+              umop: umop,
+              originalUmop: umop, // 保存原始 UMOP 用于更新时查找
+              messageType: parsedUmop.messageType || '*',
+              sessionId: parsedUmop.sessionId || '*',
+              configId: confId
+            });
           }
         }
 
@@ -993,6 +991,10 @@ export default {
 
     isUmopMatchPlatform(umop, platformId) {
       const parsedUmop = this.parseUmop(umop);
+      return this.isParsedUmopMatchPlatform(parsedUmop, platformId);
+    },
+
+    isParsedUmopMatchPlatform(parsedUmop, platformId) {
       if (!parsedUmop) return false;
       return parsedUmop.platform === platformId || parsedUmop.platform === '' || parsedUmop.platform === '*';
     },

--- a/dashboard/src/components/platform/AddNewPlatform.vue
+++ b/dashboard/src/components/platform/AddNewPlatform.vue
@@ -861,13 +861,13 @@ export default {
         const routes = [];
         for (const [umop, confId] of Object.entries(routingTable)) {
           if (this.isUmopMatchPlatform(umop, platformId)) {
-            const parts = umop.split(':');
-            if (parts.length === 3) {
+            const parsedUmop = this.parseUmop(umop);
+            if (parsedUmop) {
               routes.push({
                 umop: umop,
                 originalUmop: umop, // 保存原始 UMOP 用于更新时查找
-                messageType: parts[1] === '' || parts[1] === '*' ? '*' : parts[1],
-                sessionId: parts[2] === '' || parts[2] === '*' ? '*' : parts[2],
+                messageType: parsedUmop.messageType === '' || parsedUmop.messageType === '*' ? '*' : parsedUmop.messageType,
+                sessionId: parsedUmop.sessionId === '' || parsedUmop.sessionId === '*' ? '*' : parsedUmop.sessionId,
                 configId: confId
               });
             }
@@ -992,11 +992,25 @@ export default {
     },
 
     isUmopMatchPlatform(umop, platformId) {
-      if (!umop) return false;
-      const parts = umop.split(':');
-      if (parts.length !== 3) return false;
-      const platform = parts[0];
-      return platform === platformId || platform === '' || platform === '*';
+      const parsedUmop = this.parseUmop(umop);
+      if (!parsedUmop) return false;
+      return parsedUmop.platform === platformId || parsedUmop.platform === '' || parsedUmop.platform === '*';
+    },
+
+    parseUmop(umop) {
+      if (!umop) return null;
+
+      const firstSeparatorIndex = umop.indexOf(':');
+      if (firstSeparatorIndex === -1) return null;
+
+      const secondSeparatorIndex = umop.indexOf(':', firstSeparatorIndex + 1);
+      if (secondSeparatorIndex === -1) return null;
+
+      return {
+        platform: umop.slice(0, firstSeparatorIndex),
+        messageType: umop.slice(firstSeparatorIndex + 1, secondSeparatorIndex),
+        sessionId: umop.slice(secondSeparatorIndex + 1)
+      };
     },
 
     // 获取消息类型标签


### PR DESCRIPTION
fixes: #7515

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [ ] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [ ] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [ ] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Handle routing table entries whose session IDs may contain colon characters by introducing structured UMOP parsing.

Bug Fixes:
- Ensure routes are correctly displayed and matched for platforms when UMOP session IDs include colon characters instead of being split incorrectly.

Enhancements:
- Introduce a reusable UMOP parsing helper and centralize platform matching and field extraction logic based on the parsed structure.