### PR TITLE
fix: detect Tencent SILK (\x02 prefix) in audio magic bytes to avoid ffmpeg failure

### DIFF
--- a/astrbot/core/utils/media_utils.py
+++ b/astrbot/core/utils/media_utils.py
@@ -350,11 +350,11 @@ def _get_audio_magic_type(audio_path: str) -> str:
     if header[:4] == b"ftyp" and b"mp4" in header[:8]:
         return "mp4"
 
-    if header[:9] == b"#!SILK_V3":
+    if header.startswith(b"#!SILK_V3"):
         return "silk"
 
     # Tencent SILK: leading \x02 byte before #!SILK_V3
-    if header[:1] == b"\x02" and header[1:10] == b"#!SILK_V3":
+    if header.startswith(b"\x02#!SILK_V3"):
         return "silk"
 
     return ""

--- a/astrbot/core/utils/media_utils.py
+++ b/astrbot/core/utils/media_utils.py
@@ -15,6 +15,7 @@ from PIL import Image as PILImage
 
 from astrbot import logger
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
+from astrbot.core.utils.tencent_record_helper import tencent_silk_to_wav
 
 IMAGE_COMPRESS_DEFAULT_MAX_SIZE = 1280
 IMAGE_COMPRESS_DEFAULT_QUALITY = 95
@@ -300,8 +301,16 @@ async def ensure_wav(audio_path: str, output_path: str | None = None) -> str:
     if not audio_path:
         return audio_path
 
-    if _get_audio_magic_type(audio_path) == "wav":
+    audio_type = _get_audio_magic_type(audio_path)
+    if audio_type == "wav":
         return audio_path
+
+    if audio_type == "silk":
+        if output_path is None:
+            temp_dir = get_astrbot_temp_path()
+            os.makedirs(temp_dir, exist_ok=True)
+            output_path = os.path.join(temp_dir, f"media_audio_{uuid.uuid4().hex}.wav")
+        return await tencent_silk_to_wav(audio_path, output_path)
 
     return await convert_audio_to_wav(audio_path, output_path)
 
@@ -341,7 +350,11 @@ def _get_audio_magic_type(audio_path: str) -> str:
     if header[:4] == b"ftyp" and b"mp4" in header[:8]:
         return "mp4"
 
-    if header[:8] == b"#!SILK_V3":
+    if header[:9] == b"#!SILK_V3":
+        return "silk"
+
+    # Tencent SILK: leading \x02 byte before #!SILK_V3
+    if header[:1] == b"\x02" and header[1:10] == b"#!SILK_V3":
         return "silk"
 
     return ""


### PR DESCRIPTION
## Root Cause

QQ official bot sends voice messages in Tencent SILK format (leading `\x02` byte before `#!SILK_V3` magic). `_get_audio_magic_type()` had two off-by-one slice errors that prevented SILK detection:

1. **Standard SILK** (line 353): `header[:8] == b"#!SILK_V3"` — `#!SILK_V3` is 9 bytes, so this never matched
2. **Tencent SILK**: QQ sends `\x02#!SILK_V3` — not detected at all

## Fix

| # | Change | Location |
|---|--------|----------|
| 1 | Import `tencent_silk_to_wav` | L18 |
| 2 | Standard SILK: `header[:9]` (was `[:8]`) | L353 |
| 3 | Tencent SILK: `header[1:10]` (new detection) | L357 |
| 4 | `ensure_wav()` routes `silk` type → `tencent_silk_to_wav()` | L308 |

## Relationship to #7832

#7832 adds silk/amr routing in `ensure_wav()`, but does not fix the magic byte detection — `_get_audio_magic_type()` still never returns `"silk"`. This PR completes the fix by correcting the two off-by-one errors so the detection actually works.

## Before / After

```
Before: QQ voice → magic returns "" → ffmpeg → "Invalid data found" error
After:  QQ voice → magic returns "silk" → tencent_silk_to_wav → WAV OK
```

## Testing

- ✅ Tencent SILK file detected as "silk" (verified with real QQ voice files)
- ✅ Standard SILK file detected as "silk"
- ✅ WAV files still short-circuit correctly
- ✅ All other audio formats (mp3, ogg, flac, amr, opus, mp4) unaffected
- ✅ No circular imports

Fixed by: Tom8266 and deepseek-v4-pro
