### PR TITLE
fix: 修复工具调用名重复拼接问题（流式响应chunk重复累积）

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -63,6 +63,17 @@ class ProviderOpenAIOfficial(Provider):
         return text[: cls._ERROR_TEXT_CANDIDATE_MAX_CHARS]
 
     @staticmethod
+    def _deduplicate_self_repeating(value: str) -> str:
+        """If string is a self-repeating pattern like 'abcabc', return 'abc'.
+        This handles streaming chunk duplication issues (e.g. 'call_xxxcall_xxx')."""
+        if not value or len(value) < 4:
+            return value
+        half = len(value) // 2
+        if value[:half] == value[half:]:
+            return value[:half]
+        return value
+
+    @staticmethod
     def _safe_json_dump(value: Any) -> str | None:
         try:
             return json.dumps(value, ensure_ascii=False, default=str)
@@ -866,13 +877,18 @@ class ProviderOpenAIOfficial(Provider):
                     else:
                         args = tool_call.function.arguments
                     args_ls.append(args)
-                    func_name_ls.append(tool_call.function.name)
-                    tool_call_ids.append(tool_call.id)
+                    func_name_ls.append(
+                        cls._deduplicate_self_repeating(tool_call.function.name)
+                    )
+                    tool_call_ids.append(
+                        cls._deduplicate_self_repeating(tool_call.id or "")
+                    )
 
                     # gemini-2.5 / gemini-3 series extra_content handling
                     extra_content = getattr(tool_call, "extra_content", None)
                     if extra_content is not None:
-                        tool_call_extra_content_dict[tool_call.id] = extra_content
+                        deduped_id = cls._deduplicate_self_repeating(tool_call.id or "")
+                        tool_call_extra_content_dict[deduped_id] = extra_content
 
             llm_response.role = "tool"
             llm_response.tools_call_args = args_ls

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -63,14 +63,23 @@ class ProviderOpenAIOfficial(Provider):
         return text[: cls._ERROR_TEXT_CANDIDATE_MAX_CHARS]
 
     @staticmethod
-    def _deduplicate_self_repeating(value: str) -> str:
-        """If string is a self-repeating pattern like 'abcabc', return 'abc'.
-        This handles streaming chunk duplication issues (e.g. 'call_xxxcall_xxx')."""
+    def _deduplicate_self_repeating(value: str | None) -> str | None:
+        """If string is a self-repeating pattern like 'abcabc' or 'abcabcabc', return the base unit.
+        This handles streaming chunk duplication issues (e.g. 'call_xxxcall_xxx').
+        Returns None unchanged."""
+        if value is None:
+            return None
         if not value or len(value) < 4:
             return value
+        # Handle arbitrary repetitions by finding the smallest repeating unit
         half = len(value) // 2
-        if value[:half] == value[half:]:
-            return value[:half]
+        for unit_size in range(1, half + 1):
+            if len(value) % unit_size != 0:
+                continue
+            unit = value[:unit_size]
+            repetitions = len(value) // unit_size
+            if unit * repetitions == value and repetitions >= 2:
+                return unit
         return value
 
     @staticmethod
@@ -869,8 +878,11 @@ class ProviderOpenAIOfficial(Provider):
                 if tool_call.type == "function":
                     # workaround for #1454
                     if isinstance(tool_call.function.arguments, str):
+                        deduped_args = self._deduplicate_self_repeating(
+                            tool_call.function.arguments
+                        )
                         try:
-                            args = json.loads(tool_call.function.arguments)
+                            args = json.loads(deduped_args)
                         except json.JSONDecodeError as e:
                             logger.error(f"解析参数失败: {e}")
                             args = {}
@@ -878,17 +890,16 @@ class ProviderOpenAIOfficial(Provider):
                         args = tool_call.function.arguments
                     args_ls.append(args)
                     func_name_ls.append(
-                        cls._deduplicate_self_repeating(tool_call.function.name)
+                        self._deduplicate_self_repeating(tool_call.function.name)
                     )
-                    tool_call_ids.append(
-                        cls._deduplicate_self_repeating(tool_call.id or "")
-                    )
+                    tool_call_ids.append(self._deduplicate_self_repeating(tool_call.id))
 
                     # gemini-2.5 / gemini-3 series extra_content handling
                     extra_content = getattr(tool_call, "extra_content", None)
                     if extra_content is not None:
-                        deduped_id = cls._deduplicate_self_repeating(tool_call.id or "")
-                        tool_call_extra_content_dict[deduped_id] = extra_content
+                        deduped_id = self._deduplicate_self_repeating(tool_call.id)
+                        if deduped_id is not None:
+                            tool_call_extra_content_dict[deduped_id] = extra_content
 
             llm_response.role = "tool"
             llm_response.tools_call_args = args_ls

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -892,14 +892,13 @@ class ProviderOpenAIOfficial(Provider):
                     func_name_ls.append(
                         self._deduplicate_self_repeating(tool_call.function.name)
                     )
