### PR TITLE
feat: 支持 OpenAI 与 Gemini 兼容的嵌入模型列表获取

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -2141,6 +2141,7 @@ CONFIG_METADATA_2 = {
                         "description": "嵌入模型",
                         "type": "string",
                         "hint": "嵌入模型名称。",
+                        "_special": "get_embedding_models",
                     },
                     "embedding_api_key": {
                         "description": "API Key",

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -334,6 +334,12 @@ class EmbeddingProvider(AbstractProvider):
         """获取向量的维度"""
         ...
 
+    async def get_models(self) -> list[str]:
+        """Optional model discovery for embedding providers."""
+        raise NotImplementedError(
+            "This embedding provider does not support model discovery",
+        )
+
     async def test(self) -> None:
         await self.get_embedding("astrbot")
 

--- a/astrbot/core/provider/sources/gemini_embedding_source.py
+++ b/astrbot/core/provider/sources/gemini_embedding_source.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Any, cast
 
 from google import genai
 from google.genai import types
@@ -78,6 +78,27 @@ class GeminiEmbeddingProvider(EmbeddingProvider):
         except APIError as e:
             raise Exception(f"Gemini Embedding API批量请求失败: {e.message}")
 
+    async def get_models(self) -> list[str]:
+        try:
+            models = await self.client.models.list()
+            all_model_ids: list[str] = []
+            embedding_model_ids: list[str] = []
+
+            for model in getattr(models, "page", []):
+                model_id = self._extract_model_id(model)
+                if not model_id:
+                    continue
+                all_model_ids.append(model_id)
+                if self._supports_embedding(model, model_id):
+                    embedding_model_ids.append(model_id)
+
+            all_model_ids = sorted(dict.fromkeys(all_model_ids))
+            embedding_model_ids = sorted(dict.fromkeys(embedding_model_ids))
+
+            return embedding_model_ids or all_model_ids
+        except Exception as e:
+            raise Exception(f"获取 Gemini 嵌入模型列表失败: {e!s}") from e
+
     def get_dim(self) -> int:
         """获取向量的维度"""
         return int(self.provider_config.get("embedding_dimensions", 768))
@@ -85,3 +106,30 @@ class GeminiEmbeddingProvider(EmbeddingProvider):
     async def terminate(self):
         if self.client:
             await self.client.aclose()
+
+    @staticmethod
+    def _extract_model_id(model: Any) -> str:
+        model_name = getattr(model, "name", "") or getattr(model, "model", "")
+        if not model_name:
+            return ""
+        return str(model_name).removeprefix("models/")
+
+    @classmethod
+    def _supports_embedding(cls, model: Any, model_id: str) -> bool:
+        supported_actions = getattr(model, "supported_actions", None) or getattr(
+            model, "supported_generation_methods", []
+        )
+        if isinstance(supported_actions, list):
+            normalized_actions = {
+                str(action).lower().replace("_", "").replace("-", "")
+                for action in supported_actions
+            }
+            if "embedcontent" in normalized_actions:
+                return True
+
+        return cls._looks_like_embedding_model(model_id)
+
+    @staticmethod
+    def _looks_like_embedding_model(model_id: str) -> bool:
+        normalized_model_id = model_id.lower()
+        return "embedding" in normalized_model_id or "embed" in normalized_model_id

--- a/astrbot/core/provider/sources/gemini_embedding_source.py
+++ b/astrbot/core/provider/sources/gemini_embedding_source.py
@@ -80,11 +80,10 @@ class GeminiEmbeddingProvider(EmbeddingProvider):
 
     async def get_models(self) -> list[str]:
         try:
-            models = await self.client.models.list()
             all_model_ids: list[str] = []
             embedding_model_ids: list[str] = []
 
-            for model in getattr(models, "page", []):
+            async for model in await self.client.models.list():
                 model_id = self._extract_model_id(model)
                 if not model_id:
                     continue

--- a/astrbot/core/provider/sources/openai_embedding_source.py
+++ b/astrbot/core/provider/sources/openai_embedding_source.py
@@ -14,6 +14,15 @@ from ..register import register_provider_adapter
     provider_type=ProviderType.EMBEDDING,
 )
 class OpenAIEmbeddingProvider(EmbeddingProvider):
