### PR TITLE
fix: normalize shell background commands

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -1022,6 +1022,8 @@ def _apply_sandbox_tools(
         req.system_prompt += (
             "\n[CUA Desktop Control]\n"
             "Use `astrbot_execute_shell` with `background=true` to launch GUI apps. "
+            "Do not append `&`, `nohup`, or other shell background operators; "
+            "the tool handles detaching when `background=true`. "
             'Use Firefox for browser tasks, for example `firefox "https://example.com"`. '
             "After each visible step, call `astrbot_cua_screenshot` with "
             "`send_to_user=true` and `return_image_to_llm=true` so the user can "

--- a/astrbot/core/tools/computer_tools/shell.py
+++ b/astrbot/core/tools/computer_tools/shell.py
@@ -32,7 +32,7 @@ class ExecuteShellTool(FunctionTool):
                 },
                 "background": {
                     "type": "boolean",
-                    "description": "Whether to run the command in the background.",
+                    "description": "Whether to run the command in the background. Do not append shell background operators such as `&`; pass the foreground command and use this flag instead.",
                     "default": False,
                 },
                 "env": {
@@ -70,9 +70,12 @@ class ExecuteShellTool(FunctionTool):
                 cwd = str(current_workspace_root)
 
             env = dict(env or {})
-            effective_background = background and not _is_self_detached_command(command)
-            result = await sb.shell.exec(
+            prepared_command, effective_background = _prepare_shell_background(
                 command,
+                background,
+            )
+            result = await sb.shell.exec(
+                prepared_command,
                 cwd=cwd,
                 background=effective_background,
                 env=env,
@@ -83,24 +86,104 @@ class ExecuteShellTool(FunctionTool):
             return f"Error executing command: {detail}"
 
 
+def _prepare_shell_background(command: str, background: bool) -> tuple[str, bool]:
+    if not background:
+        return command, False
+    if _uses_explicit_background_launcher(command):
+        return command, False
+
+    stripped_command = _strip_plain_trailing_background_operator(command)
+    if stripped_command is not None:
+        return stripped_command, True
+    return command, True
+
+
+def _uses_explicit_background_launcher(command: str) -> bool:
+    tokens = _command_tokens_before_comment(command)
+    if not tokens:
+        return False
+    return tokens[0].lower() in {"nohup", "setsid", "disown", "start", "start-process"}
+
+
 def _is_self_detached_command(command: str) -> bool:
+    tokens = _command_tokens_before_comment(command)
+    if not tokens:
+        return False
+
+    if _uses_explicit_background_launcher(command):
+        return True
+    return tokens[-1] == "&"
+
+
+def _command_tokens_before_comment(command: str) -> list[str]:
     lex = shlex.shlex(command, posix=False)
     lex.whitespace_split = True
     lex.commenters = ""
     try:
         tokens = list(lex)
     except ValueError:
-        return False
+        return []
     comment_index = next(
         (index for index, token in enumerate(tokens) if token.startswith("#")),
         None,
     )
     if comment_index is not None:
         tokens = tokens[:comment_index]
-    if not tokens:
-        return False
+    return tokens
 
-    first = tokens[0].lower()
-    if first in {"nohup", "setsid", "disown", "start", "start-process"}:
-        return True
-    return tokens[-1] == "&"
+
+def _strip_plain_trailing_background_operator(command: str) -> str | None:
+    effective_end = _command_effective_end(command)
+    tail = command[:effective_end].rstrip()
+    if not tail.endswith("&"):
+        return None
+    if not _is_unquoted_char_at(tail, len(tail) - 1):
+        return None
+
+    stripped = tail[:-1].rstrip()
+    return stripped if stripped != tail else None
+
+
+def _command_effective_end(command: str) -> int:
+    quote: str | None = None
+    escaped = False
+    for index, char in enumerate(command):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\" and quote != "'":
+            escaped = True
+            continue
+        if char in {"'", '"'}:
+            if quote is None:
+                quote = char
+            elif quote == char:
+                quote = None
+            continue
+        if (
+            char == "#"
+            and quote is None
+            and (index == 0 or command[index - 1].isspace())
+        ):
+            return index
+    return len(command)
+
+
+def _is_unquoted_char_at(command: str, target_index: int) -> bool:
+    quote: str | None = None
+    escaped = False
+    for index, char in enumerate(command):
+        if index == target_index:
+            return quote is None and not escaped
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\" and quote != "'":
+            escaped = True
+            continue
+        if char in {"'", '"'}:
+            if quote is None:
+                quote = char
+            elif quote == char:
+                quote = None
+    return False

--- a/astrbot/core/tools/computer_tools/shell.py
+++ b/astrbot/core/tools/computer_tools/shell.py
@@ -1,6 +1,7 @@
 import json
 import shlex
 from dataclasses import dataclass, field
+from enum import Enum, auto
 from typing import Any
 
 from astrbot.api import FunctionTool
@@ -15,6 +16,12 @@ from .util import check_admin_permission, is_local_runtime, workspace_root
 _COMPUTER_RUNTIME_TOOL_CONFIG = {
     "provider_settings.computer_use_runtime": ("local", "sandbox"),
 }
+
+
+class BackgroundKind(Enum):
+    EXPLICIT_LAUNCHER = auto()
+    TRAILING_AMP = auto()
+    NONE = auto()
 
 
 @builtin_tool(config=_COMPUTER_RUNTIME_TOOL_CONFIG)
@@ -89,30 +96,32 @@ class ExecuteShellTool(FunctionTool):
 def _prepare_shell_background(command: str, background: bool) -> tuple[str, bool]:
     if not background:
         return command, False
-    if _uses_explicit_background_launcher(command):
-        return command, False
 
-    stripped_command = _strip_plain_trailing_background_operator(command)
-    if stripped_command is not None:
-        return stripped_command, True
+    kind = _background_kind(command)
+    if kind is BackgroundKind.EXPLICIT_LAUNCHER:
+        return command, False
+    if kind is BackgroundKind.TRAILING_AMP:
+        stripped_command = _strip_plain_trailing_background_operator(command)
+        if stripped_command is not None:
+            return stripped_command, True
+        return command, True
     return command, True
 
 
-def _uses_explicit_background_launcher(command: str) -> bool:
+def _background_kind(command: str) -> BackgroundKind:
     tokens = _command_tokens_before_comment(command)
     if not tokens:
-        return False
-    return tokens[0].lower() in {"nohup", "setsid", "disown", "start", "start-process"}
+        return BackgroundKind.NONE
+
+    if tokens[0].lower() in {"nohup", "setsid", "disown", "start", "start-process"}:
+        return BackgroundKind.EXPLICIT_LAUNCHER
+    if tokens[-1] == "&":
+        return BackgroundKind.TRAILING_AMP
+    return BackgroundKind.NONE
 
 
 def _is_self_detached_command(command: str) -> bool:
-    tokens = _command_tokens_before_comment(command)
-    if not tokens:
-        return False
-
-    if _uses_explicit_background_launcher(command):
-        return True
-    return tokens[-1] == "&"
+    return _background_kind(command) is not BackgroundKind.NONE
 
 
 def _command_tokens_before_comment(command: str) -> list[str]:
@@ -133,57 +142,9 @@ def _command_tokens_before_comment(command: str) -> list[str]:
 
 
 def _strip_plain_trailing_background_operator(command: str) -> str | None:
-    effective_end = _command_effective_end(command)
-    tail = command[:effective_end].rstrip()
-    if not tail.endswith("&"):
-        return None
-    if not _is_unquoted_char_at(tail, len(tail) - 1):
+    tokens = _command_tokens_before_comment(command)
+    if not tokens or tokens[-1] != "&":
         return None
 
-    stripped = tail[:-1].rstrip()
-    return stripped if stripped != tail else None
-
-
-def _command_effective_end(command: str) -> int:
-    quote: str | None = None
-    escaped = False
-    for index, char in enumerate(command):
-        if escaped:
-            escaped = False
-            continue
-        if char == "\\" and quote != "'":
-            escaped = True
-            continue
-        if char in {"'", '"'}:
-            if quote is None:
-                quote = char
-            elif quote == char:
-                quote = None
-            continue
-        if (
-            char == "#"
-            and quote is None
-            and (index == 0 or command[index - 1].isspace())
-        ):
-            return index
-    return len(command)
-
-
-def _is_unquoted_char_at(command: str, target_index: int) -> bool:
-    quote: str | None = None
-    escaped = False
-    for index, char in enumerate(command):
-        if index == target_index:
-            return quote is None and not escaped
-        if escaped:
-            escaped = False
-            continue
-        if char == "\\" and quote != "'":
-            escaped = True
-            continue
-        if char in {"'", '"'}:
-            if quote is None:
-                quote = char
-            elif quote == char:
-                quote = None
-    return False
+    stripped = " ".join(tokens[:-1])
+    return stripped if stripped else ""

--- a/astrbot/core/tools/computer_tools/shell.py
+++ b/astrbot/core/tools/computer_tools/shell.py
@@ -1,7 +1,6 @@
 import json
 import shlex
 from dataclasses import dataclass, field
-from enum import Enum, auto
 from typing import Any
 
 from astrbot.api import FunctionTool
@@ -16,12 +15,7 @@ from .util import check_admin_permission, is_local_runtime, workspace_root
 _COMPUTER_RUNTIME_TOOL_CONFIG = {
     "provider_settings.computer_use_runtime": ("local", "sandbox"),
 }
-
-
-class BackgroundKind(Enum):
-    EXPLICIT_LAUNCHER = auto()
-    TRAILING_AMP = auto()
-    NONE = auto()
+_EXPLICIT_BACKGROUND_LAUNCHERS = {"nohup", "setsid", "disown", "start", "start-process"}
 
 
 @builtin_tool(config=_COMPUTER_RUNTIME_TOOL_CONFIG)
@@ -81,6 +75,16 @@ class ExecuteShellTool(FunctionTool):
                 command,
                 background,
             )
+            if background and not prepared_command.strip():
+                return json.dumps(
+                    {
+                        "success": False,
+                        "stdout": "",
+                        "stderr": "error: empty shell command after removing background operator.",
+                        "exit_code": 2,
+                    },
+                    ensure_ascii=False,
+                )
             result = await sb.shell.exec(
                 prepared_command,
                 cwd=cwd,
@@ -97,31 +101,27 @@ def _prepare_shell_background(command: str, background: bool) -> tuple[str, bool
     if not background:
         return command, False
 
-    kind = _background_kind(command)
-    if kind is BackgroundKind.EXPLICIT_LAUNCHER:
+    tokens, has_explicit_launcher, has_trailing_amp = _classify_background(command)
+    if has_explicit_launcher:
         return command, False
-    if kind is BackgroundKind.TRAILING_AMP:
-        stripped_command = _strip_plain_trailing_background_operator(command)
-        if stripped_command is not None:
-            return stripped_command, True
-        return command, True
+    if has_trailing_amp:
+        return " ".join(tokens[:-1]), True
     return command, True
 
 
-def _background_kind(command: str) -> BackgroundKind:
+def _classify_background(command: str) -> tuple[list[str], bool, bool]:
     tokens = _command_tokens_before_comment(command)
     if not tokens:
-        return BackgroundKind.NONE
+        return tokens, False, False
 
-    if tokens[0].lower() in {"nohup", "setsid", "disown", "start", "start-process"}:
-        return BackgroundKind.EXPLICIT_LAUNCHER
-    if tokens[-1] == "&":
-        return BackgroundKind.TRAILING_AMP
-    return BackgroundKind.NONE
+    has_explicit_launcher = tokens[0].lower() in _EXPLICIT_BACKGROUND_LAUNCHERS
+    has_trailing_amp = tokens[-1] == "&"
+    return tokens, has_explicit_launcher, has_trailing_amp
 
 
 def _is_self_detached_command(command: str) -> bool:
-    return _background_kind(command) is not BackgroundKind.NONE
+    _, has_explicit_launcher, has_trailing_amp = _classify_background(command)
+    return has_explicit_launcher or has_trailing_amp
 
 
 def _command_tokens_before_comment(command: str) -> list[str]:
@@ -139,12 +139,3 @@ def _command_tokens_before_comment(command: str) -> list[str]:
     if comment_index is not None:
         tokens = tokens[:comment_index]
     return tokens
-
-
-def _strip_plain_trailing_background_operator(command: str) -> str | None:
-    tokens = _command_tokens_before_comment(command)
-    if not tokens or tokens[-1] != "&":
-        return None
-
-    stripped = " ".join(tokens[:-1])
-    return stripped if stripped else ""

--- a/tests/unit/test_astr_main_agent.py
+++ b/tests/unit/test_astr_main_agent.py
@@ -1582,6 +1582,7 @@ class TestApplySandboxTools:
 
         assert "Firefox" in req.system_prompt
         assert "background=true" in req.system_prompt
+        assert "Do not append `&`" in req.system_prompt
         assert 'firefox "https://example.com"' in req.system_prompt
         assert "astrbot_cua_screenshot" in req.system_prompt
         assert "astrbot_cua_key_press" not in req.system_prompt

--- a/tests/unit/test_func_tool_manager.py
+++ b/tests/unit/test_func_tool_manager.py
@@ -271,6 +271,50 @@ async def test_execute_shell_strips_plain_trailing_ampersand_when_background_fla
 
 
 @pytest.mark.asyncio
+async def test_execute_shell_keeps_quoted_ampersand_when_background_flag_is_set(
+    monkeypatch,
+):
+    from astrbot.core.tools.computer_tools import shell as shell_tools
+
+    calls = []
+
+    class FakeShell:
+        async def exec(self, command, cwd=None, background=False, env=None):
+            calls.append({"command": command, "background": background})
+            return {"success": True, "stdout": "", "stderr": "", "exit_code": 0}
+
+    class FakeBooter:
+        shell = FakeShell()
+
+    class FakeConfig:
+        def get_config(self, umo):
+            return {"provider_settings": {"computer_use_runtime": "sandbox"}}
+
+    class FakeEvent:
+        unified_msg_origin = "umo"
+        role = "admin"
+
+    class FakeAstrContext:
+        context = FakeConfig()
+        event = FakeEvent()
+
+    class FakeWrapper:
+        context = FakeAstrContext()
+
+    async def fake_get_booter(context, session_id):
+        return FakeBooter()
+
+    monkeypatch.setattr(shell_tools, "get_booter", fake_get_booter)
+
+    result = await ExecuteShellTool().call(
+        FakeWrapper(), command="echo '&'", background=True
+    )
+
+    assert json.loads(result)["success"] is True
+    assert calls == [{"command": "echo '&'", "background": True}]
+
+
+@pytest.mark.asyncio
 async def test_execute_shell_recognizes_commented_background_command(monkeypatch):
     from astrbot.core.tools.computer_tools import shell as shell_tools
 

--- a/tests/unit/test_func_tool_manager.py
+++ b/tests/unit/test_func_tool_manager.py
@@ -271,6 +271,49 @@ async def test_execute_shell_strips_plain_trailing_ampersand_when_background_fla
 
 
 @pytest.mark.asyncio
+async def test_execute_shell_rejects_bare_background_operator(monkeypatch):
+    from astrbot.core.tools.computer_tools import shell as shell_tools
+
+    calls = []
+
+    class FakeShell:
+        async def exec(self, command, cwd=None, background=False, env=None):
+            calls.append({"command": command, "background": background})
+            return {"success": True, "stdout": "", "stderr": "", "exit_code": 0}
+
+    class FakeBooter:
+        shell = FakeShell()
+
+    class FakeConfig:
+        def get_config(self, umo):
+            return {"provider_settings": {"computer_use_runtime": "sandbox"}}
+
+    class FakeEvent:
+        unified_msg_origin = "umo"
+        role = "admin"
+
+    class FakeAstrContext:
+        context = FakeConfig()
+        event = FakeEvent()
+
+    class FakeWrapper:
+        context = FakeAstrContext()
+
+    async def fake_get_booter(context, session_id):
+        return FakeBooter()
+
+    monkeypatch.setattr(shell_tools, "get_booter", fake_get_booter)
+
+    result = await ExecuteShellTool().call(FakeWrapper(), command="&", background=True)
+    payload = json.loads(result)
+
+    assert payload["success"] is False
+    assert payload["exit_code"] == 2
+    assert "empty shell command" in payload["stderr"]
+    assert calls == []
+
+
+@pytest.mark.asyncio
 async def test_execute_shell_keeps_quoted_ampersand_when_background_flag_is_set(
     monkeypatch,
 ):

--- a/tests/unit/test_func_tool_manager.py
+++ b/tests/unit/test_func_tool_manager.py
@@ -46,6 +46,10 @@ def test_computer_tools_are_registered_as_builtin_tools():
 
     assert tool.name == "astrbot_execute_shell"
     assert tool.parameters["properties"]["background"]["default"] is False
+    assert (
+        "Do not append shell background operators"
+        in tool.parameters["properties"]["background"]["description"]
+    )
     assert manager.is_builtin_tool("astrbot_execute_shell") is True
 
 
@@ -223,6 +227,50 @@ async def test_execute_shell_avoids_double_background_for_detached_commands(
 
 
 @pytest.mark.asyncio
+async def test_execute_shell_strips_plain_trailing_ampersand_when_background_flag_is_set(
+    monkeypatch,
+):
+    from astrbot.core.tools.computer_tools import shell as shell_tools
+
+    calls = []
+
+    class FakeShell:
+        async def exec(self, command, cwd=None, background=False, env=None):
+            calls.append({"command": command, "background": background})
+            return {"success": True, "stdout": "", "stderr": "", "exit_code": 0}
+
+    class FakeBooter:
+        shell = FakeShell()
+
+    class FakeConfig:
+        def get_config(self, umo):
+            return {"provider_settings": {"computer_use_runtime": "sandbox"}}
+
+    class FakeEvent:
+        unified_msg_origin = "umo"
+        role = "admin"
+
+    class FakeAstrContext:
+        context = FakeConfig()
+        event = FakeEvent()
+
+    class FakeWrapper:
+        context = FakeAstrContext()
+
+    async def fake_get_booter(context, session_id):
+        return FakeBooter()
+
+    monkeypatch.setattr(shell_tools, "get_booter", fake_get_booter)
+
+    result = await ExecuteShellTool().call(
+        FakeWrapper(), command="firefox &", background=True
+    )
+
+    assert json.loads(result)["success"] is True
+    assert calls == [{"command": "firefox", "background": True}]
+
+
+@pytest.mark.asyncio
 async def test_execute_shell_recognizes_commented_background_command(monkeypatch):
     from astrbot.core.tools.computer_tools import shell as shell_tools
 
@@ -262,7 +310,7 @@ async def test_execute_shell_recognizes_commented_background_command(monkeypatch
     )
 
     assert json.loads(result)["success"] is True
-    assert calls == [{"command": command, "background": False}]
+    assert calls == [{"command": "firefox", "background": True}]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

This fixes CUA desktop launches where the model passes both `background=true` and a shell-level trailing `&`, for example `firefox &`.

The CUA booter has its own background launcher that detaches GUI apps through a Python `subprocess.Popen` wrapper. The generic shell tool previously treated any trailing `&` as already detached and disabled the tool-level `background` flag, which bypassed the CUA wrapper and could leave GUI launch commands waiting until timeout.

## Changes

- Clarify the CUA desktop prompt so models use `background=true` without appending `&`, `nohup`, or other shell background operators.
- Clarify the `astrbot_execute_shell` `background` parameter description.
- Normalize plain trailing `&` commands when `background=true`, so `firefox &` is executed as `firefox` with tool-managed background execution.
- Preserve existing compatibility for explicit self-detaching commands such as `nohup ... &`.
- Add regression coverage for the prompt, schema, and shell normalization behavior.

## Verification

- `uv run pytest tests/unit/test_func_tool_manager.py tests/unit/test_astr_main_agent.py -q`
- `uv run pytest tests/unit/test_func_tool_manager.py tests/unit/test_astr_main_agent.py tests/unit/test_cua_computer_use.py -q`
- `uv run ruff format .`
- `uv run ruff check .`

## Summary by Sourcery

Normalize shell background handling for CUA desktop launches to rely on the tool-level background flag while preserving explicit self-detaching commands.

Bug Fixes:
- Ensure background GUI launches via `astrbot_execute_shell` still go through the CUA wrapper by stripping plain trailing `&` when the background flag is set and rejecting empty commands.

Enhancements:
- Clarify the `astrbot_execute_shell` background parameter description and the CUA desktop control prompt to discourage manual shell background operators.

Documentation:
- Update the CUA desktop system prompt text to explain correct use of `background=true` without `&` or other shell background operators.

Tests:
- Add unit tests covering shell background normalization, explicit background launchers, bare `&` rejection, quoted ampersands, and updated prompt/schema expectations.