### PR TITLE
fix: apply provider modalities after tool injection

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -1424,10 +1424,8 @@ async def build_main_agent(
     if not req.session_id:
         req.session_id = event.unified_msg_origin
 
-    _modalities_fix(provider, req)
     _plugin_tool_fix(event, req)
     await _apply_web_search_tools(event, req, plugin_context)
-    _sanitize_context_by_modalities(config, provider, req)
 
     if config.llm_safety_mode:
         _apply_llm_safety_mode(config, req)
@@ -1454,6 +1452,9 @@ async def build_main_agent(
                 SendMessageToUserTool
             )
         )
+
+    _modalities_fix(provider, req)
+    _sanitize_context_by_modalities(config, provider, req)
 
     if provider.provider_config.get("max_context_tokens", 0) <= 0:
         model = provider.get_model()

--- a/tests/unit/test_astr_main_agent.py
+++ b/tests/unit/test_astr_main_agent.py
@@ -968,6 +968,44 @@ class TestBuildMainAgent:
         assert isinstance(result, module.MainAgentBuildResult)
 
     @pytest.mark.asyncio
+    async def test_build_main_agent_strips_late_tools_when_tool_use_unsupported(
+        self, mock_event, mock_context, mock_provider
+    ):
+        """Provider modality filtering should apply after all built-in tools are added."""
+        module = ama
+        mock_provider.provider_config = {
+            "id": "test-provider",
+            "modalities": ["text"],
+        }
+        mock_context.get_provider_by_id.return_value = None
+        mock_context.get_using_provider.return_value = mock_provider
+        mock_context.get_config.return_value = {}
+
+        conv_mgr = mock_context.conversation_manager
+        _setup_conversation_for_build(conv_mgr)
+
+        with (
+            patch("astrbot.core.astr_main_agent.AgentRunner") as mock_runner_cls,
+            patch("astrbot.core.astr_main_agent.AstrAgentContext"),
+        ):
+            mock_runner = MagicMock()
+            mock_runner.reset = AsyncMock()
+            mock_runner_cls.return_value = mock_runner
+
+            result = await module.build_main_agent(
+                event=mock_event,
+                plugin_context=mock_context,
+                config=module.MainAgentBuildConfig(
+                    tool_call_timeout=60,
+                    computer_use_runtime="none",
+                    add_cron_tools=True,
+                ),
+            )
+
+        assert result is not None
+        assert result.provider_request.func_tool is None
+
+    @pytest.mark.asyncio
     async def test_build_main_agent_no_provider(self, mock_event, mock_context):
         """Test building main agent when no provider is available."""
         module = ama


### PR DESCRIPTION
## Summary
- move provider modality filtering until after built-in tool injection so models configured without tool_use do not receive late-added tools
- keep context sanitization aligned with the final provider/tool state
- add a regression test covering cron/proactive tools being stripped for text-only providers

## Verification
- confirmed the new regression test fails on current upstream before the fix
- uv run pytest tests/unit/test_astr_main_agent.py -q (80 passed)
- uv run ruff format .
- uv run ruff check .

Related to #6857.

## Summary by Sourcery

Adjust main agent build flow so provider modality filtering and context sanitization occur after all built-in tools are injected, ensuring text-only providers do not receive unsupported tools.

Bug Fixes:
- Ensure late-injected tools such as cron/proactive tools are stripped when the selected provider does not support tool use.

Tests:
- Add a regression test verifying that providers configured as text-only do not receive function tools after built-in tool injection.