### PR TITLE
feat: add temporary extra user content parts

### DIFF
--- a/astrbot/core/agent/message.py
+++ b/astrbot/core/agent/message.py
@@ -1,7 +1,7 @@
 # Inspired by MoonshotAI/kosong, credits to MoonshotAI/kosong authors for the original implementation.
 # License: Apache License 2.0
 
-from typing import Any, ClassVar, Literal, Self, cast
+from typing import Any, ClassVar, Literal, TypeVar, cast
 
 from pydantic import (
     BaseModel,
@@ -12,6 +12,8 @@ from pydantic import (
     model_validator,
 )
 from pydantic_core import core_schema
+
+ContentPartT = TypeVar("ContentPartT", bound="ContentPart")
 
 
 class ContentPart(BaseModel):
@@ -63,7 +65,7 @@ class ContentPart(BaseModel):
         # for subclasses, use the default schema
         return handler(source_type)
 
-    def mark_as_temp(self) -> Self:
+    def mark_as_temp(self: ContentPartT) -> ContentPartT:
         """Mark this content part as provider-facing only, not persisted."""
         self._no_save = True
         return self

--- a/astrbot/core/agent/message.py
+++ b/astrbot/core/agent/message.py
@@ -1,7 +1,7 @@
 # Inspired by MoonshotAI/kosong, credits to MoonshotAI/kosong authors for the original implementation.
 # License: Apache License 2.0
 
-from typing import Any, ClassVar, Literal, cast
+from typing import Any, ClassVar, Literal, Self, cast
 
 from pydantic import (
     BaseModel,
@@ -20,6 +20,7 @@ class ContentPart(BaseModel):
     __content_part_registry: ClassVar[dict[str, type["ContentPart"]]] = {}
 
     type: Literal["text", "think", "image_url", "audio_url"]
+    _no_save: bool = PrivateAttr(default=False)
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
@@ -50,7 +51,10 @@ class ContentPart(BaseModel):
                     if not isinstance(type_value, str):
                         raise ValueError(f"Cannot validate {value} as ContentPart")
                     target_class = cls.__content_part_registry[type_value]
-                    return target_class.model_validate(value)
+                    part = target_class.model_validate(value)
+                    if cast(dict[str, Any], value).get("_no_save"):
+                        part._no_save = True
+                    return part
 
                 raise ValueError(f"Cannot validate {value} as ContentPart")
 
@@ -58,6 +62,17 @@ class ContentPart(BaseModel):
 
         # for subclasses, use the default schema
         return handler(source_type)
+
+    def mark_as_temp(self) -> Self:
+        """Mark this content part as provider-facing only, not persisted."""
+        self._no_save = True
+        return self
+
+    def model_dump_for_context(self) -> dict[str, Any]:
+        data = self.model_dump()
+        if self._no_save:
+            data["_no_save"] = True
+        return data
 
 
 class TextPart(ContentPart):
@@ -329,7 +344,14 @@ def dump_messages_with_checkpoints(messages: list[Message]) -> list[dict]:
     """Dump runtime messages and reinsert bound checkpoint segments."""
     dumped: list[dict] = []
     for message in messages:
-        dumped.append(message.model_dump())
+        message_data = message.model_dump()
+        if isinstance(message.content, list):
+            message_data["content"] = [
+                part.model_dump()
+                for part in message.content
+                if not getattr(part, "_no_save", False)
+            ]
+        dumped.append(message_data)
         if message._checkpoint_after is not None:
             dumped.append(
                 CheckpointMessageSegment(content=message._checkpoint_after).model_dump()

--- a/astrbot/core/provider/entities.py
+++ b/astrbot/core/provider/entities.py
@@ -206,7 +206,7 @@ class ProviderRequest:
         # 2. 额外的内容块（系统提醒、指令等）
         if self.extra_user_content_parts:
             for part in self.extra_user_content_parts:
-                content_blocks.append(part.model_dump())
+                content_blocks.append(part.model_dump_for_context())
 
         # 3. 图片内容
         if self.image_urls:

--- a/docs/en/dev/star/guides/listen-message-event.md
+++ b/docs/en/dev/star/guides/listen-message-event.md
@@ -295,6 +295,14 @@ async def my_custom_hook_1(self, event: AstrMessageEvent, req: ProviderRequest):
 >     )
 > ```
 >
+> If the appended content should only affect the current LLM request and should not be persisted into conversation history, call `.mark_as_temp()` to mark it as temporary:
+>
+> ```python
+> req.extra_user_content_parts.append(
+>     TextPart(text="<runtime_hint>This hint only applies to the current request.</runtime_hint>").mark_as_temp()
+> )
+> ```
+>
 > For long-term memory, knowledge bases, or external system queries that may be large or unnecessary for every round, do not put everything directly into the prompt. Prefer registering them as `llm_tool` functions so the model can call them when needed, or retrieve only a small relevant summary in your plugin and append that summary through `extra_user_content_parts`.
 
 > You cannot use yield to send messages here. If you need to send, please use the `event.send()` method directly.

--- a/docs/zh/dev/star/guides/listen-message-event.md
+++ b/docs/zh/dev/star/guides/listen-message-event.md
@@ -314,6 +314,14 @@ async def my_custom_hook_1(self, event: AstrMessageEvent, req: ProviderRequest):
 >     )
 > ```
 >
+> 如果追加的内容只希望参与本轮 LLM 请求，不希望被持久化到会话历史中，可以调用 `.mark_as_temp()` 标记为临时内容（`>= v4.24.0`）：
+>
+> ```python
+> req.extra_user_content_parts.append(
+>     TextPart(text="<runtime_hint>这段提示只在本轮请求中生效。</runtime_hint>").mark_as_temp()
+> )
+> ```
+>
 > 对于长期记忆、知识库、外部系统查询等内容量较大或不一定每轮都需要的信息，不建议全部塞进提示词。可以优先注册为 `llm_tool`，让模型在需要时调用；也可以先在插件中检索出本轮真正相关的少量摘要，再放入 `extra_user_content_parts`。
 
 #### LLM 请求完成时

--- a/docs/zh/dev/star/plugin.md
+++ b/docs/zh/dev/star/plugin.md
@@ -548,6 +548,14 @@ async def my_custom_hook_1(self, event: AstrMessageEvent, req: ProviderRequest):
 >     )
 > ```
 >
+> 如果追加的内容只希望参与本轮 LLM 请求，不希望被持久化到会话历史中，可以调用 `.mark_as_temp()` 标记为临时内容：
+>
+> ```python
+> req.extra_user_content_parts.append(
+>     TextPart(text="<runtime_hint>这段提示只在本轮请求中生效。</runtime_hint>").mark_as_temp()
+> )
+> ```
+>
 > 对于长期记忆、知识库、外部系统查询等内容量较大或不一定每轮都需要的信息，不建议全部塞进提示词。可以优先注册为 `llm_tool`，让模型在需要时调用；也可以先在插件中检索出本轮真正相关的少量摘要，再放入 `extra_user_content_parts`。
 
 > 这里不能使用 yield 来发送消息。如需发送，请直接使用 `event.send()` 方法。

--- a/tests/test_conversation_checkpoint.py
+++ b/tests/test_conversation_checkpoint.py
@@ -4,11 +4,13 @@ from astrbot.core.agent.message import (
     CheckpointData,
     CheckpointMessageSegment,
     Message,
+    TextPart,
     bind_checkpoint_messages,
     dump_messages_with_checkpoints,
     get_checkpoint_id,
     strip_checkpoint_messages,
 )
+from astrbot.core.provider.entities import ProviderRequest
 from astrbot.core.provider.provider import Provider
 from astrbot.dashboard.routes.chat import ChatRoute
 
@@ -78,6 +80,60 @@ def test_dump_checkpoint_messages_drops_checkpoint_when_message_is_dropped():
 
     assert dump_messages_with_checkpoints(messages[2:]) == [
         {"role": "user", "content": "latest user"},
+    ]
+
+
+def test_dump_messages_filters_temp_content_parts():
+    messages = [
+        Message(
+            role="user",
+            content=[
+                TextPart(text="persisted"),
+                TextPart(text="temporary").mark_as_temp(),
+            ],
+        ),
+        Message(role="assistant", content="ok"),
+    ]
+
+    assert dump_messages_with_checkpoints(messages) == [
+        {"role": "user", "content": [{"type": "text", "text": "persisted"}]},
+        {"role": "assistant", "content": "ok"},
+    ]
+
+
+def test_content_part_no_save_round_trip_from_dict():
+    message = Message.model_validate(
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "persisted"},
+                {"type": "text", "text": "temporary", "_no_save": True},
+            ],
+        }
+    )
+
+    assert isinstance(message.content, list)
+    assert message.content[0]._no_save is False
+    assert message.content[1]._no_save is True
+    assert dump_messages_with_checkpoints([message]) == [
+        {"role": "user", "content": [{"type": "text", "text": "persisted"}]},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_provider_request_assemble_context_preserves_temp_content_part_marker():
+    request = ProviderRequest(
+        prompt="hello",
+        extra_user_content_parts=[TextPart(text="temporary").mark_as_temp()],
+    )
+
+    message = Message.model_validate(await request.assemble_context())
+
+    assert isinstance(message.content, list)
+    assert message.content[1].text == "temporary"
+    assert message.content[1]._no_save is True
+    assert dump_messages_with_checkpoints([message]) == [
+        {"role": "user", "content": [{"type": "text", "text": "hello"}]},
     ]
 
 


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [ ] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [ ] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [ ] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Support temporary user content parts that affect only the current LLM request without being persisted to conversation history.

New Features:
- Introduce a temporary flag on content parts with a helper to mark them as provider-only and exclude them from persisted conversation history.
- Allow extra user content parts in provider requests to carry a non-persisted marker through context assembly.

Enhancements:
- Adjust message dumping to filter out temporary content parts while still emitting checkpoint segments as before.

Documentation:
- Document the use of `.mark_as_temp()` for extra user content parts in both English and Chinese developer guides.

Tests:
- Add tests covering round-tripping of the temporary content marker, its effect on message dumping, and preservation through provider context assembly.