### PR TITLE
feat: 添加失败时保存本轮记录的配置项

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -134,6 +134,7 @@ DEFAULT_CONFIG = {
         "streaming_response": False,
         "show_tool_use_status": False,
         "show_tool_call_result": False,
+        "save_failed_agent_history": False,
         "sanitize_context_by_modalities": False,
         "max_quoted_fallback_images": 20,
         "quoted_message_parser": {
@@ -2777,6 +2778,9 @@ CONFIG_METADATA_2 = {
                     "show_tool_call_result": {
                         "type": "bool",
                     },
+                    "save_failed_agent_history": {
+                        "type": "bool",
+                    },
                     "unsupported_streaming_strategy": {
                         "type": "string",
                     },
@@ -3541,6 +3545,14 @@ CONFIG_METADATA_3 = {
                         "condition": {
                             "provider_settings.agent_runner_type": "local",
                             "provider_settings.show_tool_use_status": True,
+                        },
+                    },
+                    "provider_settings.save_failed_agent_history": {
+                        "description": "失败时保存本轮记录",
+                        "type": "bool",
+                        "hint": "启用后，当 Agent 本轮运行失败时（如模型返回空输出），也会将本轮记录保存到会话历史中，包括用户输入、工具调用记录和失败提示。",
+                        "condition": {
+                            "provider_settings.agent_runner_type": "local",
                         },
                     },
                     "provider_settings.sanitize_context_by_modalities": {

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -373,6 +373,7 @@ class InternalAgentSubStage(Stage):
                             agent_runner.run_context.messages,
                             agent_runner.stats,
                             user_aborted=agent_runner.was_aborted(),
+                            save_failed_history=self.save_failed_agent_history,
                         )
 
                     asyncio.create_task(
@@ -442,6 +443,11 @@ class InternalAgentSubStage(Stage):
         ):
             logger.debug("LLM 响应为空，不保存记录。")
             return
+
+        if save_failed_history and not llm_response.completion_text:
+            logger.info(
+                "Saving failed agent history as save_failed_agent_history is enabled."
+            )
 
         message_to_save = []
         skipped_initial_system = False

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -448,6 +448,12 @@ class InternalAgentSubStage(Stage):
             logger.info(
                 "Saving failed agent history as save_failed_agent_history is enabled."
             )
+            all_messages.append(
+                Message(
+                    role="assistant",
+                    content="[Agent run failed. History saved for debugging.]",
+                )
+            )
 
         message_to_save = []
         skipped_initial_system = False

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -67,6 +67,9 @@ class InternalAgentSubStage(Stage):
         self.show_tool_use: bool = settings.get("show_tool_use_status", True)
         self.show_tool_call_result: bool = settings.get("show_tool_call_result", False)
         self.show_reasoning = settings.get("display_reasoning_text", False)
+        self.save_failed_agent_history: bool = settings.get(
+            "save_failed_agent_history", False
+        )
         self.sanitize_context_by_modalities: bool = settings.get(
             "sanitize_context_by_modalities",
             False,
@@ -296,6 +299,7 @@ class InternalAgentSubStage(Stage):
                                 agent_runner.run_context.messages,
                                 agent_runner.stats,
                                 user_aborted=agent_runner.was_aborted(),
+                                save_failed_history=self.save_failed_agent_history,
                             )
 
                     elif streaming_response and not stream_to_general:
@@ -412,6 +416,7 @@ class InternalAgentSubStage(Stage):
         all_messages: list[Message],
         runner_stats: AgentStats | None,
         user_aborted: bool = False,
+        save_failed_history: bool = False,
     ) -> None:
         if not req or not req.conversation:
             return
@@ -433,6 +438,7 @@ class InternalAgentSubStage(Stage):
             not llm_response.completion_text
             and not req.tool_calls_result
             and not user_aborted
+            and not save_failed_history
         ):
             logger.debug("LLM 响应为空，不保存记录。")
             return


### PR DESCRIPTION
### 问题描述
目前 Agent 运行失败时（例如 EmptyModelOutputError），本轮记录通常不会写入正式会话历史。这在排查问题和长流程任务失败后希望从断点继续的场景下带来不便。

### 修复方案
添加 `save_failed_agent_history` 配置项（默认 false），启用后即使 Agent 本轮运行失败，也会将本轮记录保存到会话历史中，包括用户输入、工具调用记录和失败提示。

### 修改内容
1. `internal.py`：读取配置并传递给 `_save_to_history` 方法
2. `_save_to_history` 方法：添加 `save_failed_history` 参数控制空响应时是否保存
3. `default.py`：添加配置项定义和 UI 元数据

### Related Issue
Fixes #7620

## Summary by Sourcery

Add configurable support for saving the current agent run to conversation history even when the run fails.

New Features:
- Introduce a save_failed_agent_history configuration flag to control whether failed agent runs are persisted to conversation history.

Enhancements:
- Wire the save_failed_agent_history flag through the agent internal pipeline so that empty or failed model responses can still be saved when enabled.
- Extend chat provider template metadata to expose the new flag in the UI with appropriate description and conditions.