### PR TITLE
fix: Prevent duplicate processing of quoted images by multimodal main providers when no dedicated image caption provider is configured

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -786,10 +786,19 @@ async def _process_quote_message(
             prov = None
             path = None
             compress_path = None
+            if not img_cap_prov_id:
+                # When img_cap_prov_id is not configured, skip image captioning logic
+                # to allow multimodal main provider to handle the image directly.
+                # This avoids the issue where the main model processes the image twice:
+                # once for captioning (text_chat) and once for actual response.
+                logger.debug(
+                    "No dedicated image caption provider configured. "
+                    "Skipping quote image captioning to avoid multimodal double-call."
+                )
             if img_cap_prov_id:
                 prov = plugin_context.get_provider_by_id(img_cap_prov_id)
-            if prov is None:
-                prov = plugin_context.get_using_provider(event.unified_msg_origin)
+                if prov is None:
+                    prov = plugin_context.get_using_provider(event.unified_msg_origin)
 
             if prov and isinstance(prov, Provider):
                 path = await image_seg.convert_to_file_path()

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -752,6 +752,7 @@ async def _process_quote_message(
     plugin_context: Context,
     quoted_message_settings: QuotedMessageParserSettings = DEFAULT_QUOTED_MESSAGE_SETTINGS,
     config: MainAgentBuildConfig | None = None,
+    main_provider_supports_image: bool = False,
 ) -> None:
     quote = None
     for comp in event.message_obj.message:
@@ -781,24 +782,23 @@ async def _process_quote_message(
                 image_seg = comp
                 break
 
-    if image_seg:
+    if image_seg and main_provider_supports_image:
+        logger.debug(
+            "Skipping quote image captioning because the main provider supports image input."
+        )
+    elif image_seg and not img_cap_prov_id:
+        logger.debug(
+            "No dedicated image caption provider configured. "
+            "Skipping quote image captioning."
+        )
+    elif image_seg:
         try:
             prov = None
             path = None
             compress_path = None
-            if not img_cap_prov_id:
-                # When img_cap_prov_id is not configured, skip image captioning logic
-                # to allow multimodal main provider to handle the image directly.
-                # This avoids the issue where the main model processes the image twice:
-                # once for captioning (text_chat) and once for actual response.
-                logger.debug(
-                    "No dedicated image caption provider configured. "
-                    "Skipping quote image captioning to avoid multimodal double-call."
-                )
-            if img_cap_prov_id:
-                prov = plugin_context.get_provider_by_id(img_cap_prov_id)
-                if prov is None:
-                    prov = plugin_context.get_using_provider(event.unified_msg_origin)
+            prov = plugin_context.get_provider_by_id(img_cap_prov_id)
+            if prov is None:
+                prov = plugin_context.get_using_provider(event.unified_msg_origin)
 
             if prov and isinstance(prov, Provider):
                 path = await image_seg.convert_to_file_path()
@@ -885,6 +885,7 @@ async def _decorate_llm_request(
     req: ProviderRequest,
     plugin_context: Context,
     config: MainAgentBuildConfig,
+    provider: Provider | None = None,
 ) -> None:
     cfg = config.provider_settings or plugin_context.get_config(
         umo=event.unified_msg_origin
@@ -892,11 +893,15 @@ async def _decorate_llm_request(
 
     _apply_prompt_prefix(req, cfg)
 
+    main_provider_supports_image = provider is not None and _provider_supports_modality(
+        provider, "image"
+    )
+
     if req.conversation:
         await _ensure_persona_and_skills(req, cfg, plugin_context, event)
 
         img_cap_prov_id: str = cfg.get("default_image_caption_provider_id") or ""
-        if img_cap_prov_id and req.image_urls:
+        if img_cap_prov_id and req.image_urls and not main_provider_supports_image:
             await _ensure_img_caption(
                 event,
                 req,
@@ -914,6 +919,7 @@ async def _decorate_llm_request(
         plugin_context,
         quoted_message_settings,
         config,
+        main_provider_supports_image=main_provider_supports_image,
     )
 
     tz = config.timezone
@@ -1427,7 +1433,7 @@ async def build_main_agent(
         else:
             return None
 
-    await _decorate_llm_request(event, req, plugin_context, config)
+    await _decorate_llm_request(event, req, plugin_context, config, provider=provider)
 
     await _apply_kb(event, req, plugin_context, config)
 

--- a/tests/unit/test_astr_main_agent.py
+++ b/tests/unit/test_astr_main_agent.py
@@ -1086,6 +1086,61 @@ class TestBuildMainAgent:
         assert result is not None
 
     @pytest.mark.asyncio
+    async def test_build_main_agent_skips_caption_when_main_provider_supports_images(
+        self, mock_event, mock_context, mock_provider
+    ):
+        """Test image-capable chat providers receive quoted images directly."""
+        module = ama
+        mock_image = Image(file="file:///tmp/quoted.jpg")
+        mock_reply = Reply(
+            id="reply-1",
+            chain=[Plain(text="quoted text"), mock_image],
+            sender_nickname="",
+            message_str="quoted text",
+        )
+        mock_event.message_obj.message = [Plain(text="Hello"), mock_reply]
+
+        mock_context.get_provider_by_id.return_value = None
+        mock_context.get_using_provider.return_value = mock_provider
+        mock_context.get_config.return_value = {}
+
+        conv_mgr = mock_context.conversation_manager
+        _setup_conversation_for_build(conv_mgr)
+
+        with (
+            patch("astrbot.core.astr_main_agent.AgentRunner") as mock_runner_cls,
+            patch("astrbot.core.astr_main_agent.AstrAgentContext"),
+            patch.object(
+                Image,
+                "convert_to_file_path",
+                AsyncMock(return_value="/tmp/quoted.jpg"),
+            ),
+        ):
+            mock_runner = MagicMock()
+            mock_runner.reset = AsyncMock()
+            mock_runner_cls.return_value = mock_runner
+
+            result = await module.build_main_agent(
+                event=mock_event,
+                plugin_context=mock_context,
+                config=module.MainAgentBuildConfig(
+                    tool_call_timeout=60,
+                    provider_settings={
+                        "default_image_caption_provider_id": "caption-provider",
+                    },
+                ),
+                provider=mock_provider,
+            )
+
+        assert result is not None
+        assert result.provider_request.image_urls == ["/tmp/quoted.jpg"]
+        assert not any(
+            "Image Caption" in part.text or "<image_caption>" in part.text
+            for part in result.provider_request.extra_user_content_parts
+        )
+        mock_provider.text_chat.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_build_main_agent_uses_image_fallback_provider(
         self, mock_event, mock_context
     ):


### PR DESCRIPTION
## 问题描述

当用户配置多模态模型（如 GLM-4V、Qwen-VL 等）作为主模型，且未单独配置 `default_image_caption_provider_id` 时，引用（quote）一张图片后，AstrBot 会额外调用一次主模型做图片转述（text_chat），导致同一张图片被多模态模型处理两次，浪费 tokens。

## 根本原因分析

在 `_process_quote_message` 方法中：

```python
if img_cap_prov_id:
    prov = plugin_context.get_provider_by_id(img_cap_prov_id)
if prov is None:
    prov = plugin_context.get_using_provider(event.unified_msg_origin)  # ← fallback 到主模型
```

当 `img_cap_prov_id` 为空时，`prov` 为 None，触发第二行的 fallback 逻辑，获取主模型进行 text_chat 转述。之后转述文本被塞入 Quote Message，再次走主对话流程，导致同一图片被处理两次。

## 修复方案

将 `if prov is None` 缩进到 `if img_cap_prov_id` 块内，这样当未配置专用图转述 provider 时，`prov` 保持 None，后续逻辑自然跳过转述，让多模态主模型直接处理图片。

```diff
 if img_cap_prov_id:
     prov = plugin_context.get_provider_by_id(img_cap_prov_id)
+    if prov is None:
+        prov = plugin_context.get_using_provider(event.unified_msg_origin)
-if prov is None:
-    prov = plugin_context.get_using_provider(event.unified_msg_origin)
```

## Summary by Sourcery

Prevent duplicate processing of quoted images by multimodal main providers when no dedicated image caption provider is configured.

Bug Fixes:
- Skip image captioning for quoted images when no dedicated image caption provider is set, avoiding an extra text_chat call to the main multimodal model.

Enhancements:
- Add debug logging to clarify when quote image captioning is skipped due to missing dedicated image caption provider.