### PR TITLE
feat: add /stats command to view conversation token usage

### DIFF
--- a/astrbot/builtin_stars/builtin_commands/commands/conversation.py
+++ b/astrbot/builtin_stars/builtin_commands/commands/conversation.py
@@ -1,3 +1,5 @@
+from sqlalchemy import select
+
 from astrbot.api import sp, star
 from astrbot.api.event import AstrMessageEvent, MessageEventResult
 from astrbot.core import logger
@@ -7,6 +9,7 @@ from astrbot.core.agent.runners.deerflow.constants import (
     DEERFLOW_THREAD_ID_KEY,
 )
 from astrbot.core.agent.runners.deerflow.deerflow_api_client import DeerFlowAPIClient
+from astrbot.core.db.po import ProviderStat
 from astrbot.core.utils.active_event_registry import active_event_registry
 
 from .utils.rst_scene import RstScene
@@ -246,3 +249,55 @@ class ConversationCommands:
                 f"✅ Switched to new conversation: {cid[:4]}。"
             ),
         )
+
+    async def stats(self, message: AstrMessageEvent) -> None:
+        """Show token usage statistics for the current conversation."""
+        umo = message.unified_msg_origin
+        cid = await self.context.conversation_manager.get_curr_conversation_id(umo)
+
+        if not cid:
+            message.set_result(
+                MessageEventResult().message(
+                    "❌ You are not in a conversation. Use /new to create one."
+                ),
+            )
+            return
+
+        db = self.context.get_db()
+        async with db.get_db() as session:
+            result = await session.execute(
+                select(ProviderStat).where(
+                    ProviderStat.agent_type == "internal",
+                    ProviderStat.conversation_id == cid,
+                )
+            )
+            records = result.scalars().all()
+
+        if not records:
+            message.set_result(
+                MessageEventResult().message(
+                    "📊 No stats available for this conversation yet."
+                ),
+            )
+            return
+
+        total_calls = len(records)
+        total_input_other = sum(r.token_input_other for r in records)
+        total_input_cached = sum(r.token_input_cached for r in records)
+        total_output = sum(r.token_output for r in records)
+        total_tokens = total_input_other + total_input_cached + total_output
+        success_count = sum(1 for r in records if r.status != "error")
+
+        ret = (
+            f"📊 Conversation Stats (ID: {cid[:8]}...)\n"
+            f"───\n"
+            f"Total Calls: {total_calls}\n"
+            f"Successful: {success_count}\n"
+            f"───\n"
+            f"Input Tokens (other): {total_input_other:,}\n"
+            f"Input Tokens (cached): {total_input_cached:,}\n"
+            f"Output Tokens:        {total_output:,}\n"
+            f"Total Tokens:         {total_tokens:,}"
+        )
+
+        message.set_result(MessageEventResult().message(ret))

--- a/astrbot/builtin_stars/builtin_commands/commands/conversation.py
+++ b/astrbot/builtin_stars/builtin_commands/commands/conversation.py
@@ -301,7 +301,7 @@ class ConversationCommands:
         total_tokens = total_input_other + total_input_cached + total_output
 
         ret = (
-            f"📊 Token usage (ID: {cid[:8]}...)\n"
+            f"📊 Conversation Token usage (ID: {cid[:8]}...)\n"
             f"Total:          {total_tokens:,}\n"
             f"Input (cached): {total_input_cached:,}\n"
             f"Input (other):  {total_input_other:,}\n"

--- a/astrbot/builtin_stars/builtin_commands/commands/conversation.py
+++ b/astrbot/builtin_stars/builtin_commands/commands/conversation.py
@@ -290,8 +290,8 @@ class ConversationCommands:
         ret = (
             f"📊 Token usage (ID: {cid[:8]}...)\n"
             f"Total:          {total_tokens:,}\n"
-            f"Input (other):  {total_input_other:,}\n"
             f"Input (cached): {total_input_cached:,}\n"
+            f"Input (other):  {total_input_other:,}\n"
             f"Output:         {total_output:,}\n"
         )
 

--- a/astrbot/builtin_stars/builtin_commands/commands/conversation.py
+++ b/astrbot/builtin_stars/builtin_commands/commands/conversation.py
@@ -1,4 +1,5 @@
 from sqlalchemy import select
+from sqlmodel import col
 
 from astrbot.api import sp, star
 from astrbot.api.event import AstrMessageEvent, MessageEventResult
@@ -267,8 +268,8 @@ class ConversationCommands:
         async with db.get_db() as session:
             result = await session.execute(
                 select(ProviderStat).where(
-                    ProviderStat.agent_type == "internal",
-                    ProviderStat.conversation_id == cid,
+                    col(ProviderStat.agent_type) == "internal",
+                    col(ProviderStat.conversation_id) == cid,
                 )
             )
             records = result.scalars().all()
@@ -281,23 +282,17 @@ class ConversationCommands:
             )
             return
 
