### PR TITLE
fix(dashboard): use v-autocomplete for list+options config field (#7884)

### DIFF
--- a/dashboard/src/components/shared/ConfigItemRenderer.vue
+++ b/dashboard/src/components/shared/ConfigItemRenderer.vue
@@ -87,10 +87,11 @@
       ></v-checkbox>
     </div>
 
-    <v-select
+    <v-autocomplete
       v-else-if="itemMeta?.type === 'list' && itemMeta?.options"
       :model-value="modelValue"
-      @update:model-value="emitUpdate"
+      @update:model-value="val => { emitUpdate(val); listSearchText = '' }"
+      v-model:search="listSearchText"
       :items="getSelectItems(itemMeta)"
       item-title="title"
       item-value="value"
@@ -101,7 +102,7 @@
       hide-details
       chips
       multiple
-    ></v-select>
+    ></v-autocomplete>
 
     <v-select
       v-else-if="itemMeta?.options"
@@ -242,6 +243,7 @@ import { ref } from 'vue'
 import { useI18n, useModuleI18n } from '@/i18n/composables'
 
 const numericTemp = ref(null)
+const listSearchText = ref('')
 
 const props = defineProps({
   modelValue: {

--- a/dashboard/src/components/shared/ConfigItemRenderer.vue
+++ b/dashboard/src/components/shared/ConfigItemRenderer.vue
@@ -92,7 +92,7 @@
       :model-value="modelValue"
       @update:model-value="val => { emitUpdate(val); listSearchText = '' }"
       v-model:search="listSearchText"
-      :items="getSelectItems(itemMeta)"
+      :items="listSelectItems"
       item-title="title"
       item-value="value"
       :disabled="itemMeta?.readonly"
@@ -239,7 +239,7 @@ import PersonaSelector from './PersonaSelector.vue'
 import KnowledgeBaseSelector from './KnowledgeBaseSelector.vue'
 import PluginSetSelector from './PluginSetSelector.vue'
 import T2ITemplateEditor from './T2ITemplateEditor.vue'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n, useModuleI18n } from '@/i18n/composables'
 
 const numericTemp = ref(null)
@@ -279,6 +279,12 @@ const { getRaw } = useModuleI18n('features/config-metadata')
 function emitUpdate(val) {
   emit('update:modelValue', val)
 }
+
+const listSelectItems = computed(() =>
+  props.itemMeta?.type === 'list' && props.itemMeta?.options
+    ? getSelectItems(props.itemMeta)
+    : []
+)
 
 function toNumber(val) {
   const n = parseFloat(val)


### PR DESCRIPTION
close https://github.com/AstrBotDevs/AstrBot/issues/7884 

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

将插件配置中 `list + options` 字段的渲染组件从 Vuetify `v-select` 替换为 `v-autocomplete`：在多选场景下，键入字符不再触发 `v-select` 内置的"键盘 typeahead 自动 toggle 首个前缀匹配项"行为（该行为对长 options 列表完全不可用，例如 `astrbot_plugin_repo_of_today` 中含上千项的语言选择字段），改为按输入文本过滤下拉候选。

同时新增本地 `listSearchText` ref，通过 `v-model:search` 绑定，并在 `@update:model-value` 中清空，使每次选中后搜索框自动重置，可连续键入下一个关键词搜索而无需手动退格。

**修改文件**
- `dashboard/src/components/shared/ConfigItemRenderer.vue` — 将 `type === 'list' && options` 分支由 `v-select` 改为 `v-autocomplete`，新增 `listSearchText` ref 与选中清空逻辑。

未改动：单选 `v-select` 分支、`render_type: 'checkbox'` 渲染变体、`checkbox` 与其他 schema 类型分支。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

修改前， 选中`python` 后输入`ty`, python chip被覆盖， 并且自动选中`typesciprt`, 忽略后面的`typst` 等等
<img width="413" height="238" alt="Image" src="https://github.com/user-attachments/assets/3a9793ce-1c92-41c0-969a-de8defa7f93c" />
<img width="413" height="238" alt="Image" src="https://github.com/user-attachments/assets/f442b63c-f9fd-4c38-b916-fc4d4a4d3bb8" />

修改后,
<img width="413" height="238" alt="image" src="https://github.com/user-attachments/assets/547bd57a-a984-46cf-9035-eff42e724e29" />
<img width="457" height="315" alt="image" src="https://github.com/user-attachments/assets/728b1b58-eff8-49a0-bc2f-a8bc99a20bf2" />

会只进行字符串匹配， 并且不自动选中
---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Improve dashboard plugin list option selection by switching to an autocomplete-based multi-select with better search behavior.

Bug Fixes:
- Prevent multi-select list option fields from unintentionally toggling and overwriting selections when typing in large option sets.

Enhancements:
- Use an autocomplete input for list+options configuration fields to support inline text filtering and automatic clearing of the search term after each selection.