### PR TITLE
fix: remove tool messages whose tool_call_id no longer matches any preceding assistant tool_calls after context truncation, avoiding 400 errors from unexpected tool_use_ids

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -477,7 +477,40 @@ class ProviderOpenAIOfficial(Provider):
 
             cleaned.append(msg)
 
-        payloads["messages"] = cleaned
+        # Drop orphaned or duplicate tool messages whose assistant(tool_calls)
+        # was removed by context truncation / compression.
+        pending_tool_call_ids: set[str] = set()
+        final: list = []
+        removed_tool_messages = 0
+        for msg in cleaned:
+            if not isinstance(msg, dict):
+                final.append(msg)
+                pending_tool_call_ids = set()
+                continue
+            role = msg.get("role")
+            if role == "assistant" and msg.get("tool_calls"):
+                pending_tool_call_ids = {
+                    tc["id"]
+                    for tc in msg["tool_calls"]
+                    if isinstance(tc, dict) and "id" in tc
+                }
+                final.append(msg)
+            elif role == "tool":
+                tool_call_id = msg.get("tool_call_id")
+                if tool_call_id in pending_tool_call_ids:
+                    final.append(msg)
+                    pending_tool_call_ids.remove(tool_call_id)
+                else:
+                    removed_tool_messages += 1
+            else:
+                pending_tool_call_ids = set()
+                final.append(msg)
+        if removed_tool_messages:
+            logger.debug(
+                "Filtered %d orphaned or duplicate tool message(s)",
+                removed_tool_messages,
+            )
+        payloads["messages"] = final
 
     async def _query(
         self,

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -1479,6 +1479,152 @@ async def test_query_stream_extracts_usage_from_empty_choices_chunk(monkeypatch)
         await provider.terminate()
 
 
+def test_sanitize_assistant_messages_removes_orphaned_tool_messages():
+    payloads = {
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "tool",
+                "tool_call_id": "missing_call",
+                "content": "stale result",
+            },
+            {"role": "user", "content": "continue"},
+        ]
+    }
+
+    ProviderOpenAIOfficial._sanitize_assistant_messages(payloads)
+
+    assert payloads["messages"] == [
+        {"role": "user", "content": "hello"},
+        {"role": "user", "content": "continue"},
+    ]
+
+
+def test_sanitize_assistant_messages_keeps_valid_tool_messages_only():
+    payloads = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_00",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_00", "content": "one"},
+            {
+                "role": "tool",
+                "tool_call_id": "",
+                "content": "empty id should not be valid",
+            },
+        ]
+    }
+
+    ProviderOpenAIOfficial._sanitize_assistant_messages(payloads)
+
+    assert payloads["messages"] == [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_00",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_00", "content": "one"},
+    ]
+
+
+def test_sanitize_assistant_messages_removes_stale_duplicate_tool_message():
+    payloads = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_00",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_00", "content": "one"},
+            {
+                "role": "tool",
+                "tool_call_id": "call_00",
+                "content": "stale duplicate",
+            },
+            {"role": "assistant", "content": "done"},
+        ]
+    }
+
+    ProviderOpenAIOfficial._sanitize_assistant_messages(payloads)
+
+    assert payloads["messages"] == [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_00",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_00", "content": "one"},
+        {"role": "assistant", "content": "done"},
+    ]
+
+
+def test_sanitize_assistant_messages_resets_tool_ids_after_non_tool_message():
+    payloads = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_00",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "user", "content": "new turn"},
+            {
+                "role": "tool",
+                "tool_call_id": "call_00",
+                "content": "stale late result",
+            },
+        ]
+    }
+
+    ProviderOpenAIOfficial._sanitize_assistant_messages(payloads)
+
+    assert payloads["messages"] == [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_00",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "user", "content": "new turn"},
+    ]
+
+
 @pytest.mark.asyncio
 async def test_query_filters_empty_assistant_message_without_tool_calls(monkeypatch):
     """Test that empty assistant messages without tool_calls are filtered out."""


### PR DESCRIPTION
Fixes #8349

After context truncation or compression removes an `assistant` message containing `tool_calls`, the corresponding `role: "tool"` response messages may remain in the conversation history. The API then rejects the request with:

> 400: unexpected tool_use_id found in tool_result blocks

### Modifications / 改动点

- Added a second pass in `_sanitize_assistant_messages()` (`openai_source.py`) that removes any `role: "tool"` message whose `tool_call_id` does not match a `tool_calls` entry in a preceding `assistant` message
- Acts as a last-line-of-defense before API dispatch, complementing the existing `fix_messages()` in `ContextTruncator`

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

Error before fix:
[sources.openai_source]: Chat Model request error: Error code: 400 - {'error': {'message': 'unexpected tool_use_id found in tool_result blocks: toolu_01AGPDyN5PStuEuoumrdgC9o. Each tool_result block must have a corresponding tool_use block in the previous message.'}}

After fix, orphaned messages are silently filtered and the request succeeds:
[sources.openai_source]: Filtered 4 orphaned tool message(s)

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Remove tool messages whose tool_call_id no longer matches any preceding assistant tool_calls after context truncation, avoiding 400 errors from unexpected tool_use_ids.