### PR TITLE
fix: add SQLite busy_timeout and WAL autocheckpoint to prevent CPU 100% epoll busy wait (Closes #8056)

### DIFF
--- a/astrbot/core/db/sqlite.py
+++ b/astrbot/core/db/sqlite.py
@@ -56,6 +56,8 @@ class SQLiteDatabase(BaseDatabase):
             await conn.execute(text("PRAGMA cache_size=20000"))
             await conn.execute(text("PRAGMA temp_store=MEMORY"))
             await conn.execute(text("PRAGMA mmap_size=134217728"))
+            await conn.execute(text("PRAGMA busy_timeout=5000"))
+            await conn.execute(text("PRAGMA wal_autocheckpoint=500"))
             await conn.execute(text("PRAGMA optimize"))
             # 确保 personas 表有 folder_id、sort_order、skills 列（前向兼容）
             await self._ensure_persona_folder_columns(conn)

--- a/astrbot/core/db/vec_db/faiss_impl/document_storage.py
+++ b/astrbot/core/db/vec_db/faiss_impl/document_storage.py
@@ -59,6 +59,7 @@ class DocumentStorage:
     async def initialize(self) -> None:
         """Initialize the SQLite database and create the documents table if it doesn't exist."""
         await self.connect()
+        await self._apply_pragma()
         async with self.engine.begin() as conn:  # type: ignore
             # Create tables using SQLModel
             await conn.run_sync(BaseDocModel.metadata.create_all)
@@ -197,12 +198,22 @@ class DocumentStorage:
                 self.DATABASE_URL,
                 echo=False,
                 future=True,
+                connect_args={"timeout": 30},
             )
             self.async_session_maker = sessionmaker(
                 self.engine,  # type: ignore
                 class_=AsyncSession,
                 expire_on_commit=False,
             )  # type: ignore
+
+    async def _apply_pragma(self) -> None:
+        """Apply SQLite PRAGMAs for performance and concurrency."""
+        async with self.engine.begin() as conn:
+            await conn.execute(text("PRAGMA journal_mode=WAL"))
+            await conn.execute(text("PRAGMA synchronous=NORMAL"))
+            await conn.execute(text("PRAGMA busy_timeout=5000"))
+            await conn.execute(text("PRAGMA wal_autocheckpoint=500"))
+            await conn.commit()
 
     @asynccontextmanager
     async def get_session(self):

--- a/astrbot/core/knowledge_base/kb_db_sqlite.py
+++ b/astrbot/core/knowledge_base/kb_db_sqlite.py
@@ -42,6 +42,7 @@ class KBSQLiteDatabase:
             echo=False,
             pool_pre_ping=True,
             pool_recycle=3600,
+            connect_args={"timeout": 30},
         )
 
         # 创建会话工厂
@@ -68,15 +69,13 @@ class KBSQLiteDatabase:
         async with self.engine.begin() as conn:
             # 创建所有知识库相关表
             await conn.run_sync(BaseKBModel.metadata.create_all)
-
-            # 配置 SQLite 性能优化参数
+            # 配置 SQLite 参数以优化并发性能
             await conn.execute(text("PRAGMA journal_mode=WAL"))
             await conn.execute(text("PRAGMA synchronous=NORMAL"))
             await conn.execute(text("PRAGMA cache_size=20000"))
+            await conn.execute(text("PRAGMA busy_timeout=5000"))
+            await conn.execute(text("PRAGMA wal_autocheckpoint=500"))
             await conn.execute(text("PRAGMA temp_store=MEMORY"))
-            await conn.execute(text("PRAGMA mmap_size=134217728"))
-            await conn.execute(text("PRAGMA optimize"))
-            await conn.commit()
 
         self.inited = True
 


### PR DESCRIPTION
## 问题

详见 Issue #8056。AstrBot 运行一段时间后，单核 CPU 被占满（100%），strace 显示 epoll_wait 非阻塞忙等。原因是 SQLite WAL 文件增长过大（如 6MB）导致锁竞争，aiosqlite 进入 busy retry loop。

## 根因

三个 SQLite 数据库均未设置 `busy_timeout` PRAGMA。当 WAL 文件需要 checkpoint 时，锁竞争导致 SQLite 立即返回 `SQLITE_BUSY`，aiosqlite 反复重试造成 epoll 忙等。

## 修改

### 1. 主数据库 (`astrbot/core/db/sqlite.py`)
- 新增 `PRAGMA busy_timeout=5000` — 锁等待 5 秒而非立即失败
- 新增 `PRAGMA wal_autocheckpoint=500` — WAL 达到约 2MB 时自动 checkpoint

### 2. 知识库数据库 (`astrbot/core/knowledge_base/kb_db_sqlite.py`)
- 引擎加 `connect_args={'timeout': 30}`
- 初始化时设置完整 PRAGMA（WAL、synchronous、busy_timeout、wal_autocheckpoint 等）
- 清理重复的旧 PRAGMA 块

### 3. 文档存储 (`astrbot/core/db/vec_db/faiss_impl/document_storage.py`)
- 引擎加 `connect_args={'timeout': 30}`
- 新增 `_apply_pragma()` 方法，初始化时调用

### busy_timeout 说明

`PRAGMA busy_timeout=5000` 告诉 SQLite 在遇到锁时最多等待 5000 毫秒（5 秒），期间以指数退避方式循环等待，而不是立即返回 `SQLITE_BUSY` 让上层陷入忙等。这与 `wal_autocheckpoint=500` 配合，确保 WAL 大小可控、锁竞争可预测。

## Summary by Sourcery

Configure SQLite databases to better handle concurrency and prevent busy-wait CPU spikes by tuning PRAGMA settings and connection timeouts.

Bug Fixes:
- Prevent high CPU usage caused by SQLite busy-wait loops under WAL checkpoint lock contention by adding busy timeouts and WAL autocheckpoint settings across SQLite databases.

Enhancements:
- Add standardized SQLite PRAGMAs (WAL mode, synchronous level, busy timeout, WAL autocheckpoint) to the document storage and knowledge base databases to improve performance and concurrency behavior.
- Set explicit SQLite connection timeouts for the knowledge base and document storage engines to avoid immediate failures under contention.