### PR TITLE
feat: add python tool timeout param

### DIFF
--- a/astrbot/core/tools/computer_tools/python.py
+++ b/astrbot/core/tools/computer_tools/python.py
@@ -33,6 +33,11 @@ param_schema = {
             "description": "Whether to suppress the output of the code execution.",
             "default": False,
         },
+        "timeout": {
+            "type": "integer",
+            "description": "Optional timeout in seconds for code execution. Omit or set to 0 to use tool_call_timeout.",
+            "default": 0,
+        },
     },
     "required": ["code"],
 }
@@ -77,7 +82,11 @@ class PythonTool(FunctionTool):
     parameters: dict = field(default_factory=lambda: param_schema)
 
     async def call(
-        self, context: ContextWrapper[AstrAgentContext], code: str, silent: bool = False
+        self,
+        context: ContextWrapper[AstrAgentContext],
+        code: str,
+        silent: bool = False,
+        timeout: int = 0,
     ) -> ToolExecResult:
         if permission_error := check_admin_permission(context, "Python execution"):
             return permission_error
@@ -85,8 +94,17 @@ class PythonTool(FunctionTool):
             context.context.context,
             context.context.event.unified_msg_origin,
         )
+        effective_timeout = (
+            min(timeout, context.tool_call_timeout)
+            if timeout > 0
+            else context.tool_call_timeout
+        )
         try:
-            result = await sb.python.exec(code, silent=silent)
+            result = await sb.python.exec(
+                code,
+                timeout=effective_timeout,
+                silent=silent,
+            )
             return await handle_result(result, context.context.event)
         except Exception as e:
             return f"Error executing code: {str(e)}"
@@ -104,13 +122,26 @@ class LocalPythonTool(FunctionTool):
     parameters: dict = field(default_factory=lambda: param_schema)
 
     async def call(
-        self, context: ContextWrapper[AstrAgentContext], code: str, silent: bool = False
+        self,
+        context: ContextWrapper[AstrAgentContext],
+        code: str,
+        silent: bool = False,
+        timeout: int = 0,
     ) -> ToolExecResult:
         if permission_error := check_admin_permission(context, "Python execution"):
             return permission_error
         sb = get_local_booter()
+        effective_timeout = (
+            min(timeout, context.tool_call_timeout)
+            if timeout > 0
+            else context.tool_call_timeout
+        )
         try:
-            result = await sb.python.exec(code, silent=silent)
+            result = await sb.python.exec(
+                code,
+                timeout=effective_timeout,
+                silent=silent,
+            )
             return await handle_result(result, context.context.event)
         except Exception as e:
             return f"Error executing code: {str(e)}"

--- a/astrbot/core/tools/computer_tools/python.py
+++ b/astrbot/core/tools/computer_tools/python.py
@@ -35,8 +35,8 @@ param_schema = {
         },
         "timeout": {
             "type": "integer",
-            "description": "Optional timeout in seconds for code execution. Omit or set to 0 to use tool_call_timeout.",
-            "default": 0,
+            "description": "Optional timeout in seconds for code execution.",
+            "default": 30,
         },
     },
     "required": ["code"],
@@ -86,7 +86,7 @@ class PythonTool(FunctionTool):
         context: ContextWrapper[AstrAgentContext],
         code: str,
         silent: bool = False,
-        timeout: int = 0,
+        timeout: int = 30,
     ) -> ToolExecResult:
         if permission_error := check_admin_permission(context, "Python execution"):
             return permission_error
@@ -126,7 +126,7 @@ class LocalPythonTool(FunctionTool):
         context: ContextWrapper[AstrAgentContext],
         code: str,
         silent: bool = False,
-        timeout: int = 0,
+        timeout: int = 30,
     ) -> ToolExecResult:
         if permission_error := check_admin_permission(context, "Python execution"):
             return permission_error


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
Fixes #7952 
Refs #7925
This PR implements LLM-controlled timeouts for Python execution tools. The previous local Python execution timeout was effectively hardcoded at 30 seconds, not configurable and not LLM-controlled. Following maintainer @Soulter 's guidance, the timeout is now provided as a tool parameter and capped by the global tool_call_timeout so all tools respect the same upper bound.
### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
- Expose a `timeout` parameter on `astrbot_execute_python` and `astrbot_execute_ipython`.

- Clamp per-call timeout to `tool_call_timeout` and fall back to the global limit when omitted or invalid.

- Core file modified: astrbot/core/tools/computer_tools/python.py
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
```
ruff format .
ruff check .
```

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Add LLM-controlled, per-call timeouts to Python execution tools while respecting the global tool_call_timeout cap.

New Features:
- Expose an optional timeout parameter on the astrbot Python and local Python execution tools to control per-call execution duration.

Enhancements:
- Clamp the per-call Python execution timeout to the global tool_call_timeout and fall back to the global limit when the parameter is omitted or invalid.

## Summary by Sourcery

Add LLM-controlled per-call timeouts to Python execution tools while respecting the global tool_call_timeout cap.

New Features:
- Expose an optional timeout parameter on the remote and local Python execution tools to control per-call code execution duration.

Enhancements:
- Derive an effective timeout per call that falls back to the global tool_call_timeout and clamps user-specified values to this upper bound.