### PR TITLE
fix: 钉钉连接超时后自动重连失败

### DIFF
--- a/astrbot/core/platform/sources/dingtalk/dingtalk_adapter.py
+++ b/astrbot/core/platform/sources/dingtalk/dingtalk_adapter.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import threading
+import time
 import uuid
 from pathlib import Path
 from typing import Literal, NoReturn, cast
@@ -747,22 +748,54 @@ class DingtalkPlatformAdapter(Platform):
     async def run(self) -> None:
         # await self.client_.start()
         # 钉钉的 SDK 并没有实现真正的异步，start() 里面有堵塞方法。
+        # SDK 内部已有 while True 重连循环，但需要监控 task 状态，
+        # 如果 task 意外退出则重新启动。
+        MAX_RETRIES = 5
+        retry_count = 0
+
         def start_client(loop: asyncio.AbstractEventLoop) -> None:
-            try:
-                self._shutdown_event = threading.Event()
-                task = loop.create_task(self.client_.start())
-                self._shutdown_event.wait()
-                if task.done():
-                    task.result()
-            except Exception as e:
-                if "Graceful shutdown" in str(e):
-                    logger.info("钉钉适配器已被关闭")
+            nonlocal retry_count
+            while retry_count < MAX_RETRIES:
+                try:
+                    self._shutdown_event = threading.Event()
+                    task = loop.create_task(self.client_.start())
+                    self._shutdown_event.wait()
+                    if task.done():
+                        exc = task.exception()
+                        if exc:
+                            if "Graceful shutdown" in str(exc):
+                                logger.info("钉钉适配器已被关闭")
+                                return
+                            logger.error(f"钉钉 SDK task 异常退出: {exc}")
+                            retry_count += 1
+                            if retry_count < MAX_RETRIES:
+                                logger.info(
+                                    f"钉钉适配器尝试重连 ({retry_count}/{MAX_RETRIES})..."
+                                )
+                                time.sleep(10)
+                                continue
+                            else:
+                                logger.error("钉钉适配器重连失败，已达最大重试次数")
+                                return
+                    # task 仍在运行，shutdown_event 被设置（正常关闭）
                     return
-                logger.error(f"钉钉机器人启动失败: {e}")
-            finally:
-                # 确保 task 完成或取消
-                if not task.done():
-                    task.cancel()
+                except Exception as e:
+                    if "Graceful shutdown" in str(e):
+                        logger.info("钉钉适配器已被关闭")
+                        return
+                    logger.error(f"钉钉机器人启动失败: {e}")
+                    retry_count += 1
+                    if retry_count < MAX_RETRIES:
+                        logger.info(
+                            f"钉钉适配器尝试重连 ({retry_count}/{MAX_RETRIES})..."
+                        )
+                        time.sleep(10)
+                    else:
+                        logger.error("钉钉适配器重连失败，已达最大重试次数")
+                        return
+                finally:
+                    if not task.done():
+                        task.cancel()
 
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, start_client, loop)

--- a/astrbot/core/platform/sources/dingtalk/dingtalk_adapter.py
+++ b/astrbot/core/platform/sources/dingtalk/dingtalk_adapter.py
@@ -751,10 +751,23 @@ class DingtalkPlatformAdapter(Platform):
         # SDK 内部已有 while True 重连循环，但需要监控 task 状态，
         # 如果 task 意外退出则重新启动。
         MAX_RETRIES = 5
-        retry_count = 0
+        RETRY_INTERVAL = 10
 
         def start_client(loop: asyncio.AbstractEventLoop) -> None:
-            nonlocal retry_count
+            retry_count = 0
+
+            def handle_retry(error_msg: str) -> bool:
+                """处理重试逻辑，返回 True 表示需要继续重试，False 表示放弃。"""
+                nonlocal retry_count
+                logger.error(error_msg)
+                retry_count += 1
+                if retry_count < MAX_RETRIES:
+                    logger.info(f"钉钉适配器尝试重连 ({retry_count}/{MAX_RETRIES})...")
+                    time.sleep(RETRY_INTERVAL)
+                    return True
+                logger.error("钉钉适配器重连失败，已达最大重试次数")
+                return False
+
             while retry_count < MAX_RETRIES:
                 task = None
                 try:
