### PR TITLE
fix(core): make StarTools.get_data_dir() robust under submodules / debug environments

### DIFF
--- a/astrbot/core/star/star_tools.py
+++ b/astrbot/core/star/star_tools.py
@@ -18,11 +18,11 @@
 """
 
 import inspect
-import logging
 import os
 import uuid
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from pathlib import Path
+from types import ModuleType
 from typing import Any, ClassVar
 
 from astrbot.api.platform import AstrBotMessage, MessageMember, MessageType
@@ -36,50 +36,131 @@ from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_platform_adapter import (
     AiocqhttpAdapter,
 )
 from astrbot.core.star.context import Context
-from astrbot.core.star.star import star_map
-from astrbot.core.utils.astrbot_path import get_astrbot_data_path
+from astrbot.core.star.star import StarMetadata, star_map
+from astrbot.core.utils.astrbot_path import (
+    get_astrbot_data_path,
+    get_astrbot_path,
+    get_astrbot_plugin_path,
+)
 from astrbot.core.utils.io import ensure_dir
 
-logger = logging.getLogger("astrbot")
+_PLUGIN_MODULE_FLAGS = {"plugins", "builtin_stars"}
 
 
-def _resolve_plugin_from_star_map(module, star_map):
-    return star_map.get(module.__name__)
+def _split_module_path(module_path: str | None) -> list[str]:
+    if not module_path:
+        return []
+    return module_path.split(".")
 
 
-def _resolve_plugin_from_prefix(module, star_map):
-    if "." not in module.__name__:
-        return None
-    caller_name = module.__name__
-    # Prefer main modules or shorter paths deterministically
-    sorted_keys = sorted(
-        star_map.keys(), key=lambda k: (not k.endswith(".main"), len(k))
-    )
-    for mod_name in sorted_keys:
-        mod_package = mod_name.rpartition(".")[0] if "." in mod_name else mod_name
-        if caller_name == mod_package or caller_name.startswith(mod_package + "."):
-            return star_map[mod_name]
+def _plugin_root_from_module_path(module_path: str | None) -> tuple[str, str] | None:
+    parts = _split_module_path(module_path)
+    for index, part in enumerate(parts):
+        if part in _PLUGIN_MODULE_FLAGS and index + 1 < len(parts):
+            return part, parts[index + 1]
     return None
 
 
-def _resolve_plugin_from_path(module):
-    if not (hasattr(module, "__file__") and module.__file__):
-        return None
-    try:
-        from astrbot.core.utils.astrbot_path import get_astrbot_plugin_path
+def _metadata_root_dir_name(
+    metadata: StarMetadata,
+    module_path: str | None,
+) -> str | None:
+    if metadata.root_dir_name:
+        return metadata.root_dir_name
 
-        plugin_root = Path(get_astrbot_plugin_path()).resolve()
-        module_path = Path(module.__file__).resolve()
-        return module_path.relative_to(plugin_root).parts[0]
+    root_info = _plugin_root_from_module_path(metadata.module_path or module_path)
+    return root_info[1] if root_info else None
+
+
+def _iter_star_metadata(
+    stars: Mapping[str, StarMetadata],
+) -> list[tuple[str, StarMetadata]]:
+    seen: set[int] = set()
+    metadata_items: list[tuple[str, StarMetadata]] = []
+    for module_path, metadata in reversed(tuple(stars.items())):
+        metadata_id = id(metadata)
+        if metadata_id in seen:
+            continue
+        seen.add(metadata_id)
+        metadata_items.append((module_path, metadata))
+    return metadata_items
+
+
+def _resolve_plugin_from_root_dir(
+    root_dir_name: str,
+    stars: Mapping[str, StarMetadata],
+    module_flag: str | None = None,
+) -> StarMetadata | None:
+    for module_path, metadata in _iter_star_metadata(stars):
+        registered_module_path = metadata.module_path or module_path
+        registered_root = _plugin_root_from_module_path(registered_module_path)
+        if module_flag and registered_root and registered_root[0] != module_flag:
+            continue
+        if _metadata_root_dir_name(metadata, module_path) == root_dir_name:
+            return metadata
+    return None
+
+
+def _resolve_plugin_from_registered_package(
+    module_path: str,
+    stars: Mapping[str, StarMetadata],
+) -> StarMetadata | None:
+    root_info = _plugin_root_from_module_path(module_path)
+    if not root_info:
+        return None
+
+    module_flag, root_dir_name = root_info
+    return _resolve_plugin_from_root_dir(root_dir_name, stars, module_flag)
+
+
+def _plugin_search_roots() -> tuple[tuple[str, Path], ...]:
+    return (
+        ("plugins", Path(get_astrbot_plugin_path()).resolve()),
+        (
+            "builtin_stars",
+            Path(get_astrbot_path()).resolve() / "astrbot" / "builtin_stars",
+        ),
+    )
+
+
+def _resolve_plugin_from_file_path(
+    module: ModuleType,
+    stars: Mapping[str, StarMetadata],
+) -> StarMetadata | None:
+    module_file = getattr(module, "__file__", None)
+    if not module_file:
+        return None
+
+    try:
+        module_path = Path(module_file).resolve()
     except Exception:
         return None
 
+    for module_flag, plugin_root in _plugin_search_roots():
+        try:
+            relative_parts = module_path.relative_to(plugin_root).parts
+        except ValueError:
+            continue
 
-def _fallback_plugin_name(module):
-    logger.warning(
-        f"无法获取模块 {module.__name__} 的元数据信息，已安全回退到 'unknown_plugin'"
+        if relative_parts:
+            return _resolve_plugin_from_root_dir(
+                relative_parts[0],
+                stars,
+                module_flag,
+            )
+
+    return None
+
+
+def _resolve_plugin_metadata(
+    module: ModuleType,
+    stars: Mapping[str, StarMetadata],
+) -> StarMetadata | None:
+    return (
+        stars.get(module.__name__)
+        or _resolve_plugin_from_registered_package(module.__name__, stars)
+        or _resolve_plugin_from_file_path(module, stars)
     )
-    return "unknown_plugin"
 
 
 class StarTools:
@@ -333,16 +414,15 @@ class StarTools:
             if not module:
                 raise RuntimeError("无法获取调用者模块信息")
 
-            metadata = _resolve_plugin_from_star_map(
-                module, star_map
-            ) or _resolve_plugin_from_prefix(module, star_map)
+            metadata = _resolve_plugin_metadata(module, star_map)
 
-            if metadata:
-                plugin_name = metadata.name
-            else:
-                plugin_name = _resolve_plugin_from_path(
-                    module
-                ) or _fallback_plugin_name(module)
+            if not metadata:
+                raise RuntimeError(f"无法获取模块 {module.__name__} 的元数据信息")
+
+            plugin_name = metadata.name
+
+        if not plugin_name:
+            raise ValueError("无法获取插件名称")
 
         data_dir = Path(
             os.path.join(get_astrbot_data_path(), "plugin_data", plugin_name),

--- a/astrbot/core/star/star_tools.py
+++ b/astrbot/core/star/star_tools.py
@@ -20,6 +20,7 @@
 import inspect
 import os
 import uuid
+import logging
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any, ClassVar
@@ -38,6 +39,46 @@ from astrbot.core.star.context import Context
 from astrbot.core.star.star import star_map
 from astrbot.core.utils.astrbot_path import get_astrbot_data_path
 from astrbot.core.utils.io import ensure_dir
+
+logger = logging.getLogger("astrbot")
+
+
+def _resolve_plugin_from_star_map(module, star_map):
+    return star_map.get(module.__name__)
+
+
+def _resolve_plugin_from_prefix(module, star_map):
+    if "." not in module.__name__:
+        return None
+    caller_parts = module.__name__.split('.')
+    # Prefer main modules or shorter paths deterministically
+    sorted_keys = sorted(star_map.keys(), key=lambda k: (not k.endswith('.main'), len(k)))
+    for mod_name in sorted_keys:
+        mod_parts = mod_name.split('.')
+        if mod_parts and caller_parts and mod_parts[0] == caller_parts[0]:
+            return star_map[mod_name]
+    return None
+
+
+def _resolve_plugin_from_path(module):
+    if not (hasattr(module, "__file__") and module.__file__):
+        return None
+    try:
+        path_parts = Path(module.__file__).resolve().parts
+        if "plugins" in path_parts:
+            idx = path_parts.index("plugins")
+            if idx + 1 < len(path_parts):
+                return path_parts[idx + 1]
+    except Exception:
+        return None
+    return None
+
+
+def _fallback_plugin_name(module):
+    logger.warning(
+        f"无法获取模块 {module.__name__} 的元数据信息，已安全回退到 'unknown_plugin'"
+    )
+    return "unknown_plugin"
 
 
 class StarTools:
@@ -291,42 +332,15 @@ class StarTools:
             if not module:
                 raise RuntimeError("无法获取调用者模块信息")
 
-            # 1. Try direct match in star_map
-            metadata = star_map.get(module.__name__, None)
-
-            # 2. Try prefix match for submodule calls
-            if not metadata and "." in module.__name__:
-                caller_parts = module.__name__.split('.')
-                for mod_name, meta in star_map.items():
-                    mod_parts = mod_name.split('.')
-                    if mod_parts and caller_parts and mod_parts[0] == caller_parts[0]:
-                        metadata = meta
-                        break
+            metadata = (
+                _resolve_plugin_from_star_map(module, star_map)
+                or _resolve_plugin_from_prefix(module, star_map)
+            )
 
             if metadata:
                 plugin_name = metadata.name
             else:
-                # 3. Try to resolve from file path if it resides in plugins/
-                if hasattr(module, "__file__") and module.__file__:
-                    try:
-                        path_parts = Path(module.__file__).resolve().parts
-                        if "plugins" in path_parts:
-                            idx = path_parts.index("plugins")
-                            if idx + 1 < len(path_parts):
-                                plugin_name = path_parts[idx + 1]
-                    except Exception:
-                        pass
-
-            # 4. Safe fallback to avoid breaking the bot
-            if not plugin_name:
-                import logging
-                logging.getLogger("astrbot").warning(
-                    f"无法获取模块 {module.__name__} 的元数据信息，已安全回退到 'unknown_plugin'"
-                )
-                plugin_name = 'unknown_plugin'
-
-        if not plugin_name:
-            raise ValueError("无法获取插件名称")
+                plugin_name = _resolve_plugin_from_path(module) or _fallback_plugin_name(module)
 
         data_dir = Path(
             os.path.join(get_astrbot_data_path(), "plugin_data", plugin_name),

--- a/astrbot/core/star/star_tools.py
+++ b/astrbot/core/star/star_tools.py
@@ -50,12 +50,12 @@ def _resolve_plugin_from_star_map(module, star_map):
 def _resolve_plugin_from_prefix(module, star_map):
     if "." not in module.__name__:
         return None
-    caller_parts = module.__name__.split('.')
+    caller_name = module.__name__
     # Prefer main modules or shorter paths deterministically
     sorted_keys = sorted(star_map.keys(), key=lambda k: (not k.endswith('.main'), len(k)))
     for mod_name in sorted_keys:
-        mod_parts = mod_name.split('.')
-        if mod_parts and caller_parts and mod_parts[0] == caller_parts[0]:
+        mod_package = mod_name.rpartition('.')[0] if "." in mod_name else mod_name
+        if caller_name == mod_package or caller_name.startswith(mod_package + "."):
             return star_map[mod_name]
     return None
 
@@ -64,14 +64,12 @@ def _resolve_plugin_from_path(module):
     if not (hasattr(module, "__file__") and module.__file__):
         return None
     try:
-        path_parts = Path(module.__file__).resolve().parts
-        if "plugins" in path_parts:
-            idx = path_parts.index("plugins")
-            if idx + 1 < len(path_parts):
-                return path_parts[idx + 1]
+        from astrbot.core.utils.astrbot_path import get_astrbot_plugin_path
+        plugin_root = Path(get_astrbot_plugin_path()).resolve()
+        module_path = Path(module.__file__).resolve()
+        return module_path.relative_to(plugin_root).parts[0]
     except Exception:
         return None
-    return None
 
 
 def _fallback_plugin_name(module):

--- a/astrbot/core/star/star_tools.py
+++ b/astrbot/core/star/star_tools.py
@@ -18,9 +18,9 @@
 """
 
 import inspect
