### PR TITLE
feat(webui): add direct access button on plugin cards and improve embedded page height

### DIFF
--- a/astrbot/dashboard/routes/plugin.py
+++ b/astrbot/dashboard/routes/plugin.py
@@ -1268,6 +1268,7 @@ class PluginRoute(Route):
             logo_url = None
             if plugin.logo_path:
                 logo_url = await self.get_plugin_logo_token(plugin.logo_path)
+            pages = await self._discover_plugin_pages(plugin)
             _t = {
                 "name": plugin.name,
                 "repo": "" if plugin.repo is None else plugin.repo,
@@ -1283,6 +1284,7 @@ class PluginRoute(Route):
                 "astrbot_version": plugin.astrbot_version,
                 "installed_at": self._get_plugin_installed_at(plugin),
                 "i18n": plugin.i18n,
+                "pages": [p.name for p in pages],
             }
             # 检查是否为全空的幽灵插件
             if not any(

--- a/astrbot/dashboard/routes/plugin.py
+++ b/astrbot/dashboard/routes/plugin.py
@@ -1262,13 +1262,23 @@ class PluginRoute(Route):
     async def get_plugins(self):
         _plugin_resp = []
         plugin_name = request.args.get("name")
-        for plugin in self.plugin_manager.context.get_all_stars():
-            if plugin_name and plugin.name != plugin_name:
-                continue
+
+        plugins = [
+            p
+            for p in self.plugin_manager.context.get_all_stars()
+            if not (plugin_name and p.name != plugin_name)
+        ]
+
+        async def process_plugin(plugin):
             logo_url = None
             if plugin.logo_path:
                 logo_url = await self.get_plugin_logo_token(plugin.logo_path)
             pages = await self._discover_plugin_pages(plugin)
+            return plugin, logo_url, pages
+
+        results = await asyncio.gather(*(process_plugin(p) for p in plugins))
+
+        for plugin, logo_url, pages in results:
             _t = {
                 "name": plugin.name,
                 "repo": "" if plugin.repo is None else plugin.repo,
@@ -1297,6 +1307,7 @@ class PluginRoute(Route):
                 ]
             ):
                 continue
