### PR TITLE
fix(openai-embedding): enhance stability, empty query handling, and SiliconFlow domain compatibility

### DIFF
--- a/astrbot/core/provider/sources/openai_embedding_source.py
+++ b/astrbot/core/provider/sources/openai_embedding_source.py
@@ -1,6 +1,7 @@
 from urllib.parse import urlparse
 
 import httpx
+import openai
 from openai import AsyncOpenAI
 
 from astrbot import logger
@@ -20,12 +21,29 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         super().__init__(provider_config, provider_settings)
         self.provider_config = provider_config
         self.provider_settings = provider_settings
-        proxy = provider_config.get("proxy", "")
+
         provider_id = provider_config.get("id", "unknown_id")
+
+        # 1. 强制校验 API Key (Fail-Fast)
+        api_key: str = provider_config.get("embedding_api_key", "")
+        if not api_key:
+            raise ValueError(
+                f"OpenAI embedding provider [{provider_id}] 配置错误: 缺少必需成 'embedding_api_key'"
+            )
+
+        # 2. 安全获取并转换 timeout 避免空字符串导致 int() 崩溃
+        raw_timeout = provider_config.get("timeout", 20)
+        try:
+            timeout_val = int(raw_timeout) if raw_timeout else 20
+        except (ValueError, TypeError):
+            timeout_val = 20
+
+        proxy = provider_config.get("proxy", "")
         http_client = None
         if proxy:
             logger.info(f"[OpenAI Embedding] {provider_id} Using proxy: {proxy}")
             http_client = httpx.AsyncClient(proxy=proxy)
+
         api_base = (
             provider_config.get("embedding_api_base", "https://api.openai.com/v1")
             .strip()
@@ -35,34 +53,56 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         if api_base and not api_base.endswith("/v1") and not api_base.endswith("/v4"):
             # /v4 see #5699
             api_base = api_base + "/v1"
+
         logger.info(f"[OpenAI Embedding] {provider_id} Using API Base: {api_base}")
+
         self.client = AsyncOpenAI(
-            api_key=provider_config.get("embedding_api_key"),
+            api_key=api_key,
             base_url=api_base,
-            timeout=int(provider_config.get("timeout", 20)),
+            timeout=timeout_val,
             http_client=http_client,
         )
         self.model = provider_config.get("embedding_model", "text-embedding-3-small")
 
     async def get_embedding(self, text: str) -> list[float]:
         """获取文本的嵌入"""
+        # 3. 拦截空文本防 400 报错
+        if not text or not text.strip():
+            raise ValueError("输入文本不能为空")
+
         kwargs = self._embedding_kwargs()
-        embedding = await self.client.embeddings.create(
-            input=text,
-            model=self.model,
-            **kwargs,
-        )
-        return embedding.data[0].embedding
+
+        try:
+            embedding = await self.client.embeddings.create(
+                input=text,
+                model=self.model,
+                **kwargs,
+            )
+            return embedding.data[0].embedding
+        except openai.OpenAIError as e:
+            # 4. 包装规范异常，使用 from e 保留原始调用栈
+            raise Exception(f"OpenAI Embedding API 请求失败: {e}") from e
 
     async def get_embeddings(self, text: list[str]) -> list[list[float]]:
         """批量获取文本的嵌入"""
+        # 5. 拦截空列表和内部脏数据，与 get_embedding 逻辑保持一致
+        if not text:
+            raise ValueError("批量输入列表不能为空")
+
+        if any(not s or not s.strip() for s in text):
+            raise ValueError("批量输入文本列表中不能包含空文本")
+
         kwargs = self._embedding_kwargs()
-        embeddings = await self.client.embeddings.create(
-            input=text,
-            model=self.model,
-            **kwargs,
-        )
-        return [item.embedding for item in embeddings.data]
+
+        try:
+            embeddings = await self.client.embeddings.create(
+                input=text,
+                model=self.model,
+                **kwargs,
+            )
+            return [item.embedding for item in embeddings.data]
+        except openai.OpenAIError as e:
+            raise Exception(f"OpenAI Embedding API 批量请求失败: {e}") from e
 
     def _embedding_kwargs(self) -> dict:
         """构建嵌入请求的可选参数"""
@@ -111,5 +151,6 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         return 0
 
     async def terminate(self):
-        if self.client:
+        """释放资源"""
+        if getattr(self, "client", None):
             await self.client.close()

--- a/astrbot/core/provider/sources/openai_embedding_source.py
+++ b/astrbot/core/provider/sources/openai_embedding_source.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse
+
 import httpx
 from openai import AsyncOpenAI
 
@@ -74,21 +76,27 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
                 )
 
         # Fix: SiliconFlow provider does not support dimensions parameter, except for Qwen models.