-        total_calls = len(records)
         total_input_other = sum(r.token_input_other for r in records)
         total_input_cached = sum(r.token_input_cached for r in records)
         total_output = sum(r.token_output for r in records)
         total_tokens = total_input_other + total_input_cached + total_output
-        success_count = sum(1 for r in records if r.status != "error")
 
         ret = (
-            f"📊 Conversation Stats (ID: {cid[:8]}...)\n"
-            f"───\n"
-            f"Total Calls: {total_calls}\n"
-            f"Successful: {success_count}\n"
-            f"───\n"
-            f"Input Tokens (other): {total_input_other:,}\n"
-            f"Input Tokens (cached): {total_input_cached:,}\n"
-            f"Output Tokens:        {total_output:,}\n"
-            f"Total Tokens:         {total_tokens:,}"
+            f"📊 Token usage (ID: {cid[:8]}...)\n"
+            f"Total:          {total_tokens:,}\n"
+            f"Input (other):  {total_input_other:,}\n"
+            f"Input (cached): {total_input_cached:,}\n"
+            f"Output:         {total_output:,}\n"
         )
 
         message.set_result(MessageEventResult().message(ret))

--- a/astrbot/builtin_stars/builtin_commands/commands/conversation.py
+++ b/astrbot/builtin_stars/builtin_commands/commands/conversation.py
@@ -1,4 +1,4 @@
-from sqlalchemy import select
+from sqlalchemy import case, func, select
 from sqlmodel import col
 
 from astrbot.api import sp, star
