### PR TITLE
fix(aiocqhttp): 修复 At 组件与后续内容的间距问题

### DIFF
--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -417,7 +417,7 @@ class ResultDecorateStage(Stage):
                         # At 与正文之间用一个空格分隔，不强制换行
                         # 各平台适配器（如 aiocqhttp）会在发送时进一步处理前导空白，
                         # 确保最终渲染为 "@用户 你好" 而非 "@用户\n你好"
-                        result.chain[1].text = " " + result.chain[1].text
+                        result.chain[1] = Plain(" " + result.chain[1].text)
 
                 # 引用回复
                 if self.reply_with_quote:

--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -414,7 +414,10 @@ class ResultDecorateStage(Stage):
                         At(qq=event.get_sender_id(), name=event.get_sender_name()),
                     )
                     if len(result.chain) > 1 and isinstance(result.chain[1], Plain):
-                        result.chain[1].text = "\n" + result.chain[1].text
+                        # At 与正文之间用一个空格分隔，不强制换行
+                        # 各平台适配器（如 aiocqhttp）会在发送时进一步处理前导空白，
+                        # 确保最终渲染为 "@用户 你好" 而非 "@用户\n你好"
+                        result.chain[1].text = " " + result.chain[1].text
 
                 # 引用回复
                 if self.reply_with_quote:

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
@@ -75,7 +75,7 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
         - At + Plain 文本:确保一个空格分隔,避免粘连或双空格
         - At + 非 Plain(图片/文件等):插入空格文本段分隔
         - At 在链末尾:不添加多余空格
-        - 纯空白 Plain(如仅含换行/空格):跳过,重置 At 标志位
+        - 纯空白 Plain(如仅含换行/空格):跳过,不重置 At 标志位
         """
         ret = []
 
@@ -103,7 +103,6 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
                     # result_decorate 阶段可能已在文本前加了空格或换行，
                     # 直接拼接会导致 "@用户  \n你好" 这样的双空白
                     # 统一用 " " 替换所有前导空白，确保 @ 与正文之间仅有一个空格
-                    segment.text = " " + segment.text.lstrip()
                     # 注意：不修改 segment.text，避免污染原始 MessageChain（影响 hook 等消费者）
                     text = " " + segment.text.lstrip()
                     prev_is_at = False

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
@@ -68,22 +68,57 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
 
     @staticmethod
     async def _parse_onebot_json(message_chain: MessageChain):
-        """解析成 OneBot json 格式"""
+        """解析成 OneBot json 格式
+
+        将消息链转换为 OneBot 协议的消息段数组.
+        特别处理 At 组件与后续内容的间距:
+        - At + Plain 文本:确保一个空格分隔,避免粘连或双空格
+        - At + 非 Plain(图片/文件等):插入空格文本段分隔
+        - At 在链末尾:不添加多余空格
+        - 纯空白 Plain(如仅含换行/空格):跳过,重置 At 标志位
+        """
         ret = []
+
+        # 标记前一个段是否为 At 组件，用于决定是否需要在当前段前插入空格
+        prev_is_at = False
+
         for segment in message_chain.chain:
             if isinstance(segment, At):
-                # At 组件后插入一个空格，避免与后续文本粘连
+                # At 组件:记录到结果,并设置标志位
+                # 空格由后续段决定如何插入(避免无条件插入导致末尾多余空格)
                 d = await AiocqhttpMessageEvent._from_segment_to_dict(segment)
                 ret.append(d)
-                ret.append({"type": "text", "data": {"text": " "}})
+                prev_is_at = True
+
             elif isinstance(segment, Plain):
+                # 跳过纯空白文本(如单独的换行符、空格等)
                 if not segment.text.strip():
+                    prev_is_at = False
                     continue
+
+                if prev_is_at:
+                    # 前一个是 At：去除 Plain 的前导空白后，统一在前面加一个空格
+                    # .lstrip() 的作用：
+                    # result_decorate 阶段可能已在文本前加了空格或换行，
+                    # 直接拼接会导致 "@用户  \n你好" 这样的双空白
+                    # 统一用 " " 替换所有前导空白，确保 @ 与正文之间仅有一个空格
+                    segment.text = " " + segment.text.lstrip()
+                    prev_is_at = False
+
                 d = await AiocqhttpMessageEvent._from_segment_to_dict(segment)
                 ret.append(d)
+
             else:
+                # 非 At、非 Plain 的组件(Image、Record、Video、File 等)
+                if prev_is_at:
+                    # At 后紧跟媒体组件，插入一个空格文本段防止粘连
+                    # 例如：[At] [Image] → [At] [空格] [Image]
+                    ret.append({"type": "text", "data": {"text": " "}})
+                    prev_is_at = False
+
                 d = await AiocqhttpMessageEvent._from_segment_to_dict(segment)
                 ret.append(d)
+
         return ret
 
     @classmethod

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
@@ -92,8 +92,9 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
 
             elif isinstance(segment, Plain):
                 # 跳过纯空白文本(如单独的换行符、空格等)
+                # 注意:不重置 prev_is_at,避免 [At, Plain("\n"), Plain("你好")]
+                #   这种场景下空白 Plain 阻断空格插入
                 if not segment.text.strip():
-                    prev_is_at = False
                     continue
 
                 if prev_is_at:
@@ -103,7 +104,11 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
                     # 直接拼接会导致 "@用户  \n你好" 这样的双空白
                     # 统一用 " " 替换所有前导空白，确保 @ 与正文之间仅有一个空格
                     segment.text = " " + segment.text.lstrip()
+                    # 注意：不修改 segment.text，避免污染原始 MessageChain（影响 hook 等消费者）
+                    text = " " + segment.text.lstrip()
                     prev_is_at = False
+                    ret.append({"type": "text", "data": {"text": text}})
+                    continue
 
                 d = await AiocqhttpMessageEvent._from_segment_to_dict(segment)
                 ret.append(d)


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
- 确保 At 组件与 Plain 文本之间有一个空格分隔，避免粘连
- 处理 At 组件后紧跟媒体组件时的空格插入
- 跳过纯空白 Plain 文本，重置 At 标志位

close #8519 
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
```
test session starts 
platform win32 -- Python 3.12.12, pytest-9.0.3, pluggy-1.6.0
rootdir: D:\Nayey\Code\NayukiChiba\Astrbot
configfile: pyproject.toml
plugins: anyio-4.13.0, asyncio-1.4.0, cov-7.1.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 6 items                                                                                     

tests\unit\test_aiocqhttp_reply.py ...... [100%]
6 passed in 2.16s 

```
---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Adjust OneBot message conversion and result decoration to correctly handle spacing around At mentions and subsequent content in aiocqhttp messages.

Bug Fixes:
- Ensure a single space is inserted between At mentions and following plain text to prevent text from sticking or double spaces.
- Insert a separating space segment when an At mention is followed by non-text media components to avoid visual concatenation.
- Skip purely whitespace plain text segments while resetting At-state to prevent them from interfering with spacing logic.

Enhancements:
- Refine result decoration so that At mentions are followed by a space instead of a forced newline, letting platform adapters render mentions inline.