### PR TITLE
fix: treat Discord voice attachments as records

### DIFF
--- a/astrbot/core/platform/sources/discord/discord_platform_adapter.py
+++ b/astrbot/core/platform/sources/discord/discord_platform_adapter.py
@@ -209,8 +209,7 @@ class DiscordPlatformAdapter(Platform):
         return str(content_type).split(";", maxsplit=1)[0].strip().lower()
 
     @staticmethod
-    def _is_audio_attachment(attachment: Any) -> bool:
-        content_type = DiscordPlatformAdapter._get_attachment_content_type(attachment)
+    def _is_audio_attachment(attachment: Any, content_type: str) -> bool:
         if content_type.startswith("audio/"):
             return True
 
@@ -269,7 +268,7 @@ class DiscordPlatformAdapter(Platform):
                     message_chain.append(
                         Image(file=attachment.url, filename=attachment.filename),
                     )
-                elif self._is_audio_attachment(attachment):
+                elif self._is_audio_attachment(attachment, content_type):
                     message_chain.append(
                         Record(file=attachment.url, url=attachment.url),
                     )

--- a/astrbot/core/platform/sources/discord/discord_platform_adapter.py
+++ b/astrbot/core/platform/sources/discord/discord_platform_adapter.py
@@ -1,6 +1,7 @@
 import asyncio
 import re
 import sys
+from pathlib import Path
 from typing import Any, cast
 
 import discord
@@ -9,7 +10,7 @@ from discord.channel import DMChannel
 
 from astrbot import logger
 from astrbot.api.event import MessageChain
