### PR TITLE
Feat/dashboard auth improvements

### DIFF
--- a/astrbot/core/config/astrbot_config.py
+++ b/astrbot/core/config/astrbot_config.py
@@ -1,3 +1,4 @@
+import copy
 import enum
 import json
 import logging
@@ -16,6 +17,14 @@ from .default import DEFAULT_CONFIG, DEFAULT_VALUE_MAP
 ASTRBOT_CONFIG_PATH = os.path.join(get_astrbot_data_path(), "cmd_config.json")
 DASHBOARD_INITIAL_PASSWORD_ENV = "ASTRBOT_DASHBOARD_INITIAL_PASSWORD"
 logger = logging.getLogger("astrbot")
+_DASHBOARD_AUTH_KEYS = {
+    "username",
+    "password",
+    "pbkdf2_password",
+    "password_storage_upgraded",
+    "password_change_required",
+    "jwt_secret",
+}
 
 
 class RateLimitStrategy(enum.Enum):
@@ -97,6 +106,56 @@ class AstrBotConfig(dict):
             self.save_config()
 
         self.update(conf)
+        self._remember_file_state()
+
+    def _get_dashboard_auth_state(self, conf: dict | None = None) -> dict:
+        dashboard_conf = (conf or self).get("dashboard")
+        if not isinstance(dashboard_conf, dict):
+            return {}
+        return {
+            key: copy.deepcopy(dashboard_conf.get(key))
+            for key in _DASHBOARD_AUTH_KEYS
+            if key in dashboard_conf
+        }
+
+    def _remember_file_state(self) -> None:
+        try:
+            mtime_ns = os.stat(self.config_path).st_mtime_ns
+        except OSError:
+            mtime_ns = None
+        object.__setattr__(self, "_last_config_mtime_ns", mtime_ns)
+        object.__setattr__(
+            self,
+            "_dashboard_auth_snapshot",
+            self._get_dashboard_auth_state(),
+        )
+
+    def _preserve_external_dashboard_auth_changes(self) -> None:
+        last_mtime_ns = getattr(self, "_last_config_mtime_ns", None)
+        if last_mtime_ns is None:
+            return
+        try:
+            current_mtime_ns = os.stat(self.config_path).st_mtime_ns
+        except OSError:
+            return
+        if current_mtime_ns == last_mtime_ns:
+            return
+
+        try:
+            with open(self.config_path, encoding="utf-8-sig") as f:
+                disk_conf = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return
+
+        disk_auth_state = self._get_dashboard_auth_state(disk_conf)
+        loaded_auth_state = getattr(self, "_dashboard_auth_snapshot", {})
+        current_auth_state = self._get_dashboard_auth_state()
+        if (
+            disk_auth_state
+            and disk_auth_state != loaded_auth_state
+            and current_auth_state == loaded_auth_state
+        ):
+            self["dashboard"].update(disk_auth_state)
 
     def _reset_generated_dashboard_password(self, conf: dict) -> None:
         generated_password = self._resolve_initial_dashboard_password()
