### PR TITLE
fix: 尝试修复主动回复导致普通 @ 对话失忆及群聊上下文被污染的问题

### DIFF
--- a/astrbot/builtin_stars/astrbot/constants.py
+++ b/astrbot/builtin_stars/astrbot/constants.py
@@ -1,0 +1,1 @@
+LTM_ACTIVE_REPLY_KEY = "_ltm_active_reply"

--- a/astrbot/builtin_stars/astrbot/long_term_memory.py
+++ b/astrbot/builtin_stars/astrbot/long_term_memory.py
@@ -156,7 +156,11 @@ class LongTermMemory:
         chats_str = "\n---\n".join(self.session_chats[event.unified_msg_origin])
 
         cfg = self.cfg(event)
-        if cfg["enable_active_reply"]:
+        is_active_reply = event.get_extra("_ltm_active_reply", False)
+
+        if cfg["enable_active_reply"] and is_active_reply:
+            # 仅在本次请求确实由主动回复触发时，才执行 chatroom 改写
+            # 避免普通 @ 请求也被错误地清空 req.contexts
             prompt = req.prompt
             req.prompt = (
                 f"You are now in a chatroom. The chat history is as follows:\n{chats_str}"
@@ -164,7 +168,7 @@ class LongTermMemory:
                 "Please react to it. Only output your response and do not output any other information. "
                 "You MUST use the SAME language as the chatroom is using."
             )
