### PR TITLE
fix: increase anthropic default max tokens

### DIFF
--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -293,7 +293,7 @@ class ProviderAnthropic(Provider):
         extra_body = self.provider_config.get("custom_extra_body", {})
 
         if "max_tokens" not in payloads:
-            payloads["max_tokens"] = 1024
+            payloads["max_tokens"] = 65536
         self._apply_thinking_config(payloads)
 
         try:
@@ -389,7 +389,7 @@ class ProviderAnthropic(Provider):
         reasoning_signature = ""
 
         if "max_tokens" not in payloads:
-            payloads["max_tokens"] = 1024
+            payloads["max_tokens"] = 65536
         self._apply_thinking_config(payloads)
 
         async with self.client.messages.stream(


### PR DESCRIPTION
## Summary
- Increase ProviderAnthropic default max_tokens to 65536 for non-streaming requests.
- Apply the same default to streaming requests.

## Checks
- uv run ruff format .
- uv run ruff check .

## Summary by Sourcery

Increase the default max_tokens for Anthropic provider requests when not explicitly specified.

Bug Fixes:
- Raise the default max_tokens for non-streaming Anthropic requests to avoid premature truncation of responses.

Enhancements:
- Align streaming Anthropic requests with the higher default max_tokens value for consistency across request types.