### PR TITLE
fix: add retry on DNS/connection transient errors for QQ Official API

### DIFF
--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -53,13 +53,13 @@ def _patch_qq_botpy_formdata() -> None:
 _patch_qq_botpy_formdata()
 
 # Retry decorator for QQ Official API transient errors (HTTP 500/504)
-_qqofficial_retry = retry(
+_qqo_official_retry = retry(
     retry=retry_if_exception_type(
         (
             botpy.errors.ServerError,
             botpy.errors.SequenceNumberError,
-            ConnectionError,
             OSError,
+            asyncio.TimeoutError,
         )
     ),
     stop=stop_after_attempt(5),
@@ -566,7 +566,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                     ttl=result.get("ttl", 0),
                 )
         except (botpy.errors.ServerError, botpy.errors.SequenceNumberError):
-            logger.error(f"上传媒体文件失败，共尝试3次后放弃: {file_source}")
+            logger.error(f"上传媒体文件失败，共尝试5次后放弃: {file_source}")
         except Exception as e:
             logger.error(f"上传请求错误: {e}")
 

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -58,10 +58,12 @@ _qqofficial_retry = retry(
         (
             botpy.errors.ServerError,
             botpy.errors.SequenceNumberError,
+            ConnectionError,
+            OSError,
         )
     ),
-    stop=stop_after_attempt(3),
-    wait=wait_exponential(multiplier=1, min=1, max=10),
+    stop=stop_after_attempt(5),
+    wait=wait_exponential(multiplier=2, min=2, max=30),
     before_sleep=before_sleep_log(logger, logging.WARNING),
     reraise=True,
 )

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -53,7 +53,7 @@ def _patch_qq_botpy_formdata() -> None:
 _patch_qq_botpy_formdata()
 
 # Retry decorator for QQ Official API transient errors (HTTP 500/504)
-_qqo_official_retry = retry(
+_qqofficial_retry = retry(
     retry=retry_if_exception_type(
         (
             botpy.errors.ServerError,


### PR DESCRIPTION
## Summary by Sourcery

Increase resilience of QQ Official API interactions by broadening and tuning retry behavior for transient errors.

Bug Fixes:
- Handle transient DNS and connection-related errors when calling the QQ Official API by retrying the requests.

Enhancements:
- Increase maximum retry attempts and adjust exponential backoff parameters for QQ Official API calls to better tolerate temporary failures.