### PR TITLE
fix: 修复 NapCat 语音消息的 Record 文件路径解析问题

### DIFF
--- a/astrbot/core/message/components.py
+++ b/astrbot/core/message/components.py
@@ -146,25 +146,26 @@ class Record(BaseMessageComponent):
             str: 语音的本地路径，以绝对路径表示。
 
         """
-        if not self.file:
-            raise Exception(f"not a valid file: {self.file}")
-        if self.file.startswith("file:///"):
-            return self.file[8:]
-        if self.file.startswith("http"):
-            file_path = await download_image_by_url(self.file)
+        url = self.url or self.file
+        if not url:
+            raise Exception(f"not a valid file: {url}")
+        if url.startswith("file:///"):
+            return url[8:]
+        if url.startswith("http"):
+            file_path = await download_image_by_url(url)
             return os.path.abspath(file_path)
-        if self.file.startswith("base64://"):
-            bs64_data = self.file.removeprefix("base64://")
+        if url.startswith("base64://"):
+            bs64_data = url.removeprefix("base64://")
             image_bytes = base64.b64decode(bs64_data)
             file_path = os.path.join(
-                get_astrbot_temp_path(), f"recordseg_{uuid.uuid4()}.jpg"
+                get_astrbot_temp_path(), f"recordseg_{uuid.uuid4()}.amr"
             )
             with open(file_path, "wb") as f:
                 f.write(image_bytes)
             return os.path.abspath(file_path)
-        if os.path.exists(self.file):
-            return os.path.abspath(self.file)
-        raise Exception(f"not a valid file: {self.file}")
+        if os.path.exists(url):
+            return os.path.abspath(url)
+        raise Exception(f"not a valid file: {url}")
 
     async def convert_to_base64(self) -> str:
         """将语音统一转换为 base64 编码。这个方法避免了手动判断语音数据类型，直接返回语音数据的 base64 编码。
@@ -173,20 +174,20 @@ class Record(BaseMessageComponent):
             str: 语音的 base64 编码，不以 base64:// 或者 data:image/jpeg;base64, 开头。
 
         """
-        # convert to base64
-        if not self.file:
-            raise Exception(f"not a valid file: {self.file}")
-        if self.file.startswith("file:///"):
-            bs64_data = file_to_base64(self.file[8:])
-        elif self.file.startswith("http"):
-            file_path = await download_image_by_url(self.file)
+        url = self.url or self.file
+        if not url:
+            raise Exception(f"not a valid file: {url}")
+        if url.startswith("file:///"):
+            bs64_data = file_to_base64(url[8:])
+        elif url.startswith("http"):
+            file_path = await download_image_by_url(url)
             bs64_data = file_to_base64(file_path)
-        elif self.file.startswith("base64://"):
-            bs64_data = self.file
-        elif os.path.exists(self.file):
-            bs64_data = file_to_base64(self.file)
+        elif url.startswith("base64://"):
+            bs64_data = url
+        elif os.path.exists(url):
+            bs64_data = file_to_base64(url)
         else:
-            raise Exception(f"not a valid file: {self.file}")
+            raise Exception(f"not a valid file: {url}")
         bs64_data = bs64_data.removeprefix("base64://")
         return bs64_data
 

--- a/astrbot/core/message/components.py
+++ b/astrbot/core/message/components.py
@@ -148,11 +148,14 @@ class Record(BaseMessageComponent):
         """
         url = self.url or self.file
         if not url:
-            raise Exception(f"not a valid file: {url}")
+            raise ValueError("No valid file or URL provided")
         if url.startswith("file:///"):
             return url[8:]
         if url.startswith("http"):
-            file_path = await download_image_by_url(url)
+            file_path = os.path.join(
+                get_astrbot_temp_path(), f"recordseg_{uuid.uuid4()}.amr"
+            )
+            await download_file(url, file_path)
             return os.path.abspath(file_path)
         if url.startswith("base64://"):
             bs64_data = url.removeprefix("base64://")
@@ -176,11 +179,14 @@ class Record(BaseMessageComponent):
         """
         url = self.url or self.file
         if not url:
-            raise Exception(f"not a valid file: {url}")
+            raise ValueError("No valid file or URL provided")
         if url.startswith("file:///"):
             bs64_data = file_to_base64(url[8:])
         elif url.startswith("http"):
-            file_path = await download_image_by_url(url)
+            file_path = os.path.join(
+                get_astrbot_temp_path(), f"recordseg_{uuid.uuid4()}.amr"
+            )
+            await download_file(url, file_path)
             bs64_data = file_to_base64(file_path)
         elif url.startswith("base64://"):
             bs64_data = url


### PR DESCRIPTION
## 变更说明

修复 Docker + NapCat 场景下语音消息 `Record` 组件的文件路径解析问题。

当前 `Record.convert_to_file_path` 和 `Record.convert_to_base64` 主要只使用 `self.file`，在 NapCat 场景下，这个值可能只是文件名，或者是 AstrBot 容器内不可直接访问的路径，导致语音预处理时报错：

`Voice processing failed: not a valid file: xxx.amr`

本次修改让 `Record` 和 `Image` 的处理逻辑保持一致，优先使用：

`self.url or self.file`

## 问题原因

在 Docker + NapCat 部署下，语音文件虽然已经在协议端成功下载，但 AstrBot 收到的 `Record.file` 可能只是文件名或不可直接访问的路径。

由于 `Record` 组件没有像 `Image` 一样优先使用 `url`，因此会把本来有效的语音消息误判为无效文件。

## 修改内容

修改文件：

- `astrbot/core/message/components.py`

调整内容：

- `Record.convert_to_file_path` 改为优先使用 `self.url or self.file`
- `Record.convert_to_base64` 改为优先使用 `self.url or self.file`
- 顺手将语音 base64 落地临时文件扩展名从 `.jpg` 调整为更合理的 `.amr`

## 验证结果

已在本地 Docker + NapCat 环境中验证：

- 修改前：接收语音消息会报 `not a valid file: xxx.amr`
- 修改后：该报错不再出现
- 语音消息可以继续进入后续 STT 流程

Closes #7686

## Summary by Sourcery

Fix voice Record message path resolution to correctly handle NapCat and Docker deployments by aligning its source selection with Image handling.

Bug Fixes:
- Resolve failures when processing NapCat voice messages by falling back to the component URL when the file path is not directly accessible.

Enhancements:
- Change temporary voice file extension from .jpg to .amr when decoding base64 voice data for more accurate file typing.