### PR TITLE
fix: strip segment text to remove extra blank lines in segmented reply

### DIFF
--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -246,7 +246,7 @@ class ResultDecorateStage(Stage):
                                 if self.content_cleanup_rule:
                                     seg = re.sub(self.content_cleanup_rule, "", seg)
                                 if seg.strip():
-                                    new_chain.append(Plain(seg))
+                                    new_chain.append(Plain(seg.strip()))
                         else:
                             # 非 Plain 类型的消息段不分段
                             new_chain.append(comp)
@@ -368,7 +368,7 @@ class ResultDecorateStage(Stage):
                         return
                     if time.time() - render_start > 3:
                         logger.warning(
-                            "文本转图片耗时超过了 3 秒，如果觉得很慢可以使用 /t2i 关闭文本转图片模式。",
+                            "文本转图片耗时超过了 3 秒，如果觉得很慢可以在 WebUI 中关闭文本转图片模式。",
                         )
                     if url:
                         if url.startswith("http"):

--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -245,8 +245,9 @@ class ResultDecorateStage(Stage):
                             for seg in split_response:
                                 if self.content_cleanup_rule:
                                     seg = re.sub(self.content_cleanup_rule, "", seg)
-                                if seg.strip():
-                                    new_chain.append(Plain(seg.strip()))
+                                seg = seg.strip()
+                                if seg:
+                                    new_chain.append(Plain(seg))
                         else:
                             # 非 Plain 类型的消息段不分段
                             new_chain.append(comp)


### PR DESCRIPTION
## 修复说明

修复分段回复时 Plain(seg) 未 strip 导致 QQ 消息出现多余空行的问题。

### 问题描述
在 stage.py 的分段回复逻辑中，分段后的文本 seg 在添加到 new_chain 前只做了非空判断（if seg.strip()），但实际添加到链中时使用的是原始的 Plain(seg) 而非 Plain(seg.strip())，这导致每段文本的收尾空格/换行被保留，在 QQ 消息中产生多余空行。

### 修复方案
将 new_chain.append(Plain(seg)) 改为 new_chain.append(Plain(seg.strip()))，确保每段文本的首尾空白字符被去除。

关联 Issue: #8300

## Summary by Sourcery

Strip whitespace in segmented replies to avoid extra blank lines and clarify guidance for disabling text-to-image mode when rendering is slow.

Bug Fixes:
- Remove leading and trailing whitespace from segmented plain text replies to prevent extra blank lines in QQ messages.

Enhancements:
- Update the slow text-to-image rendering warning message to direct users to disable the mode via the WebUI.