### PR TITLE
fix: handle rate_limit_count=0 to prevent IndexError

### DIFF
--- a/astrbot/core/pipeline/rate_limit_check/stage.py
+++ b/astrbot/core/pipeline/rate_limit_check/stage.py
@@ -63,7 +63,9 @@ class RateLimitStage(Stage):
                 timestamps = self.event_timestamps[session_id]
                 self._remove_expired_timestamps(timestamps, now)
 
-                if self.rate_limit_count <= 0 or len(timestamps) < self.rate_limit_count:
+                if self.rate_limit_count <= 0:
+                    break
+                if len(timestamps) < self.rate_limit_count:
                     timestamps.append(now)
                     break
                 next_window_time = timestamps[0] + self.rate_limit_time

--- a/astrbot/core/pipeline/rate_limit_check/stage.py
+++ b/astrbot/core/pipeline/rate_limit_check/stage.py
@@ -63,7 +63,7 @@ class RateLimitStage(Stage):
                 timestamps = self.event_timestamps[session_id]
                 self._remove_expired_timestamps(timestamps, now)
 
-                if len(timestamps) < self.rate_limit_count:
+                if self.rate_limit_count <= 0 or len(timestamps) < self.rate_limit_count:
                     timestamps.append(now)
                     break
                 next_window_time = timestamps[0] + self.rate_limit_time


### PR DESCRIPTION
When rate_limit_count is set to 0 (disabling rate limiting), messages fail with IndexError because the check  is always False when rate_limit_count is 0, causing execution to fall through to timestamps[0] access on an empty deque.

Changed the condition to  so that count=0 means no rate limiting is applied.

Fixes #7619

## Summary by Sourcery

Bug Fixes:
- Avoid IndexError in the rate limiting pipeline stage when rate_limit_count is set to zero or a negative value, by skipping rate checks in that case.