### PR TITLE
fix: 当LTM provider未设置时，回退到全局图片转述模型配置

### DIFF
--- a/astrbot/builtin_stars/astrbot/long_term_memory.py
+++ b/astrbot/builtin_stars/astrbot/long_term_memory.py
@@ -70,8 +70,10 @@ class LongTermMemory:
         image_caption_prompt: str,
     ) -> str:
         if not image_caption_provider_id:
-            image_caption_provider_id = self.ctx.astrbot_config["provider_settings"].get(
-                "default_image_caption_provider_id"
+            image_caption_provider_id = (
+                self.ctx.astrbot_config["provider_settings"].get(
+                    "default_image_caption_provider_id"
+                )
             )
         if not image_caption_provider_id:
             provider = self.context.get_using_provider()

--- a/astrbot/builtin_stars/astrbot/long_term_memory.py
+++ b/astrbot/builtin_stars/astrbot/long_term_memory.py
@@ -70,6 +70,10 @@ class LongTermMemory:
         image_caption_prompt: str,
     ) -> str:
         if not image_caption_provider_id:
+            image_caption_provider_id = self.ctx.astrbot_config["provider_settings"].get(
+                "default_image_caption_provider_id"
+            )
+        if not image_caption_provider_id:
             provider = self.context.get_using_provider()
         else:
             provider = self.context.get_provider_by_id(image_caption_provider_id)

--- a/astrbot/builtin_stars/astrbot/long_term_memory.py
+++ b/astrbot/builtin_stars/astrbot/long_term_memory.py
@@ -34,6 +34,10 @@ class LongTermMemory:
         image_caption_provider_id = cfg["provider_ltm_settings"].get(
             "image_caption_provider_id"
         )
+        if not image_caption_provider_id:
+            image_caption_provider_id = cfg["provider_settings"].get(
+                "default_image_caption_provider_id"
+            )
         image_caption = cfg["provider_ltm_settings"]["image_caption"] and bool(
             image_caption_provider_id
         )
@@ -70,7 +74,7 @@ class LongTermMemory:
         image_caption_prompt: str,
     ) -> str:
         if not image_caption_provider_id:
-            image_caption_provider_id = self.ctx.astrbot_config[
+            image_caption_provider_id = self.context.get_config()[
                 "provider_settings"
             ].get("default_image_caption_provider_id")
         if not image_caption_provider_id:

--- a/astrbot/builtin_stars/astrbot/long_term_memory.py
+++ b/astrbot/builtin_stars/astrbot/long_term_memory.py
@@ -70,11 +70,9 @@ class LongTermMemory:
         image_caption_prompt: str,
     ) -> str:
         if not image_caption_provider_id:
-            image_caption_provider_id = (
-                self.ctx.astrbot_config["provider_settings"].get(
-                    "default_image_caption_provider_id"
-                )
-            )
+            image_caption_provider_id = self.ctx.astrbot_config[
+                "provider_settings"
+            ].get("default_image_caption_provider_id")
         if not image_caption_provider_id:
             provider = self.context.get_using_provider()
         else:


### PR DESCRIPTION
## Summary by Sourcery

确保图片转述模型在群组配置缺失时能够使用全局默认配置。

Bug Fixes:
- 当群组未配置专用图片转述模型时，回退使用全局默认图片转述模型。

Tests:
- 新增测试覆盖群组模型未设置、为空及已配置时的图片转述模型选择行为。