### PR TITLE
Fix noto sans cyrillic

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -9,7 +9,7 @@
     <meta name="robots" content="noindex, nofollow" />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Outfit&family=Noto+Sans+SC:wght@100..900&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Outfit&family=Noto+Sans:wght@100..900&family=Noto+Sans+SC:wght@100..900&display=swap"
     />
     <!-- VAD (Voice Activity Detection) Libraries -->
     <script src="https://cdn.jsdelivr.net/npm/onnxruntime-web@1.22.0/dist/ort.wasm.min.js"></script>

--- a/dashboard/src/scss/_variables.scss
+++ b/dashboard/src/scss/_variables.scss
@@ -9,7 +9,7 @@ $color-pack: false;
 // Global font size and border radius
 $font-size-root: 1rem;
 $border-radius-root: 8px;
-$cjk-sans-fallback: 'PingFang SC', 'Hiragino Sans GB', 'Noto Sans CJK SC', 'Microsoft YaHei' !default;
+$cjk-sans-fallback: 'PingFang SC', 'Hiragino Sans GB', 'Noto Sans CJK SC', 'Microsoft YaHei', 'Noto Sans SC', 'Noto Sans' !default;
 $cjk-mono-fallback: 'PingFang SC', 'PingFang TC', 'Hiragino Sans GB', 'Noto Sans CJK SC', 'Microsoft YaHei' !default;
 $code-text-color: #111827 !default;
 


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

The WebUI currently loads `Noto Sans SC` (Simplified Chinese variant) from Google Fonts, which does not include Cyrillic glyphs. As a result, Russian text falls back to the system `sans-serif`, causing inconsistent and often poor rendering depending on the user's OS.

This change ensures Cyrillic text renders correctly while preserving optimal CJK text rendering.

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- **index.html**: Added `family=Noto+Sans` to the Google Fonts URL (loaded alongside existing `Noto+Sans+SC`)
- **_variables.scss**: Added `'Noto Sans'` at the **end** of `$cjk-sans-fallback` so Chinese text still prefers system CJK fonts first, while Cyrillic text falls through to `Noto Sans`


- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

Verified locally: Russian text in WebUI now renders with `Noto Sans` instead of system fallback.

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Improve dashboard font support for Cyrillic text and extend default web search configuration keys.

Bug Fixes:
- Ensure the WebUI loads a base Noto Sans font to correctly render Cyrillic characters instead of falling back to system sans-serif.

Enhancements:
- Extend the CJK sans-serif fallback stack to include Noto Sans while preserving preferred system CJK fonts.
- Add a default configuration entry for the Firecrawl web search API key.