### PR TITLE
fix: emit final response after stream parse fallback

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -655,6 +655,9 @@ class ProviderOpenAIOfficial(Provider):
         llm_response = LLMResponse("assistant", is_chunk=True)
 
         state = ChatCompletionStreamState()
+        streamed_text_parts: list[str] = []
+        streamed_reasoning_parts: list[str] = []
+        latest_usage = None
 
         async for chunk in stream:
             choice = chunk.choices[0] if chunk.choices else None
@@ -688,20 +691,24 @@ class ProviderOpenAIOfficial(Provider):
             llm_response.completion_text = ""
             if reasoning is not None:
                 llm_response.reasoning_content = reasoning
+                streamed_reasoning_parts.append(reasoning)
                 _y = True
             if delta and delta.content:
                 # Don't strip streaming chunks to preserve spaces between words
                 completion_text = self._normalize_content(delta.content, strip=False)
+                streamed_text_parts.append(completion_text)
                 llm_response.result_chain = MessageChain(
                     chain=[Comp.Plain(completion_text)],
                 )
                 _y = True
             if chunk.usage:
                 llm_response.usage = self._extract_usage(chunk.usage)
+                latest_usage = llm_response.usage
             elif choice and (choice_usage := getattr(choice, "usage", None)):
                 # Workaround for some providers that only return usage in choices[].usage, e.g. MoonshotAI
                 # See https://github.com/AstrBotDevs/AstrBot/issues/6614
                 llm_response.usage = self._extract_usage(choice_usage)
+                latest_usage = llm_response.usage
                 state.current_completion_snapshot.usage = choice_usage
             if _y:
                 yield llm_response
@@ -712,8 +719,15 @@ class ProviderOpenAIOfficial(Provider):
             yield llm_response
         except Exception as e:
             logger.error("get_final_completion error: " + str(e))
-            # 流式内容已通过 yield 发出，记录错误后正常结束即可
-            return
+            if streamed_text_parts or streamed_reasoning_parts:
+                yield LLMResponse(
+                    "assistant",
+                    completion_text="".join(streamed_text_parts),
+                    reasoning_content="".join(streamed_reasoning_parts) or None,
+                    usage=latest_usage,
+                )
+                return
+            raise
 
     def _extract_reasoning_content(
         self,

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -1326,6 +1326,65 @@ async def test_query_stream_extracts_usage_from_empty_choices_chunk(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_query_stream_yields_final_response_when_final_completion_parse_fails(
+    monkeypatch,
+):
+    provider = _make_provider()
+    try:
+        chunks = [
+            ChatCompletionChunk.model_validate(
+                {
+                    "id": "chatcmpl-stream",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "gpt-4o-mini",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "role": "assistant",
+                                "content": "hello",
+                            },
+                            "finish_reason": None,
+                        }
+                    ],
+                }
+            )
+        ]
+
+        async def fake_stream():
+            for chunk in chunks:
+                yield chunk
+
+        async def fake_create(**kwargs):
+            return fake_stream()
+
+        async def fake_parse_completion(completion, tools):
+            raise EmptyModelOutputError("final completion was empty")
+
+        monkeypatch.setattr(provider.client.chat.completions, "create", fake_create)
+        monkeypatch.setattr(provider, "_parse_openai_completion", fake_parse_completion)
+
+        responses = [
+            response
+            async for response in provider._query_stream(
+                payloads={
+                    "model": "gpt-4o-mini",
+                    "messages": [{"role": "user", "content": "hello"}],
+                },
+                tools=None,
+            )
+        ]
+
+        assert len(responses) == 2
+        assert responses[0].is_chunk
+        assert not responses[-1].is_chunk
+        assert responses[-1].completion_text == "hello"
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
 async def test_query_filters_empty_assistant_message_without_tool_calls(monkeypatch):
     """Test that empty assistant messages without tool_calls are filtered out."""
     provider = _make_provider()


### PR DESCRIPTION
## Summary

- preserve streamed text, reasoning, and usage while reading OpenAI-compatible streaming chunks
- emit a final non-chunk assistant response from streamed content if final completion parsing fails
- re-raise the final parsing error when no usable streamed output exists

Fixes #8366

## Tests

- `uv run pytest tests/test_openai_source.py`
- `uv run ruff check astrbot/core/provider/sources/openai_source.py tests/test_openai_source.py`

## Summary by Sourcery

Ensure OpenAI-compatible streaming queries emit a usable final assistant response when final completion parsing fails while preserving streamed output.

Bug Fixes:
- Return a synthesized final assistant response from accumulated streaming chunks when final completion parsing fails but partial output exists.
- Propagate final completion parsing errors when no usable streamed content was produced to avoid silent failures.

Enhancements:
- Capture and aggregate streamed text, reasoning content, and usage metadata during OpenAI-compatible streaming responses for reuse in the final response.

Tests:
- Add a streaming query test that verifies a final non-chunk assistant response is emitted when final completion parsing raises an empty model output error.