### PR TITLE
fix(core): avoid false repeated-tool warnings

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -1,5 +1,7 @@
 import asyncio
 import copy
+import hashlib
+import json
 import sys
 import time
 import traceback
@@ -279,7 +281,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
         self._abort_signal = asyncio.Event()
         self._pending_follow_ups: list[FollowUpTicket] = []
         self._follow_up_seq = 0
-        self._last_tool_name: str | None = None
+        self._last_tool_call_key: tuple[str, str] | None = None
         self._same_tool_streak = 0
 
         # These two are used for tool schema mode handling
@@ -657,11 +659,25 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             return content
         return f"{content}{notice}"
 
-    def _track_tool_call_streak(self, tool_name: str) -> int:
-        if tool_name == self._last_tool_name:
+    def _fingerprint_tool_args(self, tool_args: T.Any) -> str:
+        try:
+            payload = json.dumps(
+                tool_args,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+                default=str,
+            )
+        except Exception:
+            payload = str(tool_args)
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    def _track_tool_call_streak(self, tool_name: str, tool_args: T.Any) -> int:
+        tool_key = (tool_name, self._fingerprint_tool_args(tool_args))
+        if tool_key == self._last_tool_call_key:
             self._same_tool_streak += 1
         else:
-            self._last_tool_name = tool_name
+            self._last_tool_call_key = tool_key
             self._same_tool_streak = 1
         return self._same_tool_streak
 
@@ -990,7 +1006,9 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             llm_response.tools_call_ids,
         ):
             tool_result_blocks_start = len(tool_call_result_blocks)
-            tool_call_streak = self._track_tool_call_streak(func_tool_name)
+            tool_call_streak = self._track_tool_call_streak(
+                func_tool_name, func_tool_args
+            )
             yield _HandleFunctionToolsResult.from_message_chain(
                 MessageChain(
                     type="tool_call",

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -668,7 +668,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 separators=(",", ":"),
                 default=str,
             )
-        except Exception:
+        except (TypeError, ValueError):
             payload = str(tool_args)
         return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -866,6 +866,86 @@ async def test_same_tool_consecutive_calls_with_different_args_do_not_trigger_gu
 
 
 @pytest.mark.asyncio
+async def test_same_tool_consecutive_calls_with_equivalent_args_trigger_guidance(
+    runner, mock_tool_executor, mock_hooks
+):
+    runner_cls = type(runner)
+    total_calls = runner_cls.REPEATED_TOOL_NOTICE_L3_THRESHOLD
+    provider = SequentialToolProvider(
+        ["test_tool"] * total_calls,
+        tool_args_factory=lambda i: (
+            {"a": 1, "b": 2} if i % 2 == 0 else {"b": 2, "a": 1}
+        ),
+    )
+    tool = FunctionTool(
+        name="test_tool",
+        description="test tool",
+        parameters={
+            "type": "object",
+            "properties": {
+                "a": {"type": "integer"},
+                "b": {"type": "integer"},
+            },
+            "required": ["a", "b"],
+        },
+        handler=AsyncMock(),
+    )
+    request = ProviderRequest(
+        prompt="run tool",
+        func_tool=ToolSet(tools=[tool]),
+        contexts=[],
+    )
+
+    await runner.reset(
+        provider=provider,
+        request=request,
+        run_context=ContextWrapper(context=None),
+        tool_executor=mock_tool_executor,
+        agent_hooks=mock_hooks,
+        streaming=False,
+    )
+
+    async for _ in runner.step_until_done(total_calls + 1):
+        pass
+
+    tool_messages = [
+        m for m in runner.run_context.messages if getattr(m, "role", None) == "tool"
+    ]
+    assert len(tool_messages) == total_calls
+
+    tool_contents = [str(message.content) for message in tool_messages]
+    level_1_notice = runner_cls.REPEATED_TOOL_NOTICE_L1_TEMPLATE.format(
+        tool_name="test_tool",
+        streak=runner_cls.REPEATED_TOOL_NOTICE_L1_THRESHOLD,
+    )
+    level_2_notice = runner_cls.REPEATED_TOOL_NOTICE_L2_TEMPLATE.format(
+        tool_name="test_tool",
+        streak=runner_cls.REPEATED_TOOL_NOTICE_L2_THRESHOLD,
+    )
+    level_3_notice = runner_cls.REPEATED_TOOL_NOTICE_L3_TEMPLATE.format(
+        tool_name="test_tool",
+        streak=runner_cls.REPEATED_TOOL_NOTICE_L3_THRESHOLD,
+    )
+    for streak, content in enumerate(tool_contents, start=1):
+        if streak < runner_cls.REPEATED_TOOL_NOTICE_L1_THRESHOLD:
+            assert level_1_notice not in content
+            assert level_2_notice not in content
+            assert level_3_notice not in content
+        elif streak < runner_cls.REPEATED_TOOL_NOTICE_L2_THRESHOLD:
+            assert level_1_notice in content
+            assert level_2_notice not in content
+            assert level_3_notice not in content
+        elif streak < runner_cls.REPEATED_TOOL_NOTICE_L3_THRESHOLD:
+            assert level_1_notice not in content
+            assert level_2_notice in content
+            assert level_3_notice not in content
+        else:
+            assert level_1_notice not in content
+            assert level_2_notice not in content
+            assert level_3_notice in content
+
+
+@pytest.mark.asyncio
 async def test_same_tool_streak_resets_after_switching_tools(
     runner, mock_tool_executor, mock_hooks
 ):

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -3,7 +3,7 @@ import os
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any, Callable, cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -261,9 +261,14 @@ class SingleToolThenFinalProvider(MockProvider):
 
 
 class SequentialToolProvider(MockProvider):
-    def __init__(self, tool_sequence: list[str]):
+    def __init__(
+        self,
+        tool_sequence: list[str],
+        tool_args_factory: Callable[[int], dict[str, Any]] | None = None,
+    ):
         super().__init__()
         self.tool_sequence = tool_sequence
+        self.tool_args_factory = tool_args_factory
 
     async def text_chat(self, **kwargs) -> LLMResponse:
         self.call_count += 1
@@ -276,11 +281,16 @@ class SequentialToolProvider(MockProvider):
             )
 
         tool_name = self.tool_sequence[self.call_count - 1]
