### PR TITLE
feat(context): 压缩上下文时保留尾部发言，以免丢失用户最新指示

### DIFF
--- a/astrbot/core/agent/context/compressor.py
+++ b/astrbot/core/agent/context/compressor.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-from ..message import Message
+from ..message import Message, TextPart
 
 if TYPE_CHECKING:
     from astrbot import logger
@@ -16,6 +16,35 @@ if TYPE_CHECKING:
     from astrbot.core.provider.provider import Provider
 
 from ..context.truncator import ContextTruncator
+
+# Maximum number of characters to preserve from the tail of summarized messages.
+PRESERVE_TAIL_CHARS = 10000
+
+
+def extract_text_from_messages(messages: list[Message]) -> str:
+    """Extract text content from a list of messages into a single string.
+
+    Each message is formatted as "[role]: content" for readability.
+
+    Args:
+        messages: The messages to extract text from.
+
+    Returns:
+        A concatenated string of all text content.
+    """
+    parts: list[str] = []
+    for msg in messages:
+        if msg.content is None:
+            continue
+        if isinstance(msg.content, str):
+            parts.append(f"[{msg.role}]: {msg.content}")
+        elif isinstance(msg.content, list):
+            text_segments = [
+                part.text for part in msg.content if isinstance(part, TextPart)
+            ]
+            if text_segments:
+                parts.append(f"[{msg.role}]: {''.join(text_segments)}")
+    return "\n".join(parts)
 
 
 @runtime_checkable
@@ -227,14 +256,29 @@ class LLMSummaryCompressor:
             logger.warning("LLM context compression returned an empty summary.")
             return messages
 
+        # Extract the tail of the original conversation text to preserve recent details.
+        # This ensures the compressed context retains both a high-level summary
+        # and the most recent raw conversation from the summarized portion.
+        tail_text = extract_text_from_messages(messages_to_summarize)
+        if len(tail_text) > PRESERVE_TAIL_CHARS:
+            tail_text = tail_text[-PRESERVE_TAIL_CHARS:]
+
         # build result
         result = []
         result.extend(system_messages)
 
+        compressed_content = (
+            f"Our previous history conversation summary:\n{summary_content}"
+        )
+        if tail_text:
+            compressed_content += (
+                f"\n\n---\nRecent conversation details before compression:\n{tail_text}"
+            )
+
         result.append(
             Message(
                 role="user",
-                content=f"Our previous history conversation summary: {summary_content}",
+                content=compressed_content,
             )
         )
         result.append(

--- a/astrbot/core/agent/context/compressor.py
+++ b/astrbot/core/agent/context/compressor.py
@@ -17,14 +17,16 @@ if TYPE_CHECKING:
 
 from ..context.truncator import ContextTruncator
 
-# Maximum number of characters to preserve from the tail of summarized messages.
-PRESERVE_TAIL_CHARS = 10000
+# Default number of characters to preserve from the tail of summarized messages.
+DEFAULT_PRESERVE_TAIL_CHARS = 10000
 
 
 def extract_text_from_messages(messages: list[Message]) -> str:
     """Extract text content from a list of messages into a single string.
 
     Each message is formatted as "[role]: content" for readability.
+    Only text content is extracted; tool_calls are intentionally omitted
+    as they are verbose and already covered by the LLM-generated summary.
 
     Args:
         messages: The messages to extract text from.
@@ -183,6 +185,7 @@ class LLMSummaryCompressor:
         keep_recent: int = 4,
         instruction_text: str | None = None,
         compression_threshold: float = 0.82,
+        preserve_tail_chars: int = DEFAULT_PRESERVE_TAIL_CHARS,
     ) -> None:
         """Initialize the LLM summary compressor.
 
@@ -191,10 +194,13 @@ class LLMSummaryCompressor:
             keep_recent: The number of latest messages to keep (default: 4).
             instruction_text: Custom instruction for summary generation.
             compression_threshold: The compression trigger threshold (default: 0.82).
+            preserve_tail_chars: Maximum characters to preserve from the tail of
+                summarized messages (default: 10000). Set to 0 to disable.
         """
         self.provider = provider
         self.keep_recent = keep_recent
         self.compression_threshold = compression_threshold
+        self.preserve_tail_chars = preserve_tail_chars
 
         self.instruction_text = instruction_text or (
             "Based on our full conversation history, produce a concise summary of key takeaways and/or project progress.\n"
@@ -259,9 +265,11 @@ class LLMSummaryCompressor:
         # Extract the tail of the original conversation text to preserve recent details.
         # This ensures the compressed context retains both a high-level summary
         # and the most recent raw conversation from the summarized portion.
-        tail_text = extract_text_from_messages(messages_to_summarize)
-        if len(tail_text) > PRESERVE_TAIL_CHARS:
-            tail_text = tail_text[-PRESERVE_TAIL_CHARS:]
+        tail_text = ""
+        if self.preserve_tail_chars > 0:
+            tail_text = extract_text_from_messages(messages_to_summarize)
+            if len(tail_text) > self.preserve_tail_chars:
+                tail_text = "..." + tail_text[-self.preserve_tail_chars :]
 
         # build result
         result = []


### PR DESCRIPTION
### Motivation / 动机

`LLMSummaryCompressor` 在压缩上下文时，仅使用 LLM 生成的摘要作为压缩消息。摘要是高度概括的，会丢失具体的代码片段、报错信息、配置参数等细节，导致模型在后续对话中"失忆"。

此 PR 在保留摘要的同时，额外保留被压缩消息尾部最后 10K 字符的原始对话内容，让模型仍能引用到压缩前最近的具体上下文。

注：codex默认保留20K，这里10K是保守估计

### Modifications / 改动点

- 新增 `PRESERVE_TAIL_CHARS` 常量（10000），控制保留的尾部字符数
- 新增 `extract_text_from_messages()` 辅助函数，从消息列表中提取文本内容
- 修改 `LLMSummaryCompressor.__call__()`，在生成摘要后追加尾部原文到压缩消息中

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```
41 passed in 2.41s
```

所有现有测试通过，无新增依赖。

---

### Checklist / 检查清单

- [x] My changes have been well-tested, **and verification steps and screenshots have been provided above**.
- [x] I have ensured that no new dependencies are introduced.
- [x] My changes do not introduce malicious code.

## Summary by Sourcery

Preserve recent raw conversation details alongside LLM-generated summaries during context compression to reduce information loss.

New Features:
- Introduce configurable preservation of up to 10,000 tail characters from summarized messages in the compressed context.
- Add a helper to extract readable text content from message objects, including structured text parts, for reuse in compression.

Enhancements:
- Update LLMSummaryCompressor to include both the high-level summary and the most recent original conversation text in the compressed user message.