### PR TITLE
fix: preserve ModelScope MCP transport

### DIFF
--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -147,6 +147,24 @@ PY_TO_JSON_TYPE = {
 FuncTool = FunctionTool
 
 
+def _modelscope_mcp_transport_from_url_info(url_info: Mapping[str, Any]) -> str:
+    for key in ("transport", "transport_type", "type", "protocol"):
+        raw_value = url_info.get(key)
+        if isinstance(raw_value, Mapping):
+            raw_value = raw_value.get("type") or raw_value.get("name")
+        if isinstance(raw_value, str):
+            value = raw_value.strip().lower().replace("-", "_").replace(" ", "_")
+            if value in {"streamable_http", "streamablehttp", "http"}:
+                return "streamable_http"
+            if value in {"sse", "server_sent_events"}:
+                return "sse"
+
+    path = urllib.parse.urlparse(str(url_info.get("url", ""))).path.rstrip("/").lower()
+    if path.endswith("/sse"):
+        return "sse"
+    return "streamable_http"
+
+
 def _prepare_config(config: dict) -> dict:
     """准备配置，处理嵌套格式"""
     if config.get("mcpServers"):
@@ -1109,7 +1127,9 @@ class FunctionToolManager:
                             # 添加到配置中(同名会覆盖)
                             server_config = {
                                 "url": server_url,
-                                "transport": "sse",
+                                "transport": _modelscope_mcp_transport_from_url_info(
+                                    url_info
+                                ),
                                 "active": True,
                                 "provider": "modelscope",
                             }

--- a/tests/unit/test_func_tool_manager.py
+++ b/tests/unit/test_func_tool_manager.py
@@ -8,7 +8,10 @@ import pytest
 from astrbot.core import sp
 from astrbot.core.computer.booters.local import LocalShellComponent
 from astrbot.core.provider import func_tool_manager as ftm
-from astrbot.core.provider.func_tool_manager import FunctionToolManager
+from astrbot.core.provider.func_tool_manager import (
+    FunctionToolManager,
+    _modelscope_mcp_transport_from_url_info,
+)
 from astrbot.core.tools.computer_tools.shell import (
     ExecuteShellTool,
     LocalExecuteShellTool,
@@ -605,6 +608,20 @@ def test_is_self_detached_command_handles_quotes_and_comments(command, expected)
     assert _is_self_detached_command(command) is expected
 
 
+@pytest.mark.parametrize(
+    ("url_info", "expected"),
+    [
+        ({"transport": "Streamable HTTP", "url": "https://example.com/mcp"}, "streamable_http"),
+        ({"transport_type": "sse", "url": "https://example.com/mcp"}, "sse"),
+        ({"type": "streamable_http", "url": "https://example.com/mcp"}, "streamable_http"),
+        ({"url": "https://example.com/mcp/sse"}, "sse"),
+        ({"url": "https://example.com/mcp"}, "streamable_http"),
+    ],
+)
+def test_modelscope_mcp_transport_from_url_info(url_info, expected):
+    assert _modelscope_mcp_transport_from_url_info(url_info) == expected
+
+
 @pytest.mark.asyncio
 async def test_execute_shell_reports_blank_exception_type(monkeypatch):
     from astrbot.core.tools.computer_tools import shell as shell_tools
@@ -775,7 +792,7 @@ async def test_modelscope_sync_enables_only_synced_servers(monkeypatch):
             "mcpServers": {
                 "valid": {
                     "url": "https://example.com/mcp",
-                    "transport": "sse",
+                    "transport": "streamable_http",
                     "active": True,
                     "provider": "modelscope",
                 }
@@ -787,7 +804,7 @@ async def test_modelscope_sync_enables_only_synced_servers(monkeypatch):
             "valid",
             {
                 "url": "https://example.com/mcp",
-                "transport": "sse",
+                "transport": "streamable_http",
                 "active": True,
                 "provider": "modelscope",
             },


### PR DESCRIPTION
﻿## Summary
- preserve the transport returned by ModelScope MCP sync metadata instead of hardcoding every synced server as SSE
- fall back from the URL shape when ModelScope does not include an explicit transport field
- cover Streamable HTTP, SSE, and `/sse` URL fallback cases

Fixes #8269

## Test Plan
- `uv run pytest tests/unit/test_func_tool_manager.py::test_modelscope_mcp_transport_from_url_info -q --basetemp .tmp/pytest-modelscope-transport -o cache_dir=.tmp/pytest-cache-modelscope`
- `uv run pytest tests/unit/test_func_tool_manager.py -q --basetemp .tmp/pytest-func-tool-manager -o cache_dir=.tmp/pytest-cache-func-tool-manager`
- `uv run ruff check astrbot/core/provider/func_tool_manager.py tests/unit/test_func_tool_manager.py`
- `python -m py_compile astrbot/core/provider/func_tool_manager.py tests/unit/test_func_tool_manager.py`
- `git diff --check`

## Summary by Sourcery

Preserve and infer the correct transport type for synced ModelScope MCP servers based on provided metadata or URL patterns.

Bug Fixes:
- Fix ModelScope MCP server configuration to use the transport indicated by metadata instead of always defaulting to SSE.

Enhancements:
- Infer MCP transport type from multiple possible metadata keys or URL path, supporting Streamable HTTP and SSE transports.

Tests:
- Add parameterized unit tests covering transport inference from ModelScope MCP URL and metadata information.