### PR TITLE
perf: tool rendering in conversation page

### DIFF
--- a/dashboard/src/views/ConversationPage.vue
+++ b/dashboard/src/views/ConversationPage.vue
@@ -539,28 +539,54 @@ export default {
 
         // 将对话历史转换为 MessageList 组件期望的格式
         formattedMessages() {
-            return this.conversationHistory.map(msg => {
-                console.log('处理消息:', msg.role, msg.content);
-                
-                // 将消息内容转换为 MessagePart[] 格式
-                const messageParts = this.convertContentToMessageParts(msg.content);
-                
-                if (msg.role === 'user') {
-                    return {
-                        content: {
-                            type: 'user',
-                            message: messageParts
-                        }
-                    };
-                } else {
-                    return {
-                        content: {
-                            type: 'bot',
-                            message: messageParts
-                        }
-                    };
+            // 按 tool_call_id 索引 tool 角色消息的执行结果
+            const toolResultsById = {};
+            for (const msg of this.conversationHistory) {
+                if (msg.role === 'tool' && msg.tool_call_id) {
+                    toolResultsById[msg.tool_call_id] = msg.content;
                 }
-            });
+            }
+
+            return this.conversationHistory
+                // tool / system 等非聊天角色不直接渲染为气泡，避免大文本走 markdown 路径卡死页面
+                .filter(msg => msg.role === 'user' || msg.role === 'assistant')
+                .map(msg => {
+                    console.log('处理消息:', msg.role, msg.content);
+
+                    const messageParts = this.convertContentToMessageParts(msg.content)
+                        // 丢弃 convertContentToMessageParts 兜底插入的空 plain，避免 assistant 仅有工具调用时渲染空气泡
+                        .filter(part => part.type !== 'plain' || (part.text && part.text.trim()));
+
+                    // 把 OpenAI 风格的 assistant.tool_calls 转成 MessageList 已支持的 tool_call part
+                    if (msg.role === 'assistant' && Array.isArray(msg.tool_calls) && msg.tool_calls.length) {
+                        const toolCalls = msg.tool_calls.map(tc => {
+                            const fn = tc.function || {};
+                            return {
+                                id: tc.id,
+                                name: fn.name || tc.name,
+                                args: fn.arguments ?? tc.arguments,
+                                result: toolResultsById[tc.id],
+                                // 历史回放无真实耗时数据：
+                                // ts: 0  → ToolCallCard.toolCallDuration 在 startTime<=0 时早退，跳过时长显示
+                                // finished_ts: 1 → MessageList.toolCallStatusText 视为已完成（避免误显示"运行中"）
+                                ts: 0,
+                                finished_ts: 1,
+                            };
+                        });
+                        messageParts.push({ type: 'tool_call', tool_calls: toolCalls });
+                    }
+
+                    const finalParts = messageParts.length
+                        ? messageParts
+                        : [{ type: 'plain', text: '' }];
+
+                    return {
+                        content: {
+                            type: msg.role === 'user' ? 'user' : 'bot',
+                            message: finalParts,
+                        }
+                    };
+                });
         }
     },
 

--- a/dashboard/src/views/ConversationPage.vue
+++ b/dashboard/src/views/ConversationPage.vue
@@ -1199,6 +1199,18 @@ export default {
     background-color: #f9f9f9;
 }
 
+/* 让 ToolCallCard 内部的 args/result 自然展开，由外层容器统一滚动，避免双滚动条 */
+.conversation-messages-container .detail-json,
+.conversation-messages-container .detail-result {
+    max-height: none;
+    overflow: visible;
+}
+
+/* 历史回放无真实状态数据，隐藏 IPython 工具的"已完成"标签，与其它工具卡片保持一致 */
+.conversation-messages-container .tool-call-inline-status {
+    display: none;
+}
+
 /* 暗色模式下的聊天消息容器 */
 .v-theme--dark .conversation-messages-container {
     background-color: #1e1e1e;


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

close https://github.com/AstrBotDevs/AstrBot/issues/7929

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

仅修改 `dashboard/src/views/ConversationPage.vue`。

**Commit 1** — `formattedMessages` computed（原 L541）

- 过滤 `role` 仅保留 `user` / `assistant`，跳过 `tool` / `system` / `_checkpoint`
  → tool 大文本不再进 `MarkdownMessagePart`（`MessageList.vue:77`），消除卡死
- 按 `tool_call_id` 索引 tool 消息的 content
- 把 `assistant.tool_calls` 转成 `{type:'tool_call'}` MessagePart，由现有 `ToolCallCard` 渲染（`MessageList.vue:124`），默认折叠
- 哨兵时间戳处理（历史回放无真实耗时数据）：
  - `ts: 0` → `ToolCallCard.vue:92` 在 `startTime <= 0` 时早返回，避免显示假的实时 ticking 时长（"0.1s, 0.2s..."）
  - `finished_ts: 1` → `ToolCallCard.vue:131` 跳过 `setInterval(updateTime, 100)`，避免每个工具调用各自起一个定时器

**Commit 2** — 新增两段 CSS（`<style>` 块内），父级选择器限定作用域，仅在历史预览内生效，主聊天界面不受影响：

```css
/* 双滚动条：让 ToolCallCard 的 args/result 自然展开，由外层容器统一滚动 */
.conversation-messages-container .detail-json,
.conversation-messages-container .detail-result {
    max-height: none;
    overflow: visible;
}

/* 历史回放无真实状态数据，隐藏 IPython 工具的"已完成"标签，与其它工具卡片保持一致 */
.conversation-messages-container .tool-call-inline-status {
    display: none;
}
```


**行为变化**：`tool` 消息合并进对应 assistant 的 `ToolCallCard.result`，不再是独立气泡（与主聊天 UI 一致）。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

对于[这个对话](https://github.com/user-attachments/files/27271064/d.json) (python tool)

修改前:

<img width="907" height="690" alt="image" src="https://github.com/user-attachments/assets/56a055b2-9bfc-4dab-9001-589619f34d7f" />

工具调用结果被当成bot message, 进入md渲染

---

修改后

<img width="648" height="425" alt="image" src="https://github.com/user-attachments/assets/0858cec7-1adc-4553-9fc4-d4b1d19bb99d" />

进入思考结果

对于一般工具

<img width="888" height="685" alt="image" src="https://github.com/user-attachments/assets/68937eaf-5a0e-4151-9db7-0c36d9c63faf" />


---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Stop rendering raw tool messages as standalone chat bubbles in conversation history and instead integrate tool call data into assistant messages for consistent tool call display and improved performance.

Bug Fixes:
- Prevent large tool outputs in conversation history from being rendered via markdown as bot messages, avoiding UI freezes and incorrect message bubbles.

Enhancements:
- Aggregate tool role messages into assistant ToolCallCard results based on tool_call_id to align conversation history with the main chat UI.
- Normalize assistant tool call metadata and timestamps when replaying conversation history so tool calls appear as completed without fake live duration updates.
- Adjust conversation history styles so tool call arguments/results expand naturally under the main scroll container and hide redundant inline completion status labels.