### PR TITLE
feat(components): override repr_args to truncate long base64 fields for safe logging

### DIFF
--- a/astrbot/core/message/components.py
+++ b/astrbot/core/message/components.py
@@ -74,6 +74,25 @@ class BaseMessageComponent(BaseModel):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
 
+    def __repr_args__(self):
+        """截断超长 / base64 字段值，避免 repr() 与日志输出被 base64 正文污染。
+
+        覆盖 pydantic 默认 repr，作用于所有消息组件（Image/Record/Video/File 等），
+        因此任何 logger、异常信息中的组件输出都自动安全，无需在调用点单独处理。
+        """
+        max_len = 64
+
+        def truncate(value):
+            if isinstance(value, str):
+                if value.startswith("base64://"):
+                    return f"base64://<{len(value) - 9} chars>"
+                if len(value) > max_len:
+                    return f"{value[:max_len]}...<{len(value)} chars>"
+            return value
+
+        for key, value in super().__repr_args__():
+            yield key, truncate(value)
+
     def toDict(self):
         data = {}
         for k, v in self.__dict__.items():


### PR DESCRIPTION
When a message component carrying base64-encoded media (e.g. an `Image` built via `fromBase64`) is logged or appears in a traceback, pydantic's default `repr()` dumps the entire base64 string into the log. A single image can flood the logs with thousands of characters, making them unreadable and bloating log files. This was observed on the Discord adapter (`logger.debug(f"... {image_component}")`) but affects any place that stringifies a component.
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
### Modifications / 改动点
- `astrbot/core/message/components.py`: Override `__repr_args__` on the `BaseMessageComponent` base class to truncate long / base64 string field values in the repr only. Fields starting with `base64://` render as `base64://<N chars>`, and any other string over 64 chars is truncated with a length suffix. This is purely a display-layer change — it wraps pydantic's default `__repr_args__` and never mutates the stored data, so serialization (`toDict`), sending, and file conversion still see the full payload. Because it lives on the base class, all components (Image/Record/Video/File, etc.) are covered automatically with no per-call-site handling.
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
Before:
<img width="1166" height="214" alt="HapiGo_2026-06-05_01 18 42" src="https://github.com/user-attachments/assets/fbac9988-2cf3-4b4e-ae0e-53557220cb83" />
After:
<img width="1152" height="49" alt="HapiGo_2026-06-05_01 17 57" src="https://github.com/user-attachments/assets/9800b8b9-3d09-4276-bf46-379003ea9731" />
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Enhancements:
- Override BaseMessageComponent repr to truncate base64 and overly long string fields while preserving full underlying data for normal usage.