### PR TITLE
fix: avoid success toast on failed provider test

### DIFF
--- a/dashboard/src/views/ProviderPage.vue
+++ b/dashboard/src/views/ProviderPage.vue
@@ -676,18 +676,29 @@ async function testSingleProvider(provider) {
 
     const startTime = performance.now()
     const res = await axios.get(`/api/config/provider/check_one?id=${provider.id}`)
-    if (res.data && res.data.status === 'ok') {
-      const index = providerStatuses.value.findIndex(s => s.id === provider.id)
-      if (index !== -1) {
-        providerStatuses.value.splice(index, 1, res.data.data)
-      }
-      const latency = Math.max(0, Math.round(performance.now() - startTime))
-      showMessage(tm('models.testSuccessWithLatency', { id: provider.id, latency }))
-    } else {
+    if (!res.data || res.data.status !== 'ok') {
       throw new Error(res.data?.message || `Failed to check status for ${provider.id}`)
     }
+
+    const result = res.data.data
+    if (!result) {
+      throw new Error(`Failed to check status for ${provider.id}`)
+    }
+
+    const index = providerStatuses.value.findIndex(s => s.id === provider.id)
+    if (index !== -1) {
+      providerStatuses.value.splice(index, 1, result)
+    }
+
+    const isAvailable = result.status === 'available' && result.error == null
+    if (!isAvailable) {
+      throw new Error(result.error || tm('models.testError'))
+    }
+
+    const latency = Math.max(0, Math.round(performance.now() - startTime))
+    showMessage(tm('models.testSuccessWithLatency', { id: provider.id, latency }))
   } catch (err) {
-    const errorMessage = err.response?.data?.message || err.message || 'Unknown error'
+    const errorMessage = err.response?.data?.message || err.message || tm('models.testError')
     const index = providerStatuses.value.findIndex(s => s.id === provider.id)
     const failedStatus = {
       id: provider.id,
@@ -698,6 +709,7 @@ async function testSingleProvider(provider) {
     if (index !== -1) {
       providerStatuses.value.splice(index, 1, failedStatus)
     }
+    showMessage(errorMessage, 'error')
   } finally {
     const index = testingProviders.value.indexOf(provider.id)
     if (index > -1) {


### PR DESCRIPTION
Fixes #7933. The Provider page test flow previously reported success based on the HTTP wrapper status, which could show a success toast even when the provider test result was unavailable. This change ensures the success toast only appears when the provider is actually available.

### Modifications / 改动点

- Update the non-chat Provider page test flow to validate provider availability before showing a success toast.
- On failure, show a standard error toast to avoid misleading success feedback.
- Core file modified: dashboard/src/views/ProviderPage.vue

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```
ruff format .
ruff check .
```
This is the original bug screenshot:
<img width="2559" height="1366" alt="Astrbot" src="https://github.com/user-attachments/assets/6678e826-4447-468c-9966-6c71ba553e17" />

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
	/ 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
	/ 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
	/ 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
	/ 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure provider test success feedback only appears when the provider is actually available and surface clear error feedback on failures.

Bug Fixes:
- Prevent success toasts from showing when a provider test returns no result or an unavailable status, and instead treat these as failures.

Enhancements:
- Align provider status updates and error handling in the Provider page test flow to consistently reflect backend check results.