### PR TITLE
fix: retry provider stats on sqlite lock

### DIFF
--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -5,6 +5,8 @@ import base64
 from collections.abc import AsyncGenerator
 from dataclasses import replace
 
+from sqlalchemy.exc import OperationalError
+
 from astrbot.core import db_helper, logger
 from astrbot.core.agent.message import (
     CheckpointData,
@@ -520,6 +522,12 @@ BLOCKED = {"dGZid2h2d3IuY2xvdWQuc2VhbG9zLmlv", "a291cmljaGF0"}
 decoded_blocked = [base64.b64decode(b).decode("utf-8") for b in BLOCKED]
 
 
+def _is_sqlite_database_locked_error(exc: Exception) -> bool:
+    return (
+        isinstance(exc, OperationalError) and "database is locked" in str(exc).lower()
+    )
+
+
 async def _record_internal_agent_stats(
     event: AstrMessageEvent,
     req: ProviderRequest | None,
@@ -535,29 +543,35 @@ async def _record_internal_agent_stats(
     if provider is None or stats is None:
         return
 
-    try:
-        provider_config = getattr(provider, "provider_config", {}) or {}
-        conversation_id = (
-            req.conversation.cid
-            if req is not None and req.conversation is not None
-            else None
-        )
+    provider_config = getattr(provider, "provider_config", {}) or {}
+    conversation_id = (
+        req.conversation.cid
+        if req is not None and req.conversation is not None
+        else None
+    )
 
-        if agent_runner.was_aborted():
-            status = "aborted"
-        elif final_resp is not None and final_resp.role == "err":
-            status = "error"
-        else:
-            status = "completed"
+    if agent_runner.was_aborted():
+        status = "aborted"
+    elif final_resp is not None and final_resp.role == "err":
+        status = "error"
+    else:
+        status = "completed"
 
-        await db_helper.insert_provider_stat(
-            umo=event.unified_msg_origin,
-            conversation_id=conversation_id,
-            provider_id=provider_config.get("id", "") or provider.meta().id,
-            provider_model=provider.get_model(),
-            status=status,
-            stats=stats.to_dict(),
-            agent_type="internal",
-        )
-    except Exception as e:
-        logger.warning("Persist provider stats failed: %s", e, exc_info=True)
+    for attempt in range(3):
+        try:
+            await db_helper.insert_provider_stat(
+                umo=event.unified_msg_origin,
+                conversation_id=conversation_id,
+                provider_id=provider_config.get("id", "") or provider.meta().id,
+                provider_model=provider.get_model(),
+                status=status,
+                stats=stats.to_dict(),
+                agent_type="internal",
+            )
+            return
+        except Exception as e:
+            if _is_sqlite_database_locked_error(e) and attempt < 2:
+                await asyncio.sleep(0.2 * (2**attempt))
+                continue
+            logger.warning("Persist provider stats failed: %s", e, exc_info=True)
+            return

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -521,10 +521,25 @@ class InternalAgentSubStage(Stage):
 BLOCKED = {"dGZid2h2d3IuY2xvdWQuc2VhbG9zLmlv", "a291cmljaGF0"}
 decoded_blocked = [base64.b64decode(b).decode("utf-8") for b in BLOCKED]
 
+PROVIDER_STATS_SQLITE_LOCK_RETRY_ATTEMPTS = 3
+PROVIDER_STATS_SQLITE_LOCK_RETRY_BASE_DELAY = 0.2
+
+
+def _iter_exception_messages(exc: BaseException):
+    yield str(exc)
+    orig = getattr(exc, "orig", None)
+    if orig is not None and orig is not exc:
+        yield str(orig)
+        yield from (str(arg) for arg in getattr(orig, "args", ()) if arg)
+    yield from (str(arg) for arg in getattr(exc, "args", ()) if arg)
+
 
 def _is_sqlite_database_locked_error(exc: Exception) -> bool:
-    return (
-        isinstance(exc, OperationalError) and "database is locked" in str(exc).lower()
+    if not isinstance(exc, OperationalError):
+        return False
+    return any(
+        "database" in message.lower() and "locked" in message.lower()
+        for message in _iter_exception_messages(exc)
     )
 
 
@@ -557,7 +572,7 @@ async def _record_internal_agent_stats(
     else:
         status = "completed"
 
-    for attempt in range(3):
+    for attempt in range(PROVIDER_STATS_SQLITE_LOCK_RETRY_ATTEMPTS):
         try:
             await db_helper.insert_provider_stat(
                 umo=event.unified_msg_origin,
@@ -569,9 +584,19 @@ async def _record_internal_agent_stats(
                 agent_type="internal",
             )
             return
-        except Exception as e:
-            if _is_sqlite_database_locked_error(e) and attempt < 2:
-                await asyncio.sleep(0.2 * (2**attempt))
+        except OperationalError as e:
+            if (
+                _is_sqlite_database_locked_error(e)
+                and attempt < PROVIDER_STATS_SQLITE_LOCK_RETRY_ATTEMPTS - 1
+            ):
+                await asyncio.sleep(
+                    PROVIDER_STATS_SQLITE_LOCK_RETRY_BASE_DELAY * (2**attempt)
+                )
                 continue
+            logger.warning("Persist provider stats failed: %s", e, exc_info=True)
+            return
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
             logger.warning("Persist provider stats failed: %s", e, exc_info=True)
             return

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -525,22 +525,10 @@ PROVIDER_STATS_SQLITE_LOCK_RETRY_ATTEMPTS = 3
 PROVIDER_STATS_SQLITE_LOCK_RETRY_BASE_DELAY = 0.2
 
 
-def _iter_exception_messages(exc: BaseException):
-    yield str(exc)
-    orig = getattr(exc, "orig", None)
-    if orig is not None and orig is not exc:
-        yield str(orig)
-        yield from (str(arg) for arg in getattr(orig, "args", ()) if arg)
-    yield from (str(arg) for arg in getattr(exc, "args", ()) if arg)
-
-
-def _is_sqlite_database_locked_error(exc: Exception) -> bool:
-    if not isinstance(exc, OperationalError):
-        return False
-    return any(
-        "database" in message.lower() and "locked" in message.lower()
-        for message in _iter_exception_messages(exc)
-    )
+def _is_sqlite_database_locked_error(exc: OperationalError) -> bool:
+    raw = getattr(exc, "orig", exc)
+    message = str(raw).lower()
+    return "database" in message and "locked" in message
 
 
 async def _record_internal_agent_stats(
@@ -558,21 +546,28 @@ async def _record_internal_agent_stats(
     if provider is None or stats is None:
         return
 
-    provider_config = getattr(provider, "provider_config", {}) or {}
-    conversation_id = (
-        req.conversation.cid
-        if req is not None and req.conversation is not None
-        else None
-    )
+    try:
+        provider_config = getattr(provider, "provider_config", {}) or {}
+        conversation_id = (
+            req.conversation.cid
+            if req is not None and req.conversation is not None
+            else None
+        )
 
-    if agent_runner.was_aborted():
-        status = "aborted"
-    elif final_resp is not None and final_resp.role == "err":
-        status = "error"
-    else:
-        status = "completed"
+        if agent_runner.was_aborted():
+            status = "aborted"
+        elif final_resp is not None and final_resp.role == "err":
+            status = "error"
+        else:
+            status = "completed"
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning("Persist provider stats failed: %s", e, exc_info=True)
+        return
 
     for attempt in range(PROVIDER_STATS_SQLITE_LOCK_RETRY_ATTEMPTS):
+        last_attempt = attempt == PROVIDER_STATS_SQLITE_LOCK_RETRY_ATTEMPTS - 1
         try:
             await db_helper.insert_provider_stat(
                 umo=event.unified_msg_origin,
@@ -583,20 +578,17 @@ async def _record_internal_agent_stats(
                 stats=stats.to_dict(),
                 agent_type="internal",
             )
-            return
+            break
+        except asyncio.CancelledError:
+            raise
         except OperationalError as e:
-            if (
-                _is_sqlite_database_locked_error(e)
-                and attempt < PROVIDER_STATS_SQLITE_LOCK_RETRY_ATTEMPTS - 1
-            ):
+            if _is_sqlite_database_locked_error(e) and not last_attempt:
                 await asyncio.sleep(
                     PROVIDER_STATS_SQLITE_LOCK_RETRY_BASE_DELAY * (2**attempt)
                 )
                 continue
             logger.warning("Persist provider stats failed: %s", e, exc_info=True)
-            return
-        except asyncio.CancelledError:
-            raise
+            break
         except Exception as e:
             logger.warning("Persist provider stats failed: %s", e, exc_info=True)
-            return
+            break

--- a/tests/unit/test_provider_stats.py
+++ b/tests/unit/test_provider_stats.py
@@ -66,31 +66,7 @@ async def test_record_internal_agent_stats_persists_provider_stat(
     assert record.time_to_first_token == 0.6
 
 
-@pytest.mark.asyncio
-async def test_record_internal_agent_stats_retries_transient_database_lock(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    attempts = 0
-
-    class LockedOnceDb:
-        async def insert_provider_stat(self, **kwargs):
-            nonlocal attempts
-            attempts += 1
-            if attempts == 1:
-                raise OperationalError(
-                    "insert into provider_stats",
-                    {},
-                    Exception("database is locked"),
-                )
-            return SimpleNamespace(**kwargs)
-
-    monkeypatch.setattr(internal, "db_helper", LockedOnceDb())
-
-    async def no_sleep(delay: float) -> None:
-        return None
-
-    monkeypatch.setattr(internal.asyncio, "sleep", no_sleep)
-
+def _provider_stats_recording_args():
     event = SimpleNamespace(unified_msg_origin="webchat:FriendMessage:session-42")
     req = ProviderRequest(conversation=SimpleNamespace(cid="conv-123"))
     provider = SimpleNamespace(
@@ -103,20 +79,21 @@ async def test_record_internal_agent_stats_retries_transient_database_lock(
         stats=AgentStats(),
         was_aborted=lambda: False,
     )
+    return event, req, agent_runner, SimpleNamespace(role="assistant")
 
-    await internal._record_internal_agent_stats(
-        event,
-        req,
-        agent_runner,
-        SimpleNamespace(role="assistant"),
-    )
 
-    assert attempts == 2
+def _provider_stats_operational_error(message: str) -> OperationalError:
+    return OperationalError("insert into provider_stats", {}, Exception(message))
 
 
 @pytest.mark.asyncio
-async def test_record_internal_agent_stats_retries_database_table_lock(
+@pytest.mark.parametrize(
+    "lock_message",
+    ["database is locked", "database table is locked"],
+)
+async def test_record_internal_agent_stats_retries_transient_database_locks(
     monkeypatch: pytest.MonkeyPatch,
+    lock_message: str,
 ):
     attempts = 0
 
@@ -125,11 +102,7 @@ async def test_record_internal_agent_stats_retries_database_table_lock(
             nonlocal attempts
             attempts += 1
             if attempts == 1:
-                raise OperationalError(
-                    "insert into provider_stats",
-                    {},
-                    Exception("database table is locked"),
-                )
+                raise _provider_stats_operational_error(lock_message)
             return SimpleNamespace(**kwargs)
 
     monkeypatch.setattr(internal, "db_helper", LockedOnceDb())
@@ -139,26 +112,44 @@ async def test_record_internal_agent_stats_retries_database_table_lock(
 
     monkeypatch.setattr(internal.asyncio, "sleep", no_sleep)
 
-    event = SimpleNamespace(unified_msg_origin="webchat:FriendMessage:session-42")
-    provider = SimpleNamespace(
-        provider_config={"id": "provider-1"},
-        meta=lambda: SimpleNamespace(id="provider-1", type="openai"),
-        get_model=lambda: "gpt-4.1",
-    )
-    agent_runner = SimpleNamespace(
-        provider=provider,
-        stats=AgentStats(),
-        was_aborted=lambda: False,
-    )
-
     await internal._record_internal_agent_stats(
-        event,
-        ProviderRequest(conversation=SimpleNamespace(cid="conv-123")),
-        agent_runner,
-        SimpleNamespace(role="assistant"),
+        *_provider_stats_recording_args(),
     )
 
     assert attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_record_internal_agent_stats_logs_after_exhausting_database_lock_retries(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    attempts = 0
+    sleep_delays = []
+    warnings = []
+
+    class AlwaysLockedDb:
+        async def insert_provider_stat(self, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            raise _provider_stats_operational_error("database is locked")
+
+    monkeypatch.setattr(internal, "db_helper", AlwaysLockedDb())
+
+    async def record_sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(internal.asyncio, "sleep", record_sleep)
+    monkeypatch.setattr(
+        internal.logger,
+        "warning",
+        lambda *args, **kwargs: warnings.append((args, kwargs)),
+    )
+
+    await internal._record_internal_agent_stats(*_provider_stats_recording_args())
+
+    assert attempts == internal.PROVIDER_STATS_SQLITE_LOCK_RETRY_ATTEMPTS
+    assert sleep_delays == [0.2, 0.4]
+    assert len(warnings) == 1
 
 
 @pytest.mark.asyncio
@@ -172,11 +163,7 @@ async def test_record_internal_agent_stats_does_not_retry_other_operational_erro
         async def insert_provider_stat(self, **kwargs):
             nonlocal attempts
             attempts += 1
-            raise OperationalError(
-                "insert into provider_stats",
-                {},
-                Exception("no such table: provider_stats"),
-            )
+            raise _provider_stats_operational_error("no such table: provider_stats")
 
     monkeypatch.setattr(internal, "db_helper", FailingDb())
     monkeypatch.setattr(
@@ -185,24 +172,7 @@ async def test_record_internal_agent_stats_does_not_retry_other_operational_erro
         lambda *args, **kwargs: warnings.append((args, kwargs)),
     )
 
-    event = SimpleNamespace(unified_msg_origin="webchat:FriendMessage:session-42")
-    provider = SimpleNamespace(
-        provider_config={"id": "provider-1"},
-        meta=lambda: SimpleNamespace(id="provider-1", type="openai"),
-        get_model=lambda: "gpt-4.1",
-    )
-    agent_runner = SimpleNamespace(
-        provider=provider,
-        stats=AgentStats(),
-        was_aborted=lambda: False,
-    )
-
-    await internal._record_internal_agent_stats(
-        event,
-        ProviderRequest(conversation=SimpleNamespace(cid="conv-123")),
-        agent_runner,
-        SimpleNamespace(role="assistant"),
-    )
+    await internal._record_internal_agent_stats(*_provider_stats_recording_args())
 
     assert attempts == 1
     assert len(warnings) == 1

--- a/tests/unit/test_provider_stats.py
+++ b/tests/unit/test_provider_stats.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -148,7 +149,12 @@ async def test_record_internal_agent_stats_logs_after_exhausting_database_lock_r
     await internal._record_internal_agent_stats(*_provider_stats_recording_args())
 
     assert attempts == internal.PROVIDER_STATS_SQLITE_LOCK_RETRY_ATTEMPTS
-    assert sleep_delays == [0.2, 0.4]
+    base_delay = internal.PROVIDER_STATS_SQLITE_LOCK_RETRY_BASE_DELAY
+    expected_sleep_delays = [
+        base_delay * (2**attempt)
+        for attempt in range(internal.PROVIDER_STATS_SQLITE_LOCK_RETRY_ATTEMPTS - 1)
+    ]
+    assert sleep_delays == expected_sleep_delays
     assert len(warnings) == 1
 
 
@@ -176,3 +182,26 @@ async def test_record_internal_agent_stats_does_not_retry_other_operational_erro
 
     assert attempts == 1
     assert len(warnings) == 1
+
+
+@pytest.mark.asyncio
+async def test_record_internal_agent_stats_propagates_cancelled_error(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    warnings = []
+
+    class CancellingDb:
+        async def insert_provider_stat(self, **kwargs):
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(internal, "db_helper", CancellingDb())
+    monkeypatch.setattr(
+        internal.logger,
+        "warning",
+        lambda *args, **kwargs: warnings.append((args, kwargs)),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await internal._record_internal_agent_stats(*_provider_stats_recording_args())
+
+    assert warnings == []

--- a/tests/unit/test_provider_stats.py
+++ b/tests/unit/test_provider_stats.py
@@ -112,3 +112,97 @@ async def test_record_internal_agent_stats_retries_transient_database_lock(
     )
 
     assert attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_record_internal_agent_stats_retries_database_table_lock(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    attempts = 0
+
+    class LockedOnceDb:
+        async def insert_provider_stat(self, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise OperationalError(
+                    "insert into provider_stats",
+                    {},
+                    Exception("database table is locked"),
+                )
+            return SimpleNamespace(**kwargs)
+
+    monkeypatch.setattr(internal, "db_helper", LockedOnceDb())
+
+    async def no_sleep(delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(internal.asyncio, "sleep", no_sleep)
+
+    event = SimpleNamespace(unified_msg_origin="webchat:FriendMessage:session-42")
+    provider = SimpleNamespace(
+        provider_config={"id": "provider-1"},
+        meta=lambda: SimpleNamespace(id="provider-1", type="openai"),
+        get_model=lambda: "gpt-4.1",
+    )
+    agent_runner = SimpleNamespace(
+        provider=provider,
+        stats=AgentStats(),
+        was_aborted=lambda: False,
+    )
+
+    await internal._record_internal_agent_stats(
+        event,
+        ProviderRequest(conversation=SimpleNamespace(cid="conv-123")),
+        agent_runner,
+        SimpleNamespace(role="assistant"),
+    )
+
+    assert attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_record_internal_agent_stats_does_not_retry_other_operational_errors(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    attempts = 0
+    warnings = []
+
+    class FailingDb:
+        async def insert_provider_stat(self, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            raise OperationalError(
+                "insert into provider_stats",
+                {},
+                Exception("no such table: provider_stats"),
+            )
+
+    monkeypatch.setattr(internal, "db_helper", FailingDb())
+    monkeypatch.setattr(
+        internal.logger,
+        "warning",
+        lambda *args, **kwargs: warnings.append((args, kwargs)),
+    )
+
+    event = SimpleNamespace(unified_msg_origin="webchat:FriendMessage:session-42")
+    provider = SimpleNamespace(
+        provider_config={"id": "provider-1"},
+        meta=lambda: SimpleNamespace(id="provider-1", type="openai"),
+        get_model=lambda: "gpt-4.1",
+    )
+    agent_runner = SimpleNamespace(
+        provider=provider,
+        stats=AgentStats(),
+        was_aborted=lambda: False,
+    )
+
+    await internal._record_internal_agent_stats(
+        event,
+        ProviderRequest(conversation=SimpleNamespace(cid="conv-123")),
+        agent_runner,
+        SimpleNamespace(role="assistant"),
+    )
+
+    assert attempts == 1
+    assert len(warnings) == 1

--- a/tests/unit/test_provider_stats.py
+++ b/tests/unit/test_provider_stats.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 import pytest
+from sqlalchemy.exc import OperationalError
 from sqlmodel import select
 
 from astrbot.core.agent.response import AgentStats
@@ -63,3 +64,51 @@ async def test_record_internal_agent_stats_persists_provider_stat(
     assert record.start_time == 100.0
     assert record.end_time == 108.5
     assert record.time_to_first_token == 0.6
+
+
+@pytest.mark.asyncio
+async def test_record_internal_agent_stats_retries_transient_database_lock(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    attempts = 0
+
+    class LockedOnceDb:
+        async def insert_provider_stat(self, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise OperationalError(
+                    "insert into provider_stats",
+                    {},
+                    Exception("database is locked"),
+                )
+            return SimpleNamespace(**kwargs)
+
+    monkeypatch.setattr(internal, "db_helper", LockedOnceDb())
+
+    async def no_sleep(delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(internal.asyncio, "sleep", no_sleep)
+
+    event = SimpleNamespace(unified_msg_origin="webchat:FriendMessage:session-42")
+    req = ProviderRequest(conversation=SimpleNamespace(cid="conv-123"))
+    provider = SimpleNamespace(
+        provider_config={"id": "provider-1"},
+        meta=lambda: SimpleNamespace(id="provider-1", type="openai"),
+        get_model=lambda: "gpt-4.1",
+    )
+    agent_runner = SimpleNamespace(
+        provider=provider,
+        stats=AgentStats(),
+        was_aborted=lambda: False,
+    )
+
+    await internal._record_internal_agent_stats(
+        event,
+        req,
+        agent_runner,
+        SimpleNamespace(role="assistant"),
+    )
+
+    assert attempts == 2


### PR DESCRIPTION
## Summary

- Retry transient SQLite `database is locked` errors when persisting internal provider stats.
- Keep the existing warning behavior if retries are exhausted or the failure is not a SQLite lock.
- Add a regression test for a lock on the first provider stat insert.

Refs #8570

## Test

- `uv run pytest tests/unit/test_provider_stats.py`
- `uv run ruff check astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py tests/unit/test_provider_stats.py`

## Summary by Sourcery

Add retry handling and logging for transient SQLite lock errors when persisting internal provider stats, and extend tests to cover the new behavior.

Bug Fixes:
- Retry internal provider stats persistence when SQLite reports a transient database lock, instead of failing immediately.
- Avoid retrying and continue propagating cancellation for non-lock and cancelled errors when inserting provider stats.
- Ensure provider stats persistence logs a warning only after retries are exhausted or on non-retriable errors.

Enhancements:
- Introduce configurable retry attempt and backoff settings for SQLite lock handling during provider stats insertion.

Tests:
- Add unit tests covering successful retry after a transient SQLite lock, retry exhaustion with exponential backoff, non-retriable operational errors, and propagation of cancellation errors during provider stats insertion.