+import logging
 import os
 import uuid
-import logging
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any, ClassVar
@@ -52,9 +52,11 @@ def _resolve_plugin_from_prefix(module, star_map):
         return None
     caller_name = module.__name__
     # Prefer main modules or shorter paths deterministically
-    sorted_keys = sorted(star_map.keys(), key=lambda k: (not k.endswith('.main'), len(k)))
+    sorted_keys = sorted(
+        star_map.keys(), key=lambda k: (not k.endswith(".main"), len(k))
+    )
     for mod_name in sorted_keys:
-        mod_package = mod_name.rpartition('.')[0] if "." in mod_name else mod_name
+        mod_package = mod_name.rpartition(".")[0] if "." in mod_name else mod_name
         if caller_name == mod_package or caller_name.startswith(mod_package + "."):
             return star_map[mod_name]
     return None
@@ -65,6 +67,7 @@ def _resolve_plugin_from_path(module):
         return None
     try:
         from astrbot.core.utils.astrbot_path import get_astrbot_plugin_path
+
         plugin_root = Path(get_astrbot_plugin_path()).resolve()
         module_path = Path(module.__file__).resolve()
         return module_path.relative_to(plugin_root).parts[0]
@@ -330,15 +333,16 @@ class StarTools:
             if not module:
                 raise RuntimeError("无法获取调用者模块信息")
 
