### PR TITLE
fix(agent): 抑制工具调用轮次的预置文本外发

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -792,7 +792,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             await self._complete_with_assistant_response(llm_resp)
 
         # 返回 LLM 结果
-        if (not has_tool_calls) and llm_resp.reasoning_content:
+        if llm_resp.reasoning_content:
             yield AgentResponse(
                 type="llm_result",
                 data=AgentResponseData(
@@ -801,18 +801,19 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                     ),
                 ),
             )
-        if (not has_tool_calls) and llm_resp.result_chain:
-            yield AgentResponse(
-                type="llm_result",
-                data=AgentResponseData(chain=llm_resp.result_chain),
-            )
-        elif (not has_tool_calls) and llm_resp.completion_text:
-            yield AgentResponse(
-                type="llm_result",
-                data=AgentResponseData(
-                    chain=MessageChain().message(llm_resp.completion_text),
-                ),
-            )
+        if not has_tool_calls:
+            if llm_resp.result_chain:
+                yield AgentResponse(
+                    type="llm_result",
+                    data=AgentResponseData(chain=llm_resp.result_chain),
+                )
+            elif llm_resp.completion_text:
+                yield AgentResponse(
+                    type="llm_result",
+                    data=AgentResponseData(
+                        chain=MessageChain().message(llm_resp.completion_text),
+                    ),
+                )
 
         # 如果有工具调用，还需处理工具调用
         if llm_resp.tools_call_name:

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -787,11 +787,12 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             )
             return
 
-        if not llm_resp.tools_call_name:
+        has_tool_calls = bool(llm_resp.tools_call_name)
+        if not has_tool_calls:
             await self._complete_with_assistant_response(llm_resp)
 
         # 返回 LLM 结果
-        if llm_resp.reasoning_content:
+        if (not has_tool_calls) and llm_resp.reasoning_content:
             yield AgentResponse(
                 type="llm_result",
                 data=AgentResponseData(
@@ -800,12 +801,12 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                     ),
                 ),
             )
-        if llm_resp.result_chain:
+        if (not has_tool_calls) and llm_resp.result_chain:
             yield AgentResponse(
                 type="llm_result",
                 data=AgentResponseData(chain=llm_resp.result_chain),
             )
