### PR TITLE
fix: improve plugin config schema compatibility

### DIFF
--- a/astrbot/core/config/astrbot_config.py
+++ b/astrbot/core/config/astrbot_config.py
@@ -1,3 +1,4 @@
+import copy
 import enum
 import json
 import logging
@@ -75,7 +76,7 @@ class AstrBotConfig(dict):
                 True,
             )
         # 检查配置完整性，并插入
-        has_new = self.check_config_integrity(default_config, conf)
+        has_new = self.check_config_integrity(default_config, conf, schema=schema)
         if (
             "dashboard" in conf
             and isinstance(conf["dashboard"], dict)
@@ -138,23 +139,211 @@ class AstrBotConfig(dict):
                         f"不受支持的配置类型 {v['type']}。支持的类型有：{DEFAULT_VALUE_MAP.keys()}",
                     )
                 if "default" in v:
-                    default = v["default"]
+                    default = copy.deepcopy(v["default"])
                 else:
-                    default = DEFAULT_VALUE_MAP[v["type"]]
+                    default = copy.deepcopy(DEFAULT_VALUE_MAP[v["type"]])
 
                 if v["type"] == "object":
                     conf[k] = {}
                     _parse_schema(v["items"], conf[k])
                 elif v["type"] == "template_list":
-                    conf[k] = default
+                    fallback = copy.deepcopy(DEFAULT_VALUE_MAP[v["type"]])
+                    conf[k], _ = self._sanitize_value_by_schema(
+                        default,
+                        fallback,
+                        v,
+                    )
                 else:
-                    conf[k] = default
+                    fallback = copy.deepcopy(DEFAULT_VALUE_MAP[v["type"]])
+                    conf[k], _ = self._sanitize_value_by_schema(
+                        default,
+                        fallback,
+                        v,
+                    )
 
         _parse_schema(schema, conf)
 
         return conf
 
