### PR TITLE
fix: drop legacy documents_fts table if exists

### DIFF
--- a/astrbot/core/db/vec_db/faiss_impl/document_storage.py
+++ b/astrbot/core/db/vec_db/faiss_impl/document_storage.py
@@ -96,36 +96,29 @@ class DocumentStorage:
 
     async def _initialize_fts5(self, executor) -> None:
         try:
-            try:
-                await executor.execute(
-                    text(
-                        f"""
-                        CREATE VIRTUAL TABLE IF NOT EXISTS {FTS_TABLE_NAME}
-                        USING fts5(
-                            search_text,
-                            content='',
-                            contentless_delete=1,
-                            tokenize='unicode61'
-                        )
-                        """,
-                    ),
+            await self._create_fts5_table(executor, if_not_exists=True)
+
+            is_valid_fts5, has_contentless_delete = await self._inspect_fts5_table(
+                executor,
+            )
+            if not is_valid_fts5:
+                logger.warning(
+                    f"Detected incompatible legacy table `{FTS_TABLE_NAME}` in "
+                    f"{self.db_path}; recreating FTS5 table.",
                 )
-                self._fts_contentless_delete = True
-            except Exception:
-                await executor.execute(
-                    text(
-                        f"""
-                        CREATE VIRTUAL TABLE IF NOT EXISTS {FTS_TABLE_NAME}
-                        USING fts5(
-                            search_text,
-                            content='',
-                            tokenize='unicode61'
-                        )
-                        """,
-                    ),
+                await executor.execute(text(f"DROP TABLE IF EXISTS {FTS_TABLE_NAME}"))
+                await self._create_fts5_table(executor, if_not_exists=False)
+
+                is_valid_fts5, has_contentless_delete = await self._inspect_fts5_table(
+                    executor,
                 )
-                self._fts_contentless_delete = False
+                if not is_valid_fts5:
+                    raise RuntimeError(
+                        f"Failed to create a valid FTS5 table `{FTS_TABLE_NAME}`",
+                    )
+
             self.fts5_available = True
+            self._fts_contentless_delete = has_contentless_delete
         except Exception as e:
             self.fts5_available = False
             self._fts_contentless_delete = False
@@ -133,6 +126,68 @@ class DocumentStorage:
                 f"SQLite FTS5 is unavailable for document storage {self.db_path}; "
                 f"falling back to in-memory BM25 sparse retrieval: {e}",
             )
+
+    async def _create_fts5_table(self, executor, if_not_exists: bool) -> None:
+        create_clause = (
+            "CREATE VIRTUAL TABLE IF NOT EXISTS"
+            if if_not_exists
+            else "CREATE VIRTUAL TABLE"
+        )
+        try:
+            await executor.execute(
+                text(
+                    f"""
+                    {create_clause} {FTS_TABLE_NAME}
+                    USING fts5(
+                        search_text,
+                        content='',
+                        contentless_delete=1,
+                        tokenize='unicode61'
+                    )
+                    """,
+                ),
+            )
+        except Exception:
+            await executor.execute(
+                text(
+                    f"""
+                    {create_clause} {FTS_TABLE_NAME}
+                    USING fts5(
+                        search_text,
+                        content='',
+                        tokenize='unicode61'
+                    )
+                    """,
+                ),
+            )
+
+    async def _inspect_fts5_table(self, executor) -> tuple[bool, bool]:
+        schema_result = await executor.execute(
+            text(
+                """
+                SELECT sql
+                FROM sqlite_master
+                WHERE type='table' AND name=:table_name
+                """,
+            ),
+            {"table_name": FTS_TABLE_NAME},
+        )
+        create_sql = schema_result.scalar_one_or_none()
+        if not create_sql:
+            return False, False
+
+        normalized_sql = create_sql.lower()
+        if "virtual table" not in normalized_sql or "using fts5" not in normalized_sql:
+            return False, False
+
+        pragma_result = await executor.execute(
+            text(f"PRAGMA table_info({FTS_TABLE_NAME})"),
+        )
+        columns = {row[1] for row in pragma_result.fetchall()}
+        if "search_text" not in columns:
+            return False, False
+
+        return True, "contentless_delete=1" in normalized_sql
 
     async def connect(self) -> None:
         """Connect to the SQLite database."""

--- a/astrbot/core/db/vec_db/faiss_impl/document_storage.py
+++ b/astrbot/core/db/vec_db/faiss_impl/document_storage.py
@@ -187,7 +187,8 @@ class DocumentStorage:
         if "search_text" not in columns:
             return False, False
 
-        return True, "contentless_delete=1" in normalized_sql
+        normalized_sql_no_whitespace = "".join(normalized_sql.split())
+        return True, "contentless_delete=1" in normalized_sql_no_whitespace
 
     async def connect(self) -> None:
         """Connect to the SQLite database."""

--- a/tests/unit/test_document_storage_fts.py
+++ b/tests/unit/test_document_storage_fts.py
@@ -1,3 +1,5 @@
+import sqlite3
+
 import pytest
 
 from astrbot.core.db.vec_db.faiss_impl.document_storage import DocumentStorage
@@ -71,5 +73,31 @@ async def test_document_storage_fts_delete_skips_missing_fts_row(tmp_path):
     await storage.delete_document_by_doc_id("legacy-chunk")
 
     assert await storage.get_document_by_doc_id("legacy-chunk") is None
+
+    await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_document_storage_fts_recovers_from_legacy_non_fts_table(tmp_path):
+    db_path = tmp_path / "doc.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE documents_fts (rowid INTEGER PRIMARY KEY)")
+    conn.commit()
+    conn.close()
+
+    storage = DocumentStorage(str(db_path))
+    await storage.initialize()
+
+    assert storage.fts5_available is True
+
+    await storage.insert_document(
+        doc_id="legacy-fix",
+        text="legacy fts recovery text",
+        metadata={"kb_doc_id": "doc-1", "kb_id": "kb-1", "chunk_index": 0},
+    )
+    results = await storage.search_sparse(["legacy"], limit=10)
+
+    assert results is not None
+    assert [result["doc_id"] for result in results] == ["legacy-fix"]
 
     await storage.close()


