### PR TITLE
fix(provider): skills-like re-query 对不支持 tool_choice 的模型降级为 auto 而非移除全部工具

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -1287,14 +1287,9 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             )
             if param_subset.tools and tool_names:
                 contexts = self._build_tool_requery_context(tool_names)
-                requery_resp = await self.provider.text_chat(
-                    contexts=self._sanitize_contexts_for_provider(contexts),
-                    func_tool=param_subset,
-                    model=self.req.model,
-                    session_id=self.req.session_id,
-                    extra_user_content_parts=self.req.extra_user_content_parts,
-                    tool_choice="required",
-                    abort_signal=self._abort_signal,
+                requery_resp = await self._requery(
+                    contexts=contexts,
+                    param_subset=param_subset,
                 )
                 if requery_resp:
                     llm_resp = requery_resp
@@ -1313,19 +1308,49 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                         tool_names,
                         extra_instruction=self.SKILLS_LIKE_REQUERY_REPAIR_INSTRUCTION,
                     )
-                    repair_resp = await self.provider.text_chat(
-                        contexts=self._sanitize_contexts_for_provider(repair_contexts),
-                        func_tool=param_subset,
-                        model=self.req.model,
-                        session_id=self.req.session_id,
-                        extra_user_content_parts=self.req.extra_user_content_parts,
-                        tool_choice="required",
-                        abort_signal=self._abort_signal,
+                    repair_resp = await self._requery(
+                        contexts=repair_contexts,
+                        param_subset=param_subset,
                     )
                     if repair_resp:
                         llm_resp = repair_resp
 
         return llm_resp, subset
+
+    async def _requery(
+        self,
+        contexts: list,
+        param_subset: ToolSet,
+    ) -> LLMResponse | None:
+        """Send a re-query with tool_choice='required', falling back to 'auto' if
+        the provider does not support the 'required' value (e.g. deepseek-reasoner).
+        """
+        try:
+            return await self.provider.text_chat(
+                contexts=self._sanitize_contexts_for_provider(contexts),
+                func_tool=param_subset,
+                model=self.req.model,
+                session_id=self.req.session_id,
+                extra_user_content_parts=self.req.extra_user_content_parts,
+                tool_choice="required",
+                abort_signal=self._abort_signal,
+            )
+        except Exception as e:
+            if "tool_choice" in str(e).lower():
+                logger.info(
+                    f"tool_choice='required' 不被当前模型支持，降级为 'auto' 重试。",
+                )
+                logger.debug(f"原始错误: {e}")
+                return await self.provider.text_chat(
+                    contexts=self._sanitize_contexts_for_provider(contexts),
+                    func_tool=param_subset,
+                    model=self.req.model,
+                    session_id=self.req.session_id,
+                    extra_user_content_parts=self.req.extra_user_content_parts,
+                    tool_choice="auto",
+                    abort_signal=self._abort_signal,
+                )
+            raise
 
     def done(self) -> bool:
         """检查 Agent 是否已完成工作"""

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -1122,15 +1122,17 @@ class ProviderOpenAIOfficial(Provider):
                 image_fallback_used=True,
             )
 
+        err_lower = str(e).lower()
         if (
             "Function calling is not enabled" in str(e)
-            or ("tool" in str(e).lower() and "support" in str(e).lower())
-            or ("function" in str(e).lower() and "support" in str(e).lower())
+            or ("tool" in err_lower and "support" in err_lower and "tool_choice" not in err_lower)
+            or ("function" in err_lower and "support" in err_lower)
         ):
             # openai, ollama, gemini openai, siliconcloud 的错误提示与 code 不统一，只能通过字符串匹配
             logger.info(
                 f"{self.get_model()} 不支持函数工具调用，已自动去除，不影响使用。",
             )
+            logger.debug(f"原始错误: {e}")
             payloads.pop("tools", None)
             return (
                 False,
@@ -1143,7 +1145,7 @@ class ProviderOpenAIOfficial(Provider):
             )
         # logger.error(f"发生了错误。Provider 配置如下: {self.provider_config}")
 
-        if "tool" in str(e).lower() and "support" in str(e).lower():
+        if "tool" in err_lower and "support" in err_lower and "tool_choice" not in err_lower:
             logger.error("疑似该模型不支持函数调用工具调用。请输入 /tool off_all")
 
         if is_connection_error(e):


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
fix: https://github.com/AstrBotDevs/AstrBot/issues/7853

### Modifications / 改动点

  1. astrbot/core/provider/sources/openai_source.py —               
  错误处理器中「不支持工具」的判定排除 tool_choice 关键词，避免将 tool_choice 不兼容误判为模型不支持工具调用。同时将原始错误信息降级为 DEBUG 日志。
  2. astrbot/core/agent/runners/tool_loop_agent_runner.py — _resolve_tool_exec 中两次 re-query 提取为 _requery() 方法，先以 tool_choice="required" 请求，若 provider 返回 tool_choice 相关错误则自动降级为 "auto" 重试，保留完整工具定义。
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

[2026-04-27 23:02:16.274] [Core] [INFO] [runners.tool_loop_agent_runner:1340]: tool_choice='required' 不被当前模型支持，降级为 'auto' 重试。

[2026-04-27 23:02:16.275] [Core] [DBUG] [runners.tool_loop_agent_runner:1343]: 原始错误: Error code: 400 - {'error': {'message': 'deepseek-reasoner does not support this tool_choice', 'type': 'invalid_request_error', 'param': None, 'code': 'invalid_request_error'}}
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Handle models that do not support `tool_choice="required"` by degrading to `tool_choice="auto"` while preserving tool definitions, and avoid misclassifying `tool_choice` incompatibility as lack of tool support.

Bug Fixes:
- Fix skills-like re-query so that models without `tool_choice="required"` support fall back to `tool_choice="auto"` instead of dropping all tools.
- Avoid treating `tool_choice`-related errors as signals that a model does not support tools, and log the original error message at debug level.