### PR TITLE
feat(cua): expire idle sandbox sessions

### DIFF
--- a/astrbot/core/computer/computer_client.py
+++ b/astrbot/core/computer/computer_client.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import time
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 
 from astrbot.api import logger
@@ -19,9 +20,16 @@ from .booters.local import LocalBooter
 
 session_booter: dict[str, ComputerBooter] = {}
 local_booter: ComputerBooter | None = None
-cua_last_used_at: dict[str, float] = {}
-cua_idle_cleanup_tasks: dict[str, asyncio.Task] = {}
 _MANAGED_SKILLS_FILE = ".astrbot_managed_skills.json"
+
+
+@dataclass(slots=True)
+class _CUAIdleState:
+    expires_at: float
+    task: asyncio.Task
+
+
+cua_idle_state: dict[str, _CUAIdleState] = {}
 
 
 def _get_cua_idle_timeout(config: dict) -> float:
@@ -35,50 +43,48 @@ def _get_cua_idle_timeout(config: dict) -> float:
 
 
 def _clear_cua_idle_state(session_id: str) -> None:
-    task = cua_idle_cleanup_tasks.pop(session_id, None)
-    if task is not None:
-        task.cancel()
+    state = cua_idle_state.pop(session_id, None)
+    if state is not None and not state.task.done():
+        state.task.cancel()
 
 
 def _schedule_cua_idle_cleanup(session_id: str, timeout: float) -> None:
     _clear_cua_idle_state(session_id)
     if timeout <= 0:
-        cua_last_used_at.pop(session_id, None)
         return
-    cua_last_used_at[session_id] = time.monotonic()
+    expires_at = time.monotonic() + timeout
 
     async def _expire_when_idle() -> None:
-        current_task = asyncio.current_task()
         try:
-            while True:
-                last_used_at = cua_last_used_at.get(session_id)
-                if last_used_at is None:
-                    return
-                remaining = timeout - (time.monotonic() - last_used_at)
-                if remaining <= 0:
-                    booter = session_booter.get(session_id)
-                    if booter is not None:
-                        try:
-                            await booter.shutdown()
-                        except Exception as shutdown_err:
-                            logger.warning(
-                                "[Computer] Failed to shutdown idle CUA sandbox for session %s: %s",
-                                session_id,
-                                shutdown_err,
-                            )
-                        finally:
-                            session_booter.pop(session_id, None)
-                    return
+            remaining = expires_at - time.monotonic()
+            if remaining > 0:
                 await asyncio.sleep(remaining)
+
+            state = cua_idle_state.get(session_id)
+            if state is None or state.expires_at != expires_at:
+                return
+
+            booter = session_booter.get(session_id)
+            if booter is not None:
+                try:
+                    await booter.shutdown()
+                except Exception as shutdown_err:
+                    logger.warning(
+                        "[Computer] Failed to shutdown idle CUA sandbox for session %s: %s",
+                        session_id,
+                        shutdown_err,
+                    )
+                finally:
+                    session_booter.pop(session_id, None)
         except asyncio.CancelledError:
             raise
         finally:
-            task = cua_idle_cleanup_tasks.get(session_id)
-            if task is current_task:
-                cua_last_used_at.pop(session_id, None)
-                cua_idle_cleanup_tasks.pop(session_id, None)
+            state = cua_idle_state.get(session_id)
+            if state is not None and state.expires_at == expires_at:
+                cua_idle_state.pop(session_id, None)
 
-    cua_idle_cleanup_tasks[session_id] = asyncio.create_task(_expire_when_idle())
+    task = asyncio.create_task(_expire_when_idle())
+    cua_idle_state[session_id] = _CUAIdleState(expires_at=expires_at, task=task)
 
 
 def _list_local_skill_dirs(skills_root: Path) -> list[Path]:

--- a/astrbot/core/computer/computer_client.py
+++ b/astrbot/core/computer/computer_client.py
@@ -1,6 +1,8 @@
+import asyncio
 import json
 import os
 import shutil
+import time
 import uuid
 from pathlib import Path
 
