### PR TITLE
feat: sync dashboard theme to plugin pages

### DIFF
--- a/astrbot/dashboard/plugin_page_bridge.js
+++ b/astrbot/dashboard/plugin_page_bridge.js
@@ -125,6 +125,12 @@
       ...(context || {}),
       ...nextContext,
     };
+    if (typeof nextContext.isDark === "boolean") {
+      document.documentElement.setAttribute(
+        "data-theme",
+        nextContext.isDark ? "dark" : "light",
+      );
+    }
     if (resolveReady) {
       resolveReady(context);
       resolveReady = null;

--- a/astrbot/dashboard/routes/plugin.py
+++ b/astrbot/dashboard/routes/plugin.py
@@ -229,6 +229,30 @@ class PluginRoute(Route):
             return default
         return locale
 
+    @staticmethod
+    def _get_request_theme() -> str | None:
+        theme = request.args.get("theme", "").strip()
+        return theme if theme in ("dark", "light") else None
+
+    @staticmethod
+    def _apply_theme_to_html(html: str, theme: str) -> str:
+        html = re.sub(
+            r"(<html\b[^>]*?)>",
+            rf'\1 data-theme="{theme}">',
+            html,
+            count=1,
+            flags=re.IGNORECASE,
+        )
+        meta_tag = f'<meta name="color-scheme" content="{theme}">'
+        head_match = re.search(r"<head\b[^>]*>", html, re.IGNORECASE)
+        if head_match:
+            html = html.replace(
+                head_match.group(0), f"{head_match.group(0)}{meta_tag}", 1
+            )
+        else:
+            html = html.replace("<html", f"<html><head>{meta_tag}</head>", 1)
+        return html
+
     def _get_plugin_page_initial_context(self) -> dict | None:
         asset_token = request.args.get("asset_token", "").strip()
         if not asset_token:
@@ -277,7 +301,7 @@ class PluginRoute(Route):
             self._get_by_path(locale_data, f"pages.{page_name}.title") or page_name
         )
 
-        theme = request.args.get("theme", "").strip()
+        theme = self._get_request_theme()
 
         return {
             "pluginName": plugin.name,
@@ -286,7 +310,7 @@ class PluginRoute(Route):
             "pageTitle": page_title,
             "locale": locale,
             "i18n": plugin_i18n,
-            "isDark": theme == "dark",
+            "isDark": theme == "dark" if theme else False,
         }
 
     @staticmethod
@@ -593,34 +617,9 @@ class PluginRoute(Route):
                 return match.group(0)
 
         rewritten_html = _HTML_ASSET_ATTR_RE.sub(replace_attr, html_text)
-        theme = (extra_query_params or {}).get("theme", "")
-        if theme in ("dark", "light"):
-            rewritten_html = re.sub(
-                r"(<html\b[^>]*?)>",
-                rf'\1 data-theme="{theme}">',
-                rewritten_html,
-                count=1,
-                flags=re.IGNORECASE,
-            )
-            color_scheme_meta = (
-                f'<meta name="color-scheme" content="{theme}">'
-            )
-            if re.search(r"<head\b", rewritten_html, re.IGNORECASE):
-                rewritten_html = re.sub(
-                    r"(<head\b[^>]*>)",
-                    rf"\1\n    {color_scheme_meta}",
-                    rewritten_html,
-                    count=1,
-                    flags=re.IGNORECASE,
-                )
-            elif re.search(r"<html\b", rewritten_html, re.IGNORECASE):
-                rewritten_html = re.sub(
-                    r"(<html\b[^>]*?>)",
-                    rf"\1\n  <head>\n    {color_scheme_meta}\n  </head>",
-                    rewritten_html,
-                    count=1,
-                    flags=re.IGNORECASE,
-                )
+        theme = (extra_query_params or {}).get("theme")
+        if theme:
+            rewritten_html = self._apply_theme_to_html(rewritten_html, theme)
         if "/api/plugin/page/bridge-sdk.js" not in rewritten_html:
             bridge_tag = f'<script src="{self._get_plugin_page_bridge_sdk_url(extra_query_params)}"></script>'
             if "</body>" in rewritten_html:
@@ -808,8 +807,8 @@ class PluginRoute(Route):
             )
         if asset_token:
             params["asset_token"] = asset_token
