### PR TITLE
fix(computer): allow non-empty skill payload args

### DIFF
--- a/astrbot/core/tools/computer_tools/shipyard_neo/neo_skills.py
+++ b/astrbot/core/tools/computer_tools/shipyard_neo/neo_skills.py
@@ -193,7 +193,13 @@ class CreateSkillPayloadTool(NeoSkillToolBase):
                                 },
                             },
                         },
-                        {"type": "array", "items": {}},
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": True,
+                            },
+                        },
                     ],
                     "description": (
                         "Skill payload JSON. Typical schema: {skill_markdown, inputs, outputs, meta}. "

--- a/astrbot/core/tools/computer_tools/shipyard_neo/neo_skills.py
+++ b/astrbot/core/tools/computer_tools/shipyard_neo/neo_skills.py
@@ -168,8 +168,32 @@ class CreateSkillPayloadTool(NeoSkillToolBase):
             "properties": {
                 "payload": {
                     "anyOf": [
-                        {"type": "object"},
-                        {"type": "array", "items": {"type": "object"}},
+                        {
+                            "type": "object",
+                            "additionalProperties": True,
+                            "properties": {
+                                "skill_markdown": {"type": "string"},
+                                "inputs": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "additionalProperties": True,
+                                    },
+                                },
+                                "outputs": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "additionalProperties": True,
+                                    },
+                                },
+                                "meta": {
+                                    "type": "object",
+                                    "additionalProperties": True,
+                                },
+                            },
+                        },
+                        {"type": "array", "items": {}},
                     ],
                     "description": (
                         "Skill payload JSON. Typical schema: {skill_markdown, inputs, outputs, meta}. "

--- a/tests/test_neo_skill_tools.py
+++ b/tests/test_neo_skill_tools.py
@@ -4,6 +4,7 @@ import asyncio
 from types import SimpleNamespace
 
 from astrbot.core.agent.run_context import ContextWrapper
+from astrbot.core.agent.tool import ToolSet
 from astrbot.core.tools.computer_tools.shipyard_neo.neo_skills import (
     CreateSkillPayloadTool,
     PromoteSkillCandidateTool,
@@ -103,4 +104,16 @@ def test_create_skill_payload_tool_schema_allows_non_empty_payload_objects():
     array_schema = next(
         s for s in payload_schema["anyOf"] if isinstance(s, dict) and s.get("type") == "array"
     )
-    assert array_schema.get("items") == {}
+    assert array_schema.get("items", {}).get("type") == "object"
+    assert array_schema.get("items", {}).get("additionalProperties") is True
+
+
+def test_create_skill_payload_tool_google_schema_keeps_object_array_items():
+    tool = CreateSkillPayloadTool()
+    schema = ToolSet([tool]).google_schema()
+    payload_schema = schema["function_declarations"][0]["parameters"]["properties"]["payload"]
+
+    array_schema = next(
+        s for s in payload_schema["anyOf"] if isinstance(s, dict) and s.get("type") == "array"
+    )
+    assert array_schema["items"]["type"] == "object"

--- a/tests/test_neo_skill_tools.py
+++ b/tests/test_neo_skill_tools.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 from astrbot.core.agent.run_context import ContextWrapper
 from astrbot.core.tools.computer_tools.shipyard_neo.neo_skills import (
+    CreateSkillPayloadTool,
     PromoteSkillCandidateTool,
 )
 
@@ -86,3 +87,20 @@ def test_promote_stable_sync_failure_auto_rolls_back(monkeypatch):
     assert isinstance(result, str)
     assert "auto rollback succeeded" in result
     assert "sync failed" in result
+
+
+def test_create_skill_payload_tool_schema_allows_non_empty_payload_objects():
+    tool = CreateSkillPayloadTool()
+    payload_schema = tool.parameters["properties"]["payload"]
+    assert "anyOf" in payload_schema
+
+    object_schema = next(
+        s for s in payload_schema["anyOf"] if isinstance(s, dict) and s.get("type") == "object"
+    )
+    assert object_schema.get("additionalProperties") is True
+    assert "skill_markdown" in object_schema.get("properties", {})
+
+    array_schema = next(
+        s for s in payload_schema["anyOf"] if isinstance(s, dict) and s.get("type") == "array"
+    )
+    assert array_schema.get("items") == {}


### PR DESCRIPTION
Fixes #7521.

Some OpenAI-compatible models tend to emit `{}` for `astrbot_create_skill_payload(payload=...)` when the schema doesn't explicitly allow/describe a non-empty object.

Changes:
- Make the `payload` schema explicitly permissive for objects (`additionalProperties: true`) and provide common top-level fields (`skill_markdown`, `inputs`, `outputs`, `meta`) as guidance.
- Keep array payload support but allow any item type (`items: {}`) to avoid over-restricting valid JSON.
- Add a small unit test asserting the schema remains permissive.

Test:
- `uv run pytest -q tests/test_neo_skill_tools.py -k create_skill_payload_tool_schema`
- `uv run ruff format .`
- `uv run ruff check .`

## Summary by Sourcery

Relax CreateSkillPayloadTool payload schema to accept richer JSON objects and arrays while remaining OpenAI-compatible.

Bug Fixes:
- Allow non-empty payload objects to be passed to CreateSkillPayloadTool without being rejected by overly strict JSON schema validation.

Enhancements:
- Broaden payload object schema with permissive additional properties and documented common top-level fields for skill definitions.
- Relax array payload schema to accept arrays of any item type instead of only objects.

Tests:
- Add a unit test to assert the payload schema remains permissive for non-empty objects and arrays.