### PR TITLE
fix: 引用消息时未配置图转述provider应跳过转述避免多模态重复调用

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -782,16 +782,18 @@ async def _process_quote_message(
                 break
 
     if image_seg:
-        try:
-            prov = None
-            path = None
-            compress_path = None
-            if img_cap_prov_id:
+        if not img_cap_prov_id:
+            # When img_cap_prov_id is not configured, skip image captioning logic
+            # to allow multimodal main provider to handle the image directly.
+            # This avoids the issue where the main model processes the image twice:
+            # once for captioning (text_chat) and once for actual response.
+            logger.debug(
+                "No dedicated image caption provider configured. "
+                "Skipping quote image captioning to avoid multimodal double-call."
+            )
+        else:
+            try:
                 prov = plugin_context.get_provider_by_id(img_cap_prov_id)
-            if prov is None:
-                prov = plugin_context.get_using_provider(event.unified_msg_origin)
-
-            if prov and isinstance(prov, Provider):
                 path = await image_seg.convert_to_file_path()
                 compress_path = await _compress_image_for_provider(
                     path,
@@ -807,20 +809,18 @@ async def _process_quote_message(
                     content_parts.append(
                         f"[Image Caption in quoted message]: {llm_resp.completion_text}"
                     )
-            else:
-                logger.warning("No provider found for image captioning in quote.")
-        except BaseException as exc:
-            logger.error("处理引用图片失败: %s", exc)
-        finally:
-            if (
-                compress_path
-                and compress_path != path
-                and os.path.exists(compress_path)
-            ):
-                try:
-                    os.remove(compress_path)
-                except Exception as exc:  # noqa: BLE001
-                    logger.warning("Fail to remove temporary compressed image: %s", exc)
+            except BaseException as exc:
+                logger.error("处理引用图片失败: %s", exc)
+            finally:
+                if (
+                    compress_path
+                    and compress_path != path
+                    and os.path.exists(compress_path)
+                ):
+                    try:
+                        os.remove(compress_path)
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning("Fail to remove temporary compressed image: %s", exc)
 
     quoted_content = "\n".join(content_parts)
     quoted_text = f"<Quoted Message>\n{quoted_content}\n</Quoted Message>"


### PR DESCRIPTION
## 问题描述

当用户配置多模态模型（如 GLM-4V、Qwen-VL 等）作为主模型，且未单独配置 `default_image_caption_provider_id` 时，引用（quote）一张图片后，AstrBot 会额外调用一次主模型做图片转述（text_chat），导致同一张图片被多模态模型处理两次，浪费 tokens。

## 根本原因分析

在 `_process_quote_message` 方法中，当 `img_cap_prov_id` 为空时：
1. `prov = plugin_context.get_provider_by_id(img_cap_prov_id)` → 返回 None
2. `if prov is None: prov = plugin_context.get_using_provider(event.unified_msg_origin)` → fallback 到主模型
3. 主模型被额外调用一次 `text_chat` 做图片描述
4. 转述文本塞入 Quote Message 后，主对话再次调用主模型 → 同一图片被处理两次

## 修复方案

当 `img_cap_prov_id` 为空（用户未配置专用图转述 provider）时，跳过图片转述逻辑，让多模态主模型在后续主对话中直接处理图片。

## 测试建议
- 多模态模型 + 无专用图转述 provider：引用图片应只调用主模型一次
- 多模态模型 + 有专用图转述 provider：功能不受影响
- 纯文本模型 + 有专用图转述 provider：功能不受影响

## Summary by Sourcery

Bug Fixes:
- Prevent duplicate processing of the same quoted image by the multimodal main provider when no image caption provider is configured.