### PR TITLE
fix: stop leaking raw exception text to chat when agent processing fails

### DIFF
--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -424,10 +424,10 @@ class InternalAgentSubStage(Stage):
             custom_error_message = extract_persona_custom_error_message_from_event(
                 event
             )
-            error_text = custom_error_message or (
-                f"Error occurred while processing agent request: {e}"
-            )
-            await event.send(MessageChain().message(error_text))
+            # PATCH: 2026-06-03 - only send custom persona error message to chat;
+            # do not leak raw exception text when no custom message is configured.
+            if custom_error_message:
+                await event.send(MessageChain().message(custom_error_message))
         finally:
             if typing_requested:
                 try:

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/third_party.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/third_party.py
@@ -80,15 +80,10 @@ async def run_third_party_agent(
             elif resp.type == "err":
                 yield resp.data["chain"], True
     except Exception as e:
-        logger.error(f"Third party agent runner error: {e}")
-        err_msg = custom_error_message
-        if not err_msg:
-            err_msg = (
-                f"Error occurred during AI execution.\n"
-                f"Error Type: {type(e).__name__} (3rd party)\n"
-                f"Error Message: {str(e)}"
-            )
-        yield MessageChain().message(err_msg), True
+        logger.error(f"Third party agent runner error: {e}", exc_info=True)
+        # PATCH: 2026-06-03 - do not leak raw exception details when no persona error message is set
+        if custom_error_message:
+            yield MessageChain().message(custom_error_message), True
 
 
 class _RunnerResultAggregator:


### PR DESCRIPTION
## Problem

When the agent pipeline encounters an exception (e.g. internal error, third-party API failure), the raw Python exception text is sent directly to the chat as a user-visible message. This leaks internal stack traces and error details to end users.

Example of leaked message:
` 
Error occurred while processing agent request: not a valid file: 70b7f094-...`` 

## Fix

- internal.py: Only send custom_error_message (configured per persona) to chat. Do NOT fall back to raw exception text when no custom message is set.
- 	hird_party.py: Same fix. Do not construct Error occurred during AI execution... message with raw exception details.

Both locations still log the full error via logger.error() for debugging.

## Changes

- strbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py: +5 / -5
- strbot/core/pipeline/process_stage/method/agent_sub_stages/third_party.py: +3 / -8

## Summary by Sourcery

Prevent internal agent exceptions from leaking raw error details into user-visible chat messages by only sending configured custom error messages when failures occur.

Bug Fixes:
- Stop sending raw Python exception text and stack details to chat when internal agent processing fails.
- Avoid exposing third-party agent error type and message details to end users, while still logging full errors for debugging.