@@ -220,8 +279,10 @@ class AstrBotConfig(dict):
         """
         if replace_config:
             self.update(replace_config)
+        self._preserve_external_dashboard_auth_changes()
         with open(self.config_path, "w", encoding="utf-8-sig") as f:
             json.dump(self, f, indent=2, ensure_ascii=False)
+        self._remember_file_state()
 
     def __getattr__(self, item):
         try:

--- a/astrbot/core/config/astrbot_config.py
+++ b/astrbot/core/config/astrbot_config.py
@@ -57,6 +57,11 @@ class AstrBotConfig(dict):
         object.__setattr__(self, "default_config", default_config)
         object.__setattr__(self, "schema", schema)
 
+        # Track config file state to detect external modifications
+        # (e.g. CLI password updates) and preserve them across saves.
+        object.__setattr__(self, "_last_config_mtime_ns", None)
+        object.__setattr__(self, "_dashboard_auth_snapshot", {})
+
         if schema:
             default_config = self._config_schema_to_default_config(schema)
 
@@ -109,7 +114,8 @@ class AstrBotConfig(dict):
         self._remember_file_state()
 
     def _get_dashboard_auth_state(self, conf: dict | None = None) -> dict:
-        dashboard_conf = (conf or self).get("dashboard")
+        base = conf if conf is not None else self
+        dashboard_conf = base.get("dashboard")
         if not isinstance(dashboard_conf, dict):
             return {}
         return {
@@ -130,8 +136,29 @@ class AstrBotConfig(dict):
             self._get_dashboard_auth_state(),
         )
 
+    @staticmethod
+    def _merge_dashboard_auth(
+        loaded_auth_state: dict,
+        current_auth_state: dict,
+        disk_auth_state: dict,
+    ) -> dict:
+        """Return the auth state to apply to ``self["dashboard"]``.
+
+        Merge policy: when the on-disk auth state differs from what we
+        loaded and the in-memory state has *not* been changed locally,
+        apply the on-disk values so external updates (e.g. CLI password
+        changes) are not overwritten by a subsequent ``save_config()``.
+        """
+        if not disk_auth_state or disk_auth_state == loaded_auth_state:
+            return current_auth_state
+        if current_auth_state != loaded_auth_state:
+            return current_auth_state
+        merged = current_auth_state.copy()
+        merged.update(disk_auth_state)
+        return merged
+
     def _preserve_external_dashboard_auth_changes(self) -> None:
-        last_mtime_ns = getattr(self, "_last_config_mtime_ns", None)
+        last_mtime_ns = self._last_config_mtime_ns
         if last_mtime_ns is None:
             return
         try:
@@ -147,15 +174,13 @@ class AstrBotConfig(dict):
         except (OSError, json.JSONDecodeError):
             return
 
-        disk_auth_state = self._get_dashboard_auth_state(disk_conf)
-        loaded_auth_state = getattr(self, "_dashboard_auth_snapshot", {})
-        current_auth_state = self._get_dashboard_auth_state()
-        if (
-            disk_auth_state
-            and disk_auth_state != loaded_auth_state
-            and current_auth_state == loaded_auth_state
-        ):
-            self["dashboard"].update(disk_auth_state)
+        merged = self._merge_dashboard_auth(
+            self._dashboard_auth_snapshot,
+            self._get_dashboard_auth_state(),
+            self._get_dashboard_auth_state(disk_conf),
+        )
+        if merged != self._get_dashboard_auth_state():
+            self.setdefault("dashboard", {}).update(merged)
 
     def _reset_generated_dashboard_password(self, conf: dict) -> None:
         generated_password = self._resolve_initial_dashboard_password()

--- a/astrbot/dashboard/routes/auth.py
+++ b/astrbot/dashboard/routes/auth.py
@@ -38,7 +38,7 @@ DEFAULT_PASSWORD_LOGIN_FAILURE_MESSAGE = (
     "随机强密码。请使用日志中提供的的初始密码来登录。了解更多："
     "https://docs.astrbot.app/faq.html"
 )
-LEGACY_PASSWORD_LOGIN_FAILURE_MESSAGE = (
+INVALID_CREDENTIALS_LOGIN_FAILURE_MESSAGE = (
     "Incorrect username or password. If you cannot log in after upgrading "
     "AstrBot even though the password is correct, see "
     "https://docs.astrbot.app/en/faq.html\n\n"
@@ -188,9 +188,7 @@ class AuthRoute(Route):
         await asyncio.sleep(3)
         if req_password == "astrbot":
             return Response().error(DEFAULT_PASSWORD_LOGIN_FAILURE_MESSAGE).__dict__
-        if is_legacy_dashboard_password(password):
-            return Response().error(LEGACY_PASSWORD_LOGIN_FAILURE_MESSAGE).__dict__
-        return Response().error("用户名或密码错误").__dict__
+        return Response().error(INVALID_CREDENTIALS_LOGIN_FAILURE_MESSAGE).__dict__
 
     async def logout(self):
         response = await make_response(

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -35,7 +35,10 @@ from astrbot.dashboard.password_state import (
     set_password_change_required,
     set_password_storage_upgraded,
 )
-from astrbot.dashboard.routes.auth import DASHBOARD_JWT_COOKIE_NAME
+from astrbot.dashboard.routes.auth import (
+    DASHBOARD_JWT_COOKIE_NAME,
+    INVALID_CREDENTIALS_LOGIN_FAILURE_MESSAGE,
+)
 from astrbot.dashboard.routes.plugin import PluginRoute
 from astrbot.dashboard.server import AstrBotDashboard
 from tests.fixtures.helpers import (
@@ -307,6 +310,7 @@ async def test_auth_login(
     )
     data = await response.get_json()
     assert data["status"] == "error"
+    assert data["message"] == INVALID_CREDENTIALS_LOGIN_FAILURE_MESSAGE
 
     response = await test_client.post(
         "/api/auth/login",

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -10,6 +10,8 @@ from astrbot.core.config.default import DEFAULT_VALUE_MAP
 from astrbot.core.config.i18n_utils import ConfigMetadataI18n
 from astrbot.core.utils.auth_password import (
     DEFAULT_DASHBOARD_PASSWORD,
+    hash_dashboard_password,
+    hash_legacy_dashboard_password,
     validate_dashboard_password,
     verify_dashboard_password,
 )
@@ -544,6 +546,55 @@ class TestConfigHotReload:
         )
 
         assert config2.platform_settings["unique_session"] is True
+
+    def test_save_preserves_external_dashboard_auth_changes(self, temp_config_path):
+        """Runtime config saves should not overwrite CLI-updated dashboard auth."""
+        original_password = "OriginalPass123"
+        external_password = "ExternalPass123"
+        default_config = {
+            "dashboard": {
+                "username": "astrbot",
+                "password": hash_legacy_dashboard_password(original_password),
+                "pbkdf2_password": hash_dashboard_password(original_password),
+                "password_storage_upgraded": True,
+                "password_change_required": False,
+                "jwt_secret": "original-secret",
+            },
+            "provider_settings": {
+                "enable": True,
+                "default_provider_id": "",
+            },
+        }
+        with open(temp_config_path, "w", encoding="utf-8-sig") as f:
+            json.dump(default_config, f)
+
+        config = AstrBotConfig(
+            config_path=temp_config_path,
+            default_config=default_config,
+        )
+        external_config = json.loads(json.dumps(default_config))
+        external_config["dashboard"]["username"] = "external-user"
+        external_config["dashboard"]["password"] = hash_legacy_dashboard_password(
+            external_password,
+        )
+        external_config["dashboard"]["pbkdf2_password"] = hash_dashboard_password(
+            external_password,
+        )
+        with open(temp_config_path, "w", encoding="utf-8-sig") as f:
+            json.dump(external_config, f)
+
+        config["provider_settings"]["enable"] = False
+        config.save_config()
+
+        with open(temp_config_path, encoding="utf-8-sig") as f:
+            saved_config = json.load(f)
+
+        assert saved_config["provider_settings"]["enable"] is False
+        assert saved_config["dashboard"]["username"] == "external-user"
+        assert verify_dashboard_password(
+            saved_config["dashboard"]["pbkdf2_password"],
+            external_password,
+        )
 
 
 class TestConfigSchemaToDefault:


### PR DESCRIPTION
Fixes #8336

This PR fixes a race condition between CLI dashboard password updates and runtime config saves.

`AstrBotConfig.save_config()` writes the full in-memory config back to `data/cmd_config.json`. If the user runs `uv run -m astrbot.cli password` while AstrBot is still running, the CLI updates the dashboard auth fields on disk, but later runtime `save_config()` calls can write stale in-memory dashboard auth fields back to disk.

This makes the CLI password command appear to succeed, but login can still fail because the password hashes may be overwritten by the running process.

### Modifications / 改动点

This PR implements a conservative reload-before-save safeguard for dashboard authentication fields.

Instead of changing merge behavior for the whole config file, `AstrBotConfig.save_config()` now checks whether the on-disk config was externally modified after the current process loaded it. If dashboard auth fields changed on disk and the current process has not intentionally changed those same fields, the on-disk auth values are preserved before writing the rest of the config.

Protected dashboard auth fields:

- `username`
- `password`
- `pbkdf2_password`
- `password_storage_upgraded`
- `password_change_required`
- `jwt_secret`

Core changes:

- Added file-state tracking in `AstrBotConfig`.
- Added dashboard auth field snapshot tracking.
- Added a save-time guard that preserves externally changed dashboard auth fields.
- Added a regression test for the CLI-password-overwritten-by-runtime-save scenario.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```bash
❯ uv run pytest tests/unit/test_config.py::TestConfigHotReload::test_save_preserves_external_dashboard_auth_changes tests/test_cli_password.py

============================================================ test session starts =============================================================
platform linux -- Python 3.12.8, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/counhopig/workspace/astrbot/AstrBot
configfile: pyproject.toml
plugins: anyio-4.13.0, cov-7.1.0, asyncio-1.3.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 4 items

tests/unit/test_config.py .                                                                                                            [ 25%]
tests/test_cli_password.py ...                                                                                                         [100%]

============================================================= 4 passed in 0.84s ==============================================================
❯ uv run ruff format .
427 files left unchanged
❯ uv run ruff check .
All checks passed!
```

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Prevent runtime config saves from overwriting externally updated dashboard authentication settings and align dashboard login failure messaging.

Bug Fixes:
- Ensure AstrBotConfig.save_config preserves externally modified dashboard authentication fields when saving other config changes to avoid race conditions between CLI password updates and runtime saves.

Enhancements:
- Track config file modification time and snapshot dashboard auth fields to detect and preserve external changes on save.
- Unify dashboard login failure responses to always return a single, informative invalid-credentials message.

Tests:
- Add a regression test verifying that runtime config saves do not overwrite dashboard credentials updated externally via the CLI.
- Extend dashboard auth login tests to assert the unified invalid-credentials error message.