### PR TITLE
fix(config): hide Baidu web search key when disabled

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -3242,6 +3242,7 @@ CONFIG_METADATA_3 = {
                         "hint": "参考：https://console.bce.baidu.com/iam/#/iam/apikey/list",
                         "condition": {
                             "provider_settings.websearch_provider": "baidu_ai_search",
+                            "provider_settings.web_search": True,
                         },
                     },
                     "provider_settings.web_search_link": {

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,7 +6,7 @@ import os
 import pytest
 
 from astrbot.core.config.astrbot_config import AstrBotConfig, RateLimitStrategy
-from astrbot.core.config.default import CONFIG_METADATA_3, DEFAULT_VALUE_MAP
+from astrbot.core.config.default import DEFAULT_VALUE_MAP
 from astrbot.core.config.i18n_utils import ConfigMetadataI18n
 
 
@@ -46,24 +46,6 @@ class TestRateLimitStrategy:
     def test_discard_value(self):
         """Test discard enum value."""
         assert RateLimitStrategy.DISCARD.value == "discard"
-
-
-class TestConfigMetadata:
-    """Tests for dashboard config metadata."""
-
-    def test_baidu_web_search_key_requires_web_search_enabled(self):
-        websearch_items = CONFIG_METADATA_3["ai_group"]["metadata"]["websearch"][
-            "items"
-        ]
-
-        condition = websearch_items[
-            "provider_settings.websearch_baidu_app_builder_key"
-        ]["condition"]
-
-        assert condition == {
-            "provider_settings.websearch_provider": "baidu_ai_search",
-            "provider_settings.web_search": True,
-        }
 
 
 class TestAstrBotConfigLoad:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,7 +6,7 @@ import os
 import pytest
 
 from astrbot.core.config.astrbot_config import AstrBotConfig, RateLimitStrategy
-from astrbot.core.config.default import DEFAULT_VALUE_MAP
+from astrbot.core.config.default import CONFIG_METADATA_3, DEFAULT_VALUE_MAP
 from astrbot.core.config.i18n_utils import ConfigMetadataI18n
 
 
@@ -46,6 +46,24 @@ class TestRateLimitStrategy:
     def test_discard_value(self):
         """Test discard enum value."""
         assert RateLimitStrategy.DISCARD.value == "discard"
+
+
+class TestConfigMetadata:
+    """Tests for dashboard config metadata."""
+
+    def test_baidu_web_search_key_requires_web_search_enabled(self):
+        websearch_items = CONFIG_METADATA_3["ai_group"]["metadata"]["websearch"][
+            "items"
+        ]
+
+        condition = websearch_items[
+            "provider_settings.websearch_baidu_app_builder_key"
+        ]["condition"]
+
+        assert condition == {
+            "provider_settings.websearch_provider": "baidu_ai_search",
+            "provider_settings.web_search": True,
+        }
 
 
 class TestAstrBotConfigLoad:


### PR DESCRIPTION
Fixes #7985.

### Modifications / 改动点

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

- 为 `provider_settings.websearch_baidu_app_builder_key` 补充 `provider_settings.web_search: True` 显示条件。
- 使百度 AI 搜索 Key 配置项与 Tavily、BoCha、Brave、Firecrawl 的 Key 配置项行为一致：关闭网页搜索后隐藏对应 Key 输入框。

### Screenshots or Test Results / 运行截图或测试结果

<img width="969" height="618" alt="image" src="https://github.com/user-attachments/assets/4b1d6a37-cbb5-4238-bebc-591e0424f375" />
<img width="973" height="264" alt="image" src="https://github.com/user-attachments/assets/0bab0490-c4be-4466-bd53-83c0d5124a74" />
<img width="932" height="608" alt="astrbotbug1 1" src="https://github.com/user-attachments/assets/dd336254-ac55-4718-8884-7f75fd48be56" />


### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Align Baidu web search key configuration visibility with other web search providers and guard it with tests.

Bug Fixes:
- Hide the Baidu web search key configuration when web search is disabled, consistent with other providers.

Tests:
- Add a regression test ensuring the Baidu web search key field is only active when Baidu is selected and web search is enabled.