### PR TITLE
fix: improve knowledge base upload error messages

### DIFF
--- a/astrbot/core/db/vec_db/faiss_impl/vec_db.py
+++ b/astrbot/core/db/vec_db/faiss_impl/vec_db.py
@@ -4,6 +4,7 @@ import uuid
 import numpy as np
 
 from astrbot import logger
+from astrbot.core.exceptions import KnowledgeBaseUploadError
 from astrbot.core.provider.provider import EmbeddingProvider, RerankProvider
 
 from ..base import BaseVecDB, Result
@@ -80,6 +81,32 @@ class FaissVecDB(BaseVecDB):
             )
             return []
 
+        content_count = len(contents)
+        if len(metadatas) != content_count:
+            raise KnowledgeBaseUploadError(
+                stage="storage",
+                user_message=(
+                    f"存储失败：文本分块数量与元数据数量不一致（期望 {content_count}，"
+                    f"实际 {len(metadatas)}）。"
+                ),
+                details={
+                    "expected_contents": content_count,
+                    "actual_metadatas": len(metadatas),
+                },
+            )
+        if len(ids) != content_count:
+            raise KnowledgeBaseUploadError(
+                stage="storage",
+                user_message=(
+                    f"存储失败：文本分块数量与文档 ID 数量不一致（期望 {content_count}，"
+                    f"实际 {len(ids)}）。"
+                ),
+                details={
+                    "expected_contents": content_count,
+                    "actual_ids": len(ids),
+                },
+            )
+
         start = time.time()
         logger.debug(f"Generating embeddings for {len(contents)} contents...")
         vectors = await self.embedding_provider.get_embeddings_batch(
@@ -93,6 +120,20 @@ class FaissVecDB(BaseVecDB):
         logger.debug(
             f"Generated embeddings for {len(contents)} contents in {end - start:.2f} seconds.",
         )
+        if len(vectors) != content_count:
+            raise KnowledgeBaseUploadError(
+                stage="embedding",
+                user_message=(
+                    "向量化失败：嵌入模型返回的向量数量与文本分块数量不一致"
+                    f"（期望 {content_count}，实际 {len(vectors)}）。"
+                    "这通常说明当前 Embedding 接口未完整返回批量结果，"
+                    "或该服务不兼容当前批量请求格式。"
+                ),
+                details={
+                    "expected_contents": content_count,
+                    "actual_vectors": len(vectors),
+                },
+            )
 
         # 使用 DocumentStorage 的批量插入方法
         int_ids = await self.document_storage.insert_documents_batch(
@@ -100,9 +141,52 @@ class FaissVecDB(BaseVecDB):
             contents,
             metadatas,
         )
+        if len(int_ids) != content_count:
+            raise KnowledgeBaseUploadError(
+                stage="storage",
+                user_message=(
+                    f"存储失败：写入文档索引后返回的内部 ID 数量与文本分块数量不一致"
+                    f"（期望 {content_count}，实际 {len(int_ids)}）。"
+                ),
+                details={
+                    "expected_contents": content_count,
+                    "actual_int_ids": len(int_ids),
+                },
+            )
 
         # 批量插入向量到 FAISS
-        vectors_array = np.array(vectors).astype("float32")
+        try:
+            vectors_array = np.asarray(vectors, dtype=np.float32)
+        except ValueError as exc:
+            raise KnowledgeBaseUploadError(
+                stage="embedding",
+                user_message=(
+                    "向量化失败：嵌入模型返回的向量格式不正确，"
+                    "无法转换为统一的浮点向量矩阵。"
+                ),
+                details={"vector_count": len(vectors)},
+            ) from exc
+        if vectors_array.ndim != 2:
+            raise KnowledgeBaseUploadError(
+                stage="embedding",
+                user_message=(
+                    "向量化失败：嵌入模型返回的向量格式不正确，无法构造成二维向量矩阵。"
+                ),
+                details={"actual_ndim": int(vectors_array.ndim)},
+            )
+        if vectors_array.shape[1] != self.embedding_storage.dimension:
+            raise KnowledgeBaseUploadError(
+                stage="embedding",
+                user_message=(
+                    "向量化失败：返回向量维度与当前知识库索引维度不一致"
+                    f"（期望 {self.embedding_storage.dimension}，"
+                    f"实际 {vectors_array.shape[1]}）。"
+                ),
+                details={
+                    "expected_dimension": self.embedding_storage.dimension,
+                    "actual_dimension": int(vectors_array.shape[1]),
+                },
+            )
         await self.embedding_storage.insert_batch(vectors_array, int_ids)
         return int_ids
 

--- a/astrbot/core/db/vec_db/faiss_impl/vec_db.py
+++ b/astrbot/core/db/vec_db/faiss_impl/vec_db.py
@@ -157,7 +157,7 @@ class FaissVecDB(BaseVecDB):
         # 批量插入向量到 FAISS
         try:
             vectors_array = np.asarray(vectors, dtype=np.float32)
-        except ValueError as exc:
+        except (TypeError, ValueError) as exc:
             raise KnowledgeBaseUploadError(
                 stage="embedding",
                 user_message=(

--- a/astrbot/core/exceptions.py
+++ b/astrbot/core/exceptions.py
@@ -11,3 +11,22 @@ class ProviderNotFoundError(AstrBotError):
 
 class EmptyModelOutputError(AstrBotError):
     """Raised when the model response contains no usable assistant output."""
+
+
+class KnowledgeBaseUploadError(AstrBotError):
+    """Raised when knowledge base upload fails with a user-facing message."""
+
+    def __init__(
+        self,
+        *,
+        stage: str,
+        user_message: str,
+        details: dict | None = None,
+    ) -> None:
+        super().__init__(user_message)
+        self.stage = stage
+        self.user_message = user_message
+        self.details = details or {}
+
+    def __str__(self) -> str:
+        return self.user_message

--- a/astrbot/core/knowledge_base/kb_helper.py
+++ b/astrbot/core/knowledge_base/kb_helper.py
@@ -422,7 +422,10 @@ class KBHelper:
                 ) from exc
             return doc
         except Exception as e:
-            logger.error(f"上传文档失败: {e}", exc_info=True)
+            if isinstance(e, KnowledgeBaseUploadError):
+                logger.warning(f"上传文档失败: {e}")
+            else:
+                logger.error(f"上传文档失败: {e}", exc_info=True)
             # if file_path.exists():
             #     file_path.unlink()
 

--- a/astrbot/core/knowledge_base/kb_helper.py
+++ b/astrbot/core/knowledge_base/kb_helper.py
@@ -10,6 +10,7 @@ import aiofiles
 
 from astrbot.core import logger
 from astrbot.core.db.vec_db.base import BaseVecDB
+from astrbot.core.exceptions import KnowledgeBaseUploadError
 from astrbot.core.provider.manager import ProviderManager
 from astrbot.core.provider.provider import (
     EmbeddingProvider,
@@ -264,10 +265,31 @@ class KBHelper:
                 if progress_callback:
                     await progress_callback("parsing", 0, 100)
 
-                parser = await select_parser(f".{file_type}")
-                parse_result = await parser.parse(file_content, file_name)
+                try:
+                    parser = await select_parser(f".{file_type}")
+                    parse_result = await parser.parse(file_content, file_name)
+                except KnowledgeBaseUploadError:
+                    raise
+                except Exception as exc:
+                    raise KnowledgeBaseUploadError(
+                        stage="parsing",
+                        user_message=(
+                            "文档解析失败：无法读取或解析上传文件。"
+                            "请确认文件格式受支持且文件内容未损坏。"
+                        ),
+                        details={"file_name": file_name},
+                    ) from exc
                 text_content = parse_result.text
                 media_items = parse_result.media
+                if not text_content or not text_content.strip():
+                    raise KnowledgeBaseUploadError(
+                        stage="parsing",
+                        user_message=(
+                            "文档解析失败：未能从文件中提取可索引文本。"
+                            "该文件可能是扫描件、纯图片 PDF，或格式暂不受支持。"
+                        ),
+                        details={"file_name": file_name},
+                    )
 
                 if progress_callback:
                     await progress_callback("parsing", 100, 100)
@@ -288,11 +310,31 @@ class KBHelper:
                 if progress_callback:
                     await progress_callback("chunking", 0, 100)
 
-                chunks_text = await self.chunker.chunk(
-                    text_content,
-                    chunk_size=chunk_size,
-                    chunk_overlap=chunk_overlap,
+                try:
+                    chunks_text = await self.chunker.chunk(
+                        text_content,
+                        chunk_size=chunk_size,
+                        chunk_overlap=chunk_overlap,
+                    )
+                except KnowledgeBaseUploadError:
+                    raise
+                except Exception as exc:
+                    raise KnowledgeBaseUploadError(
+                        stage="chunking",
+                        user_message=(
+                            "分块失败：文档内容在切分文本块时发生错误。"
+                            "请稍后重试，或调整分块参数后再次上传。"
+                        ),
+                        details={"file_name": file_name},
+                    ) from exc
+
+            if not chunks_text or not any(chunk.strip() for chunk in chunks_text):
+                raise KnowledgeBaseUploadError(
+                    stage="chunking",
+                    user_message=("分块失败：文档内容为空，未生成任何可索引文本块。"),
+                    details={"file_name": file_name},
                 )
+
             contents = []
             metadatas = []
             for idx, chunk_text in enumerate(chunks_text):
@@ -313,14 +355,23 @@ class KBHelper:
                 if progress_callback:
                     await progress_callback("embedding", current, total)
 
-            await self.vec_db.insert_batch(
-                contents=contents,
-                metadatas=metadatas,
-                batch_size=batch_size,
-                tasks_limit=tasks_limit,
-                max_retries=max_retries,
-                progress_callback=embedding_progress_callback,
-            )
+            try:
+                await self.vec_db.insert_batch(
+                    contents=contents,
+                    metadatas=metadatas,
+                    batch_size=batch_size,
+                    tasks_limit=tasks_limit,
+                    max_retries=max_retries,
+                    progress_callback=embedding_progress_callback,
+                )
+            except KnowledgeBaseUploadError:
+                raise
+            except Exception as exc:
+                raise KnowledgeBaseUploadError(
+                    stage="storage",
+                    user_message=("存储失败：文本块已生成，但写入知识库索引时出错。"),
+                    details={"file_name": file_name},
+                ) from exc
 
             # 保存文档的元数据
             doc = KBDocument(
@@ -334,22 +385,44 @@ class KBHelper:
                 chunk_count=len(chunks_text),
                 media_count=0,
             )
-            async with self.kb_db.get_db() as session:
-                async with session.begin():
-                    session.add(doc)
-                    for media in saved_media:
-                        session.add(media)
-                    await session.commit()
+            try:
+                async with self.kb_db.get_db() as session:
+                    async with session.begin():
+                        session.add(doc)
+                        for media in saved_media:
+                            session.add(media)
+                        await session.commit()
 
-                await session.refresh(doc)
+                    await session.refresh(doc)
+            except KnowledgeBaseUploadError:
+                raise
+            except Exception as exc:
+                raise KnowledgeBaseUploadError(
+                    stage="metadata",
+                    user_message=(
+                        "元数据保存失败：文本块已写入知识库，但文档记录保存失败。"
+                    ),
+                    details={"file_name": file_name, "doc_id": doc_id},
+                ) from exc
 
             vec_db: FaissVecDB = self.vec_db  # type: ignore
-            await self.kb_db.update_kb_stats(kb_id=self.kb.kb_id, vec_db=vec_db)
-            await self.refresh_kb()
-            await self.refresh_document(doc_id)
+            try:
+                await self.kb_db.update_kb_stats(kb_id=self.kb.kb_id, vec_db=vec_db)
+                await self.refresh_kb()
+                await self.refresh_document(doc_id)
+            except KnowledgeBaseUploadError:
+                raise
+            except Exception as exc:
+                raise KnowledgeBaseUploadError(
+                    stage="metadata",
+                    user_message=(
+                        "元数据更新失败：文档已上传，但知识库统计信息刷新失败。"
+                    ),
+                    details={"file_name": file_name, "doc_id": doc_id},
+                ) from exc
             return doc
         except Exception as e:
-            logger.error(f"上传文档失败: {e}")
+            logger.error(f"上传文档失败: {e}", exc_info=True)
             # if file_path.exists():
             #     file_path.unlink()
 
@@ -360,7 +433,7 @@ class KBHelper:
                 except Exception as me:
                     logger.warning(f"清理多媒体文件失败 {media_path}: {me}")
 
-            raise e
+            raise
 
     async def list_documents(
         self,

--- a/astrbot/dashboard/routes/knowledge_base.py
+++ b/astrbot/dashboard/routes/knowledge_base.py
@@ -128,6 +128,13 @@ class KnowledgeBaseRoute(Route):
 
         return _callback
 
+    @staticmethod
+    def _format_failed_doc_error(file_name: str, error: Exception) -> str:
+        message = str(error).strip() or "上传失败：发生未知错误。"
+        if message.startswith(file_name):
+            return message
+        return f"{file_name}: {message}"
+
     async def _background_upload_task(
         self,
         task_id: str,
@@ -189,7 +196,12 @@ class KnowledgeBaseRoute(Route):
                 except Exception as e:
                     logger.error(f"上传文档 {file_info['file_name']} 失败: {e}")
                     failed_docs.append(
-                        {"file_name": file_info["file_name"], "error": str(e)},
+                        {
+                            "file_name": file_info["file_name"],
+                            "error": self._format_failed_doc_error(
+                                file_info["file_name"], e
+                            ),
+                        },
                     )
 
             # 更新任务完成状态
@@ -276,7 +288,10 @@ class KnowledgeBaseRoute(Route):
                 except Exception as e:
                     logger.error(f"导入文档 {file_name} 失败: {e}")
                     failed_docs.append(
-                        {"file_name": file_name, "error": str(e)},
+                        {
+                            "file_name": file_name,
+                            "error": self._format_failed_doc_error(file_name, e),
+                        },
                     )
 
             # 更新任务完成状态

--- a/tests/test_kb_import.py
+++ b/tests/test_kb_import.py
@@ -8,8 +8,10 @@ from quart import Quart
 from astrbot.core import LogBroker
 from astrbot.core.core_lifecycle import AstrBotCoreLifecycle
 from astrbot.core.db.sqlite import SQLiteDatabase
+from astrbot.core.exceptions import KnowledgeBaseUploadError
 from astrbot.core.knowledge_base.kb_helper import KBHelper
 from astrbot.core.knowledge_base.models import KBDocument
+from astrbot.dashboard.routes.knowledge_base import KnowledgeBaseRoute
 from astrbot.dashboard.server import AstrBotDashboard
 
 
@@ -87,6 +89,9 @@ async def test_import_documents(
 ):
     """Tests the import documents functionality."""
     test_client = app.test_client()
+    kb_helper = await core_lifecycle_td.kb_manager.get_kb("test_kb_id")
+    kb_helper.upload_document.reset_mock()
+    kb_helper.upload_document.side_effect = None
 
     # Test data
     import_data = {
@@ -129,7 +134,6 @@ async def test_import_documents(
     assert result["failed_count"] == 0
 
     # Verify kb_helper.upload_document was called correctly
-    kb_helper = await core_lifecycle_td.kb_manager.get_kb("test_kb_id")
     assert kb_helper.upload_document.call_count == 2
 
     # Check first call arguments
@@ -144,6 +148,48 @@ async def test_import_documents(
     args2, kwargs2 = call_args_list[1]
     assert kwargs2["file_name"] == "test_file_2.md"
     assert kwargs2["pre_chunked_text"] == ["chunk3", "chunk4", "chunk5"]
+
+
+@pytest.mark.asyncio
+async def test_import_documents_returns_friendly_failure_message(
+    core_lifecycle_td: AstrBotCoreLifecycle,
+):
+    kb_helper = await core_lifecycle_td.kb_manager.get_kb("test_kb_id")
+    kb_helper.upload_document.reset_mock()
+    kb_helper.upload_document.side_effect = KnowledgeBaseUploadError(
+        stage="embedding",
+        user_message=(
+            "向量化失败：嵌入模型返回的向量数量与文本分块数量不一致（期望 2，实际 1）。"
+        ),
+        details={"expected_contents": 2, "actual_vectors": 1},
+    )
+
+    route = KnowledgeBaseRoute.__new__(KnowledgeBaseRoute)
+    route.upload_progress = {}
+    route.upload_tasks = {}
+
+    await KnowledgeBaseRoute._background_import_task(
+        route,
+        task_id="task-1",
+        kb_helper=kb_helper,
+        documents=[{"file_name": "broken.txt", "chunks": ["chunk1", "chunk2"]}],
+        batch_size=32,
+        tasks_limit=3,
+        max_retries=3,
+    )
+
+    assert route.upload_tasks["task-1"]["status"] == "completed"
+    result = route.upload_tasks["task-1"]["result"]
+    assert result["success_count"] == 0
+    assert result["failed_count"] == 1
+    assert result["failed"][0]["file_name"] == "broken.txt"
+    assert result["failed"][0]["error"].startswith("broken.txt:")
+    assert "向量化失败" in result["failed"][0]["error"]
+    assert "期望 2，实际 1" in result["failed"][0]["error"]
+    assert "not same nb of vectors as ids" not in result["failed"][0]["error"]
+    assert kb_helper.upload_document.await_count == 1
+
+    kb_helper.upload_document.side_effect = None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_faiss_vec_db.py
+++ b/tests/unit/test_faiss_vec_db.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from astrbot.core.db.vec_db.faiss_impl.vec_db import FaissVecDB
+from astrbot.core.exceptions import KnowledgeBaseUploadError
 
 
 @pytest.mark.asyncio
@@ -16,5 +17,30 @@ async def test_insert_batch_skips_empty_contents() -> None:
 
     assert result == []
     vec_db.embedding_provider.get_embeddings_batch.assert_not_awaited()
+    vec_db.document_storage.insert_documents_batch.assert_not_awaited()
+    vec_db.embedding_storage.insert_batch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_insert_batch_raises_friendly_error_for_embedding_count_mismatch() -> (
+    None
+):
+    vec_db = FaissVecDB.__new__(FaissVecDB)
+    vec_db.embedding_provider = AsyncMock()
+    vec_db.embedding_provider.get_embeddings_batch.return_value = [[0.1, 0.2]]
+    vec_db.document_storage = AsyncMock()
+    vec_db.embedding_storage = AsyncMock()
+    vec_db.embedding_storage.dimension = 2
+
+    with pytest.raises(KnowledgeBaseUploadError) as exc_info:
+        await FaissVecDB.insert_batch(
+            vec_db,
+            contents=["chunk-1", "chunk-2"],
+            metadatas=[{}, {}],
+            ids=["doc-1", "doc-2"],
+        )
+
+    assert "向量化失败" in str(exc_info.value)
+    assert "期望 2，实际 1" in str(exc_info.value)
     vec_db.document_storage.insert_documents_batch.assert_not_awaited()
     vec_db.embedding_storage.insert_batch.assert_not_awaited()


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

Closes #7530 

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

这个 PR 优化了知识库文档上传失败时的错误提示，主要解决用户没法通过日志定位上传失败原因的问题。  

改动内容如下：
 - 为知识库上传流程新增 `KnowledgeBaseUploadError`
 - 在向量入库前增加前置校验，提前识别以下异常情况：
   -  文本分块数量与 metadata 数量不一致
   -  文本分块数量与文档 ID 数量不一致
   -  embedding 返回数量与文本分块数量不一致
   -  embedding 返回维度与当前索引维度不一致
   -  embedding 返回格式无法构造成合法二维矩阵
- 在知识库上传流程中按阶段包装错误信息：
   - parsing 、chunking、embedding / storage、metadata
- 在后台上传结果中补充文件名，方便前端直接展示和截图定位

修复效果： 
调整前，部分场景下用户会看到类似下面这种底层错误：
  ```text
  not same nb of vectors as ids
  ```
调整后，会返回更明确的中文提示，例如：  
  ```text
broken.txt: 向量化失败：嵌入模型返回的向量数量与文本分块数量不一致（期望 2，实际 1）。
  ```

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

1.  正常上传文本
该文本为不为空的正常长文本 ，可在列表中正常看到上传结果  
<img width="1439" height="440" alt="image" src="https://github.com/user-attachments/assets/4d775b51-e183-4e33-bee6-a31590dec037" />

2. 上传空文件 / 无可索引文本
上传内容为空的文本文件，可在平台日志看到预期错误文案  
<img width="1603" height="181" alt="image" src="https://github.com/user-attachments/assets/0008d252-3aa0-43f0-9a61-985992766808" />


3. embedding 数量不一致
  此处 mock 了一个本地假的 embedding 服务进行测试   
<img width="1619" height="166" alt="image" src="https://github.com/user-attachments/assets/cd1fa47a-708d-41a7-a997-a84422c700e4" />

4. embedding 维度不一致  
<img width="1618" height="108" alt="image" src="https://github.com/user-attachments/assets/04ef5adc-4a59-45de-9684-51993ffd627e" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [×] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [×] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [×] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Improve robustness and user-friendliness of knowledge base document uploads with structured errors and validation across the upload pipeline.

Bug Fixes:
- Prevent inconsistent state and vague low-level errors during knowledge base uploads by validating counts and formats before writing embeddings and documents.
- Ensure empty or non-indexable documents are detected early in the upload flow rather than failing with downstream storage errors.

Enhancements:
- Introduce KnowledgeBaseUploadError to carry stage-aware, user-facing messages for parsing, chunking, embedding, storage, and metadata operations in the knowledge base upload flow.
- Include the file name in formatted upload/import failure messages so users can directly see which document failed in multi-file operations.
- Improve logging differentiation between expected upload errors and unexpected exceptions during document uploads.

Tests:
- Add tests to verify friendly, file-name-prefixed error messages are returned for failed document imports.
- Extend FAISS vector DB tests to validate that mismatched embedding counts produce a clear KnowledgeBaseUploadError and skip downstream operations.
- Adjust import document tests to reset and assert kb_helper.upload_document mocking behavior under the new error handling.