-            metadata = (
-                _resolve_plugin_from_star_map(module, star_map)
-                or _resolve_plugin_from_prefix(module, star_map)
-            )
+            metadata = _resolve_plugin_from_star_map(
+                module, star_map
+            ) or _resolve_plugin_from_prefix(module, star_map)
 
             if metadata:
                 plugin_name = metadata.name
             else:
-                plugin_name = _resolve_plugin_from_path(module) or _fallback_plugin_name(module)
+                plugin_name = _resolve_plugin_from_path(
+                    module
+                ) or _fallback_plugin_name(module)
 
         data_dir = Path(
             os.path.join(get_astrbot_data_path(), "plugin_data", plugin_name),

--- a/astrbot/core/star/star_tools.py
+++ b/astrbot/core/star/star_tools.py
@@ -291,12 +291,39 @@ class StarTools:
             if not module:
                 raise RuntimeError("无法获取调用者模块信息")
 
+            # 1. Try direct match in star_map
             metadata = star_map.get(module.__name__, None)
 
-            if not metadata:
-                raise RuntimeError(f"无法获取模块 {module.__name__} 的元数据信息")
+            # 2. Try prefix match for submodule calls
+            if not metadata and "." in module.__name__:
+                caller_parts = module.__name__.split('.')
+                for mod_name, meta in star_map.items():
+                    mod_parts = mod_name.split('.')
+                    if mod_parts and caller_parts and mod_parts[0] == caller_parts[0]:
+                        metadata = meta
+                        break
 
-            plugin_name = metadata.name
+            if metadata:
+                plugin_name = metadata.name
+            else:
+                # 3. Try to resolve from file path if it resides in plugins/
+                if hasattr(module, "__file__") and module.__file__:
+                    try:
+                        path_parts = Path(module.__file__).resolve().parts
+                        if "plugins" in path_parts:
+                            idx = path_parts.index("plugins")
+                            if idx + 1 < len(path_parts):
+                                plugin_name = path_parts[idx + 1]
+                    except Exception:
+                        pass
+
+            # 4. Safe fallback to avoid breaking the bot
+            if not plugin_name:
+                import logging
+                logging.getLogger("astrbot").warning(
+                    f"无法获取模块 {module.__name__} 的元数据信息，已安全回退到 'unknown_plugin'"
+                )
+                plugin_name = 'unknown_plugin'
 
         if not plugin_name:
             raise ValueError("无法获取插件名称")

--- a/tests/unit/test_star_tools.py
+++ b/tests/unit/test_star_tools.py
@@ -1,0 +1,79 @@
+from types import ModuleType
+
+import pytest
+
+from astrbot.core.star import star_tools
+from astrbot.core.star.star import StarMetadata, star_map
+from astrbot.core.star.star_tools import StarTools
+
+
+@pytest.fixture(autouse=True)
+def restore_star_map():
+    original_map = dict(star_map)
+    star_map.clear()
+    try:
+        yield
+    finally:
+        star_map.clear()
+        star_map.update(original_map)
+
+
+def make_module(name: str, file_path: str | None = None) -> ModuleType:
+    module = ModuleType(name)
+    if file_path:
+        module.__file__ = file_path
+    return module
+
+
+def set_caller_module(monkeypatch: pytest.MonkeyPatch, module: ModuleType) -> None:
+    monkeypatch.setattr(star_tools.inspect, "getmodule", lambda _frame: module)
+
+
+def test_get_data_dir_resolves_registered_plugin_submodule(monkeypatch, tmp_path):
+    data_path = tmp_path / "data"
+    monkeypatch.setattr(star_tools, "get_astrbot_data_path", lambda: str(data_path))
+    set_caller_module(
+        monkeypatch,
+        make_module("data.plugins.demo_plugin.services.cache"),
+    )
+    star_map["data.plugins.demo_plugin.main"] = StarMetadata(
+        name="demo",
+        module_path="data.plugins.demo_plugin.main",
+        root_dir_name="demo_plugin",
+    )
+
+    data_dir = StarTools.get_data_dir()
+
+    assert data_dir == (data_path / "plugin_data" / "demo").resolve()
+
+
+def test_get_data_dir_resolves_debug_module_from_plugin_path(monkeypatch, tmp_path):
+    data_path = tmp_path / "data"
+    plugin_root = tmp_path / "plugins"
+    debug_file = plugin_root / "demo_plugin" / "scripts" / "debug.py"
+    debug_file.parent.mkdir(parents=True)
+    debug_file.write_text("", encoding="utf-8")
+    monkeypatch.setattr(star_tools, "get_astrbot_data_path", lambda: str(data_path))
+    monkeypatch.setattr(star_tools, "get_astrbot_plugin_path", lambda: str(plugin_root))
+    monkeypatch.setattr(star_tools, "get_astrbot_path", lambda: str(tmp_path / "src"))
+    set_caller_module(monkeypatch, make_module("__main__", str(debug_file)))
+    star_map["data.plugins.demo_plugin.main"] = StarMetadata(
+        name="demo",
+        module_path="data.plugins.demo_plugin.main",
+        root_dir_name="demo_plugin",
+    )
+
+    data_dir = StarTools.get_data_dir()
+
+    assert data_dir == (data_path / "plugin_data" / "demo").resolve()
+
+
+def test_get_data_dir_keeps_unknown_module_failure(monkeypatch, tmp_path):
+    data_path = tmp_path / "data"
+    monkeypatch.setattr(star_tools, "get_astrbot_data_path", lambda: str(data_path))
+    set_caller_module(monkeypatch, make_module("external.module"))
+
+    with pytest.raises(RuntimeError, match="无法获取模块 external.module 的元数据信息"):
+        StarTools.get_data_dir()
+
+    assert not (data_path / "plugin_data" / "unknown_plugin").exists()


### PR DESCRIPTION
### Problem

`StarTools.get_data_dir()` can infer the plugin name when `plugin_name` is omitted, but the current implementation only checks `star_map` with the immediate caller module name.

That fails in common plugin development scenarios:

1. A plugin calls the API from a submodule, such as `data.plugins.example.services.cache`, while `star_map` only contains the registered entry module, such as `data.plugins.example.main`.
2. A plugin module is exercised through a local debug shim or `__main__` module where the module name itself is not present in `star_map`, even though the file still lives under the registered plugin directory.

In these cases, `get_data_dir()` raises at runtime even though the caller still belongs to a loaded plugin.

### Ecosystem Evidence

This is not limited to a single plugin. Several plugin-level PRs reference this core PR and work around the same failure by explicitly passing `plugin_name` to `StarTools.get_data_dir()`:

- SXP-Simon/astrbot_plugin_qq_group_daily_analysis#193 (open)
- kawayiYokami/astrbot_plugin_angel_heart#49 (merged)
- kawayiYokami/astrbot_plugin_angel_smile#7 (open)
- lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory#169 (merged)
- olozhika/astrbot_plugin_local_reminiscence#31 (merged)
- YUMU1658/astrbot_plugin_qq_tools#5 (merged)
- Renyus/astrbot_plugin_self_evolution#123 (open)

The merged plugin-side PRs are useful backward-compatible fixes for existing AstrBot installations, and the open ones show the same pattern is still being handled in plugin repositories. This core PR remains useful because it fixes the framework helper itself, so future plugin submodules and debug entrypoints do not need to repeat the same workaround.

### Solution

Make plugin-name resolution more robust while keeping explicit `plugin_name` behavior unchanged:

1. If `plugin_name` is provided, use it directly.
2. If omitted, first try the existing exact `star_map` lookup.
3. If that fails, resolve the caller by registered plugin root, supporting plugin submodules under `data.plugins.<plugin>` and built-in plugin submodules under `astrbot.builtin_stars.<plugin>`.
4. If the caller module name is not useful, resolve its `__file__` relative to the configured plugin roots and map that root back to existing `StarMetadata`.
5. If no registered plugin can be identified, keep the existing hard failure instead of silently writing to a shared fallback directory.

This intentionally avoids a generic `unknown_plugin` fallback so unrelated or truly unknown modules do not share the same plugin data directory.

### Verification

- `uv run pytest tests/unit/test_star_tools.py -q --basetemp=.pytest-tmp-star-tools`
- `uv run ruff format --check .`
- `uv run ruff check .`

### Checklist

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
- [x] My changes have been tested, and verification steps are provided above.
- [x] No new dependencies are introduced.
- [x] My changes do not introduce malicious code.