### PR TITLE
fix(telegram): normalize reply sender_id to self_id for bot replies

### DIFF
--- a/astrbot/core/platform/sources/telegram/tg_adapter.py
+++ b/astrbot/core/platform/sources/telegram/tg_adapter.py
@@ -506,11 +506,15 @@ class TelegramPlatformAdapter(Platform):
             reply_abm = await self.convert_message(reply_update, context, False)
 
             if reply_abm:
+                reply_sender_id = str(reply_abm.sender.user_id)
+                if reply_sender_id == str(context.bot.id):
+                    reply_sender_id = message.self_id
+
                 message.message.append(
                     Comp.Reply(
                         id=reply_abm.message_id,
                         chain=reply_abm.message,
-                        sender_id=reply_abm.sender.user_id,
+                        sender_id=reply_sender_id,
                         sender_nickname=reply_abm.sender.nickname,
                         time=reply_abm.timestamp,
                         message_str=reply_abm.message_str,

--- a/astrbot/core/platform/sources/telegram/tg_adapter.py
+++ b/astrbot/core/platform/sources/telegram/tg_adapter.py
@@ -506,7 +506,7 @@ class TelegramPlatformAdapter(Platform):
             reply_abm = await self.convert_message(reply_update, context, False)
 
             if reply_abm:
-                reply_sender_id = str(reply_abm.sender.user_id)
+                reply_sender_id = reply_abm.sender.user_id
                 if reply_sender_id == str(context.bot.id):
                     reply_sender_id = message.self_id
 

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -79,6 +79,77 @@ def _build_context() -> MagicMock:
     return context
 
 
+def _find_reply_component(message) -> Comp.Reply:
+    return next(
+        component for component in message.message if isinstance(component, Comp.Reply)
+    )
+
+
+@pytest.mark.asyncio
+async def test_telegram_reply_to_bot_normalizes_sender_id_to_self_id():
+    TelegramPlatformAdapter = _load_telegram_adapter()
+    adapter = TelegramPlatformAdapter(
+        make_platform_config("telegram"),
+        {},
+        asyncio.Queue(),
+    )
+    reply_to_message = create_mock_update(
+        message_text="机器人上一条回复",
+        user_id=12345678,
+        username="test_bot",
+        message_id=10,
+    ).message
+    document = create_mock_file("https://api.telegram.org/file/test/report.md")
+    document.file_name = "report.md"
+    update = create_mock_update(
+        message_text=None,
+        chat_type="group",
+        document=document,
+        caption="请继续分析",
+        reply_to_message=reply_to_message,
+    )
+
+    result = await adapter.convert_message(update, _build_context())
+
+    assert result is not None
+    reply = _find_reply_component(result)
+    assert result.self_id == "test_bot"
+    assert reply.sender_id == result.self_id
+    assert reply.qq == 12345678
+
+
+@pytest.mark.asyncio
+async def test_telegram_reply_to_user_keeps_sender_id_as_user_id():
+    TelegramPlatformAdapter = _load_telegram_adapter()
+    adapter = TelegramPlatformAdapter(
+        make_platform_config("telegram"),
+        {},
+        asyncio.Queue(),
+    )
+    reply_to_message = create_mock_update(
+        message_text="普通用户消息",
+        user_id=87654321,
+        username="alice",
+        message_id=11,
+    ).message
+    document = create_mock_file("https://api.telegram.org/file/test/report.md")
+    document.file_name = "report.md"
+    update = create_mock_update(
+        message_text=None,
+        chat_type="group",
+        document=document,
+        caption="请看附件",
+        reply_to_message=reply_to_message,
+    )
+
+    result = await adapter.convert_message(update, _build_context())
+
+    assert result is not None
+    reply = _find_reply_component(result)
+    assert reply.sender_id == "87654321"
+    assert reply.qq == 87654321
+
+
 @pytest.mark.asyncio
 async def test_telegram_document_caption_populates_message_text_and_plain():
     TelegramPlatformAdapter = _load_telegram_adapter()

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -148,6 +148,15 @@ async def test_telegram_reply_to_user_keeps_sender_id_as_user_id():
     reply = _find_reply_component(result)
     assert reply.sender_id == "87654321"
     assert reply.qq == 87654321
+    # reply metadata should be preserved
+    assert reply.id == reply_to_message.message_id
+    assert reply.chain
+    # ensure the reply chain still carries the original reply text
+    if getattr(reply_to_message, "text", None):
+        assert any(
+            getattr(component, "text", None) == reply_to_message.text
+            for component in reply.chain
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Telegram adapter stored `Reply.sender_id` as numeric user ID while `self_id` is the bot username, causing `WakingCheckStage` to never match replies to bot messages in groups.

When the `/` wake prefix is removed, replying to a bot message in a Telegram group should still wake the bot through the generic `Reply` wake check. Before this change, Telegram replies only worked in some text-message cases because of the existing `/@bot` fallback path, not because `Reply.sender_id` matched `event.get_self_id()`.

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

- Normalize Telegram `Reply.sender_id` to `message.self_id` only when the replied message was sent by the bot.
- Keep replies to normal users using their original numeric Telegram user ID.
- Keep `message.self_id` as the Telegram bot username to avoid affecting `@bot_username` wake behavior.
- Keep the existing Telegram text reply `/@bot` fallback for compatibility.
- Add Telegram adapter tests for bot replies and normal user replies.

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

```powershell
.\venv\Scripts\python.exe -m pytest tests\test_telegram_adapter.py -q
```

```text
11 passed
```

```powershell
.\venv\Scripts\python.exe -m ruff format . --check
```

```text
426 files already formatted
```

```powershell
.\venv\Scripts\python.exe -m ruff check .
```

```text
All checks passed!
```

Manual verification:

- With this fix applied, replying to a Telegram bot message wakes the bot even after removing `/` from `wake_prefix`.
- Without this fix, replying to a Telegram bot message does not wake the bot when `/` is removed.
- Adding `/` back makes the old fallback path work again, confirming the previous behavior depended on the `/@bot` text fallback instead of the generic `Reply` wake check.

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Normalize Telegram reply metadata so replies to bot messages use the bot self ID while preserving existing behavior for user replies.

Bug Fixes:
- Ensure Telegram replies to bot messages correctly match the bot self ID so generic reply-based wake checks work in group chats.

Tests:
- Add Telegram adapter tests verifying sender_id normalization for replies to bot messages and preservation of numeric IDs for replies to normal users.