### PR TITLE
feat:expose loguru logger to plugins via astrbot.api

### DIFF
--- a/astrbot/api/__init__.py
+++ b/astrbot/api/__init__.py
@@ -3,8 +3,11 @@ from astrbot.core import html_renderer, sp
 from astrbot.core.agent.tool import FunctionTool, ToolSet
 from astrbot.core.agent.tool_executor import BaseFunctionToolExecutor
 from astrbot.core.config.astrbot_config import AstrBotConfig
+from astrbot.core.log import get_loguru_logger
 from astrbot.core.star.register import register_agent as agent
 from astrbot.core.star.register import register_llm_tool as llm_tool
+
+loguru_logger = get_loguru_logger()
 
 __all__ = [
     "AstrBotConfig",
@@ -15,5 +18,6 @@ __all__ = [
     "html_renderer",
     "llm_tool",
     "logger",
+    "loguru_logger",
     "sp",
 ]

--- a/astrbot/core/log.py
+++ b/astrbot/core/log.py
@@ -415,3 +415,8 @@ class LogManager:
             backup_count=3,
             trace=True,
         )
+
+
+def get_loguru_logger():
+    """Returns the patched loguru logger for plugin use."""
+    return _loguru

--- a/astrbot/core/log.py
+++ b/astrbot/core/log.py
@@ -59,6 +59,21 @@ def _is_plugin_path(pathname: str | None) -> bool:
     return ("data/plugins" in norm_path) or ("astrbot/builtin_stars/" in norm_path)
 
 
+def _get_plugin_tag(pathname: str | None) -> str:
+    if not pathname:
+        return "[Core]"
+    norm_path = os.path.normpath(pathname)
+    for prefix in (
+        "data" + os.sep + "plugins" + os.sep,
+        "astrbot" + os.sep + "builtin_stars" + os.sep,
+    ):
+        if prefix in norm_path:
+            idx = norm_path.index(prefix) + len(prefix)
+            plugin_name = norm_path[idx:].split(os.sep)[0]
+            return f"[{plugin_name}]"
+    return "[Core]"
+
+
 def _get_short_level_name(level_name: str) -> str:
     level_map = {
         "DEBUG": "DBUG",
@@ -81,7 +96,7 @@ def _build_source_file(pathname: str | None) -> str:
 
 def _patch_record(record: "Record") -> None:
     extra = record["extra"]
-    extra.setdefault("plugin_tag", "[Core]")
+    extra.setdefault("plugin_tag", _get_plugin_tag(record["file"].path))
     extra.setdefault("short_levelname", _get_short_level_name(record["level"].name))
     level_no = record["level"].no
     extra.setdefault("astrbot_version_tag", f" [v{VERSION}]" if level_no >= 30 else "")


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
将loguru导入到plugin中使用
### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
astrbot/api/__init__.py:6,10,21 (新增)astrbot/core/log.py:420-422 (新增) exportloguru_logger viaastrbot.api full loguru API (e.g., bind(), opt(), add())  
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Expose the patched loguru logger via the astrbot.api package so plugins can access the full logging API.

New Features:
- Provide a get_loguru_logger helper in the core logging module to return the patched loguru logger for external use.
- Expose a loguru_logger object from astrbot.api to make the shared logger easily available to plugins.