### PR TITLE
fix: prevent numeric input reset to 0 on text selection blur

### DIFF
--- a/dashboard/src/components/shared/ConfigItemRenderer.vue
+++ b/dashboard/src/components/shared/ConfigItemRenderer.vue
@@ -161,7 +161,7 @@
       <v-text-field
         :model-value="numericTemp ?? modelValue"
         @update:model-value="val => (numericTemp = val)"
-        @blur="() => { emitUpdate(toNumber(numericTemp)); numericTemp = null }"
+        @blur="() => { emitUpdate(numericTemp != null ? toNumber(numericTemp) : modelValue); numericTemp = null }"
         density="compact"
         variant="outlined"
         class="config-field"

--- a/dashboard/src/components/shared/ConfigItemRenderer.vue
+++ b/dashboard/src/components/shared/ConfigItemRenderer.vue
@@ -285,8 +285,8 @@ function toValidNumber(val) {
   if (typeof val === 'number') {
     return isNaN(val) ? 0 : val
   }
-  const n = parseFloat(val)
-  return isNaN(n) ? 0 : n
+  const n = Number(val)
+  return Number.isFinite(n) ? n : 0
 }
 
 function handleNumericBlur() {

--- a/dashboard/src/components/shared/ConfigItemRenderer.vue
+++ b/dashboard/src/components/shared/ConfigItemRenderer.vue
@@ -161,7 +161,7 @@
       <v-text-field
         :model-value="numericTemp ?? modelValue"
         @update:model-value="val => (numericTemp = val)"
-        @blur="() => { emitUpdate(numericTemp != null ? toNumber(numericTemp) : modelValue); numericTemp = null }"
+        @blur="() => { if (numericTemp != null) { emitUpdate(toNumber(numericTemp)); } numericTemp = null }"
         density="compact"
         variant="outlined"
         class="config-field"

--- a/dashboard/src/components/shared/ConfigItemRenderer.vue
+++ b/dashboard/src/components/shared/ConfigItemRenderer.vue
@@ -290,8 +290,8 @@ function toValidNumber(val) {
 }
 
 function handleNumericBlur() {
-  // 只有当用户实际输入了有效值时才触发更新
-  if (numericTemp.value !== null && numericTemp.value !== undefined && numericTemp.value !== '') {
+  const hasValidInput = numericTemp.value !== null && numericTemp.value !== undefined && numericTemp.value !== ''
+  if (hasValidInput) {
     emitUpdate(toValidNumber(numericTemp.value))
   }
   numericTemp.value = null

--- a/dashboard/src/components/shared/ConfigItemRenderer.vue
+++ b/dashboard/src/components/shared/ConfigItemRenderer.vue
@@ -147,8 +147,8 @@
     >
       <v-slider
         v-if="itemMeta?.slider"
-        :model-value="toNumber(numericTemp ?? modelValue)"
-        @update:model-value="val => { numericTemp = val; emitUpdate(toNumber(val)) }"
+        :model-value="toValidNumber(numericTemp ?? modelValue)"
+        @update:model-value="val => { numericTemp = val; emitUpdate(toValidNumber(val)) }"
         @end="numericTemp = null"
         :min="itemMeta?.slider?.min ?? 0"
         :max="itemMeta?.slider?.max ?? 100"
@@ -161,7 +161,7 @@
       <v-text-field
         :model-value="numericTemp ?? modelValue"
         @update:model-value="val => (numericTemp = val)"
-        @blur="() => { if (numericTemp != null) { emitUpdate(toNumber(numericTemp)); } numericTemp = null }"
+        @blur="handleNumericBlur"
         density="compact"
         variant="outlined"
         class="config-field"
@@ -276,6 +276,27 @@ const { getRaw } = useModuleI18n('features/config-metadata')
 
 function emitUpdate(val) {
   emit('update:modelValue', val)
+}
+
+function toValidNumber(val) {
+  if (val === null || val === undefined || val === '') {
+    return 0
+  }
+  if (typeof val === 'number') {
+    return isNaN(val) ? 0 : val
+  }
+  const n = parseFloat(val)
+  return isNaN(n) ? 0 : n
+}
+
+function handleNumericBlur() {
+  if (numericTemp.value !== null && numericTemp.value !== undefined) {
+    if (numericTemp.value === '') {
+    } else {
+      emitUpdate(toValidNumber(numericTemp.value))
+    }
+  }
+  numericTemp.value = null
 }
 
 function toNumber(val) {

--- a/dashboard/src/components/shared/ConfigItemRenderer.vue
+++ b/dashboard/src/components/shared/ConfigItemRenderer.vue
@@ -290,11 +290,9 @@ function toValidNumber(val) {
 }
 
 function handleNumericBlur() {
-  if (numericTemp.value !== null && numericTemp.value !== undefined) {
-    if (numericTemp.value === '') {
-    } else {
-      emitUpdate(toValidNumber(numericTemp.value))
-    }
+  // 只有当用户实际输入了有效值时才触发更新
+  if (numericTemp.value !== null && numericTemp.value !== undefined && numericTemp.value !== '') {
+    emitUpdate(toValidNumber(numericTemp.value))
   }
   numericTemp.value = null
 }


### PR DESCRIPTION
fix: prevent numeric input reset to 0 on text selection blur

### Modifications / 改动点

- `dashboard/src/components/shared/ConfigItemRenderer.vue`: Line 164
  - 修改了数字输入框的 @blur 事件处理逻辑
  - 当用户只是选中文本而没有实际修改值时，保留原始的 modelValue 而非被重置为 0

### Screenshots or Test Results / 运行截图或测试结果

**Bug 复现步骤**：
1. 打开 AstrBot WebUI
2. 选中 "AstrBot 插件" 选项卡
3. 点击 ⚙ 按钮打开任意插件的配置页面
4. 在数字输入框中鼠标左键拖拽选中文本
5. 只点击其他地方取消选中（不做任何修改操作）
6. **Bug 结果**：数值已被重置为 0

<img width="1348" height="1018" alt="PixPin_2026-04-15_21-35-54" src="https://github.com/user-attachments/assets/7283a878-7f24-4689-a40b-22e8b5fcbe0c" />

**修复后验证**：
1. 按照上述步骤操作
2. **预期结果**：数值保持不变（不会被重置为 0）

<img width="1356" height="1022" alt="PixPin_2026-04-15_21-36-44" src="https://github.com/user-attachments/assets/8e0fefb5-c09f-4062-9342-e8873cbc765f" />

**根因分析**：
- 原代码：`@blur="() => { emitUpdate(toNumber(numericTemp)); numericTemp = null }"`
- `toNumber()` 函数使用 `parseFloat(val)`，当 val 为 null 时返回 NaN，然后 isNaN(NaN) 为 true，所以返回 0
- 修复后：当 `numericTemp != null` 时才调用 `toNumber()`，否则保留 `modelValue`

---

### Checklist / 检查清单

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Prevent numeric input fields from resetting to 0 when focus is lost after only selecting text without modifying the value.