### PR TITLE
fix(minimax-tts): surface real API error when response is not SSE

### DIFF
--- a/astrbot/core/provider/sources/minimax_tts_api_source.py
+++ b/astrbot/core/provider/sources/minimax_tts_api_source.py
@@ -111,17 +111,26 @@ class ProviderMiniMaxTTSAPI(TTSProvider):
                 # Detect by Content-Type and surface the actual API error so callers
                 # see the real status_code / status_msg instead of a confusing
                 # parsing failure later in the SSE loop.
-                content_type = response.headers.get("Content-Type", "")
-                if "text/event-stream" not in content_type:
+                # MIME types are case-insensitive (RFC 7231 §3.1.1.1), and some
+                # error responses include parameters like "application/json; charset=utf-8".
+                # Lower-case the value and compare against the bare media-type prefix.
+                content_type = response.headers.get("Content-Type", "").lower().split(";", 1)[0].strip()
+                if content_type != "text/event-stream":
                     body = await response.text()
+                    err_msg = body[:200] or "empty response body"
+                    err_code = "unknown"
                     try:
                         err_data = json.loads(body)
-                        base_resp = err_data.get("base_resp", {})
-                        err_msg = base_resp.get("status_msg", body[:200])
-                        err_code = base_resp.get("status_code", "unknown")
+                        # Guard against `base_resp: null`, missing key, or a JSON
+                        # array root — all of which would have raised
+                        # AttributeError on `.get(...)` before this change.
+                        if isinstance(err_data, dict):
+                            base_resp = err_data.get("base_resp")
+                            if isinstance(base_resp, dict):
+                                err_msg = base_resp.get("status_msg", err_msg)
+                                err_code = base_resp.get("status_code", err_code)
                     except json.JSONDecodeError:
-                        err_msg = body[:200]
-                        err_code = "unknown"
+                        pass
                     raise RuntimeError(
                         f"MiniMax TTS API error (code={err_code}): {err_msg}"
                     )

--- a/astrbot/core/provider/sources/minimax_tts_api_source.py
+++ b/astrbot/core/provider/sources/minimax_tts_api_source.py
@@ -104,6 +104,28 @@ class ProviderMiniMaxTTSAPI(TTSProvider):
             ):
                 response.raise_for_status()
 
+                # MiniMax returns a JSON error body (not SSE) for cases like:
+                #   - quota / rate limit exceeded
+                #   - invalid voice_id / model
+                #   - API key issues
+                # Detect by Content-Type and surface the actual API error so callers
+                # see the real status_code / status_msg instead of a confusing
+                # parsing failure later in the SSE loop.
+                content_type = response.headers.get("Content-Type", "")
+                if "text/event-stream" not in content_type:
+                    body = await response.text()
+                    try:
+                        err_data = json.loads(body)
+                        base_resp = err_data.get("base_resp", {})
+                        err_msg = base_resp.get("status_msg", body[:200])
+                        err_code = base_resp.get("status_code", "unknown")
+                    except json.JSONDecodeError:
+                        err_msg = body[:200]
+                        err_code = "unknown"
+                    raise RuntimeError(
+                        f"MiniMax TTS API error (code={err_code}): {err_msg}"
+                    )
+
                 buffer = b""
                 while True:
                     chunk = await response.content.read(8192)

--- a/astrbot/core/provider/sources/minimax_tts_api_source.py
+++ b/astrbot/core/provider/sources/minimax_tts_api_source.py
@@ -102,18 +102,16 @@ class ProviderMiniMaxTTSAPI(TTSProvider):
                     timeout=aiohttp.ClientTimeout(total=60),
                 ) as response,
             ):
-                response.raise_for_status()
-
-                # MiniMax returns a JSON error body (not SSE) for cases like:
-                #   - quota / rate limit exceeded
-                #   - invalid voice_id / model
-                #   - API key issues
-                # Detect by Content-Type and surface the actual API error so callers
-                # see the real status_code / status_msg instead of a confusing
-                # parsing failure later in the SSE loop.
-                # MIME types are case-insensitive (RFC 7231 §3.1.1.1), and some
-                # error responses include parameters like "application/json; charset=utf-8".
-                # Lower-case the value and compare against the bare media-type prefix.
+                # MiniMax returns a JSON error body (not SSE) for cases like quota /
+                # rate-limit exceeded, invalid voice_id / model, API key issues.
+                # Some of those come with 4xx HTTP status, others with 200 + a
+                # JSON error body. Check Content-Type *before* raise_for_status
+                # so we surface the structured `base_resp.status_code /
+                # status_msg` even on 4xx responses, instead of an opaque
+                # aiohttp.ClientResponseError. MIME types are case-insensitive
+                # (RFC 7231 §3.1.1.1) and may include parameters like
+                # `application/json; charset=utf-8` — lower-case the value and
+                # strip parameters before comparing.
                 content_type = response.headers.get("Content-Type", "").lower().split(";", 1)[0].strip()
                 if content_type != "text/event-stream":
                     body = await response.text()
@@ -134,6 +132,10 @@ class ProviderMiniMaxTTSAPI(TTSProvider):
                     raise RuntimeError(
                         f"MiniMax TTS API error (code={err_code}): {err_msg}"
                     )
+
+                # Non-SSE error path is exhausted — only here do we treat a
+                # non-2xx status as a transport-level error.
+                response.raise_for_status()
 
                 buffer = b""
                 while True:


### PR DESCRIPTION
## Bug

MiniMax TTS API returns a JSON error body (not an SSE stream) when:
- quota / rate limit exceeded
- invalid `voice_id` or model
- API key issues

Current code calls `raise_for_status()` (which doesn't trigger on `200 OK` with a JSON error body) and then parses everything as SSE. Users get a confusing parse error or empty audio with no indication of the real cause.

## Fix

Before entering the SSE parse loop, check `Content-Type`. If it's not `text/event-stream`, parse the JSON `base_resp` and raise a `RuntimeError` carrying the actual `status_code` and `status_msg`.

## Example

**Before:**
```
TTS failed: Cannot decode SSE event from b'{"base_resp":{"status_code":1027,"status_msg":"insufficient balance"}}'
```

**After:**
```
RuntimeError: MiniMax TTS API error (code=1027): insufficient balance
```

## Test

Reproduced locally with a depleted MiniMax API key — error message now clearly identifies the cause; prior version produced a confusing SSE parse error.

## Diff size

17 lines, pure error-handling. No new feature, no new dependency.

## Summary by Sourcery

Bug Fixes:
- Detect non-SSE MiniMax TTS responses via Content-Type and raise a RuntimeError with the API's status_code and status_msg instead of producing a confusing SSE parse failure.