### PR TITLE
fix(qqofficial): use appid self id for incoming messages

### DIFF
--- a/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
@@ -76,6 +76,7 @@ class botClient(Client):
         abm = await QQOfficialPlatformAdapter._parse_from_qqofficial(
             message,
             MessageType.GROUP_MESSAGE,
+            self.platform.appid,
         )
         abm.group_id = cast(str, message.group_openid)
         abm.session_id = abm.group_id
@@ -87,6 +88,7 @@ class botClient(Client):
         abm = await QQOfficialPlatformAdapter._parse_from_qqofficial(
             message,
             MessageType.GROUP_MESSAGE,
+            self.platform.appid,
         )
         abm.group_id = message.channel_id
         abm.session_id = abm.group_id
@@ -100,6 +102,7 @@ class botClient(Client):
         abm = await QQOfficialPlatformAdapter._parse_from_qqofficial(
             message,
             MessageType.FRIEND_MESSAGE,
+            self.platform.appid,
         )
         abm.session_id = abm.sender.user_id
         self.platform.remember_session_scene(abm.session_id, "friend")
@@ -110,6 +113,7 @@ class botClient(Client):
         abm = await QQOfficialPlatformAdapter._parse_from_qqofficial(
             message,
             MessageType.FRIEND_MESSAGE,
+            self.platform.appid,
         )
         abm.session_id = abm.sender.user_id
         self.platform.remember_session_scene(abm.session_id, "friend")
@@ -530,6 +534,7 @@ class QQOfficialPlatformAdapter(Platform):
         | botpy.message.DirectMessage
         | botpy.message.C2CMessage,
         message_type: MessageType,
+        appid: str,
     ) -> AstrBotMessage:
         abm = AstrBotMessage()
         abm.type = message_type
@@ -546,14 +551,14 @@ class QQOfficialPlatformAdapter(Platform):
             if isinstance(message, botpy.message.GroupMessage):
                 abm.sender = MessageMember(message.author.member_openid, "")
                 abm.group_id = message.group_openid
+                msg.append(At(qq=appid))
             else:
                 abm.sender = MessageMember(message.author.user_openid, "")
             # Parse face messages to readable text
             abm.message_str = QQOfficialPlatformAdapter._parse_face_message(
                 message.content.strip()
             )
-            abm.self_id = "unknown_selfid"
-            msg.append(At(qq="qq_official"))
+            abm.self_id = appid
             msg.append(Plain(abm.message_str))
             await QQOfficialPlatformAdapter._append_attachments(
                 msg, message.attachments
@@ -564,14 +569,11 @@ class QQOfficialPlatformAdapter(Platform):
             message,
             botpy.message.DirectMessage,
         ):
-            if isinstance(message, botpy.message.Message):
-                abm.self_id = str(message.mentions[0].id)
-            else:
-                abm.self_id = ""
+            abm.self_id = appid
 
             plain_content = QQOfficialPlatformAdapter._parse_face_message(
                 message.content.replace(
-                    "<@!" + str(abm.self_id) + ">",
+                    "<@!" + appid + ">",
                     "",
                 ).strip()
             )
@@ -585,14 +587,14 @@ class QQOfficialPlatformAdapter(Platform):
                 str(message.author.id),
                 str(message.author.username),
             )
-            msg.append(At(qq="qq_official"))
+            if isinstance(message, botpy.message.Message):
+                msg.append(At(qq=appid))
             msg.append(Plain(plain_content))
 
             if isinstance(message, botpy.message.Message):
                 abm.group_id = message.channel_id
         else:
             raise ValueError(f"Unknown message type: {message_type}")
-        abm.self_id = "qq_official"
         return abm
 
     def run(self):

--- a/astrbot/core/platform/sources/qqofficial_webhook/qo_webhook_adapter.py
+++ b/astrbot/core/platform/sources/qqofficial_webhook/qo_webhook_adapter.py
@@ -34,6 +34,7 @@ class botClient(Client):
         abm = await QQOfficialPlatformAdapter._parse_from_qqofficial(
             message,
             MessageType.GROUP_MESSAGE,
+            self.platform.appid,
         )
         abm.group_id = cast(str, message.group_openid)
         abm.session_id = abm.group_id
@@ -45,6 +46,7 @@ class botClient(Client):
         abm = await QQOfficialPlatformAdapter._parse_from_qqofficial(
             message,
             MessageType.GROUP_MESSAGE,
+            self.platform.appid,
         )
         abm.group_id = message.channel_id
         abm.session_id = abm.group_id
