### PR TITLE
fix(core): restrict send_message_to_user to current session (security fix #7822)

### DIFF
--- a/astrbot/core/tools/message_tools.py
+++ b/astrbot/core/tools/message_tools.py
@@ -14,6 +14,7 @@ from astrbot.core.astr_agent_context import AstrAgentContext
 from astrbot.core.computer.computer_client import get_booter
 from astrbot.core.message.message_event_result import MessageChain
 from astrbot.core.platform.message_session import MessageSession
+from astrbot.core.tools.computer_tools.util import check_admin_permission
 from astrbot.core.tools.registry import builtin_tool
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
 
@@ -23,12 +24,13 @@ from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
 class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
     name: str = "send_message_to_user"
     description: str = (
-        "Send message to the current user/session. "
+        "Send message to the user. "
         "Supports various message types including `plain`, `image`, `record`, `video`, `file`, and `mention_user`. "
         "Use this tool to send media files (`image`, `record`, `video`, `file`), "
         "or when you need to proactively message the user (such as cron job). "
         "For normal text replies, you can output directly. "
-        "This tool always sends the message to the current user's session and CANNOT send to other sessions."
+        "Optionally specify a `session` to send the message to a different session (admin only). "
+        "If no session is specified, the message is sent to the current user's session."
     )
     parameters: dict = Field(
         default_factory=lambda: {
@@ -67,6 +69,10 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
                         "required": ["type"],
                     },
                 },
+            },
+            "session": {
+                "type": "string",
+                "description": "Optional. Target session string. Defaults to current session. Only AstrBot admins can send to other sessions.",
             },
             "required": ["messages"],
         }
@@ -115,11 +121,16 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
     async def call(
         self, context: ContextWrapper[AstrAgentContext], **kwargs
     ) -> ToolExecResult:
-        # SECURITY FIX: Always use the current session (the user who triggered the tool).
-        # Previously, the tool accepted a user-controlled "session" parameter, which allowed
-        # attackers to send arbitrary messages to arbitrary sessions (groups/chats).
+        # Security: only AstrBot admins can send messages to other sessions.
+        # Non-admin users are always restricted to their own session.
         # See https://github.com/AstrBotDevs/AstrBot/issues/7822
-        session = context.context.event.unified_msg_origin
+        current_session = context.context.event.unified_msg_origin
+        session = kwargs.get("session") or current_session
+        if session != current_session:
+            if permission_error := check_admin_permission(
+                context, "Send message to another session"
+            ):
+                return permission_error
         messages = kwargs.get("messages")
         if not isinstance(messages, list) or not messages:
             return "error: messages parameter is empty or invalid."

--- a/astrbot/core/tools/message_tools.py
+++ b/astrbot/core/tools/message_tools.py
@@ -23,10 +23,12 @@ from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
 class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
     name: str = "send_message_to_user"
     description: str = (
-        "Send message to the user. "
+        "Send message to the current user/session. "
         "Supports various message types including `plain`, `image`, `record`, `video`, `file`, and `mention_user`. "
         "Use this tool to send media files (`image`, `record`, `video`, `file`), "
-        "or when you need to proactively message the user(such as cron job). For normal text replies, you can output directly."
+        "or when you need to proactively message the user (such as cron job). "
+        "For normal text replies, you can output directly. "
+        "This tool always sends the message to the current user's session and CANNOT send to other sessions."
     )
     parameters: dict = Field(
         default_factory=lambda: {
@@ -64,10 +66,6 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
                         },
                         "required": ["type"],
                     },
-                },
-                "session": {
-                    "type": "string",
-                    "description": "Optional. Target session string. Defaults to current session.",
                 },
             },
             "required": ["messages"],
@@ -117,7 +115,11 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
     async def call(
         self, context: ContextWrapper[AstrAgentContext], **kwargs
     ) -> ToolExecResult:
-        session = kwargs.get("session") or context.context.event.unified_msg_origin
+        # SECURITY FIX: Always use the current session (the user who triggered the tool).
+        # Previously, the tool accepted a user-controlled "session" parameter, which allowed
+        # attackers to send arbitrary messages to arbitrary sessions (groups/chats).
+        # See https://github.com/AstrBotDevs/AstrBot/issues/7822
+        session = context.context.event.unified_msg_origin
         messages = kwargs.get("messages")
         if not isinstance(messages, list) or not messages:
             return "error: messages parameter is empty or invalid."

--- a/astrbot/core/tools/message_tools.py
+++ b/astrbot/core/tools/message_tools.py
@@ -27,10 +27,7 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
         "Send message to the user. "
         "Supports various message types including `plain`, `image`, `record`, `video`, `file`, and `mention_user`. "
         "Use this tool to send media files (`image`, `record`, `video`, `file`), "
-        "or when you need to proactively message the user (such as cron job). "
-        "For normal text replies, you can output directly. "
-        "Optionally specify a `session` to send the message to a different session (admin only). "
-        "If no session is specified, the message is sent to the current user's session."
+        "or when you need to proactively message the user(such as cron job). For normal text replies, you can output directly."
     )
     parameters: dict = Field(
         default_factory=lambda: {
@@ -69,10 +66,10 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
                         "required": ["type"],
                     },
                 },
-            },
-            "session": {
-                "type": "string",
-                "description": "Optional. Target session string. Defaults to current session. Only AstrBot admins can send to other sessions.",
+                "session": {
+                    "type": "string",
+                    "description": "Optional. Target session string. Defaults to current session.",
+                },
             },
             "required": ["messages"],
         }


### PR DESCRIPTION
## Description

This PR fixes a **high-security vulnerability** (Issue #7822) in the `send_message_to_user` tool.

### The Problem
The tool previously accepted a user-controlled `session` parameter, allowing any regular user to ask the LLM to send arbitrary messages to **any group chat** by crafting a target session string (e.g., `KevinBot:GroupMessage:704943246`). This is a severe security risk — attackers could send untrusted links/messages to any session.

### The Fix
1. **Removed** the `session` parameter from the tool's parameter schema — the LLM can no longer propose it.
2. **Hardcoded** the target session to `context.context.event.unified_msg_origin` — always uses the current user's own session.
3. **Updated** the tool description to clearly state that it can only send messages to the current user's session.

### Changes
- `astrbot/core/tools/message_tools.py`: +9/-7 lines

### Security Audit
Also verified that no other built-in tools (e.g., `cron_tools.py`) have similar session injection vulnerabilities.

Closes #7822

## Summary by Sourcery

Restrict the send_message_to_user tool to only send messages to the current user session to address a security vulnerability.

Bug Fixes:
- Fix a security issue where send_message_to_user could be used to send messages to arbitrary sessions by removing the user-controlled session parameter and always targeting the current session.

Documentation:
- Clarify the send_message_to_user tool description to state that it only sends messages to the current user's session and cannot target other sessions.