### PR TITLE
revert "fix: scss import warning"

### DIFF
--- a/dashboard/src/scss/components/_VButtons.scss
+++ b/dashboard/src/scss/components/_VButtons.scss
@@ -1,5 +1,3 @@
-@use '../variables' as *;
-
 //
 // Light Buttons
 //

--- a/dashboard/src/scss/components/_VCard.scss
+++ b/dashboard/src/scss/components/_VCard.scss
@@ -1,5 +1,3 @@
-@use '../variables' as *;
-
 // Outline Card
 .v-card--variant-outlined {
   border-color: rgba(var(--v-theme-borderLight), 0.36);

--- a/dashboard/src/scss/components/_VField.scss
+++ b/dashboard/src/scss/components/_VField.scss
@@ -1,5 +1,3 @@
-@use '../variables' as *;
-
 .v-field--variant-outlined .v-field__outline__start.v-locale--is-ltr,
 .v-locale--is-ltr .v-field--variant-outlined .v-field__outline__start {
   border-radius: $border-radius-root 0 0 $border-radius-root;

--- a/dashboard/src/scss/components/_VShadow.scss
+++ b/dashboard/src/scss/components/_VShadow.scss
@@ -1,5 +1,3 @@
-@use '../variables' as *;
-
 .elevation-10 {
   box-shadow: $box-shadow !important;
 }

--- a/dashboard/src/scss/components/_VTabs.scss
+++ b/dashboard/src/scss/components/_VTabs.scss
@@ -1,5 +1,3 @@
-@use '../variables' as *;
-
 .theme-tab {
   &.v-tabs {
     .v-tab {

--- a/dashboard/src/scss/layout/_container.scss
+++ b/dashboard/src/scss/layout/_container.scss
@@ -1,5 +1,3 @@
-@use '../variables' as *;
-
 html {
   overflow-y: auto;
 }

--- a/dashboard/src/scss/layout/_sidebar.scss
+++ b/dashboard/src/scss/layout/_sidebar.scss
@@ -1,5 +1,3 @@
-@use '../variables' as *;
-
 /*This is for the logo*/
 .leftSidebar {
   border: 0px;

--- a/dashboard/src/scss/style.scss
+++ b/dashboard/src/scss/style.scss
@@ -1,21 +1,21 @@
-@use './variables';
-@use 'vuetify/styles/main.sass';
-@use './override';
-@use './layout/container';
-@use './layout/sidebar';
+@import './variables';
+@import 'vuetify/styles/main.sass';
+@import './override';
+@import './layout/container';
+@import './layout/sidebar';
 
-@use './components/VButtons';
-@use './components/VCard';
-@use './components/VField';
-@use './components/VInput';
-@use './components/VNavigationDrawer';
-@use './components/VShadow';
-@use './components/VTextField';
-@use './components/VTabs';
-@use './components/VScrollbar';
-@use './components/CodeBlockDark';
+@import './components/VButtons';
+@import './components/VCard';
+@import './components/VField';
+@import './components/VInput';
+@import './components/VNavigationDrawer';
+@import './components/VShadow';
+@import './components/VTextField';
+@import './components/VTabs';
+@import './components/VScrollbar';
+@import './components/CodeBlockDark';
 
-@use './pages/dashboards';
+@import './pages/dashboards';
 
 html, body {
   overscroll-behavior-y: none;


### PR DESCRIPTION
Reverts AstrBotDevs/AstrBot#7528

## Summary by Sourcery

Revert the previous SCSS module migration by restoring global @import usage across dashboard styles.

Enhancements:
- Switch dashboard SCSS entry file back from @use to @import for variables, layout, components, and pages.
- Remove now-unneeded per-file SCSS variable @use statements in component and layout partials to rely on globally imported variables.