### PR DESCRIPTION
## 概要

这个 PR 修复了 AstrBot `v4.23.2` 引入的一个 SQLite FTS5 兼容性问题。

当用户本地数据库中已经存在一个普通表 `documents_fts` 时，执行：

```sql
CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(...)
```

SQLite 不会报错，但也不会把这个普通表替换成 FTS5 虚表。随后 AstrBot 会误认为 FTS5 已可用，并在后续写入时触发错误：

```text
sqlite3.OperationalError: table documents_fts has no column named search_text
```

## 问题根因

`DocumentStorage._initialize_fts5()` 之前只尝试创建 FTS 表，但没有校验当前已有的 `documents_fts` 是否真的是一个合法的 FTS5 虚表，也没有确认它是否包含预期的 `search_text` 字段。

这会导致以下问题场景：

1. 用户升级到 `v4.23.2`
2. 本地数据库中已存在一个同名普通表 `documents_fts`
3. AstrBot 执行 `CREATE VIRTUAL TABLE IF NOT EXISTS ...` 时被 SQLite 静默跳过
4. AstrBot 仍将 `fts5_available` 标记为 `True`
5. 后续插入 `search_text` 时直接报错

## 变更内容

本 PR 做了以下修复：

- 抽取 FTS5 表创建逻辑到独立方法
- 在初始化后增加表结构校验
- 检测 `documents_fts` 是否为合法的 FTS5 虚表
- 检测该表是否包含预期字段 `search_text`
- 如果发现是旧的普通表或结构不合法，则自动删除并重建为正确的 FTS5 表
- 根据实际表定义判断 `contentless_delete` 是否可用，而不是仅根据创建路径推断
- 补充回归测试，覆盖“已有同名普通表”的用户升级场景

## 测试

已验证以下检查通过：

- `python -m ruff check astrbot/core/db/vec_db/faiss_impl/document_storage.py tests/unit/test_document_storage_fts.py`
- `python -m pytest tests/unit/test_document_storage_fts.py tests/unit/test_sparse_retriever.py`

另外，新增的回归测试覆盖了以下场景：

- 预先创建普通表 `documents_fts`
- 初始化 `DocumentStorage`
- 验证可以自动恢复为合法 FTS5 表
- 验证后续插入与检索流程正常

## 说明

这个问题是在下游插件用户升级到 AstrBot `v4.23.2` 后暴露出来的。根本原因不在插件本身，而在 AstrBot 核心对旧 SQLite 状态的兼容处理不完整。

这个修复的目标是让 AstrBot 在面对历史遗留数据库结构时，能够自动识别并恢复到正确的 FTS5 状态，避免用户在升级后因本地数据库残留结构而直接报错。