-        theme = request.args.get("theme", "").strip()
-        if theme in ("dark", "light"):
+        theme = self._get_request_theme()
+        if theme:
             params["theme"] = theme
         return params or None
 

--- a/astrbot/dashboard/routes/plugin.py
+++ b/astrbot/dashboard/routes/plugin.py
@@ -593,6 +593,32 @@ class PluginRoute(Route):
                 return match.group(0)
 
         rewritten_html = _HTML_ASSET_ATTR_RE.sub(replace_attr, html_text)
+        theme = (extra_query_params or {}).get("theme", "")
+        if theme in ("dark", "light"):
+            rewritten_html = re.sub(
+                r"(<html\b[^>]*?)>",
+                rf'\1 data-theme="{theme}">',
+                rewritten_html,
+                count=1,
+                flags=re.IGNORECASE,
+            )
+            color_scheme_meta = (
+                f'<meta name="color-scheme" content="{theme}">'
+            )
+            if "<head>" in rewritten_html:
+                rewritten_html = rewritten_html.replace(
+                    "<head>",
+                    f"<head>\n    {color_scheme_meta}",
+                    1,
+                )
+            elif re.search(r"<html\b", rewritten_html, re.IGNORECASE):
+                rewritten_html = re.sub(
+                    r"(<html\b[^>]*?>)",
+                    rf"\1\n  <head>\n    {color_scheme_meta}\n  </head>",
+                    rewritten_html,
+                    count=1,
+                    flags=re.IGNORECASE,
+                )
         if "/api/plugin/page/bridge-sdk.js" not in rewritten_html:
             bridge_tag = f'<script src="{self._get_plugin_page_bridge_sdk_url(extra_query_params)}"></script>'
             if "</body>" in rewritten_html:

--- a/astrbot/dashboard/routes/plugin.py
+++ b/astrbot/dashboard/routes/plugin.py
@@ -277,6 +277,8 @@ class PluginRoute(Route):
             self._get_by_path(locale_data, f"pages.{page_name}.title") or page_name
         )
 
+        theme = request.args.get("theme", "").strip()
+
         return {
             "pluginName": plugin.name,
             "displayName": display_name,
@@ -284,6 +286,7 @@ class PluginRoute(Route):
             "pageTitle": page_title,
             "locale": locale,
             "i18n": plugin_i18n,
+            "isDark": theme == "dark",
         }
 
     @staticmethod
@@ -769,12 +772,18 @@ class PluginRoute(Route):
         plugin_name: str,
         page_name: str,
     ) -> dict[str, str] | None:
+        params: dict[str, str] = {}
         asset_token = request.args.get("asset_token", "").strip()
         if not asset_token:
             asset_token = (
                 self._issue_plugin_page_asset_token(plugin_name, page_name) or ""
             )
-        return {"asset_token": asset_token} if asset_token else None
+        if asset_token:
+            params["asset_token"] = asset_token
+        theme = request.args.get("theme", "").strip()
+        if theme in ("dark", "light"):
+            params["theme"] = theme
+        return params or None
 
     @staticmethod
     async def _plugin_page_error_response(status_code: int, message: str):

--- a/astrbot/dashboard/routes/plugin.py
+++ b/astrbot/dashboard/routes/plugin.py
@@ -335,7 +335,7 @@ class PluginRoute(Route):
             "pageTitle": page_title,
             "locale": locale,
             "i18n": plugin_i18n,
-            "isDark": theme == "dark" if theme else False,
+            "isDark": theme == "dark",
         }
 
     @staticmethod
@@ -824,18 +824,22 @@ class PluginRoute(Route):
         plugin_name: str,
         page_name: str,
     ) -> dict[str, str] | None:
-        params: dict[str, str] = {}
         asset_token = request.args.get("asset_token", "").strip()
         if not asset_token:
             asset_token = (
                 self._issue_plugin_page_asset_token(plugin_name, page_name) or ""
             )
+        theme = self._get_request_theme()
+
+        if not asset_token and not theme:
+            return None
+
+        params: dict[str, str] = {}
         if asset_token:
             params["asset_token"] = asset_token
-        theme = self._get_request_theme()
         if theme:
             params["theme"] = theme