-        provider_api_base = self.provider_config.get("embedding_api_base")
+        provider_api_base = self.provider_config.get("embedding_api_base", "")
         provider_id = self.provider_config.get("id", "unknown_id")
-        if (
-            provider_api_base
-            # Hard-code SiliconFlow API Base Prefix and Model Name, as it's just a temporary workaround.
-            and "siliconflow" in provider_api_base.lower()
-            and not self.model.lower().startswith("qwen")
-        ):
-            # For SiliconFlow and Non-Qwen models, dimensions parameter is not supported. so remove it.
-            removed_dimensions = kwargs.pop("dimensions", None)
-            if removed_dimensions is not None:
-                # Log a warning message if dimensions parameter is removed.
-                logger.warning(
-                    f"dimensions not supported for model '{self.model}' of provider '{provider_id}' as SiliconFlow does not support this parameter for non-Qwen models: '{removed_dimensions}'."
-                )
+        if provider_api_base:
+            api_base = provider_api_base.strip().lower()
+            # 兼容不带 http:// 或 https:// 头的 api_base，确保 urlparse 能正常解析 hostname
+            if not api_base.startswith(("http://", "https://")):
+                api_base = "https://" + api_base
+            hostname = urlparse(api_base).hostname or ""
+
+            if hostname in {
+                "api.siliconflow.cn",
+                "api.siliconflow.com",
+            } and not self.model.lower().startswith("qwen"):
+                # For SiliconFlow and Non-Qwen models, dimensions parameter is not supported, so remove it.
+                removed_dimensions = kwargs.pop("dimensions", None)
+                if removed_dimensions is not None:
+                    # Log a warning message if dimensions parameter is removed.
+                    logger.warning(
+                        f"dimensions not supported for model '{self.model}' of provider '{provider_id}' "
+                        f"as SiliconFlow does not support this parameter for non-Qwen models: '{removed_dimensions}'."
+                    )
         return kwargs
 
     def get_dim(self) -> int:

--- a/astrbot/core/provider/sources/openai_embedding_source.py
+++ b/astrbot/core/provider/sources/openai_embedding_source.py
@@ -79,7 +79,7 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         if (
             provider_api_base
             # Hard-code SiliconFlow API Base Prefix and Model Name, as it's just a temporary workaround.
-            and provider_api_base.strip().startswith("https://api.siliconflow.cn")
+            and "siliconflow" in provider_api_base.lower()
             and not self.model.lower().startswith("qwen")
         ):
             # For SiliconFlow and Non-Qwen models, dimensions parameter is not supported. so remove it.


### PR DESCRIPTION
This PR introduces several robustness and stability improvements to the `openai_text_embedding` provider to prevent crashes, handle empty queries gracefully, and correctly support both SiliconFlow domain configurations.

### Key Changes
1. **SiliconFlow Domain Check**: Refactored the dimensions removal logic to support both `.cn` and `.com` domains case-insensitively (using `urlparse` to safely extract the hostname) to prevent 400 Bad Request errors (`code 20015`).
2. **Fail-Fast Key Check**: Added initialization validation to verify that `embedding_api_key` is configured, failing fast with a descriptive error instead of throwing a generic error later.
3. **Safe Timeout Parsing**: Wrapped `timeout` parsing in a `try-except` block to fall back to `20` if the value is empty or invalid, avoiding `ValueError` crashes.
4. **Empty Query Protection**: Guarded single and batch retrieval entry points to return/raise errors early if input texts are empty or whitespace-only, preventing 400 Bad Request failures.
5. **Exception Handling**: Wrapped API exceptions in standard `openai.OpenAIError` blocks to print descriptive logs during network or API request failures.
6. **Resource Cleanup**: Protected client termination by checking `getattr(self, 'client', None)` inside `terminate()` to avoid attribute error exceptions during teardown.