### PR TITLE
fix: warn instead of blocking when configured model not in hardcoded list

### DIFF
--- a/astrbot/core/provider/sources/minimax_token_plan_source.py
+++ b/astrbot/core/provider/sources/minimax_token_plan_source.py
@@ -1,5 +1,4 @@
 from astrbot import logger
-
 from astrbot.core.provider.sources.anthropic_source import ProviderAnthropic
 
 from ..register import register_provider_adapter
@@ -49,10 +48,12 @@ class ProviderMiniMaxTokenPlan(ProviderAnthropic):
         configured_model = provider_config.get("model", "MiniMax-M2.7")
         if configured_model not in MINIMAX_TOKEN_PLAN_MODELS:
             logger.warning(
-                f"Configured model {configured_model!r} is not in the known Token Plan "
-                f"model list ({', '.join(MINIMAX_TOKEN_PLAN_MODELS)}). "
+                f"Configured model {configured_model!r} is not in the known "
+                f"Token Plan model list "
+                f"({', '.join(MINIMAX_TOKEN_PLAN_MODELS)}). "
                 f"The model may still work if your plan supports it. "
-                f"If you encounter errors, please check your plan's model availability."
+                f"If you encounter errors, please check your plan's "
+                f"model availability."
             )
 
         self.set_model(configured_model)

--- a/astrbot/core/provider/sources/minimax_token_plan_source.py
+++ b/astrbot/core/provider/sources/minimax_token_plan_source.py
@@ -1,6 +1,10 @@
+import logging
+
 from astrbot.core.provider.sources.anthropic_source import ProviderAnthropic
 
 from ..register import register_provider_adapter
+
+logger = logging.getLogger(__name__)
 
 MINIMAX_TOKEN_PLAN_MODELS = [
     "MiniMax-M2.7",
@@ -43,9 +47,11 @@ class ProviderMiniMaxTokenPlan(ProviderAnthropic):
 
         configured_model = provider_config.get("model", "MiniMax-M2.7")
         if configured_model not in MINIMAX_TOKEN_PLAN_MODELS:
-            raise ValueError(
-                f"Unsupported model: {configured_model!r}. "
-                f"Supported models: {', '.join(MINIMAX_TOKEN_PLAN_MODELS)}"
+            logger.warning(
+                f"Configured model {configured_model!r} is not in the known Token Plan "
+                f"model list ({', '.join(MINIMAX_TOKEN_PLAN_MODELS)}). "
+                f"The model may still work if your plan supports it. "
+                f"If you encounter errors, please check your plan's model availability."
             )
 
         self.set_model(configured_model)

--- a/astrbot/core/provider/sources/minimax_token_plan_source.py
+++ b/astrbot/core/provider/sources/minimax_token_plan_source.py
@@ -1,15 +1,16 @@
-import logging
+from astrbot import logger
 
 from astrbot.core.provider.sources.anthropic_source import ProviderAnthropic
 
 from ..register import register_provider_adapter
 
-logger = logging.getLogger(__name__)
-
 MINIMAX_TOKEN_PLAN_MODELS = [
     "MiniMax-M2.7",
+    "MiniMax-M2.7-highspeed",
     "MiniMax-M2.5",
+    "MiniMax-M2.5-highspeed",
     "MiniMax-M2.1",
+    "MiniMax-M2.1-highspeed",
     "MiniMax-M2",
 ]
 


### PR DESCRIPTION
## 修复内容
将 MiniMax Token Plan Provider 中，不在硬编码白名单里的模型从 `ValueError` 强行阻断改为 `logger.warning` 警告。

**原因：** Plus 用户（如 MiniMax-M2.7-highspeed）被硬编码白名单阻断无法使用，但实际上 Plus plan 确实支持这些模型。

**改动：**
- 移除 `raise ValueError`
- 改为 `logger.warning` 提示用户模型可能不受支持，但仍允许配置

## 背景
由用户反馈驱动：https://github.com/AstrBotDevs/AstrBot/pull/7609#discussion-r2087650989

## Summary by Sourcery

Allow MiniMax token plan to accept configured models outside the hardcoded list while logging a warning instead of blocking.

Bug Fixes:
- Permit Plus users to use additional MiniMax models that were previously blocked by a hardcoded whitelist despite being supported by their plan.

Enhancements:
- Extend the known MiniMax token plan model list to include additional highspeed variants for better default compatibility.