### PR TITLE
feat(provider): warn when single request input context exceeds threshold

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -154,6 +154,8 @@ DEFAULT_CONFIG = {
         "unsupported_streaming_strategy": "realtime_segmenting",
         "reachability_check": False,
         "max_agent_step": 30,
+        "context_bloat_warn_enable": True,
+        "context_bloat_warn_threshold": 48000,
         "tool_call_timeout": 120,
         "tool_schema_mode": "full",
         "llm_safety_mode": True,
@@ -3607,6 +3609,19 @@ CONFIG_METADATA_3 = {
                         "hint": "当 max_context_tokens 为 0 且模型不在内置元数据中时，使用此值作为上下文窗口大小。默认 128000。",
                         "condition": {
                             "provider_settings.agent_runner_type": "local",
+                        },
+                    },
+                    "provider_settings.context_bloat_warn_enable": {
+                        "description": "启用上下文膨胀告警",
+                        "type": "bool",
+                        "hint": "当单次请求的输入上下文 token 超过阈值时，输出 warning 日志，提醒可能存在上下文异常膨胀（如历史无限累积导致 token 开销激增）。",
+                    },
+                    "provider_settings.context_bloat_warn_threshold": {
+                        "description": "上下文膨胀告警阈值",
+                        "type": "int",
+                        "hint": "单次请求输入上下文超过此 token 数时触发告警。默认 48000。",
+                        "condition": {
+                            "provider_settings.context_bloat_warn_enable": True,
                         },
                     },
                 },

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -795,7 +795,9 @@ class ProviderOpenAIOfficial(Provider):
     _CONTEXT_BLOAT_WARN_INTERVAL_S = 300
 
     def _maybe_warn_context_bloat(self, prompt_tokens: int) -> None:
-        settings = self.provider_settings if isinstance(self.provider_settings, dict) else {}
+        settings = (
+            self.provider_settings if isinstance(self.provider_settings, dict) else {}
+        )
         if not settings.get("context_bloat_warn_enable", True):
             return
         threshold = settings.get(

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -6,6 +6,7 @@ import inspect
 import json
 import random
 import re
+import time
 import uuid
 from collections.abc import AsyncGenerator
 from io import BytesIO
@@ -784,6 +785,34 @@ class ProviderOpenAIOfficial(Provider):
             return None
         return reasoning_attr
 
+    # Warn when a single request carries an unusually large input context.
+    # Helps users notice runaway context growth (e.g. unbounded history) before
+    # it silently burns tokens. Configurable via provider_settings.
+    _CONTEXT_BLOAT_DEFAULT_THRESHOLD = 48000
+    _CONTEXT_BLOAT_WARN_INTERVAL_S = 300
+    _context_bloat_last_warn: dict[str, float] = {}
+
+    def _maybe_warn_context_bloat(self, prompt_tokens: int) -> None:
+        settings = self.provider_settings if isinstance(self.provider_settings, dict) else {}
+        if not settings.get("context_bloat_warn_enable", True):
+            return
+        threshold = settings.get(
+            "context_bloat_warn_threshold", self._CONTEXT_BLOAT_DEFAULT_THRESHOLD
+        )
+        if not threshold or prompt_tokens < threshold:
+            return
+        model = self.get_model()
+        now = time.time()
+        last = self._context_bloat_last_warn.get(model, 0)
+        if now - last < self._CONTEXT_BLOAT_WARN_INTERVAL_S:
+            return
+        self._context_bloat_last_warn[model] = now
+        logger.warning(
+            f"单次请求输入上下文达 {prompt_tokens} tokens（模型 {model}，阈值 {threshold}）。"
+            "如非预期，请检查会话历史长度或 max_context_length / max_context_tokens "
+            "配置，以免持续产生过高的 token 开销。可在配置中关闭此提醒。"
+        )
+
     def _extract_usage(self, usage: CompletionUsage | dict) -> TokenUsage:
         ptd = getattr(usage, "prompt_tokens_details", None)
         cached = getattr(ptd, "cached_tokens", 0) if ptd else 0
@@ -795,6 +824,7 @@ class ProviderOpenAIOfficial(Provider):
         cached = cached or 0
         prompt_tokens = prompt_tokens or 0
         completion_tokens = completion_tokens or 0
+        self._maybe_warn_context_bloat(prompt_tokens)
         return TokenUsage(
             input_other=prompt_tokens - cached,
             input_cached=cached,

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -496,6 +496,7 @@ class ProviderOpenAIOfficial(Provider):
     def __init__(self, provider_config, provider_settings) -> None:
         super().__init__(provider_config, provider_settings)
         self.chosen_api_key = None
+        self._context_bloat_last_warn: dict[str, float] = {}
         self.api_keys: list = super().get_keys()
         self.chosen_api_key = self.api_keys[0] if len(self.api_keys) > 0 else None
         self.timeout = provider_config.get("timeout", 120)
@@ -788,9 +789,10 @@ class ProviderOpenAIOfficial(Provider):
     # Warn when a single request carries an unusually large input context.
     # Helps users notice runaway context growth (e.g. unbounded history) before
     # it silently burns tokens. Configurable via provider_settings.
+    # Throttled per-model (once per interval) to avoid log spam; uses
+    # time.monotonic() so it is unaffected by system clock changes.
     _CONTEXT_BLOAT_DEFAULT_THRESHOLD = 48000
     _CONTEXT_BLOAT_WARN_INTERVAL_S = 300
-    _context_bloat_last_warn: dict[str, float] = {}
 
     def _maybe_warn_context_bloat(self, prompt_tokens: int) -> None:
         settings = self.provider_settings if isinstance(self.provider_settings, dict) else {}
@@ -802,7 +804,7 @@ class ProviderOpenAIOfficial(Provider):
         if not threshold or prompt_tokens < threshold:
             return
         model = self.get_model()
-        now = time.time()
+        now = time.monotonic()
         last = self._context_bloat_last_warn.get(model, 0)
         if now - last < self._CONTEXT_BLOAT_WARN_INTERVAL_S:
             return


### PR DESCRIPTION
为单次 LLM 请求的输入上下文添加可配置的膨胀告警。
上下文异常膨胀沉默失效。本 PR 提供一个早期可见性信号。
Closes #8556 
### Modifications / 改动点

- astrbot/core/provider/sources/openai_source.py：在 _extract_usage 中新增 _maybe_warn_context_bloat，当单次请求 prompt_tokens 超过阈值时输出 warning，按模型节流（每 5分钟最多一次）避免刷屏。
- astrbot/core/config/default.py：新增两个配置项及 schema：
- context_bloat_warn_enable (bool, 默认 true)：告警开关
- context_bloat_warn_threshold (int, 默认 48000)：触发阈值。我也不是很清楚多少算大...

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

触发告警时的日志输出示例：
单次请求输入上下文达 111351 tokens（模型 deepseek-chat，阈值 48000）。如非预期，请检查会话历史长度或max_context_length / max_context_tokens 配置，以免持续产生过高的token 开销。可在配置中关闭此提醒。

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Add configurable warnings for unusually large input contexts in single LLM requests to improve early visibility into runaway token usage.

New Features:
- Introduce provider-level configuration to enable or disable context bloat warnings and set a token threshold for triggering them.

Enhancements:
- Log rate-limited warnings when a request's prompt tokens exceed the configured threshold, keyed by model to avoid log spam.
- Extend the default provider configuration schema with new options for context bloat warnings and their threshold.