### PR TITLE
fix(#8184): “控制台自动滚动开关持久化”特性未生效

### DIFF
--- a/dashboard/src/views/ConsolePage.vue
+++ b/dashboard/src/views/ConsolePage.vue
@@ -73,6 +73,11 @@ export default {
       status: ''
     }
   },
+  mounted() {
+    if (this.$refs.consoleDisplayer) {
+      this.$refs.consoleDisplayer.autoScroll = this.autoScrollEnabled;
+    }
+  },
   watch: {
     autoScrollEnabled(val) {
       localStorage.setItem('console_auto_scroll', val);


### PR DESCRIPTION
### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

**Bug 修复：控制台自动滚动开关持久化状态不生效**

v4.24.4 添加了控制台自动滚动开关持久化功能，但存在以下 bug：

- 前端开关的显示状态可以正确从 localStorage 读取并保持
- 但每次切换到日志页面时，无论开关记忆的状态是否为关闭，日志仍会自动滚动
- 用户必须手动点击两次开关（关→开→关），才能真正停止自动滚动
- 关联 Issue: [#8184  ](https://github.com/AstrBotDevs/AstrBot/issues/8184)
**根因分析：**

`ConsolePage.vue` 与 `ConsoleDisplayer.vue` 之间存在初始化时序问题：

1. `ConsolePage.vue` 从 localStorage 正确加载了 `autoScrollEnabled` 偏好值
2. 但 `ConsoleDisplayer.vue` 的 `autoScroll` 属性默认初始化为 `true`
3. `ConsolePage` 中的 watcher 仅在 `autoScrollEnabled` 变化时才同步给子组件，初次挂载时不会触发
4. 因此页面加载后，UI 上开关显示的是 localStorage 中保存的关闭状态，但 `ConsoleDisplayer` 内部的 `autoScroll` 实际仍为 `true`

**修改的文件：**

1. `src/views/ConsolePage.vue`
   - 新增 `mounted()` 生命周期钩子，在组件挂载时将 `autoScrollEnabled` 显式同步给 `ConsoleDisplayer` 子组件
   - 确保从 localStorage 加载的偏好值在初次渲染时即生效，无需用户手动切换

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行"验证步骤"的证据，证明此改动有效。-->

**验证步骤：**

1. 进入控制台日志页面，关闭"自动滚动"开关
2. 切换到其他页面，再切换回日志页面
3. 修复前：开关显示为关闭状态，但日志仍会自动滚动到底部
4. 修复后：开关显示为关闭状态，日志不会自动滚动，与开关状态一致

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Fix console log auto-scroll continuing to scroll on page load even when the persisted switch state is off by syncing the parent preference to the console display component on mount.