### PR TITLE
feat: dynamically fetch model list for MiniMax Token Plan via /v1/models API

### DIFF
--- a/astrbot/core/provider/sources/minimax_token_plan_source.py
+++ b/astrbot/core/provider/sources/minimax_token_plan_source.py
@@ -1,17 +1,9 @@
+import httpx
+
 from astrbot import logger
 from astrbot.core.provider.sources.anthropic_source import ProviderAnthropic
 
 from ..register import register_provider_adapter
-
-MINIMAX_TOKEN_PLAN_MODELS = [
-    "MiniMax-M2.7",
-    "MiniMax-M2.7-highspeed",
-    "MiniMax-M2.5",
-    "MiniMax-M2.5-highspeed",
-    "MiniMax-M2.1",
-    "MiniMax-M2.1-highspeed",
-    "MiniMax-M2",
-]
 
 
 @register_provider_adapter(
@@ -21,9 +13,9 @@ MINIMAX_TOKEN_PLAN_MODELS = [
 class ProviderMiniMaxTokenPlan(ProviderAnthropic):
     """MiniMax Token Plan provider.
 
-    The Token Plan API does not support the /models endpoint, so get_models()
-    returns a hard-coded model list. This is a Token Plan API limitation.
-    See https://github.com/AstrBotDevs/AstrBot/issues/7585 for details.
+    The model list is fetched dynamically from the MiniMax API's /v1/models
+    endpoint, so newly released models (e.g. MiniMax-M3) are automatically
+    discovered without a code change.
     """
 
     def __init__(
@@ -46,18 +38,24 @@ class ProviderMiniMaxTokenPlan(ProviderAnthropic):
         )
 
         configured_model = provider_config.get("model", "MiniMax-M2.7")
-        if configured_model not in MINIMAX_TOKEN_PLAN_MODELS:
-            logger.warning(
-                f"Configured model {configured_model!r} is not in the known "
-                f"Token Plan model list "
-                f"({', '.join(MINIMAX_TOKEN_PLAN_MODELS)}). "
-                f"The model may still work if your plan supports it. "
-                f"If you encounter errors, please check your plan's "
-                f"model availability."
-            )
-
         self.set_model(configured_model)
 
     async def get_models(self) -> list[str]:
-        """Return the hard-coded known model list because Token Plan cannot fetch it dynamically."""
-        return MINIMAX_TOKEN_PLAN_MODELS.copy()
+        """Dynamically fetch available models from the MiniMax API."""
+        key = self.chosen_api_key
+        if not key:
+            logger.warning("No API key configured for MiniMax Token Plan.")
+            return []
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(
+                    "https://api.minimaxi.com/v1/models",
+                    headers={"Authorization": f"Bearer {key}"},
+                    timeout=10,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                return [m["id"] for m in data.get("data", [])]
+        except Exception as e:
+            logger.error(f"Failed to fetch MiniMax model list: {e}")
+            return []


### PR DESCRIPTION
## 改动内容

将 MiniMax Token Plan Provider 的模型列表从硬编码改为通过 MiniMax API 动态获取。

### 背景

当前 `ProviderMiniMaxTokenPlan.get_models()` 返回硬编码的模型列表，不包含新发布的 MiniMax-M3。由于 Token Plan 使用 Anthropic SDK 走 `/anthropic/models` 端点返回 404，无法通过父类的 Anthropic `client.models.list()` 获取。

### 修改

- 删除 `MINIMAX_TOKEN_PLAN_MODELS` 硬编码常量
- 删除 `__init__` 中的模型存在性检查和 warning 日志
- `get_models()` 改为直接调用 MiniMax `/v1/models` 端点动态获取
- 引入 `httpx` 用于异步 HTTP 请求

这样以后 MiniMax 发布新模型（如 M4、M5 等）无需再更新代码，/model 指令会自动识别。

### 测试

已通过 curl 验证 MiniMax `/v1/models` 端点正常返回，包含 MiniMax-M3：
- MiniMax-M3
- MiniMax-M2.7 / M2.7-highspeed
- MiniMax-M2.5 / M2.5-highspeed
- MiniMax-M2.1 / M2.1-highspeed
- MiniMax-M2

Fixes #7585

## Summary by Sourcery

Fetch MiniMax Token Plan models dynamically from the MiniMax /v1/models API instead of using a hard-coded list.

New Features:
- Support dynamic discovery of MiniMax Token Plan models via the MiniMax /v1/models endpoint.

Bug Fixes:
- Ensure newly released MiniMax models become available to the Token Plan provider without code changes.

Enhancements:
- Simplify MiniMax Token Plan provider initialization by removing hard-coded model validation and warnings.
- Introduce asynchronous HTTP fetching for MiniMax model metadata using httpx.