-    def check_config_integrity(self, refer_conf: dict, conf: dict, path=""):
+    def _value_matches_options(self, value, meta: dict) -> bool:
+        options = meta.get("options")
+        if not isinstance(options, list):
+            return True
+        if value in options:
+            return True
+        type_ = meta.get("type")
+        if "default" not in meta and type_ in DEFAULT_VALUE_MAP:
+            return value == DEFAULT_VALUE_MAP[type_]
+        return False
+
+    def _sanitize_scalar_by_schema(self, value, default, meta: dict):
+        type_ = meta.get("type")
+        changed = False
+
+        if type_ == "int":
+            if type(value) is int:
+                sanitized = value
+            elif isinstance(value, str):
+                try:
+                    sanitized = int(value.strip())
+                    changed = True
+                except ValueError:
+                    return copy.deepcopy(default), True
+            elif isinstance(value, float) and value.is_integer():
+                sanitized = int(value)
+                changed = True
+            else:
+                return copy.deepcopy(default), True
+        elif type_ == "float":
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                sanitized = float(value)
+                changed = type(value) is int
+            elif isinstance(value, str):
+                try:
+                    sanitized = float(value.strip())
+                    changed = True
+                except ValueError:
+                    return copy.deepcopy(default), True
+            else:
+                return copy.deepcopy(default), True
+        elif type_ in ("string", "text"):
+            if not isinstance(value, str):
+                return copy.deepcopy(default), True
+            sanitized = value
+        elif type_ == "bool":
+            if type(value) is not bool:
+                return copy.deepcopy(default), True
+            sanitized = value
+        else:
+            sanitized = value
+
+        if not self._value_matches_options(sanitized, meta):
+            return copy.deepcopy(default), True
+
+        return sanitized, changed
+
+    def _sanitize_list_by_schema(self, value, default, meta: dict):
+        if not isinstance(value, list):
+            return copy.deepcopy(default), True
+
+        options = meta.get("options")
+        if not isinstance(options, list):
+            return value, False
+
+        filtered = [item for item in value if item in options]
+        if filtered == value:
+            return value, False
+
+        if filtered:
+            return filtered, True
+        return copy.deepcopy(default), True
+
+    def _sanitize_template_list_by_schema(self, value, default, meta: dict):
+        if not isinstance(value, list):
+            return copy.deepcopy(default), True
+
+        templates = meta.get("templates")
+        if not isinstance(templates, dict):
+            templates = {}
+
+        sanitized_entries = []
+        changed = False
+
+        for idx, item in enumerate(value):
+            if not isinstance(item, dict):
+                changed = True
+                continue
+
+            template_key = item.get("__template_key") or item.get("template")
+            template_meta = templates.get(template_key)
+            if not template_key or not isinstance(template_meta, dict):
+                changed = True
+                continue
+
+            template_items = template_meta.get("items", {})
+            if not isinstance(template_items, dict):
+                template_items = {}
+
+            entry_default = self._config_schema_to_default_config(template_items)
+            entry_data = {
+                key: item_value
+                for key, item_value in item.items()
+                if key not in {"__template_key", "template"}
+            }
+            entry_changed = self.check_config_integrity(
+                entry_default,
+                entry_data,
+                path=f"[{idx}]",
+                schema=template_items,
+            )
+
+            sanitized_entry = {"__template_key": template_key}
+            sanitized_entry.update(entry_data)
+            sanitized_entries.append(sanitized_entry)
+
+            if item.get("__template_key") != template_key:
+                entry_changed = True
+            if set(item.keys()) - set(sanitized_entry.keys()) - {"template"}:
+                entry_changed = True
+            changed |= entry_changed
+
+        if sanitized_entries != value:
+            changed = True
+        if not sanitized_entries and value:
+            return copy.deepcopy(default), True
+        return sanitized_entries, changed
+
+    def _sanitize_value_by_schema(self, value, default, meta: dict | None):
+        if not isinstance(meta, dict) or "type" not in meta:
+            return value, False
+
+        type_ = meta["type"]
+        default = copy.deepcopy(default)
+
+        if value is None:
+            return default, True
+
+        if type_ == "object":
+            if not isinstance(value, dict):
+                return default, True
+            items = meta.get("items", {})
+            if not isinstance(items, dict):
+                items = {}
+            nested_value = copy.deepcopy(value)
+            changed = self.check_config_integrity(
+                default,
+                nested_value,
+                schema=items,
+            )
+            return nested_value, changed
+
+        if type_ == "dict":
+            if not isinstance(value, dict):
+                return default, True
+            return value, False
+
+        if type_ == "template_list":
+            return self._sanitize_template_list_by_schema(value, default, meta)
+
+        if type_ == "list":
+            return self._sanitize_list_by_schema(value, default, meta)
+
+        if type_ == "file":
+            if not isinstance(value, list) or not all(
+                isinstance(item, str) for item in value
+            ):
+                return default, True
+            return value, False
+
+        return self._sanitize_scalar_by_schema(value, default, meta)
+
+    def check_config_integrity(
+        self,
+        refer_conf: dict,
+        conf: dict,
+        path="",
+        schema: dict | None = None,
+    ):
         """检查配置完整性，如果有新的配置项或顺序不一致则返回 True"""
         has_new = False
 
@@ -163,21 +352,32 @@ class AstrBotConfig(dict):
 
         # 先按照参考配置的顺序添加配置项
         for key, value in refer_conf.items():
+            item_schema = schema.get(key) if isinstance(schema, dict) else None
             if key not in conf:
                 # 配置项不存在，插入默认值
                 path_ = path + "." + key if path else key
                 logger.info("Config key missing; added default.")
-                new_conf[key] = value
+                new_conf[key] = copy.deepcopy(value)
                 has_new = True
             elif conf[key] is None:
                 # 配置项为 None，使用默认值
-                new_conf[key] = value
+                new_conf[key] = copy.deepcopy(value)
                 has_new = True
+            elif isinstance(item_schema, dict):
+                sanitized_value, value_changed = self._sanitize_value_by_schema(
+                    conf[key],
+                    value,
+                    item_schema,
+                )
+                if value_changed:
+                    logger.info("Config key incompatible with schema; sanitized.")
+                new_conf[key] = sanitized_value
+                has_new |= value_changed
             elif isinstance(value, dict):
                 # 递归检查子配置项
                 if not isinstance(conf[key], dict):
                     # 类型不匹配，使用默认值
-                    new_conf[key] = value
+                    new_conf[key] = copy.deepcopy(value)
                     has_new = True
                 else:
                     # 递归检查并同步顺序

--- a/astrbot/core/config/astrbot_config.py
+++ b/astrbot/core/config/astrbot_config.py
@@ -152,6 +152,7 @@ class AstrBotConfig(dict):
                         default,
                         fallback,
                         v,
