### PR TITLE
fix(qqofficial): use markdown payload in send_by_session for native markdown rendering

### DIFF
--- a/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
@@ -199,6 +199,13 @@ class QQOfficialPlatformAdapter(Platform):
     ) -> None:
         await self._send_by_session_common(session, message_chain)
 
+    @staticmethod
+    def _normalize_media_payload(
+        payload: dict[str, Any], plain_text: str | None
+    ) -> None:
+        payload.pop("markdown", None)
+        payload["content"] = plain_text or None
+
     async def _send_by_session_common(
         self,
         session: MessageSesion,
@@ -231,11 +238,10 @@ class QQOfficialPlatformAdapter(Platform):
             )
             return
 
-        payload: dict[str, Any] = {
-            "markdown": MarkdownPayload(content=plain_text) if plain_text else None,
-            "msg_type": 2,
-            "msg_id": msg_id,
-        }
+        payload: dict[str, Any] = {"msg_type": 2, "msg_id": msg_id}
+        if plain_text:
+            payload["markdown"] = MarkdownPayload(content=plain_text)
+
         ret: Any = None
         send_helper = SimpleNamespace(bot=self.client)
 
@@ -286,8 +292,7 @@ class QQOfficialPlatformAdapter(Platform):
                         payload["msg_type"] = 7
                         payload.pop("msg_id", None)
                 if payload.get("msg_type") == 7:
-                    payload.pop("markdown", None)
-                    payload["content"] = plain_text or None
+                    self._normalize_media_payload(payload, plain_text)
                 ret = await self.client.api.post_group_message(
                     group_openid=session.session_id,
                     **payload,
@@ -301,8 +306,8 @@ class QQOfficialPlatformAdapter(Platform):
                 )
 
         elif session.message_type == MessageType.FRIEND_MESSAGE:
-            # 参考 https://bot.q.qq.com/wiki/develop/pythonsdk/api/message/post_message.html
-            # msg_id 缺失时认为是主动推送，而似乎至少在私聊上主动推送是没有被限制的，这里直接移除 msg_id 可以避免越权或 msg_id 不可用的bug
+            # When msg_id is absent, the API treats this as a proactive push.
+            # C2C proactive push is unrestricted; drops msg_id to avoid permission errors.
             payload.pop("msg_id", None)
             payload["msg_seq"] = random.randint(1, 10000)
             if image_base64:
@@ -347,8 +352,7 @@ class QQOfficialPlatformAdapter(Platform):
                     payload["msg_type"] = 7
 
             if payload.get("msg_type") == 7:
-                payload.pop("markdown", None)
-                payload["content"] = plain_text or None
+                self._normalize_media_payload(payload, plain_text)
 
             ret = await QQOfficialMessageEvent.post_c2c_message(
                 send_helper,  # type: ignore

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
@@ -14,6 +14,7 @@ import botpy
 import botpy.message
 from botpy import Client
 from botpy.gateway import BotWebSocket
+from botpy.types.message import MarkdownPayload
 
 from astrbot import logger
 from astrbot.api.event import MessageChain
@@ -230,7 +231,11 @@ class QQOfficialPlatformAdapter(Platform):
             )
             return
 
-        payload: dict[str, Any] = {"content": plain_text, "msg_id": msg_id}
+        payload: dict[str, Any] = {
+            "markdown": MarkdownPayload(content=plain_text) if plain_text else None,
+            "msg_type": 2,
+            "msg_id": msg_id,
+        }
         ret: Any = None
         send_helper = SimpleNamespace(bot=self.client)
 
@@ -280,6 +285,9 @@ class QQOfficialPlatformAdapter(Platform):
                         payload["media"] = media
                         payload["msg_type"] = 7
                         payload.pop("msg_id", None)
+                if payload.get("msg_type") == 7:
+                    payload.pop("markdown", None)
+                    payload["content"] = plain_text or None
                 ret = await self.client.api.post_group_message(
                     group_openid=session.session_id,
                     **payload,
@@ -337,6 +345,10 @@ class QQOfficialPlatformAdapter(Platform):
                 if media:
                     payload["media"] = media
                     payload["msg_type"] = 7
+
+            if payload.get("msg_type") == 7:
+                payload.pop("markdown", None)
+                payload["content"] = plain_text or None
 
             ret = await QQOfficialMessageEvent.post_c2c_message(
                 send_helper,  # type: ignore

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
@@ -300,6 +300,8 @@ class QQOfficialPlatformAdapter(Platform):
             else:
                 if image_path:
                     payload["file_image"] = image_path
+                # Guild channel send API does not accept the QQ v2 msg_type field.
+                payload.pop("msg_type", None)
                 ret = await self.client.api.post_message(
                     channel_id=session.session_id,
                     **payload,


### PR DESCRIPTION
## Summary

Fixes missing markdown rendering in QQ Official proactive messages sent via `send_by_session()` (used by cron jobs, `send_message_to_user` tool, etc.). Previously, these messages were sent as `{"content": text}` plain text without `msg_type: 2`, causing markdown formatting to be lost on the QQ client.

Closes #7848

## Problem

The QQ Official platform has two message sending paths:

| Path | Method | Used by | Payload | Markdown |
|------|--------|---------|---------|----------|
| A | `_post_send()` | Normal chat replies | `{markdown: ..., msg_type: 2}` | Works |
| B | `_send_by_session_common()` | Cron, tools, proactive send | `{content: ...}` (no msg_type) | **Broken** |

Path B constructs `{"content": plain_text, "msg_id": msg_id}` without the `markdown` field or `msg_type: 2` that the QQ API requires for native markdown rendering. The `post_c2c_message` API explicitly supports the `markdown=` parameter (line 587 of `qqofficial_message_event.py`), but `_send_by_session_common` never passes it.

## Fix

Three changes in `astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py`, all within `_send_by_session_common()`:

### 1. Add MarkdownPayload import

### 2. Change initial payload to markdown format (line 233)
```diff
-payload: dict[str, Any] = {"content": plain_text, "msg_id": msg_id}
+payload: dict[str, Any] = {
+    "markdown": MarkdownPayload(content=plain_text) if plain_text else None,
+    "msg_type": 2,
+    "msg_id": msg_id,
+}
```
This aligns with how `QQOfficialMessageEvent._post_send()` constructs its payload.

### 3. Add media fallback for group and friend messages
When `msg_type` is changed to `7` (media message) by image/file/voice attachments, the markdown payload is incompatible. Added fallback in both group and C2C branches:
```diff
+if payload.get("msg_type") == 7:
+    payload.pop("markdown", None)
+    payload["content"] = plain_text or None
```

## Testing

- [x] Verified locally: GitHub Trending Daily Push now renders with proper markdown (tables, bold, headers, links)
- [x] Normal chat replies unaffected (`_post_send` path unchanged)
- [x] Media messages (images/voice/files) correctly fall back to `content` format with `msg_type: 7`

## Notes

- Only affects the `qq_official` platform adapter
- The `send_by_session` flow is also used by plugins calling `context.send_message()` — this fix benefits those as well

## Summary by Sourcery

Ensure QQ Official proactive messages sent via send_by_session use markdown payloads for native markdown rendering while falling back to plain content for media messages.

Bug Fixes:
- Fix missing markdown rendering in QQ Official proactive messages by sending markdown payloads with msg_type 2 through the send_by_session flow.
- Ensure QQ Official media messages in the send_by_session path fall back to plain content when msg_type is switched to media (7) to avoid incompatible markdown payloads.