### PR TITLE
fix: prevent IME enter from sending chat

### DIFF
--- a/dashboard/src/components/chat/ChatInput.vue
+++ b/dashboard/src/components/chat/ChatInput.vue
@@ -114,6 +114,8 @@
         @keydown="handleKeyDown"
         @compositionstart="handleCompositionStart"
         @compositionend="handleCompositionEnd"
+        @compositioncancel="handleCompositionEnd"
+        @blur="clearCompositionState"
         :disabled="disabled"
         placeholder="Ask AstrBot..."
         class="chat-textarea"
@@ -383,6 +385,7 @@ const showProviderSelector = ref(true);
 const isReplyClosing = ref(false);
 const isDragging = ref(false);
 const isComposing = ref(false);
+const lastCompositionEndAt = ref<number | null>(null);
 let dragLeaveTimeout: number | null = null;
 
 const localPrompt = computed({
@@ -518,7 +521,7 @@ function handleKeyDown(e: KeyboardEvent) {
     return;
   }
 
-  if (isComposingEnter(e, isComposing.value)) {
+  if (isComposingEnter(e, isComposing.value, lastCompositionEndAt.value)) {
     return;
   }
 
@@ -543,10 +546,21 @@ function handleKeyDown(e: KeyboardEvent) {
 
 function handleCompositionStart() {
   isComposing.value = true;
+  lastCompositionEndAt.value = null;
 }
 
-function handleCompositionEnd() {
+function handleCompositionEnd(e: CompositionEvent) {
+  lastCompositionEndAt.value = e.timeStamp;
+  resetComposingState();
+}
+
+function resetComposingState() {
   isComposing.value = false;
+}
+
+function clearCompositionState() {
+  isComposing.value = false;
+  lastCompositionEndAt.value = null;
 }
 
 function handleKeyUp(e: KeyboardEvent) {
@@ -650,6 +664,7 @@ onBeforeUnmount(() => {
   if (inputField.value) {
     inputField.value.removeEventListener("paste", handlePaste);
   }
+  clearCompositionState();
   document.removeEventListener("keyup", handleKeyUp);
 });
 

--- a/dashboard/src/components/chat/ChatInput.vue
+++ b/dashboard/src/components/chat/ChatInput.vue
@@ -115,7 +115,7 @@
         @compositionstart="handleCompositionStart"
         @compositionend="handleCompositionEnd"
         @compositioncancel="handleCompositionEnd"
-        @blur="clearCompositionState"
+        @blur="clearCompositionState()"
         :disabled="disabled"
         placeholder="Ask AstrBot..."
         class="chat-textarea"
@@ -551,16 +551,14 @@ function handleCompositionStart() {
 
 function handleCompositionEnd(e: CompositionEvent) {
   lastCompositionEndAt.value = e.timeStamp;
-  resetComposingState();
+  clearCompositionState({ keepLastEndAt: true });
 }
 
-function resetComposingState() {
+function clearCompositionState({ keepLastEndAt = false } = {}) {
   isComposing.value = false;
-}
-
-function clearCompositionState() {
-  isComposing.value = false;
-  lastCompositionEndAt.value = null;
+  if (!keepLastEndAt) {
+    lastCompositionEndAt.value = null;
+  }
 }
 
 function handleKeyUp(e: KeyboardEvent) {

--- a/dashboard/src/components/chat/ChatInput.vue
+++ b/dashboard/src/components/chat/ChatInput.vue
@@ -112,6 +112,8 @@
         ref="inputField"
         v-model="localPrompt"
         @keydown="handleKeyDown"
+        @compositionstart="handleCompositionStart"
+        @compositionend="handleCompositionEnd"
         :disabled="disabled"
         placeholder="Ask AstrBot..."
         class="chat-textarea"
@@ -307,6 +309,7 @@ import {
 import { useDisplay } from "vuetify";
 import { useModuleI18n } from "@/i18n/composables";
 import { useCustomizerStore } from "@/stores/customizer";
+import { isComposingEnter } from "@/utils/imeInput.mjs";
 import ConfigSelector from "./ConfigSelector.vue";
 import ProviderModelMenu from "./ProviderModelMenu.vue";
 import StyledMenu from "@/components/shared/StyledMenu.vue";
@@ -379,6 +382,7 @@ const providerModelMenuRef = ref<InstanceType<typeof ProviderModelMenu> | null>(
 const showProviderSelector = ref(true);
 const isReplyClosing = ref(false);
 const isDragging = ref(false);
+const isComposing = ref(false);
 let dragLeaveTimeout: number | null = null;
 
 const localPrompt = computed({
@@ -514,6 +518,10 @@ function handleKeyDown(e: KeyboardEvent) {
     return;
   }
 
+  if (isComposingEnter(e, isComposing.value)) {
+    return;
+  }
+
   const isSendHotkey =
     e.ctrlKey ||
     e.metaKey ||
@@ -531,6 +539,14 @@ function handleKeyDown(e: KeyboardEvent) {
     }
     return;
   }
+}
+
+function handleCompositionStart() {
+  isComposing.value = true;
+}
+
+function handleCompositionEnd() {
+  isComposing.value = false;
 }
 
 function handleKeyUp(e: KeyboardEvent) {

--- a/dashboard/src/utils/imeInput.mjs
+++ b/dashboard/src/utils/imeInput.mjs
@@ -1,6 +1,26 @@
-export function isComposingEnter(event, compositionActive) {
+/**
+ * @param {KeyboardEvent} event
+ * @param {boolean} compositionActive
+ * @param {number | null} lastCompositionEndAt
+ */
+export function isComposingEnter(
+  event,
+  compositionActive,
+  lastCompositionEndAt = null,
+) {
+  const hasLegacyCompositionKeyCode =
+    typeof event.keyCode === "number" && event.keyCode === 229;
+  const isAfterRecentCompositionEnd =
+    typeof event.timeStamp === "number" &&
+    typeof lastCompositionEndAt === "number" &&
+    event.timeStamp >= lastCompositionEndAt &&
+    event.timeStamp - lastCompositionEndAt < 100;
+
   return (
     event.key === "Enter" &&
-    (compositionActive || event.isComposing || event.keyCode === 229)
+    (compositionActive ||
+      event.isComposing ||
+      hasLegacyCompositionKeyCode ||
+      isAfterRecentCompositionEnd)
   );
 }

--- a/dashboard/src/utils/imeInput.mjs
+++ b/dashboard/src/utils/imeInput.mjs
@@ -1,0 +1,6 @@
+export function isComposingEnter(event, compositionActive) {
+  return (
+    event.key === "Enter" &&
+    (compositionActive || event.isComposing || event.keyCode === 229)
+  );
+}

--- a/dashboard/src/utils/imeInput.mjs
+++ b/dashboard/src/utils/imeInput.mjs
@@ -1,3 +1,7 @@
+// Some IMEs emit Enter right after compositionend; treat that same-keystroke
+// window as composition so selecting a candidate does not send the message.
+const RECENT_COMPOSITION_END_THRESHOLD_MS = 100;
+
 /**
  * @param {KeyboardEvent} event
  * @param {boolean} compositionActive
@@ -14,7 +18,8 @@ export function isComposingEnter(
     typeof event.timeStamp === "number" &&
     typeof lastCompositionEndAt === "number" &&
     event.timeStamp >= lastCompositionEndAt &&
-    event.timeStamp - lastCompositionEndAt < 100;
+    event.timeStamp - lastCompositionEndAt <
+      RECENT_COMPOSITION_END_THRESHOLD_MS;
 
   return (
     event.key === "Enter" &&

--- a/dashboard/tests/imeInput.test.mjs
+++ b/dashboard/tests/imeInput.test.mjs
@@ -12,3 +12,25 @@ test("does not treat normal Enter as IME composition", () => {
   assert.equal(isComposingEnter({ key: "Enter", isComposing: false }, false), false);
   assert.equal(isComposingEnter({ key: "a", isComposing: true }, true), false);
 });
+
+test("detects Enter fired immediately after composition ended", () => {
+  assert.equal(
+    isComposingEnter(
+      { key: "Enter", isComposing: false, timeStamp: 105 },
+      false,
+      100,
+    ),
+    true,
+  );
+});
+
+test("does not treat delayed Enter after composition ended as IME composition", () => {
+  assert.equal(
+    isComposingEnter(
+      { key: "Enter", isComposing: false, timeStamp: 250 },
+      false,
+      100,
+    ),
+    false,
+  );
+});

--- a/dashboard/tests/imeInput.test.mjs
+++ b/dashboard/tests/imeInput.test.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isComposingEnter } from "../src/utils/imeInput.mjs";
+
+test("detects Enter while an IME composition is active", () => {
+  assert.equal(isComposingEnter({ key: "Enter", isComposing: true }, false), true);
+  assert.equal(isComposingEnter({ key: "Enter", isComposing: false }, true), true);
+});
+
+test("does not treat normal Enter as IME composition", () => {
+  assert.equal(isComposingEnter({ key: "Enter", isComposing: false }, false), false);
+  assert.equal(isComposingEnter({ key: "a", isComposing: true }, true), false);
+});


### PR DESCRIPTION
## Summary
- Prevent chat input Enter handling from sending messages while IME composition is active.
- Track composition lifecycle on the textarea and keep existing Enter / Shift+Enter shortcut behavior unchanged.
- Add a focused Node test for IME Enter detection.

## Tests
- `node tests/imeInput.test.mjs`
- `pnpm typecheck`
- `pnpm build`
- `uv run ruff format .`
- `uv run ruff check .`

## Notes
- `pnpm lint` currently fails on the baseline ESLint configuration because it cannot parse Vue, TypeScript, and MJS files.

## Summary by Sourcery

Prevent chat messages from being sent when Enter is pressed during or immediately after IME composition in the chat input.

Bug Fixes:
- Block Enter from sending chat messages while IME composition is active or just ended in the chat textarea.

Enhancements:
- Track IME composition lifecycle for the chat input to preserve existing Enter and Shift+Enter shortcuts while avoiding accidental sends.
- Extract IME-related Enter detection into a reusable utility helper.

Tests:
- Add a dedicated Node-based test suite for IME Enter detection behavior.