### PR TITLE
fix(dashboard): resolve chat attachment 401

### DIFF
--- a/dashboard/src/composables/useMessages.ts
+++ b/dashboard/src/composables/useMessages.ts
@@ -86,6 +86,7 @@ export function useMessages(options: UseMessagesOptions) {
   const messagesBySession = reactive<Record<string, ChatRecord[]>>({});
   const loadedSessions = reactive<Record<string, boolean>>({});
   const activeConnections = reactive<Record<string, ActiveConnection>>({});
+  const attachmentBlobCache = new Map<string, string>();
   const sessionProjects = reactive<Record<string, ChatSessionProject | null>>(
     {},
   );
@@ -129,6 +130,47 @@ export function useMessages(options: UseMessagesOptions) {
     return !isUserMessage(msg) && msgIndex === activeMessages.value.length - 1;
   }
 
+  async function resolvePartMedia(part: MessagePart): Promise<void> {
+    if (part.embedded_url) return;
+    let url: string;
+    let cacheKey: string;
+    if (part.attachment_id) {
+      cacheKey = `att:${part.attachment_id}`;
+      url = `/api/chat/get_attachment?attachment_id=${encodeURIComponent(part.attachment_id)}`;
+    } else if (part.filename) {
+      cacheKey = `file:${part.filename}`;
+      url = `/api/chat/get_file?filename=${encodeURIComponent(part.filename)}`;
+    } else {
+      return;
+    }
+    const cached = attachmentBlobCache.get(cacheKey);
+    if (cached) {
+      part.embedded_url = cached;
+      return;
+    }
+    try {
+      const resp = await axios.get(url, { responseType: "blob" });
+      const blobUrl = URL.createObjectURL(resp.data);
+      attachmentBlobCache.set(cacheKey, blobUrl);
+      part.embedded_url = blobUrl;
+    } catch (e) {
+      console.error("Failed to resolve media:", cacheKey, e);
+    }
+  }
+
+  async function resolveRecordMedia(records: ChatRecord[]) {
+    const mediaTypes = ["image", "record", "video"];
+    const tasks: Promise<void>[] = [];
+    for (const record of records) {
+      for (const part of record.content?.message || []) {
+        if (mediaTypes.includes(part.type) && !part.embedded_url && (part.attachment_id || part.filename)) {
+          tasks.push(resolvePartMedia(part));
+        }
+      }
+    }
+    await Promise.all(tasks);
+  }
+
   async function loadSessionMessages(sessionId: string) {
     if (!sessionId) return;
     loadingMessages.value = true;
@@ -138,7 +180,9 @@ export function useMessages(options: UseMessagesOptions) {
       });
       const payload = response.data?.data || {};
       const history = payload.history || [];
-      messagesBySession[sessionId] = history.map(normalizeHistoryRecord);
+      const records = history.map(normalizeHistoryRecord);
+      await resolveRecordMedia(records);
+      messagesBySession[sessionId] = records;
       sessionProjects[sessionId] = normalizeSessionProject(payload.project);
       loadedSessions[sessionId] = true;
     } catch (error) {
@@ -438,7 +482,14 @@ export function useMessages(options: UseMessagesOptions) {
         .replace("[FILE]", "")
         .replace("[VIDEO]", "")
         .split("|", 1)[0];
-      messageContent(botRecord).message.push({ type: msgType, filename });
+      const mediaPart: MessagePart = { type: msgType, filename };
+      if (msgType !== "file") {
+        resolvePartMedia(mediaPart).then(() => {
+          messageContent(botRecord).message.push(mediaPart);
+        });
+      } else {
+        messageContent(botRecord).message.push(mediaPart);
+      }
     }
   }
 

