### PR TITLE
fix(provider): preserve reasoning_content for DeepSeek thinking mode

### DIFF
--- a/astrbot/core/agent/message.py
+++ b/astrbot/core/agent/message.py
@@ -216,7 +216,7 @@ class Message(BaseModel):
             return self
 
         # assistant + reasoning_content is not None: allow content to be None
-        if self.role == "assistant" and self.reasoning_content:
+        if self.role == "assistant" and self.reasoning_content is not None:
             return self
 
         # other all cases: content is required

--- a/astrbot/core/agent/message.py
+++ b/astrbot/core/agent/message.py
@@ -195,6 +195,9 @@ class Message(BaseModel):
     tool_call_id: str | None = None
     """The ID of the tool call."""
 
+    reasoning_content: str | None = None
+    """The reasoning content from thinking mode providers (e.g. DeepSeek)."""
+
     _no_save: bool = PrivateAttr(default=False)
     _checkpoint_after: CheckpointData | None = PrivateAttr(default=None)
 
@@ -212,6 +215,10 @@ class Message(BaseModel):
         if self.role == "assistant" and self.tool_calls is not None:
             return self
 
+        # assistant + reasoning_content is not None: allow content to be None
+        if self.role == "assistant" and self.reasoning_content:
+            return self
+
         # other all cases: content is required
         if self.content is None:
             raise ValueError(
@@ -226,6 +233,8 @@ class Message(BaseModel):
             data.pop("tool_calls", None)
         if self.tool_call_id is None:
             data.pop("tool_call_id", None)
+        if self.reasoning_content is None:
+            data.pop("reasoning_content", None)
         return data
 
 

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -198,7 +198,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             Message(
                 role="assistant",
                 content=parts,
-                reasoning_content=llm_resp.reasoning_content or None,
+                reasoning_content=llm_resp.reasoning_content,
             )
         )
 
@@ -897,7 +897,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 tool_calls_info=AssistantMessageSegment(
                     tool_calls=llm_resp.to_openai_to_calls_model(),
                     content=parts,
-                    reasoning_content=llm_resp.reasoning_content or None,
+                    reasoning_content=llm_resp.reasoning_content,
                 ),
                 tool_calls_result=tool_call_result_blocks,
             )
@@ -1382,7 +1382,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 Message(
                     role="assistant",
                     content=parts,
-                    reasoning_content=llm_resp.reasoning_content or None,
+                    reasoning_content=llm_resp.reasoning_content,
                 )
             )
 

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -194,7 +194,13 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             parts.append(TextPart(text=llm_resp.completion_text))
         if len(parts) == 0:
             logger.warning("LLM returned empty assistant message with no tool calls.")
-        self.run_context.messages.append(Message(role="assistant", content=parts))
+        self.run_context.messages.append(
+            Message(
+                role="assistant",
+                content=parts,
+                reasoning_content=llm_resp.reasoning_content or None,
+            )
+        )
 
         try:
             await self.agent_hooks.on_agent_done(self.run_context, llm_resp)
@@ -891,6 +897,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 tool_calls_info=AssistantMessageSegment(
                     tool_calls=llm_resp.to_openai_to_calls_model(),
                     content=parts,
+                    reasoning_content=llm_resp.reasoning_content or None,
                 ),
                 tool_calls_result=tool_call_result_blocks,
             )
@@ -1371,7 +1378,13 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
         if llm_resp.completion_text:
             parts.append(TextPart(text=llm_resp.completion_text))
         if parts:
-            self.run_context.messages.append(Message(role="assistant", content=parts))
+            self.run_context.messages.append(
+                Message(
+                    role="assistant",
+                    content=parts,
+                    reasoning_content=llm_resp.reasoning_content or None,
+                )
+            )
 
         try:
             await self.agent_hooks.on_agent_done(self.run_context, llm_resp)

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -519,6 +519,46 @@ class ProviderOpenAIOfficial(Provider):
         except NotFoundError as e:
             raise Exception(f"获取模型列表失败：{e}")
 
