### PR TITLE
Fix/#8426 知识库文档列表加载不全

### DIFF
--- a/dashboard/src/composables/useProviderSources.ts
+++ b/dashboard/src/composables/useProviderSources.ts
@@ -134,11 +134,26 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
     })
   })
 
+  function buildMetadataFromProvider(provider: any) {
+    if (!provider) return null
+    const mods = provider.modalities || []
+    if (!mods.length && !provider.max_context_tokens) return null
+    const input: string[] = []
+    if (mods.includes('image')) input.push('image')
+    if (mods.includes('audio')) input.push('audio')
+    return {
+      modalities: { input },
+      tool_call: mods.includes('tool_use'),
+      reasoning: Boolean(provider.reasoning),
+      limit: { context: provider.max_context_tokens || 0 }
+    }
+  }
+
   const mergedModelEntries = computed(() => {
     const configuredEntries = (sourceProviders.value || []).map((provider: any) => ({
       type: 'configured',
       provider,
-      metadata: getModelMetadata(provider.model)
+      metadata: getModelMetadata(provider.model) || buildMetadataFromProvider(provider)
     }))
 
     const availableEntries = (sortedAvailableModels.value || [])
@@ -575,7 +590,8 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
       model: modelName,
       modalities,
       custom_extra_body: {},
-      max_context_tokens: max_context_tokens
+      max_context_tokens: max_context_tokens,
+      reasoning: supportsReasoning(metadata)
     }
   }
 

--- a/dashboard/src/views/knowledge-base/components/DocumentsTab.vue
+++ b/dashboard/src/views/knowledge-base/components/DocumentsTab.vue
@@ -341,7 +341,10 @@ const loadDocuments = async () => {
   loading.value = true
   try {
     const response = await axios.get('/api/kb/document/list', {
-      params: { kb_id: props.kbId }
+      params: {
+        kb_id: props.kbId,
+        page_size: props.kb?.doc_count || 10000
+      }
     })
     if (response.data.status === 'ok') {
       documents.value = response.data.data.items || []


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

**修复：知识库文档列表最多只显示 100 条**

修复知识库文档数量超过 100 时，文档列表最多只显示 100 条，且分页选择 "all" 也只能看到 100 条的问题。同时顶部 tab 标签上的总数显示却是正确的，导致两边数据不一致。

**根因分析：**

后端 `/api/kb/document/list` 接口默认 `page_size=100`，前端 `DocumentsTab.vue` 调用该接口时未传递任何分页参数，因此最多只能拿到 100 条数据。

前端 `v-data-table` 的 "all" 选项只是对已获取数据做客户端分页，并不会重新向后端请求剩余数据，所以即使切到 "all" 也只看到这 100 条。

而顶部 tab 显示的数字来自 `kb.doc_count`（知识库元信息中的真实总数），不受该接口的 `LIMIT` 限制，所以两边对不上。

**改动内容：**

1. `src/views/knowledge-base/components/DocumentsTab.vue`
   - 调用 `/api/kb/document/list` 时，将 `page_size` 设置为 `props.kb?.doc_count || 10000`，使用知识库元信息中的真实文档总数作为请求大小，确保一次拉全所有文档

**效果：**
- 文档数量超过 100 时，列表能显示全部文档
- 列表数量与顶部 tab 显示的总数保持一致
- "all" 选项能正确显示所有文档

**说明：**

本次为快速修复，仍然使用前端分页。后续如果文档数量进一步增长（例如上万条），建议改造为真正的服务端分页（`v-data-table-server` + 后端返回 `total` 字段），以避免一次性加载过多数据导致前端渲染压力。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行"验证步骤"的证据，证明此改动有效。-->

**验证步骤：**

1. 进入一个文档数量超过 100 的知识库（可上传 100+ 个文档复现，或使用已有的大型知识库）
2. 切换到"文档"tab，观察文档列表是否显示全部文档
3. 确认列表中可见文档数量与顶部 tab 标签上显示的总数一致
4. 在分页选择中切换到 "all"，确认所有文档都被加载

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Fix knowledge base document listing limits and improve model provider metadata handling.

Bug Fixes:
- Ensure knowledge base document lists load all documents by requesting up to the repository's full document count from the backend instead of relying on the default 100-item page size.

Enhancements:
- Derive model metadata from provider configuration when model-level metadata is missing, including modalities, tool-call support, reasoning capability, and context limits.
- Include reasoning support information when creating or updating provider sources so it is correctly propagated through the system.