### PR TITLE
fix: 支持 object 类型 schema 使用 children 字段定义子属性

### DIFF
--- a/astrbot/core/config/astrbot_config.py
+++ b/astrbot/core/config/astrbot_config.py
@@ -82,7 +82,10 @@ class AstrBotConfig(dict):
 
                 if v["type"] == "object":
                     conf[k] = {}
-                    _parse_schema(v["items"], conf[k])
+                    # 优先使用 items，其次使用 children（兼容两种 schema 写法）
+                    sub_schema = v.get("items") or v.get("children")
+                    if sub_schema:
+                        _parse_schema(sub_schema, conf[k])
                 elif v["type"] == "template_list":
                     conf[k] = default
                 else:


### PR DESCRIPTION
## 问题描述

加载 `astrbot_plugin_schedule_assistant` 插件时报错：

```
KeyError: 'items'
  File "/AstrBot/astrbot/core/config/astrbot_config.py", line 85, in _parse_schema
    _parse_schema(v["items"], conf[k])
```

## 根本原因

`_conf_schema.json` 中 `apple_calendar` 字段定义为：
```json
"apple_calendar": {
  "type": "object",
  "children": { ... }  // 使用 children 而非 items
}
```

但 `astrbot_config.py` 第 85 行强制要求 `v["items"]`，导致 `KeyError`。

## 修复方案

在解析 `object` 类型 schema 时，同时支持 `items` 和 `children` 两种写法，兼容新旧插件配置。

```python
# 修复前
_parse_schema(v["items"], conf[k])

# 修复后
sub_schema = v.get("items") or v.get("children")
if sub_schema:
    _parse_schema(sub_schema, conf[k])
```

## 测试验证

已在本地修改 `/AstrBot/astrbot/core/config/astrbot_config.py` 确认逻辑正确。

## Summary by Sourcery

Support both `items` and `children` when parsing object-type configuration schemas to avoid KeyError and maintain compatibility with different plugin schema formats.

Bug Fixes:
- Prevent KeyError when loading plugins whose object-type schema defines sub-properties via `children` instead of `items`.

Enhancements:
- Make configuration schema parsing more flexible by allowing object-type fields to use either `items` or `children` for nested definitions.