+                        path=k,
                     )
                 else:
                     fallback = copy.deepcopy(DEFAULT_VALUE_MAP[v["type"]])
@@ -159,6 +160,7 @@ class AstrBotConfig(dict):
                         default,
                         fallback,
                         v,
+                        path=k,
                     )
 
         _parse_schema(schema, conf)
@@ -188,12 +190,12 @@ class AstrBotConfig(dict):
                     sanitized = int(value.strip())
                     changed = True
                 except ValueError:
-                    return copy.deepcopy(default), True
+                    return default, True
             elif isinstance(value, float) and value.is_integer():
                 sanitized = int(value)
                 changed = True
             else:
-                return copy.deepcopy(default), True
+                return default, True
         elif type_ == "float":
             if isinstance(value, (int, float)) and not isinstance(value, bool):
                 sanitized = float(value)
@@ -203,28 +205,28 @@ class AstrBotConfig(dict):
                     sanitized = float(value.strip())
                     changed = True
                 except ValueError:
-                    return copy.deepcopy(default), True
+                    return default, True
             else:
-                return copy.deepcopy(default), True
+                return default, True
         elif type_ in ("string", "text"):
             if not isinstance(value, str):
-                return copy.deepcopy(default), True
+                return default, True
             sanitized = value
         elif type_ == "bool":
             if type(value) is not bool:
-                return copy.deepcopy(default), True
+                return default, True
             sanitized = value
         else:
             sanitized = value
 
         if not self._value_matches_options(sanitized, meta):
-            return copy.deepcopy(default), True
+            return default, True
 
         return sanitized, changed
 
     def _sanitize_list_by_schema(self, value, default, meta: dict):
         if not isinstance(value, list):
-            return copy.deepcopy(default), True
+            return default, True
 
         options = meta.get("options")
         if not isinstance(options, list):
@@ -236,11 +238,17 @@ class AstrBotConfig(dict):
 
         if filtered:
             return filtered, True
-        return copy.deepcopy(default), True
+        return default, True
 
-    def _sanitize_template_list_by_schema(self, value, default, meta: dict):
+    def _sanitize_template_list_by_schema(
+        self,
+        value,
+        default,
+        meta: dict,
+        path="",
+    ):
         if not isinstance(value, list):
-            return copy.deepcopy(default), True
+            return default, True
 
         templates = meta.get("templates")
         if not isinstance(templates, dict):
@@ -252,12 +260,27 @@ class AstrBotConfig(dict):
         for idx, item in enumerate(value):
             if not isinstance(item, dict):
                 changed = True
+                logger.warning(
+                    "Dropping non-dict entry from template_list at index %d.",
+                    idx,
+                )
                 continue
 
             template_key = item.get("__template_key") or item.get("template")
             template_meta = templates.get(template_key)
-            if not template_key or not isinstance(template_meta, dict):
+            if not template_key:
                 changed = True
+                logger.warning(
+                    "Dropping template_list entry at index %d: missing template key.",
+                    idx,
+                )
+                continue
+            if not isinstance(template_meta, dict):
+                changed = True
+                logger.warning(
+                    "Dropping template_list entry at index %d: unknown template key.",
+                    idx,
+                )
                 continue
 
             template_items = template_meta.get("items", {})
@@ -273,7 +296,7 @@ class AstrBotConfig(dict):
             entry_changed = self.check_config_integrity(
                 entry_default,
                 entry_data,
-                path=f"[{idx}]",
+                path=f"{path}[{idx}]" if path else f"[{idx}]",
                 schema=template_items,
             )
 
@@ -290,10 +313,10 @@ class AstrBotConfig(dict):
         if sanitized_entries != value:
             changed = True
         if not sanitized_entries and value:
-            return copy.deepcopy(default), True
+            return default, True
         return sanitized_entries, changed
 
-    def _sanitize_value_by_schema(self, value, default, meta: dict | None):
+    def _sanitize_value_by_schema(self, value, default, meta: dict | None, path=""):
         if not isinstance(meta, dict) or "type" not in meta:
             return value, False
 
@@ -313,17 +336,19 @@ class AstrBotConfig(dict):
             changed = self.check_config_integrity(
                 default,
                 nested_value,
+                path=path,
                 schema=items,
             )
             return nested_value, changed
 
         if type_ == "dict":
