### PR TITLE
fix(provider): handle Moonshot/Kimi thinking mode tool_choice=required conflict (#7805)

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -181,6 +181,33 @@ class ProviderOpenAIOfficial(Provider):
             return True
         return False
 
+    def _is_tool_choice_required_incompatible_with_thinking_error(
+        self,
+        error: Exception,
+        candidates: list[str] | None = None,
+    ) -> bool:
+        if candidates is None:
+            candidates = [
+                candidate.lower()
+                for candidate in self._extract_error_text_candidates(error)
+            ]
+        exact_messages = (
+            "tool_choice 'required' is incompatible with thinking enabled",
+            'tool_choice "required" is incompatible with thinking enabled',
+        )
+        for candidate in candidates:
+            if any(message in candidate for message in exact_messages):
+                return True
+
+            if (
+                "tool_choice" in candidate
+                and re.search(r"\brequired\b", candidate)
+                and "thinking enabled" in candidate
+                and "incompatible" in candidate
+            ):
+                return True
+        return False
+
     @classmethod
     def _encode_image_file_to_data_url(
         cls,
@@ -1098,6 +1125,43 @@ class ProviderOpenAIOfficial(Provider):
                 "invalid_attachment",
                 image_fallback_used=True,
             )
+        required_tool_choice = payloads.get("tool_choice") == "required"
+        if required_tool_choice:
+            candidates = [
+                candidate.lower()
+                for candidate in self._extract_error_text_candidates(e)
+            ]
+            thinking_conflict_error = (
+                self._is_tool_choice_required_incompatible_with_thinking_error(
+                    e,
+                    candidates,
+                )
+            )
+            if thinking_conflict_error:
+                provider_name = self.provider_config.get("provider", "unknown")
+                logger.warning(
+                    "检测到 `tool_choice=required` 与 thinking 模式不兼容，"
+                    f"自动降级为 `auto` 并重试，provider={provider_name}"
+                )
+                retry_payloads = {**payloads, "tool_choice": "auto"}
+                return (
+                    False,
+                    chosen_key,
+                    available_api_keys,
+                    retry_payloads,
+                    context_query,
+                    func_tool,
+                    image_fallback_used,
+                )
+            has_related_keywords = any(
+                "tool_choice" in candidate and "thinking" in candidate
+                for candidate in candidates
+            )
+            if has_related_keywords:
+                logger.debug(
+                    "检测到 tool_choice/thinking 相关错误，但未命中降级模式，"
+                    "保持 tool_choice=required"
+                )
 
         if (
             "Function calling is not enabled" in str(e)


### PR DESCRIPTION
## Description

Fixes #7805

### The Problem
When using Moonshot AI / Kimi with **thinking mode** enabled, the upstream API rejects requests with `tool_choice="required"` and returns a 400 error:

```
tool_choice 'required' is incompatible with thinking enabled
```

This causes the tool loop runner (`_resolve_tool_exec`) to break completely when using skills_like / tool calling patterns.

### The Fix
Detects the specific upstream error in `_handle_api_error` (provider layer) and automatically:
1. **Downgrades** `tool_choice` from `"required"` to `"auto"`
2. **Retries** with a shallow copy of the payload (no mutation of original)
3. **Logs** a clear warning when the fallback is triggered

### Changes
- `astrbot/core/provider/sources/openai_source.py`: +64 lines
  - New method `_is_tool_choice_required_incompatible_with_thinking_error()` — detects exact match + heuristic fallback
  - Fallback logic in `_handle_api_error()` — shallow copy payload, set tool_choice="auto", retry
  - Debug logging for related but non-matching errors

### Design Decisions
- **Provider layer only**: No changes to runner logic
- **Shallow copy**: Uses `{**payloads, "tool_choice": "auto"}` to avoid mutating the original payloads
- **Exact match first**: Prefers known upstream error message, then falls back to keyword heuristic

### Related
- Original fix PR: #7727 (same fix, unmerged)
- Similar issue: #7177 (OpenRouter tool_choice compatibility)

Closes #7805

## Summary by Sourcery

Handle Moonshot/Kimi thinking mode incompatibility with tool_choice=required by detecting the specific API error and transparently retrying with a safer configuration.

Bug Fixes:
- Automatically downgrade tool_choice from "required" to "auto" and retry when Moonshot/Kimi thinking mode rejects required tool calling, preventing tool loop failures.

Enhancements:
- Improve provider error handling with a helper to recognize tool_choice/thinking incompatibility messages and add logging for related errors to aid debugging.