### PR TITLE
fix: add stdout startup completion signal for AstrBot Launcher

### DIFF
--- a/astrbot/core/core_lifecycle.py
+++ b/astrbot/core/core_lifecycle.py
@@ -339,6 +339,7 @@ class AstrBotCoreLifecycle:
         """
         self._load()
         logger.info("AstrBot started.")
+        print("AstrBot 启动完成", flush=True)
 
         # 执行启动完成事件钩子
         handlers = star_handlers_registry.get_handlers_by_event_type(


### PR DESCRIPTION
## 问题描述

AstrBot Launcher 通过监控 Python 进程 stdout 中的 `AstrBot 启动完成` 来判断实例是否启动完成。但当前代码使用 `logger.info("AstrBot started.")` 输出启动消息，该消息走 loguru 日志通道（stderr），Launcher 无法检测到，导致 300 秒后超时 kill 进程。

## 修复方案

在 `core_lifecycle.py` 的 `start()` 方法中添加 `print("AstrBot 启动完成", flush=True)`，将启动完成信号输出到 stdout。

## 关联 Issue

Fixes #7982

## Summary by Sourcery

Bug Fixes:
- Emit a dedicated startup completion signal via stdout in addition to the existing log message to prevent launcher timeout when monitoring process readiness via standard output.