### PR TITLE
fix(docs): fix multiple errors in plugin development guides

### DIFF
--- a/astrbot/core/star/register/star_handler.py
+++ b/astrbot/core/star/register/star_handler.py
@@ -422,11 +422,11 @@ def register_on_llm_request(**kwargs):
     from astrbot.api.provider import ProviderRequest
 
     @on_llm_request()
-    async def test(self, event: AstrMessageEvent, request: ProviderRequest) -> None:
-        request.system_prompt += "你是一个猫娘..."
+    async def test(self, event: AstrMessageEvent, req: ProviderRequest) -> None:
+        req.system_prompt += "你是一个猫娘..."
     ```
 
-    请务必接收两个参数：event, request
+    请务必接收两个参数：event, req
 
     """
 

--- a/docs/en/dev/star/guides/listen-message-event.md
+++ b/docs/en/dev/star/guides/listen-message-event.md
@@ -1,4 +1,3 @@
-
 # Handling Message Events
 
 Event listeners can receive message content delivered by the platform and implement features such as commands, command groups, and event listening.
@@ -97,7 +96,7 @@ AstrBot will automatically parse command parameters for you.
 
 ```python
 @filter.command("add")
-def add(self, event: AstrMessageEvent, a: int, b: int):
+async def add(self, event: AstrMessageEvent, a: int, b: int):
     # /add 1 2 -> Result is: 3
     yield event.plain_result(f"Wow! The answer is {a + b}!")
 ```
@@ -108,7 +107,7 @@ Command groups help you organize commands.
 
 ```python
 @filter.command_group("math")
-def math(self):
+def math():
     pass
 
 @math.command("add")
@@ -160,7 +159,7 @@ async def sub(self, event: AstrMessageEvent, a: int, b: int):
     yield event.plain_result(f"Result is: {a - b}")
 
 @calc.command("help")
-def calc_help(self, event: AstrMessageEvent):
+async def calc_help(self, event: AstrMessageEvent):
     # /math calc help
     yield event.plain_result("This is a calculator plugin with add and sub commands.")
 ```
@@ -209,7 +208,7 @@ async def on_aiocqhttp(self, event: AstrMessageEvent):
     yield event.plain_result("Received a message")
 ```
 
-In the current version, `PlatformAdapterType` includes `AIOCQHTTP`, `QQOFFICIAL`, `GEWECHAT`, and `ALL`.
+In the current version, `PlatformAdapterType` supports the following values: `AIOCQHTTP`, `QQOFFICIAL`, `QQOFFICIAL_WEBHOOK`, `TELEGRAM`, `WECOM`, `WECOM_AI_BOT`, `LARK`, `DINGTALK`, `DISCORD`, `SLACK`, `KOOK`, `VOCECHAT`, `WEIXIN_OFFICIAL_ACCOUNT`, `SATORI`, `MISSKEY`, `LINE`, `MATRIX`, `WEIXIN_OC`, `MATTERMOST`, `WEBCHAT`, `ALL`.
 
 #### Admin Commands
 
@@ -420,13 +419,14 @@ You can implement some message decoration here, such as converting to voice, con
 
 ```python
 from astrbot.api.event import filter, AstrMessageEvent
+import astrbot.api.message_components as Comp
 
 @filter.on_decorating_result()
 async def on_decorating_result(self, event: AstrMessageEvent):
     result = event.get_result()
     chain = result.chain
     print(chain) # Print the message chain
-    chain.append(Plain("!")) # Add an exclamation mark at the end of the message chain
+    chain.append(Comp.Plain("!")) # Add an exclamation mark at the end of the message chain
 ```
 
 > You cannot use yield to send messages here. This hook is only for decorating event.get_result().chain. If you need to send, please use the `event.send()` method directly.

--- a/docs/en/dev/star/guides/listen-message-event.md
+++ b/docs/en/dev/star/guides/listen-message-event.md
@@ -172,7 +172,7 @@ You can add different aliases for commands or command groups:
 
 ```python
 @filter.command("help", alias={'帮助', 'helpme'})
-def help(self, event: AstrMessageEvent):
+async def help(self, event: AstrMessageEvent):
     yield event.plain_result("This is a calculator plugin with add and sub commands.")
 ```
 

--- a/docs/en/dev/star/plugin-new.md
+++ b/docs/en/dev/star/plugin-new.md
@@ -102,8 +102,10 @@ The values in `support_platforms` must be keys from `ADAPTER_NAME_2_TYPE`. Curre
 
 - `aiocqhttp`
 - `qq_official`
