### PR TITLE
fix: 支持微信客服文件消息

### DIFF
--- a/astrbot/core/platform/sources/wecom/wecom_adapter.py
+++ b/astrbot/core/platform/sources/wecom/wecom_adapter.py
@@ -504,7 +504,6 @@ class WecomPlatformAdapter(Platform):
             file_path = temp_dir / f"weixinkefu_{uuid.uuid4().hex}_{file_name}"
             file_path.write_bytes(resp.content)
 
-            abm.message_str = "[文件]"
             abm.message = [File(name=file_name, file=str(file_path))]
         else:
             logger.warning(f"未实现的微信客服消息事件: {msg}")

--- a/astrbot/core/platform/sources/wecom/wecom_adapter.py
+++ b/astrbot/core/platform/sources/wecom/wecom_adapter.py
@@ -4,7 +4,9 @@ import sys
 import time
 import uuid
 from collections.abc import Awaitable, Callable
+from pathlib import Path
 from typing import Any, cast
+from urllib.parse import unquote
 
 import quart
 from requests import Response
@@ -15,7 +17,7 @@ from wechatpy.exceptions import InvalidSignatureException
 from wechatpy.messages import BaseMessage
 
 from astrbot.api.event import MessageChain
-from astrbot.api.message_components import Image, Plain, Record
+from astrbot.api.message_components import File, Image, Plain, Record
 from astrbot.api.platform import (
     AstrBotMessage,
     MessageMember,
@@ -38,6 +40,27 @@ if sys.version_info >= (3, 12):
     from typing import override
 else:
     from typing_extensions import override
+
+
+def _extract_wecom_media_filename(disposition: str | None) -> str | None:
+    if not disposition:
+        return None
+
+    for part in disposition.split(";"):
+        token = part.strip()
+        token_lower = token.lower()
+        if token_lower.startswith("filename*="):
+            value = token.split("=", 1)[1].strip().strip('"')
+            if value.lower().startswith("utf-8''"):
+                value = value[7:]
+            filename = Path(unquote(value).replace("\\", "/")).name
+            return filename or None
+        if token_lower.startswith("filename="):
+            value = token.split("=", 1)[1].strip().strip('"')
+            filename = Path(value.replace("\\", "/")).name
+            return filename or None
+
+    return None
 
 
 class WecomServer:
@@ -459,6 +482,30 @@ class WecomPlatformAdapter(Platform):
                 return
 
             abm.message = [Record(file=path_wav, url=path_wav)]
+        elif msgtype == "file":
+            media_id = msg.get("file", {}).get("media_id", "")
+            if not media_id:
+                logger.warning(f"微信客服文件消息缺少 media_id: {msg}")
+                return
+
+            resp: Response = await asyncio.get_running_loop().run_in_executor(
+                None,
+                self.client.media.download,
+                media_id,
+            )
+
+            file_name = (
+                _extract_wecom_media_filename(
+                    resp.headers.get("Content-Disposition"),
+                )
+                or f"weixinkefu_{media_id}.bin"
+            )
+            temp_dir = Path(get_astrbot_temp_path())
+            file_path = temp_dir / f"weixinkefu_{uuid.uuid4().hex}_{file_name}"
+            file_path.write_bytes(resp.content)
+
+            abm.message_str = "[文件]"
+            abm.message = [File(name=file_name, file=str(file_path))]
         else:
             logger.warning(f"未实现的微信客服消息事件: {msg}")
             return


### PR DESCRIPTION
修复微信客服用户上传文件时无法正确读取的问题。

当前微信客服 `kf/sync_msg` 可以拉取到 `msgtype=file` 消息，但 `convert_wechat_kf_message` 仅处理了 `text`、`image`、`voice`，导致用户上传文件时进入未实现分支，并输出“未实现的微信客服消息事件”警告。此 PR 为微信客服文件消息补充入站转换逻辑，使文件能被下载并转换为 AstrBot 标准 `File` 消息组件。

### Modifications / 改动点

- 修改 `astrbot/core/platform/sources/wecom/wecom_adapter.py`
- 为微信客服 `msgtype=file` 增加入站处理逻辑
- 通过 `file.media_id` 下载企业微信临时素材
- 从 `Content-Disposition` 中解析文件名，支持 `filename` 和 `filename*`
- 将下载后的文件保存到 AstrBot 临时目录
- 将文件消息转换为 AstrBot 内部 `File` 消息组件
- 保留原有 `text`、`image`、`voice` 处理逻辑不变

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

<img width="469" height="960" alt="`D531TLI2(4G{$%GT~J{B I_tmb" src="https://github.com/user-attachments/assets/86ce9d0b-b166-4764-94e4-febd96a3361f" />



本次修改不引入新依赖，仅补充微信客服文件消息的入站转换分支。

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Add support for handling WeCom customer service file messages and mapping them into AstrBot standard file components.

New Features:
- Handle WeCom customer service messages with msgtype=file by downloading the media and converting it into an AstrBot File message component.

Enhancements:
- Extract filenames for downloaded WeCom media from Content-Disposition headers, with fallbacks and normalized naming, before storing them in the AstrBot temporary directory.