@@ -267,14 +267,27 @@ class ConversationCommands:
         db = self.context.get_db()
         async with db.get_db() as session:
             result = await session.execute(
-                select(ProviderStat).where(
+                select(
+                    func.count(case((col(ProviderStat.id).is_not(None), 1))).label(
+                        "record_count",
+                    ),
+                    func.coalesce(func.sum(ProviderStat.token_input_other), 0).label(
+                        "total_input_other",
+                    ),
+                    func.coalesce(func.sum(ProviderStat.token_input_cached), 0).label(
+                        "total_input_cached",
+                    ),
+                    func.coalesce(func.sum(ProviderStat.token_output), 0).label(
+                        "total_output",
+                    ),
+                ).where(
                     col(ProviderStat.agent_type) == "internal",
                     col(ProviderStat.conversation_id) == cid,
                 )
             )
-            records = result.scalars().all()
+            stats = result.one()
 
-        if not records:
+        if stats.record_count == 0:
             message.set_result(
                 MessageEventResult().message(
                     "📊 No stats available for this conversation yet."
@@ -282,9 +295,9 @@ class ConversationCommands:
             )
             return
 
-        total_input_other = sum(r.token_input_other for r in records)
-        total_input_cached = sum(r.token_input_cached for r in records)
-        total_output = sum(r.token_output for r in records)
+        total_input_other = stats.total_input_other
+        total_input_cached = stats.total_input_cached
+        total_output = stats.total_output
         total_tokens = total_input_other + total_input_cached + total_output
 
         ret = (

--- a/astrbot/builtin_stars/builtin_commands/main.py
+++ b/astrbot/builtin_stars/builtin_commands/main.py
@@ -47,6 +47,11 @@ class Main(star.Star):
         """Create new conversation"""
         await self.conversation_c.new_conv(message)
 
+    @filter.command("stats")
+    async def stats(self, message: AstrMessageEvent) -> None:
+        """Show token usage statistics for the current conversation"""
+        await self.conversation_c.stats(message)
+
     @filter.permission_type(filter.PermissionType.ADMIN)
     @filter.command("provider")
     async def provider(

--- a/dashboard/src/components/chat/ChatMessageList.vue
+++ b/dashboard/src/components/chat/ChatMessageList.vue
@@ -293,6 +293,15 @@
                 />
               </template>
               <v-card class="stats-card" elevation="4">
+                <div
+                  v-if="cachedInputTokens(messageContent(msg).agentStats) > 0"
+                  class="stats-row"
+                >
+                  <span>{{ tm("stats.cachedTokens") }}</span>
+                  <strong>{{
+                    cachedInputTokens(messageContent(msg).agentStats)
+                  }}</strong>
+                </div>
                 <div class="stats-row">
                   <span>{{ tm("stats.inputTokens") }}</span>
                   <strong>{{ inputTokens(messageContent(msg).agentStats) }}</strong>
@@ -850,11 +859,15 @@ function formatTime(value: string) {
 
 function inputTokens(stats: any) {
   const usage = stats?.token_usage || {};
-  return (usage.input_other || 0) + (usage.input_cached || 0);
+  return usage.input_other || 0;
 }
 
 function outputTokens(stats: any) {
   return stats?.token_usage?.output || 0;
+}
+
+function cachedInputTokens(stats: any) {
+  return stats?.token_usage?.input_cached || 0;
 }
 
 function agentDuration(stats: any) {

--- a/dashboard/src/components/chat/MessageList.vue
+++ b/dashboard/src/components/chat/MessageList.vue
@@ -185,6 +185,15 @@
                 />
               </template>
               <v-card class="stats-card" elevation="4">
+                <div
+                  v-if="cachedInputTokens(messageContent(msg).agentStats) > 0"
+                  class="stats-row"
+                >
+                  <span>{{ tm("stats.cachedTokens") }}</span>
+                  <strong>{{
+                    cachedInputTokens(messageContent(msg).agentStats)
+                  }}</strong>
+                </div>
                 <div class="stats-row">
                   <span>{{ tm("stats.inputTokens") }}</span>
                   <strong>{{
@@ -512,11 +521,15 @@ function formatTime(value: string) {
 
 function inputTokens(stats: any) {
   const usage = stats?.token_usage || {};
-  return (usage.input_other || 0) + (usage.input_cached || 0);
+  return usage.input_other || 0;
 }
 
 function outputTokens(stats: any) {
   return stats?.token_usage?.output || 0;
+}
+
+function cachedInputTokens(stats: any) {
+  return stats?.token_usage?.input_cached || 0;
 }
 
 function agentDuration(stats: any) {

--- a/dashboard/src/i18n/locales/en-US/features/chat.json
+++ b/dashboard/src/i18n/locales/en-US/features/chat.json
@@ -137,9 +137,9 @@
   },
   "stats": {
     "tokens": "Tokens",
-    "inputTokens": "Input Tokens",
+    "inputTokens": "Input (other)",
     "outputTokens": "Output Tokens",
-    "cachedTokens": "Cached Tokens",
+    "cachedTokens": "Input (cached)",
     "duration": "Duration",
     "ttft": "Time to First Token"
   },

--- a/dashboard/src/i18n/locales/ru-RU/features/chat.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/chat.json
@@ -137,9 +137,9 @@
   },
   "stats": {
     "tokens": "Токены",
-    "inputTokens": "Входящие",
+    "inputTokens": "Входящие (прочие)",
     "outputTokens": "Исходящие",
-    "cachedTokens": "Кэшированные",
+    "cachedTokens": "Входящие (кэш)",
     "duration": "Время",
     "ttft": "Время до первого токена"
   },

--- a/dashboard/src/i18n/locales/zh-CN/features/chat.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/chat.json
@@ -137,9 +137,9 @@
   },
   "stats": {
     "tokens": "Token",
-    "inputTokens": "输入 Token",
+    "inputTokens": "输入（其他）",
     "outputTokens": "输出 Token",
-    "cachedTokens": "缓存 Token",
+    "cachedTokens": "输入（缓存）",
     "duration": "耗时",
     "ttft": "首字时间"
   },


### PR DESCRIPTION
## 改动内容

新增内置指令 `/stats`，可查看当前对话的 token 使用统计。

### 实现方式

在已有的 `ConversationCommands` 类中新增 `stats()` 方法：
- 通过 `conversation_manager.get_curr_conversation_id()` 获取当前对话 ID
- 查询 `ProviderStat` 表中该对话的所有记录
- 聚合统计 `token_input_other`、`token_input_cached`、`token_output`

### 使用效果

```
📊 Conversation Stats (ID: abc12345...)
───
Total Calls: 12
Successful: 12
───
Input Tokens (other): 8,520
Input Tokens (cached): 1,230
Output Tokens:        3,456
Total Tokens:         13,206
```

### 涉及文件
- `astrbot/builtin_stars/builtin_commands/commands/conversation.py` — 核心逻辑
- `astrbot/builtin_stars/builtin_commands/main.py` — 注册命令

## Summary by Sourcery

New Features:
- Introduce a conversation stats command that aggregates token usage metrics for the active conversation, including call counts and input/output token totals.