-        elif llm_resp.completion_text:
+        elif (not has_tool_calls) and llm_resp.completion_text:
             yield AgentResponse(
                 type="llm_result",
                 data=AgentResponseData(

--- a/astrbot/core/astr_main_agent_resources.py
+++ b/astrbot/core/astr_main_agent_resources.py
@@ -24,16 +24,18 @@ SANDBOX_MODE_PROMPT = (
 
 TOOL_CALL_PROMPT = (
     "When using tools: "
-    "never return an empty response; "
-    "briefly explain the purpose before calling a tool; "
+    "you may return only tool calls when no user-facing message is needed; "
+    'do not emit placeholder text such as "No response"; '
+    "briefly explain the purpose before calling a tool only when it helps the user; "
     "follow the tool schema exactly and do not invent parameters; "
     "after execution, briefly summarize the result for the user; "
     "keep the conversation style consistent."
 )
 
 TOOL_CALL_PROMPT_SKILLS_LIKE_MODE = (
-    "You MUST NOT return an empty response, especially after invoking a tool."
-    " Before calling any tool, provide a brief explanatory message to the user stating the purpose of the tool call."
+    "You may return only tool calls when no user-facing message is needed."
+    ' Do not emit placeholder text such as "No response".'
+    " Before calling any tool, provide a brief explanatory message to the user only when it helps."
     " Tool schemas are provided in two stages: first only name and description; "
     "if you decide to use a tool, the full parameter schema will be provided in "
     "a follow-up step. Do not guess arguments before you see the schema."

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -261,9 +261,12 @@ class SingleToolThenFinalProvider(MockProvider):
 
 
 class PreToolTextThenFinalProvider(MockProvider):
-    def __init__(self, pre_tool_text: str):
+    def __init__(
+        self, pre_tool_text: str, reasoning_content: str | None = None
+    ):
         super().__init__()
         self.pre_tool_text = pre_tool_text
+        self.reasoning_content = reasoning_content
 
     async def text_chat(self, **kwargs) -> LLMResponse:
         self.call_count += 1
@@ -278,6 +281,7 @@ class PreToolTextThenFinalProvider(MockProvider):
         return LLMResponse(
             role="assistant",
             completion_text=self.pre_tool_text,
+            reasoning_content=self.reasoning_content,
             tools_call_name=["test_tool"],
             tools_call_args=[{"query": "test"}],
             tools_call_ids=["call_pre_tool"],
@@ -565,6 +569,53 @@ async def test_tool_call_turn_does_not_emit_pre_tool_llm_result(pre_tool_text: s
     assert pre_tool_text not in llm_result_texts
     assert any(resp.type == "tool_call" for resp in responses)
     assert "final answer" in llm_result_texts
+
+
+@pytest.mark.asyncio
+async def test_tool_call_turn_still_emits_reasoning_content():
+    tool = FunctionTool(
+        name="test_tool",
+        description="test tool",
+        parameters={"type": "object", "properties": {"query": {"type": "string"}}},
+        handler=AsyncMock(),
+    )
+    provider = PreToolTextThenFinalProvider(
+        pre_tool_text="*No response*",
+        reasoning_content="thinking...",
+    )
+    request = ProviderRequest(
+        prompt="run tool",
+        func_tool=ToolSet(tools=[tool]),
+        contexts=[],
+    )
+    runner = ToolLoopAgentRunner()
+
+    await runner.reset(
+        provider=provider,
+        request=request,
+        run_context=ContextWrapper(context=None),
+        tool_executor=cast(Any, MockToolExecutor()),
+        agent_hooks=MockHooks(),
+        streaming=False,
+    )
+
+    responses = []
+    async for response in runner.step_until_done(3):
+        responses.append(response)
+
+    reasoning_texts = [
+        resp.data["chain"].get_plain_text(with_other_comps_mark=True)
+        for resp in responses
+        if resp.type == "llm_result" and resp.data["chain"].type == "reasoning"
+    ]
+    llm_result_texts = [
+        resp.data["chain"].get_plain_text(with_other_comps_mark=True)
+        for resp in responses
+        if resp.type == "llm_result"
+    ]
+
+    assert "thinking..." in reasoning_texts
+    assert "*No response*" not in llm_result_texts
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -260,6 +260,31 @@ class SingleToolThenFinalProvider(MockProvider):
         )
 
 
+class PreToolTextThenFinalProvider(MockProvider):
+    def __init__(self, pre_tool_text: str):
+        super().__init__()
+        self.pre_tool_text = pre_tool_text
+
+    async def text_chat(self, **kwargs) -> LLMResponse:
+        self.call_count += 1
+        func_tool = kwargs.get("func_tool")
+        if func_tool is None or self.call_count > 1:
+            return LLMResponse(
+                role="assistant",
+                completion_text="final answer",
+                usage=TokenUsage(input_other=10, output=5),
+            )
+
+        return LLMResponse(
+            role="assistant",
+            completion_text=self.pre_tool_text,
+            tools_call_name=["test_tool"],
+            tools_call_args=[{"query": "test"}],
+            tools_call_ids=["call_pre_tool"],
+            usage=TokenUsage(input_other=10, output=5),
+        )
+
+
 class SequentialToolProvider(MockProvider):
     def __init__(self, tool_sequence: list[str]):
         super().__init__()
@@ -496,6 +521,50 @@ async def test_normal_completion_without_max_step(
 
     # 验证工具仍然可用（没有被禁用）
     assert runner.req.func_tool is not None, "正常完成时工具不应该被禁用"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "pre_tool_text",
+    ["*No response*", "I will check this first."],
+)
+async def test_tool_call_turn_does_not_emit_pre_tool_llm_result(pre_tool_text: str):
+    tool = FunctionTool(
+        name="test_tool",
+        description="test tool",
+        parameters={"type": "object", "properties": {"query": {"type": "string"}}},
+        handler=AsyncMock(),
+    )
+    provider = PreToolTextThenFinalProvider(pre_tool_text)
+    request = ProviderRequest(
+        prompt="run tool",
+        func_tool=ToolSet(tools=[tool]),
+        contexts=[],
+    )
+    runner = ToolLoopAgentRunner()
+
+    await runner.reset(
+        provider=provider,
+        request=request,
+        run_context=ContextWrapper(context=None),
+        tool_executor=cast(Any, MockToolExecutor()),
+        agent_hooks=MockHooks(),
+        streaming=False,
+    )
+
+    responses = []
+    async for response in runner.step_until_done(3):
+        responses.append(response)
+
+    llm_result_texts = [
+        resp.data["chain"].get_plain_text(with_other_comps_mark=True)
+        for resp in responses
+        if resp.type == "llm_result"
+    ]
+
+    assert pre_tool_text not in llm_result_texts
+    assert any(resp.type == "tool_call" for resp in responses)
+    assert "final answer" in llm_result_texts
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #7901

本 PR 修复了工具调用轮次中误发 `*No response*` 等无意义文本的问题。

在 OpenAI-compatible provider 的返回中，部分模型会在同一个 assistant 响应里同时包含 `content` 与 `tool_calls`。
此前 `ToolLoopAgentRunner.step()` 在识别到工具调用后，仍会先把 `content` 或 `result_chain` 作为普通 `llm_result` 发送，再进入工具执行分支。
这会导致 `*No response*`、`I will check this first.` 等 pre-tool 文本提前发给用户，形成噪声消息。

本次修复将 tool-call turn 视为中间执行轮次处理。
当 `llm_resp.tools_call_name` 非空时，不再外发普通 `llm_result`，而是直接进入工具调用流程。
工具执行后的最终回答仍会按原流程正常发送。

### Modifications / 改动点

- 修改 `astrbot/core/agent/runners/tool_loop_agent_runner.py`。
- 新增 `has_tool_calls = bool(llm_resp.tools_call_name)` 判断。
- 当本轮包含工具调用时，不再 `yield` 普通 `llm_result`。
- 保持工具执行、tool result 写入上下文、最终 assistant 回复流程不变。
- 不影响 skills-like re-query 失败后转普通回复的 fallback 路径。

- 修改 `astrbot/core/astr_main_agent_resources.py`。
- 调整工具调用相关 prompt 语义，允许在不需要用户可见文本时只返回 tool calls。
- 明确禁止输出 `"No response"` 一类占位文本。
- 将“调用工具前必须说明”调整为“仅在有帮助时说明”。

- 修改 `tests/test_tool_loop_agent_runner.py`。
- 新增回归测试 `test_tool_call_turn_does_not_emit_pre_tool_llm_result`。
- 覆盖 `*No response*` 与 `I will check this first.` 两类 pre-tool 文本。
- 验证 pre-tool 文本不会作为 `llm_result` 发送，且工具调用与最终回答链路仍正常。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

已执行以下测试：

```bash
uv run pytest tests/test_tool_loop_agent_runner.py -k "tool_call_turn_does_not_emit_pre_tool_llm_result" -q
```

结果：

```text
2 passed
```

完整 runner 测试：

```bash
uv run pytest tests/test_tool_loop_agent_runner.py -q
```

结果：

```text
31 passed
```

格式化与静态检查：

```bash
uv run ruff format .
uv run ruff check .
```

结果：

```text
All checks passed!
```

说明：本 PR 仅覆盖非流式 final response 路径中的 tool-call turn 文本外发问题。
流式路径在最终确认 tool calls 前若已输出文本 delta，仍需后续单独设计 buffering 策略。

---

### Checklist / 检查清单

* [x] If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. / 本 PR 不包含新功能，仅修复现有 bug。
* [x] My changes have been well-tested, and "Verification Steps" and "Screenshots" have been provided above. / 我的更改已完成验证并附上测试结果。
* [x] I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`. / 本 PR 未引入新依赖。
* [x] My changes do not introduce malicious code. / 本 PR 不包含恶意代码。

## Summary by Sourcery

Prevent pre-tool placeholder text from being emitted as user-visible LLM results during tool-calling turns and clarify tool-call prompting behavior.

Bug Fixes:
- Avoid sending pre-tool placeholder messages like '*No response*' or 'I will check this first.' as LLM results when a tool call is present in the same response.

Enhancements:
- Treat turns that include tool calls as intermediate steps so only the final, post-tool assistant answer is surfaced to the user.
- Relax and clarify tool-call prompting instructions to allow tool-only responses and discourage placeholder text while keeping optional pre-tool explanations.

Tests:
- Add regression tests ensuring pre-tool texts are not emitted as LLM results while tool calls and final answers still flow correctly.