### PR TITLE
feat: 让 LLM 能自主创建和安装 Skill

### DIFF
--- a/astrbot/core/skills/skill_manager.py
+++ b/astrbot/core/skills/skill_manager.py
@@ -279,6 +279,17 @@ def build_skills_prompt(skills: list[SkillInfo]) -> str:
         "files that are directly linked from `SKILL.md`.\n"
         "7. **Failure handling** — If a skill cannot be applied, state the "
         "issue clearly and continue with the best alternative.\n"
+        "8. **Creating new skills** — You can create new skills on behalf "
+        "of the user:\n"
+        "   - Write a `SKILL.md` file (with YAML frontmatter containing "
+        "`name` and `description`) using `astrbot_file_write_tool` to "
+        "`data/skills/<skill_name>/SKILL.md`.\n"
+        "   - The system auto-discovers skills in `data/skills/` on every "
+        "request — no manual registration needed.\n"
+        "   - For packaging or backup, use `astrbot_create_skill_zip` to "
+        "create a distributable ZIP.\n"
+        "   - To install from a ZIP (e.g. received from another user), "
+        "use `astrbot_install_skill_from_zip`.\n"
     )
 
 

--- a/astrbot/core/skills/skill_manager.py
+++ b/astrbot/core/skills/skill_manager.py
@@ -94,6 +94,10 @@ def _normalize_skill_markdown_path(
     return canonical
 
 
+# Public alias so external modules don't depend on the private name.
+find_skill_markdown = _normalize_skill_markdown_path
+
+
 @dataclass
 class SkillInfo:
     name: str

--- a/astrbot/core/tools/computer_tools/__init__.py
+++ b/astrbot/core/tools/computer_tools/__init__.py
@@ -29,6 +29,7 @@ from .shipyard_neo import (
     RunBrowserSkillTool,
     SyncSkillReleaseTool,
 )
+from .skill_tools import CreateSkillZipTool, InstallSkillFromZipTool
 from .util import check_admin_permission, normalize_umo_for_workspace
 
 __all__ = [
@@ -36,12 +37,14 @@ __all__ = [
     "BrowserBatchExecTool",
     "BrowserExecTool",
     "CreateSkillCandidateTool",
+    "CreateSkillZipTool",
     "CreateSkillPayloadTool",
     "CuaKeyboardTypeTool",
     "CuaMouseClickTool",
     "CuaScreenshotTool",
     "EvaluateSkillCandidateTool",
     "ExecuteShellTool",
+    "InstallSkillFromZipTool",
     "FileDownloadTool",
     "FileEditTool",
     "FileReadTool",

--- a/astrbot/core/tools/computer_tools/skill_tools.py
+++ b/astrbot/core/tools/computer_tools/skill_tools.py
@@ -1,4 +1,4 @@
-﻿"""Skill self-authoring tools for local runtime.
+"""Skill self-authoring tools for local runtime.
 
 These tools allow the LLM to create, package, and install skills
 in local mode. The existing neo_skills.py tools only work in
@@ -61,6 +61,7 @@ def _resolve_temp_path(local_env: bool, filename: str) -> Path:
         return Path(get_astrbot_temp_path()) / filename
     except Exception:
         import tempfile
+
         return Path(tempfile.gettempdir()) / filename
 
 
@@ -147,8 +148,7 @@ class CreateSkillZipTool(FunctionTool):
 
             if zip_path.exists() and not overwrite:
                 return (
-                    "Error: Zip file already exists. "
-                    "Set overwrite=true to replace it."
+                    "Error: Zip file already exists. Set overwrite=true to replace it."
                 )
 
             # Pack the skill directory into a zip

--- a/astrbot/core/tools/computer_tools/skill_tools.py
+++ b/astrbot/core/tools/computer_tools/skill_tools.py
@@ -1,4 +1,4 @@
-"""Skill self-authoring tools for local runtime.
+﻿"""Skill self-authoring tools for local runtime.
 
 These tools allow the LLM to create, package, and install skills
 in local mode. The existing neo_skills.py tools only work in
@@ -12,7 +12,7 @@ Prerequisites for use:
 
 Alternatively, since ``SkillManager.list_skills()`` auto-discovers any
 directory containing SKILL.md under ``data/skills/`` on every request,
-steps 2-3 are optional for immediate local use — but are useful for
+steps 2-3 are optional for immediate local use 鈥?but are useful for
 distribution, backup, or reinstall workflows.
 """
 
@@ -44,18 +44,24 @@ def _resolve_temp_path(local_env: bool, filename: str) -> Path:
     """Return temp directory path, consistent across local/sandbox runtimes.
 
     Raises ValueError if *filename* would escape the temp directory
-    (e.g. contains ``..`` components).
+    (e.g. contains ``..`` components or is absolute).
     """
     # Reject directory-traversal attempts
     clean = Path(filename)
     if clean.is_absolute() or ".." in clean.parts:
         raise ValueError(f"Invalid filename: {filename!r}")
 
-    if local_env:
-        from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
+    from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
 
+    if local_env:
         return Path(get_astrbot_temp_path()) / filename
-    return Path(f"/tmp/{filename}")
+    # Sandbox runtime: use the same AstrBot temp path when available,
+    # falling back to /tmp only on POSIX systems.
+    try:
+        return Path(get_astrbot_temp_path()) / filename
+    except Exception:
+        import tempfile
+        return Path(tempfile.gettempdir()) / filename
 
 
 def _is_within(path: Path, root: Path) -> bool:
@@ -117,7 +123,7 @@ class CreateSkillZipTool(FunctionTool):
 
         try:
             from astrbot.core.skills.skill_manager import (
-                _normalize_skill_markdown_path,
+                find_skill_markdown,
             )
             from astrbot.core.utils.astrbot_path import (
                 get_astrbot_skills_path,
@@ -129,9 +135,9 @@ class CreateSkillZipTool(FunctionTool):
             if not skill_dir.exists() or not skill_dir.is_dir():
                 return f"Error: Skill directory not found: {skill_dir}"
 
-            skill_md = _normalize_skill_markdown_path(skill_dir)
+            skill_md = find_skill_markdown(skill_dir)
             if skill_md is None:
-                return f"Error: No SKILL.md found in {skill_dir}"
+                return "Error: No SKILL.md found in the skill directory."
 
             try:
                 zip_path = _resolve_temp_path(local_env, f"{skill_name}.zip")
@@ -141,7 +147,7 @@ class CreateSkillZipTool(FunctionTool):
 
             if zip_path.exists() and not overwrite:
                 return (
-                    f"Error: Zip file already exists at {zip_path}. "
+                    "Error: Zip file already exists. "
                     "Set overwrite=true to replace it."
                 )
 
@@ -153,11 +159,14 @@ class CreateSkillZipTool(FunctionTool):
                         arcname = Path(skill_name) / file_path.relative_to(skill_dir)
                         zf.write(str(file_path), str(arcname))
 
-            return f"Skill '{skill_name}' packaged successfully: {zip_path}"
+            return f"Skill '{skill_name}' packaged successfully."
 
-        except Exception as e:
+        except ValueError as e:
+            logger.warning("Validation error in create_skill_zip: %s", e)
+            return f"Error: {e}"
+        except Exception:
             logger.exception("Error creating skill zip")
-            return f"Error creating skill zip: {type(e).__name__}: {e}"
+            return "Error: Failed to create skill zip. Check logs for details."
 
 
 @builtin_tool(config=_COMPUTER_RUNTIME_TOOL_CONFIG)
@@ -236,12 +245,10 @@ class InstallSkillFromZipTool(FunctionTool):
                     Path(get_astrbot_skills_path()),
                 ]
                 if not local_env:
+                    # Sandbox runtime uses /tmp as its temp dir
                     allowed_roots.append(Path("/tmp"))
                 if not any(_is_within(resolved, root) for root in allowed_roots):
-                    return (
-                        "Error: Absolute zip_path must be inside the temp or "
-                        "skills directory for security."
-                    )
+                    return "Error: Absolute zip_path must be inside the temp or skills directory."
             else:
                 try:
                     resolved = _resolve_temp_path(local_env, zip_path)
@@ -249,7 +256,7 @@ class InstallSkillFromZipTool(FunctionTool):
                     return f"Error: {ve}"
 
             if not resolved.exists():
-                return f"Error: ZIP file not found: {resolved}"
+                return "Error: ZIP file not found."
 
             skill_manager = SkillManager()
             installed = skill_manager.install_skill_from_zip(
@@ -260,6 +267,9 @@ class InstallSkillFromZipTool(FunctionTool):
 
             return f"Successfully installed skill(s): {installed}"
 
-        except Exception as e:
+        except ValueError as e:
+            logger.warning("Validation error in install_skill_from_zip: %s", e)
+            return f"Error: {e}"
+        except Exception:
             logger.exception("Error installing skill from zip")
-            return f"Error installing skill from zip: {type(e).__name__}: {e}"
+            return "Error: Failed to install skill from zip. Check logs for details."

--- a/astrbot/core/tools/computer_tools/skill_tools.py
+++ b/astrbot/core/tools/computer_tools/skill_tools.py
@@ -12,7 +12,7 @@ Prerequisites for use:
 
 Alternatively, since ``SkillManager.list_skills()`` auto-discovers any
 directory containing SKILL.md under ``data/skills/`` on every request,
-steps 2-3 are optional for immediate local use 鈥?but are useful for
+steps 2-3 are optional for immediate local use —but are useful for
 distribution, backup, or reinstall workflows.
 """
 
@@ -159,7 +159,7 @@ class CreateSkillZipTool(FunctionTool):
                         arcname = Path(skill_name) / file_path.relative_to(skill_dir)
                         zf.write(str(file_path), str(arcname))
 
-            return f"Skill '{skill_name}' packaged successfully."
+            return f"Skill '{skill_name}' packaged successfully. Zip file: {zip_path}"
 
         except ValueError as e:
             logger.warning("Validation error in create_skill_zip: %s", e)

--- a/astrbot/core/tools/computer_tools/skill_tools.py
+++ b/astrbot/core/tools/computer_tools/skill_tools.py
@@ -1,0 +1,265 @@
+"""Skill self-authoring tools for local runtime.
+
+These tools allow the LLM to create, package, and install skills
+in local mode. The existing neo_skills.py tools only work in
+shipyard_neo sandbox mode; these tools bridge the gap for local runtime.
+
+Prerequisites for use:
+1. The LLM writes SKILL.md (and optional supporting files) to
+   ``data/skills/<skill_name>/`` using ``astrbot_file_write_tool``.
+2. The LLM then calls ``create_skill_zip`` to package the directory.
+3. The LLM calls ``install_skill_from_zip`` to register the skill.
+
+Alternatively, since ``SkillManager.list_skills()`` auto-discovers any
+directory containing SKILL.md under ``data/skills/`` on every request,
+steps 2-3 are optional for immediate local use — but are useful for
+distribution, backup, or reinstall workflows.
+"""
+
+import logging
+import os
+import re
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from astrbot.api import FunctionTool
+from astrbot.core.agent.run_context import ContextWrapper
+from astrbot.core.agent.tool import ToolExecResult
+from astrbot.core.astr_agent_context import AstrAgentContext
+
+from ..registry import builtin_tool
+from .util import check_admin_permission, is_local_runtime
+
+logger = logging.getLogger(__name__)
+
+_COMPUTER_RUNTIME_TOOL_CONFIG = {
+    "provider_settings.computer_use_runtime": ("local", "sandbox"),
+}
+
+_SKILL_NAME_RE = re.compile(r"^[\w.\-]+$")
+
+
+def _resolve_temp_path(local_env: bool, filename: str) -> Path:
+    """Return temp directory path, consistent across local/sandbox runtimes.
+
+    Raises ValueError if *filename* would escape the temp directory
+    (e.g. contains ``..`` components).
+    """
+    # Reject directory-traversal attempts
+    clean = Path(filename)
+    if clean.is_absolute() or ".." in clean.parts:
+        raise ValueError(f"Invalid filename: {filename!r}")
+
+    if local_env:
+        from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
+
+        return Path(get_astrbot_temp_path()) / filename
+    return Path(f"/tmp/{filename}")
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    """Return True if *path* is inside *root* (after resolving both)."""
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+@builtin_tool(config=_COMPUTER_RUNTIME_TOOL_CONFIG)
+@dataclass
+class CreateSkillZipTool(FunctionTool):
+    """Package a skill directory into a ZIP archive.
+
+    The skill directory must already exist under ``data/skills/<skill_name>/``
+    and contain at least a ``SKILL.md`` file.  The resulting ZIP is written
+    to the temp directory and the path is returned so that
+    ``install_skill_from_zip`` can consume it.
+    """
+
+    name: str = "astrbot_create_skill_zip"
+    description: str = (
+        "Package an existing skill directory into a ZIP archive for installation "
+        "or distribution. The skill must already have a SKILL.md file in its directory."
+    )
+    parameters: dict = field(
+        default_factory=lambda: {
+            "type": "object",
+            "properties": {
+                "skill_name": {
+                    "type": "string",
+                    "description": "Name of the skill directory under data/skills/ to package.",
+                },
+                "overwrite": {
+                    "type": "boolean",
+                    "description": "Overwrite existing zip file if it exists. Defaults to false.",
+                    "default": False,
+                },
+            },
+            "required": ["skill_name"],
+        }
+    )
+
+    async def call(
+        self,
+        context: ContextWrapper[AstrAgentContext],
+        skill_name: str,
+        overwrite: bool = False,
+    ) -> ToolExecResult:
+        if err := check_admin_permission(context, "Skill zip creation"):
+            return err
+
+        if not skill_name or not _SKILL_NAME_RE.fullmatch(skill_name):
+            return "Error: Invalid skill name. Use only alphanumeric characters, dots, hyphens, and underscores."
+
+        local_env = is_local_runtime(context)
+
+        try:
+            from astrbot.core.skills.skill_manager import (
+                _normalize_skill_markdown_path,
+            )
+            from astrbot.core.utils.astrbot_path import (
+                get_astrbot_skills_path,
+            )
+
+            skills_root = get_astrbot_skills_path()
+            skill_dir = Path(skills_root) / skill_name
+
+            if not skill_dir.exists() or not skill_dir.is_dir():
+                return f"Error: Skill directory not found: {skill_dir}"
+
+            skill_md = _normalize_skill_markdown_path(skill_dir)
+            if skill_md is None:
+                return f"Error: No SKILL.md found in {skill_dir}"
+
+            try:
+                zip_path = _resolve_temp_path(local_env, f"{skill_name}.zip")
+            except ValueError as ve:
+                return f"Error: {ve}"
+            zip_path.parent.mkdir(parents=True, exist_ok=True)
+
+            if zip_path.exists() and not overwrite:
+                return (
+                    f"Error: Zip file already exists at {zip_path}. "
+                    "Set overwrite=true to replace it."
+                )
+
+            # Pack the skill directory into a zip
+            with zipfile.ZipFile(str(zip_path), "w", zipfile.ZIP_DEFLATED) as zf:
+                for root, _dirs, files in os.walk(skill_dir):
+                    for file in files:
+                        file_path = Path(root) / file
+                        arcname = Path(skill_name) / file_path.relative_to(skill_dir)
+                        zf.write(str(file_path), str(arcname))
+
+            return f"Skill '{skill_name}' packaged successfully: {zip_path}"
+
+        except Exception as e:
+            logger.exception("Error creating skill zip")
+            return f"Error creating skill zip: {type(e).__name__}: {e}"
+
+
+@builtin_tool(config=_COMPUTER_RUNTIME_TOOL_CONFIG)
+@dataclass
+class InstallSkillFromZipTool(FunctionTool):
+    """Install or update a skill from a ZIP archive.
+
+    Wraps ``SkillManager.install_skill_from_zip()`` so the LLM can
+    install a skill it just packaged (or received from a user).
+    The ZIP must contain a ``SKILL.md`` at root or inside a top-level
+    directory.
+    """
+
+    name: str = "astrbot_install_skill_from_zip"
+    description: str = (
+        "Install or update a skill from a ZIP file. The ZIP should contain "
+        "a SKILL.md file either at the root or inside a single top-level directory."
+    )
+    parameters: dict = field(
+        default_factory=lambda: {
+            "type": "object",
+            "properties": {
+                "zip_path": {
+                    "type": "string",
+                    "description": (
+                        "Path to the ZIP file. If relative, resolves under "
+                        "the temp directory."
+                    ),
+                },
+                "skill_name": {
+                    "type": "string",
+                    "description": (
+                        "Optional name override for the installed skill. "
+                        "If omitted, the name is derived from the zip contents."
+                    ),
+                },
+                "overwrite": {
+                    "type": "boolean",
+                    "description": "Replace existing skill if it exists. Defaults to true.",
+                    "default": True,
+                },
+            },
+            "required": ["zip_path"],
+        }
+    )
+
+    async def call(
+        self,
+        context: ContextWrapper[AstrAgentContext],
+        zip_path: str,
+        skill_name: str | None = None,
+        overwrite: bool = True,
+    ) -> ToolExecResult:
+        if err := check_admin_permission(context, "Skill installation"):
+            return err
+
+        local_env = is_local_runtime(context)
+
+        if skill_name and not _SKILL_NAME_RE.fullmatch(skill_name):
+            return "Error: Invalid skill name. Use only alphanumeric characters, dots, hyphens, and underscores."
+
+        try:
+            from astrbot.core.skills.skill_manager import SkillManager
+
+            # Resolve relative paths under temp dir; reject absolute paths
+            # that escape allowed directories.
+            if Path(zip_path).is_absolute():
+                resolved = Path(zip_path)
+                from astrbot.core.utils.astrbot_path import (
+                    get_astrbot_skills_path,
+                    get_astrbot_temp_path,
+                )
+
+                allowed_roots = [
+                    Path(get_astrbot_temp_path()),
+                    Path(get_astrbot_skills_path()),
+                ]
+                if not local_env:
+                    allowed_roots.append(Path("/tmp"))
+                if not any(_is_within(resolved, root) for root in allowed_roots):
+                    return (
+                        "Error: Absolute zip_path must be inside the temp or "
+                        "skills directory for security."
+                    )
+            else:
+                try:
+                    resolved = _resolve_temp_path(local_env, zip_path)
+                except ValueError as ve:
+                    return f"Error: {ve}"
+
+            if not resolved.exists():
+                return f"Error: ZIP file not found: {resolved}"
+
+            skill_manager = SkillManager()
+            installed = skill_manager.install_skill_from_zip(
+                zip_path=str(resolved),
+                overwrite=overwrite,
+                skill_name_hint=skill_name,
+            )
+
+            return f"Successfully installed skill(s): {installed}"
+
+        except Exception as e:
+            logger.exception("Error installing skill from zip")
+            return f"Error installing skill from zip: {type(e).__name__}: {e}"

--- a/astrbot/core/tools/computer_tools/skill_tools.py
+++ b/astrbot/core/tools/computer_tools/skill_tools.py
@@ -69,11 +69,7 @@ def _resolve_temp_path(local_env: bool, filename: str) -> Path:
 
 def _is_within(path: Path, root: Path) -> bool:
     """Return True if *path* is inside *root* (after resolving both)."""
-    try:
-        path.resolve().relative_to(root.resolve())
-        return True
-    except ValueError:
-        return False
+    return path.resolve().is_relative_to(root.resolve())
 
 
 @builtin_tool(config=_COMPUTER_RUNTIME_TOOL_CONFIG)

--- a/astrbot/core/tools/computer_tools/skill_tools.py
+++ b/astrbot/core/tools/computer_tools/skill_tools.py
@@ -16,6 +16,8 @@ steps 2-3 are optional for immediate local use —but are useful for
 distribution, backup, or reinstall workflows.
 """
 
+__all__ = ["CreateSkillZipTool", "InstallSkillFromZipTool"]
+
 import logging
 import os
 import re

--- a/tests/test_skill_self_authoring_tools.py
+++ b/tests/test_skill_self_authoring_tools.py
@@ -1,0 +1,231 @@
+﻿"""Tests for skill self-authoring tools (CreateSkillZipTool, InstallSkillFromZipTool)."""
+from __future__ import annotations
+
+import asyncio
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from astrbot.core.agent.run_context import ContextWrapper
+from astrbot.core.tools.computer_tools.skill_tools import (
+    CreateSkillZipTool,
+    InstallSkillFromZipTool,
+    _resolve_temp_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_context(role: str = "admin", runtime: str = "local") -> ContextWrapper:
+    """Build a minimal ContextWrapper that satisfies check_admin_permission and
+    is_local_runtime without requiring a real AstrBot instance."""
+    provider_settings = {
+        "computer_use_runtime": runtime,
+        "computer_use_require_admin": True,
+    }
+    cfg = {"provider_settings": provider_settings}
+    event = SimpleNamespace(role=role, unified_msg_origin="test_umo", get_sender_id=lambda: "test_user_id")
+    inner_context = SimpleNamespace(
+        get_config=lambda umo: cfg,
+        event=event,
+    )
+    outer_context = SimpleNamespace(context=inner_context, event=event)
+    return SimpleNamespace(context=outer_context)  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# _resolve_temp_path
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_temp_path_rejects_absolute():
+    # Use a platform-appropriate absolute path
+    import os
+    abs_path = "C:/Windows/System32/evil.zip" if os.name == "nt" else "/etc/passwd"
+    with pytest.raises(ValueError, match="Invalid filename"):
+        _resolve_temp_path(True, abs_path)
+
+
+def test_resolve_temp_path_rejects_dotdot():
+    with pytest.raises(ValueError, match="Invalid filename"):
+        _resolve_temp_path(True, "../escape.zip")
+
+
+def test_resolve_temp_path_local(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "astrbot.core.tools.computer_tools.skill_tools.get_astrbot_temp_path",
+        lambda: str(tmp_path),
+        raising=False,
+    )
+    # Patch the import inside the function
+    with patch(
+        "astrbot.core.utils.astrbot_path.get_astrbot_temp_path",
+        return_value=str(tmp_path),
+    ):
+        result = _resolve_temp_path(True, "my_skill.zip")
+    assert result == tmp_path / "my_skill.zip"
+
+
+# ---------------------------------------------------------------------------
+# CreateSkillZipTool
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSkillZipTool:
+    def test_invalid_skill_name_rejected(self):
+        ctx = _make_context()
+        tool = CreateSkillZipTool()
+        result = asyncio.run(tool.call(ctx, skill_name="../evil"))
+        assert "Invalid skill name" in result
+
+    def test_missing_skill_dir_returns_error(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "astrbot.core.utils.astrbot_path.get_astrbot_skills_path",
+            lambda: str(tmp_path / "skills"),
+        )
+        ctx = _make_context()
+        tool = CreateSkillZipTool()
+        result = asyncio.run(tool.call(ctx, skill_name="nonexistent"))
+        assert "not found" in result.lower()
+
+    def test_missing_skill_md_returns_error(self, tmp_path, monkeypatch):
+        skills_root = tmp_path / "skills"
+        skill_dir = skills_root / "myskill"
+        skill_dir.mkdir(parents=True)
+        # No SKILL.md
+
+        monkeypatch.setattr(
+            "astrbot.core.utils.astrbot_path.get_astrbot_skills_path",
+            lambda: str(skills_root),
+        )
+        monkeypatch.setattr(
+            "astrbot.core.utils.astrbot_path.get_astrbot_temp_path",
+            lambda: str(tmp_path / "temp"),
+        )
+        ctx = _make_context()
+        tool = CreateSkillZipTool()
+        result = asyncio.run(tool.call(ctx, skill_name="myskill"))
+        assert "SKILL.md" in result
+
+    def test_happy_path_creates_zip(self, tmp_path, monkeypatch):
+        skills_root = tmp_path / "skills"
+        skill_dir = skills_root / "myskill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("name: myskill\ndescription: test\n")
+        (skill_dir / "helper.py").write_text("# helper\n")
+
+        temp_root = tmp_path / "temp"
+        temp_root.mkdir()
+
+        monkeypatch.setattr(
+            "astrbot.core.utils.astrbot_path.get_astrbot_skills_path",
+            lambda: str(skills_root),
+        )
+        monkeypatch.setattr(
+            "astrbot.core.utils.astrbot_path.get_astrbot_temp_path",
+            lambda: str(temp_root),
+        )
+
+        ctx = _make_context()
+        tool = CreateSkillZipTool()
+        result = asyncio.run(tool.call(ctx, skill_name="myskill"))
+
+        assert "packaged successfully" in result
+        zip_file = temp_root / "myskill.zip"
+        assert zip_file.exists()
+        with zipfile.ZipFile(zip_file) as zf:
+            names = zf.namelist()
+        assert any("SKILL.md" in n for n in names)
+        assert any("helper.py" in n for n in names)
+
+    def test_overwrite_false_blocks_existing_zip(self, tmp_path, monkeypatch):
+        skills_root = tmp_path / "skills"
+        skill_dir = skills_root / "myskill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("name: myskill\ndescription: test\n")
+
+        temp_root = tmp_path / "temp"
+        temp_root.mkdir()
+        (temp_root / "myskill.zip").write_bytes(b"existing")
+
+        monkeypatch.setattr(
+            "astrbot.core.utils.astrbot_path.get_astrbot_skills_path",
+            lambda: str(skills_root),
+        )
+        monkeypatch.setattr(
+            "astrbot.core.utils.astrbot_path.get_astrbot_temp_path",
+            lambda: str(temp_root),
+        )
+
+        ctx = _make_context()
+        tool = CreateSkillZipTool()
+        result = asyncio.run(tool.call(ctx, skill_name="myskill", overwrite=False))
+        assert "already exists" in result.lower()
+
+    def test_non_admin_blocked(self):
+        ctx = _make_context(role="member")
+        tool = CreateSkillZipTool()
+        result = asyncio.run(tool.call(ctx, skill_name="myskill"))
+        assert "Permission denied" in result or result.startswith("error:")
+
+
+# ---------------------------------------------------------------------------
+# InstallSkillFromZipTool
+# ---------------------------------------------------------------------------
+
+
+class TestInstallSkillFromZipTool:
+    def test_invalid_skill_name_override_rejected(self):
+        ctx = _make_context()
+        tool = InstallSkillFromZipTool()
+        result = asyncio.run(
+            tool.call(ctx, zip_path="myskill.zip", skill_name="../evil")
+        )
+        assert "Invalid skill name" in result
+
+    def test_missing_zip_returns_error(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "astrbot.core.utils.astrbot_path.get_astrbot_temp_path",
+            lambda: str(tmp_path),
+        )
+        ctx = _make_context()
+        tool = InstallSkillFromZipTool()
+        result = asyncio.run(tool.call(ctx, zip_path="nonexistent.zip"))
+        assert "not found" in result.lower()
+
+    def test_happy_path_installs_skill(self, tmp_path, monkeypatch):
+        # Create a valid skill zip
+        skill_zip = tmp_path / "myskill.zip"
+        with zipfile.ZipFile(skill_zip, "w") as zf:
+            zf.writestr("myskill/SKILL.md", "name: myskill\ndescription: test\n")
+
+        monkeypatch.setattr(
+            "astrbot.core.utils.astrbot_path.get_astrbot_temp_path",
+            lambda: str(tmp_path),
+        )
+
+        mock_manager = MagicMock()
+        mock_manager.install_skill_from_zip.return_value = "myskill"
+
+        with patch(
+            "astrbot.core.skills.skill_manager.SkillManager",
+            return_value=mock_manager,
+        ):
+            ctx = _make_context()
+            tool = InstallSkillFromZipTool()
+            result = asyncio.run(tool.call(ctx, zip_path="myskill.zip"))
+
+        assert "Successfully installed" in result
+        mock_manager.install_skill_from_zip.assert_called_once()
+
+    def test_non_admin_blocked(self):
+        ctx = _make_context(role="member")
+        tool = InstallSkillFromZipTool()
+        result = asyncio.run(tool.call(ctx, zip_path="myskill.zip"))
+        assert "Permission denied" in result or result.startswith("error:")

--- a/tests/test_skill_self_authoring_tools.py
+++ b/tests/test_skill_self_authoring_tools.py
@@ -1,9 +1,9 @@
-﻿"""Tests for skill self-authoring tools (CreateSkillZipTool, InstallSkillFromZipTool)."""
+"""Tests for skill self-authoring tools (CreateSkillZipTool, InstallSkillFromZipTool)."""
+
 from __future__ import annotations
 
 import asyncio
 import zipfile
-from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -15,7 +15,6 @@ from astrbot.core.tools.computer_tools.skill_tools import (
     InstallSkillFromZipTool,
     _resolve_temp_path,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -30,7 +29,9 @@ def _make_context(role: str = "admin", runtime: str = "local") -> ContextWrapper
         "computer_use_require_admin": True,
     }
     cfg = {"provider_settings": provider_settings}
-    event = SimpleNamespace(role=role, unified_msg_origin="test_umo", get_sender_id=lambda: "test_user_id")
+    event = SimpleNamespace(
+        role=role, unified_msg_origin="test_umo", get_sender_id=lambda: "test_user_id"
+    )
     inner_context = SimpleNamespace(
         get_config=lambda umo: cfg,
         event=event,
@@ -47,6 +48,7 @@ def _make_context(role: str = "admin", runtime: str = "local") -> ContextWrapper
 def test_resolve_temp_path_rejects_absolute():
     # Use a platform-appropriate absolute path
     import os
+
     abs_path = "C:/Windows/System32/evil.zip" if os.name == "nt" else "/etc/passwd"
     with pytest.raises(ValueError, match="Invalid filename"):
         _resolve_temp_path(True, abs_path)


### PR DESCRIPTION
关联 #7657

## 改动

- 新增 `skill_tools.py`：`CreateSkillZipTool` 和 `InstallSkillFromZipTool` 两个 FunctionTool
- 更新 `__init__.py`：导出新工具
- 更新 `build_skills_prompt`：加了创建 Skill 的规则说明

## 背景

AstrBot 的 Neo Skills 工具链只在 shipyard_neo 沙箱模式可用，local 模式下 LLM 无法自主创建 Skill。现有 `SkillManager.install_skill_from_zip()` 方法存在但未暴露为 FunctionTool。

## 工作流

LLM 用 `astrbot_file_write_tool` 写 SKILL.md → `create_skill_zip` 打包 → `install_skill_from_zip` 安装。或者直接写文件到 `data/skills/{name}/` 即可自动发现。

## Summary by Sourcery

Enable LLMs running in local mode to self-author, package, and install skills via new computer tools and updated skill usage guidelines.

New Features:
- Expose CreateSkillZipTool and InstallSkillFromZipTool as computer tools so LLMs can package and install skills from ZIP archives in local runtime.
- Allow external callers to locate SKILL.md via a public find_skill_markdown alias.

Enhancements:
- Extend the skills prompt with instructions for creating new skills, packaging them, and installing from ZIPs to support autonomous skill authoring workflows.

Tests:
- Add comprehensive unit tests for the new skill self-authoring tools, including temp-path validation, permission handling, and success/error scenarios.