### PR TITLE
fix(webui): add Noto Sans to global font-family stack for Cyrillic text

### DIFF
--- a/dashboard/src/scss/_variables.scss
+++ b/dashboard/src/scss/_variables.scss
@@ -9,7 +9,7 @@ $color-pack: false;
 // Global font size and border radius
 $font-size-root: 1rem;
 $border-radius-root: 8px;
-$cjk-sans-fallback: 'PingFang SC', 'Hiragino Sans GB', 'Noto Sans CJK SC', 'Microsoft YaHei', 'Noto Sans SC', 'Noto Sans' !default;
+$cjk-sans-fallback: 'PingFang SC', 'Hiragino Sans GB', 'Noto Sans CJK SC', 'Microsoft YaHei', 'Noto Sans SC' !default;
 $cjk-mono-fallback: 'PingFang SC', 'PingFang TC', 'Hiragino Sans GB', 'Noto Sans CJK SC', 'Microsoft YaHei' !default;
 $code-text-color: #111827 !default;
 
@@ -19,7 +19,7 @@ $code-text-color: #111827 !default;
   --astrbot-code-color: #{$code-text-color};
 }
 
-$body-font-family: $cjk-sans-fallback, sans-serif !default;
+$body-font-family: 'Outfit', 'Noto Sans', $cjk-sans-fallback, sans-serif !default;
 $heading-font-family: $body-font-family !default;
 $btn-font-weight: 400 !default;
 $btn-letter-spacing: 0 !default;

--- a/dashboard/src/scss/layout/_container.scss
+++ b/dashboard/src/scss/layout/_container.scss
@@ -80,7 +80,7 @@ $sizes: (
 
 body {
   .Outfit {
-    font-family: 'Outfit', $cjk-sans-fallback, sans-serif !important;
+    font-family: $body-font-family !important;
   }
 }
 


### PR DESCRIPTION
PR #8015 added 'Noto Sans' to the Google Fonts link and CJK fallback list, but the font was placed at the end of $cjk-sans-fallback where browsers never reach it for Cyrillic text. The global $body-font-family also lacked 'Outfit' entirely, causing Vuetify to use CJK fonts as the primary face.

Changes:
- Remove 'Noto Sans' from the end of $cjk-sans-fallback (it is not a CJK font)
- Add 'Outfit' and 'Noto Sans' to $body-font-family before CJK fallbacks
- Update .Outfit class in _container.scss to match the new stack

This ensures:
- Latin text → Outfit
- Cyrillic text → Noto Sans (loaded by vite-plugin-webfont-dl)
- CJK text → Noto Sans SC / PingFang SC etc.

Fixes follow-up to #8015.

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
Verified via browser DevTools → Network → Fonts: `Noto Sans` is now loaded alongside `Outfit` and `Noto Sans SC`. Cyrillic text renders correctly with `Noto Sans` glyphs.

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Adjust global font-family stacks so Latin text uses Outfit, Cyrillic text uses Noto Sans, and CJK text continues to use appropriate CJK fonts.

Bug Fixes:
- Ensure Cyrillic text renders with Noto Sans instead of falling back to CJK fonts.

Enhancements:
- Set Outfit and Noto Sans as primary fonts in the global body font stack and align the .Outfit utility class with the new stack.