-                    tool_call_ids.append(self._deduplicate_self_repeating(tool_call.id))
+                    deduped_id = self._deduplicate_self_repeating(tool_call.id)
+                    tool_call_ids.append(deduped_id)
 
                     # gemini-2.5 / gemini-3 series extra_content handling
                     extra_content = getattr(tool_call, "extra_content", None)
-                    if extra_content is not None:
-                        deduped_id = self._deduplicate_self_repeating(tool_call.id)
-                        if deduped_id is not None:
-                            tool_call_extra_content_dict[deduped_id] = extra_content
+                    if extra_content is not None and deduped_id is not None:
+                        tool_call_extra_content_dict[deduped_id] = extra_content
 
             llm_response.role = "tool"
             llm_response.tools_call_args = args_ls

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -63,7 +63,9 @@ class ProviderOpenAIOfficial(Provider):
         return text[: cls._ERROR_TEXT_CANDIDATE_MAX_CHARS]
 
     @staticmethod
-    def _deduplicate_self_repeating(value: str | None, min_length: int = 20) -> str | None:
+    def _deduplicate_self_repeating(
+        value: str | None, min_length: int = 20
+    ) -> str | None:
         """If string is a self-repeating pattern like 'astr_kb_searchastr_kb_search'
         (exactly 2 repetitions, min 20 chars), return the base unit.
         This handles streaming chunk duplication issues for tool names/IDs.

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -63,13 +63,14 @@ class ProviderOpenAIOfficial(Provider):
         return text[: cls._ERROR_TEXT_CANDIDATE_MAX_CHARS]
 
     @staticmethod
-    def _deduplicate_self_repeating(value: str | None) -> str | None:
-        """If string is a self-repeating pattern like 'abcabc' (exactly 2 repetitions),
-        return the base unit. This handles streaming chunk duplication issues.
+    def _deduplicate_self_repeating(value: str | None, min_length: int = 20) -> str | None:
+        """If string is a self-repeating pattern like 'astr_kb_searchastr_kb_search'
+        (exactly 2 repetitions, min 20 chars), return the base unit.
+        This handles streaming chunk duplication issues for tool names/IDs.
         Returns None unchanged."""
         if value is None:
             return None
-        if not value or len(value) < 4:
+        if not value or len(value) < min_length:
             return value
         half = len(value) // 2
         if value[:half] == value[half:]:

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -64,22 +64,16 @@ class ProviderOpenAIOfficial(Provider):
 
     @staticmethod
     def _deduplicate_self_repeating(value: str | None) -> str | None:
-        """If string is a self-repeating pattern like 'abcabc' or 'abcabcabc', return the base unit.
-        This handles streaming chunk duplication issues (e.g. 'call_xxxcall_xxx').
+        """If string is a self-repeating pattern like 'abcabc' (exactly 2 repetitions),
+        return the base unit. This handles streaming chunk duplication issues.
         Returns None unchanged."""
         if value is None:
             return None
         if not value or len(value) < 4:
             return value
-        # Handle arbitrary repetitions by finding the smallest repeating unit
         half = len(value) // 2
-        for unit_size in range(1, half + 1):
-            if len(value) % unit_size != 0:
-                continue
-            unit = value[:unit_size]
-            repetitions = len(value) // unit_size
-            if unit * repetitions == value and repetitions >= 2:
-                return unit
+        if value[:half] == value[half:]:
+            return value[:half]
         return value
 
     @staticmethod


### PR DESCRIPTION
## 问题描述

使用 MiniMax 模型通过 NVIDIA 代理调用时，工具调用名出现重复拼接：

- `astr_kb_search` → `astr_kb_searchastr_kb_search`
- `call_xxx` → `call_xxxcall_xxx`

这是因为流式响应处理过程中 `chunk` 被重复累积导致的。

## 修复方案

在 `openai_source.py` 的 `_parse_openai_completion` 方法中，对 tool call 的 `id` 和 `name` 增加去重校验。当检测到字符串是由前半段和后半段相同的“自重复”模式构成时（例如 `abcabc` → `abc`），取前半段作为正确值。

## 修改内容

1. 在 `ProviderOpenAIOfficial` 类中添加 `_deduplicate_self_repeating` 静态方法，用于检测并修复自重复字符串。
2. 在解析 `tool_calls` 时，对 `function.name`、`id` 和 `extra_content` 的 key 都应用去重处理。

## 关联 Issue

Fixes #7694

## Summary by Sourcery

Deduplicate repeated values in OpenAI-compatible streaming tool calls to restore correct tool invocation behavior.

Bug Fixes:
- Prevent duplicated tool-call names, IDs, and string arguments caused by repeated accumulation of streaming response chunks.

Enhancements:
- Normalize self-repeating tool-call values before parsing arguments and associating extra tool-call content.