@@ -17,7 +19,66 @@ from .booters.local import LocalBooter
 
 session_booter: dict[str, ComputerBooter] = {}
 local_booter: ComputerBooter | None = None
+cua_last_used_at: dict[str, float] = {}
+cua_idle_cleanup_tasks: dict[str, asyncio.Task] = {}
 _MANAGED_SKILLS_FILE = ".astrbot_managed_skills.json"
+
+
+def _get_cua_idle_timeout(config: dict) -> float:
+    sandbox_cfg = config.get("provider_settings", {}).get("sandbox", {})
+    value = sandbox_cfg.get("cua_idle_timeout", 0)
+    try:
+        timeout = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(timeout, 0.0)
+
+
+def _clear_cua_idle_state(session_id: str) -> None:
+    task = cua_idle_cleanup_tasks.pop(session_id, None)
+    if task is not None:
+        task.cancel()
+
+
+def _schedule_cua_idle_cleanup(session_id: str, timeout: float) -> None:
+    _clear_cua_idle_state(session_id)
+    if timeout <= 0:
+        cua_last_used_at.pop(session_id, None)
+        return
+    cua_last_used_at[session_id] = time.monotonic()
+
+    async def _expire_when_idle() -> None:
+        current_task = asyncio.current_task()
+        try:
+            while True:
+                last_used_at = cua_last_used_at.get(session_id)
+                if last_used_at is None:
+                    return
+                remaining = timeout - (time.monotonic() - last_used_at)
+                if remaining <= 0:
+                    booter = session_booter.get(session_id)
+                    if booter is not None:
+                        try:
+                            await booter.shutdown()
+                        except Exception as shutdown_err:
+                            logger.warning(
+                                "[Computer] Failed to shutdown idle CUA sandbox for session %s: %s",
+                                session_id,
+                                shutdown_err,
+                            )
+                        finally:
+                            session_booter.pop(session_id, None)
+                    return
+                await asyncio.sleep(remaining)
+        except asyncio.CancelledError:
+            raise
+        finally:
+            task = cua_idle_cleanup_tasks.get(session_id)
+            if task is current_task:
+                cua_last_used_at.pop(session_id, None)
+                cua_idle_cleanup_tasks.pop(session_id, None)
+
+    cua_idle_cleanup_tasks[session_id] = asyncio.create_task(_expire_when_idle())
 
 
 def _list_local_skill_dirs(skills_root: Path) -> list[Path]:
@@ -486,6 +547,7 @@ async def get_booter(
 
     sandbox_cfg = config.get("provider_settings", {}).get("sandbox", {})
     booter_type = sandbox_cfg.get("booter", "shipyard_neo")
+    cua_idle_timeout = _get_cua_idle_timeout(config) if booter_type == "cua" else 0.0
 
     if session_id in session_booter:
         booter = session_booter[session_id]
@@ -506,6 +568,7 @@ async def get_booter(
                     session_id,
                     shutdown_err,
                 )
+            _clear_cua_idle_state(session_id)
             session_booter.pop(session_id, None)
     if session_id not in session_booter:
         uuid_str = uuid.uuid5(uuid.NAMESPACE_DNS, session_id).hex
@@ -579,9 +642,12 @@ async def get_booter(
                     session_id,
                     shutdown_error,
                 )
+            _clear_cua_idle_state(session_id)
             raise e
 
         session_booter[session_id] = client
+    if booter_type == "cua":
+        _schedule_cua_idle_cleanup(session_id, cua_idle_timeout)
     return session_booter[session_id]
 
 

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -179,6 +179,7 @@ DEFAULT_CONFIG = {
             "cua_image": CUA_DEFAULT_CONFIG["image"],
             "cua_os_type": CUA_DEFAULT_CONFIG["os_type"],
             "cua_ttl": CUA_DEFAULT_CONFIG["ttl"],
+            "cua_idle_timeout": 0,
             "cua_telemetry_enabled": CUA_DEFAULT_CONFIG["telemetry_enabled"],
             "cua_local": CUA_DEFAULT_CONFIG["local"],
             "cua_api_key": CUA_DEFAULT_CONFIG["api_key"],

--- a/tests/unit/test_cua_computer_use.py
+++ b/tests/unit/test_cua_computer_use.py
@@ -22,8 +22,9 @@ class FakeContext:
 
 def _clear_cua_session_state(computer_client, session_id: str) -> None:
     computer_client.session_booter.pop(session_id, None)
-    getattr(computer_client, "cua_idle_cleanup_tasks", {}).pop(session_id, None)
-    getattr(computer_client, "cua_last_used_at", {}).pop(session_id, None)
+    state = getattr(computer_client, "cua_idle_state", {}).pop(session_id, None)
+    if state is not None and not state.task.done():
+        state.task.cancel()
 
 
 class FakeShell:
@@ -388,14 +389,14 @@ async def test_cua_idle_timeout_shuts_down_session_proactively(monkeypatch):
                 "computer_use_runtime": "sandbox",
                 "sandbox": {
                     "booter": "cua",
-                    "cua_idle_timeout": 0.01,
+                    "cua_idle_timeout": 0.1,
                 },
             }
         }
     )
 
     booter = await computer_client.get_booter(ctx, "cua-idle-expire")
