### PR TITLE
fix: display cron last_run_at in local timezone

### DIFF
--- a/astrbot/core/cron/manager.py
+++ b/astrbot/core/cron/manager.py
@@ -196,7 +196,9 @@ class CronJobManager:
 
     def _get_next_run_time(self, job_id: str):
         aps_job = self.scheduler.get_job(job_id)
-        return aps_job.next_run_time if aps_job else None
+        if not aps_job or aps_job.next_run_time is None:
+            return None
+        return aps_job.next_run_time.astimezone(timezone.utc)
 
     async def _run_job(self, job_id: str) -> None:
         job = await self.db.get_cron_job(job_id)

--- a/astrbot/dashboard/routes/cron.py
+++ b/astrbot/dashboard/routes/cron.py
@@ -1,5 +1,5 @@
 import traceback
-from datetime import datetime
+from datetime import datetime, timezone
 
 from quart import jsonify, request
 
@@ -26,8 +26,12 @@ class CronRoute(Route):
     def _serialize_job(self, job) -> dict:
         data = job.model_dump() if hasattr(job, "model_dump") else job.__dict__
         for k in ["created_at", "updated_at", "last_run_at", "next_run_time"]:
-            if isinstance(data.get(k), datetime):
-                data[k] = data[k].isoformat()
+            v = data.get(k)
+            if isinstance(v, datetime):
+                # Attach UTC
+                if v.tzinfo is None:
+                    v = v.replace(tzinfo=timezone.utc)
+                data[k] = v.isoformat()
         # expose note explicitly for UI (prefer payload.note then description)
         payload = data.get("payload") or {}
         data["note"] = payload.get("note") or data.get("description") or ""


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
On the scheduled tasks page of the WebUI, `last_run_at `was displayed in UTC while `next_run_time` was correctly displayed in the browser's local timezone. The root cause is inconsistent datetime semantics crossing the SQLite boundary: `last_run_at` was written via `datetime.now(timezone.utc)` (UTC-aware), while `next_run_time` came from APScheduler as an aware datetime in the job's configured timezone. SQLite strips tzinfo on round-trip, so the serializer emitted naive ISO strings without offsets. The frontend's `new Date(iso).toLocaleString()` then interpreted both as local time — correct by coincidence for `next_run_time`, but shifted for `last_run_at`.
### Modifications / 改动点
- `astrbot/core/cron/manager.py`: `_get_next_run_time` now normalizes APScheduler's aware datetime to UTC before persisting, so all cron datetime columns share the convention "stored as UTC".
- `astrbot/dashboard/routes/cron.py`: the route serializer attaches `tzinfo=UTC` to any naive datetime before `isoformat()`, so the API emits ISO strings with an explicit `+00:00` offset that the frontend converts to the user's local timezone.
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
Before:
<img width="737" height="152" alt="49b3a0a30115ac1f0735060b10b6a383" src="https://github.com/user-attachments/assets/861adf7b-120a-4a5f-804d-be276cdb1501" />
After:
<img width="742" height="148" alt="4acd32c14f869dee936b381f0fd412ef" src="https://github.com/user-attachments/assets/737dc70d-d0cb-4d2a-a125-add7e3c4b67c" />
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->


---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure cron job timestamps are stored and serialized with consistent UTC timezone information so the WebUI can display them correctly in the user’s local time.

Bug Fixes:
- Fix inconsistent timezone handling causing cron job last_run_at to display in the wrong timezone in the WebUI.

Enhancements:
- Normalize APScheduler next_run_time values to UTC before persistence so all cron timestamps follow a unified storage convention.
- Ensure API serialization of cron timestamps attaches UTC to naive datetimes before emitting ISO strings for the dashboard.