### PR TITLE
fix(agent): use full tool schema for DeepSeek V4

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -289,10 +289,12 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
         #   Light tool schema does not include tool parameters.
         #   This can reduce token usage when tools have large descriptions.
         # See #4681
-        self.tool_schema_mode = tool_schema_mode
+        self.tool_schema_mode = self._normalize_tool_schema_mode(
+            tool_schema_mode, provider, request
+        )
         self._tool_schema_param_set = None
         self._skill_like_raw_tool_set = None
-        if tool_schema_mode == "skills_like":
+        if self.tool_schema_mode == "skills_like":
             tool_set = self.req.func_tool
             if not tool_set:
                 return
@@ -321,6 +323,26 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
 
         self.stats = AgentStats()
         self.stats.start_time = time.time()
+
+    @staticmethod
+    def _normalize_tool_schema_mode(
+        tool_schema_mode: str | None,
+        provider: Provider,
+        request: ProviderRequest,
+    ) -> str | None:
+        if tool_schema_mode != "skills_like":
+            return tool_schema_mode
+
+        model = (request.model or provider.get_model() or "").lower().strip()
+        model_name = model.rsplit("/", 1)[-1]
+        if model_name not in {"deepseek-v4-flash", "deepseek-v4-pro"}:
+            return tool_schema_mode
+
+        logger.info(
+            "DeepSeek V4 does not support skills-like light tool schemas; "
+            "using full tool schemas for function calling."
+        )
+        return "full"
 
     def _read_tool_hint(self) -> str:
         if self.read_tool is not None:

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -1274,6 +1274,40 @@ async def test_skills_like_requery_passes_extra_user_content_parts():
 
 
 @pytest.mark.asyncio
+async def test_deepseek_v4_uses_full_tool_schema_instead_of_skills_like():
+    provider = MockProvider()
+    tool = FunctionTool(
+        name="test_tool",
+        description="测试",
+        parameters={"type": "object", "properties": {"query": {"type": "string"}}},
+        handler=AsyncMock(),
+    )
+    tool_set = ToolSet(tools=[tool])
+    req = ProviderRequest(
+        prompt="test",
+        func_tool=tool_set,
+        contexts=[],
+        model="deepseek-v4-flash",
+    )
+    runner = ToolLoopAgentRunner()
+
+    await runner.reset(
+        provider=provider,
+        request=req,
+        run_context=ContextWrapper(context=None),
+        tool_executor=cast(Any, MockToolExecutor()),
+        agent_hooks=MockHooks(),
+        tool_schema_mode="skills_like",
+    )
+
+    assert runner.tool_schema_mode == "full"
+    assert runner.req.func_tool is tool_set
+    assert runner.req.func_tool.tools[0].parameters == tool.parameters
+    assert runner.req.func_tool.tools[0].handler is tool.handler
+    assert runner._tool_schema_param_set is None
+
+
+@pytest.mark.asyncio
 async def test_follow_up_accepted_when_active_and_not_stopping(
     runner, mock_provider, provider_request, mock_tool_executor, mock_hooks
 ):


### PR DESCRIPTION
Fixes #7855

DeepSeek V4 rejects the skills-like light tool schema, so AstrBot can fall back as if the model does not support function calling. For DeepSeek V4 models, the local agent runner now uses the full tool schema instead of mutating `func_tool` to the light schema.

Added a regression test that verifies `deepseek-v4-flash` keeps the original full tool set when `skills_like` is selected.

### Modifications / 改动点

- Normalize `skills_like` to `full` for `deepseek-v4-flash` and `deepseek-v4-pro`.
- Keep existing `skills_like` behavior unchanged for other models.
- Add coverage for the DeepSeek V4 schema-mode override.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```bash
uv run pytest -q tests/test_tool_loop_agent_runner.py::test_deepseek_v4_uses_full_tool_schema_instead_of_skills_like tests/test_tool_loop_agent_runner.py::test_skills_like_requery_passes_extra_user_content_parts
# 2 passed, 3 warnings in 11.65s

uv run ruff check astrbot/core/agent/runners/tool_loop_agent_runner.py tests/test_tool_loop_agent_runner.py
# All checks passed!
```

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Normalize tool schema mode handling for DeepSeek V4 models to ensure compatible tool invocation while preserving behavior for other providers.

Enhancements:
- Add model-aware normalization of the `skills_like` tool schema mode, forcing DeepSeek V4 models to use the full tool schema with logging for this override.

Tests:
- Add regression test ensuring DeepSeek V4 models retain the full tool schema when `skills_like` is requested and that internal state is updated accordingly.