### PR TITLE
fix: preserve folder parent and description on rename

### DIFF
--- a/astrbot/core/persona_mgr.py
+++ b/astrbot/core/persona_mgr.py
@@ -239,8 +239,8 @@ class PersonaManager:
         self,
         folder_id: str,
         name: str | None = None,
-        parent_id: str | None = None,
-        description: str | None = None,
+        parent_id: str | None | object = NOT_GIVEN,
+        description: str | None | object = NOT_GIVEN,
         sort_order: int | None = None,
     ) -> PersonaFolder | None:
         """更新文件夹信息"""

--- a/astrbot/dashboard/routes/persona.py
+++ b/astrbot/dashboard/routes/persona.py
@@ -5,6 +5,7 @@ from quart import request
 from astrbot.core import logger
 from astrbot.core.core_lifecycle import AstrBotCoreLifecycle
 from astrbot.core.db import BaseDatabase
+from astrbot.core.sentinels import NOT_GIVEN
 
 from .route import Response, Route, RouteContext
 
@@ -415,8 +416,10 @@ class PersonaRoute(Route):
             data = await request.get_json()
             folder_id = data.get("folder_id")
             name = data.get("name")
-            parent_id = data.get("parent_id")
-            description = data.get("description")
+            parent_id = data.get("parent_id") if "parent_id" in data else NOT_GIVEN
+            description = (
+                data.get("description") if "description" in data else NOT_GIVEN
+            )
             sort_order = data.get("sort_order")
 
             if not folder_id:


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
Fixes #7973 The persona folder update endpoint treated missing `parent_id` and `description` as explicit nulls. Renaming a folder only sends `name`, so the backend wrote `parent_id = NULL`, moving the folder to root and clearing its description. This change preserves missing fields using `NOT_GIVEN`.

The root cause is that the folder update route used `data.get()` for optional fields, so when the frontend renames a folder it only sends `name`, and **missing keys were read as `None`**. That `None` then flowed through `PersonaManager.update_folder` into the DB update, which treats any provided value as an explicit update. As a result, **`parent_id = NULL` was written (moving the folder to root) and `description` was cleared**. The fix is to treat missing keys as “not provided” using `NOT_GIVEN`, so `parent_id` and `description` are only updated when the request explicitly includes those fields; explicit moves still send `parent_id`, and explicit description edits still work, while rename-only requests no longer mutate the folder hierarchy or metadata. 
根因是更新接口对可选字段使用 `data.get()`，前端重命名只发送 `name`，**缺失字段被读成 `None`**，再一路传到数据库更新逻辑，被当成“明确要更新”的值写入，**导致 `parent_id = NULL`（文件夹移到根目录）且 `description` 被清空**。修复方式是对缺失字段使用 `NOT_GIVEN` 表示“未提供”，这样只有请求体显式包含 `parent_id` 或 `description` 时才会更新，移动操作仍然通过显式 `parent_id` 生效，描述更新也不受影响，而仅重命名不会再改变层级或清空描述。

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
- Treat missing `parent_id` and `description` as `NOT_GIVEN` in the folder update route.
- Allow `PersonaManager.update_folder` to accept `NOT_GIVEN` and pass through to DB updates.
- Core files modified:
  - astrbot/dashboard/routes/persona.py
  - astrbot/core/persona_mgr.py
 
Before this PR, renaming a nested persona folder in the WebUI moves it to the root folder as a side effect unexpectedly. If the folder has a description, it will be cleared during rename unexpectedly.
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
```
ruff format .
ruff check .
```
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Preserve persona folder hierarchy and metadata when updating folders by distinguishing between omitted and explicit null fields.

Bug Fixes:
- Prevent folder rename operations from unintentionally moving folders to the root or clearing their descriptions when parent_id or description are omitted from the request.

Enhancements:
- Allow persona folder update logic to accept a NOT_GIVEN sentinel for optional fields so they are only persisted when explicitly provided.