### PR TITLE
修复appid提示不适用于所有对应适配器的问题

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -783,7 +783,7 @@ CONFIG_METADATA_2 = {
                     "appid": {
                         "description": "appid",
                         "type": "string",
-                        "hint": "必填项。QQ 官方机器人平台的 appid。如何获取请参考文档。",
+                        "hint": "必填项。当前消息平台的 AppID。如何获取请参考对应平台接入文档。",
                     },
                     "secret": {
                         "description": "secret",

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -380,7 +380,7 @@
       },
       "appid": {
         "description": "App ID",
-        "hint": "Required. App ID for the QQ Official Bot platform. See the docs for how to obtain it."
+        "hint": "Required. App ID for the current messaging platform. See the platform integration docs for how to obtain it."
       },
       "callback_server_host": {
         "description": "Callback Server Host",

--- a/dashboard/src/i18n/locales/ru-RU/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/config-metadata.json
@@ -380,7 +380,7 @@
             },
             "appid": {
                 "description": "ID приложения",
-                "hint": "Обязательно для QQ Official Bot. См. документацию."
+                "hint": "Обязательно. App ID текущей платформы сообщений. См. документацию по интеграции платформы."
             },
             "callback_server_host": {
                 "description": "Хост callback-сервера",

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -382,7 +382,7 @@
       },
       "appid": {
         "description": "appid",
-        "hint": "必填项。QQ 官方机器人平台的 appid。如何获取请参考文档。"
+        "hint": "必填项。当前消息平台的 AppID。如何获取请参考对应平台接入文档。"
       },
       "callback_server_host": {
         "description": "回调服务器主机",


### PR DESCRIPTION
## 变更说明
- 将平台配置中共享 ppid 字段的提示文案改为平台中性描述
- 同步更新后端配置元数据与前端中/英/俄文案，避免前后端说明不一致
- 不修改任何适配器配置结构和运行逻辑，仅修正文案提示

## 验证情况
- 未运行测试（仅文案/元数据修改）

Fixes #7107

## Summary by Sourcery

Update configuration metadata hints to use platform-neutral AppID wording and align backend and frontend descriptions.

Enhancements:
- Clarify the shared AppID field hint to be platform-neutral across chat providers.

Documentation:
- Synchronize AppID configuration hint text across backend metadata and frontend i18n strings in Chinese, English, and Russian.