### PR TITLE
fix(t2i): validate template content to prevent Jinja2 SSTI injection

### DIFF
--- a/astrbot/core/utils/t2i/template_manager.py
+++ b/astrbot/core/utils/t2i/template_manager.py
@@ -1,9 +1,37 @@
 # astrbot/core/utils/t2i/template_manager.py
 
+import logging
 import os
+import re
 import shutil
 
 from astrbot.core.utils.astrbot_path import get_astrbot_data_path, get_astrbot_path
+
+logger = logging.getLogger("astrbot")
+
+_ALLOWED_VARS = frozenset({"text", "version", "shiki_runtime"})
+
+_SSTI_BLACKLIST: list[tuple[str, re.Pattern]] = [
+    ("dunder_chain", re.compile(r"__\s*(class|globals|init|mro|base|bases|subclasses|reduce|getitem|builtins|import|self|func|code|reduce_ex)__")),
+    ("dangerous_builtins", re.compile(r"\b(import\s+(?!url)|os\.\w+|subprocess\.|\.popen\(|eval\(|exec\()")),
+    ("flask_context", re.compile(r"\{\{.*?\b(config|request|session|g)\b.*?\}\}")),
+]
+
+_VAR_RE = re.compile(r"\{\{\s*(\w+)\s*(\|[^}]*)?\}\}")
+
+
+def validate_template_content(content: str, *, strict: bool = False) -> None:
+    for label, pattern in _SSTI_BLACKLIST:
+        if pattern.search(content):
+            raise ValueError(f"Template contains forbidden pattern ({label}).")
+    if strict:
+        for m in _VAR_RE.finditer(content):
+            var = m.group(1)
+            if var not in _ALLOWED_VARS:
+                raise ValueError(
+                    f"Unauthorized Jinja2 variable '{var}'; "
+                    f"allowed: {', '.join(sorted(_ALLOWED_VARS))}."
+                )
 
 
 class TemplateManager:
@@ -86,6 +114,7 @@ class TemplateManager:
 
     def create_template(self, name: str, content: str) -> None:
         """在用户目录中创建一个新的模板文件。"""
+        validate_template_content(content, strict=True)
         path = self._get_user_template_path(name)
         if os.path.exists(path):
             raise FileExistsError("同名模板已存在。")
