### PR TITLE
fix(kb): 修复知识库向量维度不一致时的错误提示与更新状态

### DIFF
--- a/astrbot/core/db/vec_db/faiss_impl/embedding_storage.py
+++ b/astrbot/core/db/vec_db/faiss_impl/embedding_storage.py
@@ -8,6 +8,8 @@ import os
 
 import numpy as np
 
+from astrbot.core.exceptions import KnowledgeBaseUploadError
+
 
 class EmbeddingStorage:
     def __init__(self, dimension: int, path: str | None = None) -> None:
@@ -16,6 +18,20 @@ class EmbeddingStorage:
         self.index = None
         if path and os.path.exists(path):
             self.index = faiss.read_index(path)
+            actual_dimension = self.index.d
+            if actual_dimension != dimension:
+                raise KnowledgeBaseUploadError(
+                    stage="embedding",
+                    user_message=(
+                        "向量化失败：知识库索引维度与当前嵌入模型维度不一致"
+                        f"（索引维度 {actual_dimension}，当前模型配置维度 {dimension}）。"
+                        "请使用原嵌入模型，或删除并重建知识库索引。"
+                    ),
+                    details={
+                        "index_dimension": actual_dimension,
+                        "provider_dimension": dimension,
+                    },
+                )
         else:
             base_index = faiss.IndexFlatL2(dimension)
             self.index = faiss.IndexIDMap(base_index)

--- a/astrbot/core/db/vec_db/faiss_impl/vec_db.py
+++ b/astrbot/core/db/vec_db/faiss_impl/vec_db.py
@@ -109,13 +109,22 @@ class FaissVecDB(BaseVecDB):
 
         start = time.time()
         logger.debug(f"Generating embeddings for {len(contents)} contents...")
-        vectors = await self.embedding_provider.get_embeddings_batch(
-            contents,
-            batch_size=batch_size,
-            tasks_limit=tasks_limit,
-            max_retries=max_retries,
-            progress_callback=progress_callback,
-        )
+        try:
+            vectors = await self.embedding_provider.get_embeddings_batch(
+                contents,
+                batch_size=batch_size,
+                tasks_limit=tasks_limit,
+                max_retries=max_retries,
+                progress_callback=progress_callback,
+            )
+        except KnowledgeBaseUploadError:
+            raise
+        except Exception as exc:
+            raise KnowledgeBaseUploadError(
+                stage="embedding",
+                user_message=f"向量化失败：批量生成嵌入向量时出错。{exc}",
+                details={"content_count": content_count},
+            ) from exc
         end = time.time()
         logger.debug(
             f"Generated embeddings for {len(contents)} contents in {end - start:.2f} seconds.",

--- a/astrbot/core/knowledge_base/kb_mgr.py
+++ b/astrbot/core/knowledge_base/kb_mgr.py
@@ -249,7 +249,7 @@ class KnowledgeBaseManager:
                 f"知识库 {kb.kb_name}({kb.kb_id}) 重新初始化失败，继续使用旧实例: {e}",
                 exc_info=True,
             )
-            raise ValueError(str(e)) from e
+            raise
         except Exception as e:
             # Roll back in-memory settings and keep current helper available.
             rollback_state()

--- a/astrbot/core/knowledge_base/kb_mgr.py
+++ b/astrbot/core/knowledge_base/kb_mgr.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from astrbot.core import logger
+from astrbot.core.exceptions import KnowledgeBaseUploadError
 from astrbot.core.provider.manager import ProviderManager
 from astrbot.core.utils.astrbot_path import get_astrbot_knowledge_base_path
 
@@ -198,6 +199,19 @@ class KnowledgeBaseManager:
         }
         previous_init_error = kb_helper.init_error
 