+        tool_args = (
+            self.tool_args_factory(self.call_count)
+            if self.tool_args_factory is not None
+            else {"query": f"step-{self.call_count}"}
+        )
         return LLMResponse(
             role="assistant",
             completion_text="",
             tools_call_name=[tool_name],
-            tools_call_args=[{"query": f"step-{self.call_count}"}],
+            tools_call_args=[tool_args],
             tools_call_ids=[f"call_{self.call_count}"],
             usage=TokenUsage(input_other=10, output=5),
         )
@@ -734,7 +744,10 @@ async def test_same_tool_consecutive_results_include_escalating_guidance(
 ):
     runner_cls = type(runner)
     total_calls = runner_cls.REPEATED_TOOL_NOTICE_L3_THRESHOLD
-    provider = SequentialToolProvider(["test_tool"] * total_calls)
+    provider = SequentialToolProvider(
+        ["test_tool"] * total_calls,
+        tool_args_factory=lambda _: {"query": "same"},
+    )
     tool = FunctionTool(
         name="test_tool",
         description="测试工具",
@@ -798,13 +811,69 @@ async def test_same_tool_consecutive_results_include_escalating_guidance(
 
 
 @pytest.mark.asyncio
+async def test_same_tool_consecutive_calls_with_different_args_do_not_trigger_guidance(
+    runner, mock_tool_executor, mock_hooks
+):
+    runner_cls = type(runner)
+    total_calls = runner_cls.REPEATED_TOOL_NOTICE_L3_THRESHOLD
+    provider = SequentialToolProvider(["test_tool"] * total_calls)
+    tool = FunctionTool(
+        name="test_tool",
+        description="娴嬭瘯宸ュ叿",
+        parameters={"type": "object", "properties": {"query": {"type": "string"}}},
+        handler=AsyncMock(),
+    )
+    request = ProviderRequest(
+        prompt="run tool",
+        func_tool=ToolSet(tools=[tool]),
+        contexts=[],
+    )
+
+    await runner.reset(
+        provider=provider,
+        request=request,
+        run_context=ContextWrapper(context=None),
+        tool_executor=mock_tool_executor,
+        agent_hooks=mock_hooks,
+        streaming=False,
+    )
+
+    async for _ in runner.step_until_done(total_calls + 1):
+        pass
+
+    tool_messages = [
+        m for m in runner.run_context.messages if getattr(m, "role", None) == "tool"
+    ]
+    assert len(tool_messages) == total_calls
+
+    tool_contents = [str(message.content) for message in tool_messages]
+    level_1_notice = runner_cls.REPEATED_TOOL_NOTICE_L1_TEMPLATE.format(
+        tool_name="test_tool",
+        streak=runner_cls.REPEATED_TOOL_NOTICE_L1_THRESHOLD,
+    )
+    level_2_notice = runner_cls.REPEATED_TOOL_NOTICE_L2_TEMPLATE.format(
+        tool_name="test_tool",
+        streak=runner_cls.REPEATED_TOOL_NOTICE_L2_THRESHOLD,
+    )
+    level_3_notice = runner_cls.REPEATED_TOOL_NOTICE_L3_TEMPLATE.format(
+        tool_name="test_tool",
+        streak=runner_cls.REPEATED_TOOL_NOTICE_L3_THRESHOLD,
+    )
+    for content in tool_contents:
+        assert level_1_notice not in content
+        assert level_2_notice not in content
+        assert level_3_notice not in content
+
+
+@pytest.mark.asyncio
 async def test_same_tool_streak_resets_after_switching_tools(
     runner, mock_tool_executor, mock_hooks
 ):
     runner_cls = type(runner)
     repeated_after_reset = runner_cls.REPEATED_TOOL_NOTICE_L1_THRESHOLD
     provider = SequentialToolProvider(
-        ["test_tool", "other_tool", *(["test_tool"] * repeated_after_reset)]
+        ["test_tool", "other_tool", *(["test_tool"] * repeated_after_reset)],
+        tool_args_factory=lambda _: {"query": "same"},
     )
     tool_a = FunctionTool(
         name="test_tool",


### PR DESCRIPTION
Fixes #7784\n\n- Track repeated tool-call streaks by tool name + args fingerprint (instead of name-only)\n- Keeps guidance for true repetition (same tool + same args)\n\nTests: uv run pytest tests/test_tool_loop_agent_runner.py

## Summary by Sourcery

Track repeated tool-call streaks by both tool name and argument fingerprint to avoid false positive repetition warnings while preserving guidance for genuinely repeated calls with identical inputs.

Bug Fixes:
- Prevent repeated-tool guidance from triggering when the same tool is invoked consecutively with different arguments.

Enhancements:
- Add argument fingerprinting for tool calls to distinguish streaks by tool name and normalized arguments.

Tests:
- Extend SequentialToolProvider to customize per-call tool arguments and add coverage ensuring different-argument tool streaks do not emit repetition guidance messages.