### PR TITLE
fix(mcp): attempt to fix epoll busy-wait caused by leaked SSE exit stack

### DIFF
--- a/astrbot/core/agent/mcp_client.py
+++ b/astrbot/core/agent/mcp_client.py
@@ -400,7 +400,7 @@ class MCPClient:
 
         # Kept for internal use inside _run_connection; external code must not
         # touch the exit_stack directly.
-        self.exit_stack = AsyncExitStack()
+        self.exit_stack: AsyncExitStack | None = None
 
         self.name: str | None = None
         self.active: bool = True
@@ -413,9 +413,13 @@ class MCPClient:
         self._server_name: str | None = None
         self._reconnect_lock = asyncio.Lock()  # Lock for thread-safe reconnection
         self._reconnecting: bool = False  # For logging and debugging
-        self._session_ready = asyncio.Event()  # set when session is initialised
 
-    async def _run_connection(self, mcp_server_config: dict, name: str) -> None:
+    async def _run_connection(
+        self,
+        mcp_server_config: dict,
+        name: str,
+        ready: asyncio.Future,
+    ) -> None:
         """Own the full lifetime of one MCP connection.
 
         This coroutine is always run inside a dedicated asyncio.Task
@@ -430,17 +434,30 @@ class MCPClient:
         that previously occurred when aclose() was called from a different task
         or from the asyncio async-generator GC finalizer.
         """
-        self.exit_stack = AsyncExitStack()
+        # Capture the stack in a local variable so that if self.exit_stack is
+        # overwritten by a concurrent _run_connection (during reconnect), this
+        # task's finally block still closes only the resources it opened.
+        stack = self.exit_stack = AsyncExitStack()
         try:
-            await self._do_connect(mcp_server_config, name)
-            self._session_ready.set()
+            try:
+                await self._do_connect(mcp_server_config, name)
+            except Exception as exc:
+                if not ready.done():
+                    ready.set_exception(exc)
+                raise
+            else:
+                if not ready.done():
+                    ready.set_result(None)
             # Hold the connection open until cancelled.
             await asyncio.Event().wait()
         finally:
             try:
-                await self.exit_stack.aclose()
+                await stack.aclose()
             except Exception as e:
                 logger.debug(f"Error closing exit stack for {name}: {e}")
+            # Ensure the waiter is not left pending if we exit very early.
+            if not ready.done():
+                ready.set_exception(RuntimeError("Connection task exited early"))
 
     async def connect_to_server(self, mcp_server_config: dict, name: str) -> None:
         """Connect to MCP server by spawning a dedicated owner task.
@@ -461,43 +478,25 @@ class MCPClient:
         """
         self._mcp_server_config = mcp_server_config
         self._server_name = name
-        self._session_ready = asyncio.Event()
+
+        ready: asyncio.Future = asyncio.get_running_loop().create_future()
 
         self._connection_task = asyncio.create_task(
-            self._run_connection(mcp_server_config, name),
+            self._run_connection(mcp_server_config, name, ready),
             name=f"mcp-conn:{name}",
         )
 
-        # Wait until the session is initialised (or the task fails).
-        # We race two futures: the connection task itself (signals failure) and
-        # a waiter for _session_ready (signals success).  The waiter must be
-        # cancelled after asyncio.wait returns to avoid a task leak.
-        ready_waiter = asyncio.ensure_future(self._session_ready.wait())
         try:
-            done, _ = await asyncio.wait(
-                {self._connection_task, ready_waiter},
-                return_when=asyncio.FIRST_COMPLETED,
-            )
+            await ready
         except asyncio.CancelledError:
             # Caller was cancelled while waiting — tear down the connection task.
             # cancel() is asynchronous; the task will not finish until the next
             # event-loop iteration, so we track it in _old_connection_tasks so
             # that cleanup() can await it later.
-            if not self._connection_task.done():
+            if self._connection_task and not self._connection_task.done():
                 self._cancel_connection_task(self._connection_task)
                 self._connection_task = None
             raise
