### PR TITLE
fix(stats): TPM now only counts output tokens

### DIFF
--- a/astrbot/dashboard/routes/stat.py
+++ b/astrbot/dashboard/routes/stat.py
@@ -276,7 +276,6 @@ class StatRoute(Route):
                     total_by_umo[record.umo or "unknown"] += token_total
                     total_by_bucket[bucket_ts] += token_total
                     range_total_tokens += token_total
-                    range_total_output_tokens += record.token_output
                     range_total_calls += 1
                     if record.status != "error":
                         range_success_calls += 1
@@ -288,6 +287,7 @@ class StatRoute(Route):
                             record.end_time - record.start_time
                         ) * 1000
                         range_duration_samples += 1
+                        range_total_output_tokens += record.token_output
 
                 if created_at_local >= today_start_local:
                     today_total_calls += 1
@@ -373,7 +373,8 @@ class StatRoute(Route):
                             else 0
                         ),
                         "range_avg_tpm": (
-                            range_total_output_tokens / (range_duration_total_ms / 1000 / 60)
+                            range_total_output_tokens
+                            / (range_duration_total_ms / 1000 / 60)
                             if range_duration_total_ms > 0
                             else 0
                         ),

--- a/astrbot/dashboard/routes/stat.py
+++ b/astrbot/dashboard/routes/stat.py
@@ -243,6 +243,7 @@ class StatRoute(Route):
             total_by_umo: dict[str, int] = defaultdict(int)
             total_by_bucket: dict[int, int] = defaultdict(int)
             range_total_tokens = 0
+            range_total_output_tokens = 0
             range_total_calls = 0
             range_success_calls = 0
             range_ttft_total_ms = 0.0
@@ -275,6 +276,7 @@ class StatRoute(Route):
                     total_by_umo[record.umo or "unknown"] += token_total
                     total_by_bucket[bucket_ts] += token_total
                     range_total_tokens += token_total
+                    range_total_output_tokens += record.token_output
                     range_total_calls += 1
                     if record.status != "error":
                         range_success_calls += 1
@@ -371,7 +373,7 @@ class StatRoute(Route):
                             else 0
                         ),
                         "range_avg_tpm": (
-                            range_total_tokens / (range_duration_total_ms / 1000 / 60)
+                            range_total_output_tokens / (range_duration_total_ms / 1000 / 60)
                             if range_duration_total_ms > 0
                             else 0
                         ),

--- a/dashboard/src/i18n/locales/en-US/features/stats.json
+++ b/dashboard/src/i18n/locales/en-US/features/stats.json
@@ -67,7 +67,7 @@
     "callCount": "{count} calls",
     "avgTtft": "Average TTFT",
     "avgDuration": "Average Response Time",
-    "avgTpm": "Average TPM",
+    "avgTpm": "Average Output TPM",
     "successRate": "Success Rate"
   },
   "modelRanking": {

--- a/dashboard/src/i18n/locales/ru-RU/features/stats.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/stats.json
@@ -67,7 +67,7 @@
     "callCount": "{count} вызовов",
     "avgTtft": "Средний TTFT",
     "avgDuration": "Среднее время ответа",
-    "avgTpm": "Средний TPM",
+    "avgTpm": "Средний Output TPM",
     "successRate": "Доля успешных вызовов"
   },
   "modelRanking": {

--- a/dashboard/src/i18n/locales/zh-CN/features/stats.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/stats.json
@@ -67,7 +67,7 @@
     "callCount": "共 {count} 次调用",
     "avgTtft": "平均首字延迟（TTFT）",
     "avgDuration": "平均响应时间",
-    "avgTpm": "平均每分钟词元数（TPM）",
+    "avgTpm": "平均每分钟输出（TPM）",
     "successRate": "调用成功率"
   },
   "modelRanking": {


### PR DESCRIPTION
## 改动内容

### 问题
TPM（平均每分钟词元数）之前统计的是总 token（input + output），但作为生成性能指标，应该只统计 output tokens。

### 改动
- **后端** (`stat.py`): 新增 `range_total_output_tokens`，仅累加 `record.token_output`，TPM 公式改为使用 output tokens
- **前端国际化**: 标签明确为输出词元数
  - zh-CN: 平均每分钟输出（TPM）
  - en-US: Average Output TPM
  - ru-RU: Средний Output TPM

### 影响
- ✅ 仅 TPM 指标改为 output-only
- ✅ 其他统计（趋势图、Provider/UMO排名、今日统计等）保持原样不变

## Summary by Sourcery

Update token statistics so that TPM is calculated using only output tokens and align UI labels accordingly.

Bug Fixes:
- Correct TPM calculation to use only output tokens instead of total input+output tokens.

Enhancements:
- Add a dedicated accumulator for output tokens in provider token statistics to support accurate TPM computation.

Documentation:
- Clarify stats UI labels in all supported locales to indicate that TPM reflects average output tokens per minute.