### PR TITLE
fix: 支持日志级别运行时热切换

### DIFF
--- a/astrbot/core/log.py
+++ b/astrbot/core/log.py
@@ -339,6 +339,67 @@ class LogManager:
         )
 
     @classmethod
+    def _replace_file_sink(
+        cls,
+        *,
+        logger: logging.Logger,
+        enable_file: bool,
+        file_path: str | None,
+        max_mb: int | None,
+    ) -> None:
+        if not enable_file:
+            old_sink_id = cls._file_sink_id
+            cls._file_sink_id = None
+            cls._remove_sink(old_sink_id)
+            return
+
+        try:
+            new_sink_id = cls._add_file_sink(
+                file_path=cls._resolve_log_path(file_path),
+                level=logger.level,
+                max_mb=max_mb,
+                backup_count=3,
+                trace=False,
+            )
+        except Exception as e:
+            logger.error(f"Failed to add file sink: {e}")
+            return
+
+        old_sink_id = cls._file_sink_id
+        cls._file_sink_id = new_sink_id
+        cls._remove_sink(old_sink_id)
+
+    @classmethod
+    def _replace_trace_sink(
+        cls,
+        *,
+        enable: bool,
+        path: str | None,
+        max_mb: int | None,
+    ) -> None:
+        if not enable:
+            old_sink_id = cls._trace_sink_id
+            cls._trace_sink_id = None
+            cls._remove_sink(old_sink_id)
+            return
+
+        try:
+            new_sink_id = cls._add_file_sink(
+                file_path=cls._resolve_log_path(path or "logs/astrbot.trace.log"),
+                level=logging.INFO,
+                max_mb=max_mb,
+                backup_count=3,
+                trace=True,
+            )
+        except Exception as e:
+            logging.getLogger("astrbot").error(f"Failed to add trace sink: {e}")
+            return
+
+        old_sink_id = cls._trace_sink_id
+        cls._trace_sink_id = new_sink_id
+        cls._remove_sink(old_sink_id)
+
+    @classmethod
     def configure_logger(
         cls,
         logger: logging.Logger,
@@ -366,22 +427,12 @@ class LogManager:
                 file_path = config.get("log_file_path")
                 max_mb = config.get("log_file_max_mb")
 
-            cls._remove_sink(cls._file_sink_id)
-            cls._file_sink_id = None
-
-            if not enable_file:
-                return
-
-            try:
-                cls._file_sink_id = cls._add_file_sink(
-                    file_path=cls._resolve_log_path(file_path),
-                    level=logger.level,
-                    max_mb=max_mb,
-                    backup_count=3,
-                    trace=False,
-                )
-            except Exception as e:
-                logger.error(f"Failed to add file sink: {e}")
+            cls._replace_file_sink(
+                logger=logger,
+                enable_file=enable_file,
+                file_path=file_path,
+                max_mb=max_mb,
+            )
 
     @classmethod
     def configure_trace_logger(cls, config: dict | None) -> None:
@@ -406,16 +457,8 @@ class LogManager:
             trace_logger.setLevel(logging.INFO)
             trace_logger.propagate = False
 
-            cls._remove_sink(cls._trace_sink_id)
-            cls._trace_sink_id = None
-
-            if not enable:
-                return
-
-            cls._trace_sink_id = cls._add_file_sink(
-                file_path=cls._resolve_log_path(path or "logs/astrbot.trace.log"),
-                level=logging.INFO,
+            cls._replace_trace_sink(
+                enable=enable,
+                path=path,
                 max_mb=max_mb,
-                backup_count=3,
-                trace=True,
             )

--- a/astrbot/core/log.py
+++ b/astrbot/core/log.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import os
 import sys
+import threading
 import time
 from asyncio import Queue
 from collections import deque
@@ -173,6 +174,7 @@ class LogManager:
     _console_sink_id: int | None = None
     _file_sink_id: int | None = None
     _trace_sink_id: int | None = None
+    _reconfigure_lock = threading.RLock()
     _NOISY_LOGGER_LEVELS: dict[str, int] = {
         "aiosqlite": logging.WARNING,
         "filelock": logging.WARNING,
@@ -343,75 +345,77 @@ class LogManager:
         config: dict | None,
         override_level: str | None = None,
     ) -> None:
-        if not config:
-            return
+        with cls._reconfigure_lock:
+            if not config:
+                return
 
-        level = override_level or config.get("log_level")
-        if level:
+            level = override_level or config.get("log_level")
+            if level:
+                try:
+                    logger.setLevel(level)
+                except Exception:
+                    logger.setLevel(logging.INFO)
+
+            if "log_file" in config:
+                file_conf = config.get("log_file") or {}
+                enable_file = bool(file_conf.get("enable", False))
+                file_path = file_conf.get("path")
+                max_mb = file_conf.get("max_mb")
+            else:
+                enable_file = bool(config.get("log_file_enable", False))
+                file_path = config.get("log_file_path")
+                max_mb = config.get("log_file_max_mb")
+
+            cls._remove_sink(cls._file_sink_id)
+            cls._file_sink_id = None
+
+            if not enable_file:
+                return
+
             try:
-                logger.setLevel(level)
-            except Exception:
-                logger.setLevel(logging.INFO)
-
-        if "log_file" in config:
-            file_conf = config.get("log_file") or {}
-            enable_file = bool(file_conf.get("enable", False))
-            file_path = file_conf.get("path")
-            max_mb = file_conf.get("max_mb")
-        else:
-            enable_file = bool(config.get("log_file_enable", False))
-            file_path = config.get("log_file_path")
-            max_mb = config.get("log_file_max_mb")
-
-        cls._remove_sink(cls._file_sink_id)
-        cls._file_sink_id = None
-
-        if not enable_file:
-            return
-
-        try:
-            cls._file_sink_id = cls._add_file_sink(
-                file_path=cls._resolve_log_path(file_path),
-                level=logger.level,
-                max_mb=max_mb,
-                backup_count=3,
-                trace=False,
-            )
-        except Exception as e:
-            logger.error(f"Failed to add file sink: {e}")
+                cls._file_sink_id = cls._add_file_sink(
+                    file_path=cls._resolve_log_path(file_path),
+                    level=logger.level,
+                    max_mb=max_mb,
+                    backup_count=3,
+                    trace=False,
+                )
+            except Exception as e:
+                logger.error(f"Failed to add file sink: {e}")
 
     @classmethod
     def configure_trace_logger(cls, config: dict | None) -> None:
-        if not config:
-            return
+        with cls._reconfigure_lock:
+            if not config:
+                return
 
-        enable = bool(
-            config.get("trace_log_enable")
-            or (config.get("log_file", {}) or {}).get("trace_enable", False)
-        )
-        path = config.get("trace_log_path")
-        max_mb = config.get("trace_log_max_mb")
-        if "log_file" in config:
-            legacy = config.get("log_file") or {}
-            path = path or legacy.get("trace_path")
-            max_mb = max_mb or legacy.get("trace_max_mb")
+            enable = bool(
+                config.get("trace_log_enable")
+                or (config.get("log_file", {}) or {}).get("trace_enable", False)
+            )
+            path = config.get("trace_log_path")
+            max_mb = config.get("trace_log_max_mb")
+            if "log_file" in config:
+                legacy = config.get("log_file") or {}
+                path = path or legacy.get("trace_path")
+                max_mb = max_mb or legacy.get("trace_max_mb")
 
-        trace_logger = logging.getLogger("astrbot.trace")
-        cls._ensure_logger_enricher_filter(trace_logger)
-        cls._ensure_logger_intercept_handler(trace_logger)
-        trace_logger.setLevel(logging.INFO)
-        trace_logger.propagate = False
+            trace_logger = logging.getLogger("astrbot.trace")
+            cls._ensure_logger_enricher_filter(trace_logger)
+            cls._ensure_logger_intercept_handler(trace_logger)
+            trace_logger.setLevel(logging.INFO)
+            trace_logger.propagate = False
 
-        cls._remove_sink(cls._trace_sink_id)
-        cls._trace_sink_id = None
+            cls._remove_sink(cls._trace_sink_id)
+            cls._trace_sink_id = None
 
-        if not enable:
-            return
+            if not enable:
+                return
 
-        cls._trace_sink_id = cls._add_file_sink(
-            file_path=cls._resolve_log_path(path or "logs/astrbot.trace.log"),
-            level=logging.INFO,
-            max_mb=max_mb,
-            backup_count=3,
-            trace=True,
-        )
+            cls._trace_sink_id = cls._add_file_sink(
+                file_path=cls._resolve_log_path(path or "logs/astrbot.trace.log"),
+                level=logging.INFO,
+                max_mb=max_mb,
+                backup_count=3,
+                trace=True,
+            )

--- a/astrbot/dashboard/routes/config.py
+++ b/astrbot/dashboard/routes/config.py
@@ -89,19 +89,30 @@ def _apply_runtime_log_config_if_changed(
     if old_log_config == new_log_config and old_trace_config == new_trace_config:
         return
 
-    try:
-        if old_log_config != new_log_config:
+    updated = False
+
+    if old_log_config != new_log_config:
+        try:
             LogManager.configure_logger(logger, new_config)
+            updated = True
+        except Exception:
+            logger.error(
+                "Failed to update runtime logger:\n%s",
+                traceback.format_exc(),
+            )
 
-        if old_trace_config != new_trace_config:
+    if old_trace_config != new_trace_config:
+        try:
             LogManager.configure_trace_logger(new_config)
+            updated = True
+        except Exception:
+            logger.error(
+                "Failed to update runtime trace logger:\n%s",
+                traceback.format_exc(),
+            )
 
+    if updated:
         logger.info("Runtime log configuration updated.")
-    except Exception:
-        logger.error(
-            "Failed to update runtime log configuration:\n%s",
-            traceback.format_exc(),
-        )
 
 
 def try_cast(value: Any, type_: str):
@@ -364,11 +375,15 @@ async def _validate_neo_connectivity(
 
 
 def save_config(
-    post_config: dict, config: AstrBotConfig, is_core: bool = False
+    post_config: dict,
+    config: AstrBotConfig,
+    is_core: bool = False,
+    old_config_snapshot: dict | None = None,
 ) -> None:
     """验证并保存配置"""
     errors = None
-    old_config_snapshot = copy.deepcopy(dict(config)) if is_core else None
+    if is_core and old_config_snapshot is None:
+        old_config_snapshot = copy.deepcopy(dict(config))
 
     # Snapshot old Computer config for change detection
     if is_core:
@@ -1589,6 +1604,7 @@ class ConfigRoute(Route):
             if conf_id not in self.acm.confs:
                 raise ValueError(f"配置文件 {conf_id} 不存在")
             astrbot_config = self.acm.confs[conf_id]
+            old_config_snapshot = copy.deepcopy(dict(astrbot_config))
 
             # 保留服务端的 t2i_active_template 值
             if "t2i_active_template" in astrbot_config:
@@ -1596,7 +1612,12 @@ class ConfigRoute(Route):
                     "t2i_active_template"
                 ]
 
-            save_config(post_configs, astrbot_config, is_core=True)
+            save_config(
+                post_configs,
+                astrbot_config,
+                is_core=True,
+                old_config_snapshot=old_config_snapshot,
+            )
         except Exception as e:
             raise e
 

--- a/astrbot/dashboard/routes/config.py
+++ b/astrbot/dashboard/routes/config.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from quart import request
 
-from astrbot.core import astrbot_config, file_token_service, logger
+from astrbot.core import LogManager, astrbot_config, file_token_service, logger
 from astrbot.core.config.astrbot_config import AstrBotConfig
 from astrbot.core.config.default import (
     CONFIG_METADATA_2,
@@ -38,6 +38,70 @@ from .util import (
 )
 
 MAX_FILE_BYTES = 500 * 1024 * 1024
+
+_RUNTIME_LOG_KEYS = (
+    "log_level",
+    "log_file_enable",
+    "log_file_path",
+    "log_file_max_mb",
+)
+
+_RUNTIME_TRACE_LOG_KEYS = (
+    "trace_log_enable",
+    "trace_log_path",
+    "trace_log_max_mb",
+)
+
+
+def _runtime_log_config(conf: dict) -> dict:
+    legacy = conf.get("log_file") or {}
+    return {
+        **{key: copy.deepcopy(conf.get(key)) for key in _RUNTIME_LOG_KEYS},
+        "legacy_log_file": {
+            "enable": copy.deepcopy(legacy.get("enable")),
+            "path": copy.deepcopy(legacy.get("path")),
+            "max_mb": copy.deepcopy(legacy.get("max_mb")),
+        },
+    }
+
+
+def _runtime_trace_log_config(conf: dict) -> dict:
+    legacy = conf.get("log_file") or {}
+    return {
+        **{key: copy.deepcopy(conf.get(key)) for key in _RUNTIME_TRACE_LOG_KEYS},
+        "legacy_log_file": {
+            "trace_enable": copy.deepcopy(legacy.get("trace_enable")),
+            "trace_path": copy.deepcopy(legacy.get("trace_path")),
+            "trace_max_mb": copy.deepcopy(legacy.get("trace_max_mb")),
+        },
+    }
+
+
+def _apply_runtime_log_config_if_changed(
+    old_config: dict,
+    new_config: dict,
+) -> None:
+    old_log_config = _runtime_log_config(old_config)
+    new_log_config = _runtime_log_config(new_config)
+    old_trace_config = _runtime_trace_log_config(old_config)
+    new_trace_config = _runtime_trace_log_config(new_config)
+
+    if old_log_config == new_log_config and old_trace_config == new_trace_config:
+        return
+
+    try:
+        if old_log_config != new_log_config:
+            LogManager.configure_logger(logger, new_config)
+
+        if old_trace_config != new_trace_config:
+            LogManager.configure_trace_logger(new_config)
+
+        logger.info("Runtime log configuration updated.")
+    except Exception:
+        logger.error(
+            "Failed to update runtime log configuration:\n%s",
+            traceback.format_exc(),
+        )
 
 
 def try_cast(value: Any, type_: str):
@@ -304,6 +368,7 @@ def save_config(
 ) -> None:
     """验证并保存配置"""
     errors = None
+    old_config_snapshot = copy.deepcopy(dict(config)) if is_core else None
 
     # Snapshot old Computer config for change detection
     if is_core:
@@ -328,6 +393,9 @@ def save_config(
         raise ValueError(f"格式校验未通过: {errors}")
 
     config.save_config(post_config)
+
+    if is_core and old_config_snapshot is not None:
+        _apply_runtime_log_config_if_changed(old_config_snapshot, dict(config))
 
 
 class ConfigRoute(Route):

--- a/astrbot/dashboard/routes/config.py
+++ b/astrbot/dashboard/routes/config.py
@@ -29,6 +29,7 @@ from astrbot.core.utils.astrbot_path import (
 from astrbot.core.utils.llm_metadata import LLM_METADATAS
 from astrbot.core.utils.webhook_utils import ensure_platform_webhook_config
 
+from .restart_control import mark_runtime_log_config_saved
 from .route import Response, Route, RouteContext
 from .util import (
     config_key_to_folder,
@@ -77,17 +78,54 @@ def _runtime_trace_log_config(conf: dict) -> dict:
     }
 
 
+def _config_without_runtime_log_config(conf: dict) -> dict:
+    conf = copy.deepcopy(conf)
+    for key in (*_RUNTIME_LOG_KEYS, *_RUNTIME_TRACE_LOG_KEYS):
+        conf.pop(key, None)
+
+    legacy = conf.get("log_file")
+    if isinstance(legacy, dict):
+        for key in (
+            "enable",
+            "path",
+            "max_mb",
+            "trace_enable",
+            "trace_path",
+            "trace_max_mb",
+        ):
+            legacy.pop(key, None)
+        if not legacy:
+            conf.pop("log_file", None)
+
+    return conf
+
+
+def _runtime_log_config_changed(old_config: dict, new_config: dict) -> bool:
+    return _runtime_log_config(old_config) != _runtime_log_config(
+        new_config
+    ) or _runtime_trace_log_config(old_config) != _runtime_trace_log_config(new_config)
+
+
+def _system_config_save_requires_restart(old_config: dict, new_config: dict) -> bool:
+    if old_config == new_config:
+        return False
+
+    return _config_without_runtime_log_config(
+        old_config
+    ) != _config_without_runtime_log_config(new_config)
+
+
 def _apply_runtime_log_config_if_changed(
     old_config: dict,
     new_config: dict,
-) -> None:
+) -> bool:
     old_log_config = _runtime_log_config(old_config)
     new_log_config = _runtime_log_config(new_config)
     old_trace_config = _runtime_trace_log_config(old_config)
     new_trace_config = _runtime_trace_log_config(new_config)
 
     if old_log_config == new_log_config and old_trace_config == new_trace_config:
-        return
+        return False
 
     updated = False
 
@@ -113,6 +151,8 @@ def _apply_runtime_log_config_if_changed(
 
     if updated:
         logger.info("Runtime log configuration updated.")
+
+    return updated
 
 
 def try_cast(value: Any, type_: str):
@@ -379,7 +419,7 @@ def save_config(
     config: AstrBotConfig,
     is_core: bool = False,
     old_config_snapshot: dict | None = None,
-) -> None:
+) -> bool:
     """验证并保存配置"""
     errors = None
     if is_core and old_config_snapshot is None:
@@ -410,7 +450,9 @@ def save_config(
     config.save_config(post_config)
 
     if is_core and old_config_snapshot is not None:
-        _apply_runtime_log_config_if_changed(old_config_snapshot, dict(config))
+        return _apply_runtime_log_config_if_changed(old_config_snapshot, dict(config))
+
+    return False
 
 
 class ConfigRoute(Route):
@@ -1104,14 +1146,15 @@ class ConfigRoute(Route):
                 for key in no_update_keys:
                     config[key] = self.acm.default_conf[key]
 
-            await self._save_astrbot_configs(config, conf_id)
+            save_result = await self._save_astrbot_configs(config, conf_id)
             await self.core_lifecycle.reload_pipeline_scheduler(conf_id)
 
             # Non-blocking Bay connectivity check
             warning = await _validate_neo_connectivity(config)
+            response_data = {"requires_restart": save_result["requires_restart"]}
             if warning:
-                return Response().ok(None, f"保存成功。{warning}").__dict__
-            return Response().ok(None, "保存成功~").__dict__
+                return Response().ok(response_data, f"保存成功。{warning}").__dict__
+            return Response().ok(response_data, "保存成功~").__dict__
         except Exception as e:
             logger.error(traceback.format_exc())
             return Response().error(str(e)).__dict__
@@ -1599,7 +1642,7 @@ class ConfigRoute(Route):
 
     async def _save_astrbot_configs(
         self, post_configs: dict, conf_id: str | None = None
-    ) -> None:
+    ) -> dict:
         try:
             if conf_id not in self.acm.confs:
                 raise ValueError(f"配置文件 {conf_id} 不存在")
@@ -1612,12 +1655,20 @@ class ConfigRoute(Route):
                     "t2i_active_template"
                 ]
 
-            save_config(
+            runtime_log_config_updated = save_config(
                 post_configs,
                 astrbot_config,
                 is_core=True,
                 old_config_snapshot=old_config_snapshot,
             )
+            requires_restart = _system_config_save_requires_restart(
+                old_config_snapshot,
+                dict(astrbot_config),
+            )
+            if runtime_log_config_updated and not requires_restart:
+                mark_runtime_log_config_saved()
+
+            return {"requires_restart": requires_restart}
         except Exception as e:
             raise e
 

--- a/astrbot/dashboard/routes/restart_control.py
+++ b/astrbot/dashboard/routes/restart_control.py
@@ -1,0 +1,15 @@
+import time
+
+_RUNTIME_LOG_SAVE_RESTART_SKIP_SECONDS = 8
+_runtime_log_save_restart_skip_until = 0.0
+
+
+def mark_runtime_log_config_saved() -> None:
+    global _runtime_log_save_restart_skip_until
+    _runtime_log_save_restart_skip_until = (
+        time.monotonic() + _RUNTIME_LOG_SAVE_RESTART_SKIP_SECONDS
+    )
+
+
+def should_skip_restart_after_runtime_log_config_save() -> bool:
+    return time.monotonic() < _runtime_log_save_restart_skip_until

--- a/astrbot/dashboard/routes/stat.py
+++ b/astrbot/dashboard/routes/stat.py
@@ -25,6 +25,7 @@ from astrbot.core.utils.io import get_dashboard_version
 from astrbot.core.utils.storage_cleaner import StorageCleaner
 from astrbot.core.utils.version_comparator import VersionComparator
 
+from .restart_control import should_skip_restart_after_runtime_log_config_save
 from .route import Response, Route, RouteContext
 
 
@@ -61,6 +62,12 @@ class StatRoute(Route):
                 .error("You are not permitted to do this operation in demo mode")
                 .__dict__
             )
+
+        if should_skip_restart_after_runtime_log_config_save():
+            logger.info(
+                "Skipped restart request after runtime log configuration update.",
+            )
+            return Response().ok(message="日志配置已实时生效，无需重启。").__dict__
 
         await self.core_lifecycle.restart()
         return Response().ok().__dict__

--- a/dashboard/src/views/ConfigPage.vue
+++ b/dashboard/src/views/ConfigPage.vue
@@ -565,13 +565,19 @@ export default {
       }
 
       const previousConfig = this.parseConfigSnapshot(this.lastSavedConfigSnapshot);
-      const shouldRestart = this.isSystemConfig && this.shouldRestartAfterSystemConfigSave(
+      const localShouldRestart = this.isSystemConfig && this.shouldRestartAfterSystemConfigSave(
         previousConfig,
         postData.config
       );
 
       return axios.post('/api/config/astrbot/update', postData).then((res) => {
         if (res.data.status === "ok") {
+          const responseData = res.data.data || {};
+          const shouldRestart = this.isSystemConfig && (
+            typeof responseData.requires_restart === 'boolean'
+              ? responseData.requires_restart
+              : localShouldRestart
+          );
           this.lastSavedConfigSnapshot = this.getConfigSnapshot(this.config_data);
           this.save_message = res.data.message || this.messages.saveSuccess;
           this.save_message_snack = true;

--- a/dashboard/src/views/ConfigPage.vue
+++ b/dashboard/src/views/ConfigPage.vue
@@ -221,6 +221,25 @@ import {
 import UnsavedChangesConfirmDialog from '@/components/config/UnsavedChangesConfirmDialog.vue';
 import { normalizeTextInput } from '@/utils/inputValue';
 
+const RUNTIME_LOG_CONFIG_KEYS = [
+  'log_level',
+  'log_file_enable',
+  'log_file_path',
+  'log_file_max_mb',
+  'trace_log_enable',
+  'trace_log_path',
+  'trace_log_max_mb'
+];
+
+const LEGACY_RUNTIME_LOG_FILE_KEYS = [
+  'enable',
+  'path',
+  'max_mb',
+  'trace_enable',
+  'trace_path',
+  'trace_max_mb'
+];
+
 export default {
   name: 'ConfigPage',
   components: {
@@ -264,7 +283,12 @@ export default {
       } else if (confirmed) {
         const result = await this.updateConfig();
         if (this.isSystemConfig) {
-          next(false);
+          if (result?.success && !result?.restarted) {
+            await new Promise(resolve => setTimeout(resolve, 800));
+            next();
+          } else {
+            next(false);
+          }
         } else {
           if (result?.success) {
             await new Promise(resolve => setTimeout(resolve, 800));
@@ -540,6 +564,12 @@ export default {
         postData.conf_id = this.selectedConfigID;
       }
 
+      const previousConfig = this.parseConfigSnapshot(this.lastSavedConfigSnapshot);
+      const shouldRestart = this.isSystemConfig && this.shouldRestartAfterSystemConfigSave(
+        previousConfig,
+        postData.config
+      );
+
       return axios.post('/api/config/astrbot/update', postData).then((res) => {
         if (res.data.status === "ok") {
           this.lastSavedConfigSnapshot = this.getConfigSnapshot(this.config_data);
@@ -548,10 +578,10 @@ export default {
           this.save_message_success = "success";
           this.onConfigSaved();
 
-          if (this.isSystemConfig) {
+          if (shouldRestart) {
             restartAstrBotRuntime(this.$refs.wfr).catch(() => {})
           }
-          return { success: true };
+          return { success: true, restarted: shouldRestart };
         } else {
           this.save_message = res.data.message || this.messages.saveError;
           this.save_message_snack = true;
@@ -880,6 +910,37 @@ export default {
     },
     getConfigSnapshot(config) {
       return JSON.stringify(config ?? {});
+    },
+    parseConfigSnapshot(snapshot) {
+      if (!snapshot) {
+        return {};
+      }
+      try {
+        return JSON.parse(snapshot);
+      } catch (_error) {
+        return {};
+      }
+    },
+    getConfigWithoutRuntimeLogConfig(config) {
+      const cloned = JSON.parse(JSON.stringify(config ?? {}));
+      for (const key of RUNTIME_LOG_CONFIG_KEYS) {
+        delete cloned[key];
+      }
+      if (cloned.log_file && typeof cloned.log_file === 'object') {
+        for (const key of LEGACY_RUNTIME_LOG_FILE_KEYS) {
+          delete cloned.log_file[key];
+        }
+        if (Object.keys(cloned.log_file).length === 0) {
+          delete cloned.log_file;
+        }
+      }
+      return cloned;
+    },
+    shouldRestartAfterSystemConfigSave(previousConfig, nextConfig) {
+      const previousWithoutLog = this.getConfigWithoutRuntimeLogConfig(previousConfig);
+      const nextWithoutLog = this.getConfigWithoutRuntimeLogConfig(nextConfig);
+
+      return this.getConfigSnapshot(previousWithoutLog) !== this.getConfigSnapshot(nextWithoutLog);
     }
   },
 }

--- a/tests/test_log_manager_runtime.py
+++ b/tests/test_log_manager_runtime.py
@@ -1,0 +1,93 @@
+import logging
+
+import pytest
+
+from astrbot.core.log import LogManager
+
+
+@pytest.fixture(autouse=True)
+def restore_log_manager_sinks():
+    old_file_sink_id = LogManager._file_sink_id
+    old_trace_sink_id = LogManager._trace_sink_id
+    try:
+        yield
+    finally:
+        LogManager._file_sink_id = old_file_sink_id
+        LogManager._trace_sink_id = old_trace_sink_id
+
+
+def test_invalid_new_file_sink_keeps_existing_sink(monkeypatch):
+    removed_sink_ids = []
+    test_logger = logging.getLogger("astrbot.test.runtime")
+    LogManager._file_sink_id = 10
+
+    def fail_add_file_sink(**kwargs):
+        raise OSError("path is not writable")
+
+    monkeypatch.setattr(LogManager, "_add_file_sink", fail_add_file_sink)
+    monkeypatch.setattr(LogManager, "_remove_sink", removed_sink_ids.append)
+
+    LogManager._replace_file_sink(
+        logger=test_logger,
+        enable_file=True,
+        file_path="bad/path/astrbot.log",
+        max_mb=20,
+    )
+
+    assert LogManager._file_sink_id == 10
+    assert removed_sink_ids == []
+
+
+def test_successful_file_sink_replace_removes_old_sink(monkeypatch):
+    removed_sink_ids = []
+    test_logger = logging.getLogger("astrbot.test.runtime")
+    LogManager._file_sink_id = 10
+
+    monkeypatch.setattr(LogManager, "_add_file_sink", lambda **kwargs: 11)
+    monkeypatch.setattr(LogManager, "_remove_sink", removed_sink_ids.append)
+
+    LogManager._replace_file_sink(
+        logger=test_logger,
+        enable_file=True,
+        file_path="logs/astrbot.log",
+        max_mb=20,
+    )
+
+    assert LogManager._file_sink_id == 11
+    assert removed_sink_ids == [10]
+
+
+def test_invalid_new_trace_sink_keeps_existing_sink(monkeypatch):
+    removed_sink_ids = []
+    LogManager._trace_sink_id = 20
+
+    def fail_add_trace_sink(**kwargs):
+        raise OSError("path is not writable")
+
+    monkeypatch.setattr(LogManager, "_add_file_sink", fail_add_trace_sink)
+    monkeypatch.setattr(LogManager, "_remove_sink", removed_sink_ids.append)
+
+    LogManager._replace_trace_sink(
+        enable=True,
+        path="bad/path/astrbot.trace.log",
+        max_mb=20,
+    )
+
+    assert LogManager._trace_sink_id == 20
+    assert removed_sink_ids == []
+
+
+def test_disabling_trace_sink_removes_existing_sink(monkeypatch):
+    removed_sink_ids = []
+    LogManager._trace_sink_id = 20
+
+    monkeypatch.setattr(LogManager, "_remove_sink", removed_sink_ids.append)
+
+    LogManager._replace_trace_sink(
+        enable=False,
+        path="logs/astrbot.trace.log",
+        max_mb=20,
+    )
+
+    assert LogManager._trace_sink_id is None
+    assert removed_sink_ids == [20]

--- a/tests/test_runtime_log_config_restart.py
+++ b/tests/test_runtime_log_config_restart.py
@@ -1,0 +1,41 @@
+from astrbot.dashboard.routes.config import (
+    _runtime_log_config_changed,
+    _system_config_save_requires_restart,
+)
+
+
+def test_log_level_change_does_not_require_restart():
+    old_config = {"log_level": "INFO", "timezone": "Asia/Shanghai"}
+    new_config = {"log_level": "DEBUG", "timezone": "Asia/Shanghai"}
+
+    assert _runtime_log_config_changed(old_config, new_config)
+    assert not _system_config_save_requires_restart(old_config, new_config)
+
+
+def test_legacy_log_file_change_does_not_require_restart():
+    old_config = {
+        "timezone": "Asia/Shanghai",
+        "log_file": {"enable": False, "path": "logs/astrbot.log"},
+    }
+    new_config = {
+        "timezone": "Asia/Shanghai",
+        "log_file": {"enable": True, "path": "logs/astrbot.log"},
+    }
+
+    assert _runtime_log_config_changed(old_config, new_config)
+    assert not _system_config_save_requires_restart(old_config, new_config)
+
+
+def test_non_log_config_change_requires_restart():
+    old_config = {"log_level": "INFO", "timezone": "Asia/Shanghai"}
+    new_config = {"log_level": "INFO", "timezone": "UTC"}
+
+    assert not _runtime_log_config_changed(old_config, new_config)
+    assert _system_config_save_requires_restart(old_config, new_config)
+
+
+def test_no_config_change_does_not_require_restart():
+    config = {"log_level": "INFO", "timezone": "Asia/Shanghai"}
+
+    assert not _runtime_log_config_changed(config, config)
+    assert not _system_config_save_requires_restart(config, config)


### PR DESCRIPTION
### Motivation / 动机

我平时跑 AstrBot 的时候，基本都把日志级别挂在 `INFO`，不然控制台和 WebUI 里全是调试信息，看着挺乱的。但偶尔排查问题又必须临时切到 `DEBUG` 看一眼详细日志，之前系统配置里改了 `log_level` 之后，正在跑的 logger 根本不认新配置，非得重启整个 AstrBot 才能生效。

这个体验对临时查问题来说挺不友好的——只是想看一眼 debug 日志，却要打断当前正在运行的服务。所以这个 PR 给日志配置加上了运行时热更新，让日志级别可以从 `INFO` 到 `DEBUG` 之间随意切，不用重启，改完配置马上生效。

### Modifications / 改动点

核心思路就是在系统配置保存后，自动检查日志相关配置有没有发生变化，如果变了就立刻应用到运行中的 logger，并且保证这个过程是安全的。具体做了这么几件事：

1. **配置变更检测**  
   系统配置保存成功后，会对比运行时日志相关配置项是否被修改，包括：
   - `log_level`
   - `log_file_enable`
   - `log_file_path`
   - `log_file_max_mb`
   - `trace_log_enable`
   - `trace_log_path`
   - `trace_log_max_mb`
   同时也兼容旧版的 `log_file` 配置结构，不会因为配置字段迁移导致检测失效。

2. **即时应用新日志配置**  
   一旦发现上述配置有变动，就立刻把新的日志配置推到当前正在运行的 logger 里。  
   - 改 `log_level` 后，不管是文件日志还是 WebUI 实时日志，都不用重启就能看到效果。  
   - 从 `INFO` 切到 `DEBUG`，之后新打出来的 debug 日志会马上出现。  
   - 再从 `DEBUG` 切回 `INFO`，之后新产生的 debug 日志会立刻被过滤掉。

3. **给日志重配置加了锁**  
   在 `LogManager` 里加了一个 `RLock`，防止多个配置保存请求并发触发时，file sink 和 trace sink 交叉 remove / add，导致日志输出状态乱掉。

4. **优化 sink 替换逻辑，保证不中断已有日志**  
   文件日志和 trace 日志的 sink 替换都遵循“先建新的，成功后再换旧的”原则。  
   如果新的日志路径不可写或者 sink 创建失败，会保留正在用的旧 sink，不会因为一次配置错误就把原本好使的日志输出给掐了。

5. **普通日志和 trace 日志的热更新互相独立**  
   普通日志热更新失败不会影响 trace 日志的热更新，反过来也一样。两边异常各自捕获、各自处理，不会互相拖累。

6. **`save_config()` 支持传入旧配置快照**  
   为了防止调用方在保存前已经修改了内存里的配置对象，导致差异检测拿不到真正的“旧值”，现在允许显式传入一份旧配置快照。系统配置页在保存前会先把旧配置截下来，后面日志配置变更判断就用这份快照，保证比对结果是准的。

### Modified Files / 修改文件

- `astrbot/core/log.py`  
  - 加了日志重配置锁。  
  - 新增 `_replace_file_sink()` 和 `_replace_trace_sink()`。  
  - 调整了 `configure_logger()` 和 `configure_trace_logger()` 的 sink 替换逻辑，改成先创建新 sink 再替换。

- `astrbot/dashboard/routes/config.py`  
  - 增加了运行时日志配置差异判断逻辑。  
  - 系统配置保存成功后，按需触发日志配置的热应用。  
  - 支持传入 `old_config_snapshot`，避免差异检测被提前修改的配置值影响。

- `tests/test_log_manager_runtime.py`  
  - 新增了运行时 sink 替换相关的测试用例。

- [x] 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

先跑了代码风格检查和语法校验：

```bash
uv run ruff format .
uv run ruff check .
python -S -m py_compile astrbot/core/log.py astrbot/dashboard/routes/config.py
pytest tests/test_log_manager_runtime.py -q
```

结果：  
`4 passed`

然后在真实的 AstrBot 进程里做了一整套验证，流程是：

1. 启动 AstrBot，登录 WebUI API。  
2. 通过 `/api/config/astrbot/update` 把 `log_level` 设成 `INFO`。  
3. 触发生成 `logger.debug()` 的场景，确认文件日志和 WebUI 里都没有 debug 日志。  
4. 不重启，直接把 `log_level` 切到 `DEBUG`。  
5. 再次触发同样的 debug 场景，确认 debug 日志**立刻**写入了文件日志，并且在 WebUI 日志历史里也出现了。  
6. 再次不重启，切回 `INFO`。  
7. 再触发一次 debug 场景，确认新 debug 日志不再出现。

最终得到的真实测试结果：

```json
{
  login: ok,
  debug_present_while_info: false,
  debug_present_after_debug_switch_without_restart: true,
  debug_count_before_switch_back_info: 1,
  debug_count_after_switch_back_info: 1,
  webui_debug_visible_while_info: false,
  webui_debug_visible_after_debug_switch_without_restart: true,
  webui_debug_visible_after_switch_back_info: false
}
```

### Notes / 说明

- 日志级别切换完全不需要重启，保存配置就生效。  
- 文件日志和 WebUI 实时日志都能跟着 `log_level` 热切换，行为一致。  
- 切换只影响之后新产生的日志。之前在旧级别下被筛掉的 debug 日志不会补回来，这是符合预期的。  
- 这个 PR 没有去修改 `trace_enable` 和 `trace_log_enable` 之间原本的语义差异，只处理了系统配置页里日志级别和文件日志配置的热切换。

---

### Checklist / 检查清单

- [x] 如果 PR 中有新加入的功能，已经通过 Issue / 说明等方式解释了动机和使用场景。
- [x] 我的更改经过了测试，并已在上方提供验证步骤和测试结果。
- [x] 我确认没有引入新依赖。
- [x] 我的更改没有引入恶意代码。

<img width="2559" height="1226" alt="QQ_1778487377464" src="https://github.com/user-attachments/assets/402f5334-e5d2-4c09-b996-909ad0db9970" />


## Summary by Sourcery

Enable runtime reconfiguration of logging and trace settings without restarting AstrBot.

New Features:
- Allow core configuration saves to trigger live updates of log level and file-based logging settings when they change.
- Allow trace logging configuration changes to be applied at runtime independently of normal logging.
- Support passing an old configuration snapshot into save_config for accurate change detection.

Enhancements:
- Make LogManager file and trace sink replacement resilient by creating new sinks before swapping and preserving existing sinks on failure.
- Protect logger reconfiguration with a re-entrant lock to avoid race conditions during concurrent config updates.

Tests:
- Add runtime LogManager tests to ensure sink replacement preserves existing sinks on failure and cleans up correctly when disabling sinks.