### PR TITLE
fix: 子代理无法使用内置工具（如 web_search_tavily）

### DIFF
--- a/astrbot/core/astr_agent_tool_exec.py
+++ b/astrbot/core/astr_agent_tool_exec.py
@@ -241,6 +241,37 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
         return {}
 
     @classmethod
+    def _apply_web_search_tools(
+        cls,
+        toolset: ToolSet,
+        tool_mgr: T.Any,
+        cfg: dict,
+    ) -> None:
+        """根据配置添加 Web 搜索工具，复用主代理的逻辑。"""
+        prov_settings = cfg.get("provider_settings", {})
+        if not prov_settings.get("web_search", False):
+            return
+
+        provider = prov_settings.get("websearch_provider", "tavily")
+        try:
+            if provider == "tavily":
+                toolset.add_tool(tool_mgr.get_builtin_tool("web_search_tavily"))
+                toolset.add_tool(tool_mgr.get_builtin_tool("tavily_extract_web_page"))
+            elif provider == "bocha":
+                toolset.add_tool(tool_mgr.get_builtin_tool("web_search_bocha"))
+            elif provider == "brave":
+                toolset.add_tool(tool_mgr.get_builtin_tool("web_search_brave"))
+            elif provider == "firecrawl":
+                toolset.add_tool(tool_mgr.get_builtin_tool("web_search_firecrawl"))
+                toolset.add_tool(
+                    tool_mgr.get_builtin_tool("firecrawl_extract_web_page")
+                )
+            elif provider == "baidu_ai_search":
+                toolset.add_tool(tool_mgr.get_builtin_tool("web_search_baidu"))
+        except KeyError:
+            pass
+
+    @classmethod
     def _build_handoff_toolset(
         cls,
         run_context: ContextWrapper[AstrAgentContext],
@@ -266,18 +297,17 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
         # "all tools", including runtime computer-use tools.
         if tools is None:
             toolset = ToolSet()
-            # Add registered tools (MCP tools and plugin tools)
-            for registered_tool in llm_tools.func_list:
+            # 使用 tool_mgr 代替全局 llm_tools，确保多租户环境一致性
+            for registered_tool in tool_mgr.func_list:
                 if isinstance(registered_tool, HandoffTool):
                     continue
                 if registered_tool.active:
                     toolset.add_tool(registered_tool)
-            # Add builtin tools (e.g. web_search_tavily)
-            for builtin_tool in tool_mgr.iter_builtin_tools():
-                if getattr(builtin_tool, "active", True):
-                    toolset.add_tool(builtin_tool)
+            # 添加计算机工具（根据 computer_use_runtime 配置）
             for runtime_tool in runtime_computer_tools.values():
                 toolset.add_tool(runtime_tool)
+            # 添加 Web 搜索工具（根据配置）
+            cls._apply_web_search_tools(toolset, tool_mgr, cfg)
             return None if toolset.empty() else toolset
 
         if not tools:

--- a/astrbot/core/astr_agent_tool_exec.py
+++ b/astrbot/core/astr_agent_tool_exec.py
@@ -266,11 +266,16 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
         # "all tools", including runtime computer-use tools.
         if tools is None:
             toolset = ToolSet()
+            # Add registered tools (MCP tools and plugin tools)
             for registered_tool in llm_tools.func_list:
                 if isinstance(registered_tool, HandoffTool):
                     continue
                 if registered_tool.active:
                     toolset.add_tool(registered_tool)
+            # Add builtin tools (e.g. web_search_tavily)
+            for builtin_tool in tool_mgr.iter_builtin_tools():
+                if getattr(builtin_tool, "active", True):
+                    toolset.add_tool(builtin_tool)
             for runtime_tool in runtime_computer_tools.values():
                 toolset.add_tool(runtime_tool)
             return None if toolset.empty() else toolset


### PR DESCRIPTION
## 问题描述

子代理配置 tools=None 时，只能使用 MCP 工具和插件工具，无法使用内置工具（如 web_search_tavily）。

## 根本原因

_build_handoff_toolset 方法在 	ools=None 时只遍历 llm_tools.func_list，但这个列表不包含内置工具。

## 修复方案

在遍历 llm_tools.func_list 后，也遍历 	ool_mgr.iter_builtin_tools() 添加内置工具。

## 关联 Issue

Fixes #7870

## Summary by Sourcery

Bug Fixes:
- Allow sub-agents configured with tools=None to use builtin tools in addition to MCP and plugin tools by including builtin tools in the constructed handoff toolset.