### PR TITLE
fix(docs): 更新FAQ，添加强制刷新页面的说明

### DIFF
--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -79,7 +79,7 @@ Solution:
 1. Stop AstrBot.
 2. Delete the `dist` folder under AstrBot's `data` directory: `AstrBot/data/dist`.
 3. Restart AstrBot.
-4. Access the dashboard in your browser. Press `Ctrl+Shift+R` or `Ctrl+F5` to force refresh the page.
+4. Access the dashboard in your browser. Press `Ctrl+Shift+R` or `Ctrl+F5` (or `Cmd+Shift+R` on macOS) to force refresh the page.
 
 After restart, AstrBot will reload or download WebUI files that match the current version.
 

--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -79,6 +79,7 @@ Solution:
 1. Stop AstrBot.
 2. Delete the `dist` folder under AstrBot's `data` directory: `AstrBot/data/dist`.
 3. Restart AstrBot.
+4. Access the dashboard in your browser. Press `Ctrl+Shift+R` or `Ctrl+F5` to force refresh the page.
 
 After restart, AstrBot will reload or download WebUI files that match the current version.
 

--- a/docs/zh/faq.md
+++ b/docs/zh/faq.md
@@ -80,7 +80,7 @@ Set dashboard.host in data/cmd_config.json to enable remote access.
 1. 停止 AstrBot。
 2. 删除 AstrBot 的 `data` 目录下的 `dist` 文件夹，即 `AstrBot/data/dist`。
 3. 重新启动 AstrBot。
-4. 访问管理面板后按 `Ctrl+Shift+R` 或 `Ctrl+F5` 强制刷新页面。
+4. 访问管理面板后按 `Ctrl+Shift+R` 或 `Ctrl+F5`（macOS 用户请按 `Cmd+Shift+R`）强制刷新页面。
 
 重启后，AstrBot 会重新加载或下载匹配当前版本的 WebUI 文件。
 

--- a/docs/zh/faq.md
+++ b/docs/zh/faq.md
@@ -80,6 +80,7 @@ Set dashboard.host in data/cmd_config.json to enable remote access.
 1. 停止 AstrBot。
 2. 删除 AstrBot 的 `data` 目录下的 `dist` 文件夹，即 `AstrBot/data/dist`。
 3. 重新启动 AstrBot。
+4. 访问管理面板后按 `Ctrl+Shift+R` 或 `Ctrl+F5` 强制刷新页面。
 
 重启后，AstrBot 会重新加载或下载匹配当前版本的 WebUI 文件。
 


### PR DESCRIPTION
更新文档的FAQ，添加强制刷新页面的说明。

问就是在升级AstrBot的时候，按照文档操作发现新版密码无法登录，重试好几次查找FAQ都无果，最后发现是浏览器缓存未清理导致的，特加上这一句提醒读者注意。

### Modifications / 改动点
 - 修改了 `faq.md`，添加了一些说明

文件修改：
 - `docs\zh\faq.md`
 - `docs\en\faq.md`

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。


### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Documentation:
- Add a step in both English and Chinese FAQs instructing users to force-refresh the dashboard page after restarting AstrBot.