+    _EMBEDDING_MODEL_HINTS = (
+        "embedding",
+        "bge",
+        "gte",
+        "e5",
+        "m3e",
+        "multilingual-e5",
+    )
+
     def __init__(self, provider_config: dict, provider_settings: dict) -> None:
         super().__init__(provider_config, provider_settings)
         self.provider_config = provider_config
@@ -61,6 +70,29 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
             **kwargs,
         )
         return [item.embedding for item in embeddings.data]
+
+    async def get_models(self) -> list[str]:
+        try:
+            models = await self.client.models.list()
+            all_model_ids = sorted(
+                {model.id for model in models.data if getattr(model, "id", None)}
+            )
+
+            embedding_model_ids = [
+                model_id
+                for model_id in all_model_ids
+                if self._looks_like_embedding_model(model_id)
+            ]
+
+            # Fall back to all model ids when no embedding-like names are detected.
+            return embedding_model_ids or all_model_ids
+        except Exception as e:
+            raise Exception(f"获取嵌入模型列表失败: {e!s}") from e
+
+    @classmethod
+    def _looks_like_embedding_model(cls, model_id: str) -> bool:
+        normalized = model_id.lower()
+        return any(hint in normalized for hint in cls._EMBEDDING_MODEL_HINTS)
 
     def _embedding_kwargs(self) -> dict:
         """构建嵌入请求的可选参数"""

--- a/astrbot/dashboard/routes/config.py
+++ b/astrbot/dashboard/routes/config.py
@@ -372,6 +372,10 @@ class ConfigRoute(Route):
             "/config/provider/list": ("GET", self.get_provider_config_list),
             "/config/provider/model_list": ("GET", self.get_provider_model_list),
             "/config/provider/get_embedding_dim": ("POST", self.get_embedding_dim),
