### PR TITLE
Port dev startup chain to master

### DIFF
--- a/astrbot/cli/banner.py
+++ b/astrbot/cli/banner.py
@@ -1,0 +1,28 @@
+"""ASCII logo and interactive mode utilities for CLI"""
+
+import sys
+
+logo_tmpl = r"""
+     ___           _______.___________..______      .______     ______   .___________.
+    /   \         /       |           ||   _  \     |   _  \   /  __  \  |           |
+   /  ^  \       |   (----`---|  |----`|  |_)  |    |  |_)  | |  |  |  | `---|  |----`
+  /  /_\  \       \   \       |  |     |      /     |   _  <  |  |  |  |     |  |
+ /  _____  \  .----)   |      |  |     |  |\  \----.|  |_)  | |  `--'  |     |  |
+/__/     \__\ |_______/       |__|     | _| `._____||______/   \______/      |__|
+"""
+
+
+def is_interactive() -> bool:
+    """Check if stdout is connected to a TTY (interactive terminal)"""
+    try:
+        return sys.stdout.isatty()
+    except Exception:
+        return False
+
+
+def print_logo() -> None:
+    """Print ASCII logo if in interactive mode"""
+    import click
+
+    if is_interactive():
+        click.echo(logo_tmpl)

--- a/astrbot/cli/commands/cmd_init.py
+++ b/astrbot/cli/commands/cmd_init.py
@@ -1,11 +1,15 @@
 import asyncio
+import json
 import os
+import re
 from pathlib import Path
 
 import click
 from filelock import FileLock, Timeout
 
-from ..utils import check_dashboard, get_astrbot_root
+from astrbot.cli.utils import DashboardManager
+from astrbot.core.config.default import DEFAULT_CONFIG
+from astrbot.core.utils.astrbot_path import astrbot_paths
 
 DASHBOARD_INITIAL_PASSWORD_ENV = "ASTRBOT_DASHBOARD_INITIAL_PASSWORD"
 
@@ -20,51 +24,225 @@ def _initialize_config_from_env(astrbot_root: Path) -> None:
     click.echo("Initialized data/cmd_config.json with dashboard initial password.")
 
 
-async def initialize_astrbot(astrbot_root: Path) -> None:
-    """Execute AstrBot initialization logic"""
-    dot_astrbot = astrbot_root / ".astrbot"
+def _write_default_config(config_path: Path) -> dict:
+    config = json.loads(json.dumps(DEFAULT_CONFIG))
+    config_path.write_text(
+        json.dumps(config, ensure_ascii=False, indent=2),
+        encoding="utf-8-sig",
+    )
+    return config
 
+
+def _load_or_create_config(config_path: Path) -> dict:
+    if not config_path.exists():
+        return _write_default_config(config_path)
+    try:
+        return json.loads(config_path.read_text(encoding="utf-8-sig"))
+    except json.JSONDecodeError as e:
+        raise click.ClickException(f"Failed to parse config file: {e!s}") from e
+
+
+def _set_dashboard_username(config: dict, username: str) -> None:
+    username = username.strip()
+    if not username:
+        raise click.ClickException("Dashboard username cannot be empty")
+    dashboard_config = config.setdefault("dashboard", {})
+    if not isinstance(dashboard_config, dict):
+        raise click.ClickException("Config path conflict: dashboard is not a dict")
+    dashboard_config["username"] = username
+
+
+async def initialize_astrbot(
+    astrbot_root: Path,
+    *,
+    yes: bool,
+    backend_only: bool,
+    admin_username: str | None,
+    admin_password: str | None,
+) -> None:
+    """Execute AstrBot initialization logic"""
+    from astrbot.cli.banner import print_logo
+
+    click.echo("=" * 60)
+    click.echo("AstrBot 初始化向导")
+    click.echo("=" * 60)
+    print_logo()
+    click.echo()
+
+    dot_astrbot = astrbot_root / ".astrbot"
     if not dot_astrbot.exists():
-        if click.confirm(
-            f"Install AstrBot to this directory? {astrbot_root}",
+        if yes or click.confirm(
+            f"确定要将 AstrBot 安装到以下目录吗？\n  {astrbot_root}",
             default=True,
             abort=True,
         ):
             dot_astrbot.touch()
-            click.echo(f"Created {dot_astrbot}")
-
+            click.echo(f"[OK] 已创建: {dot_astrbot}")
     paths = {
         "data": astrbot_root / "data",
         "config": astrbot_root / "data" / "config",
         "plugins": astrbot_root / "data" / "plugins",
         "temp": astrbot_root / "data" / "temp",
+        "skills": astrbot_root / "data" / "skills",
     }
-
     for name, path in paths.items():
+        existed = path.exists()
         path.mkdir(parents=True, exist_ok=True)
-        click.echo(f"{'Created' if not path.exists() else 'Directory exists'}: {path}")
+        status = "Exists" if existed else "Created"
+        click.echo(f"  [{status}] {name.title()}: {path}")
 
     _initialize_config_from_env(astrbot_root)
 
-    await check_dashboard(astrbot_root / "data")
+    config_path = astrbot_root / "data" / "cmd_config.json"
+    config_existed = config_path.exists()
+    config = _load_or_create_config(config_path)
+    if not config_existed:
+        click.echo(f"[OK] 配置文件已创建: {config_path}")
+    ASTRBOT_ROOT = astrbot_root
+    env_file = ASTRBOT_ROOT / ".env"
+    if not env_file.exists():
+        tmpl_candidates = [
+            Path("/opt/astrbot/config.template"),
+            getattr(astrbot_paths, "project_root", Path.cwd()) / "config.template",
+            Path.cwd() / "config.template",
+        ]
+        tmpl = None
+        for t in tmpl_candidates:
+            try:
+                if t.exists():
+                    tmpl = t
+                    break
+            except Exception:
+                continue
+        if tmpl is not None:
+            try:
+                txt = tmpl.read_text(encoding="utf-8")
+                instance_name = astrbot_root.name or "astrbot"
+                txt = re.sub("\\$\\{INSTANCE_NAME(:-[^}]*)?\\}", instance_name, txt)
+                port_val = (
+                    os.environ.get("ASTRBOT_PORT") or os.environ.get("PORT") or "8000"
+                )
+                txt = re.sub("\\$\\{PORT(:-[^}]*)?\\}", str(port_val), txt)
+                txt = re.sub("\\$\\{ASTRBOT_ROOT(:-[^}]*)?\\}", str(ASTRBOT_ROOT), txt)
+                header = f"# Generated from config.template by astrbot init for instance: {instance_name}\n# This file will be auto-loaded by 'astrbot run'\n\n"
+                env_file.write_text(header + txt, encoding="utf-8")
+                env_file.chmod(420)
+                click.echo(f"[OK] 环境变量文件已创建: {env_file}")
+            except Exception as e:
+                click.echo(f"[警告] 无法从模板生成 .env 文件: {e!s}")
+        else:
+            click.echo("[提示] 未找到 config.template 文件，跳过 .env 生成")
+    if admin_password is not None:
+        raise click.ClickException(
+            "--admin-password is no longer supported during init. Run 'astrbot conf admin' after initialization.",
+        )
+    effective_admin_username = (
+        admin_username.strip()
+        if admin_username
+        else str(DEFAULT_CONFIG["dashboard"]["username"])
+    )
+    if admin_username:
+        _set_dashboard_username(config, effective_admin_username)
+        config_path.write_text(
+            json.dumps(config, ensure_ascii=False, indent=2),
+            encoding="utf-8-sig",
+        )
+    click.echo(f"[OK] Dashboard admin 用户名已设置为: {effective_admin_username}")
+    click.echo()
+    click.echo("!" * 60)
+    click.echo("重要提示：")
+    click.echo("  1. Dashboard 密码尚未设置！首次登录前必须先设置密码")
+    click.echo("  2. 设置命令: astrbot conf admin")
+    click.echo("  3. 登录地址: http://localhost:6185 或 http://服务器IP:6185")
+    click.echo("!" * 60)
+    click.echo()
+    if not backend_only and (
+        yes
+        or click.confirm(
+            "是否需要集成式 WebUI？（个人电脑推荐，服务器推荐使用后端模式）",
+            default=True,
+        )
+    ):
+        await DashboardManager().ensure_installed(astrbot_root)
+    else:
+        click.echo()
+        click.echo("[提示] 你选择了后端模式，可以使用以下方式管理 AstrBot：")
+        click.echo("  - 使用在线 Dashboard: 在浏览器中访问远程服务器的 WebUI")
+        click.echo("  - 使用 CLI 命令: astrbot conf / astrbot plug 等")
+        click.echo()
+        click.echo("!" * 60)
+        click.echo("安全提示：")
+        click.echo("  HTTPS 前端只能安全连接 localhost 的 HTTP 后端")
+        click.echo("  不支持远程 + HTTP 后端（不安全）")
+        click.echo("  如需远程访问，请使用 HTTPS 后端或通过反向代理")
+        click.echo("!" * 60)
+        click.echo()
 
 
 @click.command()
-def init() -> None:
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompts")
+@click.option("--backend-only", "-b", is_flag=True, help="Only initialize the backend")
+@click.option(
+    "-u",
+    "--admin-username",
+    type=str,
+    help="Set dashboard admin username during initialization",
+)
+@click.option(
+    "-p",
+    "--admin-password",
+    type=str,
+    help="Deprecated. Run `astrbot conf admin` after initialization.",
+)
+@click.option(
+    "--root",
+    help="ASTRBOT root directory to initialize (overrides ASTRBOT_ROOT env)",
+    type=str,
+)
+def init(
+    yes: bool,
+    backend_only: bool,
+    admin_username: str | None,
+    admin_password: str | None,
+    root: str | None = None,
+) -> None:
     """Initialize AstrBot"""
     click.echo("Initializing AstrBot...")
-    astrbot_root = get_astrbot_root()
+    if os.environ.get("ASTRBOT_SYSTEMD") == "1":
+        yes = True
+    from astrbot.core.utils.astrbot_path import astrbot_paths
+
+    astrbot_root = Path(root).expanduser() if root else astrbot_paths.root
+    astrbot_root.mkdir(parents=True, exist_ok=True)
+    os.environ["ASTRBOT_ROOT"] = str(astrbot_root)
     lock_file = astrbot_root / "astrbot.lock"
     lock = FileLock(lock_file, timeout=5)
-
     try:
         with lock.acquire():
-            asyncio.run(initialize_astrbot(astrbot_root))
-            click.echo("Done! You can now run 'astrbot run' to start AstrBot")
-    except Timeout:
+            asyncio.run(
+                initialize_astrbot(
+                    astrbot_root,
+                    yes=yes,
+                    backend_only=backend_only,
+                    admin_username=admin_username,
+                    admin_password=admin_password,
+                ),
+            )
+            click.echo()
+            click.echo("=" * 60)
+            click.echo("初始化完成！")
+            click.echo("=" * 60)
+            click.echo()
+            click.echo("启动 AstrBot：")
+            click.echo("  完整模式（含 Dashboard）: astrbot run")
+            click.echo("  仅后端模式:           astrbot run --backend-only")
+            click.echo()
+            click.echo("首次使用前请先设置管理员密码：")
+            click.echo("  astrbot conf admin")
+            click.echo()
+    except Timeout as err:
         raise click.ClickException(
-            "Cannot acquire lock file. Please check if another instance is running"
-        )
-
+            "Cannot acquire lock file. Please check if another instance is running",
+        ) from err
     except Exception as e:
-        raise click.ClickException(f"Initialization failed: {e!s}")
+        raise click.ClickException(f"Initialization failed: {e!s}") from e

--- a/astrbot/cli/commands/cmd_init.py
+++ b/astrbot/cli/commands/cmd_init.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import os
-import re
+from collections.abc import Callable
 from pathlib import Path
 
 import click
@@ -10,6 +10,7 @@ from filelock import FileLock, Timeout
 from astrbot.cli.utils import DashboardManager
 from astrbot.core.config.default import DEFAULT_CONFIG
 from astrbot.core.utils.astrbot_path import astrbot_paths
