### PR TITLE
fix: default empty MiniMax timber weights

### DIFF
--- a/astrbot/core/provider/sources/minimax_tts_api_source.py
+++ b/astrbot/core/provider/sources/minimax_tts_api_source.py
@@ -12,6 +12,8 @@ from ..entities import ProviderType
 from ..provider import TTSProvider
 from ..register import register_provider_adapter
 
+DEFAULT_TIMBER_WEIGHT = '[{"voice_id": "Chinese (Mandarin)_Warm_Girl", "weight": 1}]'
+
 
 @register_provider_adapter(
     "minimax_tts_api",
@@ -37,12 +39,12 @@ class ProviderMiniMaxTTSAPI(TTSProvider):
             "minimax-is-timber-weight",
             False,
         )
-        self.timber_weight: list[dict[str, str | int]] = json.loads(
-            provider_config.get(
-                "minimax-timber-weight",
-                '[{"voice_id": "Chinese (Mandarin)_Warm_Girl", "weight": 1}]',
-            ),
+        timber_weight = (
+            provider_config.get("minimax-timber-weight") or DEFAULT_TIMBER_WEIGHT
         )
+        if isinstance(timber_weight, str) and not timber_weight.strip():
+            timber_weight = DEFAULT_TIMBER_WEIGHT
+        self.timber_weight: list[dict[str, str | int]] = json.loads(timber_weight)
 
         self.voice_setting: dict = {
             "speed": provider_config.get("minimax-voice-speed", 1.0),

--- a/astrbot/core/provider/sources/minimax_tts_api_source.py
+++ b/astrbot/core/provider/sources/minimax_tts_api_source.py
@@ -12,7 +12,17 @@ from ..entities import ProviderType
 from ..provider import TTSProvider
 from ..register import register_provider_adapter
 
-DEFAULT_TIMBER_WEIGHT = '[{"voice_id": "Chinese (Mandarin)_Warm_Girl", "weight": 1}]'
+DEFAULT_TIMBER_WEIGHT = [{"voice_id": "Chinese (Mandarin)_Warm_Girl", "weight": 1}]
+
+
+def _parse_timber_weight(timber_weight):
+    if not timber_weight:
+        return DEFAULT_TIMBER_WEIGHT.copy()
+    if isinstance(timber_weight, str):
+        if not timber_weight.strip():
+            return DEFAULT_TIMBER_WEIGHT.copy()
+        return json.loads(timber_weight)
+    return timber_weight
 
 
 @register_provider_adapter(
@@ -39,12 +49,9 @@ class ProviderMiniMaxTTSAPI(TTSProvider):
             "minimax-is-timber-weight",
             False,
         )
-        timber_weight = (
-            provider_config.get("minimax-timber-weight") or DEFAULT_TIMBER_WEIGHT
+        self.timber_weight: list[dict[str, str | int]] = _parse_timber_weight(
+            provider_config.get("minimax-timber-weight"),
         )
-        if isinstance(timber_weight, str) and not timber_weight.strip():
-            timber_weight = DEFAULT_TIMBER_WEIGHT
-        self.timber_weight: list[dict[str, str | int]] = json.loads(timber_weight)
 
         self.voice_setting: dict = {
             "speed": provider_config.get("minimax-voice-speed", 1.0),

--- a/tests/test_minimax_tts_api_source.py
+++ b/tests/test_minimax_tts_api_source.py
@@ -1,0 +1,50 @@
+from astrbot.core.provider.sources.minimax_tts_api_source import ProviderMiniMaxTTSAPI
+
+
+def _provider_config(**overrides):
+    config = {
+        "api_key": "test-key",
+        "model": "speech-02-hd",
+        "minimax-group-id": "group-id",
+    }
+    config.update(overrides)
+    return config
+
+
+def test_minimax_tts_empty_timber_weight_uses_default():
+    provider = ProviderMiniMaxTTSAPI(
+        _provider_config(**{"minimax-timber-weight": ""}),
+        {},
+    )
+
+    assert provider.timber_weight == [
+        {"voice_id": "Chinese (Mandarin)_Warm_Girl", "weight": 1},
+    ]
+
+
+def test_minimax_tts_whitespace_timber_weight_uses_default():
+    provider = ProviderMiniMaxTTSAPI(
+        _provider_config(**{"minimax-timber-weight": "  \n  "}),
+        {},
+    )
+
+    assert provider.timber_weight == [
+        {"voice_id": "Chinese (Mandarin)_Warm_Girl", "weight": 1},
+    ]
+
+
+def test_minimax_tts_keeps_custom_timber_weight():
+    provider = ProviderMiniMaxTTSAPI(
+        _provider_config(
+            **{
+                "minimax-timber-weight": (
+                    '[{"voice_id": "Chinese (Mandarin)_BashfulGirl", "weight": 3}]'
+                ),
+            },
+        ),
+        {},
+    )
+
+    assert provider.timber_weight == [
+        {"voice_id": "Chinese (Mandarin)_BashfulGirl", "weight": 3},
+    ]

--- a/tests/test_minimax_tts_api_source.py
+++ b/tests/test_minimax_tts_api_source.py
@@ -48,3 +48,20 @@ def test_minimax_tts_keeps_custom_timber_weight():
     assert provider.timber_weight == [
         {"voice_id": "Chinese (Mandarin)_BashfulGirl", "weight": 3},
     ]
+
+
+def test_minimax_tts_accepts_parsed_timber_weight():
+    provider = ProviderMiniMaxTTSAPI(
+        _provider_config(
+            **{
+                "minimax-timber-weight": [
+                    {"voice_id": "Chinese (Mandarin)_BashfulGirl", "weight": 3},
+                ],
+            },
+        ),
+        {},
+    )
+
+    assert provider.timber_weight == [
+        {"voice_id": "Chinese (Mandarin)_BashfulGirl", "weight": 3},
+    ]


### PR DESCRIPTION
﻿## Summary
- use the default MiniMax timber-weight config when the saved field is empty
- also handle whitespace-only values from the dashboard
- keep valid custom timber-weight JSON unchanged

Fixes #8100.

## To verify
- `python -m py_compile astrbot\core\provider\sources\minimax_tts_api_source.py tests\test_minimax_tts_api_source.py`
- `python -m pytest tests\test_minimax_tts_api_source.py -q`
- `python -m ruff check astrbot\core\provider\sources\minimax_tts_api_source.py tests\test_minimax_tts_api_source.py`
- `git diff --check`

## Summary by Sourcery

Handle MiniMax TTS timber weight configuration defaults more robustly when the saved value is empty or whitespace-only.

Bug Fixes:
- Fallback to the default MiniMax timber-weight configuration when the stored timber-weight value is empty or whitespace-only while preserving valid custom JSON values.

Tests:
- Add unit tests covering empty, whitespace-only, and custom timber-weight configurations for the MiniMax TTS provider.