+- `qq_official_webhook`
 - `telegram`
 - `wecom`
+- `wecom_ai_bot`
 - `lark`
 - `dingtalk`
 - `discord`
@@ -111,9 +113,12 @@ The values in `support_platforms` must be keys from `ADAPTER_NAME_2_TYPE`. Curre
 - `kook`
 - `vocechat`
 - `weixin_official_account`
+- `weixin_oc`
 - `satori`
 - `misskey`
 - `line`
+- `matrix`
+- `mattermost`
 
 ### Declare AstrBot Version Range (Optional)
 

--- a/docs/zh/dev/star/guides/ai.md
+++ b/docs/zh/dev/star/guides/ai.md
@@ -1,4 +1,3 @@
-
 # AI
 
 AstrBot 内置了对多种大语言模型（LLM）提供商的支持，并且提供了统一的接口，方便插件开发者调用各种 LLM 服务。
@@ -490,7 +489,7 @@ persona_mgr = self.context.persona_manager
 - __Arguments__  
   - `persona_id: str` – 待删除的人格 ID
 - __Raises__  
-  `Valueable` – 若 `persona_id` 不存在
+  `ValueError` – 若 `persona_id` 不存在
 
 #### `get_default_persona_v3`
 

--- a/docs/zh/dev/star/guides/listen-message-event.md
+++ b/docs/zh/dev/star/guides/listen-message-event.md
@@ -98,7 +98,7 @@ AstrBot 会自动帮你解析指令的参数。
 @filter.command("add")
 async def add(self, event: AstrMessageEvent, a: int, b: int):
     # /add 1 2 -> 结果是: 3
-    yield event.plain_result(f"Wow! The anwser is {a + b}!")
+    yield event.plain_result(f"Wow! The answer is {a + b}!")
 ```
 
 ## 指令组
@@ -172,7 +172,7 @@ async def calc_help(self, event: AstrMessageEvent):
 
 ```python
 @filter.command("help", alias={'帮助', 'helpme'})
-def help(self, event: AstrMessageEvent):
+async def help(self, event: AstrMessageEvent):
     yield event.plain_result("这是一个计算器插件，拥有 add, sub 指令。")
 ```
 

--- a/docs/zh/dev/star/guides/listen-message-event.md
+++ b/docs/zh/dev/star/guides/listen-message-event.md
@@ -1,4 +1,3 @@
-
 # 处理消息事件
 
 事件监听器可以收到平台下发的消息内容，可以实现指令、指令组、事件监听等功能。
@@ -97,7 +96,7 @@ AstrBot 会自动帮你解析指令的参数。
 
 ```python
 @filter.command("add")
-def add(self, event: AstrMessageEvent, a: int, b: int):
+async def add(self, event: AstrMessageEvent, a: int, b: int):
     # /add 1 2 -> 结果是: 3
     yield event.plain_result(f"Wow! The anwser is {a + b}!")
 ```
@@ -108,7 +107,7 @@ def add(self, event: AstrMessageEvent, a: int, b: int):
 
 ```python
 @filter.command_group("math")
-def math(self):
+def math():
     pass
 
 @math.command("add")
@@ -160,7 +159,7 @@ async def sub(self, event: AstrMessageEvent, a: int, b: int):
     yield event.plain_result(f"结果是: {a - b}")
 
 @calc.command("help")
-def calc_help(self, event: AstrMessageEvent):
+async def calc_help(self, event: AstrMessageEvent):
     # /math calc help
     yield event.plain_result("这是一个计算器插件，拥有 add, sub 指令。")
 ```
@@ -209,7 +208,7 @@ async def on_aiocqhttp(self, event: AstrMessageEvent):
     yield event.plain_result("收到了一条信息")
 ```
 
-当前版本下，`PlatformAdapterType` 有 `AIOCQHTTP`, `QQOFFICIAL`, `GEWECHAT`, `ALL`。
+当前版本下，`PlatformAdapterType` 支持以下值：`AIOCQHTTP`、`QQOFFICIAL`、`QQOFFICIAL_WEBHOOK`、`TELEGRAM`、`WECOM`、`WECOM_AI_BOT`、`LARK`、`DINGTALK`、`DISCORD`、`SLACK`、`KOOK`、`VOCECHAT`、`WEIXIN_OFFICIAL_ACCOUNT`、`SATORI`、`MISSKEY`、`LINE`、`MATRIX`、`WEIXIN_OC`、`MATTERMOST`、`WEBCHAT`、`ALL`。
 
 #### 管理员指令
 
