### PR TITLE
fix: translateIfKey breaks plugin config labels by treating plain text as i18n keys

### DIFF
--- a/dashboard/src/composables/useConfigTextResolver.js
+++ b/dashboard/src/composables/useConfigTextResolver.js
@@ -8,7 +8,7 @@ export function useConfigTextResolver(props = {}) {
   const translateIfKey = (value) => {
     if (!value || typeof value !== 'string') return value
     if (!value.includes('.')) return value
-    return getRaw(value) ? tm(value) : null
+    return getRaw(value) ? tm(value) : value
   }
 
   const hasPluginI18n = () => {

--- a/dashboard/src/composables/useConfigTextResolver.js
+++ b/dashboard/src/composables/useConfigTextResolver.js
@@ -7,7 +7,8 @@ export function useConfigTextResolver(props = {}) {
 
   const translateIfKey = (value) => {
     if (!value || typeof value !== 'string') return value
-    return getRaw(value) ? tm(value) : value
+    if (!value.includes('.')) return value
+    return getRaw(value) ? tm(value) : null
   }
 
   const hasPluginI18n = () => {


### PR DESCRIPTION
## Problem

	ranslateIfKey() in useConfigTextResolver.js treats ALL non-i18n-key strings as translation failures and returns 
ull, causing plugin configuration field labels (descriptions, hints) to disappear entirely in the WebUI.

## Root Cause

The function calls getRaw(value) on the raw config field text. When the plugin provides plain text descriptions (e.g. API Key, Timeout) that don't correspond to any i18n key path, getRaw() returns undefined, and the function returns 
ull.

## Fix

Added a check: if the value doesn't contain ., it's plain text (not an i18n dot-separated path), so return it as-is. Only attempt i18n resolution for dot-separated key paths.

## Changes

- dashboard/src/composables/useConfigTextResolver.js: +2 / -1

## Summary by Sourcery

Bug Fixes:
- Prevent plain-text plugin configuration labels from being treated as missing i18n keys and disappearing in the UI.