### PR TITLE
fix: 移除 Gemini 工具声明阶段不支持的 examples 字段

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -527,6 +527,18 @@ class ProviderOpenAIOfficial(Provider):
                 omit_empty_parameter_field=omit_empty_param_field,
             )
             if tool_list:
+                # 清洗Gemini中的examples字段
+                if "gemini" in model:
+                    def remove_examples(schema):
+                        if isinstance(schema, dict):
+                            schema.pop("examples", None)
+                            for val in schema.values():
+                                remove_examples(val)
+                        elif isinstance(schema, list):
+                            for item in schema:
+                                remove_examples(item)
+
+                    remove_examples(tool_list)
                 payloads["tools"] = tool_list
                 payloads["tool_choice"] = payloads.get("tool_choice", "auto")
 
@@ -599,6 +611,18 @@ class ProviderOpenAIOfficial(Provider):
                 omit_empty_parameter_field=omit_empty_param_field,
             )
             if tool_list:
+                # 清洗Gemini中的examples字段
+                if "gemini" in model:
+                    def remove_examples(schema):
+                        if isinstance(schema, dict):
+                            schema.pop("examples", None)
+                            for val in schema.values():
+                                remove_examples(val)
+                        elif isinstance(schema, list):
+                            for item in schema:
+                                remove_examples(item)
+
+                    remove_examples(tool_list)
                 payloads["tools"] = tool_list
                 payloads["tool_choice"] = payloads.get("tool_choice", "auto")
 

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -181,6 +181,15 @@ class ProviderOpenAIOfficial(Provider):
             return True
         return False
 
+    @staticmethod
+    def _clean_gemini_tool_list(schema: Any) -> Any:
+        """非破坏性地递归移除 JSON Schema 中的 examples 字段，以适配 Gemini。"""
+        if isinstance(schema, dict):
+            return {k: ProviderOpenAIOfficial._clean_gemini_tool_list(v) for k, v in schema.items() if k != "examples"}
+        if isinstance(schema, list):
+            return [ProviderOpenAIOfficial._clean_gemini_tool_list(i) for i in schema]
+        return schema
+        
     @classmethod
     def _encode_image_file_to_data_url(
         cls,
@@ -528,17 +537,9 @@ class ProviderOpenAIOfficial(Provider):
             )
             if tool_list:
                 # 清洗Gemini中的examples字段
-                if "gemini" in model:
-                    def remove_examples(schema):
-                        if isinstance(schema, dict):
-                            schema.pop("examples", None)
-                            for val in schema.values():
-                                remove_examples(val)
-                        elif isinstance(schema, list):
-                            for item in schema:
-                                remove_examples(item)
-
-                    remove_examples(tool_list)
+                model_basename = model.split("/")[-1] if "/" in model else model
+                if model_basename.startswith("gemini"):
+                    tool_list = self._clean_gemini_tool_list(tool_list)
                 payloads["tools"] = tool_list
                 payloads["tool_choice"] = payloads.get("tool_choice", "auto")
 
@@ -612,17 +613,9 @@ class ProviderOpenAIOfficial(Provider):
             )
             if tool_list:
                 # 清洗Gemini中的examples字段
-                if "gemini" in model:
-                    def remove_examples(schema):
-                        if isinstance(schema, dict):
-                            schema.pop("examples", None)
-                            for val in schema.values():
-                                remove_examples(val)
-                        elif isinstance(schema, list):
-                            for item in schema:
-                                remove_examples(item)
-
-                    remove_examples(tool_list)
+                model_basename = model.split("/")[-1] if "/" in model else model
+                if model_basename.startswith("gemini"):
+                    tool_list = self._clean_gemini_tool_list(tool_list)
                 payloads["tools"] = tool_list
                 payloads["tool_choice"] = payloads.get("tool_choice", "auto")
 


### PR DESCRIPTION
Motivation / 动机
修复 #7572 Gemini 模型通过 OpenAI 适配器调用工具时报 400 错误的问题。

在使用 openai_chat_completion 提供商调用 Gemini 系列模型（如 gemini-3.1-pro-preview）时，若插件注册的工具函数中包含 examples 字段（常见于官方插件或第三方复杂插件），Gemini 会因为其极其严格的 Schema 校验（不支持 examples 字段）而直接拒绝请求，报错信息为：Invalid JSON payload received. Unknown name "examples" at 'tools[0].function_declarations[...].properties[0].value'。

此更改在发送请求前增加了递归清洗逻辑，确保在调用 Gemini 模型时剔除工具声明中不支持的 examples 字段，从而实现全量插件的兼容。

Modifications / 改动点
修改核心文件：astrbot/core/provider/sources/openai_source.py

在 _query 和 _query_stream 方法中，针对 gemini 系列模型，增加了 remove_examples 递归清洗函数。

在工具列表（tool_list）被注入 payloads 之前，自动剥离所有的 examples 键值对。

[x] This is NOT a breaking change. / 这不是一个破坏性变更。

Screenshots or Test Results / 运行截图或测试结果
测试环境： Windows Launcher
测试结果：
成功声明工具，模型能够识别并正常发起函数调用请求（已成功触发 claude_code 询问 API Key 的逻辑）。
<img width="1698" height="396" alt="image" src="https://github.com/user-attachments/assets/cc962ae1-78a2-487e-a7d0-771939e902bc" />


Checklist / 检查清单
[x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.

[x] 👀 My changes have been well-tested, and "Verification Steps" and "Screenshots" have been provided above.

[x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in requirements.txt and pyproject.toml.

[x] 😮 My changes do not introduce malicious code.

## Summary by Sourcery

Ensure Gemini models invoked via the OpenAI provider can use tools whose schemas include unsupported `examples` fields by sanitizing tool definitions before requests are sent.

Bug Fixes:
- Strip unsupported `examples` fields from tool schemas when calling Gemini models through the OpenAI source to prevent 400 errors.

Enhancements:
- Apply a recursive cleanup of tool schemas for Gemini models in both standard and streaming query paths to improve plugin compatibility.