@@ -58,6 +60,7 @@ class botClient(Client):
         abm = await QQOfficialPlatformAdapter._parse_from_qqofficial(
             message,
             MessageType.FRIEND_MESSAGE,
+            self.platform.appid,
         )
         abm.session_id = abm.sender.user_id
         self.platform.remember_session_scene(abm.session_id, "friend")
@@ -68,6 +71,7 @@ class botClient(Client):
         abm = await QQOfficialPlatformAdapter._parse_from_qqofficial(
             message,
             MessageType.FRIEND_MESSAGE,
+            self.platform.appid,
         )
         abm.session_id = abm.sender.user_id
         self.platform.remember_session_scene(abm.session_id, "friend")

--- a/tests/test_qqofficial_adapter.py
+++ b/tests/test_qqofficial_adapter.py
@@ -1,0 +1,216 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from astrbot.api.message_components import At
+from astrbot.api.platform import AstrBotMessage, MessageType
+from astrbot.core.platform.sources.qqofficial import qqofficial_platform_adapter
+from astrbot.core.platform.sources.qqofficial.qqofficial_platform_adapter import (
+    QQOfficialPlatformAdapter,
+)
+from astrbot.core.platform.sources.qqofficial_webhook import qo_webhook_adapter
+
+APPID = "1024"
+
+
+class _FakeGroupMessage:
+    def __init__(self, content: str = "hello") -> None:
+        self.id = "group-msg"
+        self.content = content
+        self.group_openid = "group-openid"
+        self.author = SimpleNamespace(member_openid="member-openid")
+        self.attachments = []
+
+
+class _FakeChannelMessage:
+    def __init__(self, content: str = f"<@!{APPID}> channel hello") -> None:
+        self.id = "channel-msg"
+        self.content = content
+        self.channel_id = "channel-id"
+        self.author = SimpleNamespace(id="author-id", username="alice")
+        self.attachments = []
+
+
+class _FakeDirectMessage:
+    def __init__(self, content: str = "direct hello") -> None:
+        self.id = "direct-msg"
+        self.content = content
+        self.author = SimpleNamespace(id="author-id", username="alice")
+        self.sender = SimpleNamespace(user_id="direct-user")
+        self.attachments = []
+
+
+class _FakeC2CMessage:
+    def __init__(self, content: str = "c2c hello") -> None:
+        self.id = "c2c-msg"
+        self.content = content
+        self.author = SimpleNamespace(user_openid="user-openid")
+        self.sender = SimpleNamespace(user_id="c2c-user")
+        self.attachments = []
+
+
+@pytest.fixture
+def fake_qqofficial_message_types(monkeypatch):
+    monkeypatch.setattr(
+        qqofficial_platform_adapter.botpy.message,
+        "GroupMessage",
+        _FakeGroupMessage,
+    )
+    monkeypatch.setattr(
+        qqofficial_platform_adapter.botpy.message,
+        "Message",
+        _FakeChannelMessage,
+    )
+    monkeypatch.setattr(
+        qqofficial_platform_adapter.botpy.message,
+        "DirectMessage",
+        _FakeDirectMessage,
+    )
+    monkeypatch.setattr(
+        qqofficial_platform_adapter.botpy.message,
+        "C2CMessage",
+        _FakeC2CMessage,
+    )
+
+
+def _at_targets(message: AstrBotMessage) -> list[str]:
+    return [
+        str(component.qq) for component in message.message if isinstance(component, At)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_qqofficial_group_message_uses_appid_self_id_and_at(
+    fake_qqofficial_message_types,
+):
+    abm = await QQOfficialPlatformAdapter._parse_from_qqofficial(
+        _FakeGroupMessage(),
+        MessageType.GROUP_MESSAGE,
+        APPID,
+    )
+
+    assert abm.self_id == APPID
+    assert abm.group_id == "group-openid"
+    assert _at_targets(abm) == [APPID]
+
+
+@pytest.mark.asyncio
+async def test_qqofficial_channel_message_uses_appid_self_id_and_at(
+    fake_qqofficial_message_types,
+):
+    abm = await QQOfficialPlatformAdapter._parse_from_qqofficial(
+        _FakeChannelMessage(),
+        MessageType.GROUP_MESSAGE,
+        APPID,
+    )
+
+    assert abm.self_id == APPID
+    assert abm.group_id == "channel-id"
+    assert abm.message_str == "channel hello"
+    assert _at_targets(abm) == [APPID]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("message", "expected_sender_id"),
+    [
+        (_FakeDirectMessage(), "author-id"),
+        (_FakeC2CMessage(), "user-openid"),
+    ],
+)
+async def test_qqofficial_private_messages_use_appid_self_id_without_at(
+    fake_qqofficial_message_types,
+    message,
+    expected_sender_id: str,
+):
+    abm = await QQOfficialPlatformAdapter._parse_from_qqofficial(
+        message,
+        MessageType.FRIEND_MESSAGE,
+        APPID,
+    )
+
+    assert abm.self_id == APPID
+    assert abm.sender.user_id == expected_sender_id
+    assert _at_targets(abm) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("client_cls", "handler_name", "message", "message_type"),
+    [
+        (
+            qqofficial_platform_adapter.botClient,
+            "on_group_at_message_create",
+            _FakeGroupMessage(),
+            MessageType.GROUP_MESSAGE,
+        ),
+        (
+            qqofficial_platform_adapter.botClient,
+            "on_at_message_create",
+            _FakeChannelMessage(),
+            MessageType.GROUP_MESSAGE,
+        ),
+        (
+            qqofficial_platform_adapter.botClient,
+            "on_direct_message_create",
+            _FakeDirectMessage(),
+            MessageType.FRIEND_MESSAGE,
+        ),
+        (
+            qqofficial_platform_adapter.botClient,
+            "on_c2c_message_create",
+            _FakeC2CMessage(),
+            MessageType.FRIEND_MESSAGE,
+        ),
+        (
+            qo_webhook_adapter.botClient,
+            "on_group_at_message_create",
+            _FakeGroupMessage(),
+            MessageType.GROUP_MESSAGE,
+        ),
+        (
+            qo_webhook_adapter.botClient,
+            "on_at_message_create",
+            _FakeChannelMessage(),
+            MessageType.GROUP_MESSAGE,
+        ),
+        (
+            qo_webhook_adapter.botClient,
+            "on_direct_message_create",
+            _FakeDirectMessage(),
+            MessageType.FRIEND_MESSAGE,
+        ),
+        (
+            qo_webhook_adapter.botClient,
+            "on_c2c_message_create",
+            _FakeC2CMessage(),
+            MessageType.FRIEND_MESSAGE,
+        ),
+    ],
+)
+async def test_qqofficial_handlers_pass_platform_appid_to_parser(
+    client_cls,
+    handler_name: str,
+    message,
+    message_type: MessageType,
+):
+    client = client_cls.__new__(client_cls)
+    client.platform = SimpleNamespace(
+        appid=APPID,
+        remember_session_scene=MagicMock(),
+    )
+    client._commit = MagicMock()
+
+    parsed_message = AstrBotMessage()
+    parsed_message.sender = SimpleNamespace(user_id="sender-id")
+    parse_mock = AsyncMock(return_value=parsed_message)
+
+    with patch.object(
+        QQOfficialPlatformAdapter,
+        "_parse_from_qqofficial",
+        parse_mock,
+    ):
+        await getattr(client, handler_name)(message)
+
+    parse_mock.assert_awaited_once_with(message, message_type, APPID)