-        finally:
-            # Always clean up ready_waiter regardless of how we exit.
-            if not ready_waiter.done():
-                ready_waiter.cancel()
-
-        if self._connection_task in done:
-            # Task finished before session was ready — it raised an exception.
-            exc = self._connection_task.exception()
-            if exc:
-                raise exc
-            raise Exception(f"MCP connection task for {name} exited unexpectedly")
 
     async def _do_connect(self, mcp_server_config: dict, name: str) -> None:
         """Internal: perform the actual connection inside _run_connection's task."""
@@ -620,6 +619,9 @@ class MCPClient:
 
     def _cancel_connection_task(self, task: asyncio.Task) -> None:
         """Cancel a connection owner task and track it until it finishes."""
+        # Prune already-finished tasks to avoid accumulating references over
+        # many reconnections in a long-running process.
+        self._old_connection_tasks = [t for t in self._old_connection_tasks if not t.done()]
         if task.done():
             return
         task.cancel()
@@ -729,16 +731,12 @@ class MCPClient:
 
     async def cleanup(self) -> None:
         """Clean up resources by cancelling the connection owner task."""
-        # Cancel the current connection task.  Its finally block calls aclose()
-        # from the correct task context, so anyio cancel scopes exit cleanly.
-        if self._connection_task and not self._connection_task.done():
-            self._connection_task.cancel()
-            try:
-                await self._connection_task
-            except (asyncio.CancelledError, Exception) as e:
-                logger.debug(f"Connection task for {self._server_name} finished: {e}")
+        # Cancel current and any old connection tasks via the shared helper so
+        # all cancellation + tracking behaviour goes through one code path.
+        if self._connection_task:
+            self._cancel_connection_task(self._connection_task)
+            self._connection_task = None
 
-        # Wait for any old connection tasks from previous reconnects to finish.
         if self._old_connection_tasks:
             pending = [t for t in self._old_connection_tasks if not t.done()]
             if pending:

--- a/astrbot/core/agent/mcp_client.py
+++ b/astrbot/core/agent/mcp_client.py
@@ -385,8 +385,22 @@ class MCPClient:
     def __init__(self) -> None:
         # Initialize session and client objects
         self.session: mcp.ClientSession | None = None
+
+        # _connection_task owns the AsyncExitStack and the sse_client/stdio_client
+        # context manager for the *current* connection.  Cleaning up is done by
+        # cancelling this task: because the task itself entered the anyio
+        # create_task_group cancel scope, anyio's _host_task check passes and the
+        # scope exits cleanly in its own task context, avoiding the
+        #   RuntimeError: Attempted to exit cancel scope in a different task
+        # that occurred when aclose() was called from a different task (or from the
+        # GC finalizer).  Old connection tasks are kept in _old_connection_tasks
+        # until they finish after being cancelled.
+        self._connection_task: asyncio.Task | None = None
+        self._old_connection_tasks: list[asyncio.Task] = []
+
+        # Kept for internal use inside _run_connection; external code must not
+        # touch the exit_stack directly.
         self.exit_stack = AsyncExitStack()
-        self._old_exit_stacks: list[AsyncExitStack] = []  # Track old stacks for cleanup
 
         self.name: str | None = None
         self.active: bool = True
@@ -399,9 +413,42 @@ class MCPClient:
         self._server_name: str | None = None
         self._reconnect_lock = asyncio.Lock()  # Lock for thread-safe reconnection
         self._reconnecting: bool = False  # For logging and debugging
+        self._session_ready = asyncio.Event()  # set when session is initialised
+
+    async def _run_connection(self, mcp_server_config: dict, name: str) -> None:
+        """Own the full lifetime of one MCP connection.
+
+        This coroutine is always run inside a dedicated asyncio.Task
+        (_connection_task).  Because *this task* is the one that enters every
+        anyio cancel scope (via sse_client / streamablehttp_client), anyio's
+        _host_task check is always satisfied when the stack is later closed —
+        either in the task's own finally block (normal path) or when the task
+        is cancelled from outside (cleanup / reconnect path).
+
+        This avoids the
+            RuntimeError: Attempted to exit cancel scope in a different task
+        that previously occurred when aclose() was called from a different task
+        or from the asyncio async-generator GC finalizer.
+        """
+        self.exit_stack = AsyncExitStack()
+        try:
+            await self._do_connect(mcp_server_config, name)
+            self._session_ready.set()
+            # Hold the connection open until cancelled.
+            await asyncio.Event().wait()
+        finally:
+            try:
+                await self.exit_stack.aclose()
+            except Exception as e:
+                logger.debug(f"Error closing exit stack for {name}: {e}")
 
     async def connect_to_server(self, mcp_server_config: dict, name: str) -> None:
-        """Connect to MCP server
+        """Connect to MCP server by spawning a dedicated owner task.
+
+        The owner task (_connection_task) holds the AsyncExitStack and all
+        anyio cancel scopes for the lifetime of this connection.  To disconnect,
+        cancel _connection_task — the finally block in _run_connection will call
+        aclose() from within the correct task context.
 
         If `url` parameter exists:
             1. When transport is specified as `streamable_http`, use Streamable HTTP connection.
@@ -412,10 +459,48 @@ class MCPClient:
             mcp_server_config (dict): Configuration for the MCP server. See https://modelcontextprotocol.io/quickstart/server
 
         """
-        # Store config for reconnection
         self._mcp_server_config = mcp_server_config
         self._server_name = name
+        self._session_ready = asyncio.Event()
 
+        self._connection_task = asyncio.create_task(
+            self._run_connection(mcp_server_config, name),
+            name=f"mcp-conn:{name}",
+        )
+
+        # Wait until the session is initialised (or the task fails).
+        # We race two futures: the connection task itself (signals failure) and
+        # a waiter for _session_ready (signals success).  The waiter must be
+        # cancelled after asyncio.wait returns to avoid a task leak.
+        ready_waiter = asyncio.ensure_future(self._session_ready.wait())
+        try:
+            done, _ = await asyncio.wait(
+                {self._connection_task, ready_waiter},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        except asyncio.CancelledError:
+            # Caller was cancelled while waiting — tear down the connection task.
+            # cancel() is asynchronous; the task will not finish until the next
+            # event-loop iteration, so we track it in _old_connection_tasks so
+            # that cleanup() can await it later.
+            if not self._connection_task.done():
+                self._cancel_connection_task(self._connection_task)
+                self._connection_task = None
+            raise
+        finally:
+            # Always clean up ready_waiter regardless of how we exit.
+            if not ready_waiter.done():
+                ready_waiter.cancel()
+
+        if self._connection_task in done:
+            # Task finished before session was ready — it raised an exception.
+            exc = self._connection_task.exception()
+            if exc:
+                raise exc
+            raise Exception(f"MCP connection task for {name} exited unexpectedly")
+
+    async def _do_connect(self, mcp_server_config: dict, name: str) -> None:
+        """Internal: perform the actual connection inside _run_connection's task."""
         cfg = _prepare_config(mcp_server_config.copy())
 
         def logging_callback(
@@ -533,8 +618,20 @@ class MCPClient:
         self.tools = response.tools
         return response
 
+    def _cancel_connection_task(self, task: asyncio.Task) -> None:
+        """Cancel a connection owner task and track it until it finishes."""
+        if task.done():
+            return
+        task.cancel()
+        self._old_connection_tasks.append(task)
+
     async def _reconnect(self) -> None:
         """Reconnect to the MCP server using the stored configuration.
+
+        Cancels the current _connection_task (which owns the exit_stack and all
+        anyio cancel scopes) and starts a fresh one.  Because each connection
+        task enters and exits its own anyio cancel scope, there is no
+        cross-task cancel-scope violation and no GC finalizer surprise.
 
         Uses asyncio.Lock to ensure thread-safe reconnection in concurrent environments.
 
@@ -542,7 +639,6 @@ class MCPClient:
             Exception: raised when reconnection fails
         """
         async with self._reconnect_lock:
-            # Check if already reconnecting (useful for logging)
             if self._reconnecting:
                 logger.debug(
                     f"MCP Client {self._server_name} is already reconnecting, skipping"
@@ -558,17 +654,16 @@ class MCPClient:
                     f"Attempting to reconnect to MCP server {self._server_name}..."
                 )
 
-                # Save old exit_stack for later cleanup (don't close it now to avoid cancel scope issues)
-                if self.exit_stack:
-                    self._old_exit_stacks.append(self.exit_stack)
-
-                # Mark old session as invalid
+                # Cancel the old connection task.  Its finally block will call
+                # exit_stack.aclose() from within the correct task context, so
+                # anyio cancel scopes are exited cleanly without triggering the
+                # GC-finalizer busy-spin bug.
+                if self._connection_task and not self._connection_task.done():
+                    self._cancel_connection_task(self._connection_task)
+                self._connection_task = None
                 self.session = None
 
-                # Create new exit stack for new connection
-                self.exit_stack = AsyncExitStack()
-
-                # Reconnect using stored config
+                # Reconnect — this creates a new _connection_task.
                 await self.connect_to_server(self._mcp_server_config, self._server_name)
                 await self.list_tools_and_save()
 
@@ -633,19 +728,24 @@ class MCPClient:
         return await _call_with_retry()
 
     async def cleanup(self) -> None:
-        """Clean up resources including old exit stacks from reconnections"""
-        # Close current exit stack
-        try:
-            await self.exit_stack.aclose()
-        except Exception as e:
-            logger.debug(f"Error closing current exit stack: {e}")
+        """Clean up resources by cancelling the connection owner task."""
+        # Cancel the current connection task.  Its finally block calls aclose()
+        # from the correct task context, so anyio cancel scopes exit cleanly.
+        if self._connection_task and not self._connection_task.done():
+            self._connection_task.cancel()
+            try:
+                await self._connection_task
+            except (asyncio.CancelledError, Exception) as e:
+                logger.debug(f"Connection task for {self._server_name} finished: {e}")
 
-        # Don't close old exit stacks as they may be in different task contexts
-        # They will be garbage collected naturally
-        # Just clear the list to release references
-        self._old_exit_stacks.clear()
+        # Wait for any old connection tasks from previous reconnects to finish.
+        if self._old_connection_tasks:
+            pending = [t for t in self._old_connection_tasks if not t.done()]
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+            self._old_connection_tasks.clear()
 
-        # Set running_event first to unblock any waiting tasks
+        # Set running_event to unblock any waiting tasks
         self.running_event.set()
 
 

--- a/astrbot/core/agent/mcp_client.py
+++ b/astrbot/core/agent/mcp_client.py
@@ -383,23 +383,15 @@ def _normalize_mcp_input_schema(schema: dict[str, Any]) -> dict[str, Any]:
 
 class MCPClient:
     def __init__(self) -> None:
-        # Initialize session and client objects
         self.session: mcp.ClientSession | None = None
 
-        # _connection_task owns the AsyncExitStack and the sse_client/stdio_client
-        # context manager for the *current* connection.  Cleaning up is done by
-        # cancelling this task: because the task itself entered the anyio
-        # create_task_group cancel scope, anyio's _host_task check passes and the
-        # scope exits cleanly in its own task context, avoiding the
+        # Each connection runs in its own task so that anyio cancel scopes
+        # are always exited from the task that entered them, preventing
         #   RuntimeError: Attempted to exit cancel scope in a different task
-        # that occurred when aclose() was called from a different task (or from the
-        # GC finalizer).  Old connection tasks are kept in _old_connection_tasks
-        # until they finish after being cancelled.
         self._connection_task: asyncio.Task | None = None
         self._old_connection_tasks: list[asyncio.Task] = []
 
-        # Kept for internal use inside _run_connection; external code must not
-        # touch the exit_stack directly.
+        # Internal; managed exclusively by _run_connection.
         self.exit_stack: AsyncExitStack | None = None
 
         self.name: str | None = None
@@ -408,11 +400,10 @@ class MCPClient:
         self.server_errlogs: list[str] = []
         self.running_event = asyncio.Event()
 
-        # Store connection config for reconnection
         self._mcp_server_config: dict | None = None
         self._server_name: str | None = None
         self._reconnect_lock = asyncio.Lock()  # Lock for thread-safe reconnection
-        self._reconnecting: bool = False  # For logging and debugging
+        self._reconnecting: bool = False
 
     async def _run_connection(
         self,
@@ -455,7 +446,11 @@ class MCPClient:
                 await stack.aclose()
             except Exception as e:
                 logger.debug(f"Error closing exit stack for {name}: {e}")
-            # Ensure the waiter is not left pending if we exit very early.
+            # Clear the instance reference only if it still points to this task's
+            # stack; a concurrent reconnect may have already replaced it.
+            if self.exit_stack is stack:
+                self.exit_stack = None
+            # Guard against the task exiting before ready was resolved.
             if not ready.done():
                 ready.set_exception(RuntimeError("Connection task exited early"))
 
@@ -481,6 +476,12 @@ class MCPClient:
 
         ready: asyncio.Future = asyncio.get_running_loop().create_future()
 
+        # Defensively cancel any existing connection task that was not cleaned
+        # up before this call (e.g. if connect_to_server is called twice).
+        if self._connection_task and not self._connection_task.done():
+            self._cancel_connection_task(self._connection_task)
+            self._connection_task = None
+
         self._connection_task = asyncio.create_task(
             self._run_connection(mcp_server_config, name, ready),
             name=f"mcp-conn:{name}",
@@ -495,11 +496,22 @@ class MCPClient:
             # that cleanup() can await it later.
             if self._connection_task and not self._connection_task.done():
                 self._cancel_connection_task(self._connection_task)
-                self._connection_task = None
+            self._connection_task = None
+            raise
+        except Exception:
+            # _do_connect raised; the connection task's finally block may still
+            # be running (e.g. awaiting stack.aclose()).  Track it so that
+            # cleanup() can await it, but do NOT cancel it — we want the
+            # finally block to finish cleaning up resources naturally.
+            if self._connection_task and not self._connection_task.done():
+                self._old_connection_tasks.append(self._connection_task)
+            self._connection_task = None
             raise
 
     async def _do_connect(self, mcp_server_config: dict, name: str) -> None:
         """Internal: perform the actual connection inside _run_connection's task."""
+        # exit_stack is always set by _run_connection before _do_connect is called.
+        assert self.exit_stack is not None
         cfg = _prepare_config(mcp_server_config.copy())
 
         def logging_callback(
@@ -621,7 +633,9 @@ class MCPClient:
         """Cancel a connection owner task and track it until it finishes."""
         # Prune already-finished tasks to avoid accumulating references over
         # many reconnections in a long-running process.
-        self._old_connection_tasks = [t for t in self._old_connection_tasks if not t.done()]
+        self._old_connection_tasks = [
+            t for t in self._old_connection_tasks if not t.done()
+        ]
         if task.done():
             return
         task.cancel()


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
attempt to fix #8056

修改 `astrbot/core/agent/mcp_client.py`。

MCP 重连时旧的 `AsyncExitStack` 未关闭，GC 回收时 asyncio 在错误的 task 里退出 anyio cancel scope，触发 `_deliver_cancellation` 的 `call_soon` 自循环，导致 `epoll_wait` 以 `timeout=0` 无限空转，主线程 CPU 100%。

### Modifications / 改动点
用 owner task 模式替代原有的 `_old_exit_stacks` 方案，每次连接在独立的 `_connection_task` 中运行并持有 `AsyncExitStack`，清理时直接 cancel 该 task，确保 anyio cancel scope 始终在正确的 task context 里退出。

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
<img width="1200" height="630" alt="image" src="https://github.com/user-attachments/assets/b246180f-4a8e-4f47-8fc0-f8242fb2897f" />
验证脚本模拟了核心行为，无异常
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure MCP client connections are owned and cleaned up by dedicated asyncio tasks to prevent cancel-scope violations and event-loop busy-waiting during reconnects and cleanup.

Bug Fixes:
- Fix epoll busy-wait and CPU spin caused by AsyncExitStack being closed from the wrong task or GC finalizer during MCP reconnections.

Enhancements:
- Refactor MCP client connection management to use per-connection owner tasks that encapsulate the AsyncExitStack lifecycle and reconnection handling.
- Improve MCP client cleanup to cancel and await all connection tasks, avoiding leaked resources across reconnections.