--- a/dashboard/src/composables/useMessages.ts
+++ b/dashboard/src/composables/useMessages.ts
@@ -86,7 +86,7 @@ export function useMessages(options: UseMessagesOptions) {
   const messagesBySession = reactive<Record<string, ChatRecord[]>>({});
   const loadedSessions = reactive<Record<string, boolean>>({});
   const activeConnections = reactive<Record<string, ActiveConnection>>({});
-  const attachmentBlobCache = new Map<string, string>();
+  const attachmentBlobCache = new Map<string, Promise<string>>();
   const sessionProjects = reactive<Record<string, ChatSessionProject | null>>(
     {},
   );
@@ -99,6 +99,10 @@ export function useMessages(options: UseMessagesOptions) {
 
   onBeforeUnmount(() => {
     cleanupConnections();
+    for (const promise of attachmentBlobCache.values()) {
+      promise.then((url) => URL.revokeObjectURL(url)).catch(() => {});
+    }
+    attachmentBlobCache.clear();
   });
 
   function isSessionRunning(sessionId: string) {
@@ -143,17 +147,17 @@ export function useMessages(options: UseMessagesOptions) {
     } else {
       return;
     }
-    const cached = attachmentBlobCache.get(cacheKey);
-    if (cached) {
-      part.embedded_url = cached;
-      return;
+    let promise = attachmentBlobCache.get(cacheKey);
+    if (!promise) {
+      promise = axios
+        .get(url, { responseType: "blob" })
+        .then((resp) => URL.createObjectURL(resp.data));
+      attachmentBlobCache.set(cacheKey, promise);
     }
     try {
-      const resp = await axios.get(url, { responseType: "blob" });
-      const blobUrl = URL.createObjectURL(resp.data);
-      attachmentBlobCache.set(cacheKey, blobUrl);
-      part.embedded_url = blobUrl;
+      part.embedded_url = await promise;
     } catch (e) {
+      attachmentBlobCache.delete(cacheKey);
       console.error("Failed to resolve media:", cacheKey, e);
     }
   }


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
After the #7485 chatui style refactor, the old `getAttachment()` / `getMediaFile()` functions in `useMessages.ts` were removed. These functions used `axios.get()` (which carries the JWT `Authorization` header) to fetch attachment blobs and convert them to `blob:` URLs via `URL.createObjectURL()`. The refactored code replaced this with a `partUrl()` function that returns raw API paths like `/api/chat/get_attachment?attachment_id=...` directly into `<img src>` attributes. Since `<img>` tags cannot send custom HTTP headers, the browser makes unauthenticated GET requests, which the server's auth middleware rejects with 401 Unauthorized. This breaks all image, audio, and video rendering in the WebChat UI.

<img width="885" height="724" alt="2026-04-15_11 48 38" src="https://github.com/user-attachments/assets/c79825d4-1bd1-4aba-834f-679d556cbd49" />
<img width="854" height="354" alt="2026-04-15_11 49 10" src="https://github.com/user-attachments/assets/a621a62c-67e4-4561-9fe2-097fb6cbd760" />

### Modifications / 改动点
- `dashboard/src/composables/useMessages.ts`: Restore authenticated blob URL resolution for media attachments. Added `resolvePartMedia()` to fetch attachment/file content via axios (with JWT), convert to blob URL, and write back to `part.embedded_url` with a cache layer. Added `resolveRecordMedia()` to batch-resolve all media parts in history records. History messages are fully resolved before being assigned to the reactive store to prevent intermediate 401 requests. Streaming media parts are resolved before being pushed into the reactive message array.
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
<img width="657" height="322" alt="HapiGo_2026-04-15_11 51 36" src="https://github.com/user-attachments/assets/e0f6fa8a-b5d9-4bc2-8bd1-03d71112a631" />
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。


- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Restore authenticated resolution of media attachments in the WebChat dashboard to prevent unauthorized (401) requests and ensure media renders correctly.

Bug Fixes:
- Fix unauthorized (401) errors when loading chat media attachments by avoiding direct use of unauthenticated API URLs in media tags.

Enhancements:
- Add centralized media resolution helpers that fetch attachment and file blobs with authentication, cache blob URLs, and apply them to message parts before they are rendered.