### PR TITLE
feat(provider): add Astraflow (UModelverse) chat completion provider

### DIFF
--- a/astrbot/core/provider/manager.py
+++ b/astrbot/core/provider/manager.py
@@ -381,6 +381,10 @@ class ProviderManager:
                 from .sources.openrouter_source import (
                     ProviderOpenRouter as ProviderOpenRouter,
                 )
+            case "astraflow_chat_completion":
+                from .sources.oai_astraflow_source import (
+                    ProviderAstraflow as ProviderAstraflow,
+                )
             case "anthropic_chat_completion":
                 from .sources.anthropic_source import (
                     ProviderAnthropic as ProviderAnthropic,

--- a/astrbot/core/provider/sources/oai_astraflow_source.py
+++ b/astrbot/core/provider/sources/oai_astraflow_source.py
@@ -1,0 +1,34 @@
+from ..register import register_provider_adapter
+from .openai_source import ProviderOpenAIOfficial
+
+# Astraflow (UCloud / 优刻得 优模方舟 / UModelverse) is an OpenAI-compatible AI
+# model aggregation platform that supports 200+ models.
+#
+# Endpoints:
+#   - Global: https://api-us-ca.umodelverse.ai/v1   (env var: ASTRAFLOW_API_KEY)
+#   - China:  https://api.modelverse.cn/v1          (env var: ASTRAFLOW_CN_API_KEY)
+#
+# Because the API is OpenAI-compatible, this adapter only needs to set a
+# default ``api_base``. Users may still override it via provider config
+# (e.g. switching to the China endpoint).
+ASTRAFLOW_DEFAULT_API_BASE = "https://api-us-ca.umodelverse.ai/v1"
+
+
+@register_provider_adapter(
+    "astraflow_chat_completion",
+    "Astraflow (UModelverse) Chat Completion Provider Adapter",
+)
+class ProviderAstraflow(ProviderOpenAIOfficial):
+    def __init__(
+        self,
+        provider_config: dict,
+        provider_settings: dict,
+    ) -> None:
+        # Apply the default Astraflow base URL when the user has not
+        # explicitly configured one. This makes the adapter work out of
+        # the box for the global endpoint while still allowing users to
+        # override ``api_base`` (e.g. to point at the China endpoint
+        # https://api.modelverse.cn/v1).
+        if not provider_config.get("api_base"):
+            provider_config["api_base"] = ASTRAFLOW_DEFAULT_API_BASE
+        super().__init__(provider_config, provider_settings)


### PR DESCRIPTION
## Summary

Adds support for [Astraflow](https://www.umodelverse.ai/) (UCloud / 优刻得 优模方舟 / UModelverse), an OpenAI-compatible AI model aggregation platform supporting 200+ models, as a new chat completion provider in AstrBot.

## Endpoints

- **Global**: `https://api-us-ca.umodelverse.ai/v1` (env var: `ASTRAFLOW_API_KEY`)
- **China**: `https://api.modelverse.cn/v1` (env var: `ASTRAFLOW_CN_API_KEY`)

## Changes

This is a minimal integration that follows the exact pattern used by other OpenAI-compatible providers already in the repo (AIHubMix, OpenRouter, Groq, xAI, etc.):

1. **New file** `astrbot/core/provider/sources/oai_astraflow_source.py` — defines `ProviderAstraflow`, a subclass of `ProviderOpenAIOfficial` that defaults `api_base` to the Astraflow global endpoint. Users can override `api_base` in the provider config to switch to the China endpoint.
2. **`astrbot/core/provider/manager.py`** — registers `astraflow_chat_completion` in the `dynamic_import_provider` dispatch (placed next to `openrouter_chat_completion`, the most similar adapter).

No new dependencies are required because Astraflow is fully OpenAI-API-compatible and uses the existing `openai` Python SDK already vendored by AstrBot.

## Usage

Users can add a new chat completion provider with type `astraflow_chat_completion` and supply their `ASTRAFLOW_API_KEY`. To use the China endpoint, override `api_base` to `https://api.modelverse.cn/v1` and use `ASTRAFLOW_CN_API_KEY`.

## Summary by Sourcery

Add a new Astraflow (UModelverse) chat completion provider integrated as an OpenAI-compatible adapter with default endpoint configuration and provider registration.

New Features:
- Introduce the Astraflow chat completion provider adapter based on the existing OpenAI-compatible provider abstraction.

Enhancements:
- Register the Astraflow provider in the dynamic provider manager for runtime selection alongside other OpenAI-compatible providers.