+        def rollback_state() -> None:
+            kb.kb_name = previous_state["kb_name"]
+            kb.description = previous_state["description"]
+            kb.emoji = previous_state["emoji"]
+            kb.embedding_provider_id = previous_state["embedding_provider_id"]
+            kb.rerank_provider_id = previous_state["rerank_provider_id"]
+            kb.chunk_size = previous_state["chunk_size"]
+            kb.chunk_overlap = previous_state["chunk_overlap"]
+            kb.top_k_dense = previous_state["top_k_dense"]
+            kb.top_k_sparse = previous_state["top_k_sparse"]
+            kb.top_m_final = previous_state["top_m_final"]
+            kb_helper.init_error = previous_init_error
+
         if kb_name is not None:
             kb.kb_name = kb_name
         if description is not None:
@@ -229,24 +243,21 @@ class KnowledgeBaseManager:
 
         try:
             await new_helper.initialize()
-        except Exception as e:
-            # Roll back in-memory settings and keep current helper available.
-            kb.kb_name = previous_state["kb_name"]
-            kb.description = previous_state["description"]
-            kb.emoji = previous_state["emoji"]
-            kb.embedding_provider_id = previous_state["embedding_provider_id"]
-            kb.rerank_provider_id = previous_state["rerank_provider_id"]
-            kb.chunk_size = previous_state["chunk_size"]
-            kb.chunk_overlap = previous_state["chunk_overlap"]
-            kb.top_k_dense = previous_state["top_k_dense"]
-            kb.top_k_sparse = previous_state["top_k_sparse"]
-            kb.top_m_final = previous_state["top_m_final"]
-            kb_helper.init_error = previous_init_error
+        except KnowledgeBaseUploadError as e:
+            rollback_state()
             logger.error(
                 f"知识库 {kb.kb_name}({kb.kb_id}) 重新初始化失败，继续使用旧实例: {e}",
                 exc_info=True,
             )
-            return kb_helper
+            raise ValueError(str(e)) from e
+        except Exception as e:
+            # Roll back in-memory settings and keep current helper available.
+            rollback_state()
+            logger.error(
+                f"知识库 {kb.kb_name}({kb.kb_id}) 重新初始化失败，继续使用旧实例: {e}",
+                exc_info=True,
+            )
+            raise ValueError(f"知识库重新初始化失败：{e}") from e
 
         async with self.kb_db.get_db() as session:
             session.add(kb)

--- a/tests/unit/test_faiss_vec_db.py
+++ b/tests/unit/test_faiss_vec_db.py
@@ -40,7 +40,7 @@ async def test_insert_batch_raises_friendly_error_for_embedding_count_mismatch()
         )
 
     assert exc_info.value.stage == "embedding"
-    assert "expected_contents" in exc_info.value.details
+    assert "期望 2，实际 1" in str(exc_info.value)
     assert exc_info.value.details["expected_contents"] == 2
     assert exc_info.value.details["actual_vectors"] == 1
     vec_db.document_storage.insert_documents_batch.assert_not_awaited()
@@ -94,3 +94,23 @@ def test_embedding_storage_rejects_existing_index_dimension_mismatch() -> None:
         "index_dimension": 768,
         "provider_dimension": 1536,
     }
+
+
+def test_embedding_storage_accepts_existing_index_dimension_match() -> None:
+    mock_index = MagicMock()
+    mock_index.d = 768
+
+    with (
+        patch(
+            "astrbot.core.db.vec_db.faiss_impl.embedding_storage.os.path.exists",
+            return_value=True,
+        ),
+        patch(
+            "astrbot.core.db.vec_db.faiss_impl.embedding_storage.faiss.read_index",
+            return_value=mock_index,
+        ),
+    ):
+        storage = EmbeddingStorage(768, "existing-index.faiss")
+
+    assert storage.index is mock_index
+    assert storage.dimension == 768

