### PR TITLE
Fix/plugin metadata repo type guard

### DIFF
--- a/astrbot/dashboard/routes/plugin.py
+++ b/astrbot/dashboard/routes/plugin.py
@@ -1270,7 +1270,7 @@ class PluginRoute(Route):
                 logo_url = await self.get_plugin_logo_token(plugin.logo_path)
             _t = {
                 "name": plugin.name,
-                "repo": "" if plugin.repo is None else plugin.repo,
+                "repo": "" if plugin.repo is None else str(plugin.repo),
                 "author": plugin.author,
                 "desc": plugin.desc,
                 "version": plugin.version,
@@ -1320,7 +1320,7 @@ class PluginRoute(Route):
                 .ok(
                     {
                         "name": plugin.name,
-                        "repo": "" if plugin.repo is None else plugin.repo,
+                        "repo": "" if plugin.repo is None else str(plugin.repo),
                         "author": plugin.author,
                         "desc": plugin.desc,
                         "version": plugin.version,

--- a/dashboard/src/views/extension/useExtensionPage.js
+++ b/dashboard/src/views/extension/useExtensionPage.js
@@ -14,8 +14,6 @@ import { getValidHashTab, replaceTabRoute } from "@/utils/hashRouteTabs.mjs";
 import { ref, computed, onMounted, onUnmounted, reactive, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
-// 安全地将 repo 字段转为小写字符串，防止非字符串类型导致 toLowerCase 报错
-const safeRepoStr = (repo) => (typeof repo === "string" ? repo : String(repo ?? "")).trim();
 
 const buildFailedPluginItems = (raw) => {
   return Object.entries(raw || {}).map(([dirName, info]) => {
@@ -622,12 +620,12 @@ export const useExtensionPage = () => {
 
   const findMarketPluginForExtension = (extension) => {
     if (!extension) return null;
-    const repo = safeRepoStr(normalizeInstallUrl(extension.repo)).toLowerCase();
+    const repo = normalizeInstallUrl(extension.repo).toLowerCase();
     return (
       pluginMarketData.value.find(
         (plugin) =>
           repo &&
-          safeRepoStr(normalizeInstallUrl(plugin?.repo)).toLowerCase() === repo,
+          normalizeInstallUrl(plugin?.repo).toLowerCase() === repo,
       ) ||
       pluginMarketData.value.find((plugin) => plugin.name === extension.name) ||
       null
@@ -643,14 +641,14 @@ export const useExtensionPage = () => {
 
     pluginMarketData.value.forEach((plugin) => {
       if (plugin.repo) {
-        onlinePluginsMap.set(safeRepoStr(plugin.repo).toLowerCase(), plugin);
+        onlinePluginsMap.set(normalizeInstallUrl(plugin.repo).toLowerCase(), plugin);
       }
       onlinePluginsNameMap.set(plugin.name, plugin);
     });
 
     const data = Array.isArray(extension_data?.data) ? extension_data.data : [];
     data.forEach((extension) => {
-      const repoKey = extension.repo ? safeRepoStr(extension.repo).toLowerCase() : undefined;
+      const repoKey = extension.repo ? normalizeInstallUrl(extension.repo).toLowerCase() : undefined;
       const onlinePlugin = repoKey ? onlinePluginsMap.get(repoKey) : null;
       const onlinePluginByName = onlinePluginsNameMap.get(extension.name);
       const matchedPlugin = onlinePlugin || onlinePluginByName;
@@ -1236,21 +1234,25 @@ export const useExtensionPage = () => {
 
   const checkAlreadyInstalled = () => {
     const data = Array.isArray(extension_data?.data) ? extension_data.data : [];
-    const installedRepos = new Set(data.map((ext) => ext.repo ? safeRepoStr(ext.repo).toLowerCase() : undefined));
+    const installedRepos = new Set(
+      data
+        .filter((ext) => ext.repo)
+        .map((ext) => normalizeInstallUrl(ext.repo).toLowerCase()),
+    );
     const installedNames = new Set(
       data.map((ext) => normalizeStr(ext.name).replace(/_/g, "-")),
     ); //统一格式，以防下面的匹配不生效
     const installedByRepo = new Map(
       data
         .filter((ext) => ext.repo)
-        .map((ext) => [safeRepoStr(ext.repo).toLowerCase(), ext]),
+        .map((ext) => [normalizeInstallUrl(ext.repo).toLowerCase(), ext]),
     );
     const installedByName = new Map(data.map((ext) => [ext.name, ext]));
 
     for (let i = 0; i < pluginMarketData.value.length; i++) {
       const plugin = pluginMarketData.value[i];
       const matchedInstalled =
-        (plugin.repo && installedByRepo.get(safeRepoStr(plugin.repo).toLowerCase())) ||
+        (plugin.repo && installedByRepo.get(normalizeInstallUrl(plugin.repo).toLowerCase())) ||
         installedByName.get(plugin.name);
 
       // 兜底：市场源未提供字段时，回填本地已安装插件中的元数据，便于在市场页直接展示
@@ -1268,7 +1270,7 @@ export const useExtensionPage = () => {
       }
 
       plugin.installed =
-        installedRepos.has(plugin.repo ? safeRepoStr(plugin.repo).toLowerCase() : undefined) ||
+        (plugin.repo && installedRepos.has(normalizeInstallUrl(plugin.repo).toLowerCase())) ||
         installedNames.has(normalizeStr(plugin.name).replace(/_/g, "-")); //统一格式，防止匹配失败
     }
 

--- a/dashboard/src/views/extension/useExtensionPage.js
+++ b/dashboard/src/views/extension/useExtensionPage.js
@@ -14,6 +14,9 @@ import { getValidHashTab, replaceTabRoute } from "@/utils/hashRouteTabs.mjs";
 import { ref, computed, onMounted, onUnmounted, reactive, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
+// 安全地将 repo 字段转为小写字符串，防止非字符串类型导致 toLowerCase 报错
+const safeRepoStr = (repo) => (typeof repo === "string" ? repo : String(repo ?? "")).trim();
+
 const buildFailedPluginItems = (raw) => {
   return Object.entries(raw || {}).map(([dirName, info]) => {
     const detail = info && typeof info === "object" ? info : {};
@@ -619,12 +622,12 @@ export const useExtensionPage = () => {
 
   const findMarketPluginForExtension = (extension) => {
     if (!extension) return null;
-    const repo = normalizeInstallUrl(extension.repo).toLowerCase();
+    const repo = safeRepoStr(normalizeInstallUrl(extension.repo)).toLowerCase();
     return (
       pluginMarketData.value.find(
         (plugin) =>
           repo &&
-          normalizeInstallUrl(plugin?.repo).toLowerCase() === repo,
+          safeRepoStr(normalizeInstallUrl(plugin?.repo)).toLowerCase() === repo,
       ) ||
       pluginMarketData.value.find((plugin) => plugin.name === extension.name) ||
       null
@@ -640,14 +643,14 @@ export const useExtensionPage = () => {
 
     pluginMarketData.value.forEach((plugin) => {
       if (plugin.repo) {
-        onlinePluginsMap.set(plugin.repo.toLowerCase(), plugin);
+        onlinePluginsMap.set(safeRepoStr(plugin.repo).toLowerCase(), plugin);
       }
       onlinePluginsNameMap.set(plugin.name, plugin);
     });
 
     const data = Array.isArray(extension_data?.data) ? extension_data.data : [];
     data.forEach((extension) => {
-      const repoKey = extension.repo?.toLowerCase();
+      const repoKey = extension.repo ? safeRepoStr(extension.repo).toLowerCase() : undefined;
       const onlinePlugin = repoKey ? onlinePluginsMap.get(repoKey) : null;
       const onlinePluginByName = onlinePluginsNameMap.get(extension.name);
       const matchedPlugin = onlinePlugin || onlinePluginByName;
@@ -1233,21 +1236,21 @@ export const useExtensionPage = () => {
 
   const checkAlreadyInstalled = () => {
     const data = Array.isArray(extension_data?.data) ? extension_data.data : [];
-    const installedRepos = new Set(data.map((ext) => ext.repo?.toLowerCase()));
+    const installedRepos = new Set(data.map((ext) => ext.repo ? safeRepoStr(ext.repo).toLowerCase() : undefined));
     const installedNames = new Set(
       data.map((ext) => normalizeStr(ext.name).replace(/_/g, "-")),
     ); //统一格式，以防下面的匹配不生效
     const installedByRepo = new Map(
       data
         .filter((ext) => ext.repo)
-        .map((ext) => [ext.repo.toLowerCase(), ext]),
+        .map((ext) => [safeRepoStr(ext.repo).toLowerCase(), ext]),
     );
     const installedByName = new Map(data.map((ext) => [ext.name, ext]));
 
     for (let i = 0; i < pluginMarketData.value.length; i++) {
       const plugin = pluginMarketData.value[i];
       const matchedInstalled =
-        (plugin.repo && installedByRepo.get(plugin.repo.toLowerCase())) ||
+        (plugin.repo && installedByRepo.get(safeRepoStr(plugin.repo).toLowerCase())) ||
         installedByName.get(plugin.name);
 
       // 兜底：市场源未提供字段时，回填本地已安装插件中的元数据，便于在市场页直接展示
@@ -1265,7 +1268,7 @@ export const useExtensionPage = () => {
       }
 
       plugin.installed =
-        installedRepos.has(plugin.repo?.toLowerCase()) ||
+        installedRepos.has(plugin.repo ? safeRepoStr(plugin.repo).toLowerCase() : undefined) ||
         installedNames.has(normalizeStr(plugin.name).replace(/_/g, "-")); //统一格式，防止匹配失败
     }
 

--- a/dashboard/src/views/extension/useExtensionPage.js
+++ b/dashboard/src/views/extension/useExtensionPage.js
@@ -14,7 +14,6 @@ import { getValidHashTab, replaceTabRoute } from "@/utils/hashRouteTabs.mjs";
 import { ref, computed, onMounted, onUnmounted, reactive, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
-
 const buildFailedPluginItems = (raw) => {
   return Object.entries(raw || {}).map(([dirName, info]) => {
     const detail = info && typeof info === "object" ? info : {};
@@ -1234,19 +1233,15 @@ export const useExtensionPage = () => {
 
   const checkAlreadyInstalled = () => {
     const data = Array.isArray(extension_data?.data) ? extension_data.data : [];
-    const installedRepos = new Set(
-      data
-        .filter((ext) => ext.repo)
-        .map((ext) => normalizeInstallUrl(ext.repo).toLowerCase()),
-    );
-    const installedNames = new Set(
-      data.map((ext) => normalizeStr(ext.name).replace(/_/g, "-")),
-    ); //统一格式，以防下面的匹配不生效
     const installedByRepo = new Map(
       data
         .filter((ext) => ext.repo)
         .map((ext) => [normalizeInstallUrl(ext.repo).toLowerCase(), ext]),
     );
+    const installedRepos = new Set(installedByRepo.keys());
+    const installedNames = new Set(
+      data.map((ext) => normalizeStr(ext.name).replace(/_/g, "-")),
+    ); //统一格式，以防下面的匹配不生效
     const installedByName = new Map(data.map((ext) => [ext.name, ext]));
 
     for (let i = 0; i < pluginMarketData.value.length; i++) {


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
Fix #8206: When a plugin's metadata.yaml has a non-string repo field (e.g. integer 111), the backend only checks for None and passes the value through as-is. This causes the frontend to crash with TypeError: Pn.toLowerCase is not a function when calling .toLowerCase() in checkUpdate() and checkAlreadyInstalled(), displaying an error message on the plugin page when reloading any plugin.
### Modifications / 改动点
- `astrbot/dashboard/routes/plugin.py`: In get_plugins and get_plugin_detail, wrap the repo field with str() when serializing, ensuring the frontend always receives a string.
- `dashboard/src/views/extension/useExtensionPage.js`: Add a safeRepoStr() helper function and apply it to all 6 repo.toLowerCase() call sites in findMarketPluginForExtension, checkUpdate, and checkAlreadyInstalled to guard against non-string types.
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
After setting repo to a non-string value (e.g. repo: 111) in a plugin's metadata.yaml, reloading the plugin no longer triggers the TypeError. The plugin reloads successfully without any error message.
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure plugin repository metadata is consistently treated as a normalized string across backend responses and frontend extension matching to prevent runtime errors and improve installed/market plugin reconciliation.

Bug Fixes:
- Prevent frontend TypeError when plugin metadata repo fields are non-string values by normalizing and lowercasing repos safely before comparison.

Enhancements:
- Normalize repository URLs when mapping and matching plugins between installed extensions and the plugin marketplace for more robust repo-based lookups.