### PR TITLE
fix: prevent numeric input from resetting to zero on blur without edit

### DIFF
--- a/dashboard/src/components/shared/ConfigItemRenderer.vue
+++ b/dashboard/src/components/shared/ConfigItemRenderer.vue
@@ -161,7 +161,7 @@
       <v-text-field
         :model-value="numericTemp ?? modelValue"
         @update:model-value="val => (numericTemp = val)"
-        @blur="() => { emitUpdate(toNumber(numericTemp)); numericTemp = null }"
+        @blur="() => { if (numericTemp != null) { emitUpdate(toNumber(numericTemp)) } numericTemp = null }"
         density="compact"
         variant="outlined"
         class="config-field"


### PR DESCRIPTION
## Summary
- Fix numeric input fields (e.g., `kb_fusion_top_k`, `kb_final_top_k`) resetting to 0 when focused and blurred without editing
- Root cause: `@blur` handler in `ConfigItemRenderer.vue` called `toNumber(null)` when `numericTemp` was never set (no edits), and `parseFloat(null)` → `NaN` → fallback to `0`
- Fix: skip emitting update when `numericTemp` is `null` (user made no changes), only reset `numericTemp` to `null`

## Test plan
- [ ] Open config page with numeric fields (e.g., knowledge base settings with "融合检索结果数" = 20)
- [ ] Click the numeric input to focus it, then click outside without editing → value should remain 20 (not reset to 0)
- [ ] Edit the value (e.g., change 20 to 10), then click outside → value should update to 10
- [ ] Verify slider + text-field combo still works correctly for numeric fields with sliders

## Summary by Sourcery

Bug Fixes:
- Avoid emitting numeric value updates on blur when the temporary numeric value was never modified, preventing fields from resetting to zero on focus/blur without edits.