### PR TITLE
fix: Support DeepSeek-v4 by preserving reasoning content

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -508,6 +508,37 @@ class ProviderOpenAIOfficial(Provider):
         extra_body.pop("think", None)
         extra_body["reasoning_effort"] = "none"
 
+    def _clean_assistant_messages_for_chat_completion(
+        self, payloads: dict[str, Any]
+    ) -> None:
+        messages = payloads.get("messages")
+        if not isinstance(messages, list):
+            return
+
+        cleaned_messages: list[Any] = []
+        for idx, msg in enumerate(messages):
+            if isinstance(msg, dict) and msg.get("role") == "assistant":
+                content = msg.get("content")
+                tool_calls = msg.get("tool_calls")
+                reasoning_content = msg.get("reasoning_content") or msg.get("reasoning")
+
+                if (
+                    not tool_calls
+                    and not reasoning_content
+                    and (content == "" or content is None)
+                ):
+                    logger.warning(
+                        f"过滤第 {idx} 条空 assistant 消息 (无工具调用且无推理内容)"
+                    )
+                    continue
+
+                if content == "" and tool_calls:
+                    msg["content"] = None
+
+            cleaned_messages.append(msg)
+
+        payloads["messages"] = cleaned_messages
+
     async def get_models(self):
         try:
             models_str = []
@@ -546,28 +577,7 @@ class ProviderOpenAIOfficial(Provider):
             extra_body.update(custom_extra_body)
         self._apply_provider_specific_extra_body_overrides(extra_body)
 
