### PR TITLE
fix: 未配置图片转述provider时不fallback到主模型避免多模态重复调用

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -788,8 +788,8 @@ async def _process_quote_message(
             compress_path = None
             if img_cap_prov_id:
                 prov = plugin_context.get_provider_by_id(img_cap_prov_id)
-            if prov is None:
-                prov = plugin_context.get_using_provider(event.unified_msg_origin)
+                if prov is None:
+                    prov = plugin_context.get_using_provider(event.unified_msg_origin)
 
             if prov and isinstance(prov, Provider):
                 path = await image_seg.convert_to_file_path()


### PR DESCRIPTION
## 问题描述

当用户配置多模态模型（如 GLM-4V、Qwen-VL 等）作为主模型，且未单独配置 `default_image_caption_provider_id` 时，引用（quote）一张图片后，AstrBot 会额外调用一次主模型做图片转述（text_chat），导致同一张图片被多模态模型处理两次，浪费 tokens。

## 根本原因分析

在 `_process_quote_message` 方法中：

```python
if img_cap_prov_id:
    prov = plugin_context.get_provider_by_id(img_cap_prov_id)
if prov is None:
    prov = plugin_context.get_using_provider(event.unified_msg_origin)  # ← fallback 到主模型
```

当 `img_cap_prov_id` 为空时，`prov` 为 None，触发第二行的 fallback 逻辑，获取主模型进行 text_chat 转述。之后转述文本被塞入 Quote Message，再次走主对话流程，导致同一图片被处理两次。

## 修复方案

将 `if prov is None` 缩进到 `if img_cap_prov_id` 块内，这样当未配置专用图转述 provider 时，`prov` 保持 None，后续逻辑自然跳过转述，让多模态主模型直接处理图片。

```diff
 if img_cap_prov_id:
     prov = plugin_context.get_provider_by_id(img_cap_prov_id)
+    if prov is None:
+        prov = plugin_context.get_using_provider(event.unified_msg_origin)
-if prov is None:
-    prov = plugin_context.get_using_provider(event.unified_msg_origin)
```

## Summary by Sourcery

Bug Fixes:
- Prevent fallback to the main multimodal provider for image captioning when no dedicated image caption provider is configured, avoiding duplicate processing of the same image.