### PR TITLE
fix(dashboard): relax frame security headers when running under launcher

### DIFF
--- a/astrbot/dashboard/routes/plugin.py
+++ b/astrbot/dashboard/routes/plugin.py
@@ -798,15 +798,11 @@ class PluginRoute(Route):
         # cross-origin iframe (the Tauri webview).  Since frame-ancestors and
         # X-Frame-Options inspect the *entire* ancestor chain, enforcing them here
         # would block plugin pages from loading inside the nested iframe.
-        if not os.environ.get("ASTRBOT_LAUNCHER"):
+        csp = "object-src 'none'; base-uri 'self'"
+        if os.environ.get("ASTRBOT_LAUNCHER") not in ("1", "true"):
             response.headers["X-Frame-Options"] = "SAMEORIGIN"
-            response.headers["Content-Security-Policy"] = (
-                "frame-ancestors 'self'; object-src 'none'; base-uri 'self'"
-            )
-        else:
-            response.headers["Content-Security-Policy"] = (
-                "object-src 'none'; base-uri 'self'"
-            )
+            csp = f"frame-ancestors 'self'; {csp}"
+        response.headers["Content-Security-Policy"] = csp
 
         return response
 

--- a/astrbot/dashboard/routes/plugin.py
+++ b/astrbot/dashboard/routes/plugin.py
@@ -789,14 +789,21 @@ class PluginRoute(Route):
         response.headers["Cache-Control"] = "no-store"
         response.headers["Referrer-Policy"] = "no-referrer"
         response.headers["X-Content-Type-Options"] = "nosniff"
-        response.headers["X-Frame-Options"] = "SAMEORIGIN"
         response.headers["Cross-Origin-Resource-Policy"] = "cross-origin"
         # Sandboxed iframes without allow-same-origin load ES modules with Origin: null.
         # CORS read access is allowed here; JWT/asset_token still protects the assets.
         response.headers["Access-Control-Allow-Origin"] = "*"
-        response.headers["Content-Security-Policy"] = (
-            "frame-ancestors 'self'; object-src 'none'; base-uri 'self'"
-        )
+
+        # When running under the AstrBot Launcher the dashboard is embedded in a
+        # cross-origin iframe (the Tauri webview).  Since frame-ancestors and
+        # X-Frame-Options inspect the *entire* ancestor chain, enforcing them here
+        # would block plugin pages from loading inside the nested iframe.
+        if not os.environ.get("ASTRBOT_LAUNCHER"):
+            response.headers["X-Frame-Options"] = "SAMEORIGIN"
+            response.headers["Content-Security-Policy"] = (
+                "frame-ancestors 'self'; object-src 'none'; base-uri 'self'"
+            )
+
         return response
 
     async def _serve_plugin_page_html_asset(

--- a/astrbot/dashboard/routes/plugin.py
+++ b/astrbot/dashboard/routes/plugin.py
@@ -803,6 +803,10 @@ class PluginRoute(Route):
             response.headers["Content-Security-Policy"] = (
                 "frame-ancestors 'self'; object-src 'none'; base-uri 'self'"
             )
+        else:
+            response.headers["Content-Security-Policy"] = (
+                "object-src 'none'; base-uri 'self'"
+            )
 
         return response
 


### PR DESCRIPTION
When AstrBot is launched by the AstrBot Launcher, the dashboard is embedded in a cross-origin iframe (the Tauri webview).  The plugin page responses set X-Frame-Options: SAMEORIGIN and CSP frame-ancestors 'self', both of which inspect the *entire* ancestor chain — not just the immediate parent.  Because the top-level Tauri webview has a different origin, these headers block the plugin page from loading inside the nested iframe, resulting in 'localhost refused to connect'.

Fix: skip the restrictive frame headers when ASTRBOT_LAUNCHER=1 is set, which the launcher already injects as an environment variable.  Other security measures (iframe sandbox, JWT asset_token, postMessage bridge) remain in place.

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
- astrbot/dashboard/routes/plugin.py — _apply_plugin_page_security_headers(): conditionally set X-Frame-Options and frame-ancestors CSP only when NOT running under the AstrBot Launcher.
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
Before the repair：
<img width="1920" height="1146" alt="6d425942776186f37d4a5863102b2725" src="https://github.com/user-attachments/assets/b10668d3-5ef1-4ecd-9139-5da5472bbbb1" />
After repair：
<img width="1565" height="1127" alt="image" src="https://github.com/user-attachments/assets/655f5d17-483a-4774-8e5d-b2e5638c0811" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Fix plugin pages failing to load under the AstrBot Launcher due to restrictive X-Frame-Options and frame-ancestors CSP on the dashboard responses.