### PR TITLE
feat(tools): add image caption fallback for FileReadTool when provider lacks image modality

### DIFF
--- a/astrbot/core/tools/computer_tools/fs.py
+++ b/astrbot/core/tools/computer_tools/fs.py
@@ -38,6 +38,8 @@ import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import mcp.types
+
 from astrbot.api import FunctionTool, logger
 from astrbot.api.event import MessageChain
 from astrbot.core.agent.run_context import ContextWrapper
@@ -215,6 +217,66 @@ def _decode_escaped_text(value: str) -> str:
     )
 
 
+def _provider_supports_image(context: ContextWrapper[AstrAgentContext]) -> bool:
+    """Check if the current provider supports image modality."""
+    try:
+        umo = context.context.event.unified_msg_origin
+        provider = context.context.context.get_using_provider(umo=umo)
+        if provider is None:
+            return True  # Cannot determine, assume supported
+        modalities = provider.provider_config.get("modalities", [])
+        return "image" in modalities
+    except Exception:
+        return True  # Cannot determine, assume supported
+
+
+async def _caption_image_fallback(
+    context: ContextWrapper[AstrAgentContext],
+    image_path: str,
+) -> ToolExecResult:
+    """Try to caption an image using the configured image caption provider.
+
+    Returns the caption text or an error message if no caption provider is available.
+    """
+    from astrbot.core.provider.provider import Provider
+
+    umo = context.context.event.unified_msg_origin
+    cfg = context.context.context.get_config(umo=umo)
+    provider_settings = cfg.get("provider_settings", {})
+    caption_provider_id = provider_settings.get("default_image_caption_provider_id", "")
+
+    if not caption_provider_id:
+        return (
+            "Error: your provider does not support image modality, "
+            "and no image caption provider is configured. Unable to read image file."
+        )
+
+    caption_provider = context.context.context.get_provider_by_id(caption_provider_id)
+    if caption_provider is None or not isinstance(caption_provider, Provider):
+        return (
+            "Error: your provider does not support image modality, "
+            f"and the configured image caption provider `{caption_provider_id}` is not available. "
+            "Unable to read image file."
+        )
+
+    caption_prompt = provider_settings.get(
+        "image_caption_prompt", "Please describe the image."
+    )
+
+    try:
+        llm_resp = await caption_provider.text_chat(
+            prompt=caption_prompt,
+            image_urls=[image_path],
+        )
+        caption = (llm_resp.completion_text or "").strip()
+        if not caption:
+            return "Error: image caption provider returned an empty description."
+        return f"[Image description]: {caption}"
+    except Exception as exc:
+        logger.error(f"Image captioning failed: {exc}")
+        return f"Error: failed to generate image description: {exc}"
+
+
 @builtin_tool(config=_COMPUTER_RUNTIME_TOOL_CONFIG)
 @dataclass
 class FileReadTool(FunctionTool):
@@ -281,7 +343,7 @@ class FileReadTool(FunctionTool):
                 context.context.context,
                 context.context.event.unified_msg_origin,
             )
-            return await read_file_tool_result(
+            result = await read_file_tool_result(
                 sb,
                 local_mode=local_env,
                 path=normalized_path,
@@ -293,6 +355,20 @@ class FileReadTool(FunctionTool):
                     else None
                 ),
             )
+
+            # If the result is an image and the provider doesn't support image modality,
+            # fall back to image captioning or return an error.
+            if (
+                isinstance(result, mcp.types.CallToolResult)
+                and result.content
+                and any(
+                    isinstance(item, mcp.types.ImageContent) for item in result.content
+                )
+                and not _provider_supports_image(context)
+            ):
+                return await _caption_image_fallback(context, normalized_path)
+
+            return result
         except PermissionError as exc:
             return f"Error: {exc}"
         except Exception as exc:


### PR DESCRIPTION
### Motivation / 动机

当前 `FileReadTool` 读取图片文件时，直接返回 `ImageContent` 给 LLM。如果当前使用的 provider 不支持多模态（image modality），图片内容会被缓存但模型完全看不到图片内容，等于白读。

此 PR 增加了降级逻辑：
1. 如果当前 provider 支持图片 → 行为不变，返回 `ImageContent`
2. 如果不支持图片，但配置了图转文模型（`default_image_caption_provider_id`）→ 调用图转文模型生成文字描述返回
3. 如果不支持图片，也没有配置图转文模型 → 返回明确的错误提示："您的供应商不支持多模态，并且当前没有配置图转文模型，无法读取图片"

### Modifications / 改动点

- 修改 `astrbot/core/tools/computer_tools/fs.py`
  - 新增 `_provider_supports_image()` 辅助函数：检查当前 provider 是否支持 image modality
  - 新增 `_caption_image_fallback()` 辅助函数：调用配置的图转文 provider 生成图片描述
  - 修改 `FileReadTool.call()`：在返回 `ImageContent` 前检查 provider 能力，必要时降级

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```
11 passed (image test included), 3 pre-existing failures unrelated to this change
```

---

### Checklist / 检查清单

- [x] My changes have been well-tested, **and verification steps and screenshots have been provided above**.
- [x] I have ensured that no new dependencies are introduced.
- [x] My changes do not introduce malicious code.

## Summary by Sourcery

Add an image-captioning fallback for FileReadTool so image files remain usable when the active provider lacks image modality support.

New Features:
- Provide automatic image captioning for image reads when a dedicated image caption provider is configured but the main provider does not support image modality.

Enhancements:
- Detect provider image-modality support before returning ImageContent from FileReadTool and transparently degrade to text captions or clear error messages when unsupported.