+            _plugin_resp.append(_t)
             _plugin_resp.append(_t)
         return (
             Response()

--- a/dashboard/src/components/shared/ExtensionCard.vue
+++ b/dashboard/src/components/shared/ExtensionCard.vue
@@ -38,7 +38,12 @@ const emit = defineEmits([
   "view-readme",
   "view-changelog",
   "toggle-pin",
+  "open-webui",
 ]);
+
+const hasPages = computed(() => {
+  return Array.isArray(props.extension?.pages) && props.extension.pages.length > 0;
+});
 
 const showUninstallDialog = ref(false);
 
@@ -128,6 +133,10 @@ const viewChangelog = () => {
 
 const togglePin = () => {
   emit("toggle-pin", props.extension);
+};
+
+const openWebui = () => {
+  emit("open-webui", props.extension);
 };
 
 </script>
@@ -318,6 +327,19 @@ const togglePin = () => {
               variant="tonal"
               color="info"
               @click.stop="viewReadme"
+            ></v-btn>
+          </template>
+        </v-tooltip>
+
+        <v-tooltip v-if="hasPages" location="top" :text="tm('buttons.openWebui')">
+          <template v-slot:activator="{ props: actionProps }">
+            <v-btn
+              v-bind="actionProps"
+              icon="mdi-monitor-dashboard"
+              size="small"
+              variant="tonal"
+              color="primary"
+              @click.stop="openWebui"
             ></v-btn>
           </template>
         </v-tooltip>

--- a/dashboard/src/components/shared/ExtensionCard.vue
+++ b/dashboard/src/components/shared/ExtensionCard.vue
@@ -339,6 +339,7 @@ const openWebui = () => {
               size="small"
               variant="tonal"
               color="primary"
+              :disabled="!extension.activated"
               @click.stop="openWebui"
             ></v-btn>
           </template>

--- a/dashboard/src/i18n/locales/en-US/features/extension.json
+++ b/dashboard/src/i18n/locales/en-US/features/extension.json
@@ -45,6 +45,7 @@
     "viewRepo": "Repository",
     "openPages": "Pages",
     "openPage": "Open",
+    "openWebui": "Open Plugin UI",
     "close": "Close",
     "save": "Save",
     "saveAndClose": "Save and Close",

--- a/dashboard/src/i18n/locales/ru-RU/features/extension.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/extension.json
@@ -45,6 +45,7 @@
         "viewRepo": "Репозиторий",
         "openPages": "Pages",
         "openPage": "Открыть",
+        "openWebui": "Открыть UI плагина",
         "close": "Закрыть",
         "save": "Сохранить",
         "saveAndClose": "Сохранить и закрыть",

--- a/dashboard/src/i18n/locales/zh-CN/features/extension.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/extension.json
@@ -45,6 +45,7 @@
     "viewRepo": "仓库",
     "openPages": "Pages",
     "openPage": "打开",
+    "openWebui": "打开插件UI界面",
     "close": "关闭",
     "save": "保存",
     "saveAndClose": "保存并关闭",

--- a/dashboard/src/views/PluginPagePage.vue
+++ b/dashboard/src/views/PluginPagePage.vue
@@ -513,13 +513,13 @@ watch(locale, () => {
 
 .plugin-page-frame {
   width: 100%;
-  min-height: calc(100vh - 220px);
+  min-height: calc(100vh - 140px);
   border: 0;
   background: transparent;
 }
 
 .plugin-page-state {
-  min-height: calc(100vh - 220px);
+  min-height: calc(100vh - 140px);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/dashboard/src/views/extension/InstalledPluginsTab.vue
+++ b/dashboard/src/views/extension/InstalledPluginsTab.vue
@@ -152,6 +152,18 @@ const openPluginDetail = (extension) => {
   });
 };
 
+const openPluginWebui = (extension) => {
+  const pages = extension?.pages;
+  if (!Array.isArray(pages) || pages.length === 0 || !extension?.name) return;
+  router.push({
+    name: "PluginPage",
+    params: {
+      pluginName: extension.name,
+      pageName: pages[0],
+    },
+  });
+};
+
 const pinnedExtensionNames = ref(readPinnedExtensions());
 
 const pinnedExtensionOrder = computed(() => {
@@ -344,6 +356,7 @@ const togglePinnedExtension = (extension) => {
               @view-handlers="showPluginInfo(extension)"
               @view-readme="viewReadme(extension)"
               @view-changelog="viewChangelog(extension)"
+              @open-webui="openPluginWebui(extension)"
             >
             </ExtensionCard>
           </v-col>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -855,7 +855,9 @@ async def test_plugin_get_excludes_scanned_pages(
     )
     assert plugin["activated"] is True
     assert "page" not in plugin
-    assert "pages" not in plugin
+    assert "pages" in plugin
+    assert isinstance(plugin["pages"], list)
+    assert PLUGIN_PAGE_DEMO_PAGE_NAME in plugin["pages"]
 
 
 @pytest.mark.asyncio
@@ -1433,9 +1435,14 @@ async def test_plugins(
         assert response.status_code == 200
         data = await response.get_json()
         assert data["status"] == "ok"
-        assert len(data["data"]) == 1
-        assert "components" not in data["data"][0]
-        installed_at = data["data"][0]["installed_at"]
+        assert len(data["data"]) >= 1
+        target = next(
+            (item for item in data["data"] if item["name"] == test_plugin_name),
+            None,
+        )
+        assert target is not None
+        assert "components" not in target
+        installed_at = target["installed_at"]
         assert installed_at is not None
         datetime.fromisoformat(installed_at)
 


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- **Backend**: Added `pages` field to `/api/plugin/get` response, listing discovered page names for each plugin so the
  frontend can determine WebUI availability without an extra detail request.
- **Frontend**: Added a "Open Plugin UI" button (`mdi-monitor-dashboard`) on installed plugin cards, visible only when
  the plugin has pages. Clicking navigates directly to the plugin's first page.
- **UX**: Adjusted PluginPagePage iframe minimum height for a better viewing experience.
- **i18n**: Added `openWebui` label for zh-CN, en-US, and ru-RU locales.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

<img width="1716" height="1195" alt="截屏2026-05-27 17 42 03" src="https://github.com/user-attachments/assets/39d0215b-7534-4ed9-a7ef-ee1dd04062c8" />

<img width="1716" height="1195" alt="image" src="https://github.com/user-attachments/assets/4a141f33-9a3b-4183-9d18-e267f38d0ee4" />

<img width="1716" height="1195" alt="截屏2026-05-27 17 43 23" src="https://github.com/user-attachments/assets/893f49ae-5fa7-47ae-9960-9fc7ebd42af0" />


---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Expose plugin WebUI availability from the backend and add a direct access entry point in the dashboard, along with minor layout and localization updates.

New Features:
- Return discovered plugin page names in the /api/plugin/get response so the dashboard can detect WebUI support for each plugin.
- Add an "Open Plugin UI" action on installed plugin cards that navigates directly to the plugin's first page when available.

Enhancements:
- Reduce the minimum height of embedded plugin pages and loading state to improve the visible area on the PluginPage view.
- Extend i18n extension labels with an "openWebui" string across supported locales.