### PR TITLE
fix: parse JSON string messages in send_message_to_user

### DIFF
--- a/astrbot/core/tools/message_tools.py
+++ b/astrbot/core/tools/message_tools.py
@@ -138,7 +138,7 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
         if isinstance(messages, str):
             try:
                 messages = json.loads(messages)
-            except (json.JSONDecodeError, TypeError):
+            except json.JSONDecodeError:
                 pass
         if not isinstance(messages, list) or not messages:
             return "error: messages parameter is empty or invalid."

--- a/astrbot/core/tools/message_tools.py
+++ b/astrbot/core/tools/message_tools.py
@@ -132,6 +132,14 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
             ):
                 return permission_error
         messages = kwargs.get("messages")
+        # Some LLMs (e.g. MiniMax) may serialize the array value as a JSON string
+        # when the text contains newlines. Try to recover.
+        # https://github.com/AstrBotDevs/AstrBot/issues/7961
+        if isinstance(messages, str):
+            try:
+                messages = json.loads(messages)
+            except (json.JSONDecodeError, TypeError):
+                pass
         if not isinstance(messages, list) or not messages:
             return "error: messages parameter is empty or invalid."
 

--- a/tests/unit/test_message_tools.py
+++ b/tests/unit/test_message_tools.py
@@ -133,3 +133,44 @@ async def test_send_message_empty_messages_returns_error():
     result = await tool.call(ctx, messages=[], session="oc_xxx")
     assert "error:" in result
     assert "messages" in result.lower()
+
+
+# JSON-string messages compatibility for issue #7961.
+
+
+@pytest.mark.asyncio
+async def test_messages_as_json_string_parsed():
+    """JSON-string array messages are parsed before validation."""
+    tool = SendMessageToUserTool()
+    ctx = _make_context(current_session="feishu:GroupMessage:oc_xxx")
+    messages_str = '[{"type": "plain", "text": "hello from string"}]'
+    result = await tool.call(ctx, messages=messages_str, session="oc_xxx")
+    assert "Message sent to session" in result
+
+
+@pytest.mark.asyncio
+async def test_messages_as_json_string_with_newlines():
+    """JSON-string messages preserve multiline text after parsing."""
+    tool = SendMessageToUserTool()
+    ctx = _make_context(current_session="feishu:GroupMessage:oc_xxx")
+    import json as _json
+
+    long_text = "line1\n\nline2\nline3"
+    messages_str = _json.dumps([{"type": "plain", "text": long_text}])
+    result = await tool.call(ctx, messages=messages_str, session="oc_xxx")
+    assert "Message sent to session" in result
+    call_args = ctx.context.context.send_message.call_args
+    chain = call_args[0][1]
+    assert len(chain.chain) == 1
+    assert chain.chain[0].text == long_text
+
+
+@pytest.mark.asyncio
+async def test_messages_as_invalid_json_string_returns_error():
+    """Invalid JSON-string messages still return a validation error."""
+    tool = SendMessageToUserTool()
+    ctx = _make_context()
+    result = await tool.call(ctx, messages="not valid json at all", session="oc_xxx")
+    assert "error:" in result or "invalid" in result.lower()
+    result2 = await tool.call(ctx, messages="", session="oc_xxx")
+    assert "error:" in result2 or "invalid" in result2.lower()

--- a/tests/unit/test_message_tools.py
+++ b/tests/unit/test_message_tools.py
@@ -1,5 +1,6 @@
 """Tests for send_message_to_user session handling."""
 
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -153,10 +154,9 @@ async def test_messages_as_json_string_with_newlines():
     """JSON-string messages preserve multiline text after parsing."""
     tool = SendMessageToUserTool()
     ctx = _make_context(current_session="feishu:GroupMessage:oc_xxx")
-    import json as _json
 
     long_text = "line1\n\nline2\nline3"
-    messages_str = _json.dumps([{"type": "plain", "text": long_text}])
+    messages_str = json.dumps([{"type": "plain", "text": long_text}])
     result = await tool.call(ctx, messages=messages_str, session="oc_xxx")
     assert "Message sent to session" in result
     call_args = ctx.context.context.send_message.call_args


### PR DESCRIPTION
Fixes #7961

CronJob-triggered `send_message_to_user` calls can receive `messages` as a JSON string when some providers serialize a multiline message array inside the tool arguments. The tool previously rejected that value before building the message chain.

### Modifications / 改动点

- Parse `messages` with `json.loads()` when the value arrives as a string, then keep the existing list/object validation path.
- Add regression coverage for JSON-string message arrays, multiline text preservation, and invalid JSON strings.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```bash
uv run pytest tests/unit/test_message_tools.py
# 9 passed

uv run ruff check astrbot/core/tools/message_tools.py tests/unit/test_message_tools.py
# All checks passed!

uv run ruff format --check astrbot/core/tools/message_tools.py tests/unit/test_message_tools.py
# 2 files already formatted
```

---

### Checklist / 检查清单

- [x] If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。
- [x] My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**. / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。
- [x] I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`. / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] My changes do not introduce malicious code. / 我的更改没有引入恶意代码。

## Summary by Sourcery

Handle JSON-string message payloads in send_message_to_user and add regression tests for this behavior.

Bug Fixes:
- Allow send_message_to_user to accept messages provided as a JSON string by deserializing them before validation, while still rejecting empty or invalid payloads.

Tests:
- Add tests covering JSON-string message arrays, preservation of multiline text after parsing, and error handling for invalid JSON strings.