-            req.contexts = []  # 清空上下文，当使用了主动回复，所有聊天记录都在一个prompt中。
+            req.contexts = []  # 清空上下文，主动回复时所有聊天记录都在一个 prompt 中
         else:
             req.system_prompt += (
                 "You are now in a chatroom. The chat history is as follows: \n"

--- a/astrbot/builtin_stars/astrbot/long_term_memory.py
+++ b/astrbot/builtin_stars/astrbot/long_term_memory.py
@@ -11,6 +11,8 @@ from astrbot.api.platform import MessageType
 from astrbot.api.provider import LLMResponse, Provider, ProviderRequest
 from astrbot.core.astrbot_config_mgr import AstrBotConfigManager
 
+from .constants import LTM_ACTIVE_REPLY_KEY
+
 """
 聊天记忆增强
 """
@@ -156,7 +158,8 @@ class LongTermMemory:
         chats_str = "\n---\n".join(self.session_chats[event.unified_msg_origin])
 
         cfg = self.cfg(event)
-        is_active_reply = event.get_extra("_ltm_active_reply", False)
+        active_reply_req_id = event.get_extra(LTM_ACTIVE_REPLY_KEY, None)
+        is_active_reply = active_reply_req_id is not None and id(req) == active_reply_req_id
 
         if cfg["enable_active_reply"] and is_active_reply:
             # 仅在本次请求确实由主动回复触发时，才执行 chatroom 改写

--- a/astrbot/builtin_stars/astrbot/main.py
+++ b/astrbot/builtin_stars/astrbot/main.py
@@ -79,7 +79,7 @@ class Main(star.Star):
                     req = event.request_llm(
                         prompt=prompt,
                         session_id=event.session_id,
-                        conversation=none,
+                        conversation=None,
                     )
                     event.set_extra(LTM_ACTIVE_REPLY_KEY, id(req))  # 存 req 的 id，避免影响其他插件触发的 LLM 请求
                     yield req

--- a/astrbot/builtin_stars/astrbot/main.py
+++ b/astrbot/builtin_stars/astrbot/main.py
@@ -6,6 +6,7 @@ from astrbot.api.message_components import Image, Plain
 from astrbot.api.provider import LLMResponse, ProviderRequest
 from astrbot.core import logger
 
+from .constants import LTM_ACTIVE_REPLY_KEY
 from .long_term_memory import LongTermMemory
 
 
@@ -75,12 +76,13 @@ class Main(star.Star):
                         logger.error("未找到对话，无法主动回复")
                         return
 
-                    event.set_extra("_ltm_active_reply", True)  # 在 yield 前打标记，确保后续 filter 阶段能读到
-                    yield event.request_llm(
+                    req = event.request_llm(
                         prompt=prompt,
                         session_id=event.session_id,
                         conversation=conv,
                     )
+                    event.set_extra(LTM_ACTIVE_REPLY_KEY, id(req))  # 存 req 的 id，避免影响其他插件触发的 LLM 请求
+                    yield req
                 except BaseException as e:
                     logger.error(traceback.format_exc())
                     logger.error(f"主动回复失败: {e}")
@@ -104,7 +106,7 @@ class Main(star.Star):
         if self.ltm and self.ltm_enabled(event):
             # 主动回复的响应不记入 session_chats
             # 避免 chatroom 风格的回复污染后续主动回复所使用的群聊上下文
-            if event.get_extra("_ltm_active_reply", False):
+            if event.get_extra(LTM_ACTIVE_REPLY_KEY, None) is not None:
                 return
             try:
                 await self.ltm.after_req_llm(event, resp)
@@ -121,3 +123,5 @@ class Main(star.Star):
                     await self.ltm.remove_session(event)
             except Exception as e:
                 logger.error(f"ltm: {e}")
+        # 清除主动回复标记，避免 event 被复用时意外影响后续流程
+        event.set_extra(LTM_ACTIVE_REPLY_KEY, None)

--- a/astrbot/builtin_stars/astrbot/main.py
+++ b/astrbot/builtin_stars/astrbot/main.py
@@ -75,6 +75,7 @@ class Main(star.Star):
                         logger.error("未找到对话，无法主动回复")
                         return
 
+                    event.set_extra("_ltm_active_reply", True)  # 在 yield 前打标记，确保后续 filter 阶段能读到
                     yield event.request_llm(
                         prompt=prompt,
                         session_id=event.session_id,
@@ -101,6 +102,10 @@ class Main(star.Star):
     ) -> None:
         """在 LLM 响应后记录对话"""
         if self.ltm and self.ltm_enabled(event):
+            # 主动回复的响应不记入 session_chats
+            # 避免 chatroom 风格的回复污染后续主动回复所使用的群聊上下文
+            if event.get_extra("_ltm_active_reply", False):
+                return
             try:
                 await self.ltm.after_req_llm(event, resp)
             except Exception as e:

--- a/astrbot/builtin_stars/astrbot/main.py
+++ b/astrbot/builtin_stars/astrbot/main.py
@@ -79,7 +79,7 @@ class Main(star.Star):
                     req = event.request_llm(
                         prompt=prompt,
                         session_id=event.session_id,
-                        conversation=conv,
+                        conversation=none,
                     )
                     event.set_extra(LTM_ACTIVE_REPLY_KEY, id(req))  # 存 req 的 id，避免影响其他插件触发的 LLM 请求
                     yield req


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
在群聊中同时开启群聊上下文感知和主动回复后，bot 在普通 @ 对话中也会表现为失忆——无论之前聊过多少内容，超过 `max_cnt` 条的历史会被完全忽略。经过排查，问题出在 `on_req_llm` 和 `record_llm_resp_to_ltm` 没有区分请求的触发来源，导致主动回复的处理逻辑错误地应用到了所有 LLM 请求上。
### Modifications / 改动点
**`main.py`**
- 主动回复触发时，在 `yield event.request_llm(...)` 之前通过 `event.set_extra("_ltm_active_reply", True)` 打标记，确保后续 filter 阶段能正确识别本次请求的触发类型
- `record_llm_resp_to_ltm` 中检查该标记，主动回复的响应不再写入 `session_chats`，避免 chatroom 风格内容污染群聊上下文记忆

**`long_term_memory.py`**
- `on_req_llm` 的判断条件从 `cfg["enable_active_reply"]` 改为 `cfg["enable_active_reply"] and is_active_reply`
- 只有真正由主动回复触发的请求才进入 chatroom 改写分支
- 普通 @ 请求保留完整的 `req.contexts`，长期会话记忆不受影响
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
（已开启主动回复的测试结果）
<img width="1486" height="479" alt="image" src="https://github.com/user-attachments/assets/13a45d92-d8f0-4fa4-9cf8-4e760a9201b1" />
验证步骤：
1. 开启 主动回复
2. @ bot 聊几句
3.发送/history查看信息是否还存在

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure long-term memory handling differentiates between active replies and normal @ mentions to preserve group chat context and avoid pollution.

Bug Fixes:
- Fix normal @ conversations losing earlier context when active reply is enabled by only applying chatroom-style prompt rewriting to genuinely active-reply-triggered requests.
- Prevent active-reply-generated responses from being stored into long-term session history to avoid contaminating subsequent group chat context.

## Summary by Sourcery

Differentiate long-term memory handling between active replies and normal @ mentions in group chats to preserve expected context behavior.

Bug Fixes:
- Prevent normal @ conversations from losing historical context when active reply is enabled by only applying chatroom-style prompt rewriting to requests actually triggered by active replies.
- Avoid polluting group chat long-term memory with chatroom-style responses by excluding active-reply-generated messages from session history.

Enhancements:
- Introduce an internal flag on events to track active-reply-triggered LLM requests and clear it after use for safe event reuse.

Chores:
- Add a shared constant for the long-term memory active reply marker key.