### PR TITLE
fix(dashboard): propagate dark mode to code blocks inside list items

### DIFF
--- a/dashboard/src/components/shared/ThemeAwareMarkdownCodeBlock.vue
+++ b/dashboard/src/components/shared/ThemeAwareMarkdownCodeBlock.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, inject, type Ref } from "vue";
 import { MarkdownCodeBlockNode } from "markstream-vue";
 import { useAttrs } from "vue";
 
@@ -21,20 +21,21 @@ defineOptions({
   inheritAttrs: false,
 });
 
-const props = withDefaults(
-  defineProps<{
-    node: Record<string, unknown>;
-    isDark?: boolean;
-  }>(),
-  {
-    isDark: false,
-  },
+const props = defineProps<{
+  node: Record<string, unknown>;
+  isDark?: boolean;
+}>();
+
+const injectedIsDark = inject<Ref<boolean> | boolean>("isDark", undefined);
+const effectiveIsDark = computed(
+  () => props.isDark ?? (injectedIsDark instanceof Object && 'value' in injectedIsDark ? injectedIsDark.value : injectedIsDark) ?? false,
 );
 
 const attrs = useAttrs();
 const forwardedBindings = computed(() => ({
   ...attrs,
   ...props,
+  isDark: effectiveIsDark.value,
 }));
-const themeRenderKey = computed(() => (props.isDark ? "dark" : "light"));
+const themeRenderKey = computed(() => (effectiveIsDark.value ? "dark" : "light"));
 </script>


### PR DESCRIPTION
The upstream `markstream-vue` library's `ListItemNode` does not forward the `isDark` prop to nested `NodeRenderer`, causing code blocks inside list items to always render with a light background in dark mode.

This fix makes `ThemeAwareMarkdownCodeBlock` fall back to the `isDark` value provided via Vue's `inject()` (already set by `MarkdownMessagePart.vue`) when the prop is not correctly passed down by the upstream library.

Fixes #7664

### Modifications / 改动点

- `dashboard/src/components/shared/ThemeAwareMarkdownCodeBlock.vue`: Added `inject("isDark")` as a fallback when the `isDark` prop is not propagated by the upstream `markstream-vue` `ListItemNode`. The component now computes an `effectiveIsDark` that uses `props.isDark || injectedIsDark` to ensure code blocks nested inside list items correctly receive the dark mode state.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

**Before**: In dark mode, code blocks at the top level display correctly with a dark background, but code blocks nested inside list items (`<li>`) render with a white background (`bg-white`, `background-color: #ffffff`).
<img width="1866" height="837" alt="2" src="https://github.com/user-attachments/assets/5a47fb97-484b-4469-b5a2-10832bf1a5f9" />


**After**: All code blocks, including those nested inside list items, correctly display with a dark background (`bg-gray-900`, `background-color: #121212`) in dark mode.

<img width="1878" height="843" alt="1" src="https://github.com/user-attachments/assets/4f07804c-7a14-461e-9f15-1283170106d4" />

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Fix dark mode styling for markdown code blocks nested inside list items by deriving the dark mode state from injected context when the prop is missing.