-        return params or None
+        return params
 
     @staticmethod
     async def _plugin_page_error_response(status_code: int, message: str):

--- a/astrbot/dashboard/routes/plugin.py
+++ b/astrbot/dashboard/routes/plugin.py
@@ -236,21 +236,33 @@ class PluginRoute(Route):
 
     @staticmethod
     def _apply_theme_to_html(html: str, theme: str) -> str:
+        def _replace_html_tag(m: re.Match) -> str:
+            attrs = m.group(1) or ""
+            attrs = re.sub(
+                r'\s+data-theme\s*=\s*["\'][^"\']*["\']',
+                "",
+                attrs,
+                flags=re.IGNORECASE,
+            )
+            return f'<html{attrs} data-theme="{theme}">'
+
         html = re.sub(
-            r"\s+data-theme\s*=\s*[\"'][^\"']*[\"']",
+            r"<html(\b[^>]*)>",
+            _replace_html_tag,
+            html,
+            count=1,
+            flags=re.IGNORECASE,
+        )
+
+        meta_tag = f'<meta name="color-scheme" content="{theme}">'
+
+        html = re.sub(
+            r'<meta\s[^>]*name\s*=\s*["\']color-scheme["\'][^>]*>',
             "",
             html,
-            count=1,
             flags=re.IGNORECASE,
         )
