### PR TITLE
fix(aiocqhttp): normalize quoted media sources in replies

### DIFF
--- a/astrbot/core/message/components.py
+++ b/astrbot/core/message/components.py
@@ -46,9 +46,9 @@ def _write_base64_payload_to_temp_file(
     suffix: str,
 ) -> str:
     file_bytes = base64.b64decode(payload)
-    file_path = os.path.join(
-        get_astrbot_temp_path(), f"{prefix}_{uuid.uuid4().hex}{suffix}"
-    )
+    temp_dir = get_astrbot_temp_path()
+    os.makedirs(temp_dir, exist_ok=True)
+    file_path = os.path.join(temp_dir, f"{prefix}_{uuid.uuid4().hex}{suffix}")
     with open(file_path, "wb") as f:
         f.write(file_bytes)
     return os.path.abspath(file_path)

--- a/astrbot/core/message/components.py
+++ b/astrbot/core/message/components.py
@@ -39,6 +39,21 @@ from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
 from astrbot.core.utils.io import download_file, download_image_by_url, file_to_base64
 
 
+def _write_base64_payload_to_temp_file(
+    payload: str,
+    *,
+    prefix: str,
+    suffix: str,
+) -> str:
+    file_bytes = base64.b64decode(payload)
+    file_path = os.path.join(
+        get_astrbot_temp_path(), f"{prefix}_{uuid.uuid4().hex}{suffix}"
+    )
+    with open(file_path, "wb") as f:
+        f.write(file_bytes)
+    return os.path.abspath(file_path)
+
+
 class ComponentType(str, Enum):
     # Basic Segment Types
     Plain = "Plain"  # plain text message
@@ -139,6 +154,12 @@ class Record(BaseMessageComponent):
     def fromBase64(bs64_data: str, **_):
         return Record(file=f"base64://{bs64_data}", **_)
 
+    def _get_source(self) -> str:
+        for candidate in (self.url, self.file, self.path):
+            if isinstance(candidate, str) and candidate:
+                return candidate
+        return ""
+
     async def convert_to_file_path(self) -> str:
         """将这个语音统一转换为本地文件路径。这个方法避免了手动判断语音数据类型，直接返回语音数据的本地路径（如果是网络 URL, 则会自动进行下载）。
 
@@ -146,25 +167,24 @@ class Record(BaseMessageComponent):
             str: 语音的本地路径，以绝对路径表示。
 
         """
-        if not self.file:
+        source = self._get_source()
+        if not source:
             raise Exception(f"not a valid file: {self.file}")
-        if self.file.startswith("file:///"):
-            return self.file[8:]
-        if self.file.startswith("http"):
-            file_path = await download_image_by_url(self.file)
+        if source.startswith("file:///"):
+            return source[8:]
+        if source.startswith("http"):
+            file_path = await download_image_by_url(source)
             return os.path.abspath(file_path)
