### PR TITLE
fix: use <title> from index.html for plugin page title instead of folder name (Closes #8057)

### DIFF
--- a/astrbot/dashboard/routes/plugin.py
+++ b/astrbot/dashboard/routes/plugin.py
@@ -374,10 +374,25 @@ class PluginRoute(Route):
             entry_path = page_dir / _PLUGIN_PAGE_ENTRY_FILE_NAME
             if not await aio_ospath.isfile(str(entry_path)):
                 continue
+            # 尝试从 index.html 的 <title> 标签中读取页面标题，避免使用文件夹名
+            page_title = page_name
+            try:
+                html_text = await self._read_plugin_page_text(entry_path)
+                title_match = re.search(
+                    r"<title[^>]*>(.*?)</title>",
+                    html_text,
+                    re.IGNORECASE | re.DOTALL,
+                )
+                if title_match:
+                    extracted = title_match.group(1).strip()
+                    if extracted:
+                        page_title = extracted
+            except (OSError, ValueError):
+                pass
             pages.append(
                 PluginPage(
                     name=page_name,
-                    title=page_name,
+                    title=page_title,
                     entry_file=_PLUGIN_PAGE_ENTRY_FILE_NAME,
                 )
             )


### PR DESCRIPTION
## 问题

详见 Issue #8057。插件注册页面的标题显示的是文件夹名而非 index.html 中定义的 `<title>` 标签内容。用户如果想显示中文页面标题，必须让文件夹名也是中文，这很不合理。

## 修改

在 `_discover_plugin_pages()` 中，读取插件 page 目录下的 `index.html` 文件，通过正则解析 `<title>` 标签来获取页面标题。如果未找到 `<title>` 标签，则回退使用文件夹名作为标题。

### 修改文件

- `astrbot/dashboard/routes/plugin.py` — `_discover_plugin_pages()` 方法

## Summary by Sourcery

Bug Fixes:
- Ensure plugin page titles reflect the <title> in index.html instead of always using the folder name.