### PR TITLE
fix(dashboard): add sub-command count label

### DIFF
--- a/dashboard/src/i18n/locales/en-US/features/extension.json
+++ b/dashboard/src/i18n/locales/en-US/features/extension.json
@@ -107,6 +107,7 @@
     "docsEmpty": "No documentation",
     "changelogTitle": "Changelog",
     "changelogEmpty": "No changelog",
+    "subCommandsCount": "{count} sub-commands",
     "handlerGroups": {
       "page": "Pages",
       "skill": "Skills",

--- a/dashboard/src/i18n/locales/ru-RU/features/extension.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/extension.json
@@ -107,6 +107,7 @@
         "docsEmpty": "Документация отсутствует",
         "changelogTitle": "Журнал изменений",
         "changelogEmpty": "Журнал изменений отсутствует",
+        "subCommandsCount": "{count} подкоманд",
         "handlerGroups": {
             "page": "Pages",
             "skill": "Skills",

--- a/dashboard/src/i18n/locales/zh-CN/features/extension.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/extension.json
@@ -107,6 +107,7 @@
     "docsEmpty": "暂无文档",
     "changelogTitle": "更新日志",
     "changelogEmpty": "暂无更新日志",
+    "subCommandsCount": "{count} 个子指令",
     "handlerGroups": {
       "page": "页面",
       "skill": "技能",


### PR DESCRIPTION
## Summary
- add the missing detail.subCommandsCount translation used by the plugin detail command-group row
- keep zh-CN, en-US, and ru-RU locale files in sync so the dashboard no longer renders [MISSING: features.extension.detail.subCommandsCount]

Fixes #8378

## To verify
- node -e JSON.parse(fs.readFileSync(...)) over the three extension locale files
- npm run typecheck
- git diff --check

## Summary by Sourcery

Add the missing sub-commands count translation to the dashboard extension detail view and synchronize the affected locale files.

Bug Fixes:
- Restore the missing features.extension.detail.subCommandsCount label so the dashboard no longer renders a missing-translation placeholder.

Enhancements:
- Align en-US, zh-CN, and ru-RU extension locale files to keep translation keys consistent across languages.