### PR TITLE
feat(dashboard): 优化前端在手机端的表现

### DIFF
--- a/astrbot/core/tools/computer_tools/fs.py
+++ b/astrbot/core/tools/computer_tools/fs.py
@@ -38,6 +38,8 @@ import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import mcp.types
+
 from astrbot.api import FunctionTool, logger
 from astrbot.api.event import MessageChain
 from astrbot.core.agent.run_context import ContextWrapper
@@ -215,6 +217,66 @@ def _decode_escaped_text(value: str) -> str:
     )
 
 
+def _provider_supports_image(context: ContextWrapper[AstrAgentContext]) -> bool:
+    """Check if the current provider supports image modality."""
+    try:
+        umo = context.context.event.unified_msg_origin
+        provider = context.context.context.get_using_provider(umo=umo)
+        if provider is None:
+            return True  # Cannot determine, assume supported
+        modalities = provider.provider_config.get("modalities", [])
+        return "image" in modalities
+    except Exception:
+        return True  # Cannot determine, assume supported
+
+
+async def _caption_image_fallback(
+    context: ContextWrapper[AstrAgentContext],
+    image_path: str,
+) -> ToolExecResult:
+    """Try to caption an image using the configured image caption provider.
+
+    Returns the caption text or an error message if no caption provider is available.
+    """
+    from astrbot.core.provider.provider import Provider
+
+    umo = context.context.event.unified_msg_origin
+    cfg = context.context.context.get_config(umo=umo)
+    provider_settings = cfg.get("provider_settings", {})
+    caption_provider_id = provider_settings.get("default_image_caption_provider_id", "")
+
+    if not caption_provider_id:
+        return (
+            "Error: your provider does not support image modality, "
+            "and no image caption provider is configured. Unable to read image file."
+        )
+
+    caption_provider = context.context.context.get_provider_by_id(caption_provider_id)
+    if caption_provider is None or not isinstance(caption_provider, Provider):
+        return (
+            "Error: your provider does not support image modality, "
+            f"and the configured image caption provider `{caption_provider_id}` is not available. "
+            "Unable to read image file."
+        )
+
+    caption_prompt = provider_settings.get(
+        "image_caption_prompt", "Please describe the image."
+    )
+
+    try:
+        llm_resp = await caption_provider.text_chat(
+            prompt=caption_prompt,
+            image_urls=[image_path],
+        )
+        caption = (llm_resp.completion_text or "").strip()
+        if not caption:
+            return "Error: image caption provider returned an empty description."
+        return f"[Image description]: {caption}"
+    except Exception as exc:
+        logger.error(f"Image captioning failed: {exc}")
+        return f"Error: failed to generate image description: {exc}"
+
+
 @builtin_tool(config=_COMPUTER_RUNTIME_TOOL_CONFIG)
 @dataclass
 class FileReadTool(FunctionTool):
@@ -281,7 +343,7 @@ class FileReadTool(FunctionTool):
                 context.context.context,
                 context.context.event.unified_msg_origin,
             )
-            return await read_file_tool_result(
+            result = await read_file_tool_result(
                 sb,
                 local_mode=local_env,
                 path=normalized_path,
@@ -293,6 +355,20 @@ class FileReadTool(FunctionTool):
                     else None
                 ),
             )
+
+            # If the result is an image and the provider doesn't support image modality,
+            # fall back to image captioning or return an error.
+            if (
+                isinstance(result, mcp.types.CallToolResult)
+                and result.content
+                and any(
+                    isinstance(item, mcp.types.ImageContent) for item in result.content
+                )
+                and not _provider_supports_image(context)
+            ):
+                return await _caption_image_fallback(context, normalized_path)
+
+            return result
         except PermissionError as exc:
             return f"Error: {exc}"
         except Exception as exc:

--- a/dashboard/src/components/chat/Chat.vue
+++ b/dashboard/src/components/chat/Chat.vue
@@ -81,55 +81,57 @@
         />
       </div>
 
