### PR TITLE
fix: 修复 run_agent() 共享引用污染和 send_message() 历史丢失

### DIFF
--- a/astrbot/core/astr_agent_run_util.py
+++ b/astrbot/core/astr_agent_run_util.py
@@ -257,7 +257,7 @@ async def run_agent(
                     )
                     astr_event.set_result(
                         MessageEventResult(
-                            chain=resp.data["chain"].chain,
+                            chain=list(resp.data["chain"].chain),
                             result_content_type=content_typ,
                         ),
                     )
@@ -275,7 +275,7 @@ async def run_agent(
                 if merged_chain:
                     astr_event.set_result(
                         MessageEventResult(
-                            chain=merged_chain.chain,
+                            chain=list(merged_chain.chain),
                             result_content_type=ResultContentType.LLM_RESULT,
                         ),
                     )

--- a/astrbot/core/astr_agent_run_util.py
+++ b/astrbot/core/astr_agent_run_util.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import re
 import time
 import traceback
@@ -257,7 +258,7 @@ async def run_agent(
                     )
                     astr_event.set_result(
                         MessageEventResult(
-                            chain=list(resp.data["chain"].chain),
+                            chain=copy.deepcopy(resp.data["chain"].chain),
                             result_content_type=content_typ,
                         ),
                     )
@@ -275,7 +276,7 @@ async def run_agent(
                 if merged_chain:
                     astr_event.set_result(
                         MessageEventResult(
-                            chain=list(merged_chain.chain),
+                            chain=copy.deepcopy(merged_chain.chain),
                             result_content_type=ResultContentType.LLM_RESULT,
                         ),
                     )

--- a/astrbot/core/star/context.py
+++ b/astrbot/core/star/context.py
@@ -472,9 +472,7 @@ class Context:
             if platform.meta().id == session.platform_name:
                 await platform.send_by_session(session, message_chain)
 
-                await self._persist_sent_message_to_history(
-                    session, message_chain
-                )
+                await self._persist_sent_message_to_history(session, message_chain)
 
                 return True
         logger.warning(

--- a/astrbot/core/star/context.py
+++ b/astrbot/core/star/context.py
@@ -471,6 +471,47 @@ class Context:
         for platform in self.platform_manager.platform_insts:
             if platform.meta().id == session.platform_name:
                 await platform.send_by_session(session, message_chain)
+
+                # Persist the sent message to conversation history so that
+                # LLM can see proactive / split messages in subsequent turns.
+                try:
+                    import json
+
+                    unified_msg_origin = str(session)
+                    cid = await self.conversation_manager.get_curr_conversation_id(
+                        unified_msg_origin
+                    )
+                    if cid:
+                        conv = await self.conversation_manager.get_conversation(
+                            unified_msg_origin, cid
+                        )
+                        if conv:
+                            history = json.loads(conv.history) if conv.history else []
+                            plain_text = message_chain.get_plain_text()
+                            if plain_text:
+                                # Deduplicate: skip if the last message is already
+                                # an assistant message with the same content.
+                                if (
+                                    history
+                                    and isinstance(history[-1], dict)
+                                    and history[-1].get("role") == "assistant"
+                                    and history[-1].get("content") == plain_text
+                                ):
+                                    pass
+                                else:
+                                    history.append(
+                                        {"role": "assistant", "content": plain_text}
+                                    )
+                                    await self.conversation_manager.update_conversation(
+                                        unified_msg_origin=unified_msg_origin,
+                                        conversation_id=cid,
+                                        history=history,
+                                    )
+                except Exception as e:
+                    logger.debug(
+                        f"send_message: failed to persist to history: {e}"
+                    )
+
                 return True
         logger.warning(
             f"cannot find platform for session {str(session)}, message not sent"

--- a/astrbot/core/star/context.py
+++ b/astrbot/core/star/context.py
@@ -471,83 +471,11 @@ class Context:
         for platform in self.platform_manager.platform_insts:
             if platform.meta().id == session.platform_name:
                 await platform.send_by_session(session, message_chain)
-
-                await self._persist_sent_message_to_history(session, message_chain)
-
                 return True
         logger.warning(
             f"cannot find platform for session {str(session)}, message not sent"
         )
         return False
-
-    async def _persist_sent_message_to_history(
-        self,
-        session: MessageSesion,
-        message_chain: MessageChain,
-    ) -> None:
-        """Persist a sent message to conversation history.
-
-        Args:
-            session: The message session.
-            message_chain: The message chain that was sent.
-        """
-        unified_msg_origin = str(session)
-        cid = None
-        try:
-            import json
-
-            cid = await self.conversation_manager.get_curr_conversation_id(
-                unified_msg_origin
-            )
-            if not cid:
-                return
-
-            conv = await self.conversation_manager.get_conversation(
-                unified_msg_origin, cid
-            )
-            if not conv:
-                return
-
-            plain_text = message_chain.get_plain_text()
-            if not plain_text:
-                return
-
-            history = json.loads(conv.history) if conv.history else []
-            if self._is_last_assistant_message(history, plain_text):
-                return
-
-            history.append({"role": "assistant", "content": plain_text})
-            await self.conversation_manager.update_conversation(
-                unified_msg_origin=unified_msg_origin,
-                conversation_id=cid,
-                history=history,
-            )
-        except json.JSONDecodeError as e:
-            logger.warning(
-                f"Failed to parse conversation history "
-                f"(session={unified_msg_origin}, cid={cid}): {e}"
-            )
-        except Exception as e:
-            logger.warning(
-                f"Failed to persist sent message to history "
-                f"(session={unified_msg_origin}, cid={cid}): {e}"
-            )
-
-    @staticmethod
-    def _is_last_assistant_message(history: list[dict], plain_text: str) -> bool:
-        """Check if the last message in history is an assistant message with the same content.
-
-        Args:
-            history: The conversation history list.
-            plain_text: The plain text content to compare.
-
-        Returns:
-            True if the last message is a matching assistant message.
-        """
-        if not history or not isinstance(history[-1], dict):
-            return False
-        last = history[-1]
-        return last.get("role") == "assistant" and last.get("content") == plain_text
 
     def add_llm_tools(self, *tools: FunctionTool) -> None:
         """添加 LLM 工具。

--- a/astrbot/core/star/context.py
+++ b/astrbot/core/star/context.py
@@ -472,51 +472,84 @@ class Context:
             if platform.meta().id == session.platform_name:
                 await platform.send_by_session(session, message_chain)
 
-                # Persist the sent message to conversation history so that
-                # LLM can see proactive / split messages in subsequent turns.
-                try:
-                    import json
-
-                    unified_msg_origin = str(session)
-                    cid = await self.conversation_manager.get_curr_conversation_id(
-                        unified_msg_origin
-                    )
-                    if cid:
-                        conv = await self.conversation_manager.get_conversation(
-                            unified_msg_origin, cid
-                        )
-                        if conv:
-                            history = json.loads(conv.history) if conv.history else []
-                            plain_text = message_chain.get_plain_text()
-                            if plain_text:
-                                # Deduplicate: skip if the last message is already
-                                # an assistant message with the same content.
-                                if (
-                                    history
-                                    and isinstance(history[-1], dict)
-                                    and history[-1].get("role") == "assistant"
-                                    and history[-1].get("content") == plain_text
-                                ):
-                                    pass
-                                else:
-                                    history.append(
-                                        {"role": "assistant", "content": plain_text}
-                                    )
-                                    await self.conversation_manager.update_conversation(
-                                        unified_msg_origin=unified_msg_origin,
-                                        conversation_id=cid,
-                                        history=history,
-                                    )
-                except Exception as e:
-                    logger.debug(
-                        f"send_message: failed to persist to history: {e}"
-                    )
+                await self._persist_sent_message_to_history(
+                    session, message_chain
+                )
 
                 return True
         logger.warning(
             f"cannot find platform for session {str(session)}, message not sent"
         )
         return False
+
+    async def _persist_sent_message_to_history(
+        self,
+        session: MessageSesion,
+        message_chain: MessageChain,
+    ) -> None:
+        """Persist a sent message to conversation history.
+
+        Args:
+            session: The message session.
+            message_chain: The message chain that was sent.
+        """
+        unified_msg_origin = str(session)
+        cid = None
+        try:
+            import json
+
+            cid = await self.conversation_manager.get_curr_conversation_id(
+                unified_msg_origin
+            )
+            if not cid:
+                return
+
+            conv = await self.conversation_manager.get_conversation(
+                unified_msg_origin, cid
+            )
+            if not conv:
+                return
+
+            plain_text = message_chain.get_plain_text()
+            if not plain_text:
+                return
+
+            history = json.loads(conv.history) if conv.history else []
+            if self._is_last_assistant_message(history, plain_text):
+                return
+
+            history.append({"role": "assistant", "content": plain_text})
+            await self.conversation_manager.update_conversation(
+                unified_msg_origin=unified_msg_origin,
+                conversation_id=cid,
+                history=history,
+            )
+        except json.JSONDecodeError as e:
+            logger.warning(
+                f"Failed to parse conversation history "
+                f"(session={unified_msg_origin}, cid={cid}): {e}"
+            )
+        except Exception as e:
+            logger.warning(
+                f"Failed to persist sent message to history "
+                f"(session={unified_msg_origin}, cid={cid}): {e}"
+            )
+
+    @staticmethod
+    def _is_last_assistant_message(history: list[dict], plain_text: str) -> bool:
+        """Check if the last message in history is an assistant message with the same content.
+
+        Args:
+            history: The conversation history list.
+            plain_text: The plain text content to compare.
+
+        Returns:
+            True if the last message is a matching assistant message.
+        """
+        if not history or not isinstance(history[-1], dict):
+            return False
+        last = history[-1]
+        return last.get("role") == "assistant" and last.get("content") == plain_text
 
     def add_llm_tools(self, *tools: FunctionTool) -> None:
         """添加 LLM 工具。

--- a/tests/unit/test_astr_agent_run_util.py
+++ b/tests/unit/test_astr_agent_run_util.py
@@ -1,0 +1,113 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from astrbot.core.astr_agent_run_util import run_agent
+from astrbot.core.message.components import Plain
+from astrbot.core.message.message_event_result import MessageChain
+
+
+class _FakeAgentRunner:
+    def __init__(self, chain: MessageChain | list[MessageChain]) -> None:
+        self.streaming = False
+        self.req = None
+        self.stats = SimpleNamespace(to_dict=lambda: {})
+        self.agent_hooks = SimpleNamespace(on_agent_done=MagicMock())
+        self.run_context = SimpleNamespace(
+            context=SimpleNamespace(event=_FakeEvent()),
+            messages=[],
+        )
+        self._chains = chain if isinstance(chain, list) else [chain]
+        self._done = False
+        self.stop_requested = False
+
+    async def step(self):
+        for chain in self._chains:
+            yield SimpleNamespace(type="llm_result", data={"chain": chain})
+        self._done = True
+
+    def done(self) -> bool:
+        return self._done
+
+    def request_stop(self) -> None:
+        self.stop_requested = True
+
+
+class _FakeEvent:
+    def __init__(self) -> None:
+        self._result = None
+        self.extras = {}
+        self.trace = SimpleNamespace(record=MagicMock())
+
+    def is_stopped(self) -> bool:
+        return False
+
+    def get_extra(self, key: str):
+        return self.extras.get(key)
+
+    def set_extra(self, key: str, value) -> None:
+        self.extras[key] = value
+
+    def set_result(self, result) -> None:
+        self._result = result
+
+    def clear_result(self) -> None:
+        self._result = None
+
+    def get_result(self):
+        return self._result
+
+    def get_platform_name(self) -> str:
+        return "test"
+
+
+@pytest.mark.asyncio
+async def test_run_agent_result_chain_is_isolated_from_llm_chain_mutation():
+    original_component = Plain("original")
+    original_chain = MessageChain(chain=[original_component])
+    runner = _FakeAgentRunner(original_chain)
+
+    agent_output = run_agent(runner)
+    yielded_chain = await anext(agent_output)
+
+    event_result = runner.run_context.context.event.get_result()
+    assert yielded_chain is original_chain
+    assert event_result.chain[0] is not original_component
+    assert event_result.chain[0].text == "original"
+
+    original_component.text = "mutated"
+    original_chain.chain.clear()
+
+    assert event_result.chain[0].text == "original"
+    assert len(event_result.chain) == 1
+
+    with pytest.raises(StopAsyncIteration):
+        await anext(agent_output)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_buffered_result_chain_is_isolated_from_source_chains():
+    first_component = Plain("first")
+    second_component = Plain("second")
+    first_chain = MessageChain(chain=[first_component])
+    second_chain = MessageChain(chain=[second_component])
+    runner = _FakeAgentRunner([first_chain, second_chain])
+
+    agent_output = run_agent(runner, buffer_intermediate_messages=True)
+    yielded_chain = await anext(agent_output)
+
+    event_result = runner.run_context.context.event.get_result()
+    assert yielded_chain.chain == [first_component, second_component]
+    assert event_result.chain[0] is not first_component
+    assert event_result.chain[1] is not second_component
+    assert [comp.text for comp in event_result.chain] == ["first", "second"]
+
+    first_component.text = "mutated-first"
+    second_chain.chain.clear()
+
+    assert [comp.text for comp in event_result.chain] == ["first", "second"]
+    assert len(event_result.chain) == 2
+
+    with pytest.raises(StopAsyncIteration):
+        await anext(agent_output)


### PR DESCRIPTION
### Modifications / 改动点

修复两个导致插件发出的消息在 LLM 对话历史中丢失或截断的核心 Bug。

**问题 1：`run_agent()` 共享引用污染**

`run_agent()` 在构造 `MessageEventResult` 时，将 Provider 层 `LLMResponse.result_chain.chain` 的 list 对象直接传递（未做拷贝）。当输出增强等插件在 `OnDecoratingResultEvent` 阶段对 `event.get_result().chain` 执行原地修改（`clear()` + `extend()`）时，会直接污染 Provider 层的 `LLMResponse.result_chain`，导致 `completion_text` property（实时从 `result_chain` 计算）被永久截断或清空。

**根因**：`astr_agent_run_util.py` 两处 `MessageEventResult(chain=...)` 直接传递了 list 引用。

**问题 2：`Context.send_message()` 不写对话历史**

`Context.send_message()` 仅将消息投递给平台适配器，无任何逻辑将消息追加到对应会话的 `conversation.history`。所有通过此 API 发出的消息（输出增强的前 N-1 分段、主动消息插件发出的消息、任何插件的主动发送）对 LLM 完全不可见。

**根因**：`context.py` 中 `send_message()` 只调用 `platform.send_by_session()`，未写入 `conversation_manager`。

**修改的文件**

- `astrbot/core/astr_agent_run_util.py` — 两处 `chain=...` 改为 `chain=list(...)`，浅拷贝切断共享引用
- `astrbot/core/star/context.py` — `send_message()` 发送成功后自动追加 assistant 消息到对话历史，含去重检查（跳过最后一条已是同内容 assistant 消息的情况）

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

独立复现脚本 `reproduce_bugs.py` 验证修复前后对比：

**修复前：**

```
复现 1：共享引用污染
  provider_chain.chain = ['完整原文：第一段。第二段。第三段。']
  [SplitStep 执行后]
  provider_chain.chain = ['最后一段']
  llm_resp.completion_text = '最后一段'
  ❌ BUG 确认：completion_text 被截断

复现 2：send_message() 不写历史
  [send_message] 发送消息: '这是分段1'
  [send_message] 发送消息: '这是分段2'
  conversation.history = []
  ❌ BUG 确认：发送 2 条消息后 history 为空

复现 3：_save_to_history 守卫误触发
  completion_text = ''
  save_to_history 结果: skipped
  ❌ BUG 确认：当 result_chain 被清空时，历史完全丢失
```

**修复后：**

```
验证 1：共享引用污染
  ✅ llm_resp.completion_text 未被截断

验证 2：send_message() 写历史
  ✅ send_message 正确写历史且去重有效

验证 3：_save_to_history 守卫
  ✅ 守卫不会误触发

验证 4：主动消息插件切断引用
  ✅ 主动插件原始 chain 未被污染

验证 5：主动消息去重适配
  ✅ 主动插件正确处理 send_message 预写入的消息

🎉 所有修复验证通过！
```

### Checklist / 检查清单

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure assistant messages sent via the platform API are persisted to conversation history and prevent plugins from mutating underlying LLM response chains through shared list references.

Bug Fixes:
- Fix run_agent using shared list references for LLM result chains that allowed plugins to inadvertently truncate or clear provider-level responses.
- Fix Context.send_message not appending sent assistant messages to the associated conversation history, causing proactive and split messages to be invisible to subsequent LLM turns.