### PR TITLE
feat(lark): add Lark streaming card footer status

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -254,6 +254,7 @@ DEFAULT_CONFIG = {
         # 平台特异配置：按平台分类，平台下按功能分组
         "lark": {
             "pre_ack_emoji": {"enable": False, "emojis": ["Typing"]},
+            "footer": {"status": False, "elapsed": False},
         },
         "telegram": {
             "pre_ack_emoji": {"enable": False, "emojis": ["✍️"]},
@@ -3874,6 +3875,14 @@ CONFIG_METADATA_3 = {
                         "condition": {
                             "platform_specific.lark.pre_ack_emoji.enable": True,
                         },
+                    },
+                    "platform_specific.lark.footer.status": {
+                        "description": "[飞书] 流式卡片底部显示生成状态",
+                        "type": "bool",
+                    },
+                    "platform_specific.lark.footer.elapsed": {
+                        "description": "[飞书] 流式卡片底部显示生成耗时",
+                        "type": "bool",
                     },
                     "platform_specific.telegram.pre_ack_emoji.enable": {
                         "description": "[Telegram] 启用预回应表情",

--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -188,6 +188,13 @@ class RespondStage(Stage):
             if result.async_stream is None:
                 logger.warning("async_stream 为空，跳过发送。")
                 return
+            if event.get_platform_name() == "lark":
+                event.set_extra(
+                    "lark_streaming_footer",
+                    self.config.get("platform_specific", {})
+                    .get("lark", {})
+                    .get("footer", {}),
+                )
             # 流式结果直接交付平台适配器处理
             realtime_segmenting = (
                 self.config.get("provider_settings", {}).get(

--- a/astrbot/core/platform/sources/lark/lark_event.py
+++ b/astrbot/core/platform/sources/lark/lark_event.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import json
 import os
+import time
 import uuid
 from io import BytesIO
 
@@ -41,6 +42,9 @@ from astrbot.core.utils.metrics import Metric
 
 
 class LarkMessageEvent(AstrMessageEvent):
+    STREAMING_TEXT_ELEMENT_ID = "markdown_1"
+    STREAMING_FOOTER_ELEMENT_ID = "footer_markdown"
+
     def __init__(
         self,
         message_str,
@@ -777,11 +781,44 @@ class LarkMessageEvent(AstrMessageEvent):
             logger.error(f"发送飞书表情回应失败({response.code}): {response.msg}")
             return
 
-    async def _create_streaming_card(self) -> str | None:
+    @staticmethod
+    def _build_streaming_footer_text(
+        *,
+        status_enabled: bool,
+        elapsed_enabled: bool,
+        completed: bool,
+        elapsed_seconds: float | None = None,
+    ) -> str:
+        parts = []
+        if status_enabled:
+            parts.append("已完成" if completed else "生成中...")
+        if elapsed_enabled and completed and elapsed_seconds is not None:
+            parts.append(f"耗时 {elapsed_seconds:.1f}s")
+        return " · ".join(parts)
+
+    async def _create_streaming_card(
+        self, footer_text: str | None = None
+    ) -> str | None:
         """创建一个开启流式更新模式的卡片实体，返回 card_id。"""
         if self.bot.cardkit is None:
             logger.error("[Lark] API Client cardkit 模块未初始化")
             return None
+
+        elements = [
+            {
+                "tag": "markdown",
+                "content": "",
+                "element_id": self.STREAMING_TEXT_ELEMENT_ID,
+            }
+        ]
+        if footer_text is not None:
+            elements.append(
+                {
+                    "tag": "markdown",
+                    "content": footer_text,
+                    "element_id": self.STREAMING_FOOTER_ELEMENT_ID,
+                }
+            )
 
         card_json = {
             "schema": "2.0",
@@ -797,15 +834,7 @@ class LarkMessageEvent(AstrMessageEvent):
                     "print_strategy": "fast",
                 },
             },
-            "body": {
-                "elements": [
-                    {
-                        "tag": "markdown",
-                        "content": "",
-                        "element_id": "markdown_1",
-                    }
-                ]
-            },
+            "body": {"elements": elements},
         }
 
         request = (
@@ -874,7 +903,7 @@ class LarkMessageEvent(AstrMessageEvent):
         request = (
             ContentCardElementRequest.builder()
             .card_id(card_id)
-            .element_id("markdown_1")
+            .element_id(self.STREAMING_TEXT_ELEMENT_ID)
             .request_body(
                 ContentCardElementRequestBody.builder()
                 .content(content)
@@ -893,6 +922,47 @@ class LarkMessageEvent(AstrMessageEvent):
 
         if not response.success():
             logger.debug(f"[Lark] 流式更新文本失败({response.code}): {response.msg}")
+            return False
+
+        return True
+
+    async def _update_streaming_footer(
+        self,
+        card_id: str,
+        content: str,
+        sequence: int,
+    ) -> bool:
+        """更新 CardKit 流式卡片底部状态文本。"""
+        if not content:
+            return True
+        if self.bot.cardkit is None:
+            logger.error("[Lark] API Client cardkit 模块未初始化")
+            return False
+
+        request = (
+            ContentCardElementRequest.builder()
+            .card_id(card_id)
+            .element_id(self.STREAMING_FOOTER_ELEMENT_ID)
+            .request_body(
+                ContentCardElementRequestBody.builder()
+                .content(content)
+                .sequence(sequence)
+                .uuid(str(uuid.uuid4()))
+                .build()
+            )
+            .build()
+        )
+
+        try:
+            response = await self.bot.cardkit.v1.card_element.acontent(request)
+        except Exception as e:
+            logger.debug(f"[Lark] 流式更新 footer 失败 (ignored): {e}")
+            return False
+
+        if not response.success():
+            logger.debug(
+                f"[Lark] 流式更新 footer 失败({response.code}): {response.msg}"
+            )
             return False
 
         return True
@@ -969,6 +1039,18 @@ class LarkMessageEvent(AstrMessageEvent):
         text_changed = asyncio.Event()
         sender_task = None
         fallback_used = False  # 回退路径已处理 Metric，避免重复上报
+        footer_cfg = self.get_extra("lark_streaming_footer", {}) or {}
+        footer_status_enabled = bool(footer_cfg.get("status", False))
+        footer_elapsed_enabled = bool(footer_cfg.get("elapsed", False))
+        footer_enabled = footer_status_enabled or footer_elapsed_enabled
+        started_at = time.monotonic()
+        initial_footer_text = None
+        if footer_enabled:
+            initial_footer_text = self._build_streaming_footer_text(
+                status_enabled=footer_status_enabled,
+                elapsed_enabled=footer_elapsed_enabled,
+                completed=False,
+            )
 
         async def _sender_loop() -> None:
             """信号驱动的文本发送循环，有新内容就发，RTT 自然限流。"""
@@ -1011,6 +1093,16 @@ class LarkMessageEvent(AstrMessageEvent):
             if delta and delta != last_sent:
                 sequence += 1
                 await self._update_streaming_text(card_id, delta, sequence)
+            if footer_enabled:
+                footer_text = self._build_streaming_footer_text(
+                    status_enabled=footer_status_enabled,
+                    elapsed_enabled=footer_elapsed_enabled,
+                    completed=True,
+                    elapsed_seconds=time.monotonic() - started_at,
+                )
+                if footer_text:
+                    sequence += 1
+                    await self._update_streaming_footer(card_id, footer_text, sequence)
             sequence += 1
             await self._close_streaming_mode(card_id, sequence)
 
@@ -1043,7 +1135,9 @@ class LarkMessageEvent(AstrMessageEvent):
 
                         # Lazy card creation on first text token
                         if card_id is None:
-                            card_id = await self._create_streaming_card()
+                            card_id = await self._create_streaming_card(
+                                initial_footer_text if footer_enabled else None
+                            )
                             if not card_id:
                                 logger.warning(
                                     "[Lark] 无法创建流式卡片，回退到非流式发送"

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -863,6 +863,14 @@
               "description": "Emoji List (Lark Emoji Enum Names)",
               "hint": "Emoji enum names reference: [https://open.feishu.cn/document/server-docs/im-v1/message-reaction/emojis-introduce](https://open.feishu.cn/document/server-docs/im-v1/message-reaction/emojis-introduce)"
             }
+          },
+          "footer": {
+            "status": {
+              "description": "[Lark] Show Generation Status in Streaming Cards"
+            },
+            "elapsed": {
+              "description": "[Lark] Show Elapsed Time in Streaming Cards"
+            }
           }
         },
         "telegram": {

--- a/dashboard/src/i18n/locales/ru-RU/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/config-metadata.json
@@ -864,6 +864,14 @@
                             "description": "Список эмодзи (Lark Enum Names)",
                             "hint": "Справка по именам эмодзи Lark."
                         }
+                    },
+                    "footer": {
+                        "status": {
+                            "description": "[Lark] Показывать статус генерации в потоковых карточках"
+                        },
+                        "elapsed": {
+                            "description": "[Lark] Показывать время генерации в потоковых карточках"
+                        }
                     }
                 },
                 "telegram": {

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -865,6 +865,14 @@
               "description": "表情列表(飞书表情枚举名)",
               "hint": "表情枚举名参考:[https://open.feishu.cn/document/server-docs/im-v1/message-reaction/emojis-introduce](https://open.feishu.cn/document/server-docs/im-v1/message-reaction/emojis-introduce)"
             }
+          },
+          "footer": {
+            "status": {
+              "description": "[飞书] 流式卡片显示生成状态"
+            },
+            "elapsed": {
+              "description": "[飞书] 流式卡片显示生成耗时"
+            }
           }
         },
         "telegram": {

--- a/tests/unit/test_lark_streaming_footer.py
+++ b/tests/unit/test_lark_streaming_footer.py
@@ -1,0 +1,142 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from astrbot.core.platform.sources.lark.lark_event import LarkMessageEvent
+
+
+class _FakeResponse:
+    def __init__(self, card_id: str = "card-id") -> None:
+        self.code = 0
+        self.msg = "ok"
+        self.data = SimpleNamespace(card_id=card_id)
+
+    def success(self) -> bool:
+        return True
+
+
+class _FakeCardApi:
+    def __init__(self) -> None:
+        self.created_request = None
+
+    async def acreate(self, request):
+        self.created_request = request
+        return _FakeResponse()
+
+
+class _FakeCardKit:
+    def __init__(self) -> None:
+        self.v1 = SimpleNamespace(card=SimpleNamespace(acreate=_FakeCardApi().acreate))
+
+
+def _extract_card_json(request) -> dict:
+    body = request.request_body
+    return json.loads(body.data)
+
+
+def _fake_lark_event(card_api: _FakeCardApi):
+    return SimpleNamespace(
+        STREAMING_TEXT_ELEMENT_ID=LarkMessageEvent.STREAMING_TEXT_ELEMENT_ID,
+        STREAMING_FOOTER_ELEMENT_ID=LarkMessageEvent.STREAMING_FOOTER_ELEMENT_ID,
+        bot=SimpleNamespace(
+            cardkit=SimpleNamespace(
+                v1=SimpleNamespace(card=SimpleNamespace(acreate=card_api.acreate))
+            )
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "status_enabled",
+        "elapsed_enabled",
+        "completed",
+        "elapsed_seconds",
+        "expected",
+    ),
+    [
+        (True, False, False, None, "生成中..."),
+        (True, False, True, None, "已完成"),
+        (False, True, False, None, ""),
+        (False, True, True, 3.24, "耗时 3.2s"),
+        (True, True, True, 3.24, "已完成 · 耗时 3.2s"),
+        (False, False, True, 3.24, ""),
+    ],
+)
+def test_build_streaming_footer_text(
+    status_enabled,
+    elapsed_enabled,
+    completed,
+    elapsed_seconds,
+    expected,
+):
+    assert (
+        LarkMessageEvent._build_streaming_footer_text(
+            status_enabled=status_enabled,
+            elapsed_enabled=elapsed_enabled,
+            completed=completed,
+            elapsed_seconds=elapsed_seconds,
+        )
+        == expected
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_streaming_card_includes_footer_element_when_enabled():
+    card_api = _FakeCardApi()
+    event = _fake_lark_event(card_api)
+
+    card_id = await LarkMessageEvent._create_streaming_card(event, "生成中...")
+
+    assert card_id == "card-id"
+    card_json = _extract_card_json(card_api.created_request)
+    elements = card_json["body"]["elements"]
+    assert elements == [
+        {
+            "tag": "markdown",
+            "content": "",
+            "element_id": LarkMessageEvent.STREAMING_TEXT_ELEMENT_ID,
+        },
+        {
+            "tag": "markdown",
+            "content": "生成中...",
+            "element_id": LarkMessageEvent.STREAMING_FOOTER_ELEMENT_ID,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_streaming_card_omits_footer_element_when_disabled():
+    card_api = _FakeCardApi()
+    event = _fake_lark_event(card_api)
+
+    card_id = await LarkMessageEvent._create_streaming_card(event, None)
+
+    assert card_id == "card-id"
+    card_json = _extract_card_json(card_api.created_request)
+    elements = card_json["body"]["elements"]
+    assert elements == [
+        {
+            "tag": "markdown",
+            "content": "",
+            "element_id": LarkMessageEvent.STREAMING_TEXT_ELEMENT_ID,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_streaming_card_keeps_empty_footer_element_for_elapsed_only():
+    card_api = _FakeCardApi()
+    event = _fake_lark_event(card_api)
+
+    card_id = await LarkMessageEvent._create_streaming_card(event, "")
+
+    assert card_id == "card-id"
+    card_json = _extract_card_json(card_api.created_request)
+    elements = card_json["body"]["elements"]
+    assert elements[-1] == {
+        "tag": "markdown",
+        "content": "",
+        "element_id": LarkMessageEvent.STREAMING_FOOTER_ELEMENT_ID,
+    }


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

Closes #7743 

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

  - 新增飞书流式卡片底部提示配置项：
    - `platform_specific.lark.footer.status`
    - `platform_specific.lark.footer.elapsed`
  - 为飞书 CardKit 流式回复卡片增加底部状态展示：
    - 开启 `status` 后，生成中显示 `生成中...`，完成后显示 `已完成`
    - 开启 `elapsed` 后，完成后显示 `耗时 x.xs`
    - 同时开启时，完成后显示 `已完成 · 耗时 x.xs`
  - 补充 WebUI 配置项文案的国际化翻译，覆盖 `zh-CN`、`en-US`、`ru-RU`
  - 增加单元测试，覆盖 footer 文案生成和 CardKit footer 元素渲染逻辑

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
 - 配置界面新增：普通配置/平台配置/其它配置
 
<img width="928" height="688" alt="image" src="https://github.com/user-attachments/assets/9ea1cbcc-bd68-4b46-808b-670ad1539db8" />

 -  原始飞书流式输出示例
 
<img width="930" height="978" alt="image" src="https://github.com/user-attachments/assets/9a1c28d0-a1c4-4451-a3d4-e3ea2dcc0be6" />

- 流式卡片显示生成状态 & 生成耗时

<img width="930" height="978" alt="image" src="https://github.com/user-attachments/assets/8f4553aa-8cd4-42d4-aa62-662618df350c" />


- 流式卡片显示生成耗时

<img width="930" height="978" alt="image" src="https://github.com/user-attachments/assets/9bafdeb8-2917-44ce-a3bd-a3dc863b6e89" />


- 流式卡片显示生成状态（生成状态是动态的，此处只截了生成完成的状态，实际还会有"生成中"的状态）

<img width="930" height="978" alt="image" src="https://github.com/user-attachments/assets/82b007bf-cdb1-4d84-b161-866d323b6cbc" />


<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Add configurable footer status information to Lark streaming cards, including generation state and elapsed time, and wire it through config, event handling, and rendering.

New Features:
- Introduce Lark streaming card footer options to show generation status and elapsed time via platform-specific configuration flags.
- Display dynamic footer text on Lark CardKit streaming replies reflecting in-progress and completed states with optional duration.
- Expose new Lark footer configuration fields in the Web UI configuration metadata with localization support.

Enhancements:
- Refactor Lark streaming card element IDs into constants to support additional elements like the footer.
- Propagate platform-specific Lark footer configuration into the streaming response pipeline for use during card rendering.

Tests:
- Add unit tests covering footer text generation logic and inclusion/omission of the footer element in created Lark streaming cards.