### PR TITLE
fix: 降低 LLM 上下文调用成本风险

### DIFF
--- a/astrbot/builtin_stars/astrbot/long_term_memory.py
+++ b/astrbot/builtin_stars/astrbot/long_term_memory.py
@@ -9,6 +9,7 @@ from astrbot.api.event import AstrMessageEvent
 from astrbot.api.message_components import At, Image, Plain
 from astrbot.api.platform import MessageType
 from astrbot.api.provider import LLMResponse, Provider, ProviderRequest
+from astrbot.core.agent.message import TextPart
 from astrbot.core.astrbot_config_mgr import AstrBotConfigManager
 
 """
@@ -17,6 +18,9 @@ from astrbot.core.astrbot_config_mgr import AstrBotConfigManager
 
 
 class LongTermMemory:
+    DEFAULT_MAX_GROUP_MESSAGES = 50
+    DEFAULT_GROUP_ICL_TOKEN_BUDGET = 4000
+
     def __init__(self, acm: AstrBotConfigManager, context: star.Context) -> None:
         self.acm = acm
         self.context = context
@@ -29,7 +33,19 @@ class LongTermMemory:
             max_cnt = int(cfg["provider_ltm_settings"]["group_message_max_cnt"])
         except BaseException as e:
             logger.error(e)
-            max_cnt = 300
+            max_cnt = self.DEFAULT_MAX_GROUP_MESSAGES
+        max_cnt = max(1, max_cnt)
+        try:
+            group_icl_token_budget = int(
+                cfg["provider_ltm_settings"].get(
+                    "group_icl_token_budget",
+                    self.DEFAULT_GROUP_ICL_TOKEN_BUDGET,
+                )
+            )
+        except BaseException as e:
+            logger.error(e)
+            group_icl_token_budget = self.DEFAULT_GROUP_ICL_TOKEN_BUDGET
+        group_icl_token_budget = max(1, group_icl_token_budget)
         image_caption_prompt = cfg["provider_settings"]["image_caption_prompt"]
         image_caption_provider_id = cfg["provider_ltm_settings"].get(
             "image_caption_provider_id"
@@ -45,6 +61,7 @@ class LongTermMemory:
         ar_whitelist = active_reply.get("whitelist", [])
         ret = {
             "max_cnt": max_cnt,
+            "group_icl_token_budget": group_icl_token_budget,
             "image_caption": image_caption,
             "image_caption_prompt": image_caption_prompt,
             "image_caption_provider_id": image_caption_provider_id,
@@ -55,6 +72,68 @@ class LongTermMemory:
             "ar_whitelist": ar_whitelist,
         }
         return ret
+
+    @staticmethod
+    def _estimate_text_tokens(text: str) -> int:
+        chinese_count = len([c for c in text if "\u4e00" <= c <= "\u9fff"])
+        other_count = len(text) - chinese_count
+        return int(chinese_count * 0.6 + other_count * 0.3)
+
+    def _trim_text_to_token_budget(self, text: str, token_budget: int) -> str:
+        marker = "[truncated]\n"
+        marker_tokens = self._estimate_text_tokens(marker)
+        if self._estimate_text_tokens(text) <= token_budget:
+            return text
+        if token_budget <= marker_tokens:
+            return marker.strip()
+
+        low = 0
+        high = len(text)
+        best = ""
+        target_budget = token_budget - marker_tokens
+        while low <= high:
+            mid = (low + high) // 2
+            candidate = text[-mid:] if mid else ""
+            if self._estimate_text_tokens(candidate) <= target_budget:
+                best = candidate
+                low = mid + 1
+            else:
+                high = mid - 1
+        return f"{marker}{best}"
+
+    def _build_chats_context(
+        self,
+        chats: list[str],
+        token_budget: int,
+    ) -> tuple[str, int, int]:
+        separator = "\n---\n"
+        separator_tokens = self._estimate_text_tokens(separator)
+        selected: list[str] = []
+        total_tokens = 0
+
+        for chat in reversed(chats):
+            chat_tokens = self._estimate_text_tokens(chat)
+            extra_tokens = chat_tokens + (separator_tokens if selected else 0)
+            if selected and total_tokens + extra_tokens > token_budget:
+                break
+            if not selected and chat_tokens > token_budget:
+                trimmed = self._trim_text_to_token_budget(chat, token_budget)
+                return trimmed, len(chats) - 1, self._estimate_text_tokens(trimmed)
+            selected.append(chat)
+            total_tokens += extra_tokens
+
+        selected.reverse()
+        omitted = len(chats) - len(selected)
+        chats_str = separator.join(selected)
+        if omitted > 0:
+            omitted_notice = (
+                f"[{omitted} earlier group messages omitted due to token budget]"
+            )
+            chats_str = f"{omitted_notice}{separator}{chats_str}"
+            total_tokens += (
+                self._estimate_text_tokens(omitted_notice) + separator_tokens
+            )
+        return chats_str, omitted, total_tokens
 
     async def remove_session(self, event: AstrMessageEvent) -> int:
         cnt = 0
@@ -153,9 +232,19 @@ class LongTermMemory:
         if event.unified_msg_origin not in self.session_chats:
             return
 
-        chats_str = "\n---\n".join(self.session_chats[event.unified_msg_origin])
-
         cfg = self.cfg(event)
+        chats_str, omitted, estimated_tokens = self._build_chats_context(
+            self.session_chats[event.unified_msg_origin],
+            cfg["group_icl_token_budget"],
+        )
+        if omitted > 0:
+            logger.warning(
+                "Group ICL context truncated by token budget. umo=%s, omitted=%s, estimated_tokens=%s, budget=%s",
+                event.unified_msg_origin,
+                omitted,
+                estimated_tokens,
+                cfg["group_icl_token_budget"],
+            )
         if cfg["enable_active_reply"]:
             prompt = req.prompt
             req.prompt = (
@@ -167,9 +256,18 @@ class LongTermMemory:
             req.contexts = []  # 清空上下文，当使用了主动回复，所有聊天记录都在一个prompt中。
         else:
             req.system_prompt += (
-                "You are now in a chatroom. The chat history is as follows: \n"
+                "\nYou may receive recent group chat context in the current user message. "
+                "Use it only as background for this request.\n"
             )
-            req.system_prompt += chats_str
+            req.extra_user_content_parts.append(
+                TextPart(
+                    text=(
+                        "[Group Chat Context]\n"
+                        "Recent group chat messages, newest messages are kept when truncated:\n"
+                        f"{chats_str}"
+                    )
+                )
+            )
 
     async def after_req_llm(
         self, event: AstrMessageEvent, llm_resp: LLMResponse

--- a/astrbot/builtin_stars/astrbot/long_term_memory.py
+++ b/astrbot/builtin_stars/astrbot/long_term_memory.py
@@ -99,7 +99,10 @@ class LongTermMemory:
                 low = mid + 1
             else:
                 high = mid - 1
-        return f"{marker}{best}"
+        result = f"{marker}{best}"
+        while result and self._estimate_text_tokens(result) > token_budget:
+            result = result[:-1]
+        return result
 
     def _build_chats_context(
         self,
@@ -133,6 +136,9 @@ class LongTermMemory:
             total_tokens += (
                 self._estimate_text_tokens(omitted_notice) + separator_tokens
             )
+        if total_tokens > token_budget:
+            chats_str = self._trim_text_to_token_budget(chats_str, token_budget)
+            total_tokens = self._estimate_text_tokens(chats_str)
         return chats_str, omitted, total_tokens
 
     async def remove_session(self, event: AstrMessageEvent) -> int:
@@ -204,6 +210,11 @@ class LongTermMemory:
                     parts.append(f" {comp.text}")
                 elif isinstance(comp, Image):
                     if cfg["image_caption"]:
+                        logger.warning(
+                            "Group ICL image caption is enabled. Each group image may trigger an extra multimodal request. umo=%s, provider=%s",
+                            event.unified_msg_origin,
+                            cfg["image_caption_provider_id"],
+                        )
                         try:
                             url = comp.url if comp.url else comp.file
                             if not url:
@@ -255,18 +266,16 @@ class LongTermMemory:
             )
             req.contexts = []  # 清空上下文，当使用了主动回复，所有聊天记录都在一个prompt中。
         else:
-            req.system_prompt += (
-                "\nYou may receive recent group chat context in the current user message. "
-                "Use it only as background for this request.\n"
-            )
             req.extra_user_content_parts.append(
                 TextPart(
                     text=(
+                        "Use the following recent group chat context only as background "
+                        "for this request.\n"
                         "[Group Chat Context]\n"
                         "Recent group chat messages, newest messages are kept when truncated:\n"
                         f"{chats_str}"
                     )
-                )
+                ).mark_as_temp()
             )
 
     async def after_req_llm(

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -110,6 +110,8 @@ ToolExecutorResultT = T.TypeVar("ToolExecutorResultT")
 class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
     TOOL_RESULT_MAX_ESTIMATED_TOKENS = 27_500
     TOOL_RESULT_PREVIEW_MAX_ESTIMATED_TOKENS = 7000
+    REQUEST_WARN_ESTIMATED_INPUT_TOKENS = 16_000
+    REQUEST_WARN_IMAGE_COUNT = 1
     EMPTY_OUTPUT_RETRY_ATTEMPTS = 3
     EMPTY_OUTPUT_RETRY_WAIT_MIN_S = 1
     EMPTY_OUTPUT_RETRY_WAIT_MAX_S = 4
@@ -175,6 +177,43 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
         """Read persona-level custom error message from event extras when available."""
         event = getattr(self.run_context.context, "event", None)
         return extract_persona_custom_error_message_from_event(event)
+
+    @staticmethod
+    def _count_image_parts(messages: list[Message]) -> int:
+        count = 0
+        for message in messages:
+            if isinstance(message.content, list):
+                count += sum(
+                    1 for part in message.content if isinstance(part, ImageURLPart)
+                )
+        return count
+
+    def _log_request_cost_preflight(self) -> None:
+        estimated_input_tokens = EstimateTokenCounter().count_tokens(
+            self.run_context.messages
+        )
+        image_count = self._count_image_parts(self.run_context.messages)
+        logger.debug(
+            "LLM request preflight. provider=%s, model=%s, estimated_input_tokens=%s, image_count=%s",
+            self.provider.provider_config.get("id", ""),
+            self.provider.get_model(),
+            estimated_input_tokens,
+            image_count,
+        )
+        if estimated_input_tokens >= self.REQUEST_WARN_ESTIMATED_INPUT_TOKENS:
+            logger.warning(
+                "LLM request has high estimated input tokens. provider=%s, model=%s, estimated_input_tokens=%s",
+                self.provider.provider_config.get("id", ""),
+                self.provider.get_model(),
+                estimated_input_tokens,
+            )
+        if image_count > self.REQUEST_WARN_IMAGE_COUNT:
+            logger.warning(
+                "LLM request contains multiple images. provider=%s, model=%s, image_count=%s",
+                self.provider.provider_config.get("id", ""),
+                self.provider.get_model(),
+                image_count,
+            )
 
     async def _complete_with_assistant_response(self, llm_resp: LLMResponse) -> None:
         """Finalize the current step as a plain assistant response with no tool calls."""
@@ -711,6 +750,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             self.run_context.messages, trusted_token_usage=token_usage
         )
         self._simple_print_message_role("[AftCompact]")
+        self._log_request_cost_preflight()
 
         async for llm_response in self._iter_llm_responses_with_fallback():
             if llm_response.is_chunk:

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -152,10 +152,10 @@ class MainAgentBuildConfig:
     """The number of most recent turns to keep during llm_compress strategy."""
     llm_compress_provider_id: str = ""
     """The provider ID for the LLM used in context compression."""
-    max_context_length: int = -1
+    max_context_length: int = 30
     """The maximum number of turns to keep in context. -1 means no limit.
     This enforce max turns before compression"""
-    dequeue_context_length: int = 1
+    dequeue_context_length: int = 10
     """The number of oldest turns to remove when context length limit is reached."""
     fallback_max_context_tokens: int = 128000
     """Fallback max context tokens. When max_context_tokens is 0 and the model is not in LLM_METADATAS, use this value."""

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -130,8 +130,8 @@ DEFAULT_CONFIG = {
         ),
         "llm_compress_keep_recent": 6,
         "llm_compress_provider_id": "",
-        "max_context_length": -1,
-        "dequeue_context_length": 1,
+        "max_context_length": 30,
+        "dequeue_context_length": 10,
         "streaming_response": False,
         "show_tool_use_status": False,
         "show_tool_call_result": False,
@@ -217,7 +217,8 @@ DEFAULT_CONFIG = {
     },
     "provider_ltm_settings": {
         "group_icl_enable": False,
-        "group_message_max_cnt": 300,
+        "group_message_max_cnt": 50,
+        "group_icl_token_budget": 4000,
         "image_caption": False,
         "image_caption_provider_id": "",
         "active_reply": {
@@ -2862,6 +2863,9 @@ CONFIG_METADATA_2 = {
                     "group_message_max_cnt": {
                         "type": "int",
                     },
+                    "group_icl_token_budget": {
+                        "type": "int",
+                    },
                     "image_caption": {
                         "type": "bool",
                     },
@@ -4078,6 +4082,11 @@ CONFIG_METADATA_3 = {
                     "provider_ltm_settings.group_message_max_cnt": {
                         "description": "最大消息数量",
                         "type": "int",
+                    },
+                    "provider_ltm_settings.group_icl_token_budget": {
+                        "description": "群聊上下文 Token 预算",
+                        "type": "int",
+                        "hint": "每次 LLM 请求注入的群聊上下文近似 token 上限。降低该值可减少费用并降低缓存失效影响。",
                     },
                     "provider_ltm_settings.image_caption": {
                         "description": "自动理解图片",

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -240,10 +240,19 @@ class InternalAgentSubStage(Stage):
                         and not event.platform_meta.support_streaming_message
                     )
 
+                    system_prompt_before_hooks = req.system_prompt or ""
                     if await call_event_hook(event, EventType.OnLLMRequestEvent, req):
                         if reset_coro:
                             reset_coro.close()
                         return
+                    system_prompt_after_hooks = req.system_prompt or ""
+                    if system_prompt_after_hooks != system_prompt_before_hooks:
+                        logger.warning(
+                            "LLM system prompt was modified by request hooks. umo=%s, before_chars=%s, after_chars=%s",
+                            event.unified_msg_origin,
+                            len(system_prompt_before_hooks),
+                            len(system_prompt_after_hooks),
+                        )
 
                     # apply reset
                     if reset_coro:

--- a/tests/unit/test_long_term_memory_cost_safety.py
+++ b/tests/unit/test_long_term_memory_cost_safety.py
@@ -1,0 +1,63 @@
+import pytest
+
+from astrbot.api.provider import ProviderRequest
+from astrbot.builtin_stars.astrbot.long_term_memory import LongTermMemory
+from astrbot.core.agent.message import TextPart
+
+
+class DummyContext:
+    def get_config(self, umo=None):
+        return {
+            "provider_settings": {
+                "image_caption_prompt": "Describe the image.",
+            },
+            "provider_ltm_settings": {
+                "group_message_max_cnt": 50,
+                "group_icl_token_budget": 30,
+                "image_caption": False,
+                "image_caption_provider_id": "",
+                "active_reply": {
+                    "enable": False,
+                    "method": "possibility_reply",
+                    "possibility_reply": 0.1,
+                    "whitelist": [],
+                },
+            },
+        }
+
+
+class DummyEvent:
+    unified_msg_origin = "group:test"
+
+
+@pytest.mark.asyncio
+async def test_group_icl_uses_user_context_part_instead_of_system_prompt():
+    ltm = LongTermMemory(None, DummyContext())
+    ltm.session_chats[DummyEvent.unified_msg_origin] = [
+        "[alice/10:00:00]: old message",
+        "[bob/10:01:00]: recent message",
+    ]
+    req = ProviderRequest(prompt="hello", system_prompt="base system")
+
+    await ltm.on_req_llm(DummyEvent(), req)
+
+    assert "old message" not in req.system_prompt
+    assert "recent message" not in req.system_prompt
+    assert "current user message" in req.system_prompt
+    assert len(req.extra_user_content_parts) == 1
+    part = req.extra_user_content_parts[0]
+    assert isinstance(part, TextPart)
+    assert "[Group Chat Context]" in part.text
+    assert "recent message" in part.text
+
+
+def test_group_icl_context_respects_token_budget():
+    ltm = LongTermMemory(None, DummyContext())
+    chats = [f"[user{i}/10:00:0{i}]: " + ("x" * 80) for i in range(5)]
+
+    chats_str, omitted, estimated_tokens = ltm._build_chats_context(chats, 30)
+
+    assert omitted > 0
+    assert "earlier group messages omitted" in chats_str
+    assert "user4" in chats_str
+    assert estimated_tokens <= 50

--- a/tests/unit/test_long_term_memory_cost_safety.py
+++ b/tests/unit/test_long_term_memory_cost_safety.py
@@ -2,7 +2,11 @@ import pytest
 
 from astrbot.api.provider import ProviderRequest
 from astrbot.builtin_stars.astrbot.long_term_memory import LongTermMemory
-from astrbot.core.agent.message import TextPart
+from astrbot.core.agent.message import (
+    Message,
+    TextPart,
+    dump_messages_with_checkpoints,
+)
 
 
 class DummyContext:
@@ -43,21 +47,39 @@ async def test_group_icl_uses_user_context_part_instead_of_system_prompt():
 
     assert "old message" not in req.system_prompt
     assert "recent message" not in req.system_prompt
-    assert "current user message" in req.system_prompt
     assert len(req.extra_user_content_parts) == 1
     part = req.extra_user_content_parts[0]
     assert isinstance(part, TextPart)
+    assert part._no_save is True
+    assert "only as background" in part.text
     assert "[Group Chat Context]" in part.text
     assert "recent message" in part.text
+
+
+@pytest.mark.asyncio
+async def test_group_icl_context_is_not_persisted_in_history():
+    ltm = LongTermMemory(None, DummyContext())
+    ltm.session_chats[DummyEvent.unified_msg_origin] = [
+        "[bob/10:01:00]: recent message",
+    ]
+    req = ProviderRequest(prompt="hello", system_prompt="base system")
+
+    await ltm.on_req_llm(DummyEvent(), req)
+    message = Message.model_validate(await req.assemble_context())
+    dumped = dump_messages_with_checkpoints([message])
+
+    assert "hello" in str(dumped)
+    assert "[Group Chat Context]" not in str(dumped)
+    assert "recent message" not in str(dumped)
 
 
 def test_group_icl_context_respects_token_budget():
     ltm = LongTermMemory(None, DummyContext())
     chats = [f"[user{i}/10:00:0{i}]: " + ("x" * 80) for i in range(5)]
+    budget = 30
 
-    chats_str, omitted, estimated_tokens = ltm._build_chats_context(chats, 30)
+    chats_str, omitted, estimated_tokens = ltm._build_chats_context(chats, budget)
 
     assert omitted > 0
-    assert "earlier group messages omitted" in chats_str
-    assert "user4" in chats_str
-    assert estimated_tokens <= 50
+    assert chats_str
+    assert estimated_tokens <= budget


### PR DESCRIPTION
﻿<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Motivation / 动机


这个 PR 修关于调用成本 / 缓存直接相关的事，包括默认上下文策略、群聊上下文感知、图片转述以及插件修改 system prompt 时的隐患。

之前的默认行为对新用户不够友好：

- 默认不对历史轮数做限制，长聊之后输入 token 会一直涨；
- 撞到上限后每轮只丢 1 轮，上下文窗口每轮都在滑动，容易把 prefix cache 打掉；
- 群聊 ICL 的动态聊天记录会直接拼到 `system_prompt` 里，群聊每轮变化都会导致 system prompt 跟着变；
- 群聊图片转述一旦打开，每张图都可能单独触发一次多模态请求；
- 插件通过 `OnLLMRequestEvent` 修改 system prompt 时，很难快速定位是谁破坏了缓存。

这里按最小改动处理这些点：不动现有功能入口，只收紧默认参数和注入方式，让默认行为对成本和缓存更友好。

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

#### 1. 调整默认上下文策略

修改 `astrbot/core/config/default.py` 和 `astrbot/core/astr_main_agent.py`：

- `max_context_length`: `-1` → `30`
- `dequeue_context_length`: `1` → `10`

新用户默认不再无限保留上下文，达到上限后会一次丢掉 10 轮，避免长聊 token 一直增长、prefix cache 持续被打断。

#### 2. 群聊上下文不再注入 system prompt

修改 `astrbot/builtin_stars/astrbot/long_term_memory.py`。

群聊 ICL 的动态聊天记录不再拼到 `req.system_prompt`，改为作为当前 user message 的临时 extra content 注入：

- 模型本轮仍然能看到群聊上下文；
- 不再污染 system prompt，减少 prefix cache 失效风险；
- 使用 `mark_as_temp()` 标记，不会被写入 conversation history，避免群聊上下文在历史里反复堆积。

#### 3. 给群聊 ICL 增加 token budget

新增 `provider_ltm_settings.group_icl_token_budget`，默认值 `4000`。

群聊上下文会按近似的 token 预算裁剪，只保留较新的群聊消息；发生裁剪时会打 warning，方便管理员感知上下文被压缩。`group_message_max_cnt` 的默认值也从 `300` 下调到 `50`，以减少默认配置下的内存和上下文压力。

#### 4. 增加 LLM 请求成本预检日志

修改 `astrbot/core/agent/runners/tool_loop_agent_runner.py`。

在请求模型之前插入 preflight 日志，打印 provider / model、估算 input tokens、图片数。如果估算 token 偏高或图片偏多，输出 warning，方便快速定位高成本请求。

#### 5. system prompt 被 hook 修改时输出 warning

修改 `astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py`。

在 `OnLLMRequestEvent` 前后对比 system prompt，如果被插件或 hook 改了，就打 warning 并给出修改前后的长度，方便排查哪个插件导致缓存失效。

#### 6. 群聊图片转述增加成本提示

当群聊 ICL 开启 `image_caption` 时，每张群聊图片都可能触发额外的多模态请求，现在会输出 warning，提醒用户这个配置可能带来额外费用。

#### 7. 增加单元测试

新增 `tests/unit/test_long_term_memory_cost_safety.py`，覆盖：

- 群聊上下文不再写入 `system_prompt`
- 群聊上下文会作为临时 user content 注入
- 临时群聊上下文不会被持久化到 history
- 群聊上下文裁剪后不超过 token budget

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

已执行以下检查：

```bash
python -m pytest tests\unit\test_long_term_memory_cost_safety.py -q
```

```bash
python -m pytest tests\agent\test_context_manager.py tests\test_tool_loop_agent_runner.py::test_normal_completion_without_max_step -q
```

```bash
python -m ruff check .
```

```bash
python -m ruff format . --check
```

本次改动不引入新依赖。

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->

<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

* [x]  If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

* [x]  My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

* [x]  I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

* [x]  My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Tighten default context and group chat handling to reduce LLM request cost and cache disruption while adding observability around expensive requests and prompt hooks.

New Features:
- Add a configurable token budget for group chat ICL context to bound injected history size per request.
- Introduce preflight logging of estimated input tokens and image count for each LLM request.
- Emit warnings when request hooks modify the system prompt or when group image captioning may trigger extra multimodal calls.

Enhancements:
- Adjust default context length settings to limit retained turns and drop more messages at once when the limit is reached.
- Change group chat ICL to inject recent history as temporary user content instead of modifying the system prompt, and trim it to fit within the configured token budget.
- Lower the default maximum stored group messages and document the new group ICL token budget option in configuration metadata.

Tests:
- Add unit tests to ensure group chat context is injected via temporary user content, is not persisted in history, and respects the configured token budget.