### PR TITLE
fix: support rst and adoc knowledge uploads

### DIFF
--- a/astrbot/core/knowledge_base/parsers/util.py
+++ b/astrbot/core/knowledge_base/parsers/util.py
@@ -2,7 +2,7 @@ from .base import BaseParser
 
 
 async def select_parser(ext: str) -> BaseParser:
-    if ext in {".md", ".txt", ".markdown", ".xlsx", ".docx", ".xls"}:
+    if ext in {".md", ".txt", ".markdown", ".rst", ".adoc", ".xlsx", ".docx", ".xls"}:
         from .markitdown_parser import MarkitdownParser
 
         return MarkitdownParser()

--- a/dashboard/src/i18n/locales/en-US/features/knowledge-base/detail.json
+++ b/dashboard/src/i18n/locales/en-US/features/knowledge-base/detail.json
@@ -49,7 +49,7 @@
     "title": "Upload Document",
     "selectFile": "Select File",
     "dropzone": "Drop files here or click to select",
-    "supportedFormats": "Supported formats: .txt, .md, .pdf, .docx, .epub, .xls, .xlsx",
+    "supportedFormats": "Supported formats: .txt, .md, .markdown, .rst, .adoc, .pdf, .docx, .epub, .xls, .xlsx",
     "maxSize": "Max file size: 128MB",
     "chunkSettings": "Chunk Settings",
     "batchSettings": "Batch Settings",

--- a/dashboard/src/i18n/locales/ru-RU/features/knowledge-base/detail.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/knowledge-base/detail.json
@@ -49,7 +49,7 @@
         "title": "Добавление контента",
         "selectFile": "Файл",
         "dropzone": "Нажмите или перетащите файл сюда",
-        "supportedFormats": "Форматы: .txt, .md, .pdf, .docx, .epub, .xls, .xlsx",
+        "supportedFormats": "Форматы: .txt, .md, .markdown, .rst, .adoc, .pdf, .docx, .epub, .xls, .xlsx",
         "maxSize": "Максимум: 128MB",
         "chunkSettings": "Фрагментация",
         "batchSettings": "Пакетная обработка",

--- a/dashboard/src/i18n/locales/zh-CN/features/knowledge-base/detail.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/knowledge-base/detail.json
@@ -49,7 +49,7 @@
     "title": "上传文档",
     "selectFile": "选择文件",
     "dropzone": "拖放文件到这里或点击选择",
-    "supportedFormats": "支持的格式: .txt, .md, .pdf, .docx, .epub, .xls, .xlsx",
+    "supportedFormats": "支持的格式: .txt, .md, .markdown, .rst, .adoc, .pdf, .docx, .epub, .xls, .xlsx",
     "maxSize": "最大文件大小: 128MB",
     "chunkSettings": "分块设置",
     "batchSettings": "批处理设置",

--- a/dashboard/src/views/knowledge-base/components/DocumentsTab.vue
+++ b/dashboard/src/views/knowledge-base/components/DocumentsTab.vue
@@ -85,7 +85,7 @@
                 <p class="text-caption text-medium-emphasis mt-2">{{ t('upload.supportedFormats') }}</p>
                 <p class="text-caption text-medium-emphasis">{{ t('upload.maxSize') }}</p>
                 <p class="text-caption text-medium-emphasis">最多可上传 10 个文件</p>
-                <input ref="fileInput" type="file" multiple hidden accept=".txt,.md,.pdf,.docx,.epub,.xls,.xlsx"
+                <input ref="fileInput" type="file" multiple hidden accept=".txt,.md,.markdown,.rst,.adoc,.pdf,.docx,.epub,.xls,.xlsx"
                   @change="handleFileSelect" />
               </div>
 
@@ -709,6 +709,7 @@ const getFileIcon = (fileType: string) => {
   const type = fileType?.toLowerCase() || ''
   if (type.includes('pdf')) return 'mdi-file-pdf-box'
   if (type.includes('epub')) return 'mdi-book-open-page-variant'
+  if (type.includes('rst') || type.includes('adoc')) return 'mdi-file-document-outline'
   if (type.includes('md') || type.includes('markdown')) return 'mdi-language-markdown'
   if (type.includes('txt')) return 'mdi-file-document-outline'
   if (type.includes('url')) return 'mdi-link-variant'
@@ -719,6 +720,7 @@ const getFileColor = (fileType: string) => {
   const type = fileType?.toLowerCase() || ''
   if (type.includes('pdf')) return 'error'
   if (type.includes('epub')) return 'warning'
+  if (type.includes('rst') || type.includes('adoc')) return 'success'
   if (type.includes('md')) return 'info'
   if (type.includes('txt')) return 'success'
   if (type.includes('url')) return 'primary'

--- a/tests/test_epub_parser.py
+++ b/tests/test_epub_parser.py
@@ -6,6 +6,7 @@ import zipfile
 import pytest
 
 from astrbot.core.knowledge_base.parsers.epub_parser import EpubParser
+from astrbot.core.knowledge_base.parsers.markitdown_parser import MarkitdownParser
 from astrbot.core.knowledge_base.parsers.util import select_parser
 
 
@@ -172,6 +173,14 @@ async def test_select_parser_supports_epub():
     parser = await select_parser(".epub")
 
     assert isinstance(parser, EpubParser)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("ext", [".rst", ".adoc"])
+async def test_select_parser_supports_text_markup_formats(ext):
+    parser = await select_parser(ext)
+
+    assert isinstance(parser, MarkitdownParser)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
﻿## Summary
- allow the knowledge-base parser selector to route `.rst` and `.adoc` files through the existing MarkItDown parser
- include those formats in the dashboard file picker and supported-format copy
- add parser selection coverage for both extensions

Fixes #8213.

## To verify
- `python -m pytest tests/test_epub_parser.py -q`
- `python -m ruff check astrbot/core/knowledge_base/parsers/util.py tests/test_epub_parser.py`
- `python -m py_compile astrbot/core/knowledge_base/parsers/util.py tests/test_epub_parser.py`
- `pnpm install --frozen-lockfile` in `dashboard/`
- `pnpm typecheck` in `dashboard/`

Note: direct `pnpm exec eslint src/views/knowledge-base/components/DocumentsTab.vue` could not find an ESLint config in this checkout, so I did not run the repo's `lint --fix` script.

## Summary by Sourcery

Extend knowledge base text parsing and dashboard upload support to handle additional markup formats.

New Features:
- Support .rst and .adoc files in the knowledge base by routing them through the existing Markitdown-based text parser.
- Allow uploading .rst and .adoc files from the dashboard file picker with appropriate icons and colors in the document list.

Documentation:
- Update knowledge base UI copy to list .rst and .adoc among supported upload formats.

Tests:
- Add parser selection tests to ensure .rst and .adoc extensions are correctly mapped to the Markitdown parser.