### PR TITLE
perf(stt-whisper): close the audio file handle after calling the OpenAI transcription API

### DIFF
--- a/astrbot/core/provider/sources/whisper_api_source.py
+++ b/astrbot/core/provider/sources/whisper_api_source.py
@@ -116,14 +116,11 @@ class ProviderOpenAIWhisperAPI(STTProvider):
 
                 audio_url = output_path
 
-        audio_file = open(audio_url, "rb")
-        try:
+        with open(audio_url, "rb") as audio_file:
             result = await self.client.audio.transcriptions.create(
                 model=self.model_name,
                 file=("audio.wav", audio_file),
             )
-        finally:
-            audio_file.close()
 
         # remove temp file
         if output_path and os.path.exists(output_path):

--- a/astrbot/core/provider/sources/whisper_api_source.py
+++ b/astrbot/core/provider/sources/whisper_api_source.py
@@ -116,10 +116,14 @@ class ProviderOpenAIWhisperAPI(STTProvider):
 
                 audio_url = output_path
 
-        result = await self.client.audio.transcriptions.create(
-            model=self.model_name,
-            file=("audio.wav", open(audio_url, "rb")),
-        )
+        audio_file = open(audio_url, "rb")
+        try:
+            result = await self.client.audio.transcriptions.create(
+                model=self.model_name,
+                file=("audio.wav", audio_file),
+            )
+        finally:
+            audio_file.close()
 
         # remove temp file
         if output_path and os.path.exists(output_path):


### PR DESCRIPTION
核心问题：whisper_api_source.py 第 121 行用 open(audio_url, "rb") 打开文件后，文件句柄没有被关闭，导致 Windows 上报 "另一个程序正在使用此文件" 的错误，temp wav 文件无法删除。 修复方案：在调用 OpenAI API 后关闭文件句柄再删除临时文件。

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Close the audio file handle after calling the OpenAI transcription API so temporary WAV files can be deleted without file-in-use errors on Windows.