-        model = payloads.get("model", "").lower()
-
-        if "messages" in payloads and isinstance(payloads["messages"], list):
-            cleaned_messages = []
-            for idx, msg in enumerate(payloads["messages"]):
-                # 过滤空的 assistant 消息，防止严格 API（如 Moonshot）返回 400 错误
-                if msg.get("role") == "assistant":
-                    content = msg.get("content")
-                    tool_calls = msg.get("tool_calls")
-
-                    # 情况1: 空/null content 且无 tool_calls -> 过滤掉
-                    if not tool_calls and (content == "" or content is None):
-                        logger.warning(f"过滤第 {idx} 条空 assistant 消息 (无工具调用)")
-                        continue
-
-                    # 情况2: 空 content 但有 tool_calls -> 设为 None (符合 OpenAI 规范)
-                    if content == "" and tool_calls:
-                        msg["content"] = None
-
-                cleaned_messages.append(msg)
-
-            payloads["messages"] = cleaned_messages
+        self._clean_assistant_messages_for_chat_completion(payloads)
 
         completion = await self.client.chat.completions.create(
             **payloads,
@@ -618,6 +628,7 @@ class ProviderOpenAIOfficial(Provider):
         for key in to_del:
             del payloads[key]
         self._apply_provider_specific_extra_body_overrides(extra_body)
+        self._clean_assistant_messages_for_chat_completion(payloads)
 
         stream = await self.client.chat.completions.create(
             **payloads,
@@ -629,6 +640,7 @@ class ProviderOpenAIOfficial(Provider):
         llm_response = LLMResponse("assistant", is_chunk=True)
 
         state = ChatCompletionStreamState()
+        accumulated_reasoning_content = ""
 
         async for chunk in stream:
             choice = chunk.choices[0] if chunk.choices else None
@@ -656,6 +668,7 @@ class ProviderOpenAIOfficial(Provider):
             llm_response.completion_text = ""
             if reasoning:
                 llm_response.reasoning_content = reasoning
+                accumulated_reasoning_content += reasoning
                 _y = True
             if delta and delta.content:
                 # Don't strip streaming chunks to preserve spaces between words
@@ -675,7 +688,22 @@ class ProviderOpenAIOfficial(Provider):
                 yield llm_response
 
         final_completion = state.get_final_completion()
-        llm_response = await self._parse_openai_completion(final_completion, tools)
+        try:
+            llm_response = await self._parse_openai_completion(final_completion, tools)
+        except EmptyModelOutputError:
+            if not accumulated_reasoning_content:
+                raise
+            llm_response = LLMResponse(
+                "assistant",
+                reasoning_content=accumulated_reasoning_content,
+            )
+            llm_response.raw_completion = final_completion
+            llm_response.id = final_completion.id
+            if final_completion.usage:
+                llm_response.usage = self._extract_usage(final_completion.usage)
+        else:
+            if accumulated_reasoning_content and not llm_response.reasoning_content:
+                llm_response.reasoning_content = accumulated_reasoning_content
 
         yield llm_response
 

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -246,6 +246,70 @@ async def test_openai_payload_keeps_reasoning_content_in_assistant_history():
 
 
 @pytest.mark.asyncio
+async def test_openai_payload_keeps_reasoning_only_assistant_history(monkeypatch):
+    provider = _make_provider()
+    try:
+        payloads = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "think", "think": "step 1"},
+                    ],
+                }
+            ]
+        }
+
+        provider._finally_convert_payload(payloads)
+
+        assistant_message = payloads["messages"][0]
+        assert assistant_message["content"] is None
+        assert assistant_message["reasoning_content"] == "step 1"
+
+        captured_kwargs = {}
+
+        async def fake_create(**kwargs):
+            captured_kwargs.update(kwargs)
+            return ChatCompletion.model_validate(
+                {
+                    "id": "chatcmpl-test",
+                    "object": "chat.completion",
+                    "created": 0,
+                    "model": "deepseek-reasoner",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {
+                                "role": "assistant",
+                                "content": "ok",
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                }
+            )
+
+        provider.set_model("deepseek-reasoner")
+        monkeypatch.setattr(provider.client.chat.completions, "create", fake_create)
+        await provider._query(payloads=payloads, tools=None)
+
+        assert captured_kwargs["messages"] == [
+            {
+                "role": "assistant",
+                "content": None,
+                "reasoning_content": "step 1",
+            }
+        ]
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
 async def test_groq_payload_drops_reasoning_content_from_assistant_history():
     provider = _make_groq_provider()
     try:
@@ -1264,6 +1328,108 @@ async def test_query_stream_extracts_usage_from_empty_choices_chunk(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_query_stream_accumulates_reasoning_content_in_final_response(monkeypatch):
+    provider = _make_provider({"model": "deepseek-reasoner"})
+    try:
+        chunks = [
+            ChatCompletionChunk.model_validate(
+                {
+                    "id": "chatcmpl-stream",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "deepseek-reasoner",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "role": "assistant",
+                                "reasoning_content": "step 1",
+                            },
+                            "finish_reason": None,
+                        }
+                    ],
+                }
+            ),
+            ChatCompletionChunk.model_validate(
+                {
+                    "id": "chatcmpl-stream",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "deepseek-reasoner",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "reasoning_content": " step 2",
+                            },
+                            "finish_reason": None,
+                        }
+                    ],
+                }
+            ),
+            ChatCompletionChunk.model_validate(
+                {
+                    "id": "chatcmpl-stream",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "deepseek-reasoner",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "content": "final answer",
+                            },
+                            "finish_reason": None,
+                        }
+                    ],
+                }
+            ),
+            ChatCompletionChunk.model_validate(
+                {
+                    "id": "chatcmpl-stream",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "deepseek-reasoner",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                }
+            ),
+        ]
+
+        async def fake_stream():
+            for chunk in chunks:
+                yield chunk
+
+        async def fake_create(**kwargs):
+            return fake_stream()
+
+        monkeypatch.setattr(provider.client.chat.completions, "create", fake_create)
+
+        responses = [
+            (response.reasoning_content, response.completion_text)
+            async for response in provider._query_stream(
+                payloads={
+                    "model": "deepseek-reasoner",
+                    "messages": [{"role": "user", "content": "hello"}],
+                },
+                tools=None,
+            )
+        ]
+
+        assert responses[0] == ("step 1", "")
+        final_reasoning, final_text = responses[-1]
+        assert final_text == "final answer"
+        assert final_reasoning == "step 1 step 2"
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
 async def test_query_filters_empty_assistant_message_without_tool_calls(monkeypatch):
     """Test that empty assistant messages without tool_calls are filtered out."""
     provider = _make_provider()
