### PR TITLE
fix: handle delta=None chunks in streaming to prevent SDK to_dict() error

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -1420,12 +1420,4 @@ class ProviderOpenAIOfficial(Provider):
 
     async def terminate(self):
         if self.client:
-        try:
-            final_completion = state.get_final_completion()
-            llm_response = await self._parse_openai_completion(final_completion, tools)
-            yield llm_response
-        except Exception as e:
-            logger.error("get_final_completion error: " + str(e))
-            # 流式内容已通过 yield 发出，记录错误后正常结束即可
-            return
             await self.client.close()

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -706,20 +706,12 @@ class ProviderOpenAIOfficial(Provider):
 
         try:
             final_completion = state.get_final_completion()
+            llm_response = await self._parse_openai_completion(final_completion, tools)
+            yield llm_response
         except Exception as e:
             logger.error("get_final_completion error: " + str(e))
-            # fallback: 构造空 ChatCompletion（内容已通过流式 yield 发出）
-            from openai.types.chat.chat_completion import ChatCompletion
-            final_completion = ChatCompletion(
-                id='',
-                choices=[],
-                created=0,
-                model='',
-                object='chat.completion',
-            )
-        llm_response = await self._parse_openai_completion(final_completion, tools)
-
-        yield llm_response
+            # 流式内容已通过 yield 发出，记录错误后正常结束即可
+            return
 
     def _extract_reasoning_content(
         self,

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -669,9 +669,14 @@ class ProviderOpenAIOfficial(Provider):
                     # Gemini and some OpenAI-compatible proxies omit this field
                     if not hasattr(tc, "index") or tc.index is None:
                         tc.index = idx
-            try:
-                state.handle_chunk(chunk)
-            except Exception as e:
+            # 跳过 delta=None 的 chunk，避免 SDK 内部 _convert_initial_chunk_into_snapshot
+            # 第 747 行 choice.delta.to_dict() 抛出 NoneType 错误。
+            # refs: AstrBot#6689 / openai-python#5069 / #5047
+            if delta is not None:
+                try:
+                    state.handle_chunk(chunk)
+                except Exception as e:
+                    logger.error("Saving chunk state error: " + str(e))
                 logger.error("Saving chunk state error: " + str(e))
             # logger.debug(f"chunk delta: {delta}")
             # handle the content delta
@@ -700,7 +705,19 @@ class ProviderOpenAIOfficial(Provider):
             if _y:
                 yield llm_response
 
-        final_completion = state.get_final_completion()
+        try:
+            final_completion = state.get_final_completion()
+        except Exception as e:
+            logger.error("get_final_completion error: " + str(e))
+            # fallback: 构造空 ChatCompletion（内容已通过流式 yield 发出）
+            from openai.types.chat.chat_completion import ChatCompletion
+            final_completion = ChatCompletion(
+                id='',
+                choices=[],
+                created=0,
+                model='',
+                object='chat.completion',
+            )
         llm_response = await self._parse_openai_completion(final_completion, tools)
 
         yield llm_response
@@ -901,6 +918,9 @@ class ProviderOpenAIOfficial(Provider):
                             args = {}
                     else:
                         args = tool_call.function.arguments
+                    # Some API may return None for tools with no parameters
+                    if args is None:
+                        args = {}
                     args_ls.append(args)
                     func_name_ls.append(tool_call.function.name)
                     tool_call_ids.append(tool_call.id)

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -677,7 +677,6 @@ class ProviderOpenAIOfficial(Provider):
                     state.handle_chunk(chunk)
                 except Exception as e:
                     logger.error("Saving chunk state error: " + str(e))
-                logger.error("Saving chunk state error: " + str(e))
             # logger.debug(f"chunk delta: {delta}")
             # handle the content delta
             reasoning = self._extract_reasoning_content(chunk)
@@ -1429,4 +1428,12 @@ class ProviderOpenAIOfficial(Provider):
 
     async def terminate(self):
         if self.client:
+        try:
+            final_completion = state.get_final_completion()
+            llm_response = await self._parse_openai_completion(final_completion, tools)
+            yield llm_response
+        except Exception as e:
+            logger.error("get_final_completion error: " + str(e))
+            # 流式内容已通过 yield 发出，记录错误后正常结束即可
+            return
             await self.client.close()


### PR DESCRIPTION
## 问题描述

当使用 Gemini、DeepSeek 或部分 OpenAI 兼容中转接口时，流式响应中出现以下错误：

```
Saving chunk state error: 'NoneType' object has no attribute 'to_dict'
```

## 根因分析

错误发生在 `openai_source.py` 的 `_query_stream` 方法中。当某些提供商返回的 `ChatCompletionChunk` 中 `choice.delta` 为 `None` 时（例如 `ContentBlockDeltaEvent` 等不带 delta 的 chunk），`ChatCompletionStreamState._convert_initial_chunk_into_snapshot` 内部第 747 行调用 `choice.delta.to_dict()` 抛出异常。

相关讨论：
- openai-python#5069
- openai-python#5047

## 修复方案

**改动 1**：在调用 `state.handle_chunk()` 前检查 `delta` 是否为 `None`，跳过无贡献的 chunk。

**改动 2**：将 `get_final_completion()` 包裹在 try/except 中，失败时构造空的 `ChatCompletion` 作为降级方案。此时内容已通过流式 `yield` 发出，不会丢失。

## 影响范围

- 不删除 `ChatCompletionStreamState` 导入（保留 SDK 累积逻辑）
- 不改变 `state` 初始化（避免 NameError）
- 仅 2 处精准修改，diff 极小

## 测试环境

- AstrBot 版本：v4.25.1
- 测试提供商：Gemini、DeepSeek、OpenAI 兼容中转接口

## Summary by Sourcery

Handle edge cases in OpenAI-compatible streaming responses to avoid SDK errors while preserving streamed output.

Bug Fixes:
- Skip streaming chunks with delta=None to prevent SDK ChatCompletionStreamState errors when converting initial chunks into snapshots.
- Wrap retrieval of the final streamed completion in a fallback that constructs an empty ChatCompletion if state.get_final_completion() fails, ensuring the request still completes.
- Normalize tool-call arguments by replacing None with an empty object to avoid errors when tools are returned without parameters.