-    await asyncio.sleep(0.05)
+    await asyncio.sleep(0.2)
 
     assert shutdowns == [booter.session_id]
     assert "cua-idle-expire" not in computer_client.session_booter
@@ -436,21 +437,21 @@ async def test_cua_idle_timeout_refreshes_on_reuse(monkeypatch):
                 "computer_use_runtime": "sandbox",
                 "sandbox": {
                     "booter": "cua",
-                    "cua_idle_timeout": 0.05,
+                    "cua_idle_timeout": 0.2,
                 },
             }
         }
     )
 
     booter1 = await computer_client.get_booter(ctx, "cua-idle-refresh")
-    await asyncio.sleep(0.02)
+    await asyncio.sleep(0.05)
     booter2 = await computer_client.get_booter(ctx, "cua-idle-refresh")
-    await asyncio.sleep(0.02)
+    await asyncio.sleep(0.05)
 
     assert booter2 is booter1
     assert shutdowns == []
 
-    await asyncio.sleep(0.06)
+    await asyncio.sleep(0.25)
 
     assert shutdowns == [booter1.session_id]
     assert "cua-idle-refresh" not in computer_client.session_booter
@@ -502,6 +503,7 @@ async def test_cua_idle_timeout_zero_disables_proactive_shutdown(monkeypatch):
 
     assert shutdowns == []
     assert "cua-idle-disabled" in computer_client.session_booter
+    assert "cua-idle-disabled" not in computer_client.cua_idle_state
 
 
 @pytest.mark.asyncio
@@ -532,8 +534,7 @@ async def test_non_cua_booter_does_not_schedule_idle_cleanup(monkeypatch):
     booter = await computer_client.get_booter(ctx, "shipyard-session")
 
     assert isinstance(booter, FakeShipyardBooter)
-    assert "shipyard-session" not in computer_client.cua_idle_cleanup_tasks
-    assert "shipyard-session" not in computer_client.cua_last_used_at
+    assert "shipyard-session" not in computer_client.cua_idle_state
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_cua_computer_use.py
+++ b/tests/unit/test_cua_computer_use.py
@@ -20,6 +20,12 @@ class FakeContext:
         return self._config
 
 
+def _clear_cua_session_state(computer_client, session_id: str) -> None:
+    computer_client.session_booter.pop(session_id, None)
+    getattr(computer_client, "cua_idle_cleanup_tasks", {}).pop(session_id, None)
+    getattr(computer_client, "cua_last_used_at", {}).pop(session_id, None)
+
+
 class FakeShell:
     def __init__(self):
         self.commands = []
@@ -246,6 +252,7 @@ def test_cua_default_config_matches_booter_defaults():
     assert sandbox_defaults["cua_image"] == CUA_DEFAULT_CONFIG["image"]
     assert sandbox_defaults["cua_os_type"] == CUA_DEFAULT_CONFIG["os_type"]
     assert sandbox_defaults["cua_ttl"] == CUA_DEFAULT_CONFIG["ttl"]