### PR DESCRIPTION
## Summary
- pass the QQ official appid into WebSocket and webhook message parsing
- use appid as `self_id` so downstream code can resolve bot identity/avatar data consistently
- only inject the bot `At` component for group/channel messages and avoid polluting direct/C2C messages
- strip the channel `<@!appid>` mention from text content after preserving the structured `At` component

## Relation to existing PR
This is the narrowed replacement for #7289 / #6741. The existing `feat/6741` branch is currently conflicting and contains a large amount of unrelated historical changes. The fork branch is protected against force-push, so this PR keeps only the current QQ official appid/self_id/At fix in a clean branch.

## Validation
- `../AstrBot/.venv/bin/python -m pytest tests/test_qqofficial_adapter.py -q`
- `../AstrBot/.venv/bin/ruff check astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py astrbot/core/platform/sources/qqofficial_webhook/qo_webhook_adapter.py tests/test_qqofficial_adapter.py`
- `../AstrBot/.venv/bin/ruff format --check astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py astrbot/core/platform/sources/qqofficial_webhook/qo_webhook_adapter.py tests/test_qqofficial_adapter.py`

## Duplicate check
Checked open upstream QQ official PRs. #7289 is the previous broad/conflicting version from this fork; other open QQ official PRs target keyboard support, image upload, duplicate consumption, proactive markdown sends, or friend-message send payloads, so no other same-scope PR was found.

## Summary by Sourcery

Align QQ Official incoming message parsing with the appid-based bot identity model.

Bug Fixes:
- Set QQ Official incoming message self_id to the platform appid so downstream identity and avatar resolution work correctly.
- Avoid injecting bot At mentions into direct/C2C QQ Official messages and strip the raw appid mention from channel text content while preserving structured mentions.

Tests:
- Add unit tests covering QQ Official WebSocket and webhook handlers, ensuring they pass appid into the parser and validate self_id and At behavior for group, channel, direct, and C2C messages.