### PR TITLE
fix: skip KB retrieval for blank prompts

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -229,7 +229,7 @@ async def _apply_kb(
     config: MainAgentBuildConfig,
 ) -> None:
     if not config.kb_agentic_mode:
-        if req.prompt is None:
+        if req.prompt is None or not req.prompt.strip():
             return
         try:
             kb_result = await retrieve_knowledge_base(

--- a/tests/unit/test_astr_main_agent.py
+++ b/tests/unit/test_astr_main_agent.py
@@ -343,6 +343,23 @@ class TestApplyKb:
         assert req.system_prompt == "System"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("prompt", ["", "   \n\t"])
+    async def test_apply_kb_blank_prompt(self, prompt, mock_event, mock_context):
+        """Test applying knowledge base when prompt is blank."""
+        module = ama
+        req = ProviderRequest(prompt=prompt, system_prompt="System")
+        config = module.MainAgentBuildConfig(
+            tool_call_timeout=60, kb_agentic_mode=False
+        )
+        retrieve = AsyncMock(return_value="KB result")
+
+        with patch("astrbot.core.astr_main_agent.retrieve_knowledge_base", retrieve):
+            await module._apply_kb(mock_event, req, mock_context, config)
+
+        retrieve.assert_not_awaited()
+        assert req.system_prompt == "System"
+
+    @pytest.mark.asyncio
     async def test_apply_kb_no_result(self, mock_event, mock_context):
         """Test applying knowledge base when no result is returned."""
         module = ama


### PR DESCRIPTION
Fixes #8070.

## Summary
- Skip non-agentic knowledge-base retrieval when the provider prompt is blank or whitespace-only.
- Add a regression test so image-only or sticker messages do not send an empty query to retrieval.

## To verify
- python -m pytest tests\unit\test_astr_main_agent.py::TestApplyKb -q
- python -m ruff check astrbot\core\astr_main_agent.py tests\unit\test_astr_main_agent.py
- python -m ruff format --check astrbot\core\astr_main_agent.py tests\unit\test_astr_main_agent.py
- python -m py_compile astrbot\core\astr_main_agent.py tests\unit\test_astr_main_agent.py

## Summary by Sourcery

Skip non-agentic knowledge base retrieval when provider prompts are blank or whitespace-only and add regression coverage for this behavior.

Bug Fixes:
- Prevent knowledge base retrieval from being invoked when the provider prompt is blank or contains only whitespace.

Tests:
- Add async regression tests ensuring knowledge base retrieval is skipped and system prompts are unchanged for blank or whitespace-only prompts.