### PR TITLE
fix(qq_official): render markdown for proactive sends

### DIFF
--- a/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
@@ -14,6 +14,7 @@ import botpy
 import botpy.message
 from botpy import Client
 from botpy.gateway import BotWebSocket
+from botpy.types.message import MarkdownPayload
 
 from astrbot import logger
 from astrbot.api.event import MessageChain
@@ -230,7 +231,11 @@ class QQOfficialPlatformAdapter(Platform):
             )
             return
 
-        payload: dict[str, Any] = {"content": plain_text, "msg_id": msg_id}
+        payload: dict[str, Any] = {
+            "markdown": MarkdownPayload(content=plain_text) if plain_text else None,
+            "msg_type": 2,
+            "msg_id": msg_id,
+        }
         ret: Any = None
         send_helper = SimpleNamespace(bot=self.client)
 
@@ -247,6 +252,8 @@ class QQOfficialPlatformAdapter(Platform):
                     )
                     payload["media"] = media
                     payload["msg_type"] = 7
+                    payload.pop("markdown", None)
+                    payload["content"] = plain_text or None
                 if record_file_path:
                     media = await QQOfficialMessageEvent.upload_group_and_c2c_media(
                         send_helper,  # type: ignore
@@ -257,6 +264,8 @@ class QQOfficialPlatformAdapter(Platform):
                     if media:
                         payload["media"] = media
                         payload["msg_type"] = 7
+                        payload.pop("markdown", None)
+                        payload["content"] = plain_text or None
                 if video_file_source:
                     media = await QQOfficialMessageEvent.upload_group_and_c2c_media(
                         send_helper,  # type: ignore
@@ -267,6 +276,8 @@ class QQOfficialPlatformAdapter(Platform):
                     if media:
                         payload["media"] = media
                         payload["msg_type"] = 7
+                        payload.pop("markdown", None)
+                        payload["content"] = plain_text or None
                         payload.pop("msg_id", None)
                 if file_source:
                     media = await QQOfficialMessageEvent.upload_group_and_c2c_media(
@@ -279,6 +290,8 @@ class QQOfficialPlatformAdapter(Platform):
                     if media:
                         payload["media"] = media
                         payload["msg_type"] = 7
+                        payload.pop("markdown", None)
+                        payload["content"] = plain_text or None
                         payload.pop("msg_id", None)
                 ret = await self.client.api.post_group_message(
                     group_openid=session.session_id,
@@ -306,6 +319,8 @@ class QQOfficialPlatformAdapter(Platform):
                 )
                 payload["media"] = media
                 payload["msg_type"] = 7
+                payload.pop("markdown", None)
+                payload["content"] = plain_text or None
             if record_file_path:
                 media = await QQOfficialMessageEvent.upload_group_and_c2c_media(
                     send_helper,  # type: ignore
@@ -316,6 +331,8 @@ class QQOfficialPlatformAdapter(Platform):
                 if media:
                     payload["media"] = media
                     payload["msg_type"] = 7
+                    payload.pop("markdown", None)
+                    payload["content"] = plain_text or None
             if video_file_source:
                 media = await QQOfficialMessageEvent.upload_group_and_c2c_media(
                     send_helper,  # type: ignore
@@ -326,6 +343,8 @@ class QQOfficialPlatformAdapter(Platform):
                 if media:
                     payload["media"] = media
                     payload["msg_type"] = 7
+                    payload.pop("markdown", None)
+                    payload["content"] = plain_text or None
             if file_source:
                 media = await QQOfficialMessageEvent.upload_group_and_c2c_media(
                     send_helper,  # type: ignore
@@ -337,6 +356,8 @@ class QQOfficialPlatformAdapter(Platform):
                 if media:
                     payload["media"] = media
                     payload["msg_type"] = 7
+                    payload.pop("markdown", None)
+                    payload["content"] = plain_text or None
 
             ret = await QQOfficialMessageEvent.post_c2c_message(
                 send_helper,  # type: ignore

--- a/tests/test_qqofficial_send_by_session_markdown.py
+++ b/tests/test_qqofficial_send_by_session_markdown.py
@@ -1,0 +1,87 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from astrbot.api.event import MessageChain
+from astrbot.api.platform import MessageType
+from astrbot.core.platform.astr_message_event import MessageSesion
+from astrbot.core.platform.platform import Platform
+from astrbot.core.platform.sources.qqofficial.qqofficial_message_event import (
+    QQOfficialMessageEvent,
+)
+from astrbot.core.platform.sources.qqofficial.qqofficial_platform_adapter import (
+    QQOfficialPlatformAdapter,
+)
+
+
+@pytest.mark.asyncio
+async def test_qqofficial_send_by_session_channel_uses_markdown_payload():
+    adapter = object.__new__(QQOfficialPlatformAdapter)
+    adapter._session_last_message_id = {"sess": "msgid"}  # type: ignore[attr-defined]
+    adapter._session_scene = {"sess": "channel"}  # type: ignore[attr-defined]
+    adapter.client = MagicMock()  # type: ignore[attr-defined]
+    adapter.client.api = MagicMock()
+    adapter.client.api.post_message = AsyncMock(return_value={"id": "newid"})
+    adapter.client.api.post_group_message = AsyncMock()
+
+    session = MessageSesion("qq_official", MessageType.GROUP_MESSAGE, "sess")
+    message_chain = MessageChain()
+
+    with (
+        patch.object(Platform, "send_by_session", new=AsyncMock()),
+        patch.object(
+            QQOfficialMessageEvent,
+            "_parse_to_qqofficial",
+            new=AsyncMock(
+                return_value=("**hello**", None, None, None, None, None, None),
+            ),
+        ),
+    ):
+        await adapter._send_by_session_common(session, message_chain)
+
+    assert adapter.client.api.post_message.await_count == 1
+    _args, kwargs = adapter.client.api.post_message.await_args
+    assert kwargs["channel_id"] == "sess"
+    assert kwargs["msg_id"] == "msgid"
+    assert kwargs["msg_type"] == 2
+    assert "content" not in kwargs
+    assert kwargs["markdown"] is not None
+
+
+@pytest.mark.asyncio
+async def test_qqofficial_send_by_session_group_media_downgrades_to_content():
+    adapter = object.__new__(QQOfficialPlatformAdapter)
+    adapter._session_last_message_id = {"group_sess": "msgid"}  # type: ignore[attr-defined]
+    adapter._session_scene = {"group_sess": "group"}  # type: ignore[attr-defined]
+    adapter.client = MagicMock()  # type: ignore[attr-defined]
+    adapter.client.api = MagicMock()
+    adapter.client.api.post_group_message = AsyncMock(return_value={"id": "newid"})
+    adapter.client.api.post_message = AsyncMock()
+
+    session = MessageSesion("qq_official", MessageType.GROUP_MESSAGE, "group_sess")
+    message_chain = MessageChain()
+
+    with (
+        patch.object(Platform, "send_by_session", new=AsyncMock()),
+        patch.object(
+            QQOfficialMessageEvent,
+            "_parse_to_qqofficial",
+            new=AsyncMock(
+                return_value=("hello", "deadbeef", None, None, None, None, None),
+            ),
+        ),
+        patch.object(
+            QQOfficialMessageEvent,
+            "upload_group_and_c2c_image",
+            new=AsyncMock(return_value={"media_id": "m"}),
+        ),
+    ):
+        await adapter._send_by_session_common(session, message_chain)
+
+    assert adapter.client.api.post_group_message.await_count == 1
+    _args, kwargs = adapter.client.api.post_group_message.await_args
+    assert kwargs["group_openid"] == "group_sess"
+    assert kwargs["msg_type"] == 7
+    assert kwargs["content"] == "hello"
+    assert "markdown" not in kwargs


### PR DESCRIPTION
Fixes #7848.

- Align QQOfficialPlatformAdapter._send_by_session_common() with QQOfficialMessageEvent._post_send() by sending text as msg_type=2 + MarkdownPayload.
- When media is attached (msg_type=7), drop markdown and fall back to content.

Tests:
- uv run pytest -q tests/test_qqofficial_send_by_session_markdown.py

## Summary by Sourcery

Render proactive QQ Official sends as markdown messages by default and fall back to plain text when media is attached.

Bug Fixes:
- Ensure proactive QQ Official channel messages use markdown payloads consistent with message events.
- Avoid sending incompatible markdown payloads when QQ Official messages include media attachments by reverting to plain text content.

Tests:
- Add tests verifying markdown payload usage for channel messages and content fallback behavior for group media messages.