### PR TITLE
feat(password): add command to change AstrBot dashboard password

### DIFF
--- a/astrbot/cli/__main__.py
+++ b/astrbot/cli/__main__.py
@@ -5,7 +5,7 @@ import sys
 import click
 
 from . import __version__
-from .commands import conf, init, plug, run
+from .commands import conf, init, password, plug, run
 
 logo_tmpl = r"""
      ___           _______.___________..______      .______     ______   .___________.
@@ -54,6 +54,7 @@ cli.add_command(run)
 cli.add_command(help)
 cli.add_command(plug)
 cli.add_command(conf)
+cli.add_command(password)
 
 if __name__ == "__main__":
     cli()

--- a/astrbot/cli/commands/__init__.py
+++ b/astrbot/cli/commands/__init__.py
@@ -1,6 +1,7 @@
 from .cmd_conf import conf
 from .cmd_init import init
+from .cmd_password import password
 from .cmd_plug import plug
 from .cmd_run import run
 
-__all__ = ["conf", "init", "plug", "run"]
+__all__ = ["conf", "init", "password", "plug", "run"]

--- a/astrbot/cli/commands/cmd_conf.py
+++ b/astrbot/cli/commands/cmd_conf.py
@@ -137,6 +137,22 @@ def _get_nested_item(obj: dict[str, Any], path: str) -> Any:
     return obj
 
 
+def _set_dashboard_password(config: dict[str, Any], raw_password: str) -> None:
+    """Set dashboard password hashes and clear password migration flags."""
+    _set_nested_item(
+        config,
+        "dashboard.pbkdf2_password",
+        hash_dashboard_password(raw_password),
+    )
+    _set_nested_item(
+        config,
+        "dashboard.password",
+        hash_legacy_dashboard_password(raw_password),
+    )
+    _set_nested_item(config, "dashboard.password_storage_upgraded", True)
+    _set_nested_item(config, "dashboard.password_change_required", False)
+
+
 @click.group(name="conf")
 def conf() -> None:
     """Configuration management commands
@@ -171,16 +187,7 @@ def set_config(key: str, value: str) -> None:
         old_value = _get_nested_item(config, key)
         validated_value = CONFIG_VALIDATORS[key](value)
         if key == "dashboard.password":
-            _set_nested_item(
-                config,
-                "dashboard.pbkdf2_password",
-                hash_dashboard_password(validated_value),
-            )
-            _set_nested_item(
-                config,
-                "dashboard.password",
-                hash_legacy_dashboard_password(validated_value),
-            )
+            _set_dashboard_password(config, validated_value)
         else:
             _set_nested_item(config, key, validated_value)
         _save_config(config)

--- a/astrbot/cli/commands/cmd_password.py
+++ b/astrbot/cli/commands/cmd_password.py
@@ -1,0 +1,38 @@
+import click
+
+from .cmd_conf import (
+    _load_config,
+    _save_config,
+    _set_dashboard_password,
+    _set_nested_item,
+    _validate_dashboard_password,
+    _validate_dashboard_username,
+)
+
+
+@click.command(name="password")
+@click.option(
+    "--username",
+    help="Optional dashboard username to set together with the new password.",
+)
+def password(username: str | None) -> None:
+    """Change the AstrBot dashboard password."""
+    config = _load_config()
+
+    new_password = click.prompt(
+        "New dashboard password",
+        hide_input=True,
+        confirmation_prompt=True,
+    )
+    validated_password = _validate_dashboard_password(new_password)
+
+    if username is not None:
+        validated_username = _validate_dashboard_username(username.strip())
+        _set_nested_item(config, "dashboard.username", validated_username)
+
+    _set_dashboard_password(config, validated_password)
+    _save_config(config)
+
+    click.echo("Dashboard password updated.")
+    if username is not None:
+        click.echo(f"Dashboard username updated: {validated_username}")

--- a/tests/test_cli_password.py
+++ b/tests/test_cli_password.py
@@ -1,0 +1,90 @@
+import copy
+import json
+
+from click.testing import CliRunner
+
+from astrbot.cli.commands.cmd_conf import conf
+from astrbot.cli.commands.cmd_password import password
+from astrbot.core.config.default import DEFAULT_CONFIG
+from astrbot.core.utils.auth_password import verify_dashboard_password
+
+
+def _write_config(root):
+    (root / ".astrbot").touch()
+    data_dir = root / "data"
+    data_dir.mkdir()
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    config["dashboard"]["password_change_required"] = True
+    config["dashboard"]["password_storage_upgraded"] = False
+    config_path = data_dir / "cmd_config.json"
+    config_path.write_text(
+        json.dumps(config, ensure_ascii=False, indent=2),
+        encoding="utf-8-sig",
+    )
+    return config_path
+
+
+def _read_config(config_path):
+    return json.loads(config_path.read_text(encoding="utf-8-sig"))
+
+
+def test_password_command_changes_dashboard_password(monkeypatch, tmp_path):
+    config_path = _write_config(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        password,
+        input="AstrbotChanged123\nAstrbotChanged123\n",
+    )
+
+    assert result.exit_code == 0
+    config = _read_config(config_path)
+    dashboard_config = config["dashboard"]
+    assert verify_dashboard_password(
+        dashboard_config["pbkdf2_password"],
+        "AstrbotChanged123",
+    )
+    assert verify_dashboard_password(
+        dashboard_config["password"],
+        "AstrbotChanged123",
+    )
+    assert dashboard_config["password_storage_upgraded"] is True
+    assert dashboard_config["password_change_required"] is False
+
+
+def test_password_command_can_update_dashboard_username(monkeypatch, tmp_path):
+    config_path = _write_config(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        password,
+        ["--username", "astrbot-admin"],
+        input="AstrbotChanged123\nAstrbotChanged123\n",
+    )
+
+    assert result.exit_code == 0
+    config = _read_config(config_path)
+    assert config["dashboard"]["username"] == "astrbot-admin"
+
+
+def test_conf_set_dashboard_password_updates_password_state(monkeypatch, tmp_path):
+    config_path = _write_config(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        conf,
+        ["set", "dashboard.password", "AstrbotChanged123"],
+    )
+
+    assert result.exit_code == 0
+    config = _read_config(config_path)
+    dashboard_config = config["dashboard"]
+    assert verify_dashboard_password(
+        dashboard_config["pbkdf2_password"],
+        "AstrbotChanged123",
+    )
+    assert dashboard_config["password_storage_upgraded"] is True
+    assert dashboard_config["password_change_required"] is False


### PR DESCRIPTION
closes: #8268

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [ ] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [ ] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [ ] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Add a CLI command to change the AstrBot dashboard password and reuse shared helpers for updating password-related config state.

New Features:
- Introduce a `password` CLI command to interactively update the AstrBot dashboard password and optionally the dashboard username.

Enhancements:
- Refactor dashboard password updates into a shared helper used by both the new password command and existing config commands to keep password state flags in sync.

Tests:
- Add CLI tests covering the new password command, username update behavior, and the updated config password handling.