### PR TITLE
fix(dashboard): merge plugin-registered providers into add-provider picker

### DIFF
--- a/astrbot/dashboard/routes/config.py
+++ b/astrbot/dashboard/routes/config.py
@@ -330,6 +330,28 @@ def save_config(
     config.save_config(post_config)
 
 
+def _merge_registered_providers_into(config_template: dict) -> None:
+    """Inject providers registered via ``@register_provider_adapter`` into
+    a config_template dict, in-place.
+
+    Used by both ``GET /api/config/get`` and ``GET /api/config/provider/template``
+    so the two endpoints expose a consistent set of providers in the WebUI's
+    "Add Provider" picker.
+
+    - Uses ``is not None`` (not truthiness) so providers that intentionally
+      register an empty default template still appear.
+    - Uses ``setdefault`` so a plugin cannot silently shadow a core static
+      template that happens to share the same key.
+
+    The caller owns ``config_template`` and is responsible for handing in a
+    non-shared dict (both call sites operate on already-deep-copied metadata
+    so mutating it here does not pollute ``CONFIG_METADATA_2``).
+    """
+    for provider in provider_registry:
+        if provider.default_config_tmpl is not None:
+            config_template.setdefault(provider.type, provider.default_config_tmpl)
+
+
 class ConfigRoute(Route):
     def __init__(
         self,
@@ -507,20 +529,21 @@ class ConfigRoute(Route):
         return Response().ok(message="更新 provider source 成功").__dict__
 
     async def get_provider_template(self):
+        # Deep-copy the static schema first; the merge below mutates the
+        # config_template dict and we don't want plugin providers leaking
+        # into the global CONFIG_METADATA_2 across requests.
+        provider_section = copy.deepcopy(
+            CONFIG_METADATA_2["provider_group"]["metadata"]["provider"]
+        )
         provider_metadata = ConfigMetadataI18n.convert_to_i18n_keys(
-            {
-                "provider_group": {
-                    "metadata": {
-                        "provider": CONFIG_METADATA_2["provider_group"]["metadata"][
-                            "provider"
-                        ]
-                    }
-                }
-            }
+            {"provider_group": {"metadata": {"provider": provider_section}}}
         )
         config_schema = {
             "provider": provider_metadata["provider_group"]["metadata"]["provider"]
         }
+        _merge_registered_providers_into(
+            config_schema["provider"].setdefault("config_template", {})
+        )
         data = {
             "config_schema": config_schema,
             "providers": astrbot_config["provider"],
@@ -1479,12 +1502,9 @@ class ConfigRoute(Route):
             await asyncio.gather(*logo_registration_tasks, return_exceptions=True)
 
         # 服务提供商的默认配置模板注入
-        provider_default_tmpl = metadata["provider_group"]["metadata"]["provider"][
-            "config_template"
-        ]
-        for provider in provider_registry:
-            if provider.default_config_tmpl:
-                provider_default_tmpl[provider.type] = provider.default_config_tmpl
+        _merge_registered_providers_into(
+            metadata["provider_group"]["metadata"]["provider"]["config_template"]
+        )
 
         return {
             "metadata": metadata,

--- a/tests/unit/test_provider_template_merge.py
+++ b/tests/unit/test_provider_template_merge.py
@@ -1,0 +1,90 @@
+"""Tests for the provider-registry merge helper used by both
+``GET /api/config/get`` and ``GET /api/config/provider/template``.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from astrbot.core.provider.entities import ProviderMetaData, ProviderType
+from astrbot.core.provider.register import provider_registry
+from astrbot.dashboard.routes.config import _merge_registered_providers_into
+
+
+@pytest.fixture
+def isolated_registry(monkeypatch):
+    """Replace ``provider_registry`` with an empty list for each test."""
+    fake: list = []
+    monkeypatch.setattr(
+        "astrbot.dashboard.routes.config.provider_registry",
+        fake,
+    )
+    return fake
+
+
+def _fake_pm(type_: str, default_config_tmpl) -> ProviderMetaData:
+    return ProviderMetaData(
+        id="default",
+        model=None,
+        type=type_,
+        desc=type_,
+        provider_type=ProviderType.TEXT_TO_SPEECH,
+        cls_type=SimpleNamespace,
+        default_config_tmpl=default_config_tmpl,
+    )
+
+
+def test_injects_plugin_provider(isolated_registry) -> None:
+    isolated_registry.append(_fake_pm("plugin_tts", {"provider_type": "text_to_speech", "key": "v"}))
+    tmpl: dict = {}
+    _merge_registered_providers_into(tmpl)
+    assert "plugin_tts" in tmpl
+    assert tmpl["plugin_tts"]["provider_type"] == "text_to_speech"
+
+
+def test_setdefault_protects_existing_entry(isolated_registry) -> None:
+    """A plugin should not silently overwrite a core static template
+    that happens to share the same key."""
+    isolated_registry.append(_fake_pm("openai_compat", {"provider_type": "chat_completion", "src": "plugin"}))
+    tmpl = {"openai_compat": {"provider_type": "chat_completion", "src": "core"}}
+    _merge_registered_providers_into(tmpl)
+    assert tmpl["openai_compat"]["src"] == "core"
+
+
+def test_empty_dict_template_is_kept(isolated_registry) -> None:
+    """``is not None`` check (rather than truthiness) — a plugin that
+    registers with an intentionally empty default_config_tmpl should
+    still surface in the picker."""
+    isolated_registry.append(_fake_pm("blank_tts", {}))
+    tmpl: dict = {}
+    _merge_registered_providers_into(tmpl)
+    assert "blank_tts" in tmpl
+    assert tmpl["blank_tts"] == {}
+
+
+def test_none_template_is_skipped(isolated_registry) -> None:
+    """Providers that registered without supplying a default template
+    should not appear in the picker."""
+    isolated_registry.append(_fake_pm("no_tmpl", None))
+    tmpl: dict = {}
+    _merge_registered_providers_into(tmpl)
+    assert tmpl == {}
+
+
+def test_idempotent(isolated_registry) -> None:
+    isolated_registry.append(_fake_pm("plugin_tts", {"x": 1}))
+    tmpl: dict = {}
+    _merge_registered_providers_into(tmpl)
+    _merge_registered_providers_into(tmpl)
+    assert list(tmpl.keys()) == ["plugin_tts"]
+
+
+def test_real_registry_unaffected_by_helper_call(monkeypatch) -> None:
+    """Smoke check that calling the helper against a real registry doesn't
+    raise and yields a sensible dict."""
+    tmpl: dict = {}
+    _merge_registered_providers_into(tmpl)
+    # Real registry may be empty in the test environment; either way no error.
+    assert isinstance(tmpl, dict)
+    for k, v in tmpl.items():
+        assert isinstance(k, str)


### PR DESCRIPTION
## Summary

The **Add Provider** picker dialog calls `GET /api/config/provider/template`, which previously returned only the static `CONFIG_METADATA_2`. Plugin-registered providers (via `@register_provider_adapter`) live in `provider_registry`; that registry was already merged into the response of `GET /api/config/get` (see `_get_astrbot_config`, [`config.py:1481-1487`](https://github.com/AstrBotDevs/AstrBot/blob/master/astrbot/dashboard/routes/config.py#L1481-L1487)), but not here. As a result, plugin TTS / STT / LLM providers never appear in the picker even though they are present in `provider_registry`.

This patch mirrors the same merge in `get_provider_template` so the two endpoints are consistent.

## Repro (before fix)

1. Write a plugin that registers a custom TTS provider:
   ```python
   from astrbot.core.provider.entities import ProviderType
   from astrbot.core.provider.provider import TTSProvider
   from astrbot.core.provider.register import register_provider_adapter

   @register_provider_adapter(
       'my_custom_tts', 'My Custom TTS',
       provider_type=ProviderType.TEXT_TO_SPEECH,
       default_config_tmpl={'provider_type': 'text_to_speech', 'api_key': ''},
   )
   class MyCustomTTS(TTSProvider):
       async def get_audio(self, text: str) -> str: ...
   ```

2. Start AstrBot, confirm provider is registered (debug log: `Model provider registered: my_custom_tts`).

3. Compare the two endpoints:
   - `GET /api/config/get` → entry present at `.data.metadata.provider_group.metadata.provider.config_template.my_custom_tts` ✅
   - `GET /api/config/provider/template` → entry **missing** at `.data.config_schema.provider.config_template` ❌

4. WebUI → 服务提供商 → 添加 → the custom provider does not appear in any tab.

## After fix

`get_provider_template` performs the same merge, so both endpoints expose plugin providers. Picker now displays them in the appropriate tab (filtered by `provider_type`).

## Why no test

The existing dashboard route tests in `tests/` only cover pure helper functions (e.g. `tests/test_chat_route.py` tests `_poll_webchat_stream_result`). A route-level test for `get_provider_template` would require constructing the full `ConfigRoute` with `core_lifecycle` / DB / Quart fixtures — out of proportion to the 5-line fix. The change mirrors existing code in the same file (`_get_astrbot_config`, lines 1481-1487), so it is mechanical and easy to review.

## Test Plan

- [x] `from astrbot.dashboard.routes.config import ConfigRoute` imports cleanly
- [x] Manually verified locally: with a plugin registering a TTS provider, picker now shows the entry
- [ ] CI checks

## Summary by Sourcery

Bug Fixes:
- Ensure plugin-registered provider adapters appear in the WebUI Add Provider picker by injecting their config templates into the provider template response.