-        html = re.sub(
-            r"(<html\b[^>]*?)>",
-            rf'\1 data-theme="{theme}">',
-            html,
-            count=1,
-            flags=re.IGNORECASE,
-        )
-        meta_tag = f'<meta name="color-scheme" content="{theme}">'
+
         head_match = re.search(r"<head\b[^>]*>", html, re.IGNORECASE)
         if head_match:
             html = html.replace(
@@ -258,7 +270,7 @@ class PluginRoute(Route):
             )
         else:
             html = re.sub(
-                r"(<html\b[^>]*?>)",
+                r"(<html\b[^>]*>)",
                 rf"\1<head>{meta_tag}</head>",
                 html,
                 count=1,
@@ -630,7 +642,7 @@ class PluginRoute(Route):
                 return match.group(0)
 
         rewritten_html = _HTML_ASSET_ATTR_RE.sub(replace_attr, html_text)
-        theme = (extra_query_params or {}).get("theme")
+        theme = self._get_request_theme()
         if theme:
             rewritten_html = self._apply_theme_to_html(rewritten_html, theme)
         if "/api/plugin/page/bridge-sdk.js" not in rewritten_html:

--- a/astrbot/dashboard/routes/plugin.py
+++ b/astrbot/dashboard/routes/plugin.py
@@ -237,6 +237,13 @@ class PluginRoute(Route):
     @staticmethod
     def _apply_theme_to_html(html: str, theme: str) -> str:
         html = re.sub(
+            r"\s+data-theme\s*=\s*[\"'][^\"']*[\"']",
+            "",
+            html,
+            count=1,
+            flags=re.IGNORECASE,
+        )
+        html = re.sub(
             r"(<html\b[^>]*?)>",
             rf'\1 data-theme="{theme}">',
             html,
@@ -250,7 +257,13 @@ class PluginRoute(Route):
                 head_match.group(0), f"{head_match.group(0)}{meta_tag}", 1
             )
         else:
-            html = html.replace("<html", f"<html><head>{meta_tag}</head>", 1)
+            html = re.sub(
+                r"(<html\b[^>]*?>)",
+                rf"\1<head>{meta_tag}</head>",
+                html,
+                count=1,
+                flags=re.IGNORECASE,
+            )
         return html
 
     def _get_plugin_page_initial_context(self) -> dict | None:

--- a/astrbot/dashboard/routes/plugin.py
+++ b/astrbot/dashboard/routes/plugin.py
@@ -605,11 +605,13 @@ class PluginRoute(Route):
             color_scheme_meta = (
                 f'<meta name="color-scheme" content="{theme}">'
             )
-            if "<head>" in rewritten_html:
-                rewritten_html = rewritten_html.replace(
-                    "<head>",
-                    f"<head>\n    {color_scheme_meta}",
-                    1,
+            if re.search(r"<head\b", rewritten_html, re.IGNORECASE):
+                rewritten_html = re.sub(
+                    r"(<head\b[^>]*>)",
+                    rf"\1\n    {color_scheme_meta}",
+                    rewritten_html,
+                    count=1,
+                    flags=re.IGNORECASE,
                 )
             elif re.search(r"<html\b", rewritten_html, re.IGNORECASE):
                 rewritten_html = re.sub(

--- a/dashboard/src/stores/customizer.ts
+++ b/dashboard/src/stores/customizer.ts
@@ -1,6 +1,8 @@
 import { defineStore } from 'pinia';
 import config from '@/config';
 
+const DARK_THEMES: ReadonlySet<string> = new Set(['PurpleThemeDark']);
+
 export const useCustomizerStore = defineStore("customizer", {
   state: () => ({
     Sidebar_drawer: config.Sidebar_drawer,
@@ -13,7 +15,7 @@ export const useCustomizerStore = defineStore("customizer", {
   }),
 
   getters: {
-    isDark: (state) => state.uiTheme === 'PurpleThemeDark',
+    isDark: (state) => state.uiTheme ? DARK_THEMES.has(state.uiTheme) : false,
   },
   actions: {
     SET_SIDEBAR_DRAWER() {

--- a/dashboard/src/stores/customizer.ts
+++ b/dashboard/src/stores/customizer.ts
@@ -13,7 +13,7 @@ export const useCustomizerStore = defineStore("customizer", {
   }),
 
   getters: {
-    isDark: (state) => state.uiTheme.endsWith('Dark'),
+    isDark: (state) => state.uiTheme?.endsWith('Dark') ?? false,
   },
   actions: {
     SET_SIDEBAR_DRAWER() {

--- a/dashboard/src/stores/customizer.ts
+++ b/dashboard/src/stores/customizer.ts
@@ -13,7 +13,7 @@ export const useCustomizerStore = defineStore("customizer", {
   }),
 
   getters: {
-    isDark: (state) => state.uiTheme?.endsWith('Dark') ?? false,
+    isDark: (state) => state.uiTheme === 'PurpleThemeDark',
   },
   actions: {
     SET_SIDEBAR_DRAWER() {

--- a/dashboard/src/stores/customizer.ts
+++ b/dashboard/src/stores/customizer.ts
@@ -12,7 +12,9 @@ export const useCustomizerStore = defineStore("customizer", {
     chatSidebarOpen: false // chat mode mobile sidebar state
   }),
 
-  getters: {},
+  getters: {
+    isDark: (state) => state.uiTheme === 'PurpleThemeDark',
+  },
   actions: {
     SET_SIDEBAR_DRAWER() {
       this.Sidebar_drawer = !this.Sidebar_drawer;

--- a/dashboard/src/stores/customizer.ts
+++ b/dashboard/src/stores/customizer.ts
@@ -13,7 +13,7 @@ export const useCustomizerStore = defineStore("customizer", {
   }),
 
   getters: {
-    isDark: (state) => state.uiTheme === 'PurpleThemeDark',
+    isDark: (state) => state.uiTheme.endsWith('Dark'),
   },
   actions: {
     SET_SIDEBAR_DRAWER() {

--- a/dashboard/src/views/PluginPagePage.vue
+++ b/dashboard/src/views/PluginPagePage.vue
@@ -4,6 +4,7 @@ import { computed, onBeforeUnmount, onMounted, ref, toRaw, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useModuleI18n } from "@/i18n/composables";
 import { usePluginI18n } from "@/utils/pluginI18n";
+import { useCustomizerStore } from "@/stores/customizer";
 
 const BRIDGE_CHANNEL = "astrbot-plugin-page";
 
@@ -15,6 +16,7 @@ const {
   pluginName: pluginDisplayName,
   pluginPageTitle,
 } = usePluginI18n();
+const customizer = useCustomizerStore();
 
 const loading = ref(true);
 const errorMessage = ref("");
@@ -202,6 +204,7 @@ const sendIframeContext = () => {
       pageTitle: localizedPageTitle.value,
       locale: locale.value,
       i18n: toPostMessageData(plugin.value.i18n, {}),
+      isDark: customizer.isDark,
     },
   });
 };
@@ -432,7 +435,9 @@ const loadPluginPage = async () => {
 
     plugin.value = pluginData;
     page.value = pageEntry;
-    iframeSrc.value = pageEntry.content_path;
+    const contentUrl = new URL(pageEntry.content_path, window.location.origin);
+    contentUrl.searchParams.set('theme', customizer.isDark ? 'dark' : 'light');
+    iframeSrc.value = contentUrl.pathname + contentUrl.search;
   } catch (error) {
     errorMessage.value =
       error?.response?.data?.message ||
@@ -454,6 +459,9 @@ onBeforeUnmount(() => {
 
 watch([pluginName, pageName], loadPluginPage, { immediate: true });
 watch(locale, () => {
+  sendIframeContext();
+});
+watch(() => customizer.uiTheme, () => {
   sendIframeContext();
 });
 </script>

--- a/dashboard/src/views/PluginPagePage.vue
+++ b/dashboard/src/views/PluginPagePage.vue
@@ -38,6 +38,7 @@ const localizedPageTitle = computed(() =>
   ),
 );
 const getIframeWindow = () => iframeRef.value?.contentWindow || null;
+const themeParam = computed(() => customizer.isDark ? "dark" : "light");
 
 const toPostMessageData = (value, fallback = null) => {
   try {
@@ -436,8 +437,8 @@ const loadPluginPage = async () => {
     plugin.value = pluginData;
     page.value = pageEntry;
     const contentUrl = new URL(pageEntry.content_path, window.location.origin);
-    contentUrl.searchParams.set('theme', customizer.isDark ? 'dark' : 'light');
-    iframeSrc.value = contentUrl.pathname + contentUrl.search;
+    contentUrl.searchParams.set('theme', themeParam.value);
+    iframeSrc.value = contentUrl.pathname + contentUrl.search + contentUrl.hash;
   } catch (error) {
     errorMessage.value =
       error?.response?.data?.message ||

--- a/docs/en/dev/star/guides/plugin-pages.md
+++ b/docs/en/dev/star/guides/plugin-pages.md
@@ -116,7 +116,8 @@ The current `ready()` context looks like this:
   "pageName": "bridge-demo",
   "pageTitle": "Bridge Demo",
   "locale": "en-US",
-  "i18n": {}
+  "i18n": {},
+  "isDark": false
 }
 ```
 
@@ -167,6 +168,56 @@ If an inline script needs to access `window.AstrBotPluginPage` synchronously, mo
 ```html
 <script src="/api/plugin/page/bridge-sdk.js"></script>
 ```
+
+## Light/Dark Theme Adaptation
+
+When the user toggles light/dark mode in AstrBot, the theme state is automatically synced to Plugin Pages. The bridge SDK maintains a `data-theme` attribute on the `<html>` element:
+
+- Light mode: `<html data-theme="light">`
+- Dark mode: `<html data-theme="dark">`
+
+### CSS Adaptation
+
+CSS variables are the recommended approach:
+
+```css
+:root {
+  --bg: #ffffff;
+  --text: #1a1a1a;
+}
+
+[data-theme="dark"] {
+  --bg: #1a1a1a;
+  --text: #e0e0e0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+}
+```
+
+AstrBot injects the `data-theme` attribute on the `<html>` tag server-side when serving HTML, so there is no initial flash.
+
+### Responding to Theme Changes in JavaScript
+
+The `isDark` field in the context indicates whether dark mode is active. Use `onContext()` to listen for theme changes:
+
+```js
+const bridge = window.AstrBotPluginPage;
+
+function render() {
+  if (bridge.getContext()?.isDark) {
+    // JS logic for dark mode (e.g. chart filters)
+  }
+}
+
+await bridge.ready();
+render();
+bridge.onContext(render);
+```
+
+When the theme is toggled, the Dashboard sends the updated context to the iframe via the bridge. As long as the Page listens with `onContext()`, it will be notified.
 
 ## Asset Path Rules
 
@@ -232,7 +283,8 @@ The context usually contains:
   "pageName": "bridge-demo",
   "pageTitle": "Bridge Demo",
   "locale": "en-US",
-  "i18n": {}
+  "i18n": {},
+  "isDark": false
 }
 ```
 

--- a/docs/zh/dev/star/guides/plugin-pages.md
+++ b/docs/zh/dev/star/guides/plugin-pages.md
@@ -116,7 +116,8 @@ class MyPlugin(Star):
   "pageName": "bridge-demo",
   "pageTitle": "Bridge Demo",
   "locale": "zh-CN",
-  "i18n": {}
+  "i18n": {},
+  "isDark": false
 }
 ```
 
@@ -167,6 +168,56 @@ bridge.onContext(render);
 ```html
 <script src="/api/plugin/page/bridge-sdk.js"></script>
 ```
+
+## 亮暗主题适配
+
+AstrBot 切换亮色/暗色模式时，会自动将主题状态同步给插件 Page。bridge SDK 会在 `<html>` 元素上维护 `data-theme` 属性：
+
+- 亮色模式：`<html data-theme="light">`
+- 暗色模式：`<html data-theme="dark">`
+
+### CSS 适配
+
+推荐使用 CSS 变量：
+
+```css
+:root {
+  --bg: #ffffff;
+  --text: #1a1a1a;
+}
+
+[data-theme="dark"] {
+  --bg: #1a1a1a;
+  --text: #e0e0e0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+}
+```
+
+AstrBot 在服务端返回 HTML 时，会自动在 `<html>` 标签上注入 `data-theme` 属性，不会出现初始闪烁。
+
+### JavaScript 响应主题变化
+
+上下文中的 `isDark` 字段表示当前是否为暗色模式。通过 `onContext()` 可以监听主题切换：
+
+```js
+const bridge = window.AstrBotPluginPage;
+
+function render() {
+  if (bridge.getContext()?.isDark) {
+    // 暗色模式下的 JS 逻辑（如图表滤镜等）
+  }
+}
+
+await bridge.ready();
+render();
+bridge.onContext(render);
+```
+
+切换亮暗模式时，Dashboard 会通过 bridge 将更新后的上下文发送给 iframe；只要 Page 监听了 `onContext()`，就会收到通知。
 
 ## 静态资源路径规则
 
@@ -232,7 +283,8 @@ console.log(context.pluginName, context.pageName, context.locale);
   "pageName": "bridge-demo",
   "pageTitle": "Bridge Demo",
   "locale": "zh-CN",
-  "i18n": {}
+  "i18n": {},
+  "isDark": false
 }
 ```
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1082,7 +1082,9 @@ async def test_plugin_page_bridge_sdk_includes_is_dark_when_theme_param_provided
     assert '"isDark": true' in dark_js
 
     # theme=light → isDark: false
-    light_response = await anonymous_client.get(bridge_sdk_url.group(1) + "&theme=light")
+    light_response = await anonymous_client.get(
+        bridge_sdk_url.group(1) + "&theme=light"
+    )
     assert light_response.status_code == 200
     light_js = (await light_response.get_data()).decode("utf-8")
     assert '"isDark": false' in light_js
@@ -1094,7 +1096,9 @@ async def test_plugin_page_bridge_sdk_includes_is_dark_when_theme_param_provided
     assert '"isDark": false' in base_js
 
     # invalid theme value → should NOT be treated as dark
-    invalid_response = await anonymous_client.get(bridge_sdk_url.group(1) + "&theme=invalid")
+    invalid_response = await anonymous_client.get(
+        bridge_sdk_url.group(1) + "&theme=invalid"
+    )
     assert invalid_response.status_code == 200
     invalid_js = (await invalid_response.get_data()).decode("utf-8")
     assert '"isDark": false' in invalid_js

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1054,6 +1054,115 @@ async def test_plugin_page_content_issues_scoped_asset_token(
 
 
 @pytest.mark.asyncio
+async def test_plugin_page_bridge_sdk_includes_is_dark_when_theme_param_provided(
+    app: Quart,
+    authenticated_header: dict,
+    registered_plugin_page: StarMetadata,
+):
+    """Bridge SDK initial context should include isDark based on ?theme= query param."""
+    authorized_client = app.test_client()
+    response = await authorized_client.get(
+        f"/api/plugin/page/content/{PLUGIN_PAGE_DEMO_NAME}/{PLUGIN_PAGE_DEMO_PAGE_NAME}/",
+        headers=authenticated_header,
+    )
+    assert response.status_code == 200
+    html_text = (await response.get_data()).decode("utf-8")
+    bridge_sdk_url = re.search(
+        r'src="([^"]+/bridge-sdk\.js[^"]*)"',
+        html_text,
+    )
+    assert bridge_sdk_url is not None
+
+    anonymous_client = app.test_client()
+
+    # theme=dark → isDark: true
+    dark_response = await anonymous_client.get(bridge_sdk_url.group(1) + "&theme=dark")
+    assert dark_response.status_code == 200
+    dark_js = (await dark_response.get_data()).decode("utf-8")
+    assert '"isDark": true' in dark_js
+
+    # theme=light → isDark: false
+    light_response = await anonymous_client.get(bridge_sdk_url.group(1) + "&theme=light")
+    assert light_response.status_code == 200
+    light_js = (await light_response.get_data()).decode("utf-8")
+    assert '"isDark": false' in light_js
+
+    # no theme param → isDark: false (default)
+    base_response = await anonymous_client.get(bridge_sdk_url.group(1))
+    assert base_response.status_code == 200
+    base_js = (await base_response.get_data()).decode("utf-8")
+    assert '"isDark": false' in base_js
+
+    # invalid theme value → should NOT be treated as dark
+    invalid_response = await anonymous_client.get(bridge_sdk_url.group(1) + "&theme=invalid")
+    assert invalid_response.status_code == 200
+    invalid_js = (await invalid_response.get_data()).decode("utf-8")
+    assert '"isDark": false' in invalid_js
+
+
+@pytest.mark.asyncio
+async def test_plugin_page_content_propagates_theme_in_rewritten_urls(
+    app: Quart,
+    authenticated_header: dict,
+    registered_plugin_page: StarMetadata,
+):
+    """Theme query param should be propagated through rewritten asset and bridge URLs."""
+    test_client = app.test_client()
+    response = await test_client.get(
+        f"/api/plugin/page/content/{PLUGIN_PAGE_DEMO_NAME}/{PLUGIN_PAGE_DEMO_PAGE_NAME}/"
+        "?asset_token=&theme=dark",
+        headers=authenticated_header,
+    )
+    assert response.status_code == 200
+    html_text = (await response.get_data()).decode("utf-8")
+
+    # Verify theme=dark appears in bridge SDK URL in rewritten HTML
+    bridge_sdk_url_match = re.search(
+        r'src="([^"]+/bridge-sdk\.js[^"]*)"',
+        html_text,
+    )
+    assert bridge_sdk_url_match is not None
+    bridge_query = parse_qs(urlsplit(bridge_sdk_url_match.group(1)).query)
+    assert bridge_query.get("theme") == ["dark"]
+
+    # Verify theme=dark appears in CSS asset URL in rewritten HTML
+    css_url_match = re.search(
+        r'href="([^"]+/base\.css[^"]*)"',
+        html_text,
+    )
+    assert css_url_match is not None
+    css_query = parse_qs(urlsplit(css_url_match.group(1)).query)
+    assert css_query.get("theme") == ["dark"]
+
+    # Verify data-theme is injected on <html> tag to prevent flash
+    assert 'data-theme="dark"' in html_text
+    # Verify color-scheme meta tag is injected for browser-level default styles
+    assert '<meta name="color-scheme" content="dark">' in html_text
+
+    # theme=light → data-theme="light" on <html> and color-scheme meta
+    light_response = await test_client.get(
+        f"/api/plugin/page/content/{PLUGIN_PAGE_DEMO_NAME}/{PLUGIN_PAGE_DEMO_PAGE_NAME}/"
+        "?asset_token=&theme=light",
+        headers=authenticated_header,
+    )
+    assert light_response.status_code == 200
+    light_html = (await light_response.get_data()).decode("utf-8")
+    assert 'data-theme="light"' in light_html
+    assert '<meta name="color-scheme" content="light">' in light_html
+
+    # no theme param → no data-theme or color-scheme meta on <html>
+    no_theme_response = await test_client.get(
+        f"/api/plugin/page/content/{PLUGIN_PAGE_DEMO_NAME}/{PLUGIN_PAGE_DEMO_PAGE_NAME}/"
+        "?asset_token=",
+        headers=authenticated_header,
+    )
+    assert no_theme_response.status_code == 200
+    no_theme_html = (await no_theme_response.get_data()).decode("utf-8")
+    assert "data-theme=" not in no_theme_html
+    assert "color-scheme" not in no_theme_html
+
+
+@pytest.mark.asyncio
 async def test_plugin_page_assets_require_dashboard_auth(
     app: Quart,
     authenticated_header: dict,


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

Plugin pages embedded via iframe had no awareness of the dashboard's light/dark theme state, causing two problems:
  1. Plugin UIs always rendered in light mode regardless of the dashboard theme
  2. When entering a plugin page in dark mode, there was a visible flash of light mode before the bridge SDK initialized

  This PR adds an end-to-end theme sync mechanism so plugin pages automatically match the dashboard theme on load and react to live theme switching, with the initial theme applied server-side to eliminate flash.

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- Backend (plugin.py): Added theme query parameter propagation through the plugin page asset pipeline. The _get_plugin_page_initial_context now includes isDark. The HTML rewriter injects data-theme on <html> and a <meta name="color-scheme"> tag server-side to prevent initial flash.
- Bridge SDK (plugin_page_bridge.js): applyContext() now sets data-theme on document.documentElement when context includes isDark, enabling live theme switching.
- Frontend (PluginPagePage.vue): Appends &theme=dark/light to iframe URL and includes isDark in postMessage context. Watches uiTheme to re-send context on theme toggle.
- Store (customizer.ts): Added isDark getter.
- Tests: Added tests for isDark in bridge SDK initial context (dark/light/absent/invalid params) and theme propagation in rewritten HTML (data-theme, color-scheme meta).
- Docs: Added light/dark theme adaptation section to plugin-pages guide (zh + en).

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

Testing on the `astrbot_plugin_livingmemory` plugin showed that switching between light and dark themes using AstrBot's built-in theme switching function resulted in the Livingmemory WebUI switching themes accordingly. Furthermore, the WebUI could be switched back to the opposite theme without affecting the display of the AstrBot WebUI.

The current default behavior is to maintain the same light/dark theme as the AstrBot WebUI when entering the plugin's WebUI.

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Synchronize the dashboard’s light/dark theme with plugin pages and eliminate initial theme flash for iframe-embedded plugin UIs.

New Features:
- Propagate the dashboard light/dark theme into plugin page contexts via an isDark flag and theme query parameter so plugin pages can render with the correct theme on load.
- Automatically apply and update a data-theme attribute on plugin page HTML and the bridge SDK to keep plugin UIs in sync with live theme changes from the dashboard.

Bug Fixes:
- Remove a duplicated plugin response append in the plugin processing logic.

Enhancements:
- Extend the plugin page asset rewriting pipeline to carry through theme parameters and inject a color-scheme meta tag for browser-level dark/light defaults.
- Expose an isDark getter in the customizer store and ensure plugin iframe URLs include the current theme so the initial render matches the dashboard state.

Documentation:
- Update English and Chinese plugin page guides to document isDark in the bridge context and describe how to adapt CSS/JS to light/dark theme changes.

Tests:
- Add backend tests covering isDark handling in the bridge SDK script and theme propagation into rewritten HTML, including data-theme and color-scheme meta behavior.

## Summary by Sourcery

Synchronize the dashboard’s light/dark theme with iframe-embedded plugin pages so they load with the correct theme and stay in sync with live theme changes.

New Features:
- Propagate the dashboard theme into plugin page contexts via a theme query parameter and isDark flag, enabling plugin UIs to render in the correct light/dark mode.
- Auto-apply a data-theme attribute on plugin page HTML through the bridge SDK and server-side rewriting so plugin pages react to theme toggles and avoid initial light-mode flash.

Enhancements:
- Extend plugin page asset URL rewriting to carry the theme parameter into bridge SDK and CSS asset URLs and inject a matching color-scheme meta tag.
- Expose an isDark getter in the customizer store and append the current theme to plugin iframe URLs and postMessage context from the dashboard.

Documentation:
- Update English and Chinese plugin page guides to document isDark in the bridge context and describe how to adapt CSS/JS to light/dark theme changes.

Tests:
- Add backend tests covering isDark handling in the bridge SDK script and theme propagation into rewritten HTML, including data-theme and color-scheme meta behavior.