### PR TITLE
fix: handle MiniMax TTS timber weight configuration more robustly to avoid crashes on invalid or empty values

### DIFF
--- a/astrbot/core/core_lifecycle.py
+++ b/astrbot/core/core_lifecycle.py
@@ -340,6 +340,12 @@ class AstrBotCoreLifecycle:
         self._load()
         logger.info("AstrBot started.")
 
+        # Allow the event loop a chance to start the background tasks before emitting the signal.
+        # Emit the startup completion signal to stdout for AstrBot Launcher.
+        # The Launcher monitors stdout for this signal to determine when the instance is ready.
+        # This must use print (stdout) rather than logger (stderr) to be detectable by the Launcher.
+        await asyncio.sleep(0)
+        print("AstrBot 启动完成", flush=True)
         # 执行启动完成事件钩子
         handlers = star_handlers_registry.get_handlers_by_event_type(
             EventType.OnAstrBotLoadedEvent,

--- a/astrbot/core/core_lifecycle.py
+++ b/astrbot/core/core_lifecycle.py
@@ -340,12 +340,6 @@ class AstrBotCoreLifecycle:
         self._load()
         logger.info("AstrBot started.")
 
-        # Allow the event loop a chance to start the background tasks before emitting the signal.
-        # Emit the startup completion signal to stdout for AstrBot Launcher.
-        # The Launcher monitors stdout for this signal to determine when the instance is ready.
-        # This must use print (stdout) rather than logger (stderr) to be detectable by the Launcher.
-        await asyncio.sleep(0)
-        print("AstrBot 启动完成", flush=True)
         # 执行启动完成事件钩子
         handlers = star_handlers_registry.get_handlers_by_event_type(
             EventType.OnAstrBotLoadedEvent,

--- a/astrbot/core/provider/sources/minimax_tts_api_source.py
+++ b/astrbot/core/provider/sources/minimax_tts_api_source.py
@@ -37,12 +37,16 @@ class ProviderMiniMaxTTSAPI(TTSProvider):
             "minimax-is-timber-weight",
             False,
         )
-        self.timber_weight: list[dict[str, str | int]] = json.loads(
-            provider_config.get(
-                "minimax-timber-weight",
-                '[{"voice_id": "Chinese (Mandarin)_Warm_Girl", "weight": 1}]',
-            ),
+        timber_weight_raw = provider_config.get(
+            "minimax-timber-weight",
+            '[{"voice_id": "Chinese (Mandarin)_Warm_Girl", "weight": 1}]',
         )
+        try:
+            self.timber_weight = json.loads(timber_weight_raw)
+        except json.JSONDecodeError:
+            self.timber_weight = [
+                {"voice_id": "Chinese (Mandarin)_Warm_Girl", "weight": 1}
+            ]
 
         self.voice_setting: dict = {
             "speed": provider_config.get("minimax-voice-speed", 1.0),

--- a/astrbot/core/provider/sources/minimax_tts_api_source.py
+++ b/astrbot/core/provider/sources/minimax_tts_api_source.py
@@ -37,16 +37,21 @@ class ProviderMiniMaxTTSAPI(TTSProvider):
             "minimax-is-timber-weight",
             False,
         )
-        timber_weight_raw = provider_config.get(
-            "minimax-timber-weight",
-            '[{"voice_id": "Chinese (Mandarin)_Warm_Girl", "weight": 1}]',
-        )
-        try:
-            self.timber_weight = json.loads(timber_weight_raw)
-        except json.JSONDecodeError:
-            self.timber_weight = [
-                {"voice_id": "Chinese (Mandarin)_Warm_Girl", "weight": 1}
-            ]
+        default_timber_weight = [
+            {"voice_id": "Chinese (Mandarin)_Warm_Girl", "weight": 1}
+        ]
+        raw_timber_weight = provider_config.get("minimax-timber-weight", "")
+        if not raw_timber_weight:
+            self.timber_weight = default_timber_weight
+        else:
+            try:
+                self.timber_weight = json.loads(raw_timber_weight)
+            except json.JSONDecodeError:
+                logger.warning(
+                    "MiniMax TTS 权重配置解析失败，将使用默认值。 raw_value: %s",
+                    raw_timber_weight,
+                )
+                self.timber_weight = default_timber_weight
 
         self.voice_setting: dict = {
             "speed": provider_config.get("minimax-voice-speed", 1.0),


### PR DESCRIPTION
### 问题描述
当用户保存 MiniMax TTS 配置时，`minimax-timber-weight` 字段可能为空字符串 `""`，此时 `json.loads("")` 会抛出 `JSONDecodeError`，导致 TTS 功能无法正常使用。

### 修复方案
1. 在解析 JSON 前增加空字符串判断
2. 增加 `try-except` 异常捕获，防止解析失败时程序崩溃
3. 解析失败时使用默认值作为兜底

### 修改内容
1. `minimax_tts_api_source.py`：提取 `default_timber_weight` 变量减少重复代码；添加 `logger.warning()` 记录 JSON 解析失败

### Related Issue
Fixes #8100

## Summary by Sourcery

Handle MiniMax TTS timber weight configuration more robustly to avoid crashes on invalid or empty values.

Bug Fixes:
- Prevent JSON parsing errors when `minimax-timber-weight` is an empty or invalid string by falling back to a default configuration.

Enhancements:
- Centralize the default timber weight configuration and log a warning when JSON parsing fails.

Tests:
- Add unit tests covering empty, whitespace, invalid, custom, and missing `minimax-timber-weight` configurations for MiniMax TTS.
