### PR TITLE
fix(ltm): Web UI 删除对话/平台后 LTM 记忆未清理 & unique_session 下群聊记录隔离 (#8386)

### DIFF
--- a/astrbot/builtin_stars/astrbot/long_term_memory.py
+++ b/astrbot/builtin_stars/astrbot/long_term_memory.py
@@ -23,6 +23,12 @@ class LongTermMemory:
         self.session_chats = defaultdict(list)
         """记录群成员的群聊记录"""
 
+    def _group_key(self, event: AstrMessageEvent) -> str:
+        """获取群级别的 key，不受 unique_session 影响"""
+        if event.get_message_type() == MessageType.GROUP_MESSAGE and event.get_group_id():
+            return f"{event.get_platform_id()}:GroupMessage:{event.get_group_id()}"
+        return event.unified_msg_origin
+
     def cfg(self, event: AstrMessageEvent):
         cfg = self.context.get_config(umo=event.unified_msg_origin)
         try:
@@ -58,9 +64,10 @@ class LongTermMemory:
 
     async def remove_session(self, event: AstrMessageEvent) -> int:
         cnt = 0
-        if event.unified_msg_origin in self.session_chats:
-            cnt = len(self.session_chats[event.unified_msg_origin])
-            del self.session_chats[event.unified_msg_origin]
+        group_key = self._group_key(event)
+        if group_key in self.session_chats:
+            cnt = len(self.session_chats[group_key])
+            del self.session_chats[group_key]
         return cnt
 
     async def get_image_caption(
@@ -143,17 +150,19 @@ class LongTermMemory:
                     parts.append(f" [At: {comp.name}]")
 
             final_message = "".join(parts)
-            logger.debug(f"ltm | {event.unified_msg_origin} | {final_message}")
-            self.session_chats[event.unified_msg_origin].append(final_message)
-            if len(self.session_chats[event.unified_msg_origin]) > cfg["max_cnt"]:
-                self.session_chats[event.unified_msg_origin].pop(0)
+            group_key = self._group_key(event)
+            logger.debug(f"ltm | {group_key} | {final_message}")
+            self.session_chats[group_key].append(final_message)
+            if len(self.session_chats[group_key]) > cfg["max_cnt"]:
+                self.session_chats[group_key].pop(0)
 
     async def on_req_llm(self, event: AstrMessageEvent, req: ProviderRequest) -> None:
         """当触发 LLM 请求前，调用此方法修改 req"""
-        if event.unified_msg_origin not in self.session_chats:
+        group_key = self._group_key(event)
+        if group_key not in self.session_chats:
             return
 
-        chats_str = "\n---\n".join(self.session_chats[event.unified_msg_origin])
+        chats_str = "\n---\n".join(self.session_chats[group_key])
 
         cfg = self.cfg(event)
         if cfg["enable_active_reply"]:
@@ -174,15 +183,16 @@ class LongTermMemory:
     async def after_req_llm(
         self, event: AstrMessageEvent, llm_resp: LLMResponse
     ) -> None:
-        if event.unified_msg_origin not in self.session_chats:
+        group_key = self._group_key(event)
+        if group_key not in self.session_chats:
             return
 
         if llm_resp.completion_text:
             final_message = f"[You/{datetime.datetime.now().strftime('%H:%M:%S')}]: {llm_resp.completion_text}"
             logger.debug(
-                f"Recorded AI response: {event.unified_msg_origin} | {final_message}"
+                f"Recorded AI response: {group_key} | {final_message}"
             )
-            self.session_chats[event.unified_msg_origin].append(final_message)
+            self.session_chats[group_key].append(final_message)
             cfg = self.cfg(event)
-            if len(self.session_chats[event.unified_msg_origin]) > cfg["max_cnt"]:
-                self.session_chats[event.unified_msg_origin].pop(0)
+            if len(self.session_chats[group_key]) > cfg["max_cnt"]:
+                self.session_chats[group_key].pop(0)

--- a/astrbot/builtin_stars/astrbot/main.py
+++ b/astrbot/builtin_stars/astrbot/main.py
@@ -33,6 +33,18 @@ class Main(star.Star):
         self.ltm = None
         try:
             self.ltm = LongTermMemory(self.context.astrbot_config_mgr, self.context)
+
+            async def _clear_ltm_session(umo: str) -> None:
+                self.ltm.session_chats.pop(umo, None)
+                # Also clear group-level key for unique_session scenarios
+                parts = umo.split(":")
+                if len(parts) >= 3 and parts[1] == "GroupMessage":
+                    group_key = f"{parts[0]}:GroupMessage:{parts[2]}"
+                    self.ltm.session_chats.pop(group_key, None)
+
+            self.context.conversation_manager.register_on_session_deleted(
+                _clear_ltm_session
+            )
         except BaseException as e:
             logger.error(f"聊天增强 err: {e}")
 

--- a/astrbot/builtin_stars/astrbot/main.py
+++ b/astrbot/builtin_stars/astrbot/main.py
@@ -39,7 +39,8 @@ class Main(star.Star):
                 # Also clear group-level key for unique_session scenarios
                 parts = umo.split(":")
                 if len(parts) >= 3 and parts[1] == "GroupMessage":
-                    group_key = f"{parts[0]}:GroupMessage:{parts[2]}"
+                    group_id = parts[2].split("%")[-1]
+                    group_key = f"{parts[0]}:GroupMessage:{group_id}"
                     self.ltm.session_chats.pop(group_key, None)
 
             self.context.conversation_manager.register_on_session_deleted(

--- a/astrbot/core/conversation_mgr.py
+++ b/astrbot/core/conversation_mgr.py
@@ -142,6 +142,7 @@ class ConversationManager:
             if curr_cid == conversation_id:
                 self.session_conversations.pop(unified_msg_origin, None)
                 await sp.session_remove(unified_msg_origin, "sel_conv_id")
+            await self._trigger_session_deleted(unified_msg_origin)
 
     async def delete_conversations_by_user_id(self, unified_msg_origin: str) -> None:
         """删除会话的所有对话

--- a/astrbot/dashboard/routes/config.py
+++ b/astrbot/dashboard/routes/config.py
@@ -1315,6 +1315,14 @@ class ConfigRoute(Route):
         try:
             save_config(self.config, self.config, is_core=True)
             await self.core_lifecycle.platform_manager.terminate_platform(platform_id)
+            convs = await self.core_lifecycle.db.get_conversations(
+                platform_id=platform_id
+            )
+            for conv in convs:
+                await self.core_lifecycle.conversation_manager.delete_conversation(
+                    unified_msg_origin=conv.user_id,
+                    conversation_id=conv.conversation_id,
+                )
         except Exception as e:
             return Response().error(str(e)).__dict__
         return Response().ok(None, "删除平台配置成功~").__dict__

--- a/tests/test_ltm_cleanup_on_delete.py
+++ b/tests/test_ltm_cleanup_on_delete.py
@@ -1,0 +1,174 @@
+"""测试 Web UI 删除对话后 LTM session_chats 是否被正确清理 (Issue #8386 Bug 1)"""
+
+import pytest
+import pytest_asyncio
+from collections import defaultdict
+from unittest.mock import AsyncMock, MagicMock
+
+from astrbot.core.conversation_mgr import ConversationManager
+from astrbot.core.platform.message_type import MessageType
+from astrbot.builtin_stars.astrbot.long_term_memory import LongTermMemory
+
+
+@pytest_asyncio.fixture
+async def conversation_manager():
+    db = AsyncMock()
+    db.delete_conversation = AsyncMock()
+    db.get_conversation_by_id = AsyncMock(return_value=None)
+    mgr = ConversationManager(db)
+    return mgr
+
+
+@pytest.fixture
+def ltm():
+    acm = MagicMock()
+    context = MagicMock()
+    context.get_config = MagicMock(return_value={
+        "provider_ltm_settings": {
+            "group_message_max_cnt": 300,
+            "image_caption": False,
+            "image_caption_provider_id": "",
+            "active_reply": {"enable": False, "method": "possibility_reply", "possibility_reply": 0.1},
+        },
+        "provider_settings": {"image_caption_prompt": ""},
+    })
+    return LongTermMemory(acm, context)
+
+
+@pytest.mark.asyncio
+async def test_delete_conversation_triggers_session_deleted_callback(conversation_manager):
+    """验证 delete_conversation 会触发 _on_session_deleted_callbacks"""
+    callback = AsyncMock()
+    conversation_manager.register_on_session_deleted(callback)
+
+    umo = "feishu:group:test_group_123"
+    conversation_manager.session_conversations[umo] = "conv-id-1"
+
+    await conversation_manager.delete_conversation(
+        unified_msg_origin=umo,
+        conversation_id="conv-id-1",
+    )
+
+    callback.assert_called_once_with(umo)
+
+
+@pytest.mark.asyncio
+async def test_delete_conversation_clears_ltm_session_chats(conversation_manager, ltm):
+    """模拟完整流程：LTM 注册回调后，Web UI 删除对话应清理 session_chats"""
+    umo = "feishu:group:test_group_456"
+
+    # 模拟群聊中已有 LTM 记录
+    ltm.session_chats[umo] = [
+        "[Alice/10:00:00]: 你好",
+        "[Bob/10:01:00]: 你好啊",
+        "[You/10:01:30]: 大家好！",
+    ]
+
+    # 注册回调（和 main.py 中的逻辑一致）
+    async def _clear_ltm_session(origin: str) -> None:
+        ltm.session_chats.pop(origin, None)
+
+    conversation_manager.register_on_session_deleted(_clear_ltm_session)
+
+    # 模拟当前会话指向该对话
+    conversation_manager.session_conversations[umo] = "conv-id-2"
+
+    # 执行删除（Web UI 路径）
+    await conversation_manager.delete_conversation(
+        unified_msg_origin=umo,
+        conversation_id="conv-id-2",
+    )
+
+    # 验证 LTM 内存已清理
+    assert umo not in ltm.session_chats
+
+
+@pytest.mark.asyncio
+async def test_ltm_on_req_llm_skips_after_session_cleared(conversation_manager, ltm):
+    """删除对话后，on_req_llm 不应再注入已删除的历史到 system_prompt"""
+    umo = "lark:GroupMessage:test_group_789"
+
+    # 模拟已有 LTM 记录（存储在 group-level key 下）
+    ltm.session_chats[umo] = [
+        "[User1/09:00:00]: 之前的秘密对话",
+    ]
+
+    async def _clear_ltm_session(origin: str) -> None:
+        ltm.session_chats.pop(origin, None)
+        parts = origin.split(":")
+        if len(parts) >= 3 and parts[1] == "GroupMessage":
+            group_key = f"{parts[0]}:GroupMessage:{parts[2]}"
+            ltm.session_chats.pop(group_key, None)
+
+    conversation_manager.register_on_session_deleted(_clear_ltm_session)
+    conversation_manager.session_conversations[umo] = "conv-id-3"
+
+    # 删除对话
+    await conversation_manager.delete_conversation(
+        unified_msg_origin=umo,
+        conversation_id="conv-id-3",
+    )
+
+    # 模拟后续 LLM 请求
+    event = MagicMock()
+    event.unified_msg_origin = umo
+    event.get_message_type.return_value = MessageType.GROUP_MESSAGE
+    event.get_group_id.return_value = "test_group_789"
+    event.get_platform_id.return_value = "lark"
+
+    req = MagicMock()
+    req.system_prompt = "You are a helpful assistant."
+    req.prompt = "你好"
+    req.contexts = []
+
+    await ltm.on_req_llm(event, req)
+
+    # system_prompt 不应包含已删除的历史
+    assert "秘密对话" not in req.system_prompt
+
+
+@pytest.mark.asyncio
+async def test_delete_other_conversation_does_not_affect_unrelated_session(conversation_manager, ltm):
+    """删除某个 session 的对话不应影响其他 session 的 LTM 记录"""
+    umo_a = "feishu:group:group_a"
+    umo_b = "feishu:group:group_b"
+
+    ltm.session_chats[umo_a] = ["[A/10:00:00]: hello"]
+    ltm.session_chats[umo_b] = ["[B/10:00:00]: world"]
+
+    async def _clear_ltm_session(origin: str) -> None:
+        ltm.session_chats.pop(origin, None)
+
+    conversation_manager.register_on_session_deleted(_clear_ltm_session)
+    conversation_manager.session_conversations[umo_a] = "conv-a"
+
+    # 只删除 group_a
+    await conversation_manager.delete_conversation(
+        unified_msg_origin=umo_a,
+        conversation_id="conv-a",
+    )
+
+    assert umo_a not in ltm.session_chats
+    assert ltm.session_chats[umo_b] == ["[B/10:00:00]: world"]
+
+
+@pytest.mark.asyncio
+async def test_group_key_ignores_unique_session(ltm):
+    """Bug 3: unique_session 开启时，不同用户的 group_key 应相同（都指向群级别）"""
+    # 用户 A 的 event（unique_session 改写了 unified_msg_origin）
+    event_a = MagicMock()
+    event_a.unified_msg_origin = "lark:GroupMessage:userA%group123"
+    event_a.get_message_type.return_value = MessageType.GROUP_MESSAGE
+    event_a.get_group_id.return_value = "group123"
+    event_a.get_platform_id.return_value = "lark"
+
+    # 用户 B 的 event
+    event_b = MagicMock()
+    event_b.unified_msg_origin = "lark:GroupMessage:userB%group123"
+    event_b.get_message_type.return_value = MessageType.GROUP_MESSAGE
+    event_b.get_group_id.return_value = "group123"
+    event_b.get_platform_id.return_value = "lark"
+
+    # 两者的 group_key 应该相同
+    assert ltm._group_key(event_a) == ltm._group_key(event_b)
+    assert ltm._group_key(event_a) == "lark:GroupMessage:group123"

--- a/tests/test_ltm_cleanup_on_delete.py
+++ b/tests/test_ltm_cleanup_on_delete.py
@@ -97,7 +97,8 @@ async def test_ltm_on_req_llm_skips_after_session_cleared(conversation_manager, 
         ltm.session_chats.pop(origin, None)
         parts = origin.split(":")
         if len(parts) >= 3 and parts[1] == "GroupMessage":
-            group_key = f"{parts[0]}:GroupMessage:{parts[2]}"
+            group_id = parts[2].split("%")[-1]
+            group_key = f"{parts[0]}:GroupMessage:{group_id}"
             ltm.session_chats.pop(group_key, None)
 
     conversation_manager.register_on_session_deleted(_clear_ltm_session)


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
## Summary
  修复飞书机器人对话历史管理的 3 个 bug (#8386)：

  - **Bug 1**: Web UI 删除对话后，bot 仍然记得之前的聊天内容。原因是 `delete_conversation` 没有触发
  `_trigger_session_deleted` 回调来清理 LTM 内存。
  - **Bug 2**: 删除平台适配器后，重新创建同 ID 适配器时旧对话复现。原因是删除平台时没有级联删除该平台关联的对话记录。
  - **Bug 3**: 开启 `unique_session` 后，bot 在群聊中看不到其他用户的消息。原因是 LTM 使用 `unified_msg_origin`（被
  unique_session 改写为 per-user key）作为存储 key，导致每个用户的群聊记录互相隔离。

### Modifications / 改动点
 1. `conversation_mgr.py`: `delete_conversation` 末尾调用 `_trigger_session_deleted`，与
  `delete_conversations_by_user_id` 行为一致
  2. `main.py`: 注册 session_deleted 回调，删除对话时同步清理 LTM `session_chats`
  3. `config.py`: 删除平台适配器时级联删除该平台所有对话
  4. `long_term_memory.py`: 新增 `_group_key()` 方法，群聊场景下始终使用 `{platform_id}:GroupMessage:{group_id}` 作为
  key，不受 unique_session 影响

 ## Test plan

  - [x] Bug 1: 飞书群聊中 @bot 对话 → Web UI 删除对话 → 再次 @bot，确认不再记忆之前内容（已实测通过）
  - [ ] Bug 2: 删除飞书平台适配器 → 重建同 ID 适配器 → 确认旧对话不再出现
  - [ ] Bug 3: 开启 unique_session → 两个不同用户在群聊中发言 → @bot 确认能看到两人的消息
  - [x] 单元测试 5/5 通过（含 group_key 隔离验证）
  - [x] 相关模块已有测试无回归



- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<img width="580" height="696" alt="测试" src="https://github.com/user-attachments/assets/a2628fbb-62ba-43b3-8fcb-421c305cf65a" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [ ] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Fix long-term memory cleanup and group chat keying for deleted conversations and unique_session scenarios.

Bug Fixes:
- Ensure deleting a conversation triggers session deletion callbacks so LTM session_chats are cleared.
- Cascade-delete all conversations when a platform adapter is removed to prevent resurrecting old chats on re-add.
- Use a stable group-level key for group chats so history is shared at the room level and not isolated per user under unique_session.

Tests:
- Add async tests to verify session_deleted callbacks fire, LTM session_chats are cleared on conversation deletion, unrelated sessions are preserved, and group_key ignores unique_session overrides.