### PR TITLE
fix(core): skip redundant image captioning for quoted images when main model is multimodal

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -782,14 +782,32 @@ async def _process_quote_message(
                 break
 
     if image_seg:
+        prov = None
+        path = None
+        compress_path = None
         try:
-            prov = None
-            path = None
-            compress_path = None
             if img_cap_prov_id:
                 prov = plugin_context.get_provider_by_id(img_cap_prov_id)
-            if prov is None:
-                prov = plugin_context.get_using_provider(event.unified_msg_origin)
+            else:
+                # No dedicated caption provider configured; check if the
+                # main chat model supports image input natively.
+                main_prov = plugin_context.get_using_provider(
+                    event.unified_msg_origin
+                )
+                if main_prov and isinstance(main_prov, Provider):
+                    modalities = main_prov.provider_config.get("modalities", [])
+                    if (
+                        isinstance(modalities, list)
+                        and "image" in modalities
+                    ):
+                        # The main model is multimodal and the original image
+                        # has already been appended to req.image_urls by
+                        # build_main_agent, so skip the extra captioning call.
+                        content_parts.append("[Image in quoted message]")
+                        prov = None
+                    else:
+                        # Fallback: main model does not support images.
+                        prov = main_prov
 
             if prov and isinstance(prov, Provider):
                 path = await image_seg.convert_to_file_path()
@@ -797,18 +815,30 @@ async def _process_quote_message(
                     path,
                     config.provider_settings if config else None,
                 )
-                if path and _is_generated_compressed_image_path(path, compress_path):
+                if path and _is_generated_compressed_image_path(
+                    path, compress_path
+                ):
                     event.track_temporary_local_file(compress_path)
+
+                cfg = config.provider_settings if config else {}
+                img_cap_prompt = cfg.get(
+                    "image_caption_prompt",
+                    "Please describe the image content.",
+                )
                 llm_resp = await prov.text_chat(
-                    prompt="Please describe the image content.",
+                    prompt=img_cap_prompt,
                     image_urls=[compress_path],
                 )
                 if llm_resp.completion_text:
                     content_parts.append(
-                        f"[Image Caption in quoted message]: {llm_resp.completion_text}"
+                        f"[Image Caption in quoted message]: "
+                        f"{llm_resp.completion_text}"
                     )
-            else:
-                logger.warning("No provider found for image captioning in quote.")
+            elif img_cap_prov_id:
+                logger.warning(
+                    "Configured image caption provider %s not found for quote.",
+                    img_cap_prov_id,
+                )
         except BaseException as exc:
             logger.error("处理引用图片失败: %s", exc)
         finally:
@@ -820,7 +850,9 @@ async def _process_quote_message(
                 try:
                     os.remove(compress_path)
                 except Exception as exc:  # noqa: BLE001
-                    logger.warning("Fail to remove temporary compressed image: %s", exc)
+                    logger.warning(
+                        "Fail to remove temporary compressed image: %s", exc
+                    )
 
     quoted_content = "\n".join(content_parts)
     quoted_text = f"<Quoted Message>\n{quoted_content}\n</Quoted Message>"


### PR DESCRIPTION
当用户引用包含图片的消息且未配置 `default_image_caption_provider_id` 时，
`_process_quote_message` 会无条件回退到当前主模型进行图片转述，
导致：
1. 主模型被调用**两次**（一次转述、一次回复），增加延迟和 token 开销
2. 多模态主模型无法直接看到原图，只能看到文字描述
3. 转述提示词硬编码为 "Please describe the image content."，`image_caption_prompt` 配置项完全失效

对于关闭了 LTM 自动图片理解、依赖引用图片来让 bot 看图的用户，
每次引用图片都会命中此问题。

## Modifications / 改动点

- `astrbot/core/astr_main_agent.py` — `_process_quote_message`:
  未配置转述模型时，检查主模型的 `modalities` 是否包含 `"image"`：
  - 若主模型是**多模态**：跳过额外转述调用（原图已由 `build_main_agent` 加入 `req.image_urls`），仅在引用文本中保留 `[Image in quoted message]` 占位
  - 若主模型**非多模态**：保留 fallback 转述行为，但提示词改为读取配置文件中的 `image_caption_prompt`

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

## Screenshots or Test Results / 运行截图或测试结果

**验证步骤：**
1. 配置多模态模型为主聊天模型，`default_image_caption_provider_id` 留空
2. QQ 中引用一张包含图片的历史消息，发送文字
3. 检查 debug 日志：主模型应只被调用一次，不应出现 "Please describe the image content." 的额外转述调用

**行为对比：**

| 场景 | 修改前 | 修改后 |
|------|--------|--------|
| 未配置转述模型 + 主模型多模态 | 主模型被调用两次（转述→回复） | 主模型直接看原图，调用一次 |
| 未配置转述模型 + 主模型非多模态 | 主模型被调用两次 | 保留 fallback，提示词可配置 |
| 配置了转述模型 | 指定模型转述，硬编码提示词 | 指定模型转述，读取配置提示词 |

---

## Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced.
  / 我确保没有引入新依赖库。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。
