### PR TITLE
fix(openai): 修复流式响应末尾usage信息丢失问题

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -672,7 +672,9 @@ class ProviderOpenAIOfficial(Provider):
             # 跳过 delta=None 的 chunk，避免 SDK 内部 _convert_initial_chunk_into_snapshot
             # 第 747 行 choice.delta.to_dict() 抛出 NoneType 错误。
             # refs: AstrBot#6689 / openai-python#5069 / #5047
-            if delta is not None:
+            # 例外：流末尾的 usage chunk（choices=[]，delta=None 但有 usage 数据）
+            # 需要传给 state，否则最终 completion 会丢失 usage 信息
+            if delta is not None or chunk.usage:
                 try:
                     state.handle_chunk(chunk)
                 except Exception as e:


### PR DESCRIPTION
- 修复在流式处理过程中，因跳过 delta=None 且 choices=[] 的 usage chunk 导致最终 completion 丢失 usage 数据的问题
- 在 handle_chunk 调用条件中增加 chunk.usage 判断，确保末尾 usage chunk 能被正常传递给 state 处理
- 更新相关注释，说明 usage chunk 的例外情况，保障流式响应的 usage 信息完整性

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点
`astrbot/core/provider/sources/openai_source.py` 
- 将 `state.handle_chunk(chunk)` 的调用条件从 `if delta is not None` 放宽为 `if delta is not None or chunk.usage`，确保流末尾 usage-only chunk 也能被计入最终 completion 的快照
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
```
tests/test_openai_source.py::test_query_stream_extracts_usage_from_empty_choices_chunk PASSED
```
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure OpenAI streaming completions preserve and propagate final usage-only chunks so that completion usage data is not lost.

Bug Fixes:
- Fix loss of usage data in streaming completions when the final chunk has no delta or choices but includes usage information.

Tests:
- Add a streaming query test that verifies usage is extracted from a final chunk with empty choices and no delta.