### PR TITLE
fix: force Bocha search API requests to use gzip/deflate encoding to avoid aiohttp 3.12+ brotli decoding errors.

### DIFF
--- a/astrbot/core/tools/web_search_tools.py
+++ b/astrbot/core/tools/web_search_tools.py
@@ -197,6 +197,9 @@ async def _bocha_search(
     header = {
         "Authorization": f"Bearer {bocha_key}",
         "Content-Type": "application/json",
+        # Explicitly disable brotli encoding to avoid aiohttp >= 3.13.3 brotli
+        # decompression incompatibility (TypeError: process() takes exactly 1 argument).
+        # See: https://github.com/aio-libs/aiohttp/issues/11898
         "Accept-Encoding": "gzip, deflate",
     }
     async with aiohttp.ClientSession(trust_env=True) as session:

--- a/astrbot/core/tools/web_search_tools.py
+++ b/astrbot/core/tools/web_search_tools.py
@@ -197,6 +197,7 @@ async def _bocha_search(
     header = {
         "Authorization": f"Bearer {bocha_key}",
         "Content-Type": "application/json",
+        "Accept-Encoding": "gzip, deflate",
     }
     async with aiohttp.ClientSession(trust_env=True) as session:
         async with session.post(


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

Fixes #7654

当 aiohttp >= 3.12 时，Bocha 搜索 API 返回 brotli 压缩格式的响应，而 aiohttp 3.12+ 在处理 brotli 解压时存在 bug，导致所有 Bocha 搜索请求失败，报错 `Can not decode content-encoding: br`。

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- 修改 `astrbot/core/tools/web_search_tools.py` 中的 `_bocha_search()` 函数，在请求头中添加 `Accept-Encoding: gzip, deflate`，禁止服务器返回 brotli 格式响应，从根本上规避 aiohttp 的兼容性问题。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

修复前报错：
aiohttp.http_exceptions.ContentEncodingError: 400, message:
  Can not decode content-encoding: br
aiohttp.client_exceptions.ClientPayloadError: 400, message:
  Can not decode content-encoding: br

修复后（将 aiohttp 降至 3.11.18 验证逻辑正确，加上此 header 后 aiohttp 3.13.x 下同样正常）：
Tool `web_search_bocha` 正常返回搜索结果。

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Force Bocha search API requests to use gzip/deflate encoding to avoid aiohttp 3.12+ brotli decoding errors.