### PR TITLE
fix(core): use correct asset filename in GitHub fallback download URL

### DIFF
--- a/astrbot/core/utils/io.py
+++ b/astrbot/core/utils/io.py
@@ -290,7 +290,11 @@ async def download_dashboard(
         except BaseException as _:
             if latest:
                 # Resolve latest release tag from GitHub API to construct correct asset URL
-                async with aiohttp.ClientSession() as session:
+                ssl_context = ssl.create_default_context(cafile=certifi.where())
+                async with aiohttp.ClientSession(
+                    connector=aiohttp.TCPConnector(ssl=ssl_context),
+                    trust_env=True,
+                ) as session:
                     async with session.get(
                         "https://api.github.com/repos/AstrBotDevs/AstrBot/releases/latest",
                         timeout=30,
@@ -299,9 +303,9 @@ async def download_dashboard(
                         api_resp.raise_for_status()
                         release_data = await api_resp.json()
                         tag = release_data["tag_name"]
-                dashboard_release_url = f"https://github.com/AstrBotDevs/AstrBot/releases/download/{tag}/AstrBot-{tag}-dashboard.zip"
             else:
-                dashboard_release_url = f"https://github.com/AstrBotDevs/AstrBot/releases/download/{version}/AstrBot-{version}-dashboard.zip"
+                tag = version
+            dashboard_release_url = f"https://github.com/AstrBotDevs/AstrBot/releases/download/{tag}/AstrBot-{tag}-dashboard.zip"
             if proxy:
                 dashboard_release_url = f"{proxy}/{dashboard_release_url}"
             await download_file(

--- a/astrbot/core/utils/io.py
+++ b/astrbot/core/utils/io.py
@@ -289,9 +289,19 @@ async def download_dashboard(
             )
         except BaseException as _:
             if latest:
-                dashboard_release_url = "https://github.com/AstrBotDevs/AstrBot/releases/latest/download/dist.zip"
+                # Resolve latest release tag from GitHub API to construct correct asset URL
+                async with aiohttp.ClientSession() as session:
+                    async with session.get(
+                        "https://api.github.com/repos/AstrBotDevs/AstrBot/releases/latest",
+                        timeout=30,
+                        headers={"Accept": "application/vnd.github+json"},
+                    ) as api_resp:
+                        api_resp.raise_for_status()
+                        release_data = await api_resp.json()
+                        tag = release_data["tag_name"]
+                dashboard_release_url = f"https://github.com/AstrBotDevs/AstrBot/releases/download/{tag}/AstrBot-{tag}-dashboard.zip"
             else:
-                dashboard_release_url = f"https://github.com/AstrBotDevs/AstrBot/releases/download/{version}/dist.zip"
+                dashboard_release_url = f"https://github.com/AstrBotDevs/AstrBot/releases/download/{version}/AstrBot-{version}-dashboard.zip"
             if proxy:
                 dashboard_release_url = f"{proxy}/{dashboard_release_url}"
             await download_file(


### PR DESCRIPTION
Fixes #8045 

### Modifications / 改动点
- The dashboard download fallback URLs hardcoded `dist.zip` as the asset name, but the actual GitHub Release assets follow the naming pattern `AstrBot-{TAG}-dashboard.zip`. For the `latest=True` path, the latest release tag is now resolved via the GitHub API before       constructing the download URL.

### Screenshots or Test Results / 运行截图或测试结果
<img width="1212" height="487" alt="image" src="https://github.com/user-attachments/assets/23446dfb-d3f0-477f-823f-958481295cb7" />

<img width="685" height="255" alt="image" src="https://github.com/user-attachments/assets/8487292c-41df-4318-af21-7f3937665566" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Correct the GitHub dashboard fallback download URLs to match the actual release asset naming pattern for both specific versions and the latest release.