### PR TITLE
fix: skills_like 模式下保留原始 completion_text，修复上下文分裂问题

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -816,8 +816,9 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
         # 如果有工具调用，还需处理工具调用
         if llm_resp.tools_call_name:
             if self.tool_schema_mode == "skills_like":
-                llm_resp, _ = await self._resolve_tool_exec(llm_resp)
-                if not llm_resp.tools_call_name:
+                requery_resp, _ = await self._resolve_tool_exec(llm_resp)
+                if not requery_resp.tools_call_name:
+                    llm_resp = requery_resp
                     logger.warning(
                         "skills_like tool re-query returned no tool calls; fallback to assistant response."
                     )
@@ -845,6 +846,10 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
 
                     await self._complete_with_assistant_response(llm_resp)
                     return
+                else:
+                    llm_resp.tools_call_name = requery_resp.tools_call_name
+                    llm_resp.tools_call_args = requery_resp.tools_call_args
+                    llm_resp.tools_call_ids = requery_resp.tools_call_ids
 
             tool_call_result_blocks = []
             cached_images = []  # Collect cached images for LLM visibility


### PR DESCRIPTION
修复 #8238

skills_like 模式下，`_resolve_tool_exec()` 的返回值整体覆盖了 `llm_resp`，导致已发送给用户的 `completion_text` 被 re-query 生成的不同文本替换，存入 conversation history 的内容与用户实际收到的不一致。

### Modifications / 改动点

修改文件：`astrbot/core/agent/runners/tool_loop_agent_runner.py`

将 `_resolve_tool_exec` 返回后对 `llm_resp` 的整体覆盖改为仅替换工具调用相关字段（`tools_call_name`、`tools_call_args`、`tools_call_ids`），保留原始的 `completion_text` 和 `reasoning_content`。fallback 路径（re-query 未返回工具调用）逻辑不变。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

API 调用记录：
skills_like 开启时，每次工具调用产生 3 次 API 请求：
time: input: 12454 output: 66   ← step() 首次 LLM 调用
time: input: 12481 output: 66   ← _resolve_tool_exec re-query（input 增加 27 token，为注入的 requery instruction）
time: input: 12690 output: 478  ← 工具执行后生成最终回复

改为 full 模式后，同样的操作只产生 2 次：
time: input: 14351 output: 481  ← step() LLM 调用（文本 + 工具调用）
time: input: 14854 output: 474  ← 工具执行后生成最终回复

上下文分裂示例：

用户实际收到（NapCat 发送记录可验证）：「我在你的服务器里替你跑一下。」
conversation history 中存储的（后续 LLM 调用的上下文可验证）：「好的，我curl一下。」
两段文本来自两次独立的 LLM 调用，同一个 prompt，不同输出。

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Fix skills_like mode overwriting the original assistant completion with the re-query response, which caused mismatches between sent messages and conversation history.