### PR TITLE
fix(ltm): prevent wake commands from being recorded as group chat context

### DIFF
--- a/astrbot/builtin_stars/astrbot/main.py
+++ b/astrbot/builtin_stars/astrbot/main.py
@@ -169,10 +169,14 @@ class Main(star.Star):
                 "provider_ltm_settings"
             ]["group_icl_enable"]
             if group_icl_enable:
-                try:
-                    await self.group_chat_context.handle_message(event)
-                except BaseException as e:
-                    logger.error(e)
+                # Skip recording if a command handler matched (e.g. /reset,
+                # /help, /new). Slash commands are bot instructions, not group
+                # chat context that should be injected into future LLM requests.
+                if not event.get_extra("handlers_parsed_params", {}):
+                    try:
+                        await self.group_chat_context.handle_message(event)
+                    except BaseException as e:
+                        logger.error(e)
 
             if need_active:
                 provider = self.context.get_using_provider(event.unified_msg_origin)

--- a/tests/unit/test_group_chat_context_wiring.py
+++ b/tests/unit/test_group_chat_context_wiring.py
@@ -21,6 +21,8 @@ def make_event(umo: str = "aiocqhttp:GroupMessage:user_123_group_456"):
     event.message_obj = SimpleNamespace(message=[Plain("hello")])
     event.message_str = "hello"
     event.session_id = "session-1"
+    # Simulate a regular message: no command handler matched.
+    event.get_extra.return_value = {}
     return event
 
 

--- a/tests/unit/test_group_chat_context_wiring.py
+++ b/tests/unit/test_group_chat_context_wiring.py
@@ -14,15 +14,33 @@ def make_main_with_conversation_manager(conv_mgr):
     return main
 
 
-def make_event(umo: str = "aiocqhttp:GroupMessage:user_123_group_456"):
+def _make_extras_store():
+    """Return a mutable dict and get_extra / set_extra side_effects bound to it."""
+    store: dict[str, object] = {}
+    get_extra = lambda key, default=None: store.get(key, default)  # noqa: E731
+    set_extra = store.__setitem__  # type: ignore[assignment]
+    return store, get_extra, set_extra
+
+
+def make_event(
+    umo: str = "aiocqhttp:GroupMessage:user_123_group_456",
+    *,
+    handlers_parsed_params: dict | None = None,
+):
     event = MagicMock()
     event.unified_msg_origin = umo
     event.get_platform_id.return_value = "aiocqhttp"
     event.message_obj = SimpleNamespace(message=[Plain("hello")])
     event.message_str = "hello"
     event.session_id = "session-1"
-    # Simulate a regular message: no command handler matched.
-    event.get_extra.return_value = {}
+
+    store, get_extra, set_extra = _make_extras_store()
+    # Simulate WakingCheckStage output: an empty dict means no command matched.
+    store["handlers_parsed_params"] = (
+        {} if handlers_parsed_params is None else handlers_parsed_params
+    )
+    event.get_extra.side_effect = get_extra
+    event.set_extra.side_effect = set_extra
     return event
 
 
@@ -120,3 +138,30 @@ async def test_on_message_does_not_clear_group_context_on_first_enabled_message(
     main.group_chat_context.need_active_reply.assert_awaited_once_with(event)
     main.group_chat_context.handle_message.assert_awaited_once_with(event)
     main.group_chat_context.remove_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_on_message_skips_recording_when_command_handler_matched():
+    """A slash-command message (handlers_parsed_params non-empty) must not be
+    recorded into the group context buffer."""
+    main = Main.__new__(Main)
+    main.context = MagicMock()
+    main.context.get_config.return_value = {
+        "provider_ltm_settings": {
+            "group_icl_enable": True,
+            "active_reply": {"enable": False},
+        },
+    }
+    main.group_chat_context = SimpleNamespace(
+        need_active_reply=AsyncMock(return_value=False),
+        handle_message=AsyncMock(),
+    )
+    event = make_event(
+        handlers_parsed_params={"astrbot.builtin_stars.builtin_commands.main_reset": {}},
+    )
+
+    async for _ in main.on_message(event):
+        pass
+
+    main.group_chat_context.need_active_reply.assert_awaited_once_with(event)
+    main.group_chat_context.handle_message.assert_not_awaited()


### PR DESCRIPTION
## Motivation

Slash commands (e.g. `/reset`, `/new`, `/help`) were incorrectly recorded into the group chat context buffer (`raw_records`) by the `on_message` handler. For `/reset` specifically, this caused a timing issue where the command message was re-added after `after_message_sent` had already cleared the buffer via `_clean_group_context_session`, leaving stale context that would be injected into future LLM requests.

## Changes

- **`astrbot/builtin_stars/astrbot/main.py`**: In the `on_message` handler, check `event.get_extra("handlers_parsed_params", {})` before calling `handle_message`. This dict is populated by `WakingCheckStage` only when a `CommandFilter` successfully matches — i.e. a slash command is triggered. If non-empty, skip recording because the message is a bot instruction, not group chat context. Regular `@bot` mentions (which also set `is_at_or_wake_command` but do not match any `CommandFilter`) continue to be recorded as before.

## Impact

- All built-in slash commands (`/reset`, `/new`, `/help`, `/sid`, `/stop`, `/stats`, `/set`, `/unset`, `/provider`, `/dashboard_update`) are no longer stored in the group context buffer.
- `@bot` mentions and unrecognised `/prefix` messages (which fall through to the LLM agent) are unaffected.
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

<img width="796" height="173" alt="image" src="https://github.com/user-attachments/assets/6e90a36c-30ec-4dea-b259-4a24f985f033" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Prevent command-like wake messages from being stored in group chat long-term context to avoid stale slash command instructions being injected into future LLM requests.

Bug Fixes:
- Skip recording messages into group chat context when a command handler has matched, preventing slash commands like /reset or /help from polluting long-term context.

Tests:
- Adjust group chat context wiring test fixtures to simulate regular messages with no matched command handler.