### PR TITLE
fix: sanitize file name in file component

### DIFF
--- a/astrbot/core/message/components.py
+++ b/astrbot/core/message/components.py
@@ -669,6 +669,8 @@ def _sanitize_file_component_name(name: str | None) -> str:
 
     normalized = str(name).replace("\\", "/")
     basename = PurePosixPath(normalized).name.replace("\x00", "").strip()
+    for char in ':*?"<>|':
+        basename = basename.replace(char, "_")
     if basename in {"", ".", ".."}:
         return "file"
     return basename

--- a/astrbot/core/message/components.py
+++ b/astrbot/core/message/components.py
@@ -28,6 +28,7 @@ import os
 import sys
 import uuid
 from enum import Enum
+from pathlib import Path, PurePosixPath
 
 if sys.version_info >= (3, 14):
     from pydantic import BaseModel
@@ -662,6 +663,17 @@ class Unknown(BaseMessageComponent):
     text: str
 
 
+def _sanitize_file_component_name(name: str | None) -> str:
+    if not name:
+        return "file"
+
+    normalized = str(name).replace("\\", "/")
+    basename = PurePosixPath(normalized).name.replace("\x00", "").strip()
+    if basename in {"", ".", ".."}:
+        return "file"
+    return basename
+
+
 class File(BaseMessageComponent):
     """文件消息段"""
 
@@ -773,15 +785,18 @@ class File(BaseMessageComponent):
         """下载文件"""
         if not self.url:
             raise ValueError("Download failed: No URL provided in File component.")
-        download_dir = get_astrbot_temp_path()
+        download_dir = Path(get_astrbot_temp_path())
+        download_dir.mkdir(parents=True, exist_ok=True)
         if self.name:
-            name, ext = os.path.splitext(self.name)
+            safe_name = _sanitize_file_component_name(self.name)
+            name = Path(safe_name).stem
+            ext = Path(safe_name).suffix
             filename = f"fileseg_{name}_{uuid.uuid4().hex[:8]}{ext}"
         else:
             filename = f"fileseg_{uuid.uuid4().hex}"
-        file_path = os.path.join(download_dir, filename)
-        await download_file(self.url, file_path)
-        self.file_ = os.path.abspath(file_path)
+        file_path = download_dir / filename
+        await download_file(self.url, str(file_path))
+        self.file_ = str(file_path.resolve())
 
     async def register_to_file_service(self) -> str:
         """将文件注册到文件服务。

--- a/tests/unit/test_file_message_component.py
+++ b/tests/unit/test_file_message_component.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import pytest
+
+from astrbot.core.message import components
+
+
+@pytest.mark.asyncio
+async def test_file_component_download_sanitizes_remote_name(monkeypatch, tmp_path):
+    temp_dir = tmp_path / "temp"
+    downloaded_paths: list[Path] = []
+
+    async def fake_download_file(url: str, path: str) -> None:
+        target = Path(path)
+        assert url == "https://example.com/report"
+        assert target.parent == temp_dir
+        assert target.parent.exists()
+        assert "\x00" not in target.name
+        assert "/" not in target.name
+        assert "\\" not in target.name
+        target.write_bytes(b"payload")
+        downloaded_paths.append(target)
+
+    monkeypatch.setattr(components, "download_file", fake_download_file)
+    monkeypatch.setattr(components, "get_astrbot_temp_path", lambda: str(temp_dir))
+
+    component = components.File(
+        name="..\\nested/evil\\report\x00.pdf",
+        url="https://example.com/report",
+    )
+
+    path = Path(await component.get_file())
+
+    assert path.parent == temp_dir
+    assert path.exists()
+    assert path.name.startswith("fileseg_report_")
+    assert path.suffix == ".pdf"
+    assert downloaded_paths == [path]

--- a/tests/unit/test_file_message_component.py
+++ b/tests/unit/test_file_message_component.py
@@ -18,6 +18,7 @@ async def test_file_component_download_sanitizes_remote_name(monkeypatch, tmp_pa
         assert "\x00" not in target.name
         assert "/" not in target.name
         assert "\\" not in target.name
+        assert not any(char in target.name for char in ':*?"<>|')
         target.write_bytes(b"payload")
         downloaded_paths.append(target)
 
@@ -25,7 +26,7 @@ async def test_file_component_download_sanitizes_remote_name(monkeypatch, tmp_pa
     monkeypatch.setattr(components, "get_astrbot_temp_path", lambda: str(temp_dir))
 
     component = components.File(
-        name="..\\nested/evil\\report\x00.pdf",
+        name='..\\nested/evil\\report:*?"<>|\x00.pdf',
         url="https://example.com/report",
     )
 
@@ -33,6 +34,6 @@ async def test_file_component_download_sanitizes_remote_name(monkeypatch, tmp_pa
 
     assert path.parent == temp_dir
     assert path.exists()
-    assert path.name.startswith("fileseg_report_")
+    assert path.name.startswith("fileseg_report________")
     assert path.suffix == ".pdf"
     assert downloaded_paths == [path]


### PR DESCRIPTION
## 变更内容

- 为 `File` 消息段远程下载增加文件名清洗，仅保留 basename 并移除空字节
- 下载前主动创建 AstrBot 临时目录，避免目录不存在导致写入失败
- 补充单元测试，覆盖包含路径分隔符和空字节的远程文件名

## 关联 Issue

Closes #8317

## 验证

- `UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python uv run pytest tests/unit/test_file_message_component.py`
- `UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python uv run ruff format .`
- `UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python uv run ruff check .`

## Summary by Sourcery

Sanitize remote file names in File message downloads and ensure temporary directories exist before saving, with tests verifying the new behavior.

Bug Fixes:
- Prevent unsafe or malformed remote file names from being used directly when downloading File message components by normalizing and sanitizing the basename.
- Avoid download failures caused by missing AstrBot temporary directories by creating the directory tree before writing files.

Tests:
- Add async unit test covering File component downloads with remote names containing path separators and null bytes to verify sanitization and temp directory handling.