@@ -773,32 +786,16 @@ class DingtalkPlatformAdapter(Platform):
                             if "Graceful shutdown" in str(exc):
                                 logger.info("钉钉适配器已被关闭")
                                 return
-                            logger.error(f"钉钉 SDK task 异常退出: {exc}")
-                            retry_count += 1
-                            if retry_count < MAX_RETRIES:
-                                logger.info(
-                                    f"钉钉适配器尝试重连 ({retry_count}/{MAX_RETRIES})..."
-                                )
-                                time.sleep(10)
+                            if handle_retry(f"钉钉 SDK task 异常退出: {exc}"):
                                 continue
-                            else:
-                                logger.error("钉钉适配器重连失败，已达最大重试次数")
-                                return
+                            return
                     # task 仍在运行，shutdown_event 被设置（正常关闭）
                     return
                 except Exception as e:
                     if "Graceful shutdown" in str(e):
                         logger.info("钉钉适配器已被关闭")
                         return
-                    logger.error(f"钉钉机器人启动失败: {e}")
-                    retry_count += 1
-                    if retry_count < MAX_RETRIES:
-                        logger.info(
-                            f"钉钉适配器尝试重连 ({retry_count}/{MAX_RETRIES})..."
-                        )
-                        time.sleep(10)
-                    else:
-                        logger.error("钉钉适配器重连失败，已达最大重试次数")
+                    if not handle_retry(f"钉钉机器人启动失败: {e}"):
                         return
                 finally:
                     # 仅在重试/失败路径取消 task，正常关闭不取消

--- a/astrbot/core/platform/sources/dingtalk/dingtalk_adapter.py
+++ b/astrbot/core/platform/sources/dingtalk/dingtalk_adapter.py
@@ -756,12 +756,19 @@ class DingtalkPlatformAdapter(Platform):
         def start_client(loop: asyncio.AbstractEventLoop) -> None:
             nonlocal retry_count
             while retry_count < MAX_RETRIES:
+                task = None
                 try:
                     self._shutdown_event = threading.Event()
                     task = loop.create_task(self.client_.start())
+                    # 当 task 完成时唤醒线程（无论是正常退出还是异常退出）
+                    task.add_done_callback(lambda _: self._shutdown_event.set())
                     self._shutdown_event.wait()
                     if task.done():
-                        exc = task.exception()
+                        try:
+                            exc = task.exception()
+                        except asyncio.CancelledError:
+                            logger.info("钉钉适配器 task 已取消")
+                            return
                         if exc:
                             if "Graceful shutdown" in str(exc):
                                 logger.info("钉钉适配器已被关闭")
@@ -794,7 +801,8 @@ class DingtalkPlatformAdapter(Platform):
                         logger.error("钉钉适配器重连失败，已达最大重试次数")
                         return
                 finally:
-                    if not task.done():
+                    # 仅在重试/失败路径取消 task，正常关闭不取消
+                    if task is not None and not task.done() and retry_count > 0:
                         task.cancel()
 
         loop = asyncio.get_running_loop()

--- a/astrbot/core/platform/sources/dingtalk/dingtalk_adapter.py
+++ b/astrbot/core/platform/sources/dingtalk/dingtalk_adapter.py
@@ -759,6 +759,10 @@ class DingtalkPlatformAdapter(Platform):
                     logger.info("钉钉适配器已被关闭")
                     return
                 logger.error(f"钉钉机器人启动失败: {e}")
+            finally:
+                # 确保 task 完成或取消
+                if not task.done():
+                    task.cancel()
 
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, start_client, loop)


### PR DESCRIPTION
## 问题描述

钉钉连接每12小时超时，SDK 重连后无法回复消息。

## 修复方案

改进 un() 方法，添加重试逻辑。当 SDK task 意外退出时，自动重启并重试（最多5次，每次间隔10秒）。

## 关联 Issue

Fixes #7861

## Summary by Sourcery

Improve the DingTalk adapter run loop to make the SDK task resilient to unexpected termination and connection timeouts.

Bug Fixes:
- Ensure the DingTalk SDK task is automatically restarted with limited retries when it exits unexpectedly after connection timeouts.

Enhancements:
- Add retry counting, logging, and controlled backoff delays to DingTalk client startup to avoid silent failures and repeated crash loops.