### PR TITLE
fix: deliver cron active agent fallback response

### DIFF
--- a/astrbot/core/cron/manager.py
+++ b/astrbot/core/cron/manager.py
@@ -14,6 +14,7 @@ from astrbot.core.agent.tool import ToolSet
 from astrbot.core.cron.events import CronMessageEvent
 from astrbot.core.db import BaseDatabase
 from astrbot.core.db.po import CronJob
+from astrbot.core.message.message_event_result import MessageChain
 from astrbot.core.platform.message_session import MessageSession
 from astrbot.core.provider.entites import ProviderRequest
 from astrbot.core.utils.history_saver import persist_agent_history
@@ -386,9 +387,84 @@ class CronJobManager:
             req=req,
             summary_note=summary_note,
         )
+        await self._send_active_agent_fallback_if_needed(
+            session=session,
+            req=req,
+            llm_resp=llm_resp,
+            cron_meta=cron_meta,
+        )
         if not llm_resp:
             logger.warning("Cron job agent got no response")
             return
+
+    async def _send_active_agent_fallback_if_needed(
+        self,
+        *,
+        session: MessageSession,
+        req: ProviderRequest,
+        llm_resp,
+        cron_meta: dict,
+    ) -> bool:
+        if self._agent_sent_message_to_user(req):
+            logger.info(
+                "cron active agent fallback skipped agent_sent=True session=%s job_id=%s",
+                session,
+                cron_meta.get("id"),
+            )
+            return False
+
+        text = str(getattr(llm_resp, "completion_text", "") or "").strip()
+        if not llm_resp or getattr(llm_resp, "role", "") != "assistant" or not text:
+            logger.warning(
+                "cron active agent fallback skipped no assistant text session=%s job_id=%s",
+                session,
+                cron_meta.get("id"),
+            )
+            return False
+
+        logger.info(
+            "cron active agent fallback send start session=%s job_id=%s",
+            session,
+            cron_meta.get("id"),
+        )
+        try:
+            ok = await self.ctx.send_message(session, MessageChain().message(text))
+            logger.info(
+                "cron active agent fallback send done ok=%s session=%s job_id=%s",
+                ok,
+                session,
+                cron_meta.get("id"),
+            )
+            return bool(ok)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "cron active agent fallback send exception session=%s job_id=%s err=%r",
+                session,
+                cron_meta.get("id"),
+                e,
+                exc_info=True,
+            )
+            raise
+
+    @staticmethod
+    def _agent_sent_message_to_user(req: ProviderRequest) -> bool:
+        results = getattr(req, "tool_calls_result", None)
+        if not results:
+            return False
+        if not isinstance(results, list):
+            results = [results]
+
+        for result in results:
+            call_results = getattr(result, "tool_calls_result", None) or []
+            for call_result in call_results:
+                content = getattr(call_result, "content", "")
+                if isinstance(content, list):
+                    content = " ".join(
+                        str(getattr(part, "text", part)) for part in content
+                    )
+                if "Message sent to session" in str(content):
+                    return True
+        return False
 
 
 __all__ = ["CronJobManager"]

--- a/tests/unit/test_cron_manager.py
+++ b/tests/unit/test_cron_manager.py
@@ -1,12 +1,16 @@
 """Tests for CronJobManager."""
 
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from astrbot.core.cron.manager import CronJobManager, CronJobSchedulingError
 from astrbot.core.db.po import CronJob
+from astrbot.core.platform.message_session import MessageSession
+from astrbot.core.platform.message_type import MessageType
+from astrbot.core.provider.entites import ProviderRequest
 
 
 @pytest.fixture
@@ -215,7 +219,7 @@ class TestUpdateJob:
     """Tests for update_job method."""
 
     @pytest.mark.asyncio
-    async def test_update_job(self, cron_manager, mock_db, sample_cron_job):
+    async def test_update_job(self, cron_manager, mock_db):
         """Test updating a cron job."""
         updated_job = CronJob(
             job_id="test-job-id",
@@ -480,6 +484,81 @@ class TestRunBasicJob:
 
         with pytest.raises(RuntimeError, match="handler not found"):
             await cron_manager._run_basic_job(sample_cron_job)
+
+
+class TestActiveAgentFallback:
+    """Tests for active-agent cron fallback delivery."""
+
+    @pytest.mark.asyncio
+    async def test_fallback_sends_final_text_when_agent_did_not_send_message(
+        self, cron_manager, mock_context
+    ):
+        cron_manager.ctx = mock_context
+        mock_context.send_message = AsyncMock(return_value=True)
+        session = MessageSession(
+            "test-platform",
+            MessageType.FRIEND_MESSAGE,
+            "session-1",
+        )
+        req = ProviderRequest()
+        llm_resp = SimpleNamespace(
+            role="assistant",
+            completion_text="定时任务完成。",
+        )
+
+        sent = await cron_manager._send_active_agent_fallback_if_needed(
+            session=session,
+            req=req,
+            llm_resp=llm_resp,
+            cron_meta={"id": "job-1", "name": "job"},
+        )
+
+        assert sent is True
+        mock_context.send_message.assert_awaited_once()
+        assert mock_context.send_message.await_args.args[0] == session
+        assert (
+            mock_context.send_message.await_args.args[1].chain[0].text
+            == "定时任务完成。"
+        )
+
+    @pytest.mark.asyncio
+    async def test_fallback_skips_when_agent_already_sent_message(
+        self, cron_manager, mock_context
+    ):
+        cron_manager.ctx = mock_context
+        mock_context.send_message = AsyncMock(return_value=True)
+        session = MessageSession(
+            "test-platform",
+            MessageType.FRIEND_MESSAGE,
+            "session-1",
+        )
+        req = ProviderRequest()
+        req.tool_calls_result = [
+            SimpleNamespace(
+                tool_calls_result=[
+                    SimpleNamespace(
+                        content=(
+                            "Message sent to session "
+                            "test-platform:FriendMessage:session-1"
+                        )
+                    )
+                ]
+            )
+        ]
+        llm_resp = SimpleNamespace(
+            role="assistant",
+            completion_text="定时任务完成。",
+        )
+
+        sent = await cron_manager._send_active_agent_fallback_if_needed(
+            session=session,
+            req=req,
+            llm_resp=llm_resp,
+            cron_meta={"id": "job-1", "name": "job"},
+        )
+
+        assert sent is False
+        mock_context.send_message.assert_not_awaited()
 
 
 class TestGetNextRunTime:


### PR DESCRIPTION
## Summary
- add a fallback send path for active-agent cron jobs when the agent returns final assistant text but does not call `send_message_to_user`
- detect existing send-message tool output to avoid duplicate delivery
- cover fallback send and duplicate-skip behavior in cron manager tests

## Validation
- `ruff format .`
- `ruff check .`
- `uv run pytest tests/unit/test_cron_manager.py`

## Summary by Sourcery

Ensure active-agent cron jobs always deliver assistant responses by adding a fallback send path and avoiding duplicate deliveries when the agent already sent a message.

Bug Fixes:
- Add a fallback delivery path for active-agent cron jobs when the agent returns final assistant text without explicitly sending a user message.
- Prevent duplicate message delivery by detecting prior send-message tool outputs in provider request results.

Enhancements:
- Log detailed outcomes for active-agent cron fallback behavior, including skips, sends, and exceptions.

Tests:
- Add unit tests covering active-agent cron fallback delivery and the skip path when a message has already been sent.