### PR TITLE
fix: stop_event() 后续 handler 仍然执行

### DIFF
--- a/astrbot/core/pipeline/process_stage/method/star_request.py
+++ b/astrbot/core/pipeline/process_stage/method/star_request.py
@@ -34,6 +34,8 @@ class StarRequestSubStage(Stage):
             handlers_parsed_params = {}
 
         for handler in activated_handlers:
+            if event.is_stopped():
+                break
             params = handlers_parsed_params.get(handler.handler_full_name, {})
             md = star_map.get(handler.handler_module_path)
             if not md:
@@ -46,9 +48,9 @@ class StarRequestSubStage(Stage):
                 wrapper = call_handler(event, handler.handler, **params)
                 async for ret in wrapper:
                     yield ret
-                event.clear_result()  # 清除上一个 handler 的结果
                 if event.is_stopped():
                     break
+                event.clear_result()  # 清除上一个 handler 的结果
             except Exception as e:
                 traceback_text = traceback.format_exc()
                 logger.error(traceback_text)
@@ -70,3 +72,5 @@ class StarRequestSubStage(Stage):
                     event.clear_result()
 
                 event.stop_event()
+                if event.is_stopped():
+                    break

--- a/astrbot/core/pipeline/process_stage/method/star_request.py
+++ b/astrbot/core/pipeline/process_stage/method/star_request.py
@@ -47,6 +47,8 @@ class StarRequestSubStage(Stage):
                 async for ret in wrapper:
                     yield ret
                 event.clear_result()  # 清除上一个 handler 的结果
+                if event.is_stopped():
+                    break
             except Exception as e:
                 traceback_text = traceback.format_exc()
                 logger.error(traceback_text)

--- a/astrbot/core/pipeline/process_stage/method/star_request.py
+++ b/astrbot/core/pipeline/process_stage/method/star_request.py
@@ -72,5 +72,3 @@ class StarRequestSubStage(Stage):
                     event.clear_result()
 
                 event.stop_event()
-                if event.is_stopped():
-                    break


### PR DESCRIPTION
## 问题描述

在 `star_request.py` 的 `process` 方法中，`for` 循环遍历 `activated_handlers` 时，没有在每次 `handler` 执行后检查 `event.is_stopped()`。导致某个 `handler` 调用 `stop_event()` 后，后续的 `handler` 仍然会继续执行。

## 修复方案

在 `handler` 正常执行完毕后（`event.clear_result()` 之后）添加 `if event.is_stopped(): break` 检查。

## 关联 Issue

Fixes #7898

## Summary by Sourcery

Bug Fixes:
- Prevent subsequent handlers from executing after an event has been marked as stopped during star_request processing.