### PR TITLE
feat(provider): 为模型的temperature/top_p/max_tokens 增加参数开关

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -2027,7 +2027,7 @@ CONFIG_METADATA_2 = {
                                 "description": "温度参数",
                                 "hint": "控制输出的随机性，范围通常为 0-2。值越高越随机。",
                                 "type": "float",
-                                "default": 0.6,
+                                "default": 1.0,
                                 "slider": {"min": 0, "max": 2, "step": 0.1},
                             },
                             "top_p": {
@@ -2035,7 +2035,7 @@ CONFIG_METADATA_2 = {
                                 "description": "Top-p 采样",
                                 "hint": "核采样参数，范围通常为 0-1。控制模型考虑的概率质量。",
                                 "type": "float",
-                                "default": 1.0,
+                                "default": 0.95,
                                 "slider": {"min": 0, "max": 1, "step": 0.01},
                             },
                             "max_tokens": {
@@ -2046,6 +2046,11 @@ CONFIG_METADATA_2 = {
                                 "default": 8192,
                             },
                         },
+                        "default_disabled_keys": [
+                            "temperature",
+                            "top_p",
+                            "max_tokens",
+                        ],
                     },
                     "provider": {
                         "type": "string",

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -92,6 +92,17 @@ class Provider(AbstractProvider):
             if k != "_disabled_keys" and k not in disabled_keys
         }
 
+    def _merge_custom_extra_body(self, payloads: dict) -> dict:
+        """Merge effective custom_extra_body into payloads without overwriting existing keys.
+
+        Returns a shallow copy of payloads with custom_extra_body values merged in.
+        """
+        merged = dict(payloads)
+        for k, v in self.get_effective_custom_extra_body().items():
+            if k not in merged:
+                merged[k] = v
+        return merged
+
     @abc.abstractmethod
     def get_current_key(self) -> str:
         raise NotImplementedError

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -74,6 +74,24 @@ class Provider(AbstractProvider):
         super().__init__(provider_config)
         self.provider_settings = provider_settings
 
+    def get_effective_custom_extra_body(self) -> dict:
+        """Get custom_extra_body with disabled keys filtered out.
+
+        Returns the custom_extra_body dict excluding any keys that are
+        listed in the _disabled_keys metadata field within the dict.
+        """
+        custom_extra_body = self.provider_config.get("custom_extra_body", {})
+        if not isinstance(custom_extra_body, dict):
+            return {}
+        disabled_keys = custom_extra_body.get("_disabled_keys", [])
+        if not isinstance(disabled_keys, list):
+            disabled_keys = []
+        return {
+            k: v
+            for k, v in custom_extra_body.items()
+            if k != "_disabled_keys" and k not in disabled_keys
+        }
+
     @abc.abstractmethod
     def get_current_key(self) -> str:
         raise NotImplementedError

--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -328,7 +328,14 @@ class ProviderAnthropic(Provider):
                     else "auto"
                 }
 
-        extra_body = self.provider_config.get("custom_extra_body", {})
+        extra_body = self.get_effective_custom_extra_body()
+        # Anthropic requires max_tokens - always include it even if disabled
+        full_custom_extra_body = self.provider_config.get("custom_extra_body", {})
+        if (
+            isinstance(full_custom_extra_body, dict)
+            and "max_tokens" in full_custom_extra_body
+        ):
+            extra_body["max_tokens"] = full_custom_extra_body["max_tokens"]
 
         if "max_tokens" not in payloads:
             payloads["max_tokens"] = 65536
@@ -422,7 +429,14 @@ class ProviderAnthropic(Provider):
         final_tool_calls = []
         id = None
         usage = TokenUsage()
-        extra_body = self.provider_config.get("custom_extra_body", {})
+        extra_body = self.get_effective_custom_extra_body()
+        # Anthropic requires max_tokens - always include it even if disabled
+        full_custom_extra_body = self.provider_config.get("custom_extra_body", {})
+        if (
+            isinstance(full_custom_extra_body, dict)
+            and "max_tokens" in full_custom_extra_body
+        ):
+            extra_body["max_tokens"] = full_custom_extra_body["max_tokens"]
         reasoning_content = ""
         reasoning_signature = ""
 

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -606,10 +606,7 @@ class ProviderGoogleGenAI(Provider):
     async def _query(self, payloads: dict, tools: ToolSet | None) -> LLMResponse:
         """非流式请求 Gemini API"""
         # Merge effective custom_extra_body into payloads
