### PR TITLE
fix: skip empty llm summaries

### DIFF
--- a/astrbot/core/agent/context/compressor.py
+++ b/astrbot/core/agent/context/compressor.py
@@ -218,9 +218,13 @@ class LLMSummaryCompressor:
         # generate summary
         try:
             response = await self.provider.text_chat(contexts=llm_payload)
-            summary_content = response.completion_text
+            summary_content = (response.completion_text or "").strip()
         except Exception as e:
             logger.error(f"Failed to generate summary: {e}")
+            return messages
+
+        if not summary_content:
+            logger.warning("LLM context compression returned an empty summary.")
             return messages
 
         # build result

--- a/tests/agent/test_context_manager.py
+++ b/tests/agent/test_context_manager.py
@@ -94,6 +94,25 @@ class TestContextManager:
 
         assert isinstance(manager.compressor, TruncateByTurnsCompressor)
 
+    @pytest.mark.asyncio
+    async def test_llm_compressor_keeps_history_when_summary_is_empty(self):
+        from astrbot.core.agent.context.compressor import LLMSummaryCompressor
+
+        provider = MockProvider()
+        provider.text_chat = AsyncMock(
+            return_value=LLMResponse(role="assistant", completion_text="  ")
+        )
+        compressor = LLMSummaryCompressor(provider=provider, keep_recent=2)  # type: ignore[arg-type]
+        messages = self.create_messages(6)
+
+        with patch("astrbot.core.agent.context.compressor.logger") as mock_logger:
+            result = await compressor(messages)
+
+        assert result == messages
+        mock_logger.warning.assert_called_once_with(
+            "LLM context compression returned an empty summary."
+        )
+
     # ==================== Empty and Edge Cases ====================
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- skip LLM context compression when the summary response is empty
- log a warning instead of inserting an empty summary placeholder into history
- add a regression test for blank `completion_text`

Closes #8133.

## To verify
- `.venv\Scripts\python.exe -m py_compile astrbot\core\agent\context\compressor.py tests\agent\test_context_manager.py`
- `.venv\Scripts\python.exe -m ruff check astrbot\core\agent\context\compressor.py tests\agent\test_context_manager.py`
- `.venv\Scripts\python.exe -m pytest tests\agent\test_context_manager.py -q --basetemp .tmp\pytest -p no:cacheprovider`
- `git diff --check`

## Summary by Sourcery

Handle empty LLM-generated summaries safely in the context compressor to avoid altering history when no usable summary is returned.

Bug Fixes:
- Prevent LLMSummaryCompressor from inserting an empty summary into the message history when the LLM returns blank or missing completion text.

Tests:
- Add an async regression test ensuring LLMSummaryCompressor preserves history and logs a warning when the LLM returns an empty summary.