### PR TITLE
fix: waking bot with a reply component and empty user prompt

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -1431,7 +1431,7 @@ async def build_main_agent(
     has_reply = any(isinstance(comp, Reply) for comp in event.message_obj.message)
 
     if not req.prompt and not req.image_urls and not req.audio_urls:
-        if has_reply:
+        if has_reply or req.extra_user_content_parts:
             req.prompt = "<attachment>"
         else:
             return None

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -1428,13 +1428,15 @@ async def build_main_agent(
         except Exception as exc:  # noqa: BLE001
             logger.error("Error occurred while applying file extract: %s", exc)
 
-    await _decorate_llm_request(event, req, plugin_context, config, provider=provider)
+    has_reply = any(isinstance(comp, Reply) for comp in event.message_obj.message)
 
     if not req.prompt and not req.image_urls and not req.audio_urls:
-        if req.extra_user_content_parts:
+        if has_reply:
             req.prompt = "<attachment>"
         else:
             return None
+
+    await _decorate_llm_request(event, req, plugin_context, config, provider=provider)
 
     await _apply_kb(event, req, plugin_context, config)
 

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -1428,13 +1428,13 @@ async def build_main_agent(
         except Exception as exc:  # noqa: BLE001
             logger.error("Error occurred while applying file extract: %s", exc)
 
+    await _decorate_llm_request(event, req, plugin_context, config, provider=provider)
+
     if not req.prompt and not req.image_urls and not req.audio_urls:
-        if not event.get_group_id() and req.extra_user_content_parts:
+        if req.extra_user_content_parts:
             req.prompt = "<attachment>"
         else:
             return None
-
-    await _decorate_llm_request(event, req, plugin_context, config, provider=provider)
 
     await _apply_kb(event, req, plugin_context, config)
 

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -19,7 +19,7 @@ from astrbot.core.astr_main_agent import (
     MainAgentBuildResult,
     build_main_agent,
 )
-from astrbot.core.message.components import File, Image, Record, Video
+from astrbot.core.message.components import File, Image, Record, Reply, Video
 from astrbot.core.message.message_event_result import (
     MessageChain,
     MessageEventResult,
@@ -177,11 +177,16 @@ class InternalAgentSubStage(Stage):
                 isinstance(comp, (Image, File, Record, Video))
                 for comp in event.message_obj.message
             )
+            has_reply = any(
+                isinstance(comp, Reply)
+                for comp in event.message_obj.message
+            )
 
             if (
                 not has_provider_request
                 and not has_valid_message
                 and not has_media_content
+                and not has_reply
             ):
                 logger.debug("skip llm request: empty message and no provider_request")
                 return

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -178,8 +178,7 @@ class InternalAgentSubStage(Stage):
                 for comp in event.message_obj.message
             )
             has_reply = any(
-                isinstance(comp, Reply)
-                for comp in event.message_obj.message
+                isinstance(comp, Reply) for comp in event.message_obj.message
             )
 
             if (


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
fix #8368
当用户引用任意消息并 @ Bot 但不附加文字时，消息链为 `[Reply, At]`，`message_str` 为空，导致以下两个问题：

1. `internal.py` 在 `message_str` 为空时直接跳过 LLM 请求，即使消息链中包含 `Reply` 组件。
2. `astr_main_agent.py` 在 `_decorate_llm_request` 执行之前就检查内容是否为空，此时引用消息文字尚未注入 `extra_user_content_parts`，导致 `build_main_agent` 返回 `None`。


### Modifications / 改动点

- `astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py`：新增 `has_reply` 判断，消息链含 `Reply` 组件时不跳过 LLM 请求。
- `astrbot/core/astr_main_agent.py`：将空内容检查移至 `_decorate_llm_request` 之后，确保引用消息内容已注入后再判断；同时去掉群聊限制条件 `not event.get_group_id()`。

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<img width="1270" height="540" alt="image" src="https://github.com/user-attachments/assets/297da09c-e430-4d0c-926e-6b76ff42378f" />
正常回复

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x]  🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure LLM requests are triggered when users reply to a message and mention the bot without additional text.

Bug Fixes:
- Prevent LLM requests from being skipped when the message contains only a reply and an @Bot mention with no extra text.
- Allow empty prompts to be replaced with a placeholder when there is a reply or extra user content, instead of aborting the main agent build.