### PR TITLE
fix(core): handle missing web search query params

### DIFF
--- a/astrbot/core/tools/web_search_tools.py
+++ b/astrbot/core/tools/web_search_tools.py
@@ -382,7 +382,10 @@ class TavilyWebSearchTool(FunctionTool[AstrAgentContext]):
         default_factory=lambda: {
             "type": "object",
             "properties": {
-                "query": {"type": "string", "description": "Required string: search query to execute."},
+                "query": {
+                    "type": "string",
+                    "description": "Required string: search query to execute.",
+                },
                 "max_results": {
                     "type": "integer",
                     "description": "Optional. The maximum number of results to return. Default is 7. Range is 5-20.",

--- a/astrbot/core/tools/web_search_tools.py
+++ b/astrbot/core/tools/web_search_tools.py
@@ -805,7 +805,7 @@ class BaiduWebSearchTool(FunctionTool[AstrAgentContext]):
             top_k = 50
 
         payload = {
-            "messages": [{"role": "user", "content": query [:72]}],
+            "messages": [{"role": "user", "content": query[:72]}],
             "search_source": "baidu_search_v2",
             "resource_type_filter": [{"type": "web", "top_k": top_k}],
         }

--- a/astrbot/core/tools/web_search_tools.py
+++ b/astrbot/core/tools/web_search_tools.py
@@ -805,7 +805,7 @@ class BaiduWebSearchTool(FunctionTool[AstrAgentContext]):
             top_k = 50
 
         payload = {
-            "messages": [{"role": "user", "content": str(query)[:72]}],
+            "messages": [{"role": "user", "content": query [:72]}],
             "search_source": "baidu_search_v2",
             "resource_type_filter": [{"type": "web", "top_k": top_k}],
         }

--- a/astrbot/core/tools/web_search_tools.py
+++ b/astrbot/core/tools/web_search_tools.py
@@ -117,6 +117,12 @@ def _get_runtime(context) -> tuple[dict, dict, str]:
     return cfg, provider_settings, event.unified_msg_origin
 
 
+def _validate_search_query(kwargs: dict) -> str | None:
+    # Keep provider behavior aligned when the model omits or blanks the required query.
+    query = str(kwargs.get("query") or "").strip()
+    return query or None
+
+
 def _cache_favicon(url: str, favicon: str | None) -> None:
     if favicon:
         sp.temporary_cache["_ws_favicon"][url] = favicon
@@ -424,7 +430,7 @@ class TavilyWebSearchTool(FunctionTool[AstrAgentContext]):
         if not provider_settings.get("websearch_tavily_key", []):
             return "Error: Tavily API key is not configured in AstrBot."
 
-        query = str(kwargs.get("query") or "").strip()
+        query = _validate_search_query(kwargs)
         if not query:
             return "Error: 'query' parameter is required but was not provided."
 
@@ -553,7 +559,7 @@ class BochaWebSearchTool(FunctionTool[AstrAgentContext]):
         if not provider_settings.get("websearch_bocha_key", []):
             return "Error: BoCha API key is not configured in AstrBot."
 
-        query = str(kwargs.get("query") or "").strip()
+        query = _validate_search_query(kwargs)
         if not query:
             return "Error: 'query' parameter is required but was not provided."
 
@@ -611,7 +617,7 @@ class BraveWebSearchTool(FunctionTool[AstrAgentContext]):
         if not provider_settings.get("websearch_brave_key", []):
             return "Error: Brave API key is not configured in AstrBot."
 
-        query = str(kwargs.get("query") or "").strip()
+        query = _validate_search_query(kwargs)
         if not query:
             return "Error: 'query' parameter is required but was not provided."
 
@@ -676,7 +682,7 @@ class FirecrawlWebSearchTool(FunctionTool[AstrAgentContext]):
         if not provider_settings.get("websearch_firecrawl_key", []):
             return "Error: Firecrawl API key is not configured in AstrBot."
 
-        query = str(kwargs.get("query") or "").strip()
+        query = _validate_search_query(kwargs)
         if not query:
             return "Error: 'query' parameter is required but was not provided."
 
@@ -794,7 +800,7 @@ class BaiduWebSearchTool(FunctionTool[AstrAgentContext]):
         if not provider_settings.get("websearch_baidu_app_builder_key", ""):
             return "Error: Baidu AI Search API key is not configured in AstrBot."
 
-        query = str(kwargs.get("query") or "").strip()
+        query = _validate_search_query(kwargs)
         if not query:
             return "Error: 'query' parameter is required but was not provided."
 

--- a/astrbot/core/tools/web_search_tools.py
+++ b/astrbot/core/tools/web_search_tools.py
@@ -382,7 +382,7 @@ class TavilyWebSearchTool(FunctionTool[AstrAgentContext]):
         default_factory=lambda: {
             "type": "object",
             "properties": {
-                "query": {"type": "string", "description": "Required. Search query."},
+                "query": {"type": "string", "description": "Required string: search query to execute."},
                 "max_results": {
                     "type": "integer",
                     "description": "Optional. The maximum number of results to return. Default is 7. Range is 5-20.",
@@ -421,6 +421,10 @@ class TavilyWebSearchTool(FunctionTool[AstrAgentContext]):
         if not provider_settings.get("websearch_tavily_key", []):
             return "Error: Tavily API key is not configured in AstrBot."
 
+        query = str(kwargs.get("query") or "").strip()
+        if not query:
+            return "Error: 'query' parameter is required but was not provided."
+
         search_depth = kwargs.get("search_depth", "basic")
         if search_depth not in ["basic", "advanced"]:
             search_depth = "basic"
@@ -430,7 +434,7 @@ class TavilyWebSearchTool(FunctionTool[AstrAgentContext]):
             topic = "general"
 
         payload = {
-            "query": kwargs["query"],
+            "query": query,
             "max_results": kwargs.get("max_results", 7),
             "include_favicon": True,
             "search_depth": search_depth,
@@ -546,8 +550,12 @@ class BochaWebSearchTool(FunctionTool[AstrAgentContext]):
         if not provider_settings.get("websearch_bocha_key", []):
             return "Error: BoCha API key is not configured in AstrBot."
 
+        query = str(kwargs.get("query") or "").strip()
+        if not query:
+            return "Error: 'query' parameter is required but was not provided."
+
         payload = {
-            "query": kwargs["query"],
+            "query": query,
             "count": kwargs.get("count", 10),
             "summary": bool(kwargs.get("summary", False)),
         }
@@ -600,6 +608,10 @@ class BraveWebSearchTool(FunctionTool[AstrAgentContext]):
         if not provider_settings.get("websearch_brave_key", []):
             return "Error: Brave API key is not configured in AstrBot."
 
+        query = str(kwargs.get("query") or "").strip()
+        if not query:
+            return "Error: 'query' parameter is required but was not provided."
+
         count = int(kwargs.get("count", 10))
         if count < 1:
             count = 1
@@ -607,7 +619,7 @@ class BraveWebSearchTool(FunctionTool[AstrAgentContext]):
             count = 20
 
         payload = {
-            "q": kwargs["query"],
+            "q": query,
             "count": count,
             "country": kwargs.get("country", "US"),
             "search_lang": kwargs.get("search_lang", "zh-hans"),
@@ -661,8 +673,12 @@ class FirecrawlWebSearchTool(FunctionTool[AstrAgentContext]):
         if not provider_settings.get("websearch_firecrawl_key", []):
             return "Error: Firecrawl API key is not configured in AstrBot."
 
+        query = str(kwargs.get("query") or "").strip()
+        if not query:
+            return "Error: 'query' parameter is required but was not provided."
+
         payload = {
-            "query": kwargs["query"],
+            "query": query,
             "limit": kwargs.get("limit", 5),
             "sources": ["web"],
         }
@@ -775,6 +791,10 @@ class BaiduWebSearchTool(FunctionTool[AstrAgentContext]):
         if not provider_settings.get("websearch_baidu_app_builder_key", ""):
             return "Error: Baidu AI Search API key is not configured in AstrBot."
 
+        query = str(kwargs.get("query") or "").strip()
+        if not query:
+            return "Error: 'query' parameter is required but was not provided."
+
         top_k = int(kwargs.get("top_k", 10))
         if top_k < 1:
             top_k = 1
@@ -782,7 +802,7 @@ class BaiduWebSearchTool(FunctionTool[AstrAgentContext]):
             top_k = 50
 
         payload = {
-            "messages": [{"role": "user", "content": str(kwargs["query"])[:72]}],
+            "messages": [{"role": "user", "content": str(query)[:72]}],
             "search_source": "baidu_search_v2",
             "resource_type_filter": [{"type": "web", "top_k": top_k}],
         }

--- a/tests/unit/test_web_search_tools.py
+++ b/tests/unit/test_web_search_tools.py
@@ -371,6 +371,34 @@ class _FakeFirecrawlSession:
         return self.response
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "tool_cls,provider_setting,kwargs",
+    [
+        (tools.TavilyWebSearchTool, "websearch_tavily_key", {}),
+        (tools.BochaWebSearchTool, "websearch_bocha_key", {"query": None}),
+        (tools.BraveWebSearchTool, "websearch_brave_key", {"query": "   "}),
+        (tools.FirecrawlWebSearchTool, "websearch_firecrawl_key", {"query": ""}),
+        (tools.BaiduWebSearchTool, "websearch_baidu_app_builder_key", {}),
+    ],
+)
+async def test_search_tool_returns_friendly_error_when_query_missing(
+    tool_cls, provider_setting, kwargs
+):
+    """Issue #7499: invalid query inputs must not crash search tools."""
+    tool = tool_cls()
+    settings = {provider_setting: ["test-key"]}
+    if provider_setting == "websearch_baidu_app_builder_key":
+        settings = {provider_setting: "test-key"}
+    context = _context_with_provider_settings(settings)
+
+    result = await tool.call(context, **kwargs)
+
+    assert isinstance(result, str)
+    assert "Error:" in result
+    assert "query" in result.lower()
+
+
 def _context_with_provider_settings(provider_settings):
     config = {"provider_settings": provider_settings}
     agent_context = SimpleNamespace(


### PR DESCRIPTION
Fixes #7499.

This PR prevents built-in web search tools from crashing when the LLM emits an empty or invalid `query` argument. The original issue showed `web_search_tavily` being called with `{}`, which raised `KeyError: 'query'` and fed an error back into the tool loop repeatedly.

### Modifications / 改动点

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

- Validate `query` before building provider payloads for Tavily, BoCha, Brave, Firecrawl, and Baidu AI Search.
- Return a clear tool error when `query` is missing, `null`, or blank instead of raising `KeyError`/`AttributeError`.
- Keep normal non-empty queries flowing into each provider payload unchanged, aside from trimming surrounding whitespace.
- Add a regression test covering the affected built-in web search tools.

### Screenshots or Test Results / 运行截图或测试结果

```bash
uv run pytest tests/unit/test_web_search_tools.py -q
```

```text
...............                                                          [100%]
15 passed in 2.35s
```

```bash
uv run ruff check astrbot/core/tools/web_search_tools.py tests/unit/test_web_search_tools.py
```

```text
All checks passed!
```

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Handle invalid or missing search queries in built-in web search tools to avoid crashes and return clear error messages.

Bug Fixes:
- Prevent Tavily, BoCha, Brave, Firecrawl, and Baidu web search tools from raising errors when the LLM omits or sends an empty/invalid query parameter.

Tests:
- Add regression tests ensuring each built-in web search tool returns a friendly error string when the query argument is missing, null, or blank.