### PR TITLE
fix: prevent path traversal in backup importer (CWE-22)

### DIFF
--- a/astrbot/core/backup/importer.py
+++ b/astrbot/core/backup/importer.py
@@ -68,8 +68,8 @@ def _validate_path_within(target_path: Path, base_dir: Path) -> bool:
     target path is relative to the resolved base directory.
     """
     try:
-        resolved = target_path.resolve()
-        base_resolved = base_dir.resolve()
+        resolved = target_path.resolve(strict=False)
+        base_resolved = base_dir.resolve(strict=False)
         return resolved.is_relative_to(base_resolved)
     except (OSError, ValueError):
         return False

--- a/astrbot/core/backup/importer.py
+++ b/astrbot/core/backup/importer.py
@@ -65,12 +65,12 @@ def _validate_path_within(target_path: Path, base_dir: Path) -> bool:
     """Validate that target_path is within base_dir after resolving symlinks.
 
     Prevents path traversal attacks (CWE-22) by ensuring the resolved
-    target path starts with the resolved base directory.
+    target path is relative to the resolved base directory.
     """
     try:
         resolved = target_path.resolve()
         base_resolved = base_dir.resolve()
-        return resolved == base_resolved or str(resolved).startswith(str(base_resolved) + os.sep)
+        return resolved.is_relative_to(base_resolved)
     except (OSError, ValueError):
         return False
 

--- a/astrbot/core/backup/importer.py
+++ b/astrbot/core/backup/importer.py
@@ -59,8 +59,6 @@ def _get_major_version(version_str: str) -> str:
     return "0.0"
 
 
-
-
 def _validate_path_within(target_path: Path, base_dir: Path) -> bool:
     """Validate that target_path is within base_dir after resolving symlinks.
 
@@ -73,6 +71,7 @@ def _validate_path_within(target_path: Path, base_dir: Path) -> bool:
         return resolved.is_relative_to(base_resolved)
     except (OSError, ValueError):
         return False
+
 
 CMD_CONFIG_FILE_PATH = os.path.join(get_astrbot_data_path(), "cmd_config.json")
 KB_PATH = get_astrbot_knowledge_base_path()

--- a/astrbot/core/backup/importer.py
+++ b/astrbot/core/backup/importer.py
@@ -59,6 +59,21 @@ def _get_major_version(version_str: str) -> str:
     return "0.0"
 
 
+
+
+def _validate_path_within(target_path: Path, base_dir: Path) -> bool:
+    """Validate that target_path is within base_dir after resolving symlinks.
+
+    Prevents path traversal attacks (CWE-22) by ensuring the resolved
+    target path starts with the resolved base directory.
+    """
+    try:
+        resolved = target_path.resolve()
+        base_resolved = base_dir.resolve()
+        return resolved == base_resolved or str(resolved).startswith(str(base_resolved) + os.sep)
+    except (OSError, ValueError):
+        return False
+
 CMD_CONFIG_FILE_PATH = os.path.join(get_astrbot_data_path(), "cmd_config.json")
 KB_PATH = get_astrbot_knowledge_base_path()
 DEFAULT_PLATFORM_STATS_INVALID_COUNT_WARN_LIMIT = 5
@@ -765,6 +780,10 @@ class AstrBotImporter:
                     try:
                         rel_path = name[len(media_prefix) :]
                         target_path = kb_dir / rel_path
+                        # Validate path is within kb directory (CWE-22)
+                        if not _validate_path_within(target_path, kb_dir):
+                            logger.warning(f"媒体文件路径越界，已跳过: {target_path}")
+                            continue
                         target_path.parent.mkdir(parents=True, exist_ok=True)
                         with zf.open(name) as src, open(target_path, "wb") as dst:
                             dst.write(src.read())
@@ -826,6 +845,11 @@ class AstrBotImporter:
                         target_path = Path(original_path)
                     else:
                         target_path = attachments_dir / os.path.basename(name)
+
+                    # Validate path is within attachments directory (CWE-22)
+                    if not _validate_path_within(target_path, attachments_dir):
+                        logger.warning(f"附件路径越界，已跳过: {target_path}")
+                        continue
 
                     target_path.parent.mkdir(parents=True, exist_ok=True)
                     with zf.open(name) as src, open(target_path, "wb") as dst:
@@ -904,6 +928,10 @@ class AstrBotImporter:
                             continue
 
                         target_path = target_dir / rel_path
+                        # Validate path is within target directory (CWE-22)
+                        if not _validate_path_within(target_path, target_dir):
+                            result.add_warning(f"文件路径越界，已跳过: {name}")
+                            continue
                         target_path.parent.mkdir(parents=True, exist_ok=True)
 
                         with zf.open(name) as src, open(target_path, "wb") as dst:


### PR DESCRIPTION
## Vulnerability Summary

**CWE-22: Path Traversal (Zip Slip)**  
**Severity: High**  
**File:** `astrbot/core/backup/importer.py`

### Description

The backup import functionality extracts files from user-uploaded zip archives without validating that entry names resolve to paths within the intended target directories. An attacker who crafts a zip file with entries containing path traversal sequences (e.g., `../../etc/crontab`) can write arbitrary files anywhere the process has write access.

### Data Flow

1. Authenticated user uploads a backup zip via the dashboard API (JWT required)
2. `AstrBotImporter` extracts zip entries using `zf.open(name)`
3. Entry names are joined to base directories (`kb_dir`, `attachments_dir`, `target_dir`) without validation
4. Files are written to the resulting path — which may be outside the intended directory

Three extraction points are affected (lines ~780, ~827, ~904 in the original file).

### Preconditions

- Attacker must have valid JWT authentication to the dashboard

## Fix Description

Added a `_validate_path_within()` helper that:
1. Resolves the target path and base directory to their canonical forms via `Path.resolve()`
2. Verifies the resolved target starts with the resolved base directory + `os.sep`
3. Returns `False` on any OS/value errors

This check is applied at all three zip extraction points. Entries that fail validation are skipped with a warning log.

### Why this approach

- `Path.resolve()` canonicalizes symlinks and `..` sequences, preventing bypass via symlinks or encoding tricks
- The `+ os.sep` suffix prevents prefix confusion (e.g., `/app/data2` matching `/app/data`)
- Minimal change — only adds validation, no refactoring

## Test Results

The fix was verified against:
- Normal backup import (entries within target dirs pass validation)
- Crafted zip with `../` traversal entries (correctly rejected)
- Edge cases: symlink targets, entries matching directory prefix without separator

## Disprove Analysis

**Verdict: CONFIRMED_VALID** (high confidence)

We attempted to disprove this finding by examining:
- **Preconditions:** JWT authentication is required, but any authenticated dashboard user can trigger the import
- **Existing mitigations:** No path validation exists in the current code at any extraction point
- **Exploitability:** Confirmed feasible — standard zip libraries preserve crafted entry names

The only barrier is JWT authentication, which does not mitigate the vulnerability for authenticated users. The finding is valid and the fix is recommended.

## Summary by Sourcery

Prevent path traversal during backup import by validating extracted file paths against their target directories.

Bug Fixes:
- Add centralized path validation helper to ensure extracted backup files remain within their intended base directories, mitigating CWE-22 path traversal risk.
- Apply path validation to knowledge base media, attachments, and directory imports, skipping and logging any out-of-bounds paths.