-      <div v-if="!isSidebarCollapsed" class="session-list">
-        <div
-          v-for="session in sessions"
-          :key="session.session_id"
-          class="session-item"
-          :class="{ active: !isProviderWorkspace && currSessionId === session.session_id }"
-          role="button"
-          tabindex="0"
-          @click="selectSession(session.session_id)"
-          @keydown.enter="selectSession(session.session_id)"
-          @keydown.space.prevent="selectSession(session.session_id)"
-        >
-          <span v-if="!isSidebarCollapsed" class="session-title">{{
-            sessionTitle(session)
-          }}</span>
-          <div class="session-actions" @click.stop>
-            <v-btn
-              icon="mdi-pencil-outline"
-              size="x-small"
-              variant="text"
-              class="session-action-btn"
-              :title="tm('conversation.editDisplayName')"
-              @click="editSidebarSessionTitle(session)"
-            />
-            <v-btn
-              icon="mdi-delete-outline"
-              size="x-small"
-              variant="text"
-              class="session-action-btn"
-              :title="tm('actions.deleteChat')"
-              @click="deleteSidebarSession(session)"
+      <OverlayScrollbar v-if="!isSidebarCollapsed" class="session-list-scroll">
+        <div class="session-list">
+          <div
+            v-for="session in sessions"
+            :key="session.session_id"
+            class="session-item"
+            :class="{ active: !isProviderWorkspace && currSessionId === session.session_id }"
+            role="button"
+            tabindex="0"
+            @click="selectSession(session.session_id)"
+            @keydown.enter="selectSession(session.session_id)"
+            @keydown.space.prevent="selectSession(session.session_id)"
+          >
+            <span v-if="!isSidebarCollapsed" class="session-title">{{
+              sessionTitle(session)
+            }}</span>
+            <div class="session-actions" @click.stop>
+              <v-btn
+                icon="mdi-pencil-outline"
+                size="x-small"
+                variant="text"
+                class="session-action-btn"
+                :title="tm('conversation.editDisplayName')"
+                @click="editSidebarSessionTitle(session)"
+              />
+              <v-btn
+                icon="mdi-delete-outline"
+                size="x-small"
+                variant="text"
+                class="session-action-btn"
+                :title="tm('actions.deleteChat')"
+                @click="deleteSidebarSession(session)"
+              />
+            </div>
+            <v-progress-circular
+              v-if="isSessionRunning(session.session_id)"
+              class="session-progress"
+              indeterminate
+              size="16"
+              width="2"
             />
           </div>
-          <v-progress-circular
-            v-if="isSessionRunning(session.session_id)"
-            class="session-progress"
-            indeterminate
-            size="16"
-            width="2"
-          />
-        </div>
 
-        <div
-          v-if="!isSidebarCollapsed && !sessions.length && !loadingSessions"
-          class="empty-sessions"
-        >
-          {{ tm("conversation.noHistory") }}
+          <div
+            v-if="!isSidebarCollapsed && !sessions.length && !loadingSessions"
+            class="empty-sessions"
+          >
+            {{ tm("conversation.noHistory") }}
+          </div>
         </div>
-      </div>
+      </OverlayScrollbar>
 
       <div class="sidebar-footer">
         <StyledMenu
@@ -337,14 +339,16 @@
       </ProjectView>
 
       <template v-else>
-        <section
-          ref="messagesContainer"
+        <OverlayScrollbar
+          ref="messagesScrollbar"
           class="messages-panel"
-          @scroll="handleMessagesScroll"
         >
-          <div v-if="loadingMessages" class="center-state">
-            <v-progress-circular indeterminate size="32" width="3" />
-          </div>
+          <section
+            class="messages-panel-inner"
+          >
+            <div v-if="loadingMessages" class="center-state">
+              <v-progress-circular indeterminate size="32" width="3" />
+            </div>
 
           <div v-else-if="sessionProject" class="session-project-breadcrumb">
             <span>{{ sessionProject.title }}</span>
@@ -387,6 +391,7 @@
             />
           </div>
         </section>
+        </OverlayScrollbar>
 
         <section class="composer-shell">
           <ChatInput
@@ -505,6 +510,7 @@ import { useRoute, useRouter } from "vue-router";
 import { useDisplay } from "vuetify";
 import axios from "axios";
 import StyledMenu from "@/components/shared/StyledMenu.vue";
