### PR TITLE
fix(dashboard): use autocomplete for list options

### DIFF
--- a/dashboard/src/components/shared/ConfigItemRenderer.vue
+++ b/dashboard/src/components/shared/ConfigItemRenderer.vue
@@ -87,7 +87,7 @@
       ></v-checkbox>
     </div>
 
-    <v-select
+    <v-autocomplete
       v-else-if="itemMeta?.type === 'list' && itemMeta?.options"
       :model-value="modelValue"
       @update:model-value="emitUpdate"
@@ -101,7 +101,8 @@
       hide-details
       chips
       multiple
-    ></v-select>
+      clear-on-select
+    ></v-autocomplete>
 
     <v-select
       v-else-if="itemMeta?.options"


### PR DESCRIPTION
Fixes #7884\n\n- Replace plugin config list+options field from Vuetify v-select (multiple chips) to v-autocomplete so typing filters options instead of toggling the first prefix match.\n- Enable clear-on-select so search input clears after selecting an item.

## Summary by Sourcery

Bug Fixes:
- Ensure typing in list option inputs filters available options instead of toggling the first prefix-matching item.