+            # dict is an opaque user mapping; object is recursively schema-defined.
             if not isinstance(value, dict):
                 return default, True
             return value, False
 
         if type_ == "template_list":
-            return self._sanitize_template_list_by_schema(value, default, meta)
+            return self._sanitize_template_list_by_schema(value, default, meta, path)
 
         if type_ == "list":
             return self._sanitize_list_by_schema(value, default, meta)
@@ -352,15 +377,16 @@ class AstrBotConfig(dict):
 
         # 先按照参考配置的顺序添加配置项
         for key, value in refer_conf.items():
+            path_ = path + "." + key if path else key
             item_schema = schema.get(key) if isinstance(schema, dict) else None
             if key not in conf:
                 # 配置项不存在，插入默认值
-                path_ = path + "." + key if path else key
                 logger.info("Config key missing; added default.")
                 new_conf[key] = copy.deepcopy(value)
                 has_new = True
             elif conf[key] is None:
                 # 配置项为 None，使用默认值
+                logger.info("Config key is None; added default.")
                 new_conf[key] = copy.deepcopy(value)
                 has_new = True
             elif isinstance(item_schema, dict):
@@ -368,6 +394,7 @@ class AstrBotConfig(dict):
                     conf[key],
                     value,
                     item_schema,
+                    path=path_,
                 )
                 if value_changed:
                     logger.info("Config key incompatible with schema; sanitized.")

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -4301,5 +4301,6 @@ DEFAULT_VALUE_MAP = {
     "list": [],
     "file": [],
     "object": {},
+    "dict": {},
     "template_list": [],
 }

--- a/astrbot/dashboard/routes/config.py
+++ b/astrbot/dashboard/routes/config.py
@@ -69,6 +69,30 @@ def _expect_type(value, expected_type, path_key, errors, expected_name=None) -> 
     return True
 
 
+def _default_empty_value_allowed(value, meta: dict) -> bool:
+    type_ = meta.get("type")
+    if "default" in meta or type_ not in DEFAULT_VALUE_MAP:
+        return False
+    return value == DEFAULT_VALUE_MAP[type_]
+
+
+def _validate_options(value, meta: dict, path_key: str, errors: list[str]) -> None:
+    options = meta.get("options")
+    if not isinstance(options, list):
+        return
+
+    if meta.get("type") == "list":
+        if not isinstance(value, list):
+            return
+        invalid_values = [item for item in value if item not in options]
+        if invalid_values:
+            errors.append(f"无效的选项 {path_key}: {invalid_values}")
+        return
+
+    if value not in options and not _default_empty_value_allowed(value, meta):
+        errors.append(f"无效的选项 {path_key}: {value}")
+
+
 def _validate_template_list(value, meta, path_key, errors, validate_fn) -> None:
     if not _expect_type(value, list, path_key, errors, "list"):
         return
@@ -192,6 +216,12 @@ def validate_config(data, schema: dict, is_core: bool) -> tuple[list[str], dict]
                 errors.append(
                     f"错误的类型 {path}{key}: 期望是 dict, 得到了 {type(value).__name__}",
                 )
+            elif meta["type"] == "dict" and not isinstance(value, dict):
+                errors.append(
+                    f"错误的类型 {path}{key}: 期望是 dict, 得到了 {type(value).__name__}",
+                )
+
+            _validate_options(data.get(key), meta, f"{path}{key}", errors)
 
     if is_core:
         meta_all = {


### PR DESCRIPTION
Summary:
- Sanitize persisted plugin config values against the latest schema during load/reload.
- Reset incompatible scalar values, filter removed list options, and sanitize template_list entries.
- Add dict defaults and validate dict/options values when saving from the dashboard.

Testing:
- uv run ruff check .
- uv run pytest tests/unit/test_config.py

## Summary by Sourcery

Sanitize and validate plugin configuration values against the latest schema when loading and saving, ensuring incompatible or invalid entries are reset to safe defaults.

Bug Fixes:
- Ensure missing, None, or schema-incompatible config values are replaced with deep-copied defaults during integrity checks.
- Filter or reset list and template_list entries that reference removed or invalid options when loading plugin configs.
- Validate dashboard-saved config values, including dict types and options-based fields, to prevent invalid data from being persisted.

Enhancements:
- Introduce schema-aware sanitization helpers for scalar, list, dict, and template_list config types to keep persisted configs aligned with schema changes.
- Extend default value definitions to cover dict-typed config fields for consistent initialization.