### PR TITLE
fix: accept both str and re.Pattern in RegexFilter

### DIFF
--- a/astrbot/core/star/filter/regex.py
+++ b/astrbot/core/star/filter/regex.py
@@ -10,9 +10,13 @@ from . import HandlerFilter
 class RegexFilter(HandlerFilter):
     """正则表达式过滤器"""
 
-    def __init__(self, regex: str) -> None:
-        self.regex_str = regex
-        self.regex = re.compile(regex)
+    def __init__(self, regex: str | re.Pattern) -> None:
+        if isinstance(regex, re.Pattern):
+            self.regex_str = regex.pattern
+            self.regex = regex
+        else:
+            self.regex_str = regex
+            self.regex = re.compile(regex)
 
     def filter(self, event: AstrMessageEvent, cfg: AstrBotConfig) -> bool:
         return bool(self.regex.search(event.get_message_str().strip()))

--- a/astrbot/core/star/filter/regex.py
+++ b/astrbot/core/star/filter/regex.py
@@ -11,12 +11,8 @@ class RegexFilter(HandlerFilter):
     """正则表达式过滤器"""
 
     def __init__(self, regex: str | re.Pattern) -> None:
-        if isinstance(regex, re.Pattern):
-            self.regex_str = regex.pattern
-            self.regex = regex
-        else:
-            self.regex_str = regex
-            self.regex = re.compile(regex)
+        self.regex = re.compile(regex)
+        self.regex_str = self.regex.pattern
 
     def filter(self, event: AstrMessageEvent, cfg: AstrBotConfig) -> bool:
         return bool(self.regex.search(event.get_message_str().strip()))

--- a/astrbot/core/star/register/star_handler.py
+++ b/astrbot/core/star/register/star_handler.py
@@ -284,7 +284,7 @@ def register_platform_adapter_type(
     return decorator
 
 
-def register_regex(regex: str, **kwargs):
+def register_regex(regex: str | re.Pattern, **kwargs):
     """注册一个 Regex"""
 
     def decorator(awaitable):


### PR DESCRIPTION
`RegexFilter.__init__` 现在可以处理编译后的 `re.Pattern` 对象，通过提取 `.pattern` 确保 `regex_str` 始终为字符串，防止 Dashboard 插件 API 在 JSON 序列化时出现 `TypeError`。

`RegexFilter.__init__` 原本只接受 `str` 类型的 `regex` 参数，但用户可以通过 `@filter.regex(re.compile(...))` 传入编译后的 `re.Pattern` 对象。虽然 `re.compile()` 在 Python 3.7+ 中可以静默接受 Pattern 输入，但原始 Pattern 对象会被直接存储在 `self.regex_str` 中。当 Dashboard 的 `/api/plugin/get` 接口尝试 JSON 序列化所有插件的 handler 信息时，`re.Pattern` 不可序列化，导致 `TypeError`。由于 `get_plugins` 将**所有**插件的 handler 信息放在单个响应中序列化，一个插件的 `regex_str` 类型错误会导致**整个**插件管理 API 崩溃。

这个bug引起插件面板用不了的同时，插件本身功能反而是可以正常使用的，所以排查有点费劲

### Modifications / 改动点

- regex.py：`RegexFilter.__init__` 现在同时接受 `str` 和 `re.Pattern`，对编译后的正则提取 `.pattern` 属性，确保 `regex_str` 始终为字符串。
- star_handler.py：更新 `register_regex` 的类型注解为 `str | re.Pattern`。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Ruff check 和 format 检查均通过。

---

### Checklist / 检查清单

- [x]  My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了验证步骤和运行截图**。

- [x]  I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in requirements.txt and pyproject.toml.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 requirements.txt 和 pyproject.toml 文件相应位置。

- [x]  My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。   