### PR TITLE
fix: restore legacy t2i template variable

### DIFF
--- a/astrbot/core/utils/t2i/network_strategy.py
+++ b/astrbot/core/utils/t2i/network_strategy.py
@@ -161,6 +161,6 @@ class NetworkRenderStrategy(RenderStrategy):
         text_base64 = base64.b64encode(text.encode("utf-8")).decode("ascii")
         return await self.render_custom_template(
             tmpl_str,
-            {"text_base64": text_base64, "version": f"v{VERSION}"},
+            {"text_base64": text_base64, "text": text, "version": f"v{VERSION}"},
             return_url,
         )

--- a/tests/unit/test_t2i_network_strategy.py
+++ b/tests/unit/test_t2i_network_strategy.py
@@ -1,0 +1,44 @@
+import base64
+
+import pytest
+
+from astrbot.core.config import VERSION
+from astrbot.core.utils.t2i.network_strategy import NetworkRenderStrategy
+
+
+@pytest.mark.asyncio
+async def test_network_render_strategy_passes_text_and_text_base64(monkeypatch):
+    captured: dict = {}
+
+    async def fake_get_template(self, name: str = "base") -> str:
+        return "<html>{{ text }}</html>"
+
+    async def fake_render_custom_template(
+        self,
+        tmpl_str: str,
+        tmpl_data: dict,
+        return_url: bool = True,
+        options: dict | None = None,
+    ) -> str:
+        captured["tmpl_str"] = tmpl_str
+        captured["tmpl_data"] = tmpl_data
+        captured["return_url"] = return_url
+        captured["options"] = options
+        return "ok"
+
+    monkeypatch.setattr(NetworkRenderStrategy, "get_template", fake_get_template)
+    monkeypatch.setattr(
+        NetworkRenderStrategy,
+        "render_custom_template",
+        fake_render_custom_template,
+    )
+
+    strategy = NetworkRenderStrategy(base_url="https://example.com")
+    await strategy.render("hello", return_url=True, template_name="base")
+
+    assert captured["tmpl_str"] == "<html>{{ text }}</html>"
+    assert captured["tmpl_data"]["text"] == "hello"
+    assert captured["tmpl_data"]["text_base64"] == base64.b64encode(
+        b"hello"
+    ).decode("ascii")
+    assert captured["tmpl_data"]["version"] == f"v{VERSION}"


### PR DESCRIPTION
Fixes #7750.

- Pass both 	ext_base64 (new) and 	ext (legacy) into T2I template data so existing user-overridden templates keep rendering after upgrades.
- Add a unit test to lock the behavior.

## Summary by Sourcery

Restore support for the legacy text template variable in the T2I network render strategy while preserving the new base64 variant.

Bug Fixes:
- Ensure T2I templates receive both plain text and base64-encoded text to maintain compatibility with existing user-defined templates.

Tests:
- Add a unit test verifying that the T2I network render strategy passes plain text, base64 text, and version into the template renderer.