@@ -97,6 +126,7 @@ class TemplateManager:
         如果更新的是一个内置模板，此操作实际上会在用户目录中创建一个修改后的副本，
         从而实现对内置模板的“覆盖”。
         """
+        validate_template_content(content, strict=True)
         path = self._get_user_template_path(name)
         with open(path, "w", encoding="utf-8") as f:
             f.write(content)

--- a/astrbot/core/utils/t2i/template_manager.py
+++ b/astrbot/core/utils/t2i/template_manager.py
@@ -12,8 +12,18 @@ logger = logging.getLogger("astrbot")
 _ALLOWED_VARS = frozenset({"text", "version", "shiki_runtime"})
 
 _SSTI_BLACKLIST: list[tuple[str, re.Pattern]] = [
-    ("dunder_chain", re.compile(r"__\s*(class|globals|init|mro|base|bases|subclasses|reduce|getitem|builtins|import|self|func|code|reduce_ex)__")),
-    ("dangerous_builtins", re.compile(r"\b(import\s+(?!url)|os\.\w+|subprocess\.|\.popen\(|eval\(|exec\()")),
+    (
+        "dunder_chain",
+        re.compile(
+            r"__\s*(class|globals|init|mro|base|bases|subclasses|reduce|getitem|builtins|import|self|func|code|reduce_ex)__"
+        ),
+    ),
+    (
+        "dangerous_builtins",
+        re.compile(
+            r"\b(import\s+(?!url)|os\.\w+|subprocess\.|\.popen\(|eval\(|exec\()"
+        ),
+    ),
     ("flask_context", re.compile(r"\{\{.*?\b(config|request|session|g)\b.*?\}\}")),
 ]
 
@@ -29,7 +39,9 @@ def validate_template_content(content: str, *, strict: bool = False) -> None:
         for m in _VAR_RE.finditer(content):
             var = m.group(1)
             if var not in _ALLOWED_VARS:
-                logger.warning(f"SSTI validation blocked template: unauthorized variable '{var}'")
+                logger.warning(
+                    f"SSTI validation blocked template: unauthorized variable '{var}'"
+                )
                 raise ValueError(
                     f"Unauthorized Jinja2 variable '{var}'; "
                     f"allowed: {', '.join(sorted(_ALLOWED_VARS))}."

--- a/astrbot/core/utils/t2i/template_manager.py
+++ b/astrbot/core/utils/t2i/template_manager.py
@@ -23,11 +23,13 @@ _VAR_RE = re.compile(r"\{\{\s*(\w+)\s*(\|[^}]*)?\}\}")
 def validate_template_content(content: str, *, strict: bool = False) -> None:
     for label, pattern in _SSTI_BLACKLIST:
         if pattern.search(content):
+            logger.warning(f"SSTI validation blocked template: matched rule [{label}]")
             raise ValueError(f"Template contains forbidden pattern ({label}).")
     if strict:
         for m in _VAR_RE.finditer(content):
             var = m.group(1)
             if var not in _ALLOWED_VARS:
+                logger.warning(f"SSTI validation blocked template: unauthorized variable '{var}'")
                 raise ValueError(
                     f"Unauthorized Jinja2 variable '{var}'; "
                     f"allowed: {', '.join(sorted(_ALLOWED_VARS))}."

--- a/dashboard/src/components/shared/T2ITemplateEditor.vue
+++ b/dashboard/src/components/shared/T2ITemplateEditor.vue
@@ -243,10 +243,12 @@
 import { ref, computed, nextTick, watch } from 'vue'
 import { VueMonacoEditor } from '@guolao/vue-monaco-editor'
 import { useI18n, useModuleI18n } from '@/i18n/composables'
+import { useToast } from '@/utils/toast'
 import axios from 'axios'
 
 const { t } = useI18n()
 const { tm } = useModuleI18n('core.shared')
+const toast = useToast()
 
 // --- 响应式数据 ---
 const dialog = ref(false)
@@ -448,8 +450,9 @@ const saveTemplate = async () => {
       })
     }
   } catch (error) {
-    console.error('保存模板失败:', error)
-    // 可以在此添加错误提示
+    const msg = error?.response?.data?.message || error?.message || String(error)
+    console.error('保存模板失败:', msg)
+    toast.error(msg)
   } finally {
     saveLoading.value = false
   }
@@ -461,7 +464,9 @@ const setActiveTemplate = async (name) => {
     await axios.post('/api/t2i/templates/set_active', { name })
     activeTemplate.value = name
   } catch (error) {
-    console.error(`应用模板 '${name}' 失败:`, error)
+    const msg = error?.response?.data?.message || error?.message || String(error)
+    console.error(`应用模板 '${name}' 失败:`, msg)
+    toast.error(msg)
   } finally {
     applyLoading.value = false
   }
@@ -482,7 +487,9 @@ const confirmDelete = async () => {
     await loadInitialData()
     selectedTemplate.value = 'base'
   } catch (error) {
-    console.error(`删除模板 '${selectedTemplate.value}' 失败:`, error)
+    const msg = error?.response?.data?.message || error?.message || String(error)
+    console.error(`删除模板失败:`, msg)
+    toast.error(msg)
   } finally {
     saveLoading.value = false
   }
@@ -500,7 +507,9 @@ const confirmReset = async () => {
         await setActiveTemplate('base')
     }
   } catch (error) {
-    console.error('重置模板失败:', error)
+    const msg = error?.response?.data?.message || error?.message || String(error)
+    console.error('重置模板失败:', msg)
+    toast.error(msg)
   } finally {
     resetLoading.value = false
   }

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1026,7 +1026,7 @@ async def test_t2i_set_active_template_syncs_all_configs(
             "/api/t2i/templates/create",
             json={
                 "name": template_name,
-                "content": "<html><body>{{ content }}</body></html>",
+                "content": "<html><body>{{ text }}</body></html>",
             },
             headers=authenticated_header,
         )
@@ -1093,7 +1093,7 @@ async def test_t2i_reset_default_template_syncs_all_configs(
             "/api/t2i/templates/create",
             json={
                 "name": template_name,
-                "content": "<html><body>{{ content }} reset</body></html>",
+                "content": "<html><body>{{ text }} reset</body></html>",
             },
             headers=authenticated_header,
         )
@@ -1166,7 +1166,7 @@ async def test_t2i_update_active_template_reloads_all_schedulers(
             "/api/t2i/templates/create",
             json={
                 "name": template_name,
-                "content": "<html><body>{{ content }} v1</body></html>",
+                "content": "<html><body>{{ text }} v1</body></html>",
             },
             headers=authenticated_header,
         )
@@ -1187,7 +1187,7 @@ async def test_t2i_update_active_template_reloads_all_schedulers(
 
         response = await test_client.put(
             f"/api/t2i/templates/{template_name}",
-            json={"content": "<html><body>{{ content }} v2</body></html>"},
+            json={"content": "<html><body>{{ text }} v2</body></html>"},
             headers=authenticated_header,
         )
         assert response.status_code == 200


### PR DESCRIPTION
Fixes #7330 

### Modifications / 改动点

#### fix(t2i): prevent Jinja2 SSTI via template content validation                                   
                                                                                                 
- Added input validation for T2I template create/update operations to block malicious Jinja2 payloads (CWE-1336). Previously, templates submitted through the dashboard API were stored unsanitized and sent as-is to the remote Jinja2 renderer, allowing authenticated users to inject server-side template expressions.                                                        
                                                                                                 
- Validation uses a two-tier approach:                                                            
   1. Blacklist: blocks dunder chains (__class__, __globals__, etc.), dangerous builtins (os.popen, eval, exec), and Flask/Quart context escapes (config, request, session).                                                           
   2. Allowlist: restricts stored templates to the three variables actually passed by the renderer (text, version, shiki_runtime).                               
                                                                                                 
- Security warnings are logged when templates are blocked, and the dashboard editor now surfaces API errors as toast notifications instead of silently swallowing them. 
- Plugin-side rendering via html_render() is unaffected — it passes template strings directly and does not go through the TemplateManager path.        

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<img width="1179" height="1150" alt="5f28ffbb6eb9c064d3adee815999df82" src="https://github.com/user-attachments/assets/6a4de782-1c7a-4c3e-9110-e15e42dae044" />
<img width="894" height="78" alt="0b25a7b0405c58d981b127673751b442" src="https://github.com/user-attachments/assets/49f2eb05-af00-4783-8f24-fb617b2d8492" />
<img width="895" height="47" alt="image" src="https://github.com/user-attachments/assets/7cb598c1-d9f2-4443-9dd8-b8aa3caf5a89" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Validate T2I HTML templates to prevent unsafe Jinja2 usage and surface validation errors in the dashboard UI.

Bug Fixes:
- Add server-side validation for T2I template creation and updates to block Jinja2 SSTI patterns and unauthorized variables.

Enhancements:
- Show toast error notifications in the T2I template editor when template save, apply, delete, or reset operations fail instead of silently logging errors.

Tests:
- Update dashboard integration tests to use the supported T2I template variable name in template content.