### PR TITLE
fix: improve error handling for knowledge base upload

### DIFF
--- a/astrbot/core/knowledge_base/kb_helper.py
+++ b/astrbot/core/knowledge_base/kb_helper.py
@@ -329,11 +329,18 @@ class KBHelper:
                     ) from exc
 
             if not chunks_text or not any(chunk.strip() for chunk in chunks_text):
-                raise KnowledgeBaseUploadError(
-                    stage="chunking",
-                    user_message=("分块失败：文档内容为空，未生成任何可索引文本块。"),
-                    details={"file_name": file_name},
-                )
+                if pre_chunked_text is not None:
+                    raise KnowledgeBaseUploadError(
+                        stage="validation",
+                        user_message=("预分块文本为空，未提供任何可索引文本块。"),
+                        details={"file_name": file_name},
+                    )
+                else:
+                    raise KnowledgeBaseUploadError(
+                        stage="chunking",
+                        user_message=("分块失败：文档内容为空，未生成任何可索引文本块。"),
+                        details={"file_name": file_name},
+                    )
 
             contents = []
             metadatas = []
@@ -423,7 +430,7 @@ class KBHelper:
             return doc
         except Exception as e:
             if isinstance(e, KnowledgeBaseUploadError):
-                logger.warning(f"上传文档失败: {e}")
+                logger.warning(f"上传文档失败: {e}", extra={"details": e.details})
             else:
                 logger.error(f"上传文档失败: {e}", exc_info=True)
             # if file_path.exists():

--- a/astrbot/core/knowledge_base/kb_helper.py
+++ b/astrbot/core/knowledge_base/kb_helper.py
@@ -338,7 +338,9 @@ class KBHelper:
                 else:
                     raise KnowledgeBaseUploadError(
                         stage="chunking",
-                        user_message=("分块失败：文档内容为空，未生成任何可索引文本块。"),
+                        user_message=(
+                            "分块失败：文档内容为空，未生成任何可索引文本块。"
+                        ),
                         details={"file_name": file_name},
                     )
 


### PR DESCRIPTION
## This PR improves error handling for knowledge base uploads with two key fixes:            
 - Log details field in KnowledgeBaseUploadError - The details dict was being collected   
   but never logged, making debugging harder. Now it's included in the warning log for    
   better traceability.                                                                   
 - Distinguish empty text sources - When chunks_text is empty, the error message now      
   correctly identifies whether it came from:                                             
    • Empty pre_chunked_text input (stage: "validation")                                  
    • Empty chunking result (stage: "chunking")  

### Modifications / 改动点
 • astrbot/core/knowledge_base/kb_helper.py:                                              
    • Added extra={"details": e.details} to the warning log for KnowledgeBaseUploadError  
    • Split the empty chunks check into two cases with appropriate error messages based on the source (pre_chunked_text vs normal chunking) 

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<img width="860" height="981" alt="image" src="https://github.com/user-attachments/assets/5346d950-15c2-4e2a-b952-5e8123fac121" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Improve error handling and logging for knowledge base document uploads.

Bug Fixes:
- Distinguish between empty pre-chunked input and empty chunking results when no text chunks are generated during upload.

Enhancements:
- Log knowledge base upload failures with structured details metadata to aid debugging.