-from astrbot.api.message_components import File, Image, Plain
+from astrbot.api.message_components import File, Image, Plain, Record
 from astrbot.api.platform import (
     AstrBotMessage,
     MessageMember,
@@ -31,6 +32,11 @@ if sys.version_info >= (3, 12):
     from typing import override
 else:
     from typing_extensions import override
+
+
+DISCORD_AUDIO_ATTACHMENT_EXTENSIONS = frozenset(
+    {".aac", ".flac", ".m4a", ".mp3", ".ogg", ".opus", ".wav"}
+)
 
 
 # 注册平台适配器
@@ -195,6 +201,22 @@ class DiscordPlatformAdapter(Platform):
         """根据 channel 对象获取ID"""
         return str(getattr(channel, "id", None))
 
+    @staticmethod
+    def _get_attachment_content_type(attachment: Any) -> str:
+        content_type = getattr(attachment, "content_type", None)
+        if not content_type:
+            return ""
+        return str(content_type).split(";", maxsplit=1)[0].strip().lower()
+
+    @staticmethod
+    def _is_audio_attachment(attachment: Any) -> bool:
+        content_type = DiscordPlatformAdapter._get_attachment_content_type(attachment)
+        if content_type.startswith("audio/"):
+            return True
+
+        filename = str(getattr(attachment, "filename", "") or "")
+        return Path(filename.lower()).suffix in DISCORD_AUDIO_ATTACHMENT_EXTENSIONS
+
     def _convert_message_to_abm(self, data: dict) -> AstrBotMessage:
         """将普通消息转换为 AstrBotMessage"""
         message = data["message"]
@@ -242,11 +264,14 @@ class DiscordPlatformAdapter(Platform):
             message_chain.append(Plain(text=abm.message_str))
         if message.attachments:
             for attachment in message.attachments:
-                if attachment.content_type and attachment.content_type.startswith(
-                    "image/",
-                ):
+                content_type = self._get_attachment_content_type(attachment)
+                if content_type.startswith("image/"):
                     message_chain.append(
                         Image(file=attachment.url, filename=attachment.filename),
+                    )
+                elif self._is_audio_attachment(attachment):
+                    message_chain.append(
+                        Record(file=attachment.url, url=attachment.url),
                     )
                 else:
                     message_chain.append(

--- a/astrbot/core/platform/sources/discord/discord_platform_event.py
+++ b/astrbot/core/platform/sources/discord/discord_platform_event.py
@@ -16,6 +16,7 @@ from astrbot.api.message_components import (
     File,
     Image,
     Plain,
+    Record,
     Reply,
 )
 from astrbot.api.platform import AstrBotMessage, At, PlatformMetadata
@@ -248,6 +249,24 @@ class DiscordPlatformEvent(AstrMessageEvent):
                         logger.warning(f"[Discord] 获取文件失败: {i.name}")
                 except Exception as e:
                     logger.warning(f"[Discord] 处理文件失败: {i.name}, 错误: {e}")
+            elif isinstance(i, Record):
+                try:
+                    file_path_str = await i.convert_to_file_path()
+                    path = Path(file_path_str)
+                    if await asyncio.to_thread(path.exists):
+                        file_bytes = await asyncio.to_thread(path.read_bytes)
+                        files.append(
+                            discord.File(
+                                BytesIO(file_bytes),
+                                filename=self._get_record_filename(i, path),
+                            ),
+                        )
+                    else:
+                        logger.warning(
+                            f"[Discord] 获取语音失败，路径不存在: {file_path_str}",
+                        )
+                except Exception as e:
+                    logger.warning(f"[Discord] 处理语音失败: {e}")
             elif isinstance(i, DiscordEmbed):
                 # Discord Embed消息
                 embeds.append(i.to_discord_embed())
@@ -266,6 +285,15 @@ class DiscordPlatformEvent(AstrMessageEvent):
             logger.warning("[Discord] 消息内容超过2000字符，将被截断。")
             content = content[:2000]
         return content, files, view, embeds, reference_message_id
+
+    @staticmethod
+    def _get_record_filename(record: Record, path: Path) -> str:
+        source = record.file or record.url or ""
+        if source.startswith(("http://", "https://")):
+            filename = Path(source.split("?", maxsplit=1)[0]).name
+            if filename:
+                return filename
+        return path.name
 
     async def react(self, emoji: str) -> None:
         """对原消息添加反应"""

--- a/tests/test_discord_adapter.py
+++ b/tests/test_discord_adapter.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from astrbot.api.event import MessageChain
 from astrbot.api.message_components import File, Image, Record
 from tests.fixtures.helpers import (
     create_mock_discord_attachment,
@@ -26,6 +27,37 @@ def _make_adapter(event_queue, platform_settings):
     adapter.client = MockDiscordBuilder.create_client()
     adapter.bot_self_id = str(adapter.client.user.id)
     return adapter
+
+
+def _make_event():
+    from astrbot.core.platform.astrbot_message import AstrBotMessage
+    from astrbot.core.platform.message_type import MessageType
+    from astrbot.core.platform.platform_metadata import PlatformMetadata
+    from astrbot.core.platform.sources.discord.discord_platform_event import (
+        DiscordPlatformEvent,
+    )
+    from tests.fixtures.mocks.discord import MockDiscordBuilder
+
+    message = AstrBotMessage()
+    message.type = MessageType.FRIEND_MESSAGE
+    message.self_id = "123456789"
+    message.session_id = "111222333"
+    message.message_id = "555666777"
+    message.message = []
+    message.message_str = ""
+    message.raw_message = None
+
+    return DiscordPlatformEvent(
+        "",
+        message,
+        PlatformMetadata(
+            name="discord",
+            description="Discord adapter",
+            id="discord",
+        ),
+        "111222333",
+        MockDiscordBuilder.create_client(),
+    )
 
 
 def _make_message(attachment):
@@ -111,3 +143,31 @@ def test_discord_audio_attachment_preserves_url(
     assert isinstance(abm.message[0], Record)
     assert abm.message[0].file == attachment.url
     assert abm.message[0].url == attachment.url
+
+
+@pytest.mark.asyncio
+async def test_discord_record_component_is_sent_as_file(
+    tmp_path,
+    mock_discord_modules,
+):
+    event = _make_event()
+    import discord
+
+    audio_path = tmp_path / "voice-message.ogg"
+    audio_path.write_bytes(b"voice-bytes")
+    discord.File = MagicMock()
+
+    content, files, view, embeds, reference_message_id = await event._parse_to_discord(
+        MessageChain([Record.fromFileSystem(str(audio_path))]),
+    )
+
+    assert content == ""
+    assert len(files) == 1
+    assert view is None
+    assert embeds == []
+    assert reference_message_id is None
+
+    discord.File.assert_called_once()
+    args, kwargs = discord.File.call_args
+    assert args[0].getvalue() == b"voice-bytes"
+    assert kwargs["filename"] == "voice-message.ogg"

--- a/tests/test_discord_adapter.py
+++ b/tests/test_discord_adapter.py
@@ -1,0 +1,113 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from astrbot.api.message_components import File, Image, Record
+from tests.fixtures.helpers import (
+    create_mock_discord_attachment,
+    create_mock_discord_user,
+    make_platform_config,
+)
+
+pytest_plugins = ("tests.fixtures.mocks.discord",)
+
+
+def _make_adapter(event_queue, platform_settings):
+    from astrbot.core.platform.sources.discord.discord_platform_adapter import (
+        DiscordPlatformAdapter,
+    )
+    from tests.fixtures.mocks.discord import MockDiscordBuilder
+
+    adapter = DiscordPlatformAdapter(
+        make_platform_config("discord"),
+        platform_settings,
+        event_queue,
+    )
+    adapter.client = MockDiscordBuilder.create_client()
+    adapter.bot_self_id = str(adapter.client.user.id)
+    return adapter
+
+
+def _make_message(attachment):
+    message = MagicMock()
+    message.content = ""
+    message.attachments = [attachment]
+    message.channel = MagicMock()
+    message.channel.id = 111222333
+    message.channel.guild = MagicMock()
+    message.author = create_mock_discord_user()
+    message.guild = None
+    message.role_mentions = []
+    message.id = 555666777
+    return message
+
+
+@pytest.mark.parametrize(
+    ("attachment", "expected_type"),
+    [
+        (
+            create_mock_discord_attachment(
+                filename="voice-message.ogg",
+                url="https://cdn.discordapp.com/voice-message.ogg",
+                content_type="audio/ogg",
+            ),
+            Record,
+        ),
+        (
+            create_mock_discord_attachment(
+                filename="voice-message.ogg",
+                url="https://cdn.discordapp.com/voice-message.ogg",
+                content_type=None,
+            ),
+            Record,
+        ),
+        (
+            create_mock_discord_attachment(
+                filename="image.png",
+                url="https://cdn.discordapp.com/image.png",
+                content_type="image/png",
+            ),
+            Image,
+        ),
+        (
+            create_mock_discord_attachment(
+                filename="document.txt",
+                url="https://cdn.discordapp.com/document.txt",
+                content_type="text/plain",
+            ),
+            File,
+        ),
+    ],
+)
+def test_discord_attachment_media_mapping(
+    attachment,
+    expected_type,
+    event_queue,
+    platform_settings,
+    mock_discord_modules,
+):
+    adapter = _make_adapter(event_queue, platform_settings)
+
+    abm = adapter._convert_message_to_abm({"message": _make_message(attachment)})
+
+    assert len(abm.message) == 1
+    assert isinstance(abm.message[0], expected_type)
+
+
+def test_discord_audio_attachment_preserves_url(
+    event_queue,
+    platform_settings,
+    mock_discord_modules,
+):
+    adapter = _make_adapter(event_queue, platform_settings)
+    attachment = create_mock_discord_attachment(
+        filename="voice-message.ogg",
+        url="https://cdn.discordapp.com/voice-message.ogg",
+        content_type="audio/ogg",
+    )
+
+    abm = adapter._convert_message_to_abm({"message": _make_message(attachment)})
+
+    assert isinstance(abm.message[0], Record)
+    assert abm.message[0].file == attachment.url
+    assert abm.message[0].url == attachment.url


### PR DESCRIPTION
Fixes #7580.

### Modifications / 改动点

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

This PR fixes Discord voice-message handling by mapping audio attachments to `Record` instead of generic `File` components. The adapter now detects audio attachments by normalized `audio/*` content type, with a filename-extension fallback for Discord attachments that do not expose a content type.

It also keeps the outgoing path compatible with the new component type by allowing `DiscordPlatformEvent._parse_to_discord()` to send `Record` components as Discord files. Image attachments still map to `Image`, and non-audio non-image attachments still map to `File`.

### Screenshots or Test Results / 运行截图或测试结果

- Runtime verification with the Discord adapter enabled on `astrbot:issue-7580-local`:
  - Sending a Discord voice message logs `[ComponentType.Record]`.
- `docker run --rm -v "D:\AstrBot - PRs\AstrBot_issue_7580:/workspace" -w /workspace astrbot:issue-7580-local sh -lc "python -m pip install -q pytest pytest-asyncio && python -m pytest tests/test_discord_adapter.py tests/test_mattermost_adapter.py tests/test_telegram_adapter.py -q"`
  - `17 passed, 1 warning`
- `docker run --rm -v "D:\AstrBot - PRs\AstrBot_issue_7580:/workspace" -w /workspace astrbot:issue-7580-local sh -lc "python -m pip install -q ruff && ruff check astrbot/core/platform/sources/discord/discord_platform_adapter.py astrbot/core/platform/sources/discord/discord_platform_event.py tests/test_discord_adapter.py && ruff format --check astrbot/core/platform/sources/discord/discord_platform_adapter.py astrbot/core/platform/sources/discord/discord_platform_event.py tests/test_discord_adapter.py"`
  - `All checks passed!`
  - `3 files already formatted`

---

### Checklist / 检查清单

- [x] If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。
- [x] My changes have been well-tested, and verification steps and runtime results have been provided above. / 我的更改经过了良好的测试，并已在上方提供验证步骤和运行结果。
- [x] I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`. / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] My changes do not introduce malicious code. / 我的更改没有引入恶意代码。

## Summary by Sourcery

Handle Discord voice attachments as audio records instead of generic files while preserving compatibility with outbound Discord messages.

New Features:
- Map Discord audio attachments to Record components using content type and filename extension detection.

Bug Fixes:
- Correctly classify Discord voice-message attachments so they are treated as audio records rather than generic files.

Enhancements:
- Preserve original URLs when converting Discord audio attachments into Record components.
- Allow outgoing Record components to be sent to Discord as file uploads with appropriate filenames.

Tests:
- Add unit tests covering Discord attachment type mapping, URL preservation for audio records, and sending Record components as Discord files.