+    @staticmethod
+    def _sanitize_assistant_messages(payloads: dict) -> None:
+        """在请求发送前过滤/规范化空的 assistant 消息。
+
+        严格 API（Moonshot、DeepSeek Reasoner 等）会在 assistant 消息同时缺少
+        ``content``、``tool_calls`` 和 ``reasoning_content`` 时返回 400。
+
+        把 ``""`` / ``None`` / ``[]`` 都视作空内容：
+        - 无 tool_calls/reasoning_content 时整条过滤掉；
+        - 有 tool_calls 或 reasoning_content 时将 content 设为 ``None``。
+        就地修改 ``payloads["messages"]``。
+        """
+        messages = payloads.get("messages")
+        if not isinstance(messages, list):
+            return
+
+        def _is_empty(content: Any) -> bool:
+            return content is None or content == "" or content == []
+
+        cleaned: list[Any] = []
+        for idx, msg in enumerate(messages):
+            if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                cleaned.append(msg)
+                continue
+
+            content = msg.get("content")
+            tool_calls = msg.get("tool_calls")
+            has_reasoning_content = "reasoning_content" in msg
+
+            if _is_empty(content) and not tool_calls and not has_reasoning_content:
+                logger.warning(f"过滤第 {idx} 条空 assistant 消息 (无工具调用)")
+                continue
+
+            if _is_empty(content) and (tool_calls or has_reasoning_content):
+                msg["content"] = None
+
+            cleaned.append(msg)
+
+        payloads["messages"] = cleaned
+
     async def _query(self, payloads: dict, tools: ToolSet | None) -> LLMResponse:
         if tools:
             model = payloads.get("model", "").lower()
@@ -546,33 +586,7 @@ class ProviderOpenAIOfficial(Provider):
             extra_body.update(custom_extra_body)
         self._apply_provider_specific_extra_body_overrides(extra_body)
 
