### PR TITLE
[fix] 将Minimax TTS默认输出格式改为wav以解决RIFF错误

### DIFF
--- a/astrbot/core/provider/sources/minimax_tts_api_source.py
+++ b/astrbot/core/provider/sources/minimax_tts_api_source.py
@@ -65,7 +65,7 @@ class ProviderMiniMaxTTSAPI(TTSProvider):
         self.audio_setting: dict = {
             "sample_rate": 32000,
             "bitrate": 128000,
-            "format": "mp3",
+            "format": "wav",
         }
 
         self.concat_base_url: str = f"{self.api_base}?GroupId={self.group_id}"
@@ -147,7 +147,7 @@ class ProviderMiniMaxTTSAPI(TTSProvider):
     async def get_audio(self, text: str) -> str:
         temp_dir = get_astrbot_temp_path()
         os.makedirs(temp_dir, exist_ok=True)
-        path = os.path.join(temp_dir, f"minimax_tts_api_{uuid.uuid4()}.mp3")
+        path = os.path.join(temp_dir, f"minimax_tts_api_{uuid.uuid4()}.wav")
 
         try:
             # 直接将异步生成器传递给 _audio_play 方法


### PR DESCRIPTION
## 问题
在 QQ 官方平台插件中，处理来自 Minimax TTS 的语音时，会抛出错误：`处理语音时出错: file does not start with RIFF id`。

## 原因
Minimax TTS 提供商 (`minimax_tts_api_source.py`) 默认配置的音频输出格式为 `mp3`，而 `qqofficial_message_event.py` 中的 `wav_to_tencent_silk` 函数要求输入为 WAV 格式（具有 RIFF 文件头）。 

## 解决方案
将 `minimax_tts_api_source.py` 文件中 `ProviderMiniMaxTTSAPI` 类的 `audio_setting` 字典的 `format` 键值，从 `"mp3"` 修改为 `"wav"`。 

## 结果
修改后，Minimax TTS 生成的音频文件将直接为 WAV 格式，从而被下游函数正确识别和处理，修复上述错误。

### 相关 Issue
修复 issue #7144, issue #7795

### Modifications / 改动点
- **修改文件**: `minimax_tts_api_source.py`
- **具体修改**: 第 57 行，将 `"format": "mp3"` 改为 `"format": "wav"`
- **影响范围**: 仅影响使用 Minimax TTS 服务生成的音频格式
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

[2026-04-25 12:29:05.097] [Core] [INFO] [result_decorate.stage:301]: TTS 结果: /home/astrbot/AstrBot/data/temp/minimax_tts_api_31e97f25-bf49-45cb-a9ae-4fbcac7e93d1.wav
[2026-04-25 12:29:05.098] [Core] [INFO] [respond.stage:183]: Prepare to send - /DD74A1EA717091E5085E2CF5606E1FFC: [ComponentType.Record] 
<img width="1272" height="441" alt="result" src="https://github.com/user-attachments/assets/dc399239-6ffc-49c9-b74c-2657ef21da54" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Fix Minimax TTS output format mismatch that caused RIFF-related errors in QQ official platform integration.