### PR TITLE
feat: 为已配置的模型增加能力图标

### DIFF
--- a/dashboard/src/composables/useProviderSources.ts
+++ b/dashboard/src/composables/useProviderSources.ts
@@ -134,11 +134,26 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
     })
   })
 
+  function buildMetadataFromProvider(provider: any) {
+    if (!provider) return null
+    const mods = provider.modalities || []
+    if (!mods.length && !provider.max_context_tokens) return null
+    const input: string[] = []
+    if (mods.includes('image')) input.push('image')
+    if (mods.includes('audio')) input.push('audio')
+    return {
+      modalities: { input },
+      tool_call: mods.includes('tool_use'),
+      reasoning: Boolean(provider.reasoning),
+      limit: { context: provider.max_context_tokens || 0 }
+    }
+  }
+
   const mergedModelEntries = computed(() => {
     const configuredEntries = (sourceProviders.value || []).map((provider: any) => ({
       type: 'configured',
       provider,
-      metadata: getModelMetadata(provider.model)
+      metadata: getModelMetadata(provider.model) || buildMetadataFromProvider(provider)
     }))
 
     const availableEntries = (sortedAvailableModels.value || [])
@@ -575,7 +590,8 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
       model: modelName,
       modalities,
       custom_extra_body: {},
-      max_context_tokens: max_context_tokens
+      max_context_tokens: max_context_tokens,
+      reasoning: supportsReasoning(metadata)
     }
   }
 


### PR DESCRIPTION
### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

**优化：已配置模型始终显示能力图标**

修复已配置模型在未获取模型列表或切换提供商后，能力图标（图片/音频/工具调用/推理）消失的问题。

**根因分析：**

已配置模型的能力图标依赖 `getModelMetadata(provider.model)` 返回的 metadata，而该数据仅在用户点击"获取模型列表"时填充。切换提供商后 `modelMetadata` 被清空，导致图标丢失。

但 provider 配置本身已经存储了 `modalities` 数组和 `max_context_tokens`，只是没有被利用来渲染图标。

**改动内容：**

1. `src/composables/useProviderSources.ts`
   - 新增 `buildMetadataFromProvider(provider)` 函数：当 `getModelMetadata` 返回 null 时，从 provider 自身的 `modalities` / `max_context_tokens` / `reasoning` 字段构造兼容的 metadata 对象
   - `mergedModelEntries` 中已配置模型的 metadata 增加 fallback：`getModelMetadata(provider.model) || buildMetadataFromProvider(provider)`
   - `buildModelProviderConfig` 新增 `reasoning` 字段持久化，确保添加模型时将推理能力信息一并保存

**效果：**
- 已配置模型无需点击"获取模型列表"即可显示能力图标
- 切换提供商再切回来，图标不再消失
- 新添加的模型会持久化 reasoning 信息，后续始终可显示

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行"验证步骤"的证据，证明此改动有效。-->

**验证步骤：**

1. 进入服务提供商页面，选择一个已配置模型的提供商
2. 观察"已配置的模型"列表中是否显示能力图标（图片/音频/工具/推理/上下文长度）
3. 切换到另一个提供商，再切换回来，确认图标仍然显示
4. 点击"获取模型列表"，从可用模型中添加一个新模型，确认新模型添加后也显示能力图标

<img width="1285" height="412" alt="image" src="https://github.com/user-attachments/assets/2760db47-5319-4481-8318-dd8ddd498e4d" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure configured models consistently display capability icons based on provider configuration when model metadata is unavailable.

New Features:
- Derive model capability metadata (modalities, tool use, reasoning, context length) directly from provider configuration when model metadata is missing to render capability icons.

Bug Fixes:
- Prevent disappearance of capability icons for configured models when the model list has not been fetched or after switching providers.

Enhancements:
- Persist reasoning capability information when building and saving model provider configurations so reasoning support remains available for display.