### PR TITLE
fix: handle Tencent QQ Silk/AMR voice format in ensure_wav

### DIFF
--- a/astrbot/core/utils/media_utils.py
+++ b/astrbot/core/utils/media_utils.py
@@ -295,13 +295,56 @@ async def ensure_wav(audio_path: str, output_path: str | None = None) -> str:
     """Ensure the audio path points to wav format by extension/guess and convert when needed.
 
     If the file appears to already be wav, return it directly to avoid extra conversion.
+    Handles Tencent QQ special formats (silk / amr) that ffmpeg cannot decode.
     """
 
     if not audio_path:
         return audio_path
 
-    if _get_audio_magic_type(audio_path) == "wav":
+    audio_type = _get_audio_magic_type(audio_path)
+
+    if audio_type == "wav":
         return audio_path
+
+    if audio_type in ("silk",):
+        # Tencent Silk format (commonly used by QQ). ffmpeg cannot decode it.
+        from astrbot.core.utils.tencent_record_helper import tencent_silk_to_wav
+
+        if not output_path:
+            from pathlib import Path
+            from uuid import uuid4
+
+            from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
+
+            temp_dir = Path(get_astrbot_temp_path())
+            temp_dir.mkdir(parents=True, exist_ok=True)
+            output_path = str(temp_dir / f"media_audio_{uuid4().hex}.wav")
+
+        logger.info(f"Detected Silk audio format, converting to wav: {audio_path}")
+        return await tencent_silk_to_wav(audio_path, output_path)
+
+    if audio_type in ("amr",):
+        # AMR from Tencent platforms may also be a variant that ffmpeg misdetects.
+        # Try ffmpeg first as it handles standard AMR correctly.
+        try:
+            return await convert_audio_to_wav(audio_path, output_path)
+        except Exception as e:
+            logger.warning(
+                f"ffmpeg failed to convert amr file, trying pyffmpeg fallback: {e}"
+            )
+            from astrbot.core.utils.tencent_record_helper import convert_to_pcm_wav
+
+            if not output_path:
+                from pathlib import Path
+                from uuid import uuid4
+
+                from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
+
+                temp_dir = Path(get_astrbot_temp_path())
+                temp_dir.mkdir(parents=True, exist_ok=True)
+                output_path = str(temp_dir / f"media_audio_{uuid4().hex}.wav")
+
+            return await convert_to_pcm_wav(audio_path, output_path)
 
     return await convert_audio_to_wav(audio_path, output_path)
 
@@ -341,7 +384,11 @@ def _get_audio_magic_type(audio_path: str) -> str:
     if header[:4] == b"ftyp" and b"mp4" in header[:8]:
         return "mp4"
 
-    if header[:8] == b"#!SILK_V3":
+    if (
+        header[:8] == b"#!SILK_V3"
+        or header[1:9] == b"#!SILK_V3"
+        or b"SILK" in header[:16]
+    ):
         return "silk"
 
     return ""


### PR DESCRIPTION
## Fixes #7796

### 问题
QQ 平台发送的语音文件使用腾讯专有的 **Silk 编码格式**（或特殊 AMR 变体），ffmpeg 无法解码。`ensure_wav()` 检测到非 wav 后直接丢给 ffmpeg，导致转换失败，STT 功能不可用。

### 改动（仅 `media_utils.py`）

**`ensure_wav()`** 新增 Silk / AMR 特殊处理：
- 检测到 Silk 格式 → 使用 `tencent_silk_to_wav()`（基于 `pysilk` 库）转换
- 检测到 AMR 格式 → 先用 ffmpeg 尝试（标准 AMR 可正常处理），失败则回退到 `convert_to_pcm_wav()`

**`_get_audio_magic_type()`** 增强 Silk 检测：
- 原：仅匹配 `header[:8] == b"#!SILK_V3"`
- 新：同时匹配 \`\\x02\` 前缀变体（`header[1:9]`）和 `b"SILK"` 在头部 16 字节内的任意位置

### 参考
`whisper_api_source.py` 已有类似处理逻辑，本次修复将其下沉到 `ensure_wav()` 中，使所有 STT provider 都能受益。

## Summary by Sourcery

Handle Tencent QQ Silk and AMR voice formats in WAV conversion to restore STT compatibility for these inputs.

Bug Fixes:
- Ensure ensure_wav() correctly converts Tencent Silk-encoded audio to WAV using the dedicated Silk conversion helper instead of passing it to ffmpeg, which cannot decode it.
- Add a fallback conversion path for Tencent AMR variants when ffmpeg fails, using a dedicated AMR-to-PCM-WAV converter to keep STT working for these files.

Enhancements:
- Extend audio magic-type detection to more robustly recognize Silk formats, including prefixed and offset SILK signatures, so special handling can be applied reliably.