### PR TITLE
fix: align OpenAI http_client with SDK httpx

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -441,7 +441,14 @@ class ProviderOpenAIOfficial(Provider):
     def _create_http_client(self, provider_config: dict) -> httpx.AsyncClient:
         """创建带代理的 HTTP 客户端"""
         proxy = provider_config.get("proxy", "")
-        return create_proxy_client("OpenAI", proxy)
+        httpx_module: Any = httpx
+        try:
+            from openai import _base_client as openai_base_client
+
+            httpx_module = openai_base_client.httpx
+        except Exception:
+            httpx_module = httpx
+        return create_proxy_client("OpenAI", proxy, httpx_module=httpx_module)
 
     def __init__(self, provider_config, provider_settings) -> None:
         super().__init__(provider_config, provider_settings)

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -445,9 +445,9 @@ class ProviderOpenAIOfficial(Provider):
         try:
             from openai import _base_client as openai_base_client
 
-            httpx_module = openai_base_client.httpx
-        except Exception:
-            httpx_module = httpx
+            httpx_module = getattr(openai_base_client, "httpx", httpx)
+        except ImportError:
+            pass
         return create_proxy_client("OpenAI", proxy, httpx_module=httpx_module)
 
     def __init__(self, provider_config, provider_settings) -> None:

--- a/astrbot/core/utils/network_utils.py
+++ b/astrbot/core/utils/network_utils.py
@@ -1,6 +1,7 @@
 """Network error handling utilities for providers."""
 
 import ssl
+from typing import Any
 
 import httpx
 
@@ -89,6 +90,7 @@ def create_proxy_client(
     proxy: str | None = None,
     headers: dict[str, str] | None = None,
     verify: ssl.SSLContext | str | bool | None = None,
+    httpx_module: Any = httpx,
 ) -> httpx.AsyncClient:
     """Create an httpx AsyncClient with proxy configuration if provided.
 
@@ -105,6 +107,9 @@ def create_proxy_client(
         headers: Optional custom headers to include in every request
         verify: Optional override for TLS verification. Defaults to the shared
             system SSL context when not provided.
+        httpx_module: Optional httpx module to construct AsyncClient from. This is
+            useful when a provider SDK performs isinstance checks against its own
+            httpx import.
 
     Returns:
         An httpx.AsyncClient created with the shared system SSL context; the proxy is applied only if one is provided.
@@ -112,5 +117,7 @@ def create_proxy_client(
     resolved_verify = _SYSTEM_SSL_CTX if verify is None else verify
     if proxy:
         logger.info(f"[{provider_label}] 使用代理: {proxy}")
-        return httpx.AsyncClient(proxy=proxy, verify=resolved_verify, headers=headers)
-    return httpx.AsyncClient(verify=resolved_verify, headers=headers)
+        return httpx_module.AsyncClient(
+            proxy=proxy, verify=resolved_verify, headers=headers
+        )
+    return httpx_module.AsyncClient(verify=resolved_verify, headers=headers)

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -5,6 +5,7 @@ from openai.types.chat.chat_completion import ChatCompletion
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
 from PIL import Image as PILImage
 
+import astrbot.core.provider.sources.openai_source as openai_source_module
 from astrbot.core.exceptions import EmptyModelOutputError
 from astrbot.core.provider.sources.groq_source import ProviderGroq
 from astrbot.core.provider.sources.openai_source import ProviderOpenAIOfficial
@@ -50,6 +51,33 @@ def _make_groq_provider(overrides: dict | None = None) -> ProviderGroq:
         provider_config=provider_config,
         provider_settings={},
     )
+
+
+def test_create_http_client_uses_openai_httpx_module(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_create_proxy_client(
+        provider_label: str,
+        proxy: str | None = None,
+        headers: dict[str, str] | None = None,
+        verify=None,
+        httpx_module=None,
+    ):
+        captured["httpx_module"] = httpx_module
+        return object()
+
+    monkeypatch.setattr(
+        openai_source_module,
+        "create_proxy_client",
+        fake_create_proxy_client,
+    )
+
+    provider = ProviderOpenAIOfficial.__new__(ProviderOpenAIOfficial)
+    provider._create_http_client({"proxy": ""})
+
+    from openai import _base_client as openai_base_client
+
+    assert captured["httpx_module"] is openai_base_client.httpx
 
 
 @pytest.mark.asyncio

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -1,3 +1,4 @@
+import builtins
 from types import SimpleNamespace
 
 import pytest
@@ -78,6 +79,39 @@ def test_create_http_client_uses_openai_httpx_module(monkeypatch):
     from openai import _base_client as openai_base_client
 
     assert captured["httpx_module"] is openai_base_client.httpx
+
+
+def test_create_http_client_falls_back_to_global_httpx_module(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_create_proxy_client(
+        provider_label: str,
+        proxy: str | None = None,
+        headers: dict[str, str] | None = None,
+        verify=None,
+        httpx_module=None,
+    ):
+        captured["httpx_module"] = httpx_module
+        return object()
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "openai" and fromlist:
+            raise ImportError("missing openai._base_client")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(
+        openai_source_module,
+        "create_proxy_client",
+        fake_create_proxy_client,
+    )
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    provider = ProviderOpenAIOfficial.__new__(ProviderOpenAIOfficial)
+    provider._create_http_client({"proxy": ""})
+
+    assert captured["httpx_module"] is openai_source_module.httpx
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
﻿Fixes #7770.

The OpenAI SDK validates `http_client` with `isinstance(..., httpx.AsyncClient)` using the SDK's own `httpx` import. In some packaged/Docker environments multiple `httpx` installations can be present, causing this check to fail even when passing a real AsyncClient instance.

This change lets `create_proxy_client` build the client from a caller-provided httpx module, and updates the OpenAI provider to construct the client using `openai._base_client.httpx` (falling back to the regular `httpx` import if unavailable).

Tests:
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run pytest -q tests/test_openai_source.py::test_create_http_client_uses_openai_httpx_module`

## Summary by Sourcery

Align OpenAI HTTP client construction with the OpenAI SDK’s own httpx import to avoid type mismatches in certain environments.

Bug Fixes:
- Ensure the OpenAI provider’s HTTP client is built using the OpenAI SDK’s internal httpx module to prevent isinstance checks from failing when multiple httpx installations exist.

Enhancements:
- Allow create_proxy_client to accept an injectable httpx module so callers can control which httpx implementation is used.

Tests:
- Add a test verifying that the OpenAI provider passes the OpenAI SDK’s httpx module into create_proxy_client when creating its HTTP client.