### PR TITLE
feat: upgrade MiniMax Token Plan default model to M3

### DIFF
--- a/astrbot/core/provider/sources/minimax_token_plan_source.py
+++ b/astrbot/core/provider/sources/minimax_token_plan_source.py
@@ -14,8 +14,8 @@ class ProviderMiniMaxTokenPlan(ProviderAnthropic):
     """MiniMax Token Plan provider.
 
     The model list is fetched dynamically from the MiniMax API's /v1/models
-    endpoint, so newly released models (e.g. MiniMax-M3) are automatically
-    discovered without a code change.
+    endpoint, so newly released models are automatically discovered without
+    a code change. The default model is MiniMax-M3, the current flagship.
     """
 
     def __init__(
@@ -37,7 +37,7 @@ class ProviderMiniMaxTokenPlan(ProviderAnthropic):
             provider_settings,
         )
 
-        configured_model = provider_config.get("model", "MiniMax-M2.7")
+        configured_model = provider_config.get("model", "MiniMax-M3")
         self.set_model(configured_model)
 
     async def get_models(self) -> list[str]:


### PR DESCRIPTION
## Summary

Update the MiniMax Token Plan provider's hardcoded default fallback model from `MiniMax-M2.7` to `MiniMax-M3`, the current flagship model.

## Why

After PR #8475 made the Token Plan model list fully dynamic (fetched from `/v1/models`), all MiniMax models including M3 are automatically discovered without any code changes. The only remaining hardcoded reference is the fallback used when a user has not yet configured a `model` field — and that fallback still points to the previous-generation M2.7.

M3 is the current flagship Token Plan model and is the more appropriate first-run default for new users.

## Changes

- `astrbot/core/provider/sources/minimax_token_plan_source.py`: change the default model from `MiniMax-M2.7` to `MiniMax-M3`, and update the docstring to reflect the new default.

## Compatibility

- Users who already have `model` configured in their provider config are unaffected — the value is read with `provider_config.get("model", "MiniMax-M3")`, so the new default only applies when nothing is set.
- `MiniMax-M2.7` remains a valid choice; users can continue to select it explicitly from the dynamically fetched model list.

## Testing

- `ruff format .` and `ruff check .` pass on the modified file.
- No existing tests reference the previous default model string, so no test updates are required.

## Summary by Sourcery

Update the MiniMax Token Plan provider to use MiniMax-M3 as the default fallback model and document this as the current flagship default.

Enhancements:
- Change the hardcoded MiniMax Token Plan default model from MiniMax-M2.7 to MiniMax-M3 for users without an explicit model configuration.

Documentation:
- Clarify in the MiniMax Token Plan provider docstring that MiniMax-M3 is the default flagship model used when discovering models dynamically.