### PR TITLE
fix(star): 修复重复安装插件时临时目录未清理及错误追踪误报问题

### DIFF
--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -1798,6 +1798,7 @@ class PluginManager:
             dir=self.plugin_store_path, prefix="plugin_upload_"
         )
         temp_desti_dir = desti_dir
+        skip_failed_tracking = False
 
         try:
             self.updator.unzip_file(zip_file_path, desti_dir)
@@ -1807,6 +1808,7 @@ class PluginManager:
                 metadata_dir_name,
             )
             if target_plugin_path != desti_dir and os.path.exists(target_plugin_path):
+                skip_failed_tracking = True
                 raise Exception(f"安装失败：目录 {metadata_dir_name} 已存在。")
             if target_plugin_path != desti_dir:
                 os.rename(desti_dir, target_plugin_path)
@@ -1870,17 +1872,21 @@ class PluginManager:
 
             return plugin_info
         except Exception as e:
-            self._track_failed_install_dir(
-                dir_name=dir_name,
-                plugin_path=desti_dir,
-                error=e,
-            )
+            if not skip_failed_tracking:
+                self._track_failed_install_dir(
+                    dir_name=dir_name,
+                    plugin_path=desti_dir,
+                    error=e,
+                )
             logger.warning(
                 f"安装插件 {dir_name} 失败，插件安装目录：{desti_dir}",
             )
             raise
         finally:
-            if temp_desti_dir != desti_dir and os.path.isdir(temp_desti_dir):
+            if (
+                (skip_failed_tracking or temp_desti_dir != desti_dir)
+                and os.path.isdir(temp_desti_dir)
+            ):
                 try:
                     remove_dir(temp_desti_dir)
                 except Exception as e:

--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -1883,9 +1883,8 @@ class PluginManager:
             )
             raise
         finally:
-            if (
-                (skip_failed_tracking or temp_desti_dir != desti_dir)
-                and os.path.isdir(temp_desti_dir)
+            if (skip_failed_tracking or temp_desti_dir != desti_dir) and os.path.isdir(
+                temp_desti_dir
             ):
                 try:
                     remove_dir(temp_desti_dir)

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -28,13 +28,15 @@ class MockStar:
         self.info = {"repo": TEST_PLUGIN_REPO, "readme": ""}
 
 
-def _write_local_test_plugin(plugin_path: Path, repo_url: str):
+def _write_local_test_plugin(
+    plugin_path: Path, repo_url: str, version: str = "1.0.0"
+):
     """Creates a minimal valid plugin structure."""
     plugin_path.mkdir(parents=True, exist_ok=True)
     metadata = {
         "name": TEST_PLUGIN_NAME,
         "repo": repo_url,
-        "version": "1.0.0",
+        "version": version,
         "author": "AstrBot Team",
         "desc": "Local test plugin",
         "short_desc": "Local test short description",
@@ -384,6 +386,41 @@ async def test_install_plugin_from_file_dependency_install_flow(
         await plugin_manager_pm.install_plugin_from_file(str(zip_file_path))
         assert any(e[0] == "deps" for e in events)
         assert ("load", TEST_PLUGIN_DIR) in events
+
+
+@pytest.mark.asyncio
+async def test_install_plugin_from_file_conflict_keeps_failed_plugins_clean(
+    plugin_manager_pm: PluginManager,
+    local_updator: Path,
+    monkeypatch,
+    tmp_path: Path,
+):
+    zip_file_path = tmp_path / "plugin_upload_helloworld_v2.zip"
+    zip_file_path.write_text("placeholder", encoding="utf-8")
+    plugin_store_path = Path(plugin_manager_pm.plugin_store_path)
+    existing_upload_dirs = set(plugin_store_path.glob("plugin_upload_*"))
+
+    def mock_unzip_file(zip_path: str, target_dir: str) -> None:
+        assert zip_path == str(zip_file_path)
+        _write_local_test_plugin(
+            Path(target_dir),
+            TEST_PLUGIN_REPO,
+            version="2.0.0",
+        )
+
+    assert local_updator.is_dir()
+    monkeypatch.setattr(plugin_manager_pm.updator, "unzip_file", mock_unzip_file)
+
+    with pytest.raises(Exception, match=f"安装失败：目录 {TEST_PLUGIN_DIR} 已存在。"):
+        await plugin_manager_pm.install_plugin_from_file(str(zip_file_path))
+
+    new_upload_dirs = [
+        upload_dir
+        for upload_dir in plugin_store_path.glob("plugin_upload_*")
+        if upload_dir not in existing_upload_dirs
+    ]
+    assert plugin_manager_pm.failed_plugin_dict == {}
+    assert new_upload_dirs == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- 引入 skip_failed_tracking 标志，当目标目录已存在时跳过失败安装追踪，避免将预期冲突错误误记为安装失败
- 修复 finally 块中临时目录清理逻辑，确保冲突场景下 plugin_upload_* 临时目录也能被正确删除
- 新增测试用例 test_install_plugin_from_file_conflict_keeps_failed_plugins_clean，验证重复安装同名插件时 failed_plugin_dict 为空且无残留临时目录

Ref #8122

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
```
(astrbot) PS > uv run pytest .\tests\test_plugin_manager.py
=== test session starts ===
platform win32 -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: D:\Nayey\Code\NayukiChiba\AstrBot
configfile: pyproject.toml
plugins: anyio-4.12.1, asyncio-1.3.0, cov-7.0.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 35 items                                                                                  
tests\test_plugin_manager.py ...................................                              [100%]
=== 35 passed in 1.73s ===
```
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure plugin installation from file correctly handles conflicts without leaving temporary directories or incorrect failure tracking.

Bug Fixes:
- Prevent conflict errors during plugin reinstallation from being incorrectly recorded as failed installations by introducing a skip flag in failure tracking.
- Ensure temporary plugin_upload_* directories are cleaned up even when installation fails due to existing target directories.

Tests:
- Add a regression test verifying that re-installing a plugin from file with a conflicting directory leaves no failed_plugin_dict entries and no residual plugin_upload_* temp directories.