@@ -1371,6 +1537,155 @@ async def test_query_filters_null_content_assistant_message_without_tool_calls(
         assert len(messages) == 2
         assert messages[0] == {"role": "user", "content": "hello"}
         assert messages[1] == {"role": "user", "content": "world"}
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_query_stream_filters_empty_assistant_message_without_tool_calls(
+    monkeypatch,
+):
+    provider = _make_provider()
+    try:
+        captured_kwargs = {}
+
+        async def fake_stream():
+            yield ChatCompletionChunk.model_validate(
+                {
+                    "id": "chatcmpl-stream",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "gpt-4o-mini",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "role": "assistant",
+                                "content": "ok",
+                            },
+                            "finish_reason": None,
+                        }
+                    ],
+                }
+            )
+            yield ChatCompletionChunk.model_validate(
+                {
+                    "id": "chatcmpl-stream",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "gpt-4o-mini",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                }
+            )
+
+        async def fake_create(**kwargs):
+            captured_kwargs.update(kwargs)
+            return fake_stream()
+
+        monkeypatch.setattr(provider.client.chat.completions, "create", fake_create)
+
+        responses = [
+            response
+            async for response in provider._query_stream(
+                payloads={
+                    "model": "gpt-4o-mini",
+                    "messages": [
+                        {"role": "user", "content": "hello"},
+                        {"role": "assistant", "content": ""},
+                        {"role": "user", "content": "world"},
+                    ],
+                },
+                tools=None,
+            )
+        ]
+
+        messages = captured_kwargs["messages"]
+        assert len(messages) == 2
+        assert messages[0] == {"role": "user", "content": "hello"}
+        assert messages[1] == {"role": "user", "content": "world"}
+        assert responses[-1].completion_text == "ok"
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_query_stream_keeps_reasoning_only_assistant_history(monkeypatch):
+    provider = _make_provider({"model": "deepseek-reasoner"})
+    try:
+        captured_kwargs = {}
+
+        async def fake_stream():
+            yield ChatCompletionChunk.model_validate(
+                {
+                    "id": "chatcmpl-stream",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "deepseek-reasoner",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "role": "assistant",
+                                "content": "ok",
+                            },
+                            "finish_reason": None,
+                        }
+                    ],
+                }
+            )
+            yield ChatCompletionChunk.model_validate(
+                {
+                    "id": "chatcmpl-stream",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "deepseek-reasoner",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                }
+            )
+
+        async def fake_create(**kwargs):
+            captured_kwargs.update(kwargs)
+            return fake_stream()
+
+        monkeypatch.setattr(provider.client.chat.completions, "create", fake_create)
+
+        responses = [
+            response
+            async for response in provider._query_stream(
+                payloads={
+                    "model": "deepseek-reasoner",
+                    "messages": [
+                        {
+                            "role": "assistant",
+                            "content": None,
+                            "reasoning_content": "step 1",
+                        },
+                    ],
+                },
+                tools=None,
+            )
+        ]
+
+        assert captured_kwargs["messages"] == [
+            {
+                "role": "assistant",
+                "content": None,
+                "reasoning_content": "step 1",
+            }
+        ]
+        assert responses[-1].completion_text == "ok"
     finally:
         await provider.terminate()
 


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

DeepSeek 在更新之后,旧的调用方式经常会返回报错:
```
invalid request format to deepseek-v4's API: {"error":{"message":"Thereasoning_content' in the thinking mode must be passed back to the API.","type":"invalid_request_error""param":null,"code":"invalid_request_error"}}
```
### Modifications / 改动点

  - Preserve assistant history messages that contain `reasoning_content`.
  - Accumulate streamed DeepSeek `reasoning_content` into the final `LLMResponse`.
  - Add tests for reasoning-only history messages and streamed reasoning accumulation.

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure DeepSeek-based OpenAI provider preserves and returns reasoning content, including in streaming responses.

Bug Fixes:
- Avoid dropping assistant history messages that contain only DeepSeek reasoning content when building OpenAI payloads.
- Return final responses for DeepSeek streaming completions that provide only reasoning content without visible message text.

Tests:
- Add tests covering preservation of reasoning-only assistant history messages for DeepSeek models.
- Add streaming tests that verify incremental accumulation and final aggregation of DeepSeek reasoning_content in LLM responses.