--- a/tests/unit/test_faiss_vec_db.py
+++ b/tests/unit/test_faiss_vec_db.py
@@ -1,7 +1,8 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from astrbot.core.db.vec_db.faiss_impl.embedding_storage import EmbeddingStorage
 from astrbot.core.db.vec_db.faiss_impl.vec_db import FaissVecDB
 from astrbot.core.exceptions import KnowledgeBaseUploadError
 
@@ -22,9 +23,7 @@ async def test_insert_batch_skips_empty_contents() -> None:
 
 
 @pytest.mark.asyncio
-async def test_insert_batch_raises_friendly_error_for_embedding_count_mismatch() -> (
-    None
-):
+async def test_insert_batch_raises_friendly_error_for_embedding_count_mismatch() -> None:
     vec_db = FaissVecDB.__new__(FaissVecDB)
     vec_db.embedding_provider = AsyncMock()
     vec_db.embedding_provider.get_embeddings_batch.return_value = [[0.1, 0.2]]
@@ -40,7 +39,58 @@ async def test_insert_batch_raises_friendly_error_for_embedding_count_mismatch()
             ids=["doc-1", "doc-2"],
         )
 
-    assert "向量化失败" in str(exc_info.value)
-    assert "期望 2，实际 1" in str(exc_info.value)
+    assert exc_info.value.stage == "embedding"
+    assert "expected_contents" in exc_info.value.details
+    assert exc_info.value.details["expected_contents"] == 2
+    assert exc_info.value.details["actual_vectors"] == 1
     vec_db.document_storage.insert_documents_batch.assert_not_awaited()
     vec_db.embedding_storage.insert_batch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_insert_batch_wraps_embedding_batch_failures_as_embedding_error() -> None:
+    vec_db = FaissVecDB.__new__(FaissVecDB)
+    vec_db.embedding_provider = AsyncMock()
+    vec_db.embedding_provider.get_embeddings_batch.side_effect = Exception("rate limit")
+    vec_db.document_storage = AsyncMock()
+    vec_db.embedding_storage = AsyncMock()
+    vec_db.embedding_storage.dimension = 2
+
+    with pytest.raises(KnowledgeBaseUploadError) as exc_info:
+        await FaissVecDB.insert_batch(
+            vec_db,
+            contents=["chunk-1"],
+            metadatas=[{}],
+            ids=["doc-1"],
+        )
+
+    assert exc_info.value.stage == "embedding"
+    assert "批量生成嵌入向量时出错" in str(exc_info.value)
+    assert "rate limit" in str(exc_info.value)
+    vec_db.document_storage.insert_documents_batch.assert_not_awaited()
+    vec_db.embedding_storage.insert_batch.assert_not_awaited()
+
+
+def test_embedding_storage_rejects_existing_index_dimension_mismatch() -> None:
+    mock_index = MagicMock()
+    mock_index.d = 768
+
+    with (
+        patch(
+            "astrbot.core.db.vec_db.faiss_impl.embedding_storage.os.path.exists",
+            return_value=True,
+        ),
+        patch(
+            "astrbot.core.db.vec_db.faiss_impl.embedding_storage.faiss.read_index",
+            return_value=mock_index,
+        ),
+    ):
+        with pytest.raises(KnowledgeBaseUploadError) as exc_info:
+            EmbeddingStorage(1536, "existing-index.faiss")
+
+    assert exc_info.value.stage == "embedding"
+    assert "知识库索引维度与当前嵌入模型维度不一致" in str(exc_info.value)
+    assert exc_info.value.details == {
+        "index_dimension": 768,
+        "provider_dimension": 1536,
+    }

--- a/tests/unit/test_kb_manager_resilience.py
+++ b/tests/unit/test_kb_manager_resilience.py
@@ -2,7 +2,7 @@
 Unit tests for knowledge base manager resilience behavior.
 
 Tests the following scenarios:
-1. update_kb preserves old instance when re-initialization fails
+1. update_kb surfaces re-initialization failures while preserving the old helper
 2. update_kb switches instance only after new instance initializes successfully
 3. _ensure_vec_db clears stale init_error after successful initialization
 