+from astrbot.core.utils.env_template import expand_env_placeholders
 
 DASHBOARD_INITIAL_PASSWORD_ENV = "ASTRBOT_DASHBOARD_INITIAL_PASSWORD"
 
@@ -52,15 +53,7 @@ def _set_dashboard_username(config: dict, username: str) -> None:
     dashboard_config["username"] = username
 
 
-async def initialize_astrbot(
-    astrbot_root: Path,
-    *,
-    yes: bool,
-    backend_only: bool,
-    admin_username: str | None,
-    admin_password: str | None,
-) -> None:
-    """Execute AstrBot initialization logic"""
+def _print_init_banner() -> None:
     from astrbot.cli.banner import print_logo
 
     click.echo("=" * 60)
@@ -69,15 +62,21 @@ async def initialize_astrbot(
     print_logo()
     click.echo()
 
+
+def _ensure_root_marker(astrbot_root: Path, *, yes: bool) -> None:
     dot_astrbot = astrbot_root / ".astrbot"
-    if not dot_astrbot.exists():
-        if yes or click.confirm(
-            f"确定要将 AstrBot 安装到以下目录吗？\n  {astrbot_root}",
-            default=True,
-            abort=True,
-        ):
-            dot_astrbot.touch()
-            click.echo(f"[OK] 已创建: {dot_astrbot}")
+    if dot_astrbot.exists():
+        return
+    if yes or click.confirm(
+        f"确定要将 AstrBot 安装到以下目录吗？\n  {astrbot_root}",
+        default=True,
+        abort=True,
+    ):
+        dot_astrbot.touch()
+        click.echo(f"[OK] 已创建: {dot_astrbot}")
+
+
+def _ensure_basic_directories(astrbot_root: Path) -> None:
     paths = {
         "data": astrbot_root / "data",
         "config": astrbot_root / "data" / "config",
@@ -91,51 +90,66 @@ async def initialize_astrbot(
         status = "Exists" if existed else "Created"
         click.echo(f"  [{status}] {name.title()}: {path}")
 
-    _initialize_config_from_env(astrbot_root)
 
-    config_path = astrbot_root / "data" / "cmd_config.json"
-    config_existed = config_path.exists()
-    config = _load_or_create_config(config_path)
-    if not config_existed:
-        click.echo(f"[OK] 配置文件已创建: {config_path}")
-    ASTRBOT_ROOT = astrbot_root
-    env_file = ASTRBOT_ROOT / ".env"
-    if not env_file.exists():
-        tmpl_candidates = [
-            Path("/opt/astrbot/config.template"),
-            getattr(astrbot_paths, "project_root", Path.cwd()) / "config.template",
-            Path.cwd() / "config.template",
-        ]
-        tmpl = None
-        for t in tmpl_candidates:
-            try:
-                if t.exists():
-                    tmpl = t
-                    break
-            except Exception:
-                continue
-        if tmpl is not None:
-            try:
-                txt = tmpl.read_text(encoding="utf-8")
-                instance_name = astrbot_root.name or "astrbot"
-                txt = re.sub("\\$\\{INSTANCE_NAME(:-[^}]*)?\\}", instance_name, txt)
-                port_val = (
-                    os.environ.get("ASTRBOT_PORT") or os.environ.get("PORT") or "8000"
-                )
-                txt = re.sub("\\$\\{PORT(:-[^}]*)?\\}", str(port_val), txt)
-                txt = re.sub("\\$\\{ASTRBOT_ROOT(:-[^}]*)?\\}", str(ASTRBOT_ROOT), txt)
-                header = f"# Generated from config.template by astrbot init for instance: {instance_name}\n# This file will be auto-loaded by 'astrbot run'\n\n"
-                env_file.write_text(header + txt, encoding="utf-8")
-                env_file.chmod(420)
-                click.echo(f"[OK] 环境变量文件已创建: {env_file}")
-            except Exception as e:
-                click.echo(f"[警告] 无法从模板生成 .env 文件: {e!s}")
-        else:
-            click.echo("[提示] 未找到 config.template 文件，跳过 .env 生成")
+def _find_env_template() -> Path | None:
+    tmpl_candidates = [
+        Path("/opt/astrbot/config.template"),
+        getattr(astrbot_paths, "project_root", Path.cwd()) / "config.template",
+        Path.cwd() / "config.template",
+    ]
+    for tmpl in tmpl_candidates:
+        try:
+            if tmpl.exists():
+                return tmpl
+        except Exception:
+            continue
+    return None
+
+
+def _maybe_generate_env_file(astrbot_root: Path) -> None:
+    env_file = astrbot_root / ".env"
+    if env_file.exists():
+        return
+
+    tmpl = _find_env_template()
+    if tmpl is None:
+        click.echo("[提示] 未找到 config.template 文件，跳过 .env 生成")
+        return
+
+    try:
+        instance_name = astrbot_root.name or "astrbot"
+        port_val = os.environ.get("ASTRBOT_PORT") or os.environ.get("PORT") or "8000"
+        txt = expand_env_placeholders(
+            tmpl.read_text(encoding="utf-8"),
+            overrides={
+                "INSTANCE_NAME": instance_name,
+                "PORT": str(port_val),
+                "ASTRBOT_ROOT": str(astrbot_root),
+            },
+        )
+        header = (
+            "# Generated from config.template by astrbot init for instance: "
+            f"{instance_name}\n"
+            "# This file will be auto-loaded by 'astrbot run'\n\n"
+        )
+        env_file.write_text(header + txt, encoding="utf-8")
+        env_file.chmod(0o644)
+        click.echo(f"[OK] 环境变量文件已创建: {env_file}")
+    except Exception as e:
+        click.echo(f"[警告] 无法从模板生成 .env 文件: {e!s}")
+
+
+def _configure_admin_user(
+    config_path: Path,
+    config: dict,
+    admin_username: str | None,
+    admin_password: str | None,
+) -> str:
     if admin_password is not None:
         raise click.ClickException(
             "--admin-password is no longer supported during init. Run 'astrbot conf admin' after initialization.",
         )
+
     effective_admin_username = (
         admin_username.strip()
         if admin_username
@@ -148,6 +162,10 @@ async def initialize_astrbot(
             encoding="utf-8-sig",
         )
     click.echo(f"[OK] Dashboard admin 用户名已设置为: {effective_admin_username}")
+    return effective_admin_username
+
+
+def _print_admin_guidance() -> None:
     click.echo()
     click.echo("!" * 60)
     click.echo("重要提示：")
@@ -156,27 +174,99 @@ async def initialize_astrbot(
     click.echo("  3. 登录地址: http://localhost:6185 或 http://服务器IP:6185")
     click.echo("!" * 60)
     click.echo()
-    if not backend_only and (
+
+
+def _print_backend_mode_guidance() -> None:
+    click.echo()
+    click.echo("[提示] 你选择了后端模式，可以使用以下方式管理 AstrBot：")
+    click.echo("  - 使用在线 Dashboard: 在浏览器中访问远程服务器的 WebUI")
+    click.echo("  - 使用 CLI 命令: astrbot conf / astrbot plug 等")
+    click.echo()
+    click.echo("!" * 60)
+    click.echo("安全提示：")
+    click.echo("  HTTPS 前端只能安全连接 localhost 的 HTTP 后端")
+    click.echo("  不支持远程 + HTTP 后端（不安全）")
+    click.echo("  如需远程访问，请使用 HTTPS 后端或通过反向代理")
+    click.echo("!" * 60)
+    click.echo()
+
+
+async def _maybe_install_dashboard(
+    astrbot_root: Path,
+    *,
+    yes: bool,
+    backend_only: bool,
+) -> None:
+    should_install_dashboard = not backend_only and (
         yes
         or click.confirm(
             "是否需要集成式 WebUI？（个人电脑推荐，服务器推荐使用后端模式）",
             default=True,
         )
-    ):
+    )
+    if should_install_dashboard:
         await DashboardManager().ensure_installed(astrbot_root)
-    else:
-        click.echo()
-        click.echo("[提示] 你选择了后端模式，可以使用以下方式管理 AstrBot：")
-        click.echo("  - 使用在线 Dashboard: 在浏览器中访问远程服务器的 WebUI")
-        click.echo("  - 使用 CLI 命令: astrbot conf / astrbot plug 等")
-        click.echo()
-        click.echo("!" * 60)
-        click.echo("安全提示：")
-        click.echo("  HTTPS 前端只能安全连接 localhost 的 HTTP 后端")
-        click.echo("  不支持远程 + HTTP 后端（不安全）")
-        click.echo("  如需远程访问，请使用 HTTPS 后端或通过反向代理")
-        click.echo("!" * 60)
-        click.echo()
+        return
+    _print_backend_mode_guidance()
+
+
+def _resolve_init_root(root_arg: str | None) -> Path:
+    astrbot_root = Path(root_arg).expanduser() if root_arg else astrbot_paths.root
+    astrbot_root.mkdir(parents=True, exist_ok=True)
+    os.environ["ASTRBOT_ROOT"] = str(astrbot_root)
+    return astrbot_root
+
+
+def _with_root_lock(root: Path, fn: Callable[[], None]) -> None:
+    lock_file = root / "astrbot.lock"
+    lock = FileLock(lock_file, timeout=5)
+    try:
+        with lock.acquire():
+            fn()
+    except Timeout as err:
+        raise click.ClickException(
+            "Cannot acquire lock file. Please check if another instance is running",
+        ) from err
+
+
+def _print_final_instructions() -> None:
+    click.echo()
+    click.echo("=" * 60)
+    click.echo("初始化完成！")
+    click.echo("=" * 60)
+    click.echo()
+    click.echo("启动 AstrBot：")
+    click.echo("  完整模式（含 Dashboard）: astrbot run")
+    click.echo("  仅后端模式:           astrbot run --backend-only")
+    click.echo()
+    click.echo("首次使用前请先设置管理员密码：")
+    click.echo("  astrbot conf admin")
+    click.echo()
+
+
+async def initialize_astrbot(
+    astrbot_root: Path,
+    *,
+    yes: bool,
+    backend_only: bool,
+    admin_username: str | None,
+    admin_password: str | None,
+) -> None:
+    """Execute AstrBot initialization logic"""
+    _print_init_banner()
+    _ensure_root_marker(astrbot_root, yes=yes)
+    _ensure_basic_directories(astrbot_root)
+    _initialize_config_from_env(astrbot_root)
+
+    config_path = astrbot_root / "data" / "cmd_config.json"
+    config_existed = config_path.exists()
+    config = _load_or_create_config(config_path)
+    if not config_existed:
+        click.echo(f"[OK] 配置文件已创建: {config_path}")
+    _maybe_generate_env_file(astrbot_root)
+    _configure_admin_user(config_path, config, admin_username, admin_password)
+    _print_admin_guidance()
+    await _maybe_install_dashboard(astrbot_root, yes=yes, backend_only=backend_only)
 
 
 @click.command()
@@ -210,39 +300,24 @@ def init(
     click.echo("Initializing AstrBot...")
     if os.environ.get("ASTRBOT_SYSTEMD") == "1":
         yes = True
-    from astrbot.core.utils.astrbot_path import astrbot_paths
 
-    astrbot_root = Path(root).expanduser() if root else astrbot_paths.root
-    astrbot_root.mkdir(parents=True, exist_ok=True)
-    os.environ["ASTRBOT_ROOT"] = str(astrbot_root)
-    lock_file = astrbot_root / "astrbot.lock"
-    lock = FileLock(lock_file, timeout=5)
+    astrbot_root = _resolve_init_root(root)
+
+    def _run_init() -> None:
+        asyncio.run(
+            initialize_astrbot(
+                astrbot_root,
+                yes=yes,
+                backend_only=backend_only,
+                admin_username=admin_username,
+                admin_password=admin_password,
+            ),
+        )
+        _print_final_instructions()
+
     try:
-        with lock.acquire():
-            asyncio.run(
-                initialize_astrbot(
-                    astrbot_root,
-                    yes=yes,
-                    backend_only=backend_only,
-                    admin_username=admin_username,
-                    admin_password=admin_password,
-                ),
-            )
-            click.echo()
-            click.echo("=" * 60)
-            click.echo("初始化完成！")
-            click.echo("=" * 60)
-            click.echo()
-            click.echo("启动 AstrBot：")
-            click.echo("  完整模式（含 Dashboard）: astrbot run")
-            click.echo("  仅后端模式:           astrbot run --backend-only")
-            click.echo()
-            click.echo("首次使用前请先设置管理员密码：")
-            click.echo("  astrbot conf admin")
-            click.echo()
-    except Timeout as err:
-        raise click.ClickException(
-            "Cannot acquire lock file. Please check if another instance is running",
-        ) from err
+        _with_root_lock(astrbot_root, _run_init)
+    except click.ClickException:
+        raise
     except Exception as e:
         raise click.ClickException(f"Initialization failed: {e!s}") from e

--- a/astrbot/cli/commands/cmd_run.py
+++ b/astrbot/cli/commands/cmd_run.py
@@ -1,13 +1,100 @@
+"""AstrBot Run
+Environment Variables Used in Project:
+
+Core:
+- `ASTRBOT_ROOT`: AstrBot root directory path.
+- `ASTRBOT_LOG_LEVEL`: Log level (e.g. INFO, DEBUG).
+- `ASTRBOT_CLI`: Flag indicating execution via CLI.
+- `ASTRBOT_DESKTOP_CLIENT`: Flag indicating execution via desktop client.
+- `ASTRBOT_SYSTEMD`: Flag indicating execution via systemd service.
+- `ASTRBOT_RELOAD`: Enable plugin auto-reload (set to "1").
+- `ASTRBOT_DISABLE_METRICS`: Disable metrics upload (set to "1").
+- `TESTING`: Enable testing mode.
+- `DEMO_MODE`: Enable demo mode.
+- `PYTHON`: Python executable path override (for local code execution).
+
+Dashboard / Backend:
+- `ASTRBOT_DASHBOARD_ENABLE`: Enable/Disable Dashboard.
+- `ASTRBOT_HOST`: Dashboard bind host.
+- `ASTRBOT_PORT`: Dashboard bind port.
+
+SSL (AstrBot-standard names):
+- `ASTRBOT_SSL_ENABLE`: Enable SSL for API.
+- `ASTRBOT_SSL_CERT`: SSL Certificate path for backend.
+- `ASTRBOT_SSL_KEY`: SSL Key path for backend.
+- `ASTRBOT_SSL_CA_CERTS`: SSL CA Certs path for backend.
+
+Network:
+- `http_proxy` / `https_proxy`: Proxy URL.
+- `no_proxy`: No proxy list.
+
+Internationalization:
+- `ASTRBOT_CLI_LANG`: CLI interface language (zh/en).
+
+Integrations:
+- `DASHSCOPE_API_KEY`: Alibaba DashScope API Key (for Rerank).
+- `COZE_API_KEY` / `COZE_BOT_ID`: Coze integration.
+- `BAY_DATA_DIR`: Computer Use data directory.
+
+Platform Specific:
+- `TEST_MODE`: Test mode for QQOfficial.
+"""
+
+from __future__ import annotations
+
 import asyncio
 import os
+import re
 import sys
 import traceback
 from pathlib import Path
 
 import click
+from dotenv import load_dotenv
 from filelock import FileLock, Timeout
 
-from ..utils import check_astrbot_root, check_dashboard, get_astrbot_root
+from astrbot.cli.utils import DashboardManager
+from astrbot.runtime_bootstrap import initialize_runtime_bootstrap
+
+# Python version check: require 3.12 or 3.13
+if not (sys.version_info.major == 3 and sys.version_info.minor in (12, 13)):
+    sys.exit(1)
+
+# Regular expression to find bash-like parameter expansions:
+# ${VAR:-default} or ${VAR}
+_PARAM_EXPAND_RE = re.compile(r"\$\{([^}:]+?)(:-([^}]*))?\}")
+
+
+def _expand_parameter(
+    match: re.Match,
+    env: dict[str, str],
+    local: dict[str, str],
+) -> str:
+    """Helper to expand a single ${VAR:-default} or ${VAR} occurrence.
+
+    Precedence:
+      1. local dict (parsed from the same file, earlier entries)
+      2. environment variables
+      3. default provided in the expansion (if any)
+      4. empty string
+    """
+    var = match.group(1)
+    default = match.group(3) if match.group(3) is not None else ""
+    # Prefer 'local' parsed values first
+    if var in local and local[var] != "":
+        return local[var]
+    val = env.get(var, "")
+    if val != "":
+        return val
+    return default
+
+
+def _expand_env_parameter_value(value: str) -> str:
+    local: dict[str, str] = {}
+    return _PARAM_EXPAND_RE.sub(
+        lambda match: _expand_parameter(match, os.environ, local),
+        value,
+    )
 
 
 async def run_astrbot(astrbot_root: Path) -> None:
@@ -15,7 +102,11 @@ async def run_astrbot(astrbot_root: Path) -> None:
     from astrbot.core import LogBroker, LogManager, db_helper, logger
     from astrbot.core.initial_loader import InitialLoader
 
-    await check_dashboard(astrbot_root / "data")
+    if (
+        os.environ.get("ASTRBOT_DASHBOARD_ENABLE", os.environ.get("DASHBOARD_ENABLE"))
+        == "True"
+    ):
+        await DashboardManager().ensure_installed(astrbot_root)
 
     log_broker = LogBroker()
     LogManager.set_queue_handler(logger, log_broker)
@@ -27,38 +118,327 @@ async def run_astrbot(astrbot_root: Path) -> None:
 
 
 @click.option("--reload", "-r", is_flag=True, help="Auto-reload plugins")
+@click.option("--host", "-H", help="AstrBot Dashboard Host", required=False, type=str)
 @click.option("--port", "-p", help="AstrBot Dashboard port", required=False, type=str)
+@click.option("--root", help="AstrBot root directory", required=False, type=str)
+@click.option(
+    "--service-config",
+    "-c",
+    help="Service configuration file path (supports ${VAR:-default} style expansion)",
+    required=False,
+    type=str,
+)
+@click.option(
+    "--backend-only",
+    "-b",
+    is_flag=True,
+    default=False,
+    help="Disable WebUI, run backend only",
+)
+@click.option(
+    "--log-level",
+    "-l",
+    help="Log level",
+    required=False,
+    type=str,
+    default="INFO",
+)
+@click.option(
+    "--ssl-cert",
+    help="SSL certificate file path for backend (preferred env name: ASTRBOT_SSL_CERT)",
+    required=False,
+    type=str,
+)
+@click.option(
+    "--ssl-key",
+    help="SSL private key file path for backend (preferred env name: ASTRBOT_SSL_KEY)",
+    required=False,
+    type=str,
+)
+@click.option(
+    "--ssl-ca",
+    help="SSL CA certificates file path for backend (preferred env name: ASTRBOT_SSL_CA_CERTS)",
+    required=False,
+    type=str,
+)
+@click.option("--debug", is_flag=True, help="Enable debug mode")
 @click.command()
-def run(reload: bool, port: str) -> None:
+def run(
+    reload: bool,
+    host: str,
+    port: str,
+    root: str,
+    service_config: str,
+    backend_only: bool,
+    log_level: str,
+    ssl_cert: str,
+    ssl_key: str,
+    ssl_ca: str,
+    debug: bool,
+) -> None:
     """Run AstrBot"""
+    initialize_runtime_bootstrap()
     try:
-        os.environ["ASTRBOT_CLI"] = "1"
-        astrbot_root = get_astrbot_root()
+        if debug:
+            log_level = "DEBUG"
 
-        if not check_astrbot_root(astrbot_root):
+        # --- Step 1: Resolve service-config path (if provided). We'll treat it as a .env file later. ---
+        svc_path: Path | None = None
+        if service_config:
+            expanded_service_config = _expand_env_parameter_value(service_config)
+            candidate = Path(os.path.expanduser(expanded_service_config))
+            if not candidate.exists():
+                candidate = Path.cwd() / candidate
+            if candidate.exists():
+                svc_path = candidate
+            else:
+                raise click.ClickException(
+                    f"Service configuration file not found: {service_config}",
+                )
+
+        # NOTE:
+        # Loading of common .env files (CWD/.env, packaged project .env, ASTRBOT_ROOT/.env)
+        # has been moved to astrbot.core.utils.astrbot_path during import-time to avoid
+        # early-initialization ordering issues. Those files are loaded there using
+        # `override=False` so they do not clobber environment variables provided by the
+        # systemd unit or the caller.
+        #
+        # Here we only load an explicit service-config file (if given). Service-config
+        # should be able to override the common .env files, but CLI-provided values must
+        # still win; the CLI will set/overwrite corresponding environment variables
+        # below after this load.
+        if svc_path and svc_path.exists():
+            # Load service-config as an env file and allow it to override previously-loaded
+            # .env values (those were loaded by astrbot_path). CLI variables are applied
+            # after this point and will take precedence.
+            load_dotenv(dotenv_path=str(svc_path), override=True)
+
+        # Mark CLI execution
+        os.environ["ASTRBOT_CLI"] = "1"
+
+        from astrbot.core.utils.astrbot_path import astrbot_paths
+
+        # Resolve astrbot_root with the following precedence:
+        # 1. CLI --root parameter (local variable `root`)
+        # 2. ASTRBOT_ROOT environment variable (possibly from .env or parsed service config)
+        # 3. packaged default astrbot_paths.root
+        if root:
+            os.environ["ASTRBOT_ROOT"] = root
+            astrbot_root = Path(root)
+        elif os.environ.get("ASTRBOT_ROOT"):
+            astrbot_root = Path(os.environ["ASTRBOT_ROOT"])
+        else:
+            astrbot_root = astrbot_paths.root
+
+        if not astrbot_paths.is_root:
             raise click.ClickException(
                 f"{astrbot_root} is not a valid AstrBot root directory. Use 'astrbot init' to initialize",
             )
 
+        # Ensure ASTRBOT_ROOT env var is set to the resolved root (without overriding a CLI-provided root value above)
         os.environ["ASTRBOT_ROOT"] = str(astrbot_root)
         sys.path.insert(0, str(astrbot_root))
 
-        if port:
+        # Host/Port precedence: CLI args > parsed service config/env/.env > defaults.
+        if port is not None:
+            os.environ["ASTRBOT_PORT"] = port
+            os.environ["ASTRBOT_DASHBOARD_PORT"] = port
             os.environ["DASHBOARD_PORT"] = port
+
+        if host is not None:
+            os.environ["ASTRBOT_HOST"] = host
+            os.environ["ASTRBOT_DASHBOARD_HOST"] = host
+            os.environ["DASHBOARD_HOST"] = host
+
+        # CLI-provided SSL paths should set backend-standard env names.
+        if ssl_cert is not None:
+            os.environ["ASTRBOT_SSL_CERT"] = ssl_cert
+            os.environ["ASTRBOT_DASHBOARD_SSL_CERT"] = ssl_cert
+        if ssl_key is not None:
+            os.environ["ASTRBOT_SSL_KEY"] = ssl_key
+            os.environ["ASTRBOT_DASHBOARD_SSL_KEY"] = ssl_key
+        if ssl_ca is not None:
+            os.environ["ASTRBOT_SSL_CA_CERTS"] = ssl_ca
+            os.environ["ASTRBOT_DASHBOARD_SSL_CA_CERTS"] = ssl_ca
+
+        # Dashboard enable is derived from CLI flag (--backend-only). CLI decision should win.
+        os.environ["ASTRBOT_DASHBOARD_ENABLE"] = str(not backend_only)
+
+        os.environ["ASTRBOT_LOG_LEVEL"] = log_level
 
         if reload:
             click.echo("Plugin auto-reload enabled")
             os.environ["ASTRBOT_RELOAD"] = "1"
 
+        if debug:
+            keys_to_print = [
+                "ASTRBOT_ROOT",
+                "ASTRBOT_LOG_LEVEL",
+                "ASTRBOT_CLI",
+                "ASTRBOT_DESKTOP_CLIENT",
+                "ASTRBOT_SYSTEMD",
+                "ASTRBOT_RELOAD",
+                "ASTRBOT_DISABLE_METRICS",
+                "TESTING",
+                "DEMO_MODE",
+                "PYTHON",
+                "ASTRBOT_DASHBOARD_ENABLE",
+                "DASHBOARD_ENABLE",
+                "ASTRBOT_HOST",
+                "DASHBOARD_HOST",
+                "ASTRBOT_PORT",
+                "DASHBOARD_PORT",
+                # Dashboard SSL (legacy)
+                "ASTRBOT_SSL_ENABLE",
+                "DASHBOARD_SSL_ENABLE",
+                "ASTRBOT_SSL_CERT",
+                "DASHBOARD_SSL_CERT",
+                "ASTRBOT_SSL_KEY",
+                "DASHBOARD_SSL_KEY",
+                "ASTRBOT_SSL_CA_CERTS",
+                "DASHBOARD_SSL_CA_CERTS",
+                # Backend-standard SSL (preferred)
+                "ASTRBOT_SSL_ENABLE",
+                "ASTRBOT_SSL_CERT",
+                "ASTRBOT_SSL_KEY",
+                "ASTRBOT_SSL_CA_CERTS",
+                "http_proxy",
+                "https_proxy",
+                "no_proxy",
+                "DASHSCOPE_API_KEY",
+                "COZE_API_KEY",
+                "COZE_BOT_ID",
+                "BAY_DATA_DIR",
+                "TEST_MODE",
+            ]
+            click.secho("\n[Debug Mode] Environment Variables:", fg="yellow", bold=True)
+            for key in keys_to_print:
+                if key in os.environ:
+                    val = os.environ[key]
+                    if "KEY" in key or "PASSWORD" in key or "SECRET" in key:
+                        if len(val) > 8:
+                            val = val[:4] + "****" + val[-4:]
+                        else:
+                            val = "****"
+                    click.echo(f"  {click.style(key, fg='cyan')}: {val}")
+            if svc_path:
+                click.echo(
+                    f"  {click.style('SERVICE_CONFIG', fg='cyan')}: {svc_path!s}",
+                )
+            click.echo("")
+
         lock_file = astrbot_root / "astrbot.lock"
         lock = FileLock(lock_file, timeout=5)
         with lock.acquire():
-            asyncio.run(run_astrbot(astrbot_root))
+
+            async def run_with_logging() -> None:
+                from astrbot.core import LogBroker, LogManager, db_helper, logger
+                from astrbot.core.initial_loader import InitialLoader
+
+                if (
+                    os.environ.get(
+                        "ASTRBOT_DASHBOARD_ENABLE",
+                        os.environ.get("DASHBOARD_ENABLE"),
+                    )
+                    == "True"
+                ):
+                    await DashboardManager().ensure_installed(astrbot_root)
+
+                log_broker = LogBroker()
+                LogManager.set_queue_handler(logger, log_broker)
+
+                # Register a stdout subscriber for real-time log streaming
+                log_queue = log_broker.register()
+
+                db = db_helper
+                initial_loader = InitialLoader(db, log_broker)
+
+                # Start a task to stream logs to stdout
+                async def stream_logs() -> None:
+                    """Stream logs from LogBroker to stdout."""
+                    while True:
+                        try:
+                            log_entry = await asyncio.wait_for(
+                                log_queue.get(),
+                                timeout=0.5,
+                            )
+                            # Format: [LEVEL] message
+                            level = log_entry.get("level_name", "INFO")
+                            message = log_entry.get("message", "")
+                            if message:
+                                level_color = {
+                                    "DEBUG": "cyan",
+                                    "INFO": "green",
+                                    "WARNING": "yellow",
+                                    "ERROR": "red",
+                                    "CRITICAL": "red",
+                                }.get(level, "white")
+                                click.secho(
+                                    f"[{level}]",
+                                    fg=level_color,
+                                    bold=False,
+                                    nl=False,
+                                )
+                                click.echo(f" {message}")
+                        except TimeoutError:
+                            continue
+                        except asyncio.CancelledError:
+                            break
+
+                # Start streaming task
+                stream_task = asyncio.create_task(stream_logs())
+
+                try:
+                    await initial_loader.start()
+                finally:
+                    stream_task.cancel()
+                    try:
+                        await stream_task
+                    except asyncio.CancelledError:
+                        pass
+
+            click.echo()
+            click.echo("=" * 60)
+            click.echo("AstrBot 启动中...")
+            click.echo("=" * 60)
+
+            from astrbot.cli.banner import print_logo
+
+            print_logo()
+            click.echo()
+
+            if backend_only:
+                click.echo("[模式] 仅后端模式（无本地 Dashboard）")
+                click.echo()
+                click.echo("[提示] 可以通过以下方式访问 WebUI：")
+                click.echo("  - 使用远程服务器的在线 Dashboard")
+                click.echo("  - 地址: http://服务器IP:6185")
+                click.echo()
+            else:
+                dashboard_url = f"http://{host or 'localhost'}:{port or '6185'}"
+                click.echo("[模式] 完整模式（含本地 Dashboard）")
+                click.echo()
+                click.echo(f"[Dashboard] 请访问: {dashboard_url}")
+                click.echo()
+                click.echo("!" * 60)
+                click.echo("安全提示：")
+                click.echo("  HTTPS 前端只能安全连接 localhost 的 HTTP 后端")
+                click.echo("  不支持远程 + HTTP 后端（不安全）")
+                click.echo("!" * 60)
+                click.echo()
+
+            click.echo("正在启动服务...（日志输出中）")
+            click.echo()
+
+            asyncio.run(run_with_logging())
     except KeyboardInterrupt:
         click.echo("AstrBot has been shut down.")
     except Timeout:
         raise click.ClickException(
-            "Cannot acquire lock file. Please check if another instance is running"
-        )
+            "Cannot acquire lock file. Please check if another instance is running",
+        ) from None
     except Exception as e:
-        raise click.ClickException(f"Runtime error: {e}\n{traceback.format_exc()}")
+        # Keep original traceback visible for diagnostics
+        raise click.ClickException(
+            f"Runtime error: {e}\n{traceback.format_exc()}",
+        ) from e

--- a/astrbot/cli/commands/cmd_run.py
+++ b/astrbot/cli/commands/cmd_run.py
@@ -44,7 +44,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-import re
 import sys
 import traceback
 from pathlib import Path
@@ -54,47 +53,12 @@ from dotenv import load_dotenv
 from filelock import FileLock, Timeout
 
 from astrbot.cli.utils import DashboardManager
+from astrbot.core.utils.env_template import expand_env_placeholders
 from astrbot.runtime_bootstrap import initialize_runtime_bootstrap
 
 # Python version check: require 3.12 or 3.13
 if not (sys.version_info.major == 3 and sys.version_info.minor in (12, 13)):
     sys.exit(1)
-
-# Regular expression to find bash-like parameter expansions:
-# ${VAR:-default} or ${VAR}
-_PARAM_EXPAND_RE = re.compile(r"\$\{([^}:]+?)(:-([^}]*))?\}")
-
-
-def _expand_parameter(
-    match: re.Match,
-    env: dict[str, str],
-    local: dict[str, str],
-) -> str:
-    """Helper to expand a single ${VAR:-default} or ${VAR} occurrence.
-
-    Precedence:
-      1. local dict (parsed from the same file, earlier entries)
-      2. environment variables
-      3. default provided in the expansion (if any)
-      4. empty string
-    """
-    var = match.group(1)
-    default = match.group(3) if match.group(3) is not None else ""
-    # Prefer 'local' parsed values first
-    if var in local and local[var] != "":
-        return local[var]
-    val = env.get(var, "")
-    if val != "":
-        return val
-    return default
-
-
-def _expand_env_parameter_value(value: str) -> str:
-    local: dict[str, str] = {}
-    return _PARAM_EXPAND_RE.sub(
-        lambda match: _expand_parameter(match, os.environ, local),
-        value,
-    )
 
 
 async def run_astrbot(astrbot_root: Path) -> None:
@@ -185,7 +149,7 @@ def run(
         # --- Step 1: Resolve service-config path (if provided). We'll treat it as a .env file later. ---
         svc_path: Path | None = None
         if service_config:
-            expanded_service_config = _expand_env_parameter_value(service_config)
+            expanded_service_config = expand_env_placeholders(service_config)
             candidate = Path(os.path.expanduser(expanded_service_config))
             if not candidate.exists():
                 candidate = Path.cwd() / candidate

--- a/astrbot/cli/i18n.py
+++ b/astrbot/cli/i18n.py
@@ -1,0 +1,278 @@
+"""Internationalization support for AstrBot CLI.
+
+This module provides i18n support with Chinese and English languages.
+Language is auto-detected from environment or can be set manually.
+"""
+
+from __future__ import annotations
+
+import os
+from enum import Enum
+from functools import lru_cache
+
+
+class Language(Enum):
+    """Supported languages."""
+
+    ZH = "zh"
+    EN = "en"
+
+
+# Translation dictionaries
+_TRANSLATIONS: dict[Language, dict[str, str]] = {
+    Language.ZH: {
+        # CLI welcome and general
+        "cli_welcome": "欢迎使用 AstrBot CLI!",
+        "cli_version": "AstrBot CLI 版本: {version}",
+        "cli_unknown_command": "未知命令: {command}",
+        "cli_help_available": "使用 astrbot help --all 查看所有命令",
+        # Dashboard commands
+        "dashboard_bundled": "Dashboard 已打包在安装包中 - 跳过下载",
+        "dashboard_not_installed": "Dashboard 未安装",
+        "dashboard_install_confirm": "是否安装 Dashboard?",
+        "dashboard_installing": "正在安装 Dashboard...",
+        "dashboard_install_success": "Dashboard 安装成功",
+        "dashboard_install_failed": "Dashboard 安装失败: {error}",
+        "dashboard_not_needed": "Dashboard 不需要安装",
+        "dashboard_declined": "Dashboard 安装已取消",
+        "dashboard_already_up_to_date": "Dashboard 已是最新版本",
+        "dashboard_version": "Dashboard 版本: {version}",
+        "dashboard_download_failed": "Dashboard 下载失败: {error}",
+        "dashboard_init_dir": "正在初始化 Dashboard 目录...",
+        "dashboard_init_success": "Dashboard 初始化成功",
+        # Plugin commands
+        "plugin_installing": "正在安装插件: {name}",
+        "plugin_install_success": "插件安装成功: {name}",
+        "plugin_install_failed": "插件安装失败: {name}",
+        "plugin_uninstall_confirm": "确定要卸载插件 {name} 吗?",
+        "plugin_uninstall_success": "插件卸载成功: {name}",
+        "plugin_uninstall_failed": "插件卸载失败: {name}",
+        "plugin_list_empty": "未安装任何插件",
+        "plugin_already_installed": "插件已安装: {name}",
+        "plugin_not_found": "插件未找到: {name}",
+        "plugin_already_exists": "插件已存在: {name}",
+        "plugin_not_found_or_installed": "插件未找到或已安装: {name}",
+        "plugin_uninstall_failed_ex": "插件卸载失败 {name}: {error}",
+        "plugin_no_update_needed": "没有需要更新的插件",
+        "plugin_found_update": "发现 {count} 个插件需要更新",
+        "plugin_updating": "正在更新插件 {name}...",
+        "plugin_search_no_result": "未找到匹配 '{query}' 的插件",
+        "plugin_search_results": "搜索结果: '{query}'",
+        # Config commands
+        "config_show": "显示配置",
+        "config_set_success": "配置项已更新: {key} = {value}",
+        "config_set_failed": "配置项更新失败: {key}",
+        "config_set_failed_ex": "设置配置失败: {error}",
+        "config_get_success": "{key} = {value}",
+        "config_get_not_found": "配置项未找到: {key}",
+        "config_reset_confirm": "确定要重置所有配置吗?",
+        "config_reset_success": "配置已重置",
+        # Config validators
+        "config_log_level_invalid": "日志级别必须是 DEBUG/INFO/WARNING/ERROR/CRITICAL 之一",
+        "config_port_must_be_number": "端口必须是数字",
+        "config_port_range_invalid": "端口必须在 1-65535 范围内",
+        "config_username_empty": "用户名不能为空",
+        "config_password_empty": "密码不能为空",
+        "config_timezone_invalid": "无效的时区: {value}。请使用有效的 IANA 时区名称",
+        "config_callback_invalid": "回调 API 基础路径必须以 http:// 或 https:// 开头",
+        "config_key_unsupported": "不支持的配置项: {key}",
+        "config_key_unknown": "未知的配置项: {key}",
+        "config_updated": "配置已更新: {key}",
+        # Init command
+        "init_creating": "正在创建配置目录...",
+        "init_created": "配置目录已创建: {path}",
+        "init_copying": "正在复制配置文件...",
+        "init_copied": "配置文件已复制",
+        "init_success": "AstrBot 初始化完成!",
+        "init_failed": "初始化失败: {error}",
+        # Run command
+        "run_starting": "正在启动 AstrBot...",
+        "run_started": "AstrBot 已启动!",
+        "run_backend_only": "以无界面模式启动",
+        "run_failed": "启动失败: {error}",
+        "run_stopped": "AstrBot 已停止",
+        # Common
+        "yes": "是",
+        "no": "否",
+        "cancel": "取消",
+        "confirm": "确认",
+        "error": "错误",
+        "success": "成功",
+        "warning": "警告",
+        "info": "信息",
+        "loading": "加载中...",
+        "done": "完成",
+        "failed": "失败",
+        "retry": "重试",
+        "exit": "退出",
+        "continue": "继续",
+    },
+    Language.EN: {
+        # CLI welcome and general
+        "cli_welcome": "Welcome to AstrBot CLI!",
+        "cli_version": "AstrBot CLI version: {version}",
+        "cli_unknown_command": "Unknown command: {command}",
+        "cli_help_available": "Use astrbot help --all to see all commands",
+        # Dashboard commands
+        "dashboard_bundled": "Dashboard is bundled with the package - skipping download",
+        "dashboard_not_installed": "Dashboard is not installed",
+        "dashboard_install_confirm": "Install Dashboard?",
+        "dashboard_installing": "Installing Dashboard...",
+        "dashboard_install_success": "Dashboard installed successfully",
+        "dashboard_install_failed": "Failed to install dashboard: {error}",
+        "dashboard_not_needed": "Dashboard not needed",
+        "dashboard_declined": "Dashboard installation declined.",
+        "dashboard_already_up_to_date": "Dashboard is already up to date",
+        "dashboard_version": "Dashboard version: {version}",
+        "dashboard_download_failed": "Failed to download dashboard: {error}",
+        "dashboard_init_dir": "Initializing dashboard directory...",
+        "dashboard_init_success": "Dashboard initialized successfully",
+        # Plugin commands
+        "plugin_installing": "Installing plugin: {name}",
+        "plugin_install_success": "Plugin installed successfully: {name}",
+        "plugin_install_failed": "Failed to install plugin: {name}",
+        "plugin_uninstall_confirm": "Uninstall plugin {name}?",
+        "plugin_uninstall_success": "Plugin uninstalled successfully: {name}",
+        "plugin_uninstall_failed": "Failed to uninstall plugin: {name}",
+        "plugin_list_empty": "No plugins installed",
+        "plugin_already_installed": "Plugin already installed: {name}",
+        "plugin_not_found": "Plugin not found: {name}",
+        "plugin_already_exists": "Plugin {name} already exists",
+        "plugin_not_found_or_installed": "Plugin {name} not found or already installed",
+        "plugin_uninstall_failed_ex": "Failed to uninstall plugin {name}: {error}",
+        "plugin_no_update_needed": "No plugins need updating",
+        "plugin_found_update": "Found {count} plugin(s) needing update",
+        "plugin_updating": "Updating plugin {name}...",
+        "plugin_search_no_result": "No plugins matching '{query}' found",
+        "plugin_search_results": "Search results: '{query}'",
+        # Config commands
+        "config_show": "Show configuration",
+        "config_set_success": "Configuration updated: {key} = {value}",
+        "config_set_failed": "Failed to update configuration: {key}",
+        "config_set_failed_ex": "Failed to set config: {error}",
+        "config_get_success": "{key} = {value}",
+        "config_get_not_found": "Configuration key not found: {key}",
+        "config_reset_confirm": "Reset all configuration?",
+        "config_reset_success": "Configuration reset",
+        # Config validators
+        "config_log_level_invalid": "Log level must be one of DEBUG/INFO/WARNING/ERROR/CRITICAL",
+        "config_port_must_be_number": "Port must be a number",
+        "config_port_range_invalid": "Port must be in range 1-65535",
+        "config_username_empty": "Username cannot be empty",
+        "config_password_empty": "Password cannot be empty",
+        "config_timezone_invalid": "Invalid timezone: {value}. Please use a valid IANA timezone name",
+        "config_callback_invalid": "Callback API base must start with http:// or https://",
+        "config_key_unsupported": "Unsupported config key: {key}",
+        "config_key_unknown": "Unknown config key: {key}",
+        "config_updated": "Config updated: {key}",
+        # Init command
+        "init_creating": "Creating config directory...",
+        "init_created": "Config directory created: {path}",
+        "init_copying": "Copying config files...",
+        "init_copied": "Config files copied",
+        "init_success": "AstrBot initialized successfully!",
+        "init_failed": "Initialization failed: {error}",
+        # Run command
+        "run_starting": "Starting AstrBot...",
+        "run_started": "AstrBot started!",
+        "run_backend_only": "Starting in backend-only mode",
+        "run_failed": "Failed to start: {error}",
+        "run_stopped": "AstrBot stopped",
+        # Common
+        "yes": "Yes",
+        "no": "No",
+        "cancel": "Cancel",
+        "confirm": "Confirm",
+        "error": "Error",
+        "success": "Success",
+        "warning": "Warning",
+        "info": "Info",
+        "loading": "Loading...",
+        "done": "Done",
+        "failed": "Failed",
+        "retry": "Retry",
+        "exit": "Exit",
+        "continue": "Continue",
+    },
+}
+
+
+@lru_cache(maxsize=1)
+def get_current_language() -> Language:
+    """Get the current language based on environment or default.
+
+    Detection order:
+    1. ASTRBOT_CLI_LANG environment variable (zh/en)
+    2. LANG environment variable (if contains zh/cn)
+    3. LC_ALL environment variable (if contains zh/cn)
+    4. Default to Chinese (most users are Chinese)
+    """
+    # Check explicit override first
+    explicit = os.environ.get("ASTRBOT_CLI_LANG", "").lower()
+    if explicit in ("zh", "en"):
+        return Language.ZH if explicit == "zh" else Language.EN
+
+    # Check LANG/LC_ALL for Chinese
+    for env_var in ("LANG", "LC_ALL"):
+        lang = os.environ.get(env_var, "").lower()
+        if "zh" in lang or "cn" in lang:
+            return Language.ZH
+
+    # Default to Chinese for broader appeal
+    return Language.ZH
+
+
+def set_language(lang: Language) -> None:
+    """Set the current language (clears all translation caches)."""
+    get_current_language.cache_clear()
+    _t_cached.cache_clear()
+    # Set environment variable for persistence
+    os.environ["ASTRBOT_CLI_LANG"] = lang.value
+
+
+@lru_cache(maxsize=128)
+def _t_cached(key: str, lang: Language) -> str:
+    """Cached translation lookup."""
+    return _TRANSLATIONS.get(lang, {}).get(key, key)
+
+
+def t(translation_key: str, **kwargs: str) -> str:
+    """Get translation for the given key in the current language.
+
+    Args:
+        translation_key: Translation key (e.g., "cli_welcome", "plugin_installing")
+        **kwargs: Format arguments for the translation string
+
+    Returns:
+        Translated string, or the key itself if not found
+
+    """
+    result = _t_cached(translation_key, get_current_language())
+    if kwargs:
+        result = result.format(**kwargs)
+    return result
+
+
+def tr(key: str, **kwargs: str) -> str:
+    """Get translation (alias for t())."""
+    return t(key, **kwargs)
+
+
+class CLITranslations:
+    """Translation accessor class for CLI contexts.
+
+    Usage:
+        translations = CLITranslations()
+        print(translations.cli_welcome)
+        print(translations.plugin_installing(name="my_plugin"))
+    """
+
+    def __getattr__(self, key: str) -> str:
+        return t(key)
+
+    def __call__(self, key: str, **kwargs: str) -> str:
+        return t(key, **kwargs)
+
+
+# Convenience instance
+translations = CLITranslations()

--- a/astrbot/cli/utils/__init__.py
+++ b/astrbot/cli/utils/__init__.py
@@ -3,10 +3,12 @@ from .basic import (
     check_dashboard,
     get_astrbot_root,
 )
+from .dashboard import DashboardManager
 from .plugin import PluginStatus, build_plug_list, get_git_repo, manage_plugin
 from .version_comparator import VersionComparator
 
 __all__ = [
+    "DashboardManager",
     "PluginStatus",
     "VersionComparator",
     "build_plug_list",

--- a/astrbot/cli/utils/dashboard.py
+++ b/astrbot/cli/utils/dashboard.py
@@ -1,0 +1,79 @@
+import sys
+from importlib import resources
+from pathlib import Path
+
+import click
+
+from astrbot.cli.i18n import t
+
+from .version_comparator import VersionComparator
+
+
+class DashboardManager:
+    _bundled_dist = resources.files("astrbot") / "dashboard" / "dist"
+
+    async def ensure_installed(self, astrbot_root: Path) -> None:
+        """Ensure the dashboard assets are installed and up to date."""
+        from astrbot.core.config.default import VERSION
+        from astrbot.core.utils.io import download_dashboard, get_dashboard_version
+
+        if self._bundled_dist.is_dir():
+            click.echo(t("dashboard_bundled"))
+            return
+
+        try:
+            dashboard_version = await get_dashboard_version()
+            match dashboard_version:
+                case None:
+                    click.echo(t("dashboard_not_installed"))
+                    # Skip interactive prompt in non-interactive environments
+                    if not sys.stdin.isatty():
+                        click.echo(t("dashboard_not_needed"))
+                        return
+                    if click.confirm(t("dashboard_install_confirm"), default=True):
+                        click.echo(t("dashboard_installing"))
+                        try:
+                            await download_dashboard(
+                                path="data/dashboard.zip",
+                                extract_path=str(astrbot_root / "data"),
+                                version=f"v{VERSION}",
+                                latest=False,
+                            )
+                            click.echo(t("dashboard_install_success"))
+                        except Exception as e:
+                            click.echo(t("dashboard_install_failed", error=str(e)))
+                    else:
+                        click.echo(t("dashboard_declined"))
+
+                case str():
+                    if (
+                        VersionComparator.compare_version(VERSION, dashboard_version)
+                        <= 0
+                    ):
+                        click.echo(t("dashboard_already_up_to_date"))
+                        return
+                    try:
+                        version = dashboard_version.split("v")[1]
+                        click.echo(t("dashboard_version", version=version))
+                        await download_dashboard(
+                            path="data/dashboard.zip",
+                            extract_path=str(astrbot_root / "data"),
+                            version=f"v{VERSION}",
+                            latest=False,
+                        )
+                    except Exception as e:
+                        click.echo(t("dashboard_download_failed", error=str(e)))
+                        return
+        except FileNotFoundError:
+            click.echo(t("dashboard_init_dir"))
+            try:
+                await download_dashboard(
+                    path=str(astrbot_root / "data" / "dashboard.zip"),
+                    extract_path=str(astrbot_root / "data"),
+                    version=f"v{VERSION}",
+                    latest=False,
+                )
+                click.echo(t("dashboard_init_success"))
+            except Exception as e:
+                click.echo(t("dashboard_download_failed", error=str(e)))
+                return

--- a/astrbot/cli/utils/dashboard.py
+++ b/astrbot/cli/utils/dashboard.py
@@ -34,7 +34,7 @@ class DashboardManager:
                         click.echo(t("dashboard_installing"))
                         try:
                             await download_dashboard(
-                                path="data/dashboard.zip",
+                                path=str(astrbot_root / "data" / "dashboard.zip"),
                                 extract_path=str(astrbot_root / "data"),
                                 version=f"v{VERSION}",
                                 latest=False,
@@ -56,7 +56,7 @@ class DashboardManager:
                         version = dashboard_version.split("v")[1]
                         click.echo(t("dashboard_version", version=version))
                         await download_dashboard(
-                            path="data/dashboard.zip",
+                            path=str(astrbot_root / "data" / "dashboard.zip"),
                             extract_path=str(astrbot_root / "data"),
                             version=f"v{VERSION}",
                             latest=False,

--- a/astrbot/core/utils/astrbot_path.py
+++ b/astrbot/core/utils/astrbot_path.py
@@ -1,100 +1,259 @@
-"""Centralized AstrBot path helpers.
+"""Astrbot统一路径获取
 
-Project path:
-- Fixed to the source tree location.
-
-Root path:
-- Defaults to the current working directory.
-- Can be overridden with the ``ASTRBOT_ROOT`` environment variable.
-
-Data subdirectories:
-- Most runtime data lives under ``<root>/data``.
-- A few tool-runtime files intentionally live under the system temporary
-  directory as ``.astrbot``.
+项目路径:固定为源码所在路径
+根目录路径:默认为当前工作目录,可通过环境变量 ASTRBOT_ROOT 指定
+数据目录路径:固定为根目录下的 data 目录
+配置文件路径:固定为数据目录下的 config 目录
+插件目录路径:固定为数据目录下的 plugins 目录
+插件数据目录路径:固定为数据目录下的 plugin_data 目录
+T2I 模板目录路径:固定为数据目录下的 t2i_templates 目录
+WebChat 数据目录路径:固定为数据目录下的 webchat 目录
+临时文件目录路径:固定为数据目录下的 temp 目录
+Skills 目录路径:固定为数据目录下的 skills 目录
+第三方依赖目录路径:固定为数据目录下的 site-packages 目录
 """
 
 import os
-import tempfile
+from importlib import resources
+from pathlib import Path
+
+import anyio
 
 from astrbot.core.utils.runtime_env import is_packaged_desktop_runtime
 
 
+class AstrbotPaths:
+    """Astrbot 项目路径管理类"""
+
+    def __init__(self) -> None:
+        self._root_override: Path | None = None
+        from dotenv import load_dotenv
+
+        env_candidates = []
+
+        # 1) current working directory .env
+        env_candidates.append(Path.cwd() / ".env")
+
+        # 2) ASTRBOT_ROOT/.env if ASTRBOT_ROOT already set in the environment
+        root_env = os.environ.get("ASTRBOT_ROOT")
+        if root_env:
+            env_candidates.append(Path(root_env) / ".env")
+        for p in env_candidates:
+            if p.exists():
+                load_dotenv(dotenv_path=str(p), override=False)
+
+    def _resolve_root(self) -> Path:
+        if path := os.environ.get("ASTRBOT_ROOT"):
+            return Path(path)
+        if is_packaged_desktop_runtime():
+            return Path().home() / ".astrbot"
+
+        return Path(os.getcwd())
+
+    @property
+    def root(self) -> Path:
+        if self._root_override is not None:
+            return self._root_override
+        return self._resolve_root()
+
+    @root.setter
+    def root(self, value: Path) -> None:
+        self._root_override = value
+
+    @property
+    def is_root(self) -> bool:
+        """Check if the path is an AstrBot root directory"""
+        if not self.root.exists() or not self.root.is_dir():
+            return False
+        if not (self.root / ".astrbot").exists():
+            return False
+        return True
+
+    @property
+    def has_dashboard(self) -> bool:
+        """Check if the dashboard is installed"""
+        if self.bundled_dist.is_dir():
+            return True
+        dashboard_version = self.dashboard_version
+        match dashboard_version:
+            case None:
+                return False
+            case str():
+                return True
+            case _:
+                return False
+
+    async def async_has_dashboard(self) -> bool:
+        """Check if the dashboard is installed (async)"""
+        if self.bundled_dist.is_dir():
+            return True
+        dashboard_version = await self.async_dashboard_version()
+        match dashboard_version:
+            case None:
+                return False
+            case str():
+                return True
+            case _:
+                return False
+
+    @property
+    def dashboard_version(self) -> str | None:
+        try:
+            with open(self.dist / "assets" / "version") as f:
+                return f.read().strip()
+        except FileNotFoundError:
+            return None
+
+    @property
+    def bundled_dist(self) -> Path:
+        return self.project_root / "dashboard" / "dist"
+
+    async def async_dashboard_version(self) -> str | None:
+        try:
+            # anyio.open_file returns a coroutine that yields an async file object.
+            # Await it to get the file object, then use it and close it explicitly.
+            f = await anyio.open_file(self.dist / "assets" / "version", mode="r")
+            try:
+                data = await f.read()
+                if data is None:
+                    return None
+                return data.strip()
+            finally:
+                # Ensure we close the async file handle; ignore close errors defensively.
+                try:
+                    await f.aclose()
+                except Exception:
+                    pass
+        except (FileNotFoundError, OSError):
+            return None
+        except Exception:
+            # Be defensive: any unexpected error should not raise during path utils
+            return None
+
+    @property
+    def project_root(self) -> Path:
+        """获取项目根目录路径 (package root)"""
+        with resources.as_file(resources.files("astrbot")) as path:
+            return Path(path)
+
+    @property
+    def data(self) -> Path:
+        return self.root / "data"
+
+    @property
+    def dist(self) -> Path:
+        return self.data / "dist"
+
+    @property
+    def config(self) -> Path:
+        return self.data / "config"
+
+    @property
+    def plugins(self) -> Path:
+        return self.data / "plugins"
+
+    @property
+    def temp(self) -> Path:
+        return self.data / "temp"
+
+    @property
+    def skills(self) -> Path:
+        return self.data / "skills"
+
+    @property
+    def site_packages(self) -> Path:
+        return self.data / "site-packages"
+
+    @property
+    def knowledge_base(self) -> Path:
+        return self.data / "knowledge_base"
+
+    @property
+    def backups(self) -> Path:
+        return self.data / "backups"
+
+    @property
+    def t2i_templates(self) -> Path:
+        return self.data / "t2i_templates"
+
+    @property
+    def webchat(self) -> Path:
+        return self.data / "webchat"
+
+
+astrbot_paths = AstrbotPaths()
+
+
 def get_astrbot_path() -> str:
-    """Return the AstrBot project source path."""
-    return os.path.realpath(
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../../"),
-    )
+    """获取Astrbot项目路径"""
+    return str(astrbot_paths.project_root)
 
 
 def get_astrbot_root() -> str:
-    """Return the AstrBot root directory."""
-    if path := os.environ.get("ASTRBOT_ROOT"):
-        return os.path.realpath(path)
-    if is_packaged_desktop_runtime():
-        return os.path.realpath(os.path.join(os.path.expanduser("~"), ".astrbot"))
-    return os.path.realpath(os.getcwd())
+    """获取Astrbot根目录路径"""
+    return str(astrbot_paths.root)
 
 
 def get_astrbot_data_path() -> str:
-    """Return the AstrBot data directory path."""
+    """获取Astrbot数据目录路径"""
     return os.path.realpath(os.path.join(get_astrbot_root(), "data"))
 
 
 def get_astrbot_config_path() -> str:
-    """Return the AstrBot config directory path."""
+    """获取Astrbot配置文件路径"""
     return os.path.realpath(os.path.join(get_astrbot_data_path(), "config"))
 
 
 def get_astrbot_plugin_path() -> str:
-    """Return the AstrBot plugin directory path."""
+    """获取Astrbot插件目录路径"""
     return os.path.realpath(os.path.join(get_astrbot_data_path(), "plugins"))
 
 
 def get_astrbot_plugin_data_path() -> str:
-    """Return the AstrBot plugin data directory path."""
+    """获取Astrbot插件数据目录路径"""
     return os.path.realpath(os.path.join(get_astrbot_data_path(), "plugin_data"))
 
 
 def get_astrbot_t2i_templates_path() -> str:
-    """Return the AstrBot T2I templates directory path."""
+    """获取Astrbot T2I 模板目录路径"""
     return os.path.realpath(os.path.join(get_astrbot_data_path(), "t2i_templates"))
 
 
 def get_astrbot_webchat_path() -> str:
-    """Return the AstrBot WebChat data directory path."""
+    """获取Astrbot WebChat 数据目录路径"""
     return os.path.realpath(os.path.join(get_astrbot_data_path(), "webchat"))
 
 
 def get_astrbot_temp_path() -> str:
-    """Return the AstrBot temporary data directory path."""
+    """获取Astrbot临时文件目录路径"""
     return os.path.realpath(os.path.join(get_astrbot_data_path(), "temp"))
 
 
 def get_astrbot_skills_path() -> str:
-    """Return the AstrBot skills directory path."""
+    """获取Astrbot Skills 目录路径"""
     return os.path.realpath(os.path.join(get_astrbot_data_path(), "skills"))
 
 
-def get_astrbot_workspaces_path() -> str:
-    """Return the AstrBot workspaces directory path."""
-    return os.path.realpath(os.path.join(get_astrbot_data_path(), "workspaces"))
-
-
-def get_astrbot_system_tmp_path() -> str:
-    """Return the shared system temporary directory used by local tools."""
-    return os.path.realpath(os.path.join(tempfile.gettempdir(), ".astrbot"))
-
-
 def get_astrbot_site_packages_path() -> str:
-    """Return the AstrBot third-party site-packages directory path."""
+    """获取Astrbot第三方依赖目录路径"""
     return os.path.realpath(os.path.join(get_astrbot_data_path(), "site-packages"))
 
 
 def get_astrbot_knowledge_base_path() -> str:
-    """Return the AstrBot knowledge base root path."""
+    """获取Astrbot知识库根目录路径"""
     return os.path.realpath(os.path.join(get_astrbot_data_path(), "knowledge_base"))
 
 
 def get_astrbot_backups_path() -> str:
-    """Return the AstrBot backups directory path."""
+    """获取Astrbot备份目录路径"""
     return os.path.realpath(os.path.join(get_astrbot_data_path(), "backups"))
+
+
+def get_astrbot_system_tmp_path() -> str:
+    """获取Astrbot系统临时目录路径 (/tmp/.astrbot)"""
+    return "/tmp/.astrbot"
+
+
+def get_astrbot_workspaces_path() -> str:
+    """获取Astrbot工作区目录路径"""
+    return os.path.realpath(os.path.join(get_astrbot_data_path(), "workspaces"))

--- a/astrbot/core/utils/astrbot_path.py
+++ b/astrbot/core/utils/astrbot_path.py
@@ -14,6 +14,7 @@ Skills 目录路径:固定为数据目录下的 skills 目录
 """
 
 import os
+import tempfile
 from importlib import resources
 from pathlib import Path
 
@@ -110,20 +111,12 @@ class AstrbotPaths:
 
     async def async_dashboard_version(self) -> str | None:
         try:
-            # anyio.open_file returns a coroutine that yields an async file object.
-            # Await it to get the file object, then use it and close it explicitly.
-            f = await anyio.open_file(self.dist / "assets" / "version", mode="r")
-            try:
+            async with await anyio.open_file(
+                self.dist / "assets" / "version",
+                mode="r",
+            ) as f:
                 data = await f.read()
-                if data is None:
-                    return None
-                return data.strip()
-            finally:
-                # Ensure we close the async file handle; ignore close errors defensively.
-                try:
-                    await f.aclose()
-                except Exception:
-                    pass
+                return data.strip() if data is not None else None
         except (FileNotFoundError, OSError):
             return None
         except Exception:
@@ -251,7 +244,7 @@ def get_astrbot_backups_path() -> str:
 
 def get_astrbot_system_tmp_path() -> str:
     """获取Astrbot系统临时目录路径 (/tmp/.astrbot)"""
-    return "/tmp/.astrbot"
+    return os.path.realpath(os.path.join(tempfile.gettempdir(), ".astrbot"))
 
 
 def get_astrbot_workspaces_path() -> str:

--- a/astrbot/core/utils/env_template.py
+++ b/astrbot/core/utils/env_template.py
@@ -1,0 +1,50 @@
+import os
+import re
+from collections.abc import Mapping
+
+_ENV_PLACEHOLDER_RE = re.compile(
+    r"\$(?:\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)(?::-(?P<default>[^}]*))?\}|(?P<plain>[A-Za-z_][A-Za-z0-9_]*))",
+)
+
+
+def expand_env_placeholders(
+    value: str,
+    *,
+    env: Mapping[str, str] | None = None,
+    overrides: Mapping[str, str] | None = None,
+    field_name: str = "value",
+    strict: bool = False,
+) -> str:
+    env_map = env or os.environ
+    override_map = overrides or {}
+    missing_vars: list[str] = []
+
+    def _replace(match: re.Match[str]) -> str:
+        var_name = match.group("braced") or match.group("plain")
+        default = match.group("default")
+
+        if var_name in override_map:
+            override_value = override_map[var_name]
+            if override_value != "" or default is None:
+                return override_value
+
+        env_value = env_map.get(var_name)
+        if env_value is not None and (env_value != "" or default is None):
+            return env_value
+
+        if default is not None:
+            return default
+
+        if strict:
+            missing_vars.append(var_name)
+            return match.group(0)
+
+        return ""
+
+    expanded = _ENV_PLACEHOLDER_RE.sub(_replace, value)
+    if missing_vars:
+        missing = ", ".join(sorted(set(missing_vars)))
+        raise ValueError(
+            f"Unresolved environment variable(s) in {field_name}: {missing}",
+        )
+    return expanded

--- a/astrbot/dashboard/routes/auth.py
+++ b/astrbot/dashboard/routes/auth.py
@@ -292,6 +292,7 @@ class AuthRoute(Route):
         host = (
             os.environ.get("DASHBOARD_HOST")
             or os.environ.get("ASTRBOT_DASHBOARD_HOST")
+            or os.environ.get("ASTRBOT_HOST")
             or self.config["dashboard"].get("host", "")
         )
         return str(host).strip().lower() in LOCAL_DASHBOARD_HOSTS

--- a/astrbot/dashboard/server.py
+++ b/astrbot/dashboard/server.py
@@ -2,7 +2,6 @@ import asyncio
 import hashlib
 import logging
 import os
-import re
 import socket
 from datetime import datetime
 from pathlib import Path
@@ -24,6 +23,7 @@ from astrbot.core.core_lifecycle import AstrBotCoreLifecycle
 from astrbot.core.db import BaseDatabase
 from astrbot.core.utils.astrbot_path import get_astrbot_data_path
 from astrbot.core.utils.datetime_utils import to_utc_isoformat
+from astrbot.core.utils.env_template import expand_env_placeholders
 from astrbot.core.utils.io import (
     get_bundled_dashboard_dist_path,
     get_local_ip_addresses,
@@ -48,9 +48,6 @@ class _AddrWithPort(Protocol):
 
 
 APP: Quart
-_ENV_PLACEHOLDER_RE = re.compile(
-    r"\$(?:\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)(?::-(?P<default>[^}]*))?\}|(?P<plain>[A-Za-z_][A-Za-z0-9_]*))",
-)
 
 
 def _normalize_plugin_api_route(route: str) -> str:
@@ -96,29 +93,6 @@ def _parse_env_bool(value: str | None, default: bool) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _expand_env_placeholders(value: str, field_name: str) -> str:
-    missing_vars: list[str] = []
-
-    def _replace(match: re.Match[str]) -> str:
-        var_name = match.group("braced") or match.group("plain")
-        default = match.group("default")
-        env_value = os.environ.get(var_name)
-        if env_value is not None:
-            return env_value
-        if default is not None:
-            return default
-        missing_vars.append(var_name)
-        return match.group(0)
-
-    expanded = _ENV_PLACEHOLDER_RE.sub(_replace, value)
-    if missing_vars:
-        missing = ", ".join(sorted(set(missing_vars)))
-        raise ValueError(
-            f"Unresolved environment variable(s) in dashboard {field_name}: {missing}",
-        )
-    return expanded
-
-
 def _resolve_dashboard_value(
     value: str | int | None,
     *,
@@ -126,7 +100,11 @@ def _resolve_dashboard_value(
 ) -> str | int | None:
     if not isinstance(value, str):
         return value
-    return _expand_env_placeholders(value, field_name).strip()
+    return expand_env_placeholders(
+        value,
+        field_name=f"dashboard {field_name}",
+        strict=True,
+    ).strip()
 
 
 class AstrBotJSONProvider(DefaultJSONProvider):
@@ -462,9 +440,21 @@ class AstrBotDashboard:
             or ssl_config.get("ca_certs", "")
         )
 
-        cert_file = _expand_env_placeholders(str(cert_file), "ssl.cert_file")
-        key_file = _expand_env_placeholders(str(key_file), "ssl.key_file")
-        ca_certs = _expand_env_placeholders(str(ca_certs), "ssl.ca_certs")
+        cert_file = expand_env_placeholders(
+            str(cert_file),
+            field_name="dashboard ssl.cert_file",
+            strict=True,
+        )
+        key_file = expand_env_placeholders(
+            str(key_file),
+            field_name="dashboard ssl.key_file",
+            strict=True,
+        )
+        ca_certs = expand_env_placeholders(
+            str(ca_certs),
+            field_name="dashboard ssl.ca_certs",
+            strict=True,
+        )
 
         if not cert_file or not key_file:
             logger.warning(

--- a/astrbot/dashboard/server.py
+++ b/astrbot/dashboard/server.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import logging
 import os
+import re
 import socket
 from datetime import datetime
 from pathlib import Path
@@ -47,6 +48,9 @@ class _AddrWithPort(Protocol):
 
 
 APP: Quart
+_ENV_PLACEHOLDER_RE = re.compile(
+    r"\$(?:\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)(?::-(?P<default>[^}]*))?\}|(?P<plain>[A-Za-z_][A-Za-z0-9_]*))",
+)
 
 
 def _normalize_plugin_api_route(route: str) -> str:
@@ -92,6 +96,39 @@ def _parse_env_bool(value: str | None, default: bool) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _expand_env_placeholders(value: str, field_name: str) -> str:
+    missing_vars: list[str] = []
+
+    def _replace(match: re.Match[str]) -> str:
+        var_name = match.group("braced") or match.group("plain")
+        default = match.group("default")
+        env_value = os.environ.get(var_name)
+        if env_value is not None:
+            return env_value
+        if default is not None:
+            return default
+        missing_vars.append(var_name)
+        return match.group(0)
+
+    expanded = _ENV_PLACEHOLDER_RE.sub(_replace, value)
+    if missing_vars:
+        missing = ", ".join(sorted(set(missing_vars)))
+        raise ValueError(
+            f"Unresolved environment variable(s) in dashboard {field_name}: {missing}",
+        )
+    return expanded
+
+
+def _resolve_dashboard_value(
+    value: str | int | None,
+    *,
+    field_name: str,
+) -> str | int | None:
+    if not isinstance(value, str):
+        return value
+    return _expand_env_placeholders(value, field_name).strip()
+
+
 class AstrBotJSONProvider(DefaultJSONProvider):
     def default(self, obj):
         if isinstance(obj, datetime):
@@ -132,7 +169,11 @@ class AstrBotDashboard:
                 # Fall back to expected user path (will fail gracefully later)
                 self.data_path = os.path.abspath(user_dist)
 
-        self.app = Quart("dashboard", static_folder=self.data_path, static_url_path="/")
+        self.app = Quart(
+            "AstrBotDashboard",
+            static_folder=self.data_path,
+            static_url_path="/",
+        )
         APP = self.app  # noqa
         self.app.config["MAX_CONTENT_LENGTH"] = (
             128 * 1024 * 1024
@@ -405,18 +446,25 @@ class AstrBotDashboard:
         cert_file = (
             os.environ.get("DASHBOARD_SSL_CERT")
             or os.environ.get("ASTRBOT_DASHBOARD_SSL_CERT")
+            or os.environ.get("ASTRBOT_SSL_CERT")
             or ssl_config.get("cert_file", "")
         )
         key_file = (
             os.environ.get("DASHBOARD_SSL_KEY")
             or os.environ.get("ASTRBOT_DASHBOARD_SSL_KEY")
+            or os.environ.get("ASTRBOT_SSL_KEY")
             or ssl_config.get("key_file", "")
         )
         ca_certs = (
             os.environ.get("DASHBOARD_SSL_CA_CERTS")
             or os.environ.get("ASTRBOT_DASHBOARD_SSL_CA_CERTS")
+            or os.environ.get("ASTRBOT_SSL_CA_CERTS")
             or ssl_config.get("ca_certs", "")
         )
+
+        cert_file = _expand_env_placeholders(str(cert_file), "ssl.cert_file")
+        key_file = _expand_env_placeholders(str(key_file), "ssl.key_file")
+        ca_certs = _expand_env_placeholders(str(ca_certs), "ssl.ca_certs")
 
         if not cert_file or not key_file:
             logger.warning(
@@ -456,17 +504,27 @@ class AstrBotDashboard:
     def run(self):
         ip_addr = []
         dashboard_config = self.core_lifecycle.astrbot_config.get("dashboard", {})
-        port = (
+        port_value = (
             os.environ.get("DASHBOARD_PORT")
             or os.environ.get("ASTRBOT_DASHBOARD_PORT")
+            or os.environ.get("ASTRBOT_PORT")
             or dashboard_config.get("port", 6185)
         )
-        host = (
+        port = _resolve_dashboard_value(port_value, field_name="port")
+        host_value = (
             os.environ.get("DASHBOARD_HOST")
             or os.environ.get("ASTRBOT_DASHBOARD_HOST")
+            or os.environ.get("ASTRBOT_HOST")
             or dashboard_config.get("host", "0.0.0.0")
         )
-        enable = dashboard_config.get("enable", True)
+        host = _resolve_dashboard_value(host_value, field_name="host")
+        if not isinstance(host, str) or not host:
+            raise ValueError("Dashboard host must be a non-empty string")
+        enable = _parse_env_bool(
+            os.environ.get("ASTRBOT_DASHBOARD_ENABLE")
+            or os.environ.get("DASHBOARD_ENABLE"),
+            bool(dashboard_config.get("enable", True)),
+        )
         ssl_config = dashboard_config.get("ssl", {})
         if not isinstance(ssl_config, dict):
             ssl_config = {}
@@ -486,6 +544,11 @@ class AstrBotDashboard:
             logger.info("WebUI disabled.")
             return None
 
+        if isinstance(port, str):
+            port = int(port)
+        if not isinstance(port, int) or port < 1 or port > 65535:
+            raise ValueError("Dashboard port must be an integer between 1 and 65535")
+
         logger.info("Starting WebUI at %s://%s:%s", scheme, host, port)
         if host == "0.0.0.0":
             logger.info(
@@ -497,9 +560,6 @@ class AstrBotDashboard:
                 ip_addr = get_local_ip_addresses()
             except Exception as _:
                 pass
-        if isinstance(port, str):
-            port = int(port)
-
         if self.check_port_in_use(port):
             process_info = self.get_process_using_port(port)
             logger.error(

--- a/astrbot/runtime_bootstrap.py
+++ b/astrbot/runtime_bootstrap.py
@@ -1,0 +1,50 @@
+import logging
+import ssl
+from typing import Any
+
+import aiohttp.connector as aiohttp_connector
+
+from astrbot.utils.http_ssl_common import build_ssl_context_with_certifi
+
+logger = logging.getLogger(__name__)
+
+
+def _try_patch_aiohttp_ssl_context(
+    ssl_context: ssl.SSLContext,
+    log_obj: Any | None = None,
+) -> bool:
+    log = log_obj or logger
+    attr_name = "_SSL_CONTEXT_VERIFIED"
+
+    if not hasattr(aiohttp_connector, attr_name):
+        log.warning(
+            "aiohttp connector does not expose _SSL_CONTEXT_VERIFIED; skipped patch.",
+        )
+        return False
+
+    current_value = getattr(aiohttp_connector, attr_name, None)
+    if current_value is not None and not isinstance(current_value, ssl.SSLContext):
+        log.warning(
+            "aiohttp connector exposes _SSL_CONTEXT_VERIFIED with unexpected type; skipped patch.",
+        )
+        return False
+
+    setattr(aiohttp_connector, attr_name, ssl_context)
+    log.info("Configured aiohttp verified SSL context with system+certifi trust chain.")
+    return True
+
+
+def configure_runtime_ca_bundle(log_obj: Any | None = None) -> bool:
+    log = log_obj or logger
+
+    try:
+        log.info("Bootstrapping runtime CA bundle.")
+        ssl_context = build_ssl_context_with_certifi(log_obj=log)
+        return _try_patch_aiohttp_ssl_context(ssl_context, log_obj=log)
+    except Exception as exc:
+        log.error("Failed to configure runtime CA bundle for aiohttp: %r", exc)
+        return False
+
+
+def initialize_runtime_bootstrap(log_obj: Any | None = None) -> bool:
+    return configure_runtime_ca_bundle(log_obj=log_obj)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dependencies = [
   "packaging>=24.2",
   "python-ripgrep==0.0.8",
   "python-dotenv>=1.2.2",
+  "anyio>=4.0.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dependencies = [
   "pysocks>=1.7.1",
   "packaging>=24.2",
   "python-ripgrep==0.0.8",
+  "python-dotenv>=1.2.2",
 ]
 
 [dependency-groups]

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -7,20 +7,23 @@ from astrbot.core.utils.auth_password import verify_dashboard_password
 
 
 @pytest.mark.asyncio
-async def test_init_without_initial_password_env_does_not_create_config(
+async def test_init_without_initial_password_env_creates_default_config(
     monkeypatch,
     tmp_path,
 ):
-    async def fake_check_dashboard(_data_path):
-        return None
-
     monkeypatch.delenv(cmd_init.DASHBOARD_INITIAL_PASSWORD_ENV, raising=False)
-    monkeypatch.setattr(cmd_init, "check_dashboard", fake_check_dashboard)
     (tmp_path / ".astrbot").touch()
 
-    await cmd_init.initialize_astrbot(tmp_path)
+    await cmd_init.initialize_astrbot(
+        tmp_path,
+        yes=True,
+        backend_only=True,
+        admin_username=None,
+        admin_password=None,
+    )
 
-    assert not (tmp_path / "data" / "cmd_config.json").exists()
+    assert (tmp_path / "data" / "cmd_config.json").exists()
+    assert (tmp_path / "data" / "skills").is_dir()
 
 
 @pytest.mark.asyncio
@@ -28,15 +31,17 @@ async def test_init_uses_initial_password_env_to_create_config(
     monkeypatch,
     tmp_path,
 ):
-    async def fake_check_dashboard(_data_path):
-        return None
-
     initial_password = "AstrBotInitialPassword123"
     monkeypatch.setenv(cmd_init.DASHBOARD_INITIAL_PASSWORD_ENV, initial_password)
-    monkeypatch.setattr(cmd_init, "check_dashboard", fake_check_dashboard)
     (tmp_path / ".astrbot").touch()
 
-    await cmd_init.initialize_astrbot(tmp_path)
+    await cmd_init.initialize_astrbot(
+        tmp_path,
+        yes=True,
+        backend_only=True,
+        admin_username=None,
+        admin_password=None,
+    )
 
     config_path = tmp_path / "data" / "cmd_config.json"
     config = json.loads(config_path.read_text(encoding="utf-8-sig"))
@@ -52,3 +57,25 @@ async def test_init_uses_initial_password_env_to_create_config(
     )
     assert dashboard_config["password_change_required"] is True
     assert dashboard_config["password_storage_upgraded"] is True
+
+
+@pytest.mark.asyncio
+async def test_init_sets_dashboard_username(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.delenv(cmd_init.DASHBOARD_INITIAL_PASSWORD_ENV, raising=False)
+    (tmp_path / ".astrbot").touch()
+
+    await cmd_init.initialize_astrbot(
+        tmp_path,
+        yes=True,
+        backend_only=True,
+        admin_username="alice",
+        admin_password=None,
+    )
+
+    config_path = tmp_path / "data" / "cmd_config.json"
+    config = json.loads(config_path.read_text(encoding="utf-8-sig"))
+
+    assert config["dashboard"]["username"] == "alice"

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -1,0 +1,19 @@
+from astrbot.cli.commands.cmd_run import _expand_env_parameter_value
+
+
+def test_expand_service_config_path_supports_defaults(monkeypatch):
+    monkeypatch.delenv("ASTRBOT_INSTANCE", raising=False)
+
+    assert (
+        _expand_env_parameter_value("/etc/astrbot/${ASTRBOT_INSTANCE:-default}.env")
+        == "/etc/astrbot/default.env"
+    )
+
+
+def test_expand_service_config_path_prefers_environment(monkeypatch):
+    monkeypatch.setenv("ASTRBOT_INSTANCE", "light")
+
+    assert (
+        _expand_env_parameter_value("/etc/astrbot/${ASTRBOT_INSTANCE:-default}.env")
+        == "/etc/astrbot/light.env"
+    )

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -1,11 +1,11 @@
-from astrbot.cli.commands.cmd_run import _expand_env_parameter_value
+from astrbot.core.utils.env_template import expand_env_placeholders
 
 
 def test_expand_service_config_path_supports_defaults(monkeypatch):
     monkeypatch.delenv("ASTRBOT_INSTANCE", raising=False)
 
     assert (
-        _expand_env_parameter_value("/etc/astrbot/${ASTRBOT_INSTANCE:-default}.env")
+        expand_env_placeholders("/etc/astrbot/${ASTRBOT_INSTANCE:-default}.env")
         == "/etc/astrbot/default.env"
     )
 
@@ -14,6 +14,6 @@ def test_expand_service_config_path_prefers_environment(monkeypatch):
     monkeypatch.setenv("ASTRBOT_INSTANCE", "light")
 
     assert (
-        _expand_env_parameter_value("/etc/astrbot/${ASTRBOT_INSTANCE:-default}.env")
+        expand_env_placeholders("/etc/astrbot/${ASTRBOT_INSTANCE:-default}.env")
         == "/etc/astrbot/light.env"
     )

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1208,6 +1208,44 @@ async def test_dashboard_ssl_missing_cert_and_key_falls_back_to_http(
 
 
 @pytest.mark.asyncio
+async def test_dashboard_run_accepts_astrbot_host_and_port_env_aliases(
+    core_lifecycle_td: AstrBotCoreLifecycle,
+    monkeypatch,
+):
+    shutdown_event = asyncio.Event()
+    server = AstrBotDashboard(core_lifecycle_td, core_lifecycle_td.db, shutdown_event)
+
+    async def fake_serve(app, config, shutdown_trigger):
+        return config
+
+    monkeypatch.setenv("ASTRBOT_HOST", "127.0.0.1")
+    monkeypatch.setenv("ASTRBOT_PORT", "18089")
+    monkeypatch.delenv("DASHBOARD_HOST", raising=False)
+    monkeypatch.delenv("DASHBOARD_PORT", raising=False)
+    monkeypatch.delenv("ASTRBOT_DASHBOARD_HOST", raising=False)
+    monkeypatch.delenv("ASTRBOT_DASHBOARD_PORT", raising=False)
+    monkeypatch.setattr(server, "check_port_in_use", lambda port: False)
+    monkeypatch.setattr("astrbot.dashboard.server.serve", fake_serve)
+
+    config = await server.run()
+
+    assert config.bind == ["127.0.0.1:18089"]
+
+
+@pytest.mark.asyncio
+async def test_dashboard_run_can_be_disabled_from_astrbot_env(
+    core_lifecycle_td: AstrBotCoreLifecycle,
+    monkeypatch,
+):
+    shutdown_event = asyncio.Event()
+    server = AstrBotDashboard(core_lifecycle_td, core_lifecycle_td.db, shutdown_event)
+
+    monkeypatch.setenv("ASTRBOT_DASHBOARD_ENABLE", "false")
+
+    assert server.run() is None
+
+
+@pytest.mark.asyncio
 async def test_subagent_config_accepts_default_persona(
     app: Quart,
     authenticated_header: dict,

--- a/tests/test_dashboard_manager.py
+++ b/tests/test_dashboard_manager.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+import pytest
+
+from astrbot.cli.utils.dashboard import DashboardManager
+
+
+@pytest.mark.asyncio
+async def test_dashboard_manager_downloads_to_astrbot_root(monkeypatch, tmp_path):
+    manager = DashboardManager()
+    manager._bundled_dist = tmp_path / "missing-dist"
+    downloaded_paths: list[str] = []
+
+    async def fake_get_dashboard_version():
+        return "v0.0.1"
+
+    async def fake_download_dashboard(path, extract_path, version, latest):
+        downloaded_paths.append(path)
+
+    monkeypatch.setattr(
+        "astrbot.core.utils.io.get_dashboard_version",
+        fake_get_dashboard_version,
+    )
+    monkeypatch.setattr(
+        "astrbot.core.utils.io.download_dashboard",
+        fake_download_dashboard,
+    )
+
+    await manager.ensure_installed(tmp_path)
+
+    assert downloaded_paths == [str(tmp_path / "data" / "dashboard.zip")]
+    assert Path(downloaded_paths[0]).is_absolute()


### PR DESCRIPTION
## Summary
- Port dev startup CLI chain to master: --root, --backend-only, --host, --port, --service-config, --log-level, and SSL env handling
- Align dashboard runtime env aliases with ASTRBOT_* names and keep legacy DASHBOARD_* compatibility
- Fix dashboard Quart app import name collision on master and add focused CLI/dashboard tests

## Tests
- uv run ruff check astrbot/cli/commands/cmd_init.py astrbot/cli/commands/cmd_run.py astrbot/cli/utils/__init__.py astrbot/cli/utils/dashboard.py astrbot/core/utils/astrbot_path.py astrbot/dashboard/server.py astrbot/dashboard/routes/auth.py tests/test_cli_init.py tests/test_cli_run.py tests/test_dashboard.py pyproject.toml
- uv run pytest tests/test_cli_init.py tests/test_cli_run.py tests/test_dashboard.py -q
- uv run astrbot init -b -y --root /tmp/astrbot-master-port-root-0522
- timeout 25s uv run astrbot run --backend-only --root /tmp/astrbot-master-port-root-0522 --host 127.0.0.1 --port 18089 --log-level INFO

## Summary by Sourcery

Port the development startup flow and environment handling to the main branch, aligning CLI, dashboard, and path/runtime utilities while adding i18n support and improving initialization and dashboard behavior.

New Features:
- Extend `astrbot run` CLI with root selection, backend-only mode, host/port, service-config, log level, and SSL-related options plus optional debug output.
- Introduce a centralized `AstrbotPaths` helper and `astrbot_paths` singleton to manage project, root, data, dashboard, and ancillary paths.
- Add CLI internationalization support with Chinese/English translations and an ASCII banner for interactive runs.
- Add a `DashboardManager` utility to install or update the WebUI assets on demand.
- Add runtime bootstrap utilities to configure a shared SSL context/CA bundle for aiohttp-based HTTP clients.

Bug Fixes:
- Resolve Quart app import/name collision for the dashboard by renaming the app instance.
- Allow dashboard host/port and enable flags to be controlled via ASTRBOT_* env vars in addition to legacy DASHBOARD_* names, including auth local-host checks.
- Fix dashboard SSL configuration to honor ASTRBOT_* SSL environment variables and support placeholder expansion in configured paths.
- Ensure `astrbot init` always writes a default cmd_config.json, creates the skills directory, and correctly handles admin username configuration.

Enhancements:
- Rework `astrbot run` startup to integrate runtime bootstrap, structured logging, dashboard install checks, and user-facing startup messages, including backend-only mode messaging.
- Improve environment and .env loading behavior so common env files are loaded centrally and can be overridden by explicit service config or CLI arguments.
- Enhance dashboard server configuration with environment-variable placeholder expansion, stricter validation for host/port, and clearer logging.
- Refine initialization UX with clearer prompts, backend-only setup, .env generation from templates, and guided follow-up steps for admin password setup.

Build:
- Add `python-dotenv` as a runtime dependency for environment file loading.

Tests:
- Update CLI init tests to reflect new default config creation and dashboard username behavior and to verify skills directory creation.
- Add tests for service-config parameter expansion in `astrbot run`.
- Add dashboard tests to verify ASTRBOT_* host/port/env aliases and dashboard disablement via env flags.