### PR TITLE
fix: use certifi ssl context on Windows

### DIFF
--- a/astrbot/core/utils/network_utils.py
+++ b/astrbot/core/utils/network_utils.py
@@ -6,7 +6,8 @@ import httpx
 
 from astrbot import logger
 
-_SYSTEM_SSL_CTX = ssl.create_default_context()
+from astrbot.utils.http_ssl_common import build_ssl_context_with_certifi
+_SYSTEM_SSL_CTX = build_ssl_context_with_certifi()
 
 
 def is_connection_error(exc: BaseException) -> bool:

--- a/astrbot/core/utils/network_utils.py
+++ b/astrbot/core/utils/network_utils.py
@@ -93,9 +93,9 @@ def create_proxy_client(
 ) -> httpx.AsyncClient:
     """Create an httpx AsyncClient with proxy configuration if provided.
 
-    Uses the system SSL certificate store instead of certifi, which avoids
-    SSL verification failures for endpoints whose CA chain is not in certifi
-    but is trusted by the operating system.
+    Uses a hybrid SSL context that combines the system SSL certificate store
+    with certifi as a fallback, ensuring compatibility across different
+    environments including Windows where the system store may be incomplete.
 
     Note: The caller is responsible for closing the client when done.
     Consider using the client as a context manager or calling aclose() explicitly.
@@ -104,11 +104,11 @@ def create_proxy_client(
         provider_label: The provider name for log prefix (e.g., "OpenAI", "Gemini")
         proxy: The proxy address (e.g., "http://127.0.0.1:7890"), or None/empty
         headers: Optional custom headers to include in every request
-        verify: Optional override for TLS verification. Defaults to the shared
-            system SSL context when not provided.
+        verify: Optional override for TLS verification. Defaults to the hybrid
+                SSL context (system store + certifi) when not provided.
 
     Returns:
-        An httpx.AsyncClient created with the shared system SSL context; the proxy is applied only if one is provided.
+        An httpx.AsyncClient created with the hybrid SSL context (system store + certifi); the proxy is applied only if one is provided.
     """
     resolved_verify = _SYSTEM_SSL_CTX if verify is None else verify
     if proxy:

--- a/astrbot/core/utils/network_utils.py
+++ b/astrbot/core/utils/network_utils.py
@@ -5,8 +5,8 @@ import ssl
 import httpx
 
 from astrbot import logger
-
 from astrbot.utils.http_ssl_common import build_ssl_context_with_certifi
+
 _SYSTEM_SSL_CTX = build_ssl_context_with_certifi()
 
 


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
Fixes #7775

On Windows + Python 3.11, ssl.create_default_context() cannot reliably load system certificates, causing SSL verification failures when connecting to APIs like DeepSeek (which use Amazon Root CA 1). This fix replaces the bare ssl.create_default_context() call with the existing build_ssl_context_with_certifi() utility, which loads both system certs and certifi as a fallback.
### Modifications / 改动点
- Modified astrbot/core/utils/network_utils.py
- Replaced ssl.create_default_context() with build_ssl_context_with_certifi() from astrbot.utils.http_ssl_common, which already exists in the project.
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
<img width="1080" height="323" alt="image" src="https://github.com/user-attachments/assets/ef9949f0-fbf5-4012-a596-763ee87fb0ce" />
After the fix, the model list loads successfully (as shown above), instead of the previous "Connection error" (shown below).
<img width="1910" height="883" alt="image" src="https://github.com/user-attachments/assets/cd4de440-b582-4bbe-8b61-47b315969ef7" />
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Fix SSL verification failures on Windows by replacing the default SSL context with a certifi-backed context in network utilities.