@@ -16,6 +16,8 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+from astrbot.core.exceptions import KnowledgeBaseUploadError
 
 
 @pytest.fixture
@@ -61,7 +63,6 @@ def mock_kb_db():
 @pytest.fixture
 def mock_knowledge_base():
     """Create a mock KnowledgeBase instance."""
-    # Use lazy import to avoid circular import
     from astrbot.core.knowledge_base.models import KnowledgeBase
 
     kb = KnowledgeBase(
@@ -88,7 +89,7 @@ def mock_embedding_provider():
 
 
 @pytest.mark.asyncio
-async def test_update_kb_preserves_old_instance_when_reinit_fails(
+async def test_update_kb_raises_error_and_preserves_old_instance_when_reinit_fails(
     stub_provider_manager_module,
     mock_provider_manager,
     mock_kb_db,
@@ -96,78 +97,12 @@ async def test_update_kb_preserves_old_instance_when_reinit_fails(
     mock_embedding_provider,
 ):
     """
-    Test that update_kb preserves the old KBHelper instance when
-    re-initialization fails, ensuring the knowledge base remains available.
+    Test that update_kb surfaces re-initialization failures while
+    preserving the old KBHelper instance for continued availability.
     """
-    # Lazy import to avoid circular import
     from astrbot.core.knowledge_base.kb_helper import KBHelper
     from astrbot.core.knowledge_base.kb_mgr import KnowledgeBaseManager
 
-    # Setup: create an existing KBHelper with working vec_db
-    mock_provider_manager.get_provider_by_id.return_value = mock_embedding_provider
-
-    # Create KBHelper using __new__ to avoid __init__ side effects
-    old_helper = KBHelper.__new__(KBHelper)
-    old_helper.kb = mock_knowledge_base
-    old_helper.prov_mgr = mock_provider_manager
-    old_helper.kb_db = mock_kb_db
-    old_helper.kb_root_dir = "/tmp/test_kb"
-    old_helper.chunker = MagicMock()
-    old_helper.init_error = None
-    old_helper.vec_db = MagicMock()  # Simulate existing working vec_db
-    old_helper.terminate = AsyncMock()
-
-    # Create KBManager and inject the existing helper
-    kb_mgr = KnowledgeBaseManager.__new__(KnowledgeBaseManager)
-    kb_mgr.provider_manager = mock_provider_manager
-    kb_mgr.kb_db = mock_kb_db
-    kb_mgr.kb_insts = {mock_knowledge_base.kb_id: old_helper}
-    kb_mgr.retrieval_manager = MagicMock()
-
-    # Mock KBHelper creation to simulate initialization failure
-    with patch.object(KBHelper, "initialize", new_callable=AsyncMock) as mock_init:
-        # First call (for new_helper) should fail
-        mock_init.side_effect = Exception("Embedding provider unavailable")
-
-        # Execute update_kb with a different embedding provider
-        result = await kb_mgr.update_kb(
-            kb_id=mock_knowledge_base.kb_id,
-            kb_name="updated_kb",
-            embedding_provider_id="new-embedding-provider",
-        )
-
-        # Verify: the old helper should be returned, not a new one
-        assert result is not None
-        assert result is old_helper
-        assert kb_mgr.kb_insts[mock_knowledge_base.kb_id] is old_helper
-
-        # Verify: old helper's vec_db should still be available
-        assert hasattr(result, "vec_db")
-        assert result.vec_db is not None
-
-        # Verify: failure does not replace the existing helper state
-        assert result.init_error is None
-        assert result.kb.kb_name == "test_kb"
-        assert result.kb.embedding_provider_id == "test-embedding-provider"
-
-
-@pytest.mark.asyncio
-async def test_update_kb_switches_instance_only_after_new_reinit_success(
-    stub_provider_manager_module,
-    mock_provider_manager,
-    mock_kb_db,
-    mock_knowledge_base,
-    mock_embedding_provider,
-):
-    """
-    Test that update_kb only switches to the new KBHelper instance
-    after the new instance successfully initializes.
-    """
-    # Lazy import to avoid circular import
-    from astrbot.core.knowledge_base.kb_helper import KBHelper
-    from astrbot.core.knowledge_base.kb_mgr import KnowledgeBaseManager
-
-    # Setup: create an existing KBHelper
     mock_provider_manager.get_provider_by_id.return_value = mock_embedding_provider
 
     old_helper = KBHelper.__new__(KBHelper)
@@ -186,7 +121,107 @@ async def test_update_kb_switches_instance_only_after_new_reinit_success(
     kb_mgr.kb_insts = {mock_knowledge_base.kb_id: old_helper}
     kb_mgr.retrieval_manager = MagicMock()
 
-    # Mock session context for database operations
+    with patch.object(KBHelper, "initialize", new_callable=AsyncMock) as mock_init:
+        mock_init.side_effect = Exception("Embedding provider unavailable")
+
+        with pytest.raises(ValueError) as exc_info:
+            await kb_mgr.update_kb(
+                kb_id=mock_knowledge_base.kb_id,
+                kb_name="updated_kb",
+                embedding_provider_id="new-embedding-provider",
+            )
+
+    assert "Embedding provider unavailable" in str(exc_info.value)
+    assert kb_mgr.kb_insts[mock_knowledge_base.kb_id] is old_helper
+    assert hasattr(old_helper, "vec_db")
+    assert old_helper.vec_db is not None
+    assert old_helper.init_error is None
+    assert old_helper.kb.kb_name == "test_kb"
+    assert old_helper.kb.embedding_provider_id == "test-embedding-provider"
+
+
+@pytest.mark.asyncio
+async def test_update_kb_raises_user_facing_error_for_dimension_mismatch(
+    stub_provider_manager_module,
+    mock_provider_manager,
+    mock_kb_db,
+    mock_knowledge_base,
+    mock_embedding_provider,
+):
+    from astrbot.core.knowledge_base.kb_helper import KBHelper
+    from astrbot.core.knowledge_base.kb_mgr import KnowledgeBaseManager
+
+    mock_provider_manager.get_provider_by_id.return_value = mock_embedding_provider
+
+    old_helper = KBHelper.__new__(KBHelper)
+    old_helper.kb = mock_knowledge_base
+    old_helper.prov_mgr = mock_provider_manager
+    old_helper.kb_db = mock_kb_db
+    old_helper.kb_root_dir = "/tmp/test_kb"
+    old_helper.chunker = MagicMock()
+    old_helper.init_error = None
+    old_helper.vec_db = MagicMock()
+    old_helper.terminate = AsyncMock()
+
+    kb_mgr = KnowledgeBaseManager.__new__(KnowledgeBaseManager)
+    kb_mgr.provider_manager = mock_provider_manager
+    kb_mgr.kb_db = mock_kb_db
+    kb_mgr.kb_insts = {mock_knowledge_base.kb_id: old_helper}
+    kb_mgr.retrieval_manager = MagicMock()
+
+    with patch.object(KBHelper, "initialize", new_callable=AsyncMock) as mock_init:
+        mock_init.side_effect = KnowledgeBaseUploadError(
+            stage="embedding",
+            user_message="知识库索引维度与当前嵌入模型维度不一致",
+            details={"index_dimension": 768, "provider_dimension": 1536},
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            await kb_mgr.update_kb(
+                kb_id=mock_knowledge_base.kb_id,
+                kb_name="updated_kb",
+                embedding_provider_id="new-embedding-provider",
+            )
+
+    assert "知识库索引维度与当前嵌入模型维度不一致" in str(exc_info.value)
+    assert kb_mgr.kb_insts[mock_knowledge_base.kb_id] is old_helper
+    assert old_helper.kb.kb_name == "test_kb"
+    assert old_helper.kb.embedding_provider_id == "test-embedding-provider"
+
+
+@pytest.mark.asyncio
+async def test_update_kb_switches_instance_only_after_new_reinit_success(
+    stub_provider_manager_module,
+    mock_provider_manager,
+    mock_kb_db,
+    mock_knowledge_base,
+    mock_embedding_provider,
+):
+    """
+    Test that update_kb only switches to the new KBHelper instance
+    after the new instance successfully initializes.
+    """
+    from astrbot.core.knowledge_base.kb_helper import KBHelper
+    from astrbot.core.knowledge_base.kb_mgr import KnowledgeBaseManager
+
+    mock_provider_manager.get_provider_by_id.return_value = mock_embedding_provider
+
+    old_helper = KBHelper.__new__(KBHelper)
+    old_helper.kb = mock_knowledge_base
+    old_helper.prov_mgr = mock_provider_manager
+    old_helper.kb_db = mock_kb_db
+    old_helper.kb_root_dir = "/tmp/test_kb"
+    old_helper.chunker = MagicMock()
+    old_helper.init_error = None
+    old_helper.vec_db = MagicMock()
+    old_helper.terminate = AsyncMock()
+
+    kb_mgr = KnowledgeBaseManager.__new__(KnowledgeBaseManager)
+    kb_mgr.provider_manager = mock_provider_manager
+    kb_mgr.kb_db = mock_kb_db
+    kb_mgr.kb_insts = {mock_knowledge_base.kb_id: old_helper}
+    kb_mgr.retrieval_manager = MagicMock()
+
     mock_session = MagicMock()
     mock_session.add = MagicMock()
     mock_session.commit = AsyncMock()
@@ -197,25 +232,20 @@ async def test_update_kb_switches_instance_only_after_new_reinit_success(
     mock_db_context.__aexit__ = AsyncMock()
     mock_kb_db.get_db.return_value = mock_db_context
 
-    # Mock KBHelper.initialize to succeed
     with patch.object(KBHelper, "initialize", new_callable=AsyncMock) as mock_init:
         mock_init.return_value = None
 
-        # Execute update_kb
         result = await kb_mgr.update_kb(
             kb_id=mock_knowledge_base.kb_id,
             kb_name="updated_kb",
             embedding_provider_id="new-embedding-provider",
         )
 
-        # Verify: a new helper should be returned
-        assert result is not None
-        assert result is not old_helper
-        assert result.init_error is None
-        assert kb_mgr.kb_insts[mock_knowledge_base.kb_id] is result
-
-        # Verify: old helper should be terminated
-        old_helper.terminate.assert_called_once()
+    assert result is not None
+    assert result is not old_helper
+    assert result.init_error is None
+    assert kb_mgr.kb_insts[mock_knowledge_base.kb_id] is result
+    old_helper.terminate.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -230,10 +260,8 @@ async def test_ensure_vec_db_clears_stale_init_error(
     Test that _ensure_vec_db clears the init_error attribute
     after successful initialization, removing stale error state.
     """
-    # Lazy import to avoid circular import
     from astrbot.core.knowledge_base.kb_helper import KBHelper
 
-    # Setup: create KBHelper with stale init_error
     mock_provider_manager.get_provider_by_id.return_value = mock_embedding_provider
 
     helper = KBHelper.__new__(KBHelper)
@@ -247,7 +275,6 @@ async def test_ensure_vec_db_clears_stale_init_error(
     helper.kb_medias_dir = helper.kb_dir / "medias" / mock_knowledge_base.kb_id
     helper.kb_files_dir = helper.kb_dir / "files" / mock_knowledge_base.kb_id
 
-    # Mock FaissVecDB initialization
     mock_vec_db = MagicMock()
     mock_vec_db.initialize = AsyncMock()
     mock_vec_db.close = AsyncMock()
@@ -256,12 +283,10 @@ async def test_ensure_vec_db_clears_stale_init_error(
         "astrbot.core.db.vec_db.faiss_impl.vec_db.FaissVecDB",
         return_value=mock_vec_db,
     ):
-        # Execute _ensure_vec_db
         await helper._ensure_vec_db()
 
-        # Verify: init_error should be cleared
-        assert helper.init_error is None
-        assert helper.vec_db is mock_vec_db
+    assert helper.init_error is None
+    assert helper.vec_db is mock_vec_db
 
 
 @pytest.mark.asyncio
@@ -275,10 +300,8 @@ async def test_ensure_vec_db_sets_init_error_on_failure(
     Test that _ensure_vec_db does NOT clear init_error when
     initialization fails, preserving the error state.
     """
-    # Lazy import to avoid circular import
     from astrbot.core.knowledge_base.kb_helper import KBHelper
 
-    # Setup: provider unavailable
     mock_provider_manager.get_provider_by_id.return_value = None
 
     helper = KBHelper.__new__(KBHelper)
@@ -292,14 +315,9 @@ async def test_ensure_vec_db_sets_init_error_on_failure(
     helper.kb_medias_dir = helper.kb_dir / "medias" / mock_knowledge_base.kb_id
     helper.kb_files_dir = helper.kb_dir / "files" / mock_knowledge_base.kb_id
 
-    # Execute _ensure_vec_db - should raise exception
     try:
         await helper._ensure_vec_db()
         pytest.fail("Expected exception but none was raised")
     except ValueError as e:
-        # Verify: exception should be raised
         assert "无法找到" in str(e) or "未配置" in str(e)
-
-        # Verify: init_error should NOT be cleared (still has previous error)
-        # Note: _ensure_vec_db doesn't set init_error; that's done by the caller
         assert helper.init_error is not None

--- a/tests/unit/test_kb_manager_resilience.py
+++ b/tests/unit/test_kb_manager_resilience.py
@@ -124,7 +124,7 @@ async def test_update_kb_raises_error_and_preserves_old_instance_when_reinit_fai
     with patch.object(KBHelper, "initialize", new_callable=AsyncMock) as mock_init:
         mock_init.side_effect = Exception("Embedding provider unavailable")
 
-        with pytest.raises(KnowledgeBaseUploadError) as exc_info:
+        with pytest.raises(ValueError) as exc_info:
             await kb_mgr.update_kb(
                 kb_id=mock_knowledge_base.kb_id,
                 kb_name="updated_kb",
@@ -176,7 +176,7 @@ async def test_update_kb_raises_user_facing_error_for_dimension_mismatch(
             details={"index_dimension": 768, "provider_dimension": 1536},
         )
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(KnowledgeBaseUploadError) as exc_info:
             await kb_mgr.update_kb(
                 kb_id=mock_knowledge_base.kb_id,
                 kb_name="updated_kb",

--- a/tests/unit/test_kb_manager_resilience.py
+++ b/tests/unit/test_kb_manager_resilience.py
@@ -124,7 +124,7 @@ async def test_update_kb_raises_error_and_preserves_old_instance_when_reinit_fai
     with patch.object(KBHelper, "initialize", new_callable=AsyncMock) as mock_init:
         mock_init.side_effect = Exception("Embedding provider unavailable")
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(KnowledgeBaseUploadError) as exc_info:
             await kb_mgr.update_kb(
                 kb_id=mock_knowledge_base.kb_id,
                 kb_name="updated_kb",
@@ -183,6 +183,7 @@ async def test_update_kb_raises_user_facing_error_for_dimension_mismatch(
                 embedding_provider_id="new-embedding-provider",
             )
 
+    assert exc_info.value.stage == "embedding"
     assert "知识库索引维度与当前嵌入模型维度不一致" in str(exc_info.value)
     assert kb_mgr.kb_insts[mock_knowledge_base.kb_id] is old_helper
     assert old_helper.kb.kb_name == "test_kb"


### PR DESCRIPTION
修复 #7794 喵。

这次 PR 主要修复知识库上传和更新过程中 embedding 维度不一致时的错误归因问题喵。

之前在已有 FAISS 索引维度和当前 embedding provider 配置维度不一致时，错误可能会在后续写入阶段才暴露，并且容易被包装成比较泛化的 storage error 喵。

这样用户看到的错误信息不够明确，也不容易判断到底是索引维度、embedding provider，还是文档写入本身出了问题喵。

### Modifications / 改动点 喵

- 在打开已有 FAISS index 时，增加 index 实际维度和当前 embedding provider 维度的校验喵。

- 如果两者不一致，会直接抛出用户可读的 `KnowledgeBaseUploadError`，提示用户使用原 embedding 模型，或者删除并重建知识库索引喵。

- 将批量生成 embedding 时的普通异常包装为 `stage="embedding"` 的 `KnowledgeBaseUploadError`，避免继续被上层误报为写入知识库索引失败喵。

- 调整 `update_kb()` 的失败处理逻辑，让知识库重新初始化失败时向 API 调用方返回错误，而不是静默返回旧 helper 并显示更新成功喵。

- 在失败回滚时保留旧的知识库 helper 和旧的可用 vec_db，避免一次失败更新影响现有知识库继续使用喵。

- 补充了 FAISS index 维度不匹配、维度一致、批量 embedding 失败包装，以及 `update_kb()` 初始化失败回滚的单元测试喵。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更喵。

### Screenshots or Test Results / 运行截图或测试结果 喵

本次改动已补充对应单元测试，覆盖以下场景喵。

- 空内容批量插入时不会调用 embedding provider、document storage 或 embedding storage 喵。

- embedding provider 返回的向量数量与文本分块数量不一致时，会返回明确的向量化失败信息喵。

- 批量生成 embedding 抛出普通异常时，会被归类为 embedding 阶段错误，而不是 storage 阶段错误喵。

- 已有 FAISS index 维度与当前 provider 维度不一致时，会直接抛出明确的维度不匹配错误喵。

- 已有 FAISS index 维度与当前 provider 维度一致时，可以正常加载已有索引喵。

- `update_kb()` 重新初始化失败时，会向调用方暴露错误，同时保留旧 helper 和旧 vec_db 喵。

- `update_kb()` 重新初始化成功后，才会切换到新的 helper，并关闭旧 helper 喵。

建议验证命令如下喵。

```bash
pytest tests/unit/test_faiss_vec_db.py tests/unit/test_kb_manager_resilience.py
```

### Checklist / 检查清单 喵

* [x]  If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过喵。

* [x]  My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**. / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**喵。

* [x]  I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`. / 我确认这次没有引入新的依赖库喵。

* [x]  My changes do not introduce malicious code. / 我的更改没有引入恶意代码喵。

## Summary by Sourcery

Improve knowledge base update resilience and provide clearer, user-facing errors for FAISS index and embedding failures.

Bug Fixes:
- Ensure knowledge base updates surface reinitialization failures to callers while keeping the previous helper and vector DB available.
- Validate FAISS index dimensions against the configured embedding model and fail early when they mismatch, instead of deferring to later storage errors.
- Classify batch embedding failures as embedding-stage errors rather than generic storage errors, preserving clearer error attribution.

Enhancements:
- Add rollback logic that restores prior knowledge base configuration and init error state when reinitialization of a new helper fails.

Tests:
- Extend FAISS vec DB tests to cover dimension mismatch/match, embedding count mismatch details, and wrapping of batch embedding failures into user-facing errors.
- Extend knowledge base manager resilience tests to cover surfacing reinitialization errors, preserving old helpers, and switching helpers only after successful reinit.