-        if self.file.startswith("base64://"):
-            bs64_data = self.file.removeprefix("base64://")
-            image_bytes = base64.b64decode(bs64_data)
-            file_path = os.path.join(
-                get_astrbot_temp_path(), f"recordseg_{uuid.uuid4()}.jpg"
+        if source.startswith("base64://"):
+            bs64_data = source.removeprefix("base64://")
+            return _write_base64_payload_to_temp_file(
+                bs64_data,
+                prefix="recordseg",
+                suffix=".amr",
             )
-            with open(file_path, "wb") as f:
-                f.write(image_bytes)
-            return os.path.abspath(file_path)
-        if os.path.exists(self.file):
-            return os.path.abspath(self.file)
-        raise Exception(f"not a valid file: {self.file}")
+        if os.path.exists(source):
+            return os.path.abspath(source)
+        raise Exception(f"not a valid file: {source}")
 
     async def convert_to_base64(self) -> str:
         """将语音统一转换为 base64 编码。这个方法避免了手动判断语音数据类型，直接返回语音数据的 base64 编码。
@@ -174,19 +194,20 @@ class Record(BaseMessageComponent):
 
         """
         # convert to base64
-        if not self.file:
+        source = self._get_source()
+        if not source:
             raise Exception(f"not a valid file: {self.file}")
-        if self.file.startswith("file:///"):
-            bs64_data = file_to_base64(self.file[8:])
-        elif self.file.startswith("http"):
-            file_path = await download_image_by_url(self.file)
+        if source.startswith("file:///"):
+            bs64_data = file_to_base64(source[8:])
+        elif source.startswith("http"):
+            file_path = await download_image_by_url(source)
             bs64_data = file_to_base64(file_path)
-        elif self.file.startswith("base64://"):
-            bs64_data = self.file
-        elif os.path.exists(self.file):
-            bs64_data = file_to_base64(self.file)
+        elif source.startswith("base64://"):
+            bs64_data = source
+        elif os.path.exists(source):
+            bs64_data = file_to_base64(source)
         else:
-            raise Exception(f"not a valid file: {self.file}")
+            raise Exception(f"not a valid file: {source}")
         bs64_data = bs64_data.removeprefix("base64://")
         return bs64_data
 
@@ -217,6 +238,7 @@ class Record(BaseMessageComponent):
 class Video(BaseMessageComponent):
     type: ComponentType = ComponentType.Video
     file: str
+    url: str | None = ""
     cover: str | None = ""
     # 额外
     path: str | None = ""
@@ -234,6 +256,12 @@ class Video(BaseMessageComponent):
             return Video(file=url, **_)
         raise Exception("not a valid url")
 
+    def _get_source(self) -> str:
+        for candidate in (self.url, self.file, self.path):
+            if isinstance(candidate, str) and candidate:
+                return candidate
+        return ""
+
     async def convert_to_file_path(self) -> str:
         """将这个视频统一转换为本地文件路径。这个方法避免了手动判断视频数据类型，直接返回视频数据的本地路径（如果是网络 URL，则会自动进行下载）。
 
@@ -241,7 +269,7 @@ class Video(BaseMessageComponent):
             str: 视频的本地路径，以绝对路径表示。
 
         """
-        url = self.file
+        url = self._get_source()
         if url and url.startswith("file:///"):
             return url[8:]
         if url and url.startswith("http"):
@@ -281,7 +309,7 @@ class Video(BaseMessageComponent):
 
     async def to_dict(self):
         """需要和 toDict 区分开，toDict 是同步方法"""
-        url_or_path = self.file
+        url_or_path = self._get_source()
         if url_or_path.startswith("http"):
             payload_file = url_or_path
         elif callback_host := astrbot_config.get("callback_api_base"):
@@ -440,13 +468,11 @@ class Image(BaseMessageComponent):
             return os.path.abspath(image_file_path)
         if url.startswith("base64://"):
             bs64_data = url.removeprefix("base64://")
-            image_bytes = base64.b64decode(bs64_data)
-            image_file_path = os.path.join(
-                get_astrbot_temp_path(), f"imgseg_{uuid.uuid4()}.jpg"
+            return _write_base64_payload_to_temp_file(
+                bs64_data,
+                prefix="imgseg",
+                suffix=".jpg",
             )
-            with open(image_file_path, "wb") as f:
-                f.write(image_bytes)
-            return os.path.abspath(image_file_path)
         if os.path.exists(url):
             return os.path.abspath(url)
         raise Exception(f"not a valid file: {url}")

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -2,6 +2,7 @@ import asyncio
 import inspect
 import itertools
 import logging
+import os
 import time
 import uuid
 from collections.abc import Awaitable
@@ -25,6 +26,141 @@ from astrbot.core.platform.astr_message_event import MessageSesion
 from ...register import register_platform_adapter
 from .aiocqhttp_message_event import *
 from .aiocqhttp_message_event import AiocqhttpMessageEvent
+
+
+def _looks_like_resolved_media_ref(value: str) -> bool:
+    return value.startswith(("http://", "https://", "file://")) or os.path.isabs(value)
+
+
+def _pick_usable_media_source(seg_data: dict[str, Any]) -> str:
+    for key in ("url", "file", "path", "file_path"):
+        value = seg_data.get(key)
+        if isinstance(value, str) and value.strip():
+            candidate = value.strip()
+            if _looks_like_resolved_media_ref(candidate) or os.path.exists(candidate):
+                return candidate
+    return ""
+
+
+def _unwrap_onebot_action_data(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {}
+    data = payload.get("data")
+    if isinstance(data, dict):
+        return data
+    return payload
+
+
+async def _resolve_onebot_file_reference(
+    bot: CQHttp,
+    *,
+    message_type: str,
+    group_id: str | int | None,
+    file_ref: str,
+    seg_type: str | None = None,
+) -> str | None:
+    normalized = str(file_ref or "").strip()
+    if not normalized:
+        return None
+    if _looks_like_resolved_media_ref(normalized) or os.path.exists(normalized):
+        return normalized
+
+    candidates = [normalized]
+    base_name = os.path.basename(normalized)
+    if base_name and base_name not in candidates:
+        candidates.append(base_name)
+    stem, ext = os.path.splitext(base_name)
+    if stem and ext and stem not in candidates:
+        candidates.append(stem)
+
+    actions: list[tuple[str, dict[str, Any]]] = []
+    if seg_type == "record":
+        for candidate in candidates:
+            actions.append(("get_record", {"file": candidate}))
+    for candidate in candidates:
+        actions.extend(
+            [
+                ("get_file", {"file_id": candidate}),
+                ("get_file", {"file": candidate}),
+                ("get_image", {"file": candidate}),
+                ("get_image", {"file_id": candidate}),
+                ("get_private_file_url", {"file_id": candidate}),
+            ]
+        )
+        if str(message_type).lower() == "group" and group_id not in (None, ""):
+            actions.append(
+                (
+                    "get_group_file_url",
+                    {"group_id": group_id, "file_id": candidate},
+                )
+            )
+
+    for action, params in actions:
+        try:
+            ret = await bot.call_action(action=action, **params)
+        except Exception:
+            continue
+        data = _unwrap_onebot_action_data(ret)
+        for key in ("url", "file"):
+            value = data.get(key)
+            if isinstance(value, str) and value.strip():
+                resolved = value.strip()
+                if _looks_like_resolved_media_ref(resolved) or os.path.exists(resolved):
+                    return resolved
+    return None
+
+
+async def _normalize_onebot_media_data(
+    bot: CQHttp,
+    seg_type: str,
+    seg_data: dict[str, Any],
+    *,
+    message_type: str,
+    group_id: str | int | None,
+) -> dict[str, Any]:
+    normalized = dict(seg_data)
+
+    if seg_type not in {"video", "record", "file"}:
+        return normalized
+
+    direct_url = normalized.get("url")
+    if isinstance(direct_url, str) and direct_url.strip():
+        usable_source = _pick_usable_media_source(normalized) or direct_url.strip()
+        normalized["file"] = usable_source
+        if seg_type == "file":
+            normalized.setdefault("url", usable_source)
+        return normalized
+
+    file_ref = normalized.get("file")
+    file_id = normalized.get("file_id")
+    candidate = file_ref or file_id
+    if not isinstance(candidate, str) or not candidate.strip():
+        usable_source = _pick_usable_media_source(normalized)
+        if usable_source:
+            normalized["file"] = usable_source
+            if seg_type == "file":
+                normalized.setdefault("url", usable_source)
+            return normalized
+        return normalized
+    candidate = candidate.strip()
+    if _looks_like_resolved_media_ref(candidate) or os.path.exists(candidate):
+        normalized["file"] = candidate
+        return normalized
+
+    resolved = await _resolve_onebot_file_reference(
+        bot,
+        message_type=message_type,
+        group_id=group_id,
+        file_ref=candidate,
+        seg_type=seg_type,
+    )
+    if not resolved:
+        return normalized
+
+    normalized["file"] = resolved
+    if seg_type == "file":
+        normalized.setdefault("url", resolved)
+    return normalized
 
 
 @register_platform_adapter(
@@ -265,6 +401,27 @@ class AiocqhttpAdapter(Platform):
                         abm.message.append(File(name=file_name, url=m["data"]["url"]))
                     else:
                         try:
+                            normalized_data = await _normalize_onebot_media_data(
+                                self.bot,
+                                "file",
+                                m["data"],
+                                message_type=event["message_type"],
+                                group_id=event.get("group_id"),
+                            )
+                            if normalized_data.get("url"):
+                                file_name = (
+                                    normalized_data.get("file_name", "")
+                                    or normalized_data.get("name", "")
+                                    or normalized_data.get("file", "")
+                                    or "file"
+                                )
+                                abm.message.append(
+                                    File(
+                                        name=file_name,
+                                        url=cast(str, normalized_data["url"]),
+                                    )
+                                )
+                                continue
                             # Napcat
                             ret = None
                             if abm.type == MessageType.GROUP_MESSAGE:
@@ -402,7 +559,14 @@ class AiocqhttpAdapter(Platform):
                                 f"不支持的消息段类型，已忽略: {t}, data={m['data']}"
                             )
                             continue
-                        a = ComponentTypes[t](**m["data"])
+                        normalized_data = await _normalize_onebot_media_data(
+                            self.bot,
+                            t,
+                            m["data"],
+                            message_type=event["message_type"],
+                            group_id=event.get("group_id"),
+                        )
+                        a = ComponentTypes[t](**normalized_data)
                         abm.message.append(a)
                     except Exception as e:
                         logger.exception(

--- a/tests/unit/test_record_component_sources.py
+++ b/tests/unit/test_record_component_sources.py
@@ -1,0 +1,59 @@
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from astrbot.core.message.components import Record
+
+
+@pytest.mark.asyncio
+async def test_record_convert_to_file_path_prefers_url_over_invalid_file_name():
+    record = Record(
+        file="0f47835d687410ab50cfed981e80c15c.amr",
+        url="https://example.com/audio.amr",
+    )
+
+    with patch(
+        "astrbot.core.message.components.download_image_by_url",
+        AsyncMock(return_value="/tmp/audio.amr"),
+    ):
+        path = await record.convert_to_file_path()
+
+    assert os.path.isabs(path)
+    assert os.path.basename(path) == "audio.amr"
+
+
+@pytest.mark.asyncio
+async def test_record_convert_to_base64_prefers_url_over_invalid_file_name():
+    record = Record(
+        file="0f47835d687410ab50cfed981e80c15c.amr",
+        url="https://example.com/audio.amr",
+    )
+
+    with (
+        patch(
+            "astrbot.core.message.components.download_image_by_url",
+            AsyncMock(return_value="/tmp/audio.amr"),
+        ),
+        patch(
+            "astrbot.core.message.components.file_to_base64",
+            return_value="base64://ZmFrZQ==",
+        ),
+    ):
+        encoded = await record.convert_to_base64()
+
+    assert encoded == "ZmFrZQ=="
+
+
+@pytest.mark.asyncio
+async def test_record_convert_to_file_path_writes_base64_payload_with_audio_extension():
+    record = Record(file="base64://ZmFrZQ==")
+
+    path = await record.convert_to_file_path()
+
+    assert os.path.isabs(path)
+    assert Path(path).suffix == ".amr"
+    assert Path(path).read_bytes() == b"fake"
+
+    Path(path).unlink(missing_ok=True)


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
Fixes #8049 .
修复 aiocqhttp / OneBot v11 场景下，引用消息中的语音、视频、文件媒体段在进入 AstrBot 后无法被正确消费的问题。

此前在 QQ/NapCat 的引用消息场景中，媒体段里的 `file` 字段经常只是平台内部文件名或引用值，例如 `0f47835d687410ab50cfed981e80c15c.amr`、`BV1y9Gj6****.mp4`，并不是 AstrBot 当前进程可直接访问的本地路径，也不是可直接下载的 URL。

旧逻辑会将这类 `file` 原样交给上层组件，导致：
- 引用语音触发 `not a valid file: *.amr`
- 引用视频触发 `not a valid file: *.mp4`
- 上层即使同时拿到了 `url`，部分组件仍可能优先消费无效的 `file` 值

本次修改将 quoted media 的修复前移到正确层级：
- 在平台适配器层统一规范媒体来源
- 在消息组件层统一选择可用 source

从而确保引用消息中的语音、视频、文件媒体段在进入后续 Agent / Provider / Plugin 链路前，就已经具备可直接消费的来源信息。

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
本次改动主要补齐了 aiocqhttp 引用媒体段的来源解析逻辑，并统一了 `Record` / `Video` 组件对多来源字段的消费方式。

核心改动包括：

- 在 `astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py` 中新增 OneBot 媒体来源规范化逻辑：
  - 判断 `file` 是否已经是可直接使用的引用
  - 优先复用消息段中已存在的 `url` / `path` / `file_path`
  - 当 `file` / `file_id` 只是平台内部引用值时，尝试通过 OneBot action 进一步解析为真实 URL 或文件引用
  - 在构造 `video` / `record` / `file` 组件前，将媒体段统一规范成上层可直接消费的结构

- 在 `astrbot/core/message/components.py` 中增强 `Record` 组件的 source 选择逻辑：
  - 新增统一来源选择
  - `convert_to_file_path()` 与 `convert_to_base64()` 不再只依赖 `file`
  - 改为按 `url -> file -> path` 的顺序选择真实可用来源

- 在 `astrbot/core/message/components.py` 中修正 `Record` 的 base64 临时文件落地逻辑：
  - 修复原先将语音 base64 负载误写为 `.jpg` 临时文件的 copy-paste 问题
  - 改为使用音频临时文件扩展名
  - 通过轻量共享 helper 复用 base64 临时文件写入逻辑，避免与图片分支继续漂移

- 在 `astrbot/core/message/components.py` 中增强 `Video` 组件的 source 选择逻辑：
  - 为 `Video` 增加显式 `url` 字段
  - 统一 `convert_to_file_path()` 与 `to_dict()` 的来源选择逻辑
  - 保持 `Video` 与 `Image` / `Record` 的多来源语义一致

- 在测试侧保留并补充了稳定的组件层单元测试，覆盖：
  - `Record` 在 `url` 存在而 `file` 无效时仍可正常转本地路径
  - `Record` 在同样场景下仍可正常转为 base64
  - `Record` 从 `base64://` 来源落地临时文件时，会使用正确的音频扩展名和内容写入

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
修复前引用语音消息时：
```
[2026-05-24 17:22:49.862] [Core] [DBUG] [agent_sub_stages.internal:210]: acquired session lock for llm request
[2026-05-24 17:22:49.863] [Core][ERRO][v4.25.1] [agent_sub_stages.internal:417]: Error occurred while processing agent: not a valid file: 0f47835d687410ab50cfed981e80c15c.amr
[2026-05-24 17:22:50.061] [Core] [DBUG] [pipeline.scheduler:93]: pipeline 执行完毕。
```

修复后不再报错。

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Normalize aiocqhttp/OneBot v11 media sources in quoted messages so that audio, video, and file segments are resolved to directly consumable URLs or paths before reaching higher-level components.

Bug Fixes:
- Fix failures when processing quoted audio, video, and file segments whose OneBot `file` values are only internal identifiers rather than usable paths or URLs.

Enhancements:
- Add centralized normalization of OneBot media segment data in the aiocqhttp platform adapter, resolving internal file references to usable URLs or paths and reusing existing media fields when possible.
- Unify Record and Video components’ source-selection logic to choose between `url`, `file`, and `path` consistently when converting to file paths, base64, or dictionaries.

Tests:
- Add unit tests for OneBot media normalization in the aiocqhttp adapter, covering resolution of bare file names and preference for direct URLs in reply payloads.
- Add unit tests for Record component conversion methods to ensure they prefer valid URLs over unusable file names.