+            "/config/provider/get_embedding_models": (
+                "POST",
+                self.get_embedding_models,
+            ),
             "/config/provider_sources/models": (
                 "GET",
                 self.get_provider_source_models,
@@ -844,6 +848,7 @@ class ConfigRoute(Route):
         if not provider_config:
             return Response().error("缺少参数 provider_config").__dict__
 
+        inst = None
         try:
             # 动态导入 EmbeddingProvider
             from astrbot.core.provider.provider import EmbeddingProvider
@@ -907,6 +912,80 @@ class ConfigRoute(Route):
         except Exception as e:
             logger.error(traceback.format_exc())
             return Response().error(f"获取嵌入维度失败: {e!s}").__dict__
+        finally:
+            terminate_fn = getattr(inst, "terminate", None) if inst else None
+            if inspect.iscoroutinefunction(terminate_fn):
+                try:
+                    await terminate_fn()
+                except Exception:
+                    logger.warning("释放嵌入 provider 资源失败")
+
+    async def get_embedding_models(self):
+        """根据临时 provider_config 获取可用嵌入模型列表"""
+        post_data = await request.json
+        provider_config = post_data.get("provider_config", None)
+        if not provider_config:
+            return Response().error("缺少参数 provider_config").__dict__
+
+        inst = None
+        try:
+            from astrbot.core.provider.provider import EmbeddingProvider
+            from astrbot.core.provider.register import provider_cls_map
+
+            provider_type = provider_config.get("type", None)
+            if not provider_type:
+                return Response().error("provider_config 缺少 type 字段").__dict__
+
+            if provider_type not in provider_cls_map:
+                try:
+                    self.core_lifecycle.provider_manager.dynamic_import_provider(
+                        provider_type,
+                    )
+                except ImportError:
+                    logger.error(traceback.format_exc())
+                    return Response().error("提供商适配器加载失败").__dict__
+
+            if provider_type not in provider_cls_map:
+                return (
+                    Response()
+                    .error(f"未找到适用于 {provider_type} 的提供商适配器")
+                    .__dict__
+                )
+
+            provider_metadata = provider_cls_map[provider_type]
+            cls_type = provider_metadata.cls_type
+            if not cls_type:
+                return Response().error(f"无法找到 {provider_type} 的类").__dict__
+
+            inst = cls_type(provider_config, {})
+            if not isinstance(inst, EmbeddingProvider):
+                return Response().error("提供商不是 EmbeddingProvider 类型").__dict__
+
+            init_fn = getattr(inst, "initialize", None)
+            if inspect.iscoroutinefunction(init_fn):
+                await init_fn()
+
+            try:
+                models = await inst.get_models()
+            except NotImplementedError:
+                return (
+                    Response()
+                    .error("当前提供商暂不支持自动获取模型列表，请手动填写模型 ID")
+                    .__dict__
+                )
+
+            models = sorted(dict.fromkeys(models or []))
+            return Response().ok({"models": models}).__dict__
+        except Exception as e:
+            logger.error(traceback.format_exc())
+            return Response().error(f"获取嵌入模型列表失败: {e!s}").__dict__
+        finally:
+            terminate_fn = getattr(inst, "terminate", None) if inst else None
+            if inspect.iscoroutinefunction(terminate_fn):
+                try:
+                    await terminate_fn()
+                except Exception:
+                    logger.warning("释放嵌入 provider 资源失败")
 
     async def get_provider_source_models(self):
         """获取指定 provider_source 支持的模型列表

--- a/dashboard/src/components/shared/AstrBotConfig.vue
+++ b/dashboard/src/components/shared/AstrBotConfig.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { VueMonacoEditor } from '@guolao/vue-monaco-editor'
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import ConfigItemRenderer from './ConfigItemRenderer.vue'
 import TemplateListEditor from './TemplateListEditor.vue'
 import { useI18n, useModuleI18n } from '@/i18n/composables'
@@ -88,6 +88,8 @@ const currentEditingLanguage = ref('json')
 const currentEditingTheme = ref('vs-light')
 let currentEditingKeyIterable = null
 const loadingEmbeddingDim = ref(false)
+const loadingEmbeddingModels = ref(false)
+const availableEmbeddingModels = ref([])
 
 function openEditorDialog(key, value, theme, language) {
   currentEditingKey.value = key
@@ -124,6 +126,39 @@ async function getEmbeddingDimensions(providerConfig) {
     loadingEmbeddingDim.value = false
   }
 }
+
+async function getEmbeddingModels(providerConfig) {
+  if (loadingEmbeddingModels.value) return
+
+  loadingEmbeddingModels.value = true
+  try {
+    const response = await axios.post('/api/config/provider/get_embedding_models', {
+      provider_config: providerConfig
+    })
+
+    if (response.data.status !== 'error' && Array.isArray(response.data.data?.models)) {
+      availableEmbeddingModels.value = response.data.data.models
+      useToast().success(`Fetched: ${response.data.data.models.length}`)
+    } else {
+      useToast().error(response.data.message)
+    }
+  } catch (error) {
+    console.error('Error getting embedding models:', error)
+  } finally {
+    loadingEmbeddingModels.value = false
+  }
+}
+
+watch(
+  () => [
+    props.iterable?.type,
+    props.iterable?.embedding_api_key,
+    props.iterable?.embedding_api_base
+  ],
+  () => {
+    availableEmbeddingModels.value = []
+  }
+)
 
 function getValueBySelector(obj, selector) {
   const keys = selector.split('.')
@@ -266,8 +301,11 @@ function hasVisibleItemsAfter(items, currentIndex) {
                 :plugin-name="pluginName"
                 :config-key="getItemPath(key)"
                 :loading="loadingEmbeddingDim"
+                :loading-models="loadingEmbeddingModels"
+                :available-models="availableEmbeddingModels"
                 :show-fullscreen-btn="!!metadata[metadataKey].items[key]?.editor_mode"
                 @get-embedding-dim="getEmbeddingDimensions(iterable)"
+                @get-embedding-models="getEmbeddingModels(iterable)"
                 @open-fullscreen="openEditorDialog(key, iterable, metadata[metadataKey].items[key]?.editor_theme, metadata[metadataKey].items[key]?.editor_language)"
               />
             </v-col>
@@ -311,6 +349,9 @@ function hasVisibleItemsAfter(items, currentIndex) {
             :item-meta="metadata[metadataKey]"
             :plugin-name="pluginName"
             :config-key="getItemPath(metadataKey)"
+            :loading-models="loadingEmbeddingModels"
+            :available-models="availableEmbeddingModels"
+            @get-embedding-models="getEmbeddingModels(iterable)"
           />
         </v-col>
       </v-row>

--- a/dashboard/src/components/shared/ConfigItemRenderer.vue
+++ b/dashboard/src/components/shared/ConfigItemRenderer.vue
@@ -68,6 +68,30 @@
         </v-btn>
       </div>
     </template>
+    <template v-else-if="itemMeta?._special === 'get_embedding_models'">
+      <div class="d-flex align-center gap-2">
+        <v-combobox
+          :model-value="modelValue"
+          @update:model-value="emitUpdate"
+          :items="availableModels"
+          density="compact"
+          variant="outlined"
+          class="config-field"
+          hide-details
+          clearable
+        ></v-combobox>
+        <v-btn
+          color="primary"
+          variant="tonal"
+          size="small"
+          @click="$emit('get-embedding-models')"
+          :loading="loadingModels"
+          class="ml-2"
+        >
+          {{ t('core.common.autoDetect') }}
+        </v-btn>
+      </div>
+    </template>
 
     <div
       v-else-if="itemMeta?.type === 'list' && itemMeta?.options && itemMeta?.render_type === 'checkbox'"
@@ -264,13 +288,26 @@ const props = defineProps({
     type: Boolean,
     default: false
   },
+  loadingModels: {
+    type: Boolean,
+    default: false
+  },
+  availableModels: {
+    type: Array,
+    default: () => []
+  },
   showFullscreenBtn: {
     type: Boolean,
     default: false
   }
 })
 
-const emit = defineEmits(['update:modelValue', 'get-embedding-dim', 'open-fullscreen'])
+const emit = defineEmits([
+  'update:modelValue',
+  'get-embedding-dim',
+  'get-embedding-models',
+  'open-fullscreen'
+])
 const { t } = useI18n()
 const { getRaw } = useModuleI18n('features/config-metadata')
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1243,6 +1243,25 @@ class _UnsupportedEmbeddingProvider(EmbeddingProvider):
         type(self).terminate_calls += 1
 
 
+class _ErrorEmbeddingProvider(EmbeddingProvider):
+    terminate_calls = 0
+
+    async def get_embedding(self, text: str) -> list[float]:
+        return [0.1]
+
+    async def get_embeddings(self, text: list[str]) -> list[list[float]]:
+        return [[0.1] for _ in text]
+
+    def get_dim(self) -> int:
+        return 1
+
+    async def get_models(self) -> list[str]:
+        raise RuntimeError("boom")
+
+    async def terminate(self):
+        type(self).terminate_calls += 1
+
+
 @pytest.mark.asyncio
 async def test_get_embedding_models_success_and_terminate(
     app: Quart,
@@ -1308,3 +1327,37 @@ async def test_get_embedding_models_unsupported_returns_error(
     data = await response.get_json()
     assert data["status"] == "error"
     assert _UnsupportedEmbeddingProvider.terminate_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_get_embedding_models_runtime_error_returns_error_and_terminate(
+    app: Quart,
+    authenticated_header: dict,
+    monkeypatch,
+):
+    from astrbot.core.provider.register import provider_cls_map
+
+    _ErrorEmbeddingProvider.terminate_calls = 0
+    monkeypatch.setitem(
+        provider_cls_map,
+        "test_embedding_runtime_error",
+        SimpleNamespace(cls_type=_ErrorEmbeddingProvider),
+    )
+
+    test_client = app.test_client()
+    response = await test_client.post(
+        "/api/config/provider/get_embedding_models",
+        headers=authenticated_header,
+        json={
+            "provider_config": {
+                "id": "test-embedding-provider",
+                "type": "test_embedding_runtime_error",
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    data = await response.get_json()
+    assert data["status"] == "error"
+    assert "获取嵌入模型列表失败" in data["message"]
+    assert _ErrorEmbeddingProvider.terminate_calls == 1

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1326,6 +1326,7 @@ async def test_get_embedding_models_unsupported_returns_error(
     assert response.status_code == 200
     data = await response.get_json()
     assert data["status"] == "error"
+    assert data["message"] == "当前提供商暂不支持自动获取模型列表，请手动填写模型 ID"
     assert _UnsupportedEmbeddingProvider.terminate_calls == 1
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -16,6 +16,7 @@ from werkzeug.datastructures import FileStorage
 from astrbot.core import LogBroker
 from astrbot.core.core_lifecycle import AstrBotCoreLifecycle
 from astrbot.core.db.sqlite import SQLiteDatabase
+from astrbot.core.provider.provider import EmbeddingProvider
 from astrbot.core.star.star import star_registry
 from astrbot.core.star.star_handler import star_handlers_registry
 from astrbot.core.utils.pip_installer import PipInstallError
@@ -1205,3 +1206,105 @@ async def test_batch_upload_skills_partial_success(
     assert data["data"]["failed"] == [
         {"filename": "bad_skill.zip", "error": "install failed"}
     ]
+
+
+class _DiscoverableEmbeddingProvider(EmbeddingProvider):
+    terminate_calls = 0
+
+    async def get_embedding(self, text: str) -> list[float]:
+        return [0.1]
+
+    async def get_embeddings(self, text: list[str]) -> list[list[float]]:
+        return [[0.1] for _ in text]
+
+    def get_dim(self) -> int:
+        return 1
+
+    async def get_models(self) -> list[str]:
+        return ["embedding-b", "embedding-a", "embedding-a"]
+
+    async def terminate(self):
+        type(self).terminate_calls += 1
+
+
+class _UnsupportedEmbeddingProvider(EmbeddingProvider):
+    terminate_calls = 0
+
+    async def get_embedding(self, text: str) -> list[float]:
+        return [0.1]
+
+    async def get_embeddings(self, text: list[str]) -> list[list[float]]:
+        return [[0.1] for _ in text]
+
+    def get_dim(self) -> int:
+        return 1
+
+    async def terminate(self):
+        type(self).terminate_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_get_embedding_models_success_and_terminate(
+    app: Quart,
+    authenticated_header: dict,
+    monkeypatch,
+):
+    from astrbot.core.provider.register import provider_cls_map
+
+    _DiscoverableEmbeddingProvider.terminate_calls = 0
+    monkeypatch.setitem(
+        provider_cls_map,
+        "test_embedding_discovery",
+        SimpleNamespace(cls_type=_DiscoverableEmbeddingProvider),
+    )
+
+    test_client = app.test_client()
+    response = await test_client.post(
+        "/api/config/provider/get_embedding_models",
+        headers=authenticated_header,
+        json={
+            "provider_config": {
+                "id": "test-embedding-provider",
+                "type": "test_embedding_discovery",
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    data = await response.get_json()
+    assert data["status"] == "ok"
+    assert data["data"]["models"] == ["embedding-a", "embedding-b"]
+    assert _DiscoverableEmbeddingProvider.terminate_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_get_embedding_models_unsupported_returns_error(
+    app: Quart,
+    authenticated_header: dict,
+    monkeypatch,
+):
+    from astrbot.core.provider.register import provider_cls_map
+
+    _UnsupportedEmbeddingProvider.terminate_calls = 0
+    monkeypatch.setitem(
+        provider_cls_map,
+        "test_embedding_unsupported",
+        SimpleNamespace(cls_type=_UnsupportedEmbeddingProvider),
+    )
+
+    test_client = app.test_client()
+    response = await test_client.post(
+        "/api/config/provider/get_embedding_models",
+        headers=authenticated_header,
+        json={
+            "provider_config": {
+                "id": "test-embedding-provider",
+                "type": "test_embedding_unsupported",
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    data = await response.get_json()
+    assert data["status"] == "error"
+    assert _UnsupportedEmbeddingProvider.terminate_calls == 1

--- a/tests/test_gemini_embedding_source.py
+++ b/tests/test_gemini_embedding_source.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace
+
+import pytest
+
+from astrbot.core.provider.sources.gemini_embedding_source import (
+    GeminiEmbeddingProvider,
+)
+
+
+class _FakeModelsPager:
+    def __init__(self, models) -> None:
+        self.page = models
+
+
+class _FakeModelsAPI:
+    def __init__(self, models) -> None:
+        self._models = models
+
+    async def list(self):
+        return _FakeModelsPager(self._models)
+
+
+class _FakeClient:
+    def __init__(self, models) -> None:
+        self.models = _FakeModelsAPI(models)
+        self.closed = False
+
+    async def aclose(self):
+        self.closed = True
+
+
+def _make_provider() -> GeminiEmbeddingProvider:
+    provider_config = {
+        "id": "test-gemini-embedding",
+        "type": "gemini_embedding",
+        "embedding_api_key": "test-key",
+        "embedding_api_base": "https://generativelanguage.googleapis.com",
+        "embedding_model": "gemini-embedding-exp-03-07",
+    }
+    return GeminiEmbeddingProvider(
+        provider_config=provider_config,
+        provider_settings={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_gemini_embedding_get_models_prefers_embedcontent_capability():
+    provider = _make_provider()
+    try:
+        provider.client = _FakeClient(
+            [
+                SimpleNamespace(
+                    name="models/gemini-2.5-flash",
+                    supported_actions=["generateContent"],
+                ),
+                SimpleNamespace(
+                    name="models/gemini-embedding-001",
+                    supported_actions=["embedContent"],
+                ),
+                SimpleNamespace(
+                    name="models/text-embedding-preview",
+                    supported_generation_methods=["embedContent"],
+                ),
+            ]
+        )
+        models = await provider.get_models()
+        assert models == ["gemini-embedding-001", "text-embedding-preview"]
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_gemini_embedding_get_models_falls_back_to_name_matching():
+    provider = _make_provider()
+    try:
+        provider.client = _FakeClient(
+            [
+                SimpleNamespace(name="models/chat-pro"),
+                SimpleNamespace(name="models/embed-lite"),
+                SimpleNamespace(name="models/text-embedding-preview"),
+            ]
+        )
+        models = await provider.get_models()
+        assert models == ["embed-lite", "text-embedding-preview"]
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_gemini_embedding_get_models_falls_back_to_all_when_no_match():
+    provider = _make_provider()
+    try:
+        provider.client = _FakeClient(
+            [
+                SimpleNamespace(name="models/gemini-2.5-pro"),
+                SimpleNamespace(name="models/gemini-2.5-flash"),
+                SimpleNamespace(name="models/gemini-2.5-pro"),
+            ]
+        )
+        models = await provider.get_models()
+        assert models == ["gemini-2.5-flash", "gemini-2.5-pro"]
+    finally:
+        await provider.terminate()

--- a/tests/test_gemini_embedding_source.py
+++ b/tests/test_gemini_embedding_source.py
@@ -9,7 +9,14 @@ from astrbot.core.provider.sources.gemini_embedding_source import (
 
 class _FakeModelsPager:
     def __init__(self, models) -> None:
-        self.page = models
+        self._models = models
+
+    def __aiter__(self):
+        async def _gen():
+            for model in self._models:
+                yield model
+
+        return _gen()
 
 
 class _FakeModelsAPI:

--- a/tests/test_openai_embedding_source.py
+++ b/tests/test_openai_embedding_source.py
@@ -1,0 +1,64 @@
+from types import SimpleNamespace
+
+import pytest
+
+from astrbot.core.provider.sources.openai_embedding_source import (
+    OpenAIEmbeddingProvider,
+)
+
+
+class _FakeModelsAPI:
+    def __init__(self, model_ids: list[str]) -> None:
+        self._model_ids = model_ids
+
+    async def list(self):
+        return SimpleNamespace(
+            data=[SimpleNamespace(id=model_id) for model_id in self._model_ids]
+        )
+
+
+class _FakeClient:
+    def __init__(self, model_ids: list[str]) -> None:
+        self.models = _FakeModelsAPI(model_ids)
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+
+def _make_provider() -> OpenAIEmbeddingProvider:
+    provider_config = {
+        "id": "test-openai-embedding",
+        "type": "openai_embedding",
+        "embedding_api_key": "test-key",
+        "embedding_api_base": "https://api.openai.com/v1",
+        "embedding_model": "text-embedding-3-small",
+    }
+    return OpenAIEmbeddingProvider(
+        provider_config=provider_config,
+        provider_settings={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding_get_models_filters_embedding_like_ids():
+    provider = _make_provider()
+    try:
+        provider.client = _FakeClient(
+            ["gpt-4o-mini", "text-embedding-3-small", "BAAI/bge-m3"]
+        )
+        models = await provider.get_models()
+        assert models == ["BAAI/bge-m3", "text-embedding-3-small"]
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding_get_models_falls_back_to_all_when_no_match():
+    provider = _make_provider()
+    try:
+        provider.client = _FakeClient(["chat-model-a", "vision-v1", "chat-model-a"])
+        models = await provider.get_models()
+        assert models == ["chat-model-a", "vision-v1"]
+    finally:
+        await provider.terminate()


### PR DESCRIPTION
## 背景

之前在配置嵌入模型时，用户只能手动填 `embedding_model`
我的想法是改成和对话供应商一样的，可以通过获取模型列表的方式进行选择

这次就是把这块补齐，让面板可以根据当前填写的 `API Key` 和 `Base URL` 自动拉出可用模型列表
这样用户在新增和编辑提供商时，都能直接选模型

## 改动

这次主要做了三步

- `openai_embedding` 支持通过自定义 `embedding_api_base` 和 `embedding_api_key` 获取模型列表
- `gemini_embedding` 也补上了同样的模型列表获取能力
- Dashboard 复用了现有的通用配置交互，`embedding_model` 现在可以直接下拉选择，也保留了手动输入

兼容逻辑上做了几层简单的保障

- OpenAI 兼容提供商优先筛掉明显不是嵌入模型的项
- Gemini 兼容提供商优先按模型能力判断是否支持 `embedContent`
- 如果对方返回的信息不完整，就退回到更宽松的名称判断
- 如果还是识别不出来，就直接把全部模型列出来，避免误伤可用模型

同时也保留了原来的手动填写方式
如果某个兼容平台不支持模型列表接口，或者返回格式不完整，还是可以继续手动填模型 ID

## 测试

这次补了对应测试，并且已经实际跑过

- OpenAI 嵌入模型列表获取测试
- Gemini 嵌入模型列表获取测试
- Dashboard 通用接口测试

我本地验证结果是

- `uv run ruff check` 通过
- `uv run python -m pytest tests/test_openai_embedding_source.py tests/test_gemini_embedding_source.py tests/test_dashboard.py -k "get_embedding_models or openai_embedding_get_models or gemini_embedding_get_models" -q` 通过
- 结果为 `5 passed, 22 deselected`

webui如下：
![IMG_20260423_141504.png](https://github.com/user-attachments/assets/c3a5be38-0792-4ba6-a71e-01fe7d9e9392)



## Summary by Sourcery

Add embedding model discovery support for embedding providers and expose it through the dashboard configuration API and UI.

New Features:
- Expose a new dashboard API endpoint to fetch available embedding models for a given embedding provider configuration.
- Enable OpenAI-compatible embedding providers to list and filter available embedding models based on model naming hints.
- Enable Gemini-compatible embedding providers to list and filter available embedding models based on model capabilities and naming patterns.
- Add a configurable dashboard control that lets users auto-detect and select embedding models from a fetched list while still allowing manual input.

Enhancements:
- Ensure embedding providers used for dimension and model discovery are properly terminated to release resources.
- Extend the embedding provider base class with an optional model discovery interface for implementations to override.

Tests:
- Add unit tests for OpenAI embedding providers' model discovery behavior and fallbacks.
- Add unit tests for Gemini embedding providers' model discovery behavior and fallbacks.
- Add dashboard API tests covering successful, unsupported, and error cases when fetching embedding models.