-        custom_extra_body = self.get_effective_custom_extra_body()
-        for k, v in custom_extra_body.items():
-            if k not in payloads:
-                payloads[k] = v
+        payloads = self._merge_custom_extra_body(payloads)
 
         system_instruction = next(
             (msg["content"] for msg in payloads["messages"] if msg["role"] == "system"),
@@ -701,10 +698,7 @@ class ProviderGoogleGenAI(Provider):
     ) -> AsyncGenerator[LLMResponse, None]:
         """流式请求 Gemini API"""
         # Merge effective custom_extra_body into payloads
-        custom_extra_body = self.get_effective_custom_extra_body()
-        for k, v in custom_extra_body.items():
-            if k not in payloads:
-                payloads[k] = v
+        payloads = self._merge_custom_extra_body(payloads)
 
         system_instruction = next(
             (msg["content"] for msg in payloads["messages"] if msg["role"] == "system"),

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -605,6 +605,12 @@ class ProviderGoogleGenAI(Provider):
 
     async def _query(self, payloads: dict, tools: ToolSet | None) -> LLMResponse:
         """非流式请求 Gemini API"""
+        # Merge effective custom_extra_body into payloads
+        custom_extra_body = self.get_effective_custom_extra_body()
+        for k, v in custom_extra_body.items():
+            if k not in payloads:
+                payloads[k] = v
+
         system_instruction = next(
             (msg["content"] for msg in payloads["messages"] if msg["role"] == "system"),
             None,
@@ -694,6 +700,12 @@ class ProviderGoogleGenAI(Provider):
         tools: ToolSet | None,
     ) -> AsyncGenerator[LLMResponse, None]:
         """流式请求 Gemini API"""
+        # Merge effective custom_extra_body into payloads
+        custom_extra_body = self.get_effective_custom_extra_body()
+        for k, v in custom_extra_body.items():
+            if k not in payloads:
+                payloads[k] = v
+
         system_instruction = next(
             (msg["content"] for msg in payloads["messages"] if msg["role"] == "system"),
             None,

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -586,8 +586,7 @@ class ProviderOpenAIOfficial(Provider):
 
         # 读取并合并 custom_extra_body 配置
         custom_extra_body = self.get_effective_custom_extra_body()
-        if isinstance(custom_extra_body, dict):
-            extra_body.update(custom_extra_body)
+        extra_body.update(custom_extra_body)
         self._apply_provider_specific_extra_body_overrides(extra_body)
 
         model = payloads.get("model", "").lower()
@@ -631,9 +630,7 @@ class ProviderOpenAIOfficial(Provider):
         extra_body = {}
 
         # 读取并合并 custom_extra_body 配置
-        custom_extra_body = self.get_effective_custom_extra_body()
-        if isinstance(custom_extra_body, dict):
-            extra_body.update(custom_extra_body)
+        extra_body.update(self.get_effective_custom_extra_body())
 
         to_del = []
         for key in payloads:

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -585,7 +585,7 @@ class ProviderOpenAIOfficial(Provider):
             del payloads[key]
 
         # 读取并合并 custom_extra_body 配置
-        custom_extra_body = self.provider_config.get("custom_extra_body", {})
+        custom_extra_body = self.get_effective_custom_extra_body()
         if isinstance(custom_extra_body, dict):
             extra_body.update(custom_extra_body)
         self._apply_provider_specific_extra_body_overrides(extra_body)
@@ -631,7 +631,7 @@ class ProviderOpenAIOfficial(Provider):
         extra_body = {}
 
         # 读取并合并 custom_extra_body 配置
-        custom_extra_body = self.provider_config.get("custom_extra_body", {})
+        custom_extra_body = self.get_effective_custom_extra_body()
         if isinstance(custom_extra_body, dict):
             extra_body.update(custom_extra_body)
 

--- a/dashboard/src/components/shared/ObjectEditor.vue
+++ b/dashboard/src/components/shared/ObjectEditor.vue
@@ -324,6 +324,7 @@ const nonDisableableKeys = computed(() => {
 
 // 计算要显示的键名 (exclude _disabled_keys from display)
 const displayKeys = computed(() => {
+  if (!props.modelValue) return []
   return Object.keys(props.modelValue).filter(k => k !== '_disabled_keys').slice(0, props.maxDisplayItems)
 })
 
@@ -367,7 +368,7 @@ function initializeLocalKeyValuePairs() {
   }
   originalDisabledKeys.value = [...localDisabledKeys.value]
 
-  for (const [key, value] of Object.entries(props.modelValue)) {
+  for (const [key, value] of Object.entries(props.modelValue || {})) {
     // Skip the internal _disabled_keys field
     if (key === '_disabled_keys') continue
 

--- a/dashboard/src/components/shared/ObjectEditor.vue
+++ b/dashboard/src/components/shared/ObjectEditor.vue
@@ -110,7 +110,7 @@
         <div v-if="hasTemplateSchema" class="mt-4">
           <v-divider class="mb-3"></v-divider>
           <div class="text-caption text-grey mb-2">{{ t('core.common.objectEditor.presets') }}</div>
-          <div v-for="(template, templateKey) in templateSchema" :key="templateKey" class="template-field" :class="{ 'template-field-inactive': !isTemplateKeyAdded(templateKey) }">
+          <div v-for="(template, templateKey) in templateSchema" :key="templateKey" class="template-field" :class="{ 'template-field-disabled': isTemplateKeyDisabled(templateKey) }">
             <v-row no-gutters align="center" class="mb-2">
               <v-col cols="4">
                 <div class="d-flex flex-column">
@@ -118,7 +118,7 @@
                   <span v-if="template.hint" class="text-caption text-grey" style="font-size: 0.7rem;">{{ resolveTemplateText(templateKey, 'hint', template.hint) }}</span>
                 </div>
               </v-col>
-              <v-col cols="7" class="pl-2 d-flex align-center justify-end">
+              <v-col cols="6" class="pl-2 d-flex align-center justify-end">
                 <v-text-field
                   v-if="template.type === 'string'"
                   :model-value="getTemplateValue(templateKey)"
@@ -126,6 +126,7 @@
                   density="compact"
                   variant="outlined"
                   hide-details
+                  :disabled="isTemplateKeyDisabled(templateKey)"
                   :placeholder="t('core.common.objectEditor.placeholders.stringValue')"
                 ></v-text-field>
                 <div v-else-if="template.type === 'number' || template.type === 'float' || template.type === 'int'" class="d-flex align-center ga-4 flex-grow-1">
@@ -139,6 +140,7 @@
                     color="primary"
                     density="compact"
                     hide-details
+                    :disabled="isTemplateKeyDisabled(templateKey)"
                     class="flex-grow-1"
                   ></v-slider>
                   <v-text-field
@@ -148,6 +150,7 @@
                     density="compact"
                     variant="outlined"
                     hide-details
+                    :disabled="isTemplateKeyDisabled(templateKey)"
                     :placeholder="t('core.common.objectEditor.placeholders.numberValue')"
                     :style="template.slider ? 'max-width: 120px;' : ''"
                   ></v-text-field>
@@ -158,20 +161,39 @@
                   @update:model-value="updateTemplateValue(templateKey, $event)"
                   density="compact"
                   hide-details
+                  :disabled="isTemplateKeyDisabled(templateKey)"
                   color="primary"
                 ></v-switch>
               </v-col>
-              <v-col cols="1" class="pl-2">
-                <v-btn
-                  v-if="isTemplateKeyAdded(templateKey)"
-                  icon
-                  variant="text"
-                  size="small"
-                  color="error"
-                  @click="removeTemplateKey(templateKey)"
-                >
-                  <v-icon>mdi-close</v-icon>
-                </v-btn>
+              <v-col cols="2" class="pl-2 d-flex align-center justify-end">
+                <v-tooltip :text="t('core.common.objectEditor.resetToDefault')" location="top">
+                  <template v-slot:activator="{ props: tooltipProps }">
+                    <v-btn
+                      v-bind="tooltipProps"
+                      icon
+                      variant="text"
+                      size="small"
+                      :disabled="!isTemplateValueModified(templateKey)"
+                      @click="resetTemplateKey(templateKey)"
+                    >
+                      <v-icon>mdi-restore</v-icon>
+                    </v-btn>
+                  </template>
+                </v-tooltip>
+                <v-tooltip :text="isTemplateKeyDisabled(templateKey) ? t('core.common.objectEditor.enableParam') : t('core.common.objectEditor.disableParam')" location="top">
+                  <template v-slot:activator="{ props: tooltipProps }">
+                    <v-checkbox
+                      v-bind="tooltipProps"
+                      :model-value="!isTemplateKeyDisabled(templateKey)"
+                      @update:model-value="toggleTemplateKeyDisabled(templateKey)"
+                      density="compact"
+                      hide-details
+                      color="success"
+                      :disabled="nonDisableableKeys.includes(templateKey)"
+                      class="ma-0 pa-0"
+                    ></v-checkbox>
+                  </template>
+                </v-tooltip>
               </v-col>
             </v-row>
           </div>
@@ -277,6 +299,10 @@ const newKey = ref('')
 const newValueType = ref('string')
 const nextPairId = ref(0)
 
+// Disabled keys tracking
+const localDisabledKeys = ref([])
+const originalDisabledKeys = ref([])
+
 // Template schema support
 const templateSchema = computed(() => {
   return props.itemMeta?.template_schema || {}
@@ -286,9 +312,19 @@ const hasTemplateSchema = computed(() => {
   return Object.keys(templateSchema.value).length > 0
 })
 
-// 计算要显示的键名
+// Default disabled keys from metadata
+const defaultDisabledKeys = computed(() => {
+  return props.itemMeta?.default_disabled_keys || []
+})
+
+// Keys that cannot be disabled
+const nonDisableableKeys = computed(() => {
+  return props.itemMeta?.non_disableable_keys || []
+})
+
+// 计算要显示的键名 (exclude _disabled_keys from display)
 const displayKeys = computed(() => {
-  return Object.keys(props.modelValue).slice(0, props.maxDisplayItems)
+  return Object.keys(props.modelValue).filter(k => k !== '_disabled_keys').slice(0, props.maxDisplayItems)
 })
 
 // 分离模板字段和普通字段
@@ -318,7 +354,23 @@ function createPair({ key, value, type, slider, template, jsonError = '', _origi
 function initializeLocalKeyValuePairs() {
   localKeyValuePairs.value = []
   nextPairId.value = 0
+
+  // Initialize disabled keys from modelValue or defaults
+  const existingDisabled = props.modelValue?._disabled_keys
+  if (Array.isArray(existingDisabled)) {
+    localDisabledKeys.value = existingDisabled.filter(k => !nonDisableableKeys.value.includes(k))
+  } else if (Object.keys(props.modelValue || {}).filter(k => k !== '_disabled_keys').length === 0 && defaultDisabledKeys.value.length > 0) {
+    // New/empty config: use default disabled keys
+    localDisabledKeys.value = defaultDisabledKeys.value.filter(k => !nonDisableableKeys.value.includes(k))
+  } else {
+    localDisabledKeys.value = []
+  }
+  originalDisabledKeys.value = [...localDisabledKeys.value]
+
   for (const [key, value] of Object.entries(props.modelValue)) {
+    // Skip the internal _disabled_keys field
+    if (key === '_disabled_keys') continue
+
     let _type = (typeof value) === 'object' ? 'json':(typeof value)
     let _value = _type === 'json' ? JSON.stringify(value) : value
 
@@ -431,6 +483,43 @@ function isTemplateKeyAdded(templateKey) {
   return localKeyValuePairs.value.some(pair => pair.key === templateKey)
 }
 
+function isTemplateKeyDisabled(templateKey) {
+  return localDisabledKeys.value.includes(templateKey)
+}
+
+function isTemplateValueModified(templateKey) {
+  const template = templateSchema.value[templateKey]
+  if (!template || template.default === undefined) return false
+  const pair = localKeyValuePairs.value.find(p => p.key === templateKey)
+  if (!pair) return false
+  const type = template.type || 'string'
+  if (type === 'number' || type === 'float' || type === 'int') {
+    const pairNum = Number(pair.value)
+    const defaultNum = Number(template.default)
+    if (isNaN(pairNum) && isNaN(defaultNum)) return false
+    return pairNum !== defaultNum
+  }
+  return String(pair.value) !== String(template.default)
+}
+
+function toggleTemplateKeyDisabled(templateKey) {
+  const index = localDisabledKeys.value.indexOf(templateKey)
+  if (index >= 0) {
+    // Enable: remove from disabled list
+    localDisabledKeys.value.splice(index, 1)
+  } else {
+    // Disable: add to disabled list
+    localDisabledKeys.value.push(templateKey)
+  }
+}
+
+function resetTemplateKey(templateKey) {
+  const template = templateSchema.value[templateKey]
+  if (template && template.default !== undefined) {
+    updateTemplateValue(templateKey, template.default)
+  }
+}
+
 function getTemplateValue(templateKey) {
   const pair = localKeyValuePairs.value.find(pair => pair.key === templateKey)
   if (pair) {
@@ -496,28 +585,24 @@ function confirmDialog() {
         break
       case 'float':
       case 'number':
-        // 尝试转换为数字，如果失败则保持原值（或设为默认值0）
         convertedValue = Number(pair.value)
-        // 可选：检查是否为有效数字，无效则设为0或报错
-        // if (isNaN(convertedValue)) convertedValue = 0;
         break
       case 'bool':
       case 'boolean':
-        // 布尔值通常由 v-switch 正确处理，但为保险起见可以显式转换
-        // 注意：在 JavaScript 中，只有严格的 false, 0, '', null, undefined, NaN 会被转换为 false
-        // 这里直接赋值 pair.value 应该是安全的，因为 v-model 绑定的就是布尔值
-        // convertedValue = Boolean(pair.value)
         break
       case 'json':
         convertedValue = JSON.parse(pair.value)
         break
       case 'string':
       default:
-        // 默认转换为字符串
         convertedValue = String(pair.value)
         break
     }
     updatedValue[pair.key] = convertedValue
+  }
+  // Store disabled keys in the value if there are any
+  if (localDisabledKeys.value.length > 0) {
+    updatedValue['_disabled_keys'] = [...localDisabledKeys.value]
   }
   emit('update:modelValue', updatedValue)
   dialog.value = false
@@ -526,6 +611,7 @@ function confirmDialog() {
 function cancelDialog() {
   // Reset to original state
   localKeyValuePairs.value = originalKeyValuePairs.value.map(pair => ({ ...pair }))
+  localDisabledKeys.value = [...originalDisabledKeys.value]
   dialog.value = false
 }
 
@@ -550,7 +636,7 @@ function resolveTemplateText(templateKey, attr, fallback) {
   transition: opacity 0.2s;
 }
 
-.template-field-inactive {
-  opacity: 0.8;
+.template-field-disabled {
+  opacity: 0.5;
 }
 </style>

--- a/dashboard/src/composables/useProviderModelConfigDialog.ts
+++ b/dashboard/src/composables/useProviderModelConfigDialog.ts
@@ -46,6 +46,12 @@ export function useProviderModelConfigDialog(options: UseProviderModelConfigDial
         schema.provider.items[key].invisible = true
       }
     }
+
+    // Anthropic requires max_tokens - mark it as non-disableable
+    if (sourceType === 'anthropic_chat_completion' && schema.provider.items.custom_extra_body) {
+      schema.provider.items.custom_extra_body.non_disableable_keys = ['max_tokens']
+    }
+
     return schema
   })
 

--- a/dashboard/src/i18n/locales/en-US/core/common.json
+++ b/dashboard/src/i18n/locales/en-US/core/common.json
@@ -115,6 +115,9 @@
     "valueTypeLabel": "Value type",
     "keyExists": "Key already exists",
     "invalidJson": "Invalid JSON format",
+    "resetToDefault": "Reset to default",
+    "disableParam": "Disable injection",
+    "enableParam": "Enable injection",
     "placeholders": {
       "keyName": "Key",
       "stringValue": "String value",

--- a/dashboard/src/i18n/locales/ru-RU/core/common.json
+++ b/dashboard/src/i18n/locales/ru-RU/core/common.json
@@ -115,6 +115,9 @@
         "valueTypeLabel": "Тип значения",
         "keyExists": "Ключ уже существует",
         "invalidJson": "Некорректный формат JSON",
+        "resetToDefault": "Сбросить по умолчанию",
+        "disableParam": "Отключить инъекцию",
+        "enableParam": "Включить инъекцию",
         "placeholders": {
             "keyName": "Ключ",
             "stringValue": "Строка",

--- a/dashboard/src/i18n/locales/zh-CN/core/common.json
+++ b/dashboard/src/i18n/locales/zh-CN/core/common.json
@@ -115,6 +115,9 @@
     "valueTypeLabel": "值类型",
     "keyExists": "键名已存在",
     "invalidJson": "JSON 格式错误",
+    "resetToDefault": "还原默认值",
+    "disableParam": "禁用注入",
+    "enableParam": "启用注入",
     "placeholders": {
       "keyName": "键名",
       "stringValue": "字符串值",


### PR DESCRIPTION
### Motivation / 动机

当前 `custom_extra_body` 中的 temperature/top_p/max_tokens 默认注入到所有供应商请求中，存在以下问题：

1. 默认 temperature=0.6 会导致 Kimi 等模型报错
2. top_p=1.0 对绝大多数模型来说不是最佳值(最佳是0.95)，且几乎所有现代模型推荐直接使用 temperature=1
3. 多数模型 API 自带经过调优的默认参数，强行注入反而破坏模型最佳行为
4. 原有 "X" 按钮语义不清，用户无法区分"删除"、"还原"还是"不注入"

结论：设置不如不设置，新供应商应默认不注入这些参数。

### Modifications / 改动点

- 新供应商默认不注入 temperature/top_p/max_tokens（通过 `_disabled_keys` 机制）
- UI 中将原 "X" 按钮替换为"还原默认值"按钮 + checkbox 启用/禁用注入
- Anthropic 供应商的 max_tokens checkbox 锁定不可禁用（API 强制要求）
- Gemini 供应商补充了 `custom_extra_body` 支持（此前缺失）
- 默认值调整：temperature 0.6→1.0，top_p 1.0→0.95（用户主动启用时的预设值）
- 已有供应商配置不受影响，向后兼容

核心文件：
- `astrbot/core/provider/provider.py` — 新增 `get_effective_custom_extra_body()` 方法
- `astrbot/core/provider/sources/openai_source.py` — 使用新方法
- `astrbot/core/provider/sources/anthropic_source.py` — 使用新方法 + max_tokens 强制注入
- `astrbot/core/provider/sources/gemini_source.py` — 新增 custom_extra_body 支持
- `astrbot/core/config/default.py` — 默认值和 metadata 调整
- `dashboard/src/components/shared/ObjectEditor.vue` — UI 改造
- `dashboard/src/composables/useProviderModelConfigDialog.ts` — Anthropic max_tokens 锁定

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

<img width="810" height="630" alt="image" src="https://github.com/user-attachments/assets/728089a1-6962-4299-941a-c2398f29c378" />

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [ ] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 I have ensured that no new dependencies are introduced.
- [x] 😮 My changes do not introduce malicious code.

## Summary by Sourcery

Introduce configurable disabling of custom parameter injection for model providers and update defaults to better align with provider-recommended behavior.

New Features:
- Add support for marking specific custom_extra_body keys as disabled via a _disabled_keys list and filtering them in provider requests.
- Expose UI controls in the object editor to reset template values to defaults and enable or disable individual preset parameters, with non-disableable keys support.
- Extend Gemini provider to honor custom_extra_body overrides in both streaming and non-streaming requests.

Enhancements:
- Adjust default temperature and top_p values and mark temperature/top_p/max_tokens as disabled by default for new provider configurations.
- Ensure Anthropic providers always send max_tokens even if the parameter is disabled in the UI, and prevent disabling it in the configuration schema.
- Hide the internal _disabled_keys field from display while preserving it in saved configurations.