### PR TITLE
fix(gemini-embedding): wrap batch embedding texts in Content to avoid collapse on gemini-embedding-2

### DIFF
--- a/astrbot/core/provider/sources/gemini_embedding_source.py
+++ b/astrbot/core/provider/sources/gemini_embedding_source.py
@@ -1,4 +1,3 @@
-from typing import cast
 
 from google import genai
 from google.genai import types
@@ -61,7 +60,9 @@ class GeminiEmbeddingProvider(EmbeddingProvider):
     async def get_embeddings(self, text: list[str]) -> list[list[float]]:
         """批量获取文本的嵌入"""
         try:
-            contents = [types.Content(parts=[types.Part.from_text(text=s)]) for s in text]
+            contents = [
+                types.Content(parts=[types.Part.from_text(text=s)]) for s in text
+            ]
             result = await self.client.models.embed_content(
                 model=self.model,
                 contents=contents,

--- a/astrbot/core/provider/sources/gemini_embedding_source.py
+++ b/astrbot/core/provider/sources/gemini_embedding_source.py
@@ -61,9 +61,10 @@ class GeminiEmbeddingProvider(EmbeddingProvider):
     async def get_embeddings(self, text: list[str]) -> list[list[float]]:
         """批量获取文本的嵌入"""
         try:
+            contents = [types.Content(parts=[types.Part.from_text(text=s)]) for s in text]
             result = await self.client.models.embed_content(
                 model=self.model,
-                contents=cast(types.ContentListUnion, text),
+                contents=contents,
                 config=types.EmbedContentConfig(
                     output_dimensionality=self.get_dim(),
                 ),


### PR DESCRIPTION
Fixes #8534.

This PR wraps individual text strings in `types.Content` and `types.Part.from_text` objects during batch embedding requests for Google Gemini. This prevents the `google-genai` SDK from collapsing a list of strings into a single multi-part content request (which causes `IndexError` due to returning only one embedding instead of the requested amount).

## Summary by Sourcery

Bug Fixes:
- Wrap each input string in a Content/Part structure for batch embedding requests to prevent the SDK from collapsing multiple texts into a single content and returning too few embeddings.