### PR TITLE
fix: merge streamed tool results per call

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -1076,15 +1076,13 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 )
 
                 _final_resp: CallToolResult | None = None
+                tool_result_parts: list[str] = []
                 async for resp in self._iter_tool_executor_results(executor):  # type: ignore
                     if isinstance(resp, CallToolResult):
                         res = resp
                         _final_resp = resp
                         if not res.content:
-                            _append_tool_call_result(
-                                func_tool_id,
-                                "The tool returned no content.",
-                            )
+                            tool_result_parts.append("The tool returned no content.")
                             continue
 
                         result_parts: list[str] = []
@@ -1140,18 +1138,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                                         "The tool has returned a data type that is not supported."
                                     )
                         if result_parts:
-                            inline_result = "\n\n".join(result_parts)
-                            inline_result = await self._materialize_large_tool_result(
-                                tool_call_id=func_tool_id,
-                                content=inline_result,
-                            )
-                            _append_tool_call_result(
-                                func_tool_id,
-                                inline_result
-                                + self._build_repeated_tool_call_guidance(
-                                    func_tool_name, tool_call_streak
-                                ),
-                            )
+                            tool_result_parts.append("\n\n".join(result_parts))
 
                     elif resp is None:
                         # Tool 直接请求发送消息给用户
@@ -1162,25 +1149,30 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                         )
                         self._transition_state(AgentState.DONE)
                         self.stats.end_time = time.time()
-                        _append_tool_call_result(
-                            func_tool_id,
+                        tool_result_parts.append(
                             "The tool has no return value, or has sent the result directly to the user."
-                            + self._build_repeated_tool_call_guidance(
-                                func_tool_name, tool_call_streak
-                            ),
                         )
                     else:
                         # 不应该出现其他类型
                         logger.warning(
                             f"Tool 返回了不支持的类型: {type(resp)}。",
                         )
-                        _append_tool_call_result(
-                            func_tool_id,
+                        tool_result_parts.append(
                             "*The tool has returned an unsupported type. Please tell the user to check the definition and implementation of this tool.*"
-                            + self._build_repeated_tool_call_guidance(
-                                func_tool_name, tool_call_streak
-                            ),
                         )
+
+                if tool_result_parts:
+                    inline_result = await self._materialize_large_tool_result(
+                        tool_call_id=func_tool_id,
+                        content="\n\n".join(tool_result_parts),
+                    )
+                    _append_tool_call_result(
+                        func_tool_id,
+                        inline_result
+                        + self._build_repeated_tool_call_guidance(
+                            func_tool_name, tool_call_streak
+                        ),
+                    )
 
                 try:
                     await self.agent_hooks.on_tool_end(

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -99,6 +99,22 @@ class MockToolExecutor:
         return generator()
 
 
+class MultiYieldToolExecutor:
+    @classmethod
+    def execute(cls, tool, run_context, **tool_args):
+        async def generator():
+            from mcp.types import CallToolResult, TextContent
+
+            yield CallToolResult(
+                content=[TextContent(type="text", text="first partial result")]
+            )
+            yield CallToolResult(
+                content=[TextContent(type="text", text="second partial result")]
+            )
+
+        return generator()
+
+
 class LargeTextToolExecutor:
     """模拟返回超长文本的工具执行器"""
 
@@ -633,6 +649,41 @@ async def test_tool_result_includes_all_calltoolresult_content(
             "mime_type": "image/png",
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_async_generator_tool_results_share_one_tool_call_id(
+    runner, mock_provider, provider_request, mock_hooks
+):
+    """Multiple streamed tool results should be merged into one provider result."""
+
+    mock_provider.should_call_tools = True
+    mock_provider.max_calls_before_normal_response = 1
+
+    await runner.reset(
+        provider=mock_provider,
+        request=provider_request,
+        run_context=ContextWrapper(context=None),
+        tool_executor=MultiYieldToolExecutor,
+        agent_hooks=mock_hooks,
+        streaming=False,
+    )
+
+    async for _ in runner.step_until_done(3):
+        pass
+
+    tool_messages = [
+        m for m in runner.run_context.messages if getattr(m, "role", None) == "tool"
+    ]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].tool_call_id == "call_123"
+
+    content = str(tool_messages[0].content)
+    assert "first partial result" in content
+    assert "second partial result" in content
+    assert content.index("first partial result") < content.index(
+        "second partial result"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
﻿Fixes #8028.

### Modifications / 改动点

- Collects multiple `CallToolResult` chunks produced by an async-generator tool execution and appends a single tool result block for the original `tool_call_id`.
- Keeps cached image handling and tool hook behavior in the existing flow.
- Adds a regression test that yields two `CallToolResult` values for one tool call and verifies AstrBot stores one `tool` message with both partial results.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Verification commands run locally on Windows:

```text
uv run pytest tests\test_tool_loop_agent_runner.py::test_async_generator_tool_results_share_one_tool_call_id -q
# 1 passed

uv run pytest tests\test_tool_loop_agent_runner.py -q
# 30 passed

uv run ruff check astrbot\core\agent\runners\tool_loop_agent_runner.py
# All checks passed

uv run ruff format astrbot\core\agent\runners\tool_loop_agent_runner.py tests\test_tool_loop_agent_runner.py --check
# 2 files already formatted

uv run python -m py_compile astrbot\core\agent\runners\tool_loop_agent_runner.py tests\test_tool_loop_agent_runner.py
# passed

git diff --check
# passed
```

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Merge multiple streamed tool execution results for a single tool call into one consolidated tool message.

Bug Fixes:
- Ensure multiple CallToolResult chunks from async generator tools are combined into a single provider tool message per tool_call_id instead of producing separate messages.

Tests:
- Add regression test verifying that two streamed CallToolResult yields for one tool_call_id are stored as a single tool message containing both partial results.