### PR TITLE
fix: plugin name in the marketplace does not match the local plugin

### DIFF
--- a/astrbot/dashboard/routes/plugin.py
+++ b/astrbot/dashboard/routes/plugin.py
@@ -1269,7 +1269,9 @@ class PluginRoute(Route):
             if plugin.logo_path:
                 logo_url = await self.get_plugin_logo_token(plugin.logo_path)
             _t = {
-                "name": plugin.name.replace("_", "-"),  # 统一转换为减号格式，与市场数据保持一致
+                "name": plugin.name.replace(
+                    "_", "-"
+                ),  # 统一转换为减号格式，与市场数据保持一致
                 "repo": "" if plugin.repo is None else plugin.repo,
                 "author": plugin.author,
                 "desc": plugin.desc,
@@ -1319,7 +1321,9 @@ class PluginRoute(Route):
                 Response()
                 .ok(
                     {
-                        "name": plugin.name.replace("_", "-"),  # 统一转换为减号格式，与市场数据保持一致
+                        "name": plugin.name.replace(
+                            "_", "-"
+                        ),  # 统一转换为减号格式，与市场数据保持一致
                         "repo": "" if plugin.repo is None else plugin.repo,
                         "author": plugin.author,
                         "desc": plugin.desc,
@@ -1371,7 +1375,9 @@ class PluginRoute(Route):
                 "page_name": page["name"],
                 "i18n_key": page["i18n_key"],
                 "description": "Plugin Page entry",
-                "plugin_name": plugin.name.replace("_", "-"),  # 统一转换为减号格式，与市场数据保持一致
+                "plugin_name": plugin.name.replace(
+                    "_", "-"
+                ),  # 统一转换为减号格式，与市场数据保持一致
             }
             for page in pages
         ]

--- a/astrbot/dashboard/routes/plugin.py
+++ b/astrbot/dashboard/routes/plugin.py
@@ -1269,7 +1269,7 @@ class PluginRoute(Route):
             if plugin.logo_path:
                 logo_url = await self.get_plugin_logo_token(plugin.logo_path)
             _t = {
-                "name": plugin.name,
+                "name": plugin.name.replace("_", "-"),  # 统一转换为减号格式，与市场数据保持一致
                 "repo": "" if plugin.repo is None else plugin.repo,
                 "author": plugin.author,
                 "desc": plugin.desc,
@@ -1319,7 +1319,7 @@ class PluginRoute(Route):
                 Response()
                 .ok(
                     {
-                        "name": plugin.name,
+                        "name": plugin.name.replace("_", "-"),  # 统一转换为减号格式，与市场数据保持一致
                         "repo": "" if plugin.repo is None else plugin.repo,
                         "author": plugin.author,
                         "desc": plugin.desc,
@@ -1371,7 +1371,7 @@ class PluginRoute(Route):
                 "page_name": page["name"],
                 "i18n_key": page["i18n_key"],
                 "description": "Plugin Page entry",
-                "plugin_name": plugin.name,
+                "plugin_name": plugin.name.replace("_", "-"),  # 统一转换为减号格式，与市场数据保持一致
             }
             for page in pages
         ]

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@guolao/vue-monaco-editor": "^1.5.4",
+    "@ricky0123/vad-web": "^0.0.30",
     "@tiptap/starter-kit": "2.1.7",
     "@tiptap/vue-3": "2.1.7",
     "apexcharts": "3.42.0",
@@ -31,6 +32,7 @@
     "markstream-vue": "^0.0.6",
     "mermaid": "^11.12.2",
     "monaco-editor": "^0.52.2",
+    "onnxruntime-web": "^1.26.0",
     "pinia": "2.1.6",
     "pinyin-pro": "^3.26.0",
     "qrcode": "^1.5.4",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@guolao/vue-monaco-editor": "^1.5.4",
-    "@ricky0123/vad-web": "^0.0.30",
     "@tiptap/starter-kit": "2.1.7",
     "@tiptap/vue-3": "2.1.7",
     "apexcharts": "3.42.0",
@@ -32,7 +31,6 @@
     "markstream-vue": "^0.0.6",
     "mermaid": "^11.12.2",
     "monaco-editor": "^0.52.2",
-    "onnxruntime-web": "^1.26.0",
     "pinia": "2.1.6",
     "pinyin-pro": "^3.26.0",
     "qrcode": "^1.5.4",

--- a/dashboard/src/views/extension/useExtensionPage.js
+++ b/dashboard/src/views/extension/useExtensionPage.js
@@ -484,7 +484,7 @@ export const useExtensionPage = () => {
       const failRes = await axios.get("/api/plugin/source/get-failed-plugins");
       failedPluginsDict.value = failRes.data.data || {};
 
-      checkUpdate();
+      // checkUpdate() is called after pluginMarketData is loaded in onMounted
     } catch (err) {
       toast(err, "error");
     } finally {
@@ -642,14 +642,19 @@ export const useExtensionPage = () => {
       if (plugin.repo) {
         onlinePluginsMap.set(plugin.repo.toLowerCase(), plugin);
       }
-      onlinePluginsNameMap.set(plugin.name, plugin);
+      const normalizedName = normalizeStr(plugin.name);
+      onlinePluginsNameMap.set(normalizedName, plugin);
     });
 
     const data = Array.isArray(extension_data?.data) ? extension_data.data : [];
+    
     data.forEach((extension) => {
       const repoKey = extension.repo?.toLowerCase();
       const onlinePlugin = repoKey ? onlinePluginsMap.get(repoKey) : null;
-      const onlinePluginByName = onlinePluginsNameMap.get(extension.name);
+      
+      const normalizedExtensionName = normalizeStr(extension.name);
+      const onlinePluginByName = onlinePluginsNameMap.get(normalizedExtensionName);
+      
       const matchedPlugin = onlinePlugin || onlinePluginByName;
 
       if (matchedPlugin) {
@@ -1234,9 +1239,7 @@ export const useExtensionPage = () => {
   const checkAlreadyInstalled = () => {
     const data = Array.isArray(extension_data?.data) ? extension_data.data : [];
     const installedRepos = new Set(data.map((ext) => ext.repo?.toLowerCase()));
-    const installedNames = new Set(
-      data.map((ext) => normalizeStr(ext.name).replace(/_/g, "-")),
-    ); //统一格式，以防下面的匹配不生效
+    const installedNames = new Set(data.map((ext) => normalizeStr(ext.name)));
     const installedByRepo = new Map(
       data
         .filter((ext) => ext.repo)
@@ -1266,7 +1269,7 @@ export const useExtensionPage = () => {
 
       plugin.installed =
         installedRepos.has(plugin.repo?.toLowerCase()) ||
-        installedNames.has(normalizeStr(plugin.name).replace(/_/g, "-")); //统一格式，防止匹配失败
+        installedNames.has(normalizeStr(plugin.name));
     }
 
     let installed = [];
@@ -1477,6 +1480,7 @@ export const useExtensionPage = () => {
     selectedMarketInstallPlugin.value = null;
     await getExtensions();
     checkAlreadyInstalled();
+    checkUpdate();
 
     viewReadme({
       name: resData.data.name,


### PR DESCRIPTION
相关前置PR：#7493

在插件市场获取插件时，获取到的插件分隔符为 `-` 但是本地插件的metadata全部为 `_` 会导致插件名称的匹配问题。

同时，在检查插件更新时，`checkUpdate()` 在 `getExtensions()` 中被调用时， `pluginMarketData` （远程插件市场数据）尚未加载完成，导致匹配时 ·pluginMarketData· 为空，无法找到匹配的远程插件。

本PR通过修改获取插件市场插件的时机，在后端API接口统一插件名称的方式解决了这些问题。

### Modifications / 改动点

1. 后端 ( `astrbot/dashboard/routes/plugin.py` )
修改了 3 个接口方法，统一在返回数据时转换名称格式：

- `get_plugins()` - 返回本地插件列表
- `get_plugin_detail()` - 返回插件详情
- `get_plugin_page_components()` - 返回插件页面组件信息
2. 前端 ( `dashboard/src/views/extension/useExtensionPage.js` )
- 调整 `checkUpdate()` 调用时机 ：
  
  - 从 `getExtensions()` 中移除调用（避免在 `pluginMarketData` 加载前执行）
  - 在 `finalizeSuccessfulInstall()` 中添加调用（确保安装后立即检查更新）
- 清理 `checkAlreadyInstalled()` 函数 ：移除不再需要的 replace(/_/g, "-") 操作

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

当插件repo不匹配但是名称匹配时：

<img width="775" height="234" alt="dc920828fa7e3771c74f44034055c14d" src="https://github.com/user-attachments/assets/24567356-f4b6-4cec-abe7-c77b4f06c9de" />

<img width="514" height="266" alt="5ec5715b3493291bbead642cbcb3b12b" src="https://github.com/user-attachments/assets/9dc5be4d-f43c-411a-bf12-3eb5b02f83c0" />

检查是否安装和是否更新的行为均按预期进行。

---

### Checklist / 检查清单


- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Align plugin naming between local data and the marketplace and adjust update checks to rely on normalized names and correctly loaded market data.

Bug Fixes:
- Ensure local plugins use hyphenated names in API responses to match marketplace plugin naming and avoid mismatched installs and updates.
- Normalize plugin names consistently on the frontend when mapping and matching marketplace plugins to installed extensions, preventing name-based mismatches.
- Delay plugin update checks until marketplace data is loaded and trigger them after successful installs to avoid running with empty market data.

Build:
- Add @ricky0123/vad-web and onnxruntime-web as new dashboard dependencies.