### PR TITLE
Fix&Feat: Template config optimization

### DIFF
--- a/astrbot/dashboard/routes/config.py
+++ b/astrbot/dashboard/routes/config.py
@@ -95,7 +95,7 @@ def _validate_template_list(value, meta, path_key, errors, validate_fn) -> None:
         validate_fn(
             item,
             template_meta.get("items", {}),
-            path=f"{item_path}.",
+            path=f"{path_key}.templates.{template_key}.",
         )
 
 

--- a/astrbot/dashboard/routes/util.py
+++ b/astrbot/dashboard/routes/util.py
@@ -16,6 +16,7 @@ def get_schema_item(schema: dict | None, key_path: str) -> dict | None:
     同时支持：
     - 扁平 schema（直接 key 命中）
     - 嵌套 object schema（{type: "object", items: {...}}）
+    - template_list schema（<field>.templates.<template>.items）
     """
 
     if not isinstance(schema, dict) or not key_path:
@@ -23,17 +24,31 @@ def get_schema_item(schema: dict | None, key_path: str) -> dict | None:
     if key_path in schema:
         return schema.get(key_path)
 
-    current = schema
     parts = key_path.split(".")
-    for idx, part in enumerate(parts):
+    current = schema
+    idx = 0
+    while idx < len(parts):
+        part = parts[idx]
         if part not in current:
             return None
         meta = current.get(part)
         if idx == len(parts) - 1:
             return meta
         if not isinstance(meta, dict) or meta.get("type") != "object":
-            return None
+            if not isinstance(meta, dict) or meta.get("type") != "template_list":
+                return None
+            if idx + 2 >= len(parts) or parts[idx + 1] != "templates":
+                return None
+            template_meta = meta.get("templates", {}).get(parts[idx + 2])
+            if not isinstance(template_meta, dict):
+                return None
+            if idx + 2 == len(parts) - 1:
+                return template_meta
+            current = template_meta.get("items", {})
+            idx += 3
+            continue
         current = meta.get("items", {})
+        idx += 1
     return None
 
 

--- a/dashboard/src/components/shared/AstrBotConfigV4.vue
+++ b/dashboard/src/components/shared/AstrBotConfigV4.vue
@@ -25,13 +25,25 @@ const props = defineProps({
   searchKeyword: {
     type: String,
     default: ''
+  },
+  pluginName: {
+    type: String,
+    default: ''
+  },
+  pluginI18n: {
+    type: Object,
+    default: () => ({})
+  },
+  pathPrefix: {
+    type: String,
+    default: ''
   }
 })
 
 const { t } = useI18n()
 const { getRaw } = useModuleI18n('features/config-metadata')
 const { tm: tmConfig } = useModuleI18n('features/config')
-const { translateIfKey } = useConfigTextResolver()
+const { translateIfKey, resolveConfigText } = useConfigTextResolver(props)
 
 const hintMarkdown = new MarkdownIt({
   linkify: true,
@@ -114,6 +126,18 @@ function createSelectorModel(selector) {
   })
 }
 
+function getItemPath(key) {
+  return props.pathPrefix ? `${props.pathPrefix}.${key}` : key
+}
+
+function getItemDescription(itemKey, itemMeta) {
+  return resolveConfigText(getItemPath(itemKey), 'description', itemMeta?.description) || itemKey
+}
+
+function getItemHint(itemKey, itemMeta) {
+  return resolveConfigText(getItemPath(itemKey), 'hint', itemMeta?.hint)
+}
+
 function openEditorDialog(key, value, theme, language) {
   currentEditingKey.value = key
   currentEditingLanguage.value = language || 'json'
@@ -143,8 +167,8 @@ function shouldShowItem(itemMeta, itemKey) {
 
   const searchableText = [
     itemKey,
-    translateIfKey(itemMeta?.description || ''),
-    translateIfKey(itemMeta?.hint || '')
+    getItemDescription(itemKey, itemMeta),
+    getItemHint(itemKey, itemMeta)
   ].join(' ').toLowerCase()
 
   return searchableText.includes(keyword)
@@ -259,13 +283,13 @@ function getSpecialSubtype(value) {
           <v-col cols="12" sm="6" class="property-info">
             <v-list-item density="compact">
               <v-list-item-title class="property-name">
-                {{ translateIfKey(itemMeta?.description) || itemKey }}
+                {{ getItemDescription(itemKey, itemMeta) }}
                 <span class="property-key">({{ itemKey }})</span>
               </v-list-item-title>
 
               <v-list-item-subtitle class="property-hint">
                 <span v-if="itemMeta?.obvious_hint && itemMeta?.hint" class="important-hint">‼️</span>
-                <span v-html="renderHint(itemMeta?.hint)"></span>
+                <span v-html="renderHint(getItemHint(itemKey, itemMeta))"></span>
               </v-list-item-subtitle>
             </v-list-item>
           </v-col>
@@ -274,12 +298,18 @@ function getSpecialSubtype(value) {
               v-if="itemMeta?.type === 'template_list'"
               v-model="createSelectorModel(itemKey).value"
               :templates="itemMeta?.templates || {}"
+              :plugin-name="pluginName"
+              :plugin-i18n="pluginI18n"
+              :config-path="getItemPath(itemKey)"
               class="config-field"
             />
             <ConfigItemRenderer
               v-else
               v-model="createSelectorModel(itemKey).value"
               :item-meta="itemMeta || null"
+              :plugin-name="pluginName"
+              :plugin-i18n="pluginI18n"
+              :config-key="getItemPath(itemKey)"
               :show-fullscreen-btn="!!itemMeta?.editor_mode"
               @open-fullscreen="openEditorDialog(itemKey, iterable, itemMeta?.editor_theme, itemMeta?.editor_language)"
             />
@@ -339,13 +369,13 @@ function getSpecialSubtype(value) {
                 <v-col cols="12" sm="6" class="property-info">
                   <v-list-item density="compact">
                     <v-list-item-title class="property-name">
-                      {{ translateIfKey(itemMeta?.description) || itemKey }}
+                      {{ getItemDescription(itemKey, itemMeta) }}
                       <span class="property-key">({{ itemKey }})</span>
                     </v-list-item-title>
 
                     <v-list-item-subtitle class="property-hint">
                       <span v-if="itemMeta?.obvious_hint && itemMeta?.hint" class="important-hint">‼️</span>
-                      <span v-html="renderHint(itemMeta?.hint)"></span>
+                      <span v-html="renderHint(getItemHint(itemKey, itemMeta))"></span>
                     </v-list-item-subtitle>
                   </v-list-item>
                 </v-col>
@@ -354,12 +384,18 @@ function getSpecialSubtype(value) {
                     v-if="itemMeta?.type === 'template_list'"
                     v-model="createSelectorModel(itemKey).value"
                     :templates="itemMeta?.templates || {}"
+                    :plugin-name="pluginName"
+                    :plugin-i18n="pluginI18n"
+                    :config-path="getItemPath(itemKey)"
                     class="config-field"
                   />
                   <ConfigItemRenderer
                     v-else
                     v-model="createSelectorModel(itemKey).value"
                     :item-meta="itemMeta || null"
+                    :plugin-name="pluginName"
+                    :plugin-i18n="pluginI18n"
+                    :config-key="getItemPath(itemKey)"
                     :show-fullscreen-btn="!!itemMeta?.editor_mode"
                     @open-fullscreen="openEditorDialog(itemKey, iterable, itemMeta?.editor_theme, itemMeta?.editor_language)"
                   />

--- a/dashboard/src/components/shared/TemplateListEditor.vue
+++ b/dashboard/src/components/shared/TemplateListEditor.vue
@@ -57,6 +57,9 @@
           </v-btn>
           <div class="d-flex flex-column">
             <v-list-item-title class="property-name">{{ templateLabel(entry.__template_key) }}</v-list-item-title>
+            <v-list-item-subtitle class="property-hint entry-display-text" v-if="templateDisplayText(entry)">
+              {{ templateDisplayText(entry) }}
+            </v-list-item-subtitle>
             <v-list-item-subtitle class="property-hint" v-if="getTemplate(entry)?.hint || getTemplate(entry)?.description">
               {{ templateText(entry.__template_key, 'hint', getTemplate(entry)?.hint || getTemplate(entry)?.description) }}
             </v-list-item-subtitle>
@@ -349,6 +352,43 @@ function getTemplate(entry) {
   return props.templates?.[key] || null
 }
 
+function getItemMetaBySelector(itemsMeta = {}, selector = '') {
+  const keys = selector.split('.').filter(Boolean)
+  let currentItems = itemsMeta
+  let currentMeta = null
+
+  for (let i = 0; i < keys.length; i++) {
+    currentMeta = currentItems?.[keys[i]]
+    if (!currentMeta) return null
+    if (i < keys.length - 1) {
+      if (currentMeta.type !== 'object') return null
+      currentItems = currentMeta.items || {}
+    }
+  }
+
+  return currentMeta
+}
+
+function templateDisplayText(entry) {
+  const template = getTemplate(entry)
+  const displayItem = template?.display_item
+  if (!template || typeof displayItem !== 'string' || !displayItem) return ''
+
+  const displayMeta = getItemMetaBySelector(template.items || {}, displayItem)
+  if (displayMeta?.type !== 'string') return ''
+
+  const value = getValueBySelector(entry, displayItem)
+  if (typeof value !== 'string' || !value.trim()) return ''
+
+  const label = templateItemText(
+    entry.__template_key,
+    displayItem,
+    'description',
+    displayMeta.description || displayItem,
+  )
+  return `${label}: ${value.trim()}`
+}
+
 function getValueBySelector(obj, selector) {
   const keys = selector.split('.')
   let current = obj
@@ -449,6 +489,11 @@ function hasVisibleItemsAfter(entries, currentIndex, entry) {
   font-size: 0.75rem;
   color: var(--v-theme-secondaryText);
   margin-top: 2px;
+}
+
+.entry-display-text {
+  color: var(--v-theme-primary);
+  font-weight: 500;
 }
 
 .property-key {

--- a/dashboard/src/components/shared/TemplateListEditor.vue
+++ b/dashboard/src/components/shared/TemplateListEditor.vue
@@ -60,8 +60,8 @@
             <v-list-item-subtitle class="property-hint entry-display-text" v-if="templateDisplayText(entry)">
               {{ templateDisplayText(entry) }}
             </v-list-item-subtitle>
-            <v-list-item-subtitle class="property-hint" v-if="getTemplate(entry)?.hint || getTemplate(entry)?.description">
-              {{ templateText(entry.__template_key, 'hint', getTemplate(entry)?.hint || getTemplate(entry)?.description) }}
+            <v-list-item-subtitle class="property-hint" v-if="templateHintText(entry)">
+              {{ templateHintText(entry) }}
             </v-list-item-subtitle>
           </div>
         </div>
@@ -350,6 +350,12 @@ function getTemplate(entry) {
   const key = entry.__template_key
   if (!key) return null
   return props.templates?.[key] || null
+}
+
+function templateHintText(entry) {
+  const template = getTemplate(entry)
+  if (!template || template.hide_hint_in_list) return ''
+  return templateText(entry.__template_key, 'hint', template.hint || template.description || '')
 }
 
 function getItemMetaBySelector(itemsMeta = {}, selector = '') {

--- a/dashboard/src/components/shared/TemplateListEditor.vue
+++ b/dashboard/src/components/shared/TemplateListEditor.vue
@@ -201,6 +201,7 @@ const defaultValueMap = {
   string: '',
   text: '',
   list: [],
+  file: [],
   object: {},
   template_list: []
 }

--- a/docs/en/dev/star/guides/plugin-config.md
+++ b/docs/en/dev/star/guides/plugin-config.md
@@ -146,7 +146,14 @@ Plugin developers can add a template-style configuration to `_conf_schema` in th
     "template_1": {
         "name": "Template One",
         "hint":"hint",
+        "display_item": "attr_name",
+        "hide_hint_in_list": true,
         "items": {
+          "attr_name": {
+            "description": "Attribute Name",
+            "type": "string",
+            "default": ""
+          },
           "attr_a": {
             "description": "Attribute A",
             "type": "int",
@@ -187,6 +194,7 @@ Saved config example:
 "field_id": [
     {
         "__template_key": "template_1",
+        "attr_name": "",
         "attr_a": 10,
         "attr_b": true
     },
@@ -197,6 +205,11 @@ Saved config example:
     }
 ]
 ```
+
+Templates also support these optional fields:
+
+- `display_item`: Specifies the key of a `string` item inside the template `items`. When set, the WebUI shows that field's current value in the collapsed list of added template entries, for example `Attribute Name: my-adapter`, making it easier to distinguish multiple entries created from the same template. Dot paths are supported for fields inside nested objects, for example `meta.name`.
+- `hide_hint_in_list`: When set to `true`, the WebUI hides the template `hint` in the collapsed list of added template entries. The template selection dropdown still shows the `hint`, and hints for fields inside the expanded entry are not affected.
 
 <img width="1000" alt="image" src="https://github.com/user-attachments/assets/74876d30-11a4-491b-a7a0-8ebe8d603782" />
 

--- a/docs/zh/dev/star/guides/plugin-config.md
+++ b/docs/zh/dev/star/guides/plugin-config.md
@@ -146,7 +146,14 @@ AstrBot 提供了“强大”的配置解析和可视化功能。能够让用户
     "template_1": {
         "name": "Template One",
         "hint":"hint",
+        "display_item": "attr_name",
+        "hide_hint_in_list": true,
         "items": {
+          "attr_name": {
+            "description": "Attribute Name",
+            "type": "string",
+            "default": ""
+          },
           "attr_a": {
             "description": "Attribute A",
             "type": "int",
@@ -187,6 +194,7 @@ AstrBot 提供了“强大”的配置解析和可视化功能。能够让用户
 "field_id": [
     {
         "__template_key": "template_1",
+        "attr_name": "",
         "attr_a": 10,
         "attr_b": true
     },
@@ -197,6 +205,11 @@ AstrBot 提供了“强大”的配置解析和可视化功能。能够让用户
     }
 ]
 ```
+
+模板本身还支持以下可选字段：
+
+- `display_item`: 指定模板 `items` 中一个 `string` 类型字段的 key。设置后，WebUI 会在已添加模板条目的折叠列表中显示该字段当前值，例如 `Attribute Name: my-adapter`，便于添加多个同类型模板时快速区分。支持用点号选择嵌套 object 中的字段，例如 `meta.name`。
+- `hide_hint_in_list`: 设置为 `true` 时，WebUI 会在已添加模板条目的折叠列表中隐藏该模板的 `hint`。添加模板时的下拉菜单仍会显示 `hint`，展开条目后各配置项自己的 `hint` 也不受影响。
 
 <img width="1000" alt="image" src="https://github.com/user-attachments/assets/74876d30-11a4-491b-a7a0-8ebe8d603782" />
 

--- a/tests/unit/test_dashboard_util.py
+++ b/tests/unit/test_dashboard_util.py
@@ -1,0 +1,88 @@
+"""Tests for dashboard route utility helpers."""
+
+from astrbot.dashboard.routes.config import validate_config
+from astrbot.dashboard.routes.util import get_schema_item
+
+
+def test_get_schema_item_template_list_file_item():
+    schema = {
+        "demo_templates": {
+            "type": "template_list",
+            "templates": {
+                "api_provider": {
+                    "items": {
+                        "tls_certificate_files": {"type": "file"},
+                    },
+                },
+            },
+        },
+    }
+
+    meta = get_schema_item(
+        schema,
+        "demo_templates.templates.api_provider.tls_certificate_files",
+    )
+
+    assert meta == {"type": "file"}
+
+
+def test_get_schema_item_nested_template_list_file_item():
+    schema = {
+        "group": {
+            "type": "object",
+            "items": {
+                "demo_templates": {
+                    "type": "template_list",
+                    "templates": {
+                        "nested_profile": {
+                            "items": {
+                                "profile": {
+                                    "type": "object",
+                                    "items": {
+                                        "attachments": {"type": "file"},
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    meta = get_schema_item(
+        schema,
+        "group.demo_templates.templates.nested_profile.profile.attachments",
+    )
+
+    assert meta == {"type": "file"}
+
+
+def test_validate_config_template_list_file_path_uses_template_schema_path():
+    schema = {
+        "demo_templates": {
+            "type": "template_list",
+            "templates": {
+                "api_provider": {
+                    "items": {
+                        "tls_certificate_files": {"type": "file"},
+                    },
+                },
+            },
+        },
+    }
+    data = {
+        "demo_templates": [
+            {
+                "__template_key": "api_provider",
+                "tls_certificate_files": [
+                    "files/demo_templates/templates/api_provider/tls_certificate_files/cert.pem"
+                ],
+            }
+        ]
+    }
+
+    errors, validated = validate_config(data, schema, is_core=False)
+
+    assert errors == []
+    assert validated == data


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

**解决的问题**
- fix
  - template_list 中 file 类型字段未写 default 时，前端默认值会变成 undefined。
  - AstrBotConfigV4 下复用 TemplateListEditor 时，插件 i18n 和配置路径上下文缺失。
  - 修复模板里添加 file 类型配置项时提示 Config item not found or not file type。
  - 修复 template_list 内文件路径上传/列目录/保存校验路径不一致的问题。
- feat
  - 添加多个同类型模板后，折叠状态下只能看到模板类型，难以区分具体条目。
  - 某些模板 hint 在已添加列表中占空间或重复展示，现在可通过 hide_hint_in_list 隐藏。

**更改文件**
- dashboard/src/components/shared/TemplateListEditor.vue
  - 支持 file 类型默认值。
  - 新增 display_item，可在折叠列表显示某个 string 字段值。
  - 新增 hide_hint_in_list，可只隐藏已添加条目列表里的模板 hint。
  - 保留添加模板下拉菜单中的 hint 显示。

- dashboard/src/components/shared/AstrBotConfigV4.vue
  - 补齐 pluginName、pluginI18n、pathPrefix 传递。
  - 让 V4 配置项、TemplateListEditor、ConfigItemRenderer 支持插件 i18n 和正确配置路径。

- astrbot/dashboard/routes/util.py
  - get_schema_item() 支持解析 `template_list.templates.<template>.items`路径。
  - 修复模板内 file 类型字段无法被文件接口识别的问题

- astrbot/dashboard/routes/config.py
  - template_list 保存校验改用模板 schema 路径。
  - 避免模板内 file 上传成功后保存配置时路径校验失败。

- tests/unit/test_dashboard_util.py
  - 新增单元测试覆盖模板内 file 字段、嵌套模板字段、保存路径校验。  
 
- docs/zh/dev/star/guides/plugin-config.md
  - 补充 template_list 的 display_item 和 hide_hint_in_list 中文说明与示例。  

- docs/en/dev/star/guides/plugin-config.md
  - 补充 template_list 的 display_item 和 hide_hint_in_list 英文说明与示例。
 
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<img width="946" height="748" alt="image" src="https://github.com/user-attachments/assets/f29c2a3d-2f93-4c46-a6aa-83878f0fad0f" />
<img width="938" height="748" alt="image" src="https://github.com/user-attachments/assets/966aea47-7145-4b03-a88b-1c4c998f7b68" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Optimize template-based configuration handling and display in the dashboard, particularly for file-type fields and plugin-driven configs.

New Features:
- Allow template list entries to show a configurable string field value in the collapsed list via the display_item option.
- Support hiding template-level hints from the collapsed template list using the hide_hint_in_list option.
- Propagate plugin name, i18n context, and config path into V4 config items and template lists to enable localized, path-aware rendering.

Bug Fixes:
- Ensure file-type fields in template lists have a proper default value instead of becoming undefined.
- Fix recognition of file-type fields inside templates so file upload APIs and path validation work correctly, including nested templates.
- Align template list save-time path validation with the template schema path to avoid false validation failures for uploaded files.

Enhancements:
- Improve template list entry display styling by highlighting the selected display text field.
- Extend schema lookup utility to resolve template_list templates items paths for more robust config validation and tooling.

Documentation:
- Document the display_item and hide_hint_in_list options for template_list in both English and Chinese plugin config guides, with updated examples.

Tests:
- Add unit tests covering template_list schema resolution for file fields, including nested templates, and validation of file paths based on template schema.

## Summary by Sourcery

Optimize template-based configuration handling and display for plugin configs, especially around template_list entries and file-type fields.

New Features:
- Allow templates to specify a display_item string field whose value is shown for each entry in the collapsed template_list.
- Support hide_hint_in_list on templates to hide template hints in the collapsed list while retaining them in the template selector and expanded view.
- Propagate plugin name, i18n context, and config path into V4 config items, TemplateListEditor, and ConfigItemRenderer for localized, path-aware rendering.

Bug Fixes:
- Ensure file-type fields in template_list have a defined default value instead of becoming undefined.
- Fix schema resolution and API recognition for file-type fields inside templates, including nested template_list structures, so file upload and validation work correctly.
- Align template_list save-time path validation with template schema paths to prevent false failures when saving uploaded file paths.

Enhancements:
- Improve collapsed template_list entry display by rendering a highlighted primary display text when configured.
- Extend schema lookup utility to understand template_list.templates.<template>.items paths for more robust validation and tooling.

Documentation:
- Document the display_item and hide_hint_in_list options for template_list in both English and Chinese plugin configuration guides, with examples.

Tests:
- Add unit tests covering template_list schema resolution for file items (including nested templates) and validation of file paths based on template schema.