### PR TITLE
fix: 尊重显式配置的 Shipyard Neo profile

### DIFF
--- a/astrbot/core/computer/booters/shipyard_neo.py
+++ b/astrbot/core/computer/booters/shipyard_neo.py
@@ -353,12 +353,12 @@ class ShipyardNeoBooter(ComputerBooter):
         self,
         endpoint_url: str,
         access_token: str,
-        profile: str = DEFAULT_PROFILE,
+        profile: str = "",
         ttl: int = 3600,
     ) -> None:
         self._endpoint_url = endpoint_url
         self._access_token = access_token
-        self._profile = profile
+        self._profile = profile.strip() if profile else ""
         self._ttl = ttl
         self._client: BayClient | None = None
         self._sandbox: Sandbox | None = None
@@ -431,7 +431,9 @@ class ShipyardNeoBooter(ComputerBooter):
         )
         await self._client.__aenter__()
 
-        # Resolve profile: user-specified > smart selection > default
+        # Resolve profile: user-specified > smart selection > default.
+        # An empty profile means auto-select; any non-empty profile must be
+        # honoured as an explicit choice, including "python-default".
         resolved_profile = await self._resolve_profile(self._client)
 
         self._sandbox = await self._client.create_sandbox(
@@ -535,7 +537,7 @@ class ShipyardNeoBooter(ComputerBooter):
         """Pick the best profile for this session.
 
         Resolution order:
-        1. User-specified profile (non-empty, non-default) → use as-is.
+        1. User-specified profile (non-empty) → use as-is.
         2. Query ``GET /v1/profiles`` and pick the profile with the most
            capabilities, preferring profiles that include ``"browser"``.
         3. Fall back to :attr:`DEFAULT_PROFILE`.
@@ -544,8 +546,8 @@ class ShipyardNeoBooter(ComputerBooter):
         misconfigured token, and silently falling back would just delay the
         real failure to ``create_sandbox``.
         """
-        # User explicitly set a profile → honour it
-        if self._profile and self._profile != self.DEFAULT_PROFILE:
+        # User explicitly set a profile → honour it.
+        if self._profile:
             logger.info("[Computer] Using user-specified profile: %s", self._profile)
             return self._profile
 

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -3315,7 +3315,7 @@ CONFIG_METADATA_3 = {
                     "provider_settings.sandbox.shipyard_neo_profile": {
                         "description": "Shipyard Neo Profile",
                         "type": "string",
-                        "hint": "Shipyard Neo 沙箱 profile，如 python-default。",
+                        "hint": "Shipyard Neo 沙箱 profile，如 python-default。留空时自动选择能力更完整的 profile。",
                         "condition": {
                             "provider_settings.computer_use_runtime": "sandbox",
                             "provider_settings.sandbox.booter": "shipyard_neo",

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -180,7 +180,7 @@
           },
           "shipyard_neo_profile": {
             "description": "Shipyard Neo Profile",
-            "hint": "Sandbox profile for Shipyard Neo, e.g. python-default."
+            "hint": "Sandbox profile for Shipyard Neo, e.g. python-default. Leave empty to auto-select the most capable profile."
           },
           "shipyard_neo_ttl": {
             "description": "Shipyard Neo Sandbox TTL",

--- a/dashboard/src/i18n/locales/ru-RU/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/config-metadata.json
@@ -180,7 +180,7 @@
                     },
                     "shipyard_neo_profile": {
                         "description": "Профиль Shipyard Neo",
-                        "hint": "Профиль песочницы, например, python-default."
+                        "hint": "Профиль песочницы, например, python-default. Оставьте пустым для автоматического выбора самого функционального профиля."
                     },
                     "shipyard_neo_ttl": {
                         "description": "TTL песочницы Shipyard Neo",

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -182,7 +182,7 @@
           },
           "shipyard_neo_profile": {
             "description": "Shipyard Neo Profile",
-            "hint": "Shipyard Neo 沙箱 profile，例如 python-default。"
+            "hint": "Shipyard Neo 沙箱 profile，例如 python-default。留空时自动选择能力更完整的 profile。"
           },
           "shipyard_neo_ttl": {
             "description": "Shipyard Neo Sandbox 存活时间(秒)",

--- a/docs/en/use/astrbot-agent-sandbox.md
+++ b/docs/en/use/astrbot-agent-sandbox.md
@@ -328,7 +328,7 @@ If you choose `Shipyard Neo`, the main configuration items are:
   - If AstrBot can access Bay's `credentials.json`, you may leave it empty and let AstrBot auto-discover it
 - `Shipyard Neo Profile`
   - For example `python-default` or `browser-python`
-  - If not explicitly specified, AstrBot will try to choose a profile with richer capabilities, preferring one that includes the `browser` capability, and fall back to `python-default` if needed
+  - If left empty, AstrBot will try to choose a profile with richer capabilities, preferring one that includes the `browser` capability, and fall back to `python-default` if needed
 - `Shipyard Neo Sandbox TTL`
   - The upper lifetime limit of the sandbox, defaulting to 3600 seconds (1 hour)
 

--- a/docs/zh/use/astrbot-agent-sandbox.md
+++ b/docs/zh/use/astrbot-agent-sandbox.md
@@ -434,7 +434,7 @@ docker pull soulter/shipyard-ship:latest
   - 如果是官方联合部署，且 AstrBot 能访问 Bay 的 `credentials.json`，可以留空自动发现
 - `Shipyard Neo Profile`
   - 例如 `python-default`、`browser-python`
-  - 如果未手动指定，AstrBot 会优先尝试选择能力更完整、且优先带有 `browser` capability 的 profile，失败时再回退到 `python-default`
+  - 如果留空，AstrBot 会优先尝试选择能力更完整、且优先带有 `browser` capability 的 profile，失败时再回退到 `python-default`
 - `Shipyard Neo Sandbox TTL`
   - sandbox 生命周期上限，默认值为 3600 秒（1 小时）
 

--- a/tests/test_profile_aware_tools.py
+++ b/tests/test_profile_aware_tools.py
@@ -169,7 +169,7 @@ class TestApplySandboxToolsConditional:
 class TestResolveProfile:
     """Test smart profile selection logic."""
 
-    def _make_booter(self, profile: str = "python-default"):
+    def _make_booter(self, profile: str = ""):
         from astrbot.core.computer.booters.shipyard_neo import ShipyardNeoBooter
 
         return ShipyardNeoBooter(
@@ -187,8 +187,16 @@ class TestResolveProfile:
         assert result == "browser-python"
 
     @pytest.mark.asyncio
+    async def test_user_specified_default_profile_honoured(self):
+        """User explicitly sets python-default → use it directly."""
+        booter = self._make_booter(profile="python-default")
+        client = SimpleNamespace()  # list_profiles should NOT be called
+        result = await booter._resolve_profile(client)
+        assert result == "python-default"
+
+    @pytest.mark.asyncio
     async def test_selects_browser_profile(self):
-        """When multiple profiles available, prefer one with browser."""
+        """When profile is empty, prefer an available profile with browser."""
 
         async def _mock_list_profiles():
             return SimpleNamespace(


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

修复 Shipyard Neo 在 AstrBot 里错误地把 `python-default` 当成“默认占位值”的问题。现在只要 profile 非空，就会按用户显式配置传给 Bay；只有 profile 为空时，才自动扫描并优先选择带 `browser` capability 的 profile。

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] 这不是一个破坏性变更。
- 调整 `astrbot/core/computer/booters/shipyard_neo.py` 的 profile 解析逻辑，确保 `python-default` 作为显式配置时会被尊重。
- 更新 `tests/test_profile_aware_tools.py`，补充显式 `python-default` 和空值自动选择两类用例。
- 同步更新配置提示和文档，明确“留空才自动选择”的行为。

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

已完成验证：
- `uv run pytest tests/test_profile_aware_tools.py`
- `uv run ruff format .`
- `uv run ruff check .`

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 如果这个 PR 里有新功能，我已经通过 Issue / 邮件等方式和作者讨论过。
- [x] 👀 我的更改已经充分测试，并且上方已经提供了“验证步骤”和“运行截图/日志”。
- [x] 🤓 我确保没有引入新依赖库；如果引入了新依赖，也已同步更新 `requirements.txt` 和 `pyproject.toml`。
- [x] 😮 我的更改没有引入恶意代码。
