### PR TITLE
fix: qq_official send_by_session uses markdown

### DIFF
--- a/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
@@ -14,6 +14,7 @@ import botpy
 import botpy.message
 from botpy import Client
 from botpy.gateway import BotWebSocket
+from botpy.types.message import MarkdownPayload
 
 from astrbot import logger
 from astrbot.api.event import MessageChain
@@ -230,7 +231,11 @@ class QQOfficialPlatformAdapter(Platform):
             )
             return
 
-        payload: dict[str, Any] = {"content": plain_text, "msg_id": msg_id}
+        payload: dict[str, Any] = {
+            "markdown": MarkdownPayload(content=plain_text) if plain_text else None,
+            "msg_type": 2,
+            "msg_id": msg_id,
+        }
         ret: Any = None
         send_helper = SimpleNamespace(bot=self.client)
 
@@ -247,6 +252,8 @@ class QQOfficialPlatformAdapter(Platform):
                     )
                     payload["media"] = media
                     payload["msg_type"] = 7
+                    payload.pop("markdown", None)
+                    payload["content"] = plain_text or None
                 if record_file_path:
                     media = await QQOfficialMessageEvent.upload_group_and_c2c_media(
                         send_helper,  # type: ignore
@@ -257,6 +264,8 @@ class QQOfficialPlatformAdapter(Platform):
                     if media:
                         payload["media"] = media
                         payload["msg_type"] = 7
+                        payload.pop("markdown", None)
+                        payload["content"] = plain_text or None
                 if video_file_source:
                     media = await QQOfficialMessageEvent.upload_group_and_c2c_media(
                         send_helper,  # type: ignore
@@ -267,6 +276,8 @@ class QQOfficialPlatformAdapter(Platform):
                     if media:
                         payload["media"] = media
                         payload["msg_type"] = 7
+                        payload.pop("markdown", None)
+                        payload["content"] = plain_text or None
                         payload.pop("msg_id", None)
                 if file_source:
                     media = await QQOfficialMessageEvent.upload_group_and_c2c_media(
@@ -279,6 +290,8 @@ class QQOfficialPlatformAdapter(Platform):
                     if media:
                         payload["media"] = media
                         payload["msg_type"] = 7
+                        payload.pop("markdown", None)
+                        payload["content"] = plain_text or None
                         payload.pop("msg_id", None)
                 ret = await self.client.api.post_group_message(
                     group_openid=session.session_id,
@@ -306,6 +319,8 @@ class QQOfficialPlatformAdapter(Platform):
                 )
                 payload["media"] = media
                 payload["msg_type"] = 7
+                payload.pop("markdown", None)
+                payload["content"] = plain_text or None
             if record_file_path:
                 media = await QQOfficialMessageEvent.upload_group_and_c2c_media(
                     send_helper,  # type: ignore
@@ -316,6 +331,8 @@ class QQOfficialPlatformAdapter(Platform):
                 if media:
                     payload["media"] = media
                     payload["msg_type"] = 7
+                    payload.pop("markdown", None)
+                    payload["content"] = plain_text or None
             if video_file_source:
                 media = await QQOfficialMessageEvent.upload_group_and_c2c_media(
                     send_helper,  # type: ignore
@@ -326,6 +343,8 @@ class QQOfficialPlatformAdapter(Platform):
                 if media:
                     payload["media"] = media
                     payload["msg_type"] = 7
+                    payload.pop("markdown", None)
+                    payload["content"] = plain_text or None
             if file_source:
                 media = await QQOfficialMessageEvent.upload_group_and_c2c_media(
                     send_helper,  # type: ignore
@@ -337,6 +356,8 @@ class QQOfficialPlatformAdapter(Platform):
                 if media:
                     payload["media"] = media
                     payload["msg_type"] = 7
+                    payload.pop("markdown", None)
+                    payload["content"] = plain_text or None
 
             ret = await QQOfficialMessageEvent.post_c2c_message(
                 send_helper,  # type: ignore

--- a/tests/unit/test_qqofficial_send_by_session_markdown.py
+++ b/tests/unit/test_qqofficial_send_by_session_markdown.py
@@ -1,0 +1,111 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from astrbot.api.event import MessageChain
+from astrbot.api.platform import MessageType
+from astrbot.core.platform.astr_message_event import MessageSesion
+from astrbot.core.platform.sources.qqofficial.qqofficial_message_event import (
+    QQOfficialMessageEvent,
+)
+from astrbot.core.platform.sources.qqofficial.qqofficial_platform_adapter import (
+    QQOfficialPlatformAdapter,
+)
+
+
+@pytest.mark.asyncio
+async def test_send_by_session_common_uses_markdown_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = QQOfficialPlatformAdapter(
+        platform_config={
+            "appid": "test-appid",
+            "secret": "test-secret",
+            "enable_group_c2c": True,
+            "enable_guild_direct_message": False,
+        },
+        platform_settings={},
+        event_queue=asyncio.Queue(),
+    )
+
+    captured: dict[str, object] = {}
+
+    async def post_group_message(*, group_openid: str, **payload):
+        captured["payload"] = payload
+        return {"id": "sent-1"}
+
+    adapter.client = SimpleNamespace(api=SimpleNamespace(post_group_message=post_group_message))
+
+    session = MessageSesion(
+        platform_name="qq_official",
+        message_type=MessageType.GROUP_MESSAGE,
+        session_id="group-openid-1",
+    )
+    adapter._session_last_message_id[session.session_id] = "msg-1"
+    adapter._session_scene[session.session_id] = "group"
+
+    async def fake_parse(_message: MessageChain):
+        return ("**hello**", None, None, None, None, None, None)
+
+    monkeypatch.setattr(QQOfficialMessageEvent, "_parse_to_qqofficial", fake_parse)
+
+    await adapter._send_by_session_common(session, MessageChain())
+
+    payload = captured.get("payload")
+    assert isinstance(payload, dict)
+    assert payload["msg_type"] == 2
+    assert payload["msg_id"] == "msg-1"
+    assert "content" not in payload
+    assert payload["markdown"] == {"content": "**hello**"}
+
+
+@pytest.mark.asyncio
+async def test_send_by_session_common_drops_markdown_for_media(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = QQOfficialPlatformAdapter(
+        platform_config={
+            "appid": "test-appid",
+            "secret": "test-secret",
+            "enable_group_c2c": True,
+            "enable_guild_direct_message": False,
+        },
+        platform_settings={},
+        event_queue=asyncio.Queue(),
+    )
+
+    captured: dict[str, object] = {}
+
+    async def post_group_message(*, group_openid: str, **payload):
+        captured["payload"] = payload
+        return {"id": "sent-1"}
+
+    adapter.client = SimpleNamespace(api=SimpleNamespace(post_group_message=post_group_message))
+
+    session = MessageSesion(
+        platform_name="qq_official",
+        message_type=MessageType.GROUP_MESSAGE,
+        session_id="group-openid-1",
+    )
+    adapter._session_last_message_id[session.session_id] = "msg-1"
+    adapter._session_scene[session.session_id] = "group"
+
+    async def fake_parse(_message: MessageChain):
+        return ("hello", "base64-image", None, None, None, None, None)
+
+    async def fake_upload_group_and_c2c_image(*_args, **_kwargs):
+        return "media-1"
+
+    monkeypatch.setattr(QQOfficialMessageEvent, "_parse_to_qqofficial", fake_parse)
+    monkeypatch.setattr(
+        QQOfficialMessageEvent,
+        "upload_group_and_c2c_image",
+        fake_upload_group_and_c2c_image,
+    )
+
+    await adapter._send_by_session_common(session, MessageChain())
+
+    payload = captured.get("payload")
+    assert isinstance(payload, dict)
+    assert payload["msg_type"] == 7
+    assert payload["msg_id"] == "msg-1"
+    assert payload["media"] == "media-1"
+    assert payload["content"] == "hello"
+    assert "markdown" not in payload


### PR DESCRIPTION
Fixes #7848.

- Align QQ Official proactive send_by_session payload with normal message send path (use markdown + msg_type=2).
- When media is attached (msg_type=7), drop markdown and send content instead.
- Adds unit tests for payload shape in both markdown and media cases.

Tests:
- uv run pytest -q tests/unit/test_qqofficial_send_by_session_markdown.py
- uv run ruff format .
- uv run ruff check .

## Summary by Sourcery

Align QQ Official proactive send_by_session payloads with the standard message send format and ensure correct payload shape for markdown and media messages.

Bug Fixes:
- Ensure QQ Official send_by_session uses markdown payloads with msg_type 2 for plain text messages to match the normal send path.
- Ensure media messages sent via QQ Official send_by_session use msg_type 7 with content and media fields and omit markdown.

Tests:
- Add unit tests verifying QQ Official send_by_session payload structure for markdown-only and media-attached messages.