-        model = payloads.get("model", "").lower()
-
-        if "messages" in payloads and isinstance(payloads["messages"], list):
-            cleaned_messages = []
-            for idx, msg in enumerate(payloads["messages"]):
-                # 过滤空的 assistant 消息，防止严格 API（如 Moonshot）返回 400 错误
-                if msg.get("role") == "assistant":
-                    content = msg.get("content")
-                    tool_calls = msg.get("tool_calls")
-                    has_reasoning_content = "reasoning_content" in msg
-
-                    # 情况1: 空/null content 且无 tool_calls/reasoning_content -> 过滤掉
-                    if (
-                        not tool_calls
-                        and not has_reasoning_content
-                        and (content == "" or content is None)
-                    ):
-                        logger.warning(f"过滤第 {idx} 条空 assistant 消息 (无工具调用)")
-                        continue
-
-                    # 情况2: 空 content 但有 tool_calls -> 设为 None (符合 OpenAI 规范)
-                    if content == "" and tool_calls:
-                        msg["content"] = None
-
-                cleaned_messages.append(msg)
-
-            payloads["messages"] = cleaned_messages
+        self._sanitize_assistant_messages(payloads)
 
         completion = await self.client.chat.completions.create(
             **payloads,
@@ -623,6 +637,8 @@ class ProviderOpenAIOfficial(Provider):
         for key in to_del:
             del payloads[key]
         self._apply_provider_specific_extra_body_overrides(extra_body)
+
+        self._sanitize_assistant_messages(payloads)
 
         stream = await self.client.chat.completions.create(
             **payloads,
@@ -969,20 +985,26 @@ class ProviderOpenAIOfficial(Provider):
         model = payloads.get("model", "").lower()
         is_gemini = "gemini" in model
         messages = payloads.get("messages", [])
+        if not isinstance(messages, list):
+            return
 
         for message in messages:
+            if not isinstance(message, dict):
+                continue
+
             if message.get("role") == "assistant" and isinstance(
                 message.get("content"), list
             ):
                 reasoning_content: str | None = None
                 new_content = []  # not including think part
                 for part in message["content"]:
-                    if part.get("type") == "think":
+                    if isinstance(part, dict) and part.get("type") == "think":
                         reasoning_content = (reasoning_content or "") + str(
-                            part.get("think")
+                            part.get("think") or ""
                         )
                     else:
                         new_content.append(part)
+
                 # Some providers (Grok, etc.) reject empty content lists.
                 # When all parts were think blocks, fall back to None.
                 message["content"] = new_content or None
@@ -1003,7 +1025,7 @@ class ProviderOpenAIOfficial(Provider):
                             {"result": content}, ensure_ascii=False
                         )
 
-        if self._is_deepseek_thinking_model(model) and isinstance(messages, list):
+        if self._is_deepseek_thinking_model(model):
             self._normalize_deepseek_thinking_messages(messages)
 
     @staticmethod
@@ -1015,7 +1037,7 @@ class ProviderOpenAIOfficial(Provider):
     @staticmethod
     def _normalize_deepseek_thinking_messages(messages: list[dict]) -> None:
         for message in messages:
-            if message.get("role") != "assistant":
+            if not isinstance(message, dict) or message.get("role") != "assistant":
                 continue
             message.setdefault("reasoning_content", "")
             if message.get("content") == []:

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -555,12 +555,12 @@ class ProviderOpenAIOfficial(Provider):
                 if msg.get("role") == "assistant":
                     content = msg.get("content")
                     tool_calls = msg.get("tool_calls")
-                    reasoning_content = msg.get("reasoning_content")
+                    has_reasoning_content = "reasoning_content" in msg
 
                     # 情况1: 空/null content 且无 tool_calls/reasoning_content -> 过滤掉
                     if (
                         not tool_calls
-                        and not reasoning_content
+                        and not has_reasoning_content
                         and (content == "" or content is None)
                     ):
                         logger.warning(f"过滤第 {idx} 条空 assistant 消息 (无工具调用)")
@@ -968,16 +968,19 @@ class ProviderOpenAIOfficial(Provider):
         """Finally convert the payload. Such as think part conversion, tool inject."""
         model = payloads.get("model", "").lower()
         is_gemini = "gemini" in model
+        messages = payloads.get("messages", [])
 
-        for message in payloads.get("messages", []):
+        for message in messages:
             if message.get("role") == "assistant" and isinstance(
                 message.get("content"), list
             ):
-                reasoning_content = ""
+                reasoning_content: str | None = None
                 new_content = []  # not including think part
                 for part in message["content"]:
                     if part.get("type") == "think":
-                        reasoning_content += str(part.get("think"))
+                        reasoning_content = (reasoning_content or "") + str(
+                            part.get("think")
+                        )
                     else:
                         new_content.append(part)
                 # Some providers (Grok, etc.) reject empty content lists.
@@ -999,6 +1002,24 @@ class ProviderOpenAIOfficial(Provider):
                         message["content"] = json.dumps(
                             {"result": content}, ensure_ascii=False
                         )
+
+        if self._is_deepseek_thinking_model(model) and isinstance(messages, list):
+            self._normalize_deepseek_thinking_messages(messages)
+
+    @staticmethod
+    def _is_deepseek_thinking_model(model: str) -> bool:
+        return "deepseek" in model and (
+            "v4" in model or "reasoner" in model or "flash" in model
+        )
+
+    @staticmethod
+    def _normalize_deepseek_thinking_messages(messages: list[dict]) -> None:
+        for message in messages:
+            if message.get("role") != "assistant":
+                continue
+            message.setdefault("reasoning_content", "")
+            if message.get("content") == []:
+                message["content"] = None
 
     async def _handle_api_error(
         self,

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -555,9 +555,14 @@ class ProviderOpenAIOfficial(Provider):
                 if msg.get("role") == "assistant":
                     content = msg.get("content")
                     tool_calls = msg.get("tool_calls")
+                    reasoning_content = msg.get("reasoning_content")
 
-                    # 情况1: 空/null content 且无 tool_calls -> 过滤掉
-                    if not tool_calls and (content == "" or content is None):
+                    # 情况1: 空/null content 且无 tool_calls/reasoning_content -> 过滤掉
+                    if (
+                        not tool_calls
+                        and not reasoning_content
+                        and (content == "" or content is None)
+                    ):
                         logger.warning(f"过滤第 {idx} 条空 assistant 消息 (无工具调用)")
                         continue
 

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -983,7 +983,9 @@ class ProviderOpenAIOfficial(Provider):
                 # Some providers (Grok, etc.) reject empty content lists.
                 # When all parts were think blocks, fall back to None.
                 message["content"] = new_content or None
-                if reasoning_content is not None and not message.get("reasoning_content"):
+                if reasoning_content is not None and not message.get(
+                    "reasoning_content"
+                ):
                     message["reasoning_content"] = reasoning_content
 
             # Gemini 的 function_response 要求 google.protobuf.Struct（即 JSON 对象），

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -978,7 +978,7 @@ class ProviderOpenAIOfficial(Provider):
                 # Some providers (Grok, etc.) reject empty content lists.
                 # When all parts were think blocks, fall back to None.
                 message["content"] = new_content or None
-                if reasoning_content:
+                if reasoning_content and not message.get("reasoning_content"):
                     message["reasoning_content"] = reasoning_content
 
             # Gemini 的 function_response 要求 google.protobuf.Struct（即 JSON 对象），

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -983,7 +983,7 @@ class ProviderOpenAIOfficial(Provider):
                 # Some providers (Grok, etc.) reject empty content lists.
                 # When all parts were think blocks, fall back to None.
                 message["content"] = new_content or None
-                if reasoning_content and not message.get("reasoning_content"):
+                if reasoning_content is not None and not message.get("reasoning_content"):
                     message["reasoning_content"] = reasoning_content
 
             # Gemini 的 function_response 要求 google.protobuf.Struct（即 JSON 对象），

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -246,6 +246,40 @@ async def test_openai_payload_keeps_reasoning_content_in_assistant_history():
 
 
 @pytest.mark.asyncio
+async def test_deepseek_thinking_payload_adds_empty_reasoning_content_to_assistant_history():
+    provider = _make_provider({"model": "deepseek-v4-flash"})
+    try:
+        payloads = {
+            "model": "deepseek-v4-flash",
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "foreign assistant reply"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "search", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+            ],
+        }
+
+        provider._finally_convert_payload(payloads)
+
+        assert payloads["messages"][1]["reasoning_content"] == ""
+        assert payloads["messages"][2]["reasoning_content"] == ""
+        assert "reasoning_content" not in payloads["messages"][0]
+        assert "reasoning_content" not in payloads["messages"][3]
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
 async def test_groq_payload_drops_reasoning_content_from_assistant_history():
     provider = _make_groq_provider()
     try:
@@ -1431,6 +1465,67 @@ async def test_query_keeps_reasoning_only_assistant_message(monkeypatch):
             "role": "assistant",
             "content": None,
             "reasoning_content": "deepseek reasoning",
+        }
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_query_keeps_empty_reasoning_content_assistant_message(monkeypatch):
+    """Test that empty reasoning_content still marks an assistant message as valid."""
+    provider = _make_provider()
+    try:
+        captured_kwargs = {}
+
+        async def fake_create(**kwargs):
+            captured_kwargs.update(kwargs)
+            return ChatCompletion.model_validate(
+                {
+                    "id": "chatcmpl-test",
+                    "object": "chat.completion",
+                    "created": 0,
+                    "model": "gpt-4o-mini",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {
+                                "role": "assistant",
+                                "content": "ok",
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                }
+            )
+
+        monkeypatch.setattr(provider.client.chat.completions, "create", fake_create)
+
+        payloads = {
+            "model": "gpt-4o-mini",
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "reasoning_content": "",
+                },
+                {"role": "user", "content": "world"},
+            ],
+        }
+
+        await provider._query(payloads=payloads, tools=None)
+
+        messages = captured_kwargs["messages"]
+        assert len(messages) == 3
+        assert messages[1] == {
+            "role": "assistant",
+            "content": None,
+            "reasoning_content": "",
         }
     finally:
         await provider.terminate()

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -1376,6 +1376,67 @@ async def test_query_filters_null_content_assistant_message_without_tool_calls(
 
 
 @pytest.mark.asyncio
+async def test_query_keeps_reasoning_only_assistant_message(monkeypatch):
+    """Test that reasoning-only assistant messages are preserved for thinking models."""
+    provider = _make_provider()
+    try:
+        captured_kwargs = {}
+
+        async def fake_create(**kwargs):
+            captured_kwargs.update(kwargs)
+            return ChatCompletion.model_validate(
+                {
+                    "id": "chatcmpl-test",
+                    "object": "chat.completion",
+                    "created": 0,
+                    "model": "gpt-4o-mini",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {
+                                "role": "assistant",
+                                "content": "ok",
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                }
+            )
+
+        monkeypatch.setattr(provider.client.chat.completions, "create", fake_create)
+
+        payloads = {
+            "model": "gpt-4o-mini",
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "reasoning_content": "deepseek reasoning",
+                },
+                {"role": "user", "content": "world"},
+            ],
+        }
+
+        await provider._query(payloads=payloads, tools=None)
+
+        messages = captured_kwargs["messages"]
+        assert len(messages) == 3
+        assert messages[1] == {
+            "role": "assistant",
+            "content": None,
+            "reasoning_content": "deepseek reasoning",
+        }
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
 async def test_query_converts_empty_content_to_none_with_tool_calls(monkeypatch):
     """Test that empty content with tool_calls is converted to None (OpenAI spec)."""
     provider = _make_provider()


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
Fixes https://github.com/AstrBotDevs/AstrBot/issues/7798
修复 DeepSeek 思考模式在多轮对话中失败的问题：含有 `reasoning_content` 的助手历史消息未被保存并回传给 API，导致 API 返回 `400 Bad Request: The reasoning_content in the thinking mode must be passed back to the API`。

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
- 为内部 `Message` 模型添加了 `reasoning_content` 字段，使持久化的助手历史可以保留思考模式的推理元数据。
- 在工具循环运行器追加普通助手消息、工具调用消息以及被中断的助手消息时，同时保存 `reasoning_content`。
- 更新 OpenAI 兼容的 payload 转换逻辑，保留已有的顶级 `reasoning_content`，仅当该字段缺失时才从 `ThinkPart` 中提取。
- 更新助手消息清理逻辑，允许仅有 `reasoning_content` 的助手消息被视为有效，而不是被当作空消息丢弃。
- 添加了回归测试，验证 OpenAI 兼容 payload 中仅含 `reasoning_content` 的助手消息能被正确保留。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
本地手动验证确认持久化的历史消息通过消息绑定和 OpenAI payload 转换后仍保留 reasoning_content：
```
{'role': 'assistant', 'content': 'final', 'reasoning_content': 'deepseek reasoning'}
{'role': 'assistant', 'content': 'final', 'reasoning_content': 'deepseek reasoning'}
```

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Preserve DeepSeek-style reasoning metadata across assistant messages so thinking-mode conversations remain valid for OpenAI-compatible providers.

Bug Fixes:
- Ensure assistant history messages with only reasoning_content are not filtered out when building OpenAI-compatible payloads, preventing 400 errors from thinking-mode providers.

Enhancements:
- Extend the internal Message model and tool loop runner to store and propagate reasoning_content for assistant messages, including tool call and aborted responses.

Tests:
- Add a regression test confirming reasoning-only assistant messages are preserved when querying via the OpenAI source.