### PR TITLE
feat: 添加失败时保存本轮记录的配置项

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -134,6 +134,7 @@ DEFAULT_CONFIG = {
         "streaming_response": False,
         "show_tool_use_status": False,
         "show_tool_call_result": False,
+        "save_failed_agent_history": False,
         "buffer_intermediate_messages": False,
         "sanitize_context_by_modalities": False,
         "max_quoted_fallback_images": 20,
@@ -2778,6 +2779,9 @@ CONFIG_METADATA_2 = {
                     "show_tool_call_result": {
                         "type": "bool",
                     },
+                    "save_failed_agent_history": {
+                        "type": "bool",
+                    },
                     "buffer_intermediate_messages": {
                         "type": "bool",
                     },
@@ -3545,6 +3549,14 @@ CONFIG_METADATA_3 = {
                         "condition": {
                             "provider_settings.agent_runner_type": "local",
                             "provider_settings.show_tool_use_status": True,
+                        },
+                    },
+                    "provider_settings.save_failed_agent_history": {
+                        "description": "失败时保存本轮记录",
+                        "type": "bool",
+                        "hint": "启用后，当 Agent 本轮运行失败时（如模型返回空输出），也会将本轮记录保存到会话历史中，包括用户输入、工具调用记录和失败提示。",
+                        "condition": {
+                            "provider_settings.agent_runner_type": "local",
                         },
                     },
                     "provider_settings.buffer_intermediate_messages": {

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -456,29 +456,35 @@ class InternalAgentSubStage(Stage):
             logger.debug("LLM 响应为空，不保存记录。")
             return
 
-        if save_failed_history and not llm_response.completion_text:
-            logger.info(
+        if (
+            save_failed_history
+            and not llm_response.completion_text
+            and not req.tool_calls_result
+        ):
+            logger.debug(
                 "Saving failed agent history as save_failed_agent_history is enabled."
             )
-            all_messages.append(
+            messages_to_save = all_messages + [
                 Message(
                     role="assistant",
                     content="[Agent run failed. History saved for debugging.]",
                 )
-            )
+            ]
+        else:
+            messages_to_save = all_messages
 
-        messages_to_save: list[Message] = []
+        message_to_save: list[dict] = []
         skipped_initial_system = False
-        for message in all_messages:
+        for message in messages_to_save:
             if message.role == "system" and not skipped_initial_system:
                 skipped_initial_system = True
                 continue
-            if message.role in ["assistant", "user"] and message._no_save:
-                continue
-            messages_to_save.append(message)
+            skip = message.role in ["assistant", "user"] and message._no_save
+            if not skip:
+                message_to_save.append(message.model_dump())
 
         checkpoint_id = event.get_extra("llm_checkpoint_id")
-        message_to_save = dump_messages_with_checkpoints(messages_to_save)
+        message_to_save = dump_messages_with_checkpoints(message_to_save)
         if isinstance(checkpoint_id, str) and checkpoint_id:
             message_to_save.append(
                 CheckpointMessageSegment(

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -76,6 +76,9 @@ class InternalAgentSubStage(Stage):
             False,
         )
         self.show_reasoning = settings.get("display_reasoning_text", False)
+        self.save_failed_agent_history: bool = settings.get(
+            "save_failed_agent_history", False
+        )
         self.sanitize_context_by_modalities: bool = settings.get(
             "sanitize_context_by_modalities",
             False,
@@ -306,6 +309,7 @@ class InternalAgentSubStage(Stage):
                                 agent_runner.run_context.messages,
                                 agent_runner.stats,
                                 user_aborted=agent_runner.was_aborted(),
+                                save_failed_history=self.save_failed_agent_history,
                             )
 
                     elif streaming_response and not stream_to_general:
@@ -381,6 +385,7 @@ class InternalAgentSubStage(Stage):
                             agent_runner.run_context.messages,
                             agent_runner.stats,
                             user_aborted=agent_runner.was_aborted(),
+                            save_failed_history=self.save_failed_agent_history,
                         )
 
                     asyncio.create_task(
@@ -424,6 +429,7 @@ class InternalAgentSubStage(Stage):
         all_messages: list[Message],
         runner_stats: AgentStats | None,
         user_aborted: bool = False,
+        save_failed_history: bool = False,
     ) -> None:
         if not req or not req.conversation:
             return
@@ -445,9 +451,21 @@ class InternalAgentSubStage(Stage):
             not llm_response.completion_text
             and not req.tool_calls_result
             and not user_aborted
+            and not save_failed_history
         ):
             logger.debug("LLM 响应为空，不保存记录。")
             return
+
+        if save_failed_history and not llm_response.completion_text:
+            logger.info(
+                "Saving failed agent history as save_failed_agent_history is enabled."
+            )
+            all_messages.append(
+                Message(
+                    role="assistant",
+                    content="[Agent run failed. History saved for debugging.]",
+                )
+            )
 
         messages_to_save: list[Message] = []
         skipped_initial_system = False


### PR DESCRIPTION
## Summary by Sourcery

Add a configurable option to persist agent run history even when the run fails or returns empty output.

New Features:
- Introduce the save_failed_agent_history configuration flag for agent runners to control whether failed runs are saved to conversation history.

Enhancements:
- Extend history-saving logic to optionally append a synthetic failure message so failed agent runs can still be inspected for debugging.
- Expose the new save_failed_agent_history option in default config and provider templates, including UI metadata and conditions.