+    assert sandbox_defaults["cua_idle_timeout"] == 0
     assert (
         sandbox_defaults["cua_telemetry_enabled"]
         == CUA_DEFAULT_CONFIG["telemetry_enabled"]
@@ -344,6 +351,189 @@ async def test_get_booter_shuts_down_client_when_skill_sync_fails(monkeypatch):
 
     assert len(shutdowns) == 1
     assert "cua-sync-fail" not in computer_client.session_booter
+
+
+@pytest.mark.asyncio
+async def test_cua_idle_timeout_shuts_down_session_proactively(monkeypatch):
+    from astrbot.core.computer import computer_client
+
+    shutdowns = []
+
+    class FakeCuaBooter:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def boot(self, session_id: str):
+            self.session_id = session_id
+
+        async def available(self):
+            return True
+
+        async def shutdown(self):
+            shutdowns.append(self.session_id)
+
+    monkeypatch.setattr(
+        computer_client, "_sync_skills_to_sandbox", lambda booter: asyncio.sleep(0)
+    )
+    monkeypatch.setattr(
+        "astrbot.core.computer.booters.cua.CuaBooter",
+        FakeCuaBooter,
+        raising=False,
+    )
+    _clear_cua_session_state(computer_client, "cua-idle-expire")
+
+    ctx = FakeContext(
+        {
+            "provider_settings": {
+                "computer_use_runtime": "sandbox",
+                "sandbox": {
+                    "booter": "cua",
+                    "cua_idle_timeout": 0.01,
+                },
+            }
+        }
+    )
+
+    booter = await computer_client.get_booter(ctx, "cua-idle-expire")
+    await asyncio.sleep(0.05)
+
+    assert shutdowns == [booter.session_id]
+    assert "cua-idle-expire" not in computer_client.session_booter
+
+
+@pytest.mark.asyncio
+async def test_cua_idle_timeout_refreshes_on_reuse(monkeypatch):
+    from astrbot.core.computer import computer_client
+
+    shutdowns = []
+
+    class FakeCuaBooter:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def boot(self, session_id: str):
+            self.session_id = session_id
+
+        async def available(self):
+            return True
+
+        async def shutdown(self):
+            shutdowns.append(self.session_id)
+
+    monkeypatch.setattr(
+        computer_client, "_sync_skills_to_sandbox", lambda booter: asyncio.sleep(0)
+    )
+    monkeypatch.setattr(
+        "astrbot.core.computer.booters.cua.CuaBooter",
+        FakeCuaBooter,
+        raising=False,
+    )
+    _clear_cua_session_state(computer_client, "cua-idle-refresh")
+
+    ctx = FakeContext(
+        {
+            "provider_settings": {
+                "computer_use_runtime": "sandbox",
+                "sandbox": {
+                    "booter": "cua",
+                    "cua_idle_timeout": 0.05,
+                },
+            }
+        }
+    )
+
+    booter1 = await computer_client.get_booter(ctx, "cua-idle-refresh")
+    await asyncio.sleep(0.02)
+    booter2 = await computer_client.get_booter(ctx, "cua-idle-refresh")
+    await asyncio.sleep(0.02)
+
+    assert booter2 is booter1
+    assert shutdowns == []
+
+    await asyncio.sleep(0.06)
+
+    assert shutdowns == [booter1.session_id]
+    assert "cua-idle-refresh" not in computer_client.session_booter
+
+
+@pytest.mark.asyncio
+async def test_cua_idle_timeout_zero_disables_proactive_shutdown(monkeypatch):
+    from astrbot.core.computer import computer_client
+
+    shutdowns = []
+
+    class FakeCuaBooter:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def boot(self, session_id: str):
+            self.session_id = session_id
+
+        async def available(self):
+            return True
+
+        async def shutdown(self):
+            shutdowns.append(self.session_id)
+
+    monkeypatch.setattr(
+        computer_client, "_sync_skills_to_sandbox", lambda booter: asyncio.sleep(0)
+    )
+    monkeypatch.setattr(
+        "astrbot.core.computer.booters.cua.CuaBooter",
+        FakeCuaBooter,
+        raising=False,
+    )
+    _clear_cua_session_state(computer_client, "cua-idle-disabled")
+
+    ctx = FakeContext(
+        {
+            "provider_settings": {
+                "computer_use_runtime": "sandbox",
+                "sandbox": {
+                    "booter": "cua",
+                    "cua_idle_timeout": 0,
+                },
+            }
+        }
+    )
+
+    await computer_client.get_booter(ctx, "cua-idle-disabled")
+    await asyncio.sleep(0.05)
+
+    assert shutdowns == []
+    assert "cua-idle-disabled" in computer_client.session_booter
+
+
+@pytest.mark.asyncio
+async def test_non_cua_booter_does_not_schedule_idle_cleanup(monkeypatch):
+    from astrbot.core.computer import computer_client
+
+    class FakeShipyardBooter:
+        async def available(self):
+            return True
+
+    _clear_cua_session_state(computer_client, "shipyard-session")
+    computer_client.session_booter["shipyard-session"] = FakeShipyardBooter()
+
+    ctx = FakeContext(
+        {
+            "provider_settings": {
+                "computer_use_runtime": "sandbox",
+                "sandbox": {
+                    "booter": "shipyard",
+                    "shipyard_endpoint": "http://localhost:8080",
+                    "shipyard_access_token": "token",
+                    "cua_idle_timeout": 0.01,
+                },
+            }
+        }
+    )
+
+    booter = await computer_client.get_booter(ctx, "shipyard-session")
+
+    assert isinstance(booter, FakeShipyardBooter)
+    assert "shipyard-session" not in computer_client.cua_idle_cleanup_tasks
+    assert "shipyard-session" not in computer_client.cua_last_used_at
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a CUA-only `cua_idle_timeout` config that proactively shuts down idle sandbox sessions
- track one idle cleanup task per CUA session and reset the timer whenever the session is reused
- add regression tests covering proactive expiration, timer refresh on reuse, disabled timeout behavior, and non-CUA isolation

## Problem
AstrBot caches sandbox booters per session in memory. For CUA sessions this means a local sandbox can stay alive indefinitely unless the process exits, the booter becomes unavailable, or the user explicitly asks the agent to close it. In practice that leaves local Docker-backed CUA sandboxes running far longer than users expect.

## Root Cause
`computer_client.get_booter()` stores active sandbox booters in `session_booter` and reuses them for the same session. The CUA booter itself uses an ephemeral sandbox context, but AstrBot does not currently release that context when the session becomes idle, so the sandbox lifetime ends up tied to process lifetime rather than actual usage.

## Fix
This change adds a CUA-specific proactive idle timeout.

- New config: `provider_settings.sandbox.cua_idle_timeout`
- Default: `0` (disabled, preserves current behavior)
- When enabled, AstrBot creates one async cleanup task per active CUA session
- The task sleeps until the remaining idle budget is exhausted, then calls `booter.shutdown()` and removes the session from the in-memory cache
- Reusing the same CUA session resets the timer by cancelling the previous cleanup task and scheduling a fresh one

The implementation is intentionally scoped to CUA only so other sandbox booters keep their current lifecycle behavior.

## Validation
- `uv run pytest tests/unit/test_cua_computer_use.py tests/unit/test_computer.py -q`
- `uv run ruff check astrbot/core/computer/computer_client.py astrbot/core/config/default.py tests/unit/test_cua_computer_use.py`

## Summary by Sourcery

Add configurable idle-timeout handling for CUA sandbox sessions so idle sessions are proactively shut down while preserving existing behavior by default.

New Features:
- Introduce a CUA-only configuration option to control sandbox idle timeout and default it to disabled.
- Track per-session idle state for CUA sandbox booters and schedule asynchronous cleanup when sessions exceed the configured idle timeout.

Enhancements:
- Ensure CUA idle timers are refreshed when an existing session is reused and cleared on shutdown or booter errors.
- Keep non-CUA sandbox booters unaffected by the new idle-timeout behavior.

Tests:
- Add regression tests covering proactive CUA session shutdown on idle, timer refresh on reuse, disabled-timeout behavior, and isolation from non-CUA booters.