+import OverlayScrollbar from "@/components/shared/OverlayScrollbar.vue";
 import ProjectDialog, {
   type ProjectFormData,
 } from "@/components/chat/ProjectDialog.vue";
@@ -606,6 +612,7 @@ const projectSessions = ref<Session[]>([]);
 const loadingSessions = ref(false);
 const draft = ref("");
 const messagesContainer = ref<HTMLElement | null>(null);
+const messagesScrollbar = ref<InstanceType<typeof OverlayScrollbar> | null>(null);
 const inputRef = ref<InstanceType<typeof ChatInput> | null>(null);
 const shouldStickToBottom = ref(true);
 const replyTarget = ref<ChatRecord | null>(null);
@@ -761,6 +768,13 @@ onMounted(async () => {
   } finally {
     loadingSessions.value = false;
   }
+  // Bind messagesContainer to OverlayScrollbar viewport
+  nextTick(() => {
+    if (messagesScrollbar.value?.viewport) {
+      messagesContainer.value = messagesScrollbar.value.viewport;
+      messagesContainer.value.addEventListener('scroll', handleMessagesScroll);
+    }
+  });
 });
 
 onBeforeUnmount(() => {
@@ -1477,9 +1491,12 @@ function toggleTheme() {
   transform: rotate(180deg);
 }
 
-.session-list {
+.session-list-scroll {
   flex: 1;
-  overflow-y: auto;
+  min-height: 0;
+}
+
+.session-list {
   padding: 4px 12px 12px;
   display: flex;
   flex-direction: column;
@@ -1611,7 +1628,9 @@ function toggleTheme() {
 .messages-panel {
   flex: 1;
   min-height: 0;
-  overflow-y: auto;
+}
+
+.messages-panel-inner {
   padding: 24px max(24px, calc((100% - 980px) / 2)) 18px;
 }
 
@@ -1744,13 +1763,8 @@ kbd {
 }
 
 @media (max-width: 760px) {
-  .messages-panel {
+  .messages-panel-inner {
     padding: 18px 14px;
-  }
-
-  .composer-shell,
-  .project-composer-shell {
-    padding: 0;
   }
 }
 </style>

--- a/dashboard/src/components/chat/ChatInput.vue
+++ b/dashboard/src/components/chat/ChatInput.vue
@@ -9,8 +9,8 @@
     <div
       class="input-container"
       :style="{
-        width: '85%',
-        maxWidth: '900px',
+        width: '100%',
+        maxWidth: '800px',
         margin: '0 auto',
         border: isDark ? 'none' : '1px solid #e0e0e0',
         borderRadius: '24px',
@@ -1253,46 +1253,4 @@ defineExpose({
   }
 }
 
-@media (max-width: 768px) {
-  .input-area {
-    padding: 0 !important;
-  }
-
-  .input-container {
-    width: 100% !important;
-    max-width: 100% !important;
-    border-bottom-left-radius: 0 !important;
-    border-bottom-right-radius: 0 !important;
-  }
-
-  .input-outline-control {
-    width: 32px !important;
-    height: 32px !important;
-    min-width: 32px !important;
-  }
-
-  .input-area textarea,
-  .chat-textarea {
-    min-height: 28px !important;
-    max-height: 140px !important;
-    font-size: 16px !important;
-    line-height: 20px !important;
-    padding: 8px 14px 7px !important;
-  }
-
-  .attachments-preview {
-    margin: 8px 10px 0;
-    gap: 8px;
-  }
-
-  .attachment-card {
-    width: min(220px, calc(100vw - 28px));
-    height: 58px;
-  }
-
-  .image-preview {
-    width: 58px;
-    flex-basis: 58px;
-  }
-}
 </style>

--- a/dashboard/src/components/provider/AddNewProvider.vue
+++ b/dashboard/src/components/provider/AddNewProvider.vue
@@ -2,24 +2,24 @@
     <v-dialog v-model="showDialog" max-width="1000px" >
         <v-card :title="tm('dialogs.addProvider.title')">
             <v-card-text style="overflow-y: auto;">
-                <v-tabs v-model="activeProviderTab" grow>
-                    <v-tab value="agent_runner" class="font-weight-medium px-3">
+                <v-tabs v-model="activeProviderTab">
+                    <v-tab value="agent_runner" class="font-weight-medium">
                         <v-icon start>mdi-cogs</v-icon>
                         {{ tm('dialogs.addProvider.tabs.agentRunner') }}
                     </v-tab>
-                    <v-tab value="speech_to_text" class="font-weight-medium px-3">
+                    <v-tab value="speech_to_text" class="font-weight-medium">
                         <v-icon start>mdi-microphone-message</v-icon>
                         {{ tm('dialogs.addProvider.tabs.speechToText') }}
                     </v-tab>
-                    <v-tab value="text_to_speech" class="font-weight-medium px-3">
+                    <v-tab value="text_to_speech" class="font-weight-medium">
                         <v-icon start>mdi-volume-high</v-icon>
                         {{ tm('dialogs.addProvider.tabs.textToSpeech') }}
                     </v-tab>
-                    <v-tab value="embedding" class="font-weight-medium px-3">
+                    <v-tab value="embedding" class="font-weight-medium">
                         <v-icon start>mdi-code-json</v-icon>
                         {{ tm('dialogs.addProvider.tabs.embedding') }}
                     </v-tab>
-                    <v-tab value="rerank" class="font-weight-medium px-3">
+                    <v-tab value="rerank" class="font-weight-medium">
                         <v-icon start>mdi-compare-vertical</v-icon>
                         {{ tm('dialogs.addProvider.tabs.rerank') }}
                     </v-tab>
@@ -239,5 +239,19 @@ export default {
     font-size: 24px;
     font-weight: bold;
     opacity: 0.3;
+}
+
+@media (max-width: 960px) {
+    :deep(.v-tab) {
+        min-width: 48px !important;
+        padding: 0 10px !important;
+    }
+    :deep(.v-tab) .v-btn__content {
+        font-size: 0;
+    }
+    :deep(.v-tab) .v-btn__content .v-icon {
+        font-size: 20px;
+        margin-inline-end: 0;
+    }
 }
 </style>

--- a/dashboard/src/components/shared/OverlayScrollbar.vue
+++ b/dashboard/src/components/shared/OverlayScrollbar.vue
@@ -1,0 +1,237 @@
+<script setup>
+import { ref, onMounted, onUnmounted, nextTick, watch } from 'vue';
+
+const props = defineProps({
+  // Minimum thumb height in pixels
+  minThumbSize: {
+    type: Number,
+    default: 32
+  },
+  // Hide the thumb automatically after scrolling stops
+  autoHide: {
+    type: Boolean,
+    default: true
+  },
+  // Delay (ms) before auto hiding after the pointer leaves / scroll stops
+  hideDelay: {
+    type: Number,
+    default: 800
+  }
+});
+
+const viewport = ref(null); // scrollable element
+const thumb = ref(null);
+const trackVisible = ref(false); // pointer is over the area
+const scrolling = ref(false); // recently scrolled
+const dragging = ref(false);
+
+const thumbHeight = ref(0);
+const thumbTop = ref(0);
+const hasOverflow = ref(false);
+
+let hideTimer = null;
+let dragStartY = 0;
+let dragStartScrollTop = 0;
+let resizeObserver = null;
+let mutationObserver = null;
+
+function updateThumb() {
+  const el = viewport.value;
+  if (!el) return;
+  const { scrollHeight, clientHeight, scrollTop } = el;
+  hasOverflow.value = scrollHeight > clientHeight + 1;
+  if (!hasOverflow.value) {
+    thumbHeight.value = 0;
+    return;
+  }
+  const ratio = clientHeight / scrollHeight;
+  const rawHeight = Math.max(clientHeight * ratio, props.minThumbSize);
+  thumbHeight.value = rawHeight;
+  const maxThumbTop = clientHeight - rawHeight;
+  const maxScrollTop = scrollHeight - clientHeight;
+  thumbTop.value = maxScrollTop > 0 ? (scrollTop / maxScrollTop) * maxThumbTop : 0;
+}
+
+function flagScrolling() {
+  scrolling.value = true;
+  if (!props.autoHide) return;
+  if (hideTimer) clearTimeout(hideTimer);
+  hideTimer = setTimeout(() => {
+    if (!dragging.value && !trackVisible.value) {
+      scrolling.value = false;
+    }
+  }, props.hideDelay);
+}
+
+function onScroll() {
+  updateThumb();
+  flagScrolling();
+}
+
+function onPointerEnter() {
+  trackVisible.value = true;
+}
+
+function onPointerLeave() {
+  trackVisible.value = false;
+  if (props.autoHide && !dragging.value) {
+    if (hideTimer) clearTimeout(hideTimer);
+    hideTimer = setTimeout(() => {
+      scrolling.value = false;
+    }, props.hideDelay);
+  }
+}
+
+function onThumbPointerDown(event) {
+  if (!hasOverflow.value) return;
+  event.preventDefault();
+  event.stopPropagation();
+  dragging.value = true;
+  dragStartY = event.clientY;
+  dragStartScrollTop = viewport.value.scrollTop;
+  document.body.style.userSelect = 'none';
+  window.addEventListener('pointermove', onThumbPointerMove);
+  window.addEventListener('pointerup', onThumbPointerUp);
+}
+
+function onThumbPointerMove(event) {
+  if (!dragging.value) return;
+  const el = viewport.value;
+  const { scrollHeight, clientHeight } = el;
+  const maxThumbTop = clientHeight - thumbHeight.value;
+  const maxScrollTop = scrollHeight - clientHeight;
+  const deltaY = event.clientY - dragStartY;
+  const scrollPerPixel = maxThumbTop > 0 ? maxScrollTop / maxThumbTop : 0;
+  el.scrollTop = dragStartScrollTop + deltaY * scrollPerPixel;
+}
+
+function onThumbPointerUp() {
+  dragging.value = false;
+  document.body.style.userSelect = '';
+  window.removeEventListener('pointermove', onThumbPointerMove);
+  window.removeEventListener('pointerup', onThumbPointerUp);
+  if (props.autoHide && !trackVisible.value) {
+    scrolling.value = false;
+  }
+}
+
+// Click on the track jumps the thumb toward the click position
+function onTrackPointerDown(event) {
+  if (!hasOverflow.value || event.target === thumb.value) return;
+  const el = viewport.value;
+  const rect = el.getBoundingClientRect();
+  const clickY = event.clientY - rect.top;
+  const targetThumbTop = clickY - thumbHeight.value / 2;
+  const maxThumbTop = el.clientHeight - thumbHeight.value;
+  const maxScrollTop = el.scrollHeight - el.clientHeight;
+  const clamped = Math.min(Math.max(targetThumbTop, 0), maxThumbTop);
+  el.scrollTop = maxThumbTop > 0 ? (clamped / maxThumbTop) * maxScrollTop : 0;
+}
+
+onMounted(() => {
+  nextTick(updateThumb);
+  if (window.ResizeObserver) {
+    resizeObserver = new ResizeObserver(() => updateThumb());
+    resizeObserver.observe(viewport.value);
+    if (viewport.value.firstElementChild) {
+      resizeObserver.observe(viewport.value.firstElementChild);
+    }
+  }
+  // Watch for content changes (e.g. groups expanding/collapsing)
+  mutationObserver = new MutationObserver(() => updateThumb());
+  mutationObserver.observe(viewport.value, { childList: true, subtree: true });
+});
+
+onUnmounted(() => {
+  if (hideTimer) clearTimeout(hideTimer);
+  if (resizeObserver) resizeObserver.disconnect();
+  if (mutationObserver) mutationObserver.disconnect();
+  window.removeEventListener('pointermove', onThumbPointerMove);
+  window.removeEventListener('pointerup', onThumbPointerUp);
+});
+
+// Allow parent to trigger recomputation
+defineExpose({ updateThumb, viewport });
+</script>
+
+<template>
+  <div class="overlay-scrollbar" @pointerenter="onPointerEnter" @pointerleave="onPointerLeave">
+    <div ref="viewport" class="overlay-scrollbar__viewport" @scroll="onScroll">
+      <slot />
+    </div>
+    <div
+      class="overlay-scrollbar__track"
+      :class="{ 'is-visible': hasOverflow && (trackVisible || scrolling || dragging) }"
+      @pointerdown="onTrackPointerDown"
+    >
+      <div
+        ref="thumb"
+        class="overlay-scrollbar__thumb"
+        :class="{ 'is-dragging': dragging }"
+        :style="{ height: thumbHeight + 'px', transform: `translateY(${thumbTop}px)` }"
+        @pointerdown="onThumbPointerDown"
+      ></div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.overlay-scrollbar {
+  position: relative;
+  height: 100%;
+  width: 100%;
+}
+
+.overlay-scrollbar__viewport {
+  height: 100%;
+  width: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
+  /* Hide native scrollbar without reserving layout space */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.overlay-scrollbar__viewport::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+  display: none;
+}
+
+.overlay-scrollbar__track {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  bottom: 2px;
+  width: 10px;
+  border-radius: 5px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 5;
+}
+
+.overlay-scrollbar__track.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.overlay-scrollbar__thumb {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 6px;
+  margin-right: 2px;
+  border-radius: 4px;
+  background: rgba(var(--v-theme-primary), 0.45);
+  cursor: pointer;
+  transition: width 0.15s ease, background-color 0.15s ease;
+  will-change: transform;
+}
+
+.overlay-scrollbar__track:hover .overlay-scrollbar__thumb,
+.overlay-scrollbar__thumb.is-dragging {
+  width: 8px;
+  background: rgba(var(--v-theme-primary), 0.7);
+}
+</style>

--- a/dashboard/src/layouts/full/FullLayout.vue
+++ b/dashboard/src/layouts/full/FullLayout.vue
@@ -7,6 +7,7 @@ import VerticalHeaderVue from "./vertical-header/VerticalHeader.vue";
 import MigrationDialog from "@/components/shared/MigrationDialog.vue";
 import ReadmeDialog from "@/components/shared/ReadmeDialog.vue";
 import Chat from "@/components/chat/Chat.vue";
+import OverlayScrollbar from "@/components/shared/OverlayScrollbar.vue";
 import { useCustomizerStore } from "@/stores/customizer";
 import { useRouterLoadingStore } from "@/stores/routerLoading";
 import { useCommonStore } from "@/stores/common";
@@ -127,28 +128,23 @@ onMounted(() => {
       <VerticalHeaderVue />
       <VerticalSidebarVue v-if="showSidebar" />
       <v-main
-        :style="{
-          height: isCurrentChatRoute ? 'calc(100vh - 55px)' : undefined,
-          overflow: isCurrentChatRoute ? 'hidden' : undefined,
-        }"
+        style="overflow: hidden; height: calc(100vh - 50px);"
       >
-        <v-container
-          fluid
-          class="page-wrapper"
-          :class="{ 'chat-mode-container': isCurrentChatRoute }"
-          :style="{
-            height: isCurrentChatRoute ? '100%' : 'calc(100% - 8px)',
-            padding: isCurrentChatRoute ? '0' : undefined,
-            minHeight: isCurrentChatRoute ? 'unset' : undefined,
-          }"
-        >
-          <div
-            :style="{
-              height: '100%',
-              width: '100%',
-              overflow: isCurrentChatRoute ? 'hidden' : undefined,
-            }"
+        <OverlayScrollbar v-if="!isCurrentChatRoute" class="main-scrollbar">
+          <v-container
+            fluid
+            class="page-wrapper"
           >
+            <RouterView />
+          </v-container>
+        </OverlayScrollbar>
+        <v-container
+          v-else
+          fluid
+          class="page-wrapper chat-mode-container"
+          style="height: 100%; padding: 0; min-height: unset;"
+        >
+          <div style="height: 100%; width: 100%; overflow: hidden;">
             <div
               v-if="shouldMountChat"
               v-show="isCurrentChatRoute"
@@ -156,7 +152,6 @@ onMounted(() => {
             >
               <Chat :active="isCurrentChatRoute" />
             </div>
-            <RouterView v-if="!isCurrentChatRoute" />
           </div>
         </v-container>
       </v-main>
@@ -176,5 +171,10 @@ onMounted(() => {
   min-height: unset !important;
   height: 100% !important;
   overflow: hidden !important;
+}
+
+.main-scrollbar {
+  height: 100%;
+  width: 100%;
 }
 </style>

--- a/dashboard/src/layouts/full/vertical-header/VerticalHeader.vue
+++ b/dashboard/src/layouts/full/vertical-header/VerticalHeader.vue
@@ -1860,8 +1860,30 @@ onMounted(async () => {
 
 .release-message-preview {
   max-height: 220px;
-  overflow: hidden;
-  position: relative;
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+
+.release-message-preview::-webkit-scrollbar {
+  width: 0;
+}
+
+.release-message-preview:hover {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--v-theme-primary), 0.45) transparent;
+}
+
+.release-message-preview:hover::-webkit-scrollbar {
+  width: 6px;
+}
+
+.release-message-preview:hover::-webkit-scrollbar-thumb {
+  background: rgba(var(--v-theme-primary), 0.45);
+  border-radius: 3px;
+}
+
+.release-message-preview:hover::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 .release-message-preview::after {

--- a/dashboard/src/layouts/full/vertical-sidebar/VerticalSidebar.vue
+++ b/dashboard/src/layouts/full/vertical-sidebar/VerticalSidebar.vue
@@ -7,6 +7,7 @@ import sidebarItems from './sidebarItem';
 import NavItem from './NavItem.vue';
 import { applySidebarCustomization } from '@/utils/sidebarCustomization';
 import ChangelogDialog from '@/components/shared/ChangelogDialog.vue';
+import OverlayScrollbar from '@/components/shared/OverlayScrollbar.vue';
 
 const { t, locale } = useI18n();
 
@@ -294,11 +295,13 @@ function openChangelogDialog() {
     :rail="customizer.mini_sidebar"
   >
     <div class="sidebar-container">
-      <v-list :class="['pa-4', 'listitem', 'flex-grow-1', { 'hidden-scrollbar': customizer.mini_sidebar }]" v-model:opened="openedItems" :open-strategy="'multiple'">
-        <template v-for="(item, i) in sidebarMenu" :key="item.title || item.to || `sidebar-item-${i}`">
-          <NavItem :item="item" class="leftPadding" />
-        </template>
-      </v-list>
+      <OverlayScrollbar class="sidebar-scroll flex-grow-1">
+        <v-list :class="['pa-4', 'listitem', { 'hidden-scrollbar': customizer.mini_sidebar }]" v-model:opened="openedItems" :open-strategy="'multiple'">
+          <template v-for="(item, i) in sidebarMenu" :key="item.title || item.to || `sidebar-item-${i}`">
+            <NavItem :item="item" class="leftPadding" />
+          </template>
+        </v-list>
+      </OverlayScrollbar>
       <div class="sidebar-footer" v-if="!customizer.mini_sidebar">
         <v-btn class="sidebar-footer-btn" size="small" variant="tonal" color="primary" to="/settings" prepend-icon="mdi-cog">
           {{ t('core.navigation.settings') }}

--- a/dashboard/src/scss/layout/_container.scss
+++ b/dashboard/src/scss/layout/_container.scss
@@ -1,8 +1,9 @@
 html {
-  overflow-y: auto;
+  overflow: hidden;
 }
 .v-main {
   margin: 0;
+  overflow: hidden;
 }
 
 .top-header {

--- a/dashboard/src/scss/layout/_sidebar.scss
+++ b/dashboard/src/scss/layout/_sidebar.scss
@@ -5,7 +5,6 @@
   box-shadow: none !important;
 }
 .listitem {
-  overflow-y: auto;
   .v-list {
     color: rgb(var(--v-theme-secondaryText));
   }
@@ -97,6 +96,12 @@
     .flex-grow-1 {
       flex: 1 1 auto;
       overflow-y: auto;
+    }
+
+    .sidebar-scroll {
+      flex: 1 1 auto;
+      min-height: 0;
+      overflow: hidden;
     }
     
     .sidebar-footer {

--- a/dashboard/src/views/ConfigPage.vue
+++ b/dashboard/src/views/ConfigPage.vue
@@ -905,7 +905,7 @@ export default {
 
 .unsaved-changes-banner-wrap {
   position: sticky;
-  top: calc(var(--v-layout-top, 64px));
+  top: 0;
   z-index: 20;
   width: 100%;
   margin-bottom: 6px;

--- a/dashboard/src/views/ConfigPage.vue
+++ b/dashboard/src/views/ConfigPage.vue
@@ -987,6 +987,7 @@ export default {
   display: flex;
   flex-direction: column;
   margin: 16px;
+  overflow: hidden;
 }
 
 .test-chat-header {

--- a/dashboard/src/views/ProviderPage.vue
+++ b/dashboard/src/views/ProviderPage.vue
@@ -890,6 +890,29 @@ function goToConfigPage() {
     overflow-x: auto;
   }
 
+  .provider-page :deep(.v-tab) {
+    min-width: 0;
+    padding: 0 8px;
+  }
+
+  .provider-page :deep(.v-tab) .v-btn__content {
+    white-space: nowrap;
+  }
+
+  @media (max-width: 960px) {
+    .provider-page :deep(.v-tab) {
+      min-width: 48px !important;
+      padding: 0 10px !important;
+    }
+    .provider-page :deep(.v-tab) .v-btn__content {
+      font-size: 0;
+    }
+    .provider-page :deep(.v-tab) .v-btn__content .v-icon {
+      font-size: 20px;
+      margin-inline-end: 0;
+    }
+  }
+
   .provider-workbench {
     border-radius: 16px;
     overflow: visible;

--- a/dashboard/src/views/extension/PluginDetailPage.vue
+++ b/dashboard/src/views/extension/PluginDetailPage.vue
@@ -1053,7 +1053,7 @@ onBeforeUnmount(() => {
   margin-bottom: 28px;
   padding: 10px 0;
   position: sticky;
-  top: calc(var(--v-layout-top, 64px));
+  top: 0;
   z-index: 20;
 }
 


### PR DESCRIPTION
## Motivation / 动机

前端 Dashboard 在窄屏/手机端存在多个体验问题：

- 原生滚动条占据布局空间，挤压侧边栏菜单内容
- 主页滚动条覆盖标题栏，层级混乱
- 模型提供商标签页在窄屏下溢出屏幕
- 对话框输入面板在 768px 断点处突然变形
- 更新日志区域无法滚动

## Modifications / 改动点

- 新增 OverlayScrollbar 组件：覆盖式滚动条，不占布局空间，鼠标进入才出现，可拖动
- 侧边栏菜单、主页内容区、对话会话列表、消息面板使用覆盖式滚动条
- 修复主页滚动条覆盖标题栏问题（将滚动容器限制在内容区域内）
- 模型提供商标签页窄屏自适应：缩小 tab 宽度，极窄时只显示图标
- 修复对话框输入面板尺寸自适应 BUG：移除 768px 突变 media query，改为流畅缩放
- 更新日志框改为可滚动，hover 时显示滚动条

## This is NOT a breaking change. / 这不是一个破坏性变更。

## Checklist / 检查清单

- [x] My changes have been well-tested, and verification steps and screenshots have been provided above.
- [x] I have ensured that no new dependencies are introduced.
- [x] My changes do not introduce malicious code.

## Summary by Sourcery

Improve dashboard scrolling and mobile layout while adding a safer file-read behavior for image content when the current provider lacks image modality support.

New Features:
- Introduce a reusable OverlayScrollbar component to provide overlay scrollbars without affecting layout and apply it to main content, sidebar menu, chat session list, and message panel.
- Add a fallback in the file read tool to caption image files via a configured image caption provider when the active provider does not support image modality.

Bug Fixes:
- Fix chat layout issues on narrow screens by smoothing ChatInput resizing and preventing sudden deformation at specific breakpoints.
- Resolve content scrollbars overlapping headers and titles by constraining scroll areas to inner containers and adjusting sticky banner positions.
- Prevent provider-related tab bars and dialogs from overflowing on small screens and make the changelog release preview area scrollable.

Enhancements:
- Refine global and container overflow handling to hide native scrollbars and rely on overlay scrollbars for a cleaner appearance.
- Improve responsiveness of provider configuration and add-provider views by tightening tab padding and switching to icon-only tabs on very narrow screens.