### PR TITLE
fix(provider): persist model enable toggle

### DIFF
--- a/dashboard/src/components/provider/ProviderChatCompletionPanel.vue
+++ b/dashboard/src/components/provider/ProviderChatCompletionPanel.vue
@@ -89,6 +89,7 @@
                 :supports-tool-call="supportsToolCall"
                 :supports-reasoning="supportsReasoning"
                 :format-context-limit="formatContextLimit"
+                :saving-providers="savingProviderToggles"
                 :testing-providers="testingProviders"
                 :tm="tm"
                 @fetch-models="fetchAvailableModels"
@@ -209,6 +210,7 @@ const {
   availableModels,
   loadingModels,
   savingSource,
+  savingProviderToggles,
   testingProviders,
   isSourceModified,
   configSchema,

--- a/dashboard/src/components/provider/ProviderModelsPanel.vue
+++ b/dashboard/src/components/provider/ProviderModelsPanel.vue
@@ -84,12 +84,13 @@
 
                 <div class="provider-model-row__actions" @click.stop>
                   <v-switch
-                    v-model="entry.provider.enable"
+                    :model-value="entry.provider.enable"
                     density="compact"
                     inset
                     hide-details
                     color="primary"
                     class="provider-model-row__switch"
+                    :disabled="isProviderSaving(entry.provider.id)"
                     @update:modelValue="emit('toggle-provider-enable', entry.provider, $event)"
                   ></v-switch>
 
@@ -97,7 +98,7 @@
                     icon="mdi-connection"
                     size="small"
                     variant="text"
-                    :disabled="!entry.provider.enable"
+                    :disabled="!entry.provider.enable || isProviderSaving(entry.provider.id)"
                     :loading="isProviderTesting(entry.provider.id)"
                     @click.stop="emit('test-provider', entry.provider)"
                   ></v-btn>
@@ -240,6 +241,10 @@ const props = defineProps({
     type: Array,
     default: () => []
   },
+  savingProviders: {
+    type: Array,
+    default: () => []
+  },
   tm: {
     type: Function,
     required: true
@@ -288,6 +293,7 @@ const capabilityIcons = (metadata) => {
 }
 
 const isProviderTesting = (providerId) => props.testingProviders.includes(providerId)
+const isProviderSaving = (providerId) => props.savingProviders.includes(providerId)
 </script>
 
 <style scoped>

--- a/dashboard/src/composables/useProviderSources.ts
+++ b/dashboard/src/composables/useProviderSources.ts
@@ -633,8 +633,8 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
       showMessage(error.response?.data?.message || error.message || tm('providerSources.saveError'), 'error')
       return false
     } finally {
-      savingProviderToggles.value = savingProviderToggles.value.filter((id) => id !== provider.id)
       await loadConfig()
+      savingProviderToggles.value = savingProviderToggles.value.filter((id) => id !== provider.id)
     }
   }
 
@@ -657,7 +657,7 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
   }
 
   async function loadConfig() {
-    loadProviderTemplate()
+    await loadProviderTemplate()
   }
 
   async function loadProviderTemplate() {

--- a/dashboard/src/composables/useProviderSources.ts
+++ b/dashboard/src/composables/useProviderSources.ts
@@ -58,6 +58,7 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
   const modelMetadata = ref<Record<string, any>>({})
   const loadingModels = ref(false)
   const savingSource = ref(false)
+  const savingProviderToggles = ref<string[]>([])
   const testingProviders = ref<string[]>([])
   const isSourceModified = ref(false)
   const configSchema = ref<Record<string, any>>({})
@@ -610,6 +611,33 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
     }
   }
 
+  async function toggleProviderEnable(provider: any, value: boolean) {
+    if (!provider?.id || savingProviderToggles.value.includes(provider.id)) {
+      return false
+    }
+
+    savingProviderToggles.value.push(provider.id)
+    try {
+      const nextConfig = { ...provider, enable: Boolean(value) }
+      const response = await axios.post('/api/config/provider/update', {
+        id: provider.id,
+        config: nextConfig
+      })
+      if (response.data.status === 'error') {
+        throw new Error(response.data.message)
+      }
+      provider.enable = nextConfig.enable
+      showMessage(response.data.message || tm('messages.success.statusUpdate'))
+      return true
+    } catch (error: any) {
+      showMessage(error.response?.data?.message || error.message || tm('providerSources.saveError'), 'error')
+      return false
+    } finally {
+      savingProviderToggles.value = savingProviderToggles.value.filter((id) => id !== provider.id)
+      await loadConfig()
+    }
+  }
+
   async function testProvider(provider: any) {
     testingProviders.value.push(provider.id)
     try {
@@ -670,6 +698,7 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
     modelMetadata,
     loadingModels,
     savingSource,
+    savingProviderToggles,
     testingProviders,
     isSourceModified,
     configSchema,
@@ -711,6 +740,7 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
     addModelProvider,
     deleteProvider,
     modelAlreadyConfigured,
+    toggleProviderEnable,
     testProvider,
     loadConfig,
     loadProviderTemplate


### PR DESCRIPTION
Fixes AstrBotDevs/AstrBot#7863

This PR fixes a WebUI provider model toggle issue.

When a user fetches models from an OpenAI Compatible provider source, adds a model, enables it, and immediately clicks the test button, the UI previously showed the model as enabled but did not persist the enable state or reload the provider before calling `/config/provider/check_one`.

As a result, the backend could not find the provider in `provider_manager.inst_map` and returned:

```text
Provider with id '...' not found in provider_manager.
```
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

Persist model enable/disable changes through /api/config/provider/update when toggling a configured provider model.

Refresh provider config after the toggle update so the WebUI stays in sync with backend state.

Avoid local-only optimistic switching by replacing the model switch v-model with :model-value.

Disable the model switch and test button while the enable/disable update is being saved, preventing users from testing before the provider reload completes.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

Manual verification path:

1. Configure an OpenAI Compatible provider source with a valid API Key and API Base URL.
2. Fetch models successfully.
3. Add a fetched model to the configured model list.
4. Enable the model from the switch.
5. Without opening the model config dialog or clicking save there, click the test button.
6. The provider is now persisted/reloaded before testing, so /config/provider/check_one no longer fails with not found in provider_manager.

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure provider model enable toggles are persisted and synchronized with backend state before testing.

Bug Fixes:
- Persist provider model enable/disable state via the provider update API instead of relying on local optimistic updates.
- Reload provider configuration after toggling so the WebUI and backend remain consistent, preventing missing provider errors during tests.
- Disable the model enable switch and test button while a toggle is being saved to avoid testing before the provider reload completes.

Enhancements:
- Track per-provider toggle save state in the provider sources composable and expose it to components so they can reflect saving status in the UI.