@@ -437,13 +436,14 @@ async def on_agent_done(self, event: AstrMessageEvent, run_context: ContextWrapp
 
 ```python
 from astrbot.api.event import filter, AstrMessageEvent
+import astrbot.api.message_components as Comp
 
 @filter.on_decorating_result()
 async def on_decorating_result(self, event: AstrMessageEvent):
     result = event.get_result()
     chain = result.chain
     print(chain) # 打印消息链
-    chain.append(Plain("!")) # 在消息链的最后添加一个感叹号
+    chain.append(Comp.Plain("!")) # 在消息链的最后添加一个感叹号
 ```
 
 > 这里不能使用 yield 来发送消息。这个钩子只是用来装饰 event.get_result().chain 的。如需发送，请直接使用 `event.send()` 方法。

--- a/docs/zh/dev/star/guides/simple.md
+++ b/docs/zh/dev/star/guides/simple.md
@@ -4,7 +4,7 @@
 
 ```python
 from astrbot.api.event import filter, AstrMessageEvent, MessageEventResult
-from astrbot.api.star import Context, Star, register
+from astrbot.api.star import Context, Star
 from astrbot.api import logger # 使用 astrbot 提供的 logger 接口
 
 class MyPlugin(Star):

--- a/docs/zh/dev/star/plugin-new.md
+++ b/docs/zh/dev/star/plugin-new.md
@@ -104,8 +104,10 @@ support_platforms:
 
 - `aiocqhttp`
 - `qq_official`
+- `qq_official_webhook`
 - `telegram`
 - `wecom`
+- `wecom_ai_bot`
 - `lark`
 - `dingtalk`
 - `discord`
@@ -113,9 +115,12 @@ support_platforms:
 - `kook`
 - `vocechat`
 - `weixin_official_account`
+- `weixin_oc`
 - `satori`
 - `misskey`
 - `line`
+- `matrix`
+- `mattermost`
 
 ### 声明 AstrBot 版本范围（Optional）
 


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
通过惊人的注意力发现了文档的一些错误
### Modifications / 改动点
1. `def add` / `def calc_help` 应为 `async def`
（docs/zh|en/dev/star/guides/listen-message-event.md）
2. `on_decorating_result` 示例缺少 `Plain` 导入
（docs/zh|en/dev/star/guides/listen-message-event.md）
3. `PlatformAdapterType`不完整
（docs/zh|en/dev/star/guides/listen-message-event.md）
4. `delete_persona` Raises 字段拼写错误
（docs/zh/dev/star/guides/ai.md）
`Valueable` → `ValueError`，与 `persona_mgr.py` 实际 `raise` 类型一致。
5. `support_platforms` 列表不完整
（docs/zh|en/dev/star/plugin-new.md）
缺少 `qq_official_webhook`、`wecom_ai_bot`、`weixin_oc`、`matrix`、`mattermost`  5 个平台。（还是要声明一下好？）
6. `simple.md` 导入了已废弃的 `register`
（docs/zh/dev/star/guides/simple.md）
`register_star` 装饰器自 v3.5.20 起标注 `DeprecationWarning`。
7. `star_handler.py` docstring 参数命名不一致
（astrbot/core/star/register/star_handler.py）
`register_on_llm_request` 的 docstring 示例使用 `request`，而调用处`internal.py` 变量名为 `req`，用户文档两处示例也均为 `req`。将 docstring 统一改为 `req`，消除歧义。
8. 指令组占位函数 `self` 参数前后不一致
（docs/zh|en/dev/star/guides/listen-message-event.md）
同文件两处示例，一处写 `def math(self):`，另一处写 `def math():`。统一改为无 `self`。

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
这只是一个文档错误）
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Update plugin development documentation and examples to reflect current async APIs, supported platforms, and consistent naming.

Enhancements:
- Align register_on_llm_request docstring example parameter naming with existing usage to avoid ambiguity.

Documentation:
- Correct command and helper function examples to use async definitions and consistent command group signatures in message event guides (EN/ZN).
- Expand documented PlatformAdapterType and support_platforms lists to include all currently supported adapters in both English and Chinese docs.
- Fix missing message component import and usage in on_decorating_result examples in message event guides (EN/ZH).
- Correct the documented exception type for delete_persona and remove deprecated register import from simple plugin guide (ZH).