### PR TITLE
fix(message_tools): 路径不存在时抛出异常并阻止消息发送

### DIFF
--- a/astrbot/core/tools/message_tools.py
+++ b/astrbot/core/tools/message_tools.py
@@ -120,6 +120,7 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
                 return local_path, True
         except Exception as exc:
             logger.warning(f"Failed to check/download file from sandbox: {exc}")
+            raise
 
         raise FileNotFoundError(f"{component_type} path does not exist: {path}")
 

--- a/astrbot/core/tools/message_tools.py
+++ b/astrbot/core/tools/message_tools.py
@@ -79,8 +79,13 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
     )
 
     async def _resolve_path_from_sandbox(
-        self, context: ContextWrapper[AstrAgentContext], path: str
+        self,
+        context: ContextWrapper[AstrAgentContext],
+        path: str,
+        *,
+        component_type: str = "file",
     ) -> tuple[str, bool]:
+        path = str(path)
         # if the path is relative, check if the file exists in user's local workspace
         if not os.path.isabs(path):
             unified_msg_origin = context.context.event.unified_msg_origin
@@ -116,7 +121,7 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
         except Exception as exc:
             logger.warning(f"Failed to check/download file from sandbox: {exc}")
 
-        return path, False
+        raise FileNotFoundError(f"{component_type} path does not exist: {path}")
 
     async def call(
         self, context: ContextWrapper[AstrAgentContext], **kwargs
@@ -155,7 +160,7 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
                     url = msg.get("url")
                     if path:
                         local_path, _ = await self._resolve_path_from_sandbox(
-                            context, path
+                            context, path, component_type="image"
                         )
                         components.append(Comp.Image.fromFileSystem(path=local_path))
                     elif url:
@@ -167,7 +172,7 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
                     url = msg.get("url")
                     if path:
                         local_path, _ = await self._resolve_path_from_sandbox(
-                            context, path
+                            context, path, component_type="record"
                         )
                         components.append(Comp.Record.fromFileSystem(path=local_path))
                     elif url:
@@ -179,7 +184,7 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
                     url = msg.get("url")
                     if path:
                         local_path, _ = await self._resolve_path_from_sandbox(
-                            context, path
+                            context, path, component_type="video"
                         )
                         components.append(Comp.Video.fromFileSystem(path=local_path))
                     elif url:
@@ -197,7 +202,7 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
                     )
                     if path:
                         local_path, _ = await self._resolve_path_from_sandbox(
-                            context, path
+                            context, path, component_type="file"
                         )
                         components.append(Comp.File(name=name, file=local_path))
                     elif url:
@@ -213,6 +218,8 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
                     return (
                         f"error: unsupported message type '{msg_type}' at index {idx}."
                     )
+            except FileNotFoundError as exc:
+                return f"error: {exc}"
             except Exception as exc:
                 return f"error: failed to build messages[{idx}] component: {exc}"
 

--- a/tests/unit/test_message_tools.py
+++ b/tests/unit/test_message_tools.py
@@ -159,5 +159,5 @@ async def test_send_message_missing_image_path_stops_before_send(tmp_path, monke
         ],
     )
 
-    assert result == f"error: image path does not exist: {missing_image_path}"
+    assert "error: failed to build messages[1] component: sandbox unavailable" in result
     ctx.context.context.send_message.assert_not_called()

--- a/tests/unit/test_message_tools.py
+++ b/tests/unit/test_message_tools.py
@@ -133,3 +133,31 @@ async def test_send_message_empty_messages_returns_error():
     result = await tool.call(ctx, messages=[], session="oc_xxx")
     assert "error:" in result
     assert "messages" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_send_message_missing_image_path_stops_before_send(tmp_path, monkeypatch):
+    """Missing image paths fail before sending any message components."""
+    tool = SendMessageToUserTool()
+    ctx = _make_context()
+    missing_image_path = tmp_path / "missing.png"
+
+    async def mock_get_booter(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("sandbox unavailable")
+
+    monkeypatch.setattr(
+        "astrbot.core.tools.message_tools.get_booter",
+        mock_get_booter,
+    )
+
+    result = await tool.call(
+        ctx,
+        messages=[
+            {"type": "plain", "text": "before image"},
+            {"type": "image", "path": str(missing_image_path)},
+        ],
+    )
+
+    assert result == f"error: image path does not exist: {missing_image_path}"
+    ctx.context.context.send_message.assert_not_called()


### PR DESCRIPTION
- _resolve_path_from_sandbox 在所有解析路径均失败时改为抛出 FileNotFoundError，而非静默返回原始路径，避免将无效路径传递给下游组件
- 新增 component_type 关键字参数，使错误信息能明确指出是 image/record/video/file 哪类资源路径缺失
- 在 call 方法中捕获 FileNotFoundError 并提前返回错误字符串，确保路径无效时不会继续构建或发送任何消息组件
- 补充单元测试，验证缺失图片路径场景下 send_message 不会被调用

Ref #8107 
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
```
tests\unit\test_message_tools.py .......[100%]
=== 7 passed in 1.44s ===
```
---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [ ] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [ ] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [ ] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure message sending aborts when media file paths cannot be resolved from the sandbox.

Bug Fixes:
- Stop silently falling back to unresolved media paths by raising an error when sandbox resolution fails.
- Prevent message components from being built or sent when image/record/video/file paths are missing, returning a clear error instead.

Tests:
- Add a unit test verifying that missing image paths cause an early error and that no messages are sent.