### PR TITLE
feat: add visual separator between thinking content and response

### DIFF
--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -289,7 +289,9 @@ class ResultDecorateStage(Stage):
                         ),
                     )
                 else:
-                    result.chain.insert(0, Plain(f"🤔 思考: {reasoning_content}\n"))
+                    result.chain.insert(
+                        0, Plain(f"🤔 思考: {reasoning_content}\n\n────\n")
+                    )
 
             if should_tts and tts_provider:
                 new_chain = []


### PR DESCRIPTION
## 改动说明

在显示思考内容的末尾添加一条可视分割线，使思考过程与正式回复在视觉上有更清晰的区分。

### 改动前
```
🤔 思考: 这是思考内容...
这是正式回复的内容...
```

### 改动后
```
🤔 思考: 这是思考内容...

────────────────────────
这是正式回复的内容...
```

### 变更文件
- `astrbot/core/pipeline/result_decorate/stage.py`: 在 Plain 文本末尾追加 `\n\n────────────────────────\n` 作为分隔线

### 相关
由群友 @说说 提出的建议：思考过程和正式回答加个分隔符，更容易区分。

## Summary by Sourcery

Enhancements:
- Append a horizontal separator line after displayed reasoning content to clearly distinguish it from the subsequent formal response in plain text messages.