### PR TITLE
fix: 缓解 SQLite 锁库导致的 agent 处理失败

### DIFF
--- a/astrbot/core/db/sqlite.py
+++ b/astrbot/core/db/sqlite.py
@@ -5,6 +5,7 @@ from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import CursorResult, Row
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, delete, desc, func, or_, select, text, update
 
@@ -38,6 +39,8 @@ from astrbot.core.sentinels import NOT_GIVEN
 
 TxResult = T.TypeVar("TxResult")
 CRON_FIELD_NOT_SET = object()
+SQLITE_LOCK_RETRY_ATTEMPTS = 2
+SQLITE_LOCK_RETRY_BASE_DELAY = 0.1
 
 
 class SQLiteDatabase(BaseDatabase):
@@ -46,6 +49,15 @@ class SQLiteDatabase(BaseDatabase):
         self.DATABASE_URL = f"sqlite+aiosqlite:///{db_path}"
         self.inited = False
         super().__init__()
+
+    @staticmethod
+    def _is_sqlite_database_locked_error(exc: OperationalError) -> bool:
+        raw = getattr(exc, "orig", exc)
+        message = str(raw).lower()
+        return "database" in message and "locked" in message
+
+    async def _sleep_before_locked_retry(self, attempt: int) -> None:
+        await asyncio.sleep(SQLITE_LOCK_RETRY_BASE_DELAY * (2**attempt))
 
     async def initialize(self) -> None:
         """Initialize the database by creating tables if they do not exist."""
@@ -138,30 +150,31 @@ class SQLiteDatabase(BaseDatabase):
         timestamp=None,
     ) -> None:
         """Insert a new platform statistic record."""
-        async with self.get_db() as session:
-            session: AsyncSession
-            async with session.begin():
-                if timestamp is None:
-                    timestamp = datetime.now().replace(
-                        minute=0,
-                        second=0,
-                        microsecond=0,
-                    )
-                current_hour = timestamp
-                await session.execute(
-                    text("""
+        if timestamp is None:
+            timestamp = datetime.now().replace(
+                minute=0,
+                second=0,
+                microsecond=0,
+            )
+        current_hour = timestamp
+
+        async def _op(session: AsyncSession) -> None:
+            await session.execute(
+                text("""
                     INSERT INTO platform_stats (timestamp, platform_id, platform_type, count)
                     VALUES (:timestamp, :platform_id, :platform_type, :count)
                     ON CONFLICT(timestamp, platform_id, platform_type) DO UPDATE SET
                         count = platform_stats.count + EXCLUDED.count
                     """),
-                    {
-                        "timestamp": current_hour,
-                        "platform_id": platform_id,
-                        "platform_type": platform_type,
-                        "count": count,
-                    },
-                )
+                {
+                    "timestamp": current_hour,
+                    "platform_id": platform_id,
+                    "platform_type": platform_type,
+                    "count": count,
+                },
+            )
+
+        await self._run_in_tx(_op)
 
     async def count_platform_stats(self) -> int:
         """Count the number of platform statistics records."""
@@ -347,42 +360,45 @@ class SQLiteDatabase(BaseDatabase):
             kwargs["created_at"] = created_at
         if updated_at:
             kwargs["updated_at"] = updated_at
-        async with self.get_db() as session:
-            session: AsyncSession
-            async with session.begin():
-                new_conversation = ConversationV2(
-                    user_id=user_id,
-                    content=content or [],
-                    platform_id=platform_id,
-                    title=title,
-                    persona_id=persona_id,
-                    **kwargs,
-                )
-                session.add(new_conversation)
-                return new_conversation
+        async def _op(session: AsyncSession) -> ConversationV2:
+            new_conversation = ConversationV2(
+                user_id=user_id,
+                content=content or [],
+                platform_id=platform_id,
+                title=title,
+                persona_id=persona_id,
+                **kwargs,
+            )
+            session.add(new_conversation)
+            await session.flush()
+            await session.refresh(new_conversation)
+            return new_conversation
+
+        return await self._run_in_tx(_op)
 
     async def update_conversation(
         self, cid, title=None, persona_id=None, content=None, token_usage=None
     ):
-        async with self.get_db() as session:
-            session: AsyncSession
-            async with session.begin():
-                query = update(ConversationV2).where(
-                    col(ConversationV2.conversation_id) == cid,
-                )
-                values = {}
-                if title is not None:
-                    values["title"] = title
-                if persona_id is not None:
-                    values["persona_id"] = persona_id
-                if content is not None:
-                    values["content"] = content
-                if token_usage is not None:
-                    values["token_usage"] = token_usage
-                if not values:
-                    return None
-                query = query.values(**values)
-                await session.execute(query)
+        values = {}
+        if title is not None:
+            values["title"] = title
+        if persona_id is not None:
+            values["persona_id"] = persona_id
+        if content is not None:
+            values["content"] = content
+        if token_usage is not None:
+            values["token_usage"] = token_usage
+        if not values:
+            return None
+
+        async def _op(session: AsyncSession) -> None:
+            query = update(ConversationV2).where(
+                col(ConversationV2.conversation_id) == cid,
+            )
+            query = query.values(**values)
+            await session.execute(query)
+
+        await self._run_in_tx(_op)
         return await self.get_conversation_by_id(cid)
 
     async def delete_conversation(self, cid) -> None:
@@ -524,19 +540,21 @@ class SQLiteDatabase(BaseDatabase):
         llm_checkpoint_id=None,
     ):
         """Insert a new platform message history record."""
-        async with self.get_db() as session:
-            session: AsyncSession
-            async with session.begin():
-                new_history = PlatformMessageHistory(
-                    platform_id=platform_id,
-                    user_id=user_id,
-                    content=content,
-                    sender_id=sender_id,
-                    sender_name=sender_name,
-                    llm_checkpoint_id=llm_checkpoint_id,
-                )
-                session.add(new_history)
-                return new_history
+        async def _op(session: AsyncSession) -> PlatformMessageHistory:
+            new_history = PlatformMessageHistory(
+                platform_id=platform_id,
+                user_id=user_id,
+                content=content,
+                sender_id=sender_id,
+                sender_name=sender_name,
+                llm_checkpoint_id=llm_checkpoint_id,
+            )
+            session.add(new_history)
+            await session.flush()
+            await session.refresh(new_history)
+            return new_history
+
+        return await self._run_in_tx(_op)
 
     async def update_platform_message_history(
         self,
@@ -553,14 +571,14 @@ class SQLiteDatabase(BaseDatabase):
         if not values:
             return
 
-        async with self.get_db() as session:
-            session: AsyncSession
-            async with session.begin():
-                await session.execute(
-                    update(PlatformMessageHistory)
-                    .where(PlatformMessageHistory.id == message_id)
-                    .values(**values)
-                )
+        async def _op(session: AsyncSession) -> None:
+            await session.execute(
+                update(PlatformMessageHistory)
+                .where(PlatformMessageHistory.id == message_id)
+                .values(**values)
+            )
+
+        await self._run_in_tx(_op)
 
     async def delete_platform_message_history_by_id(self, message_id: int) -> None:
         """Delete a platform message history record by ID."""
@@ -1284,10 +1302,21 @@ class SQLiteDatabase(BaseDatabase):
         self,
         fn: Callable[[AsyncSession], Awaitable[TxResult]],
     ) -> TxResult:
-        async with self.get_db() as session:
-            session: AsyncSession
-            async with session.begin():
-                return await fn(session)
+        for attempt in range(SQLITE_LOCK_RETRY_ATTEMPTS):
+            try:
+                async with self.get_db() as session:
+                    session: AsyncSession
+                    async with session.begin():
+                        return await fn(session)
+            except OperationalError as exc:
+                if (
+                    not self._is_sqlite_database_locked_error(exc)
+                    or attempt == SQLITE_LOCK_RETRY_ATTEMPTS - 1
+                ):
+                    raise
+                await self._sleep_before_locked_retry(attempt)
+
+        raise RuntimeError("unreachable sqlite transaction retry state")
 
     @staticmethod
     def _apply_updates(model, **updates) -> None:

--- a/astrbot/core/db/sqlite.py
+++ b/astrbot/core/db/sqlite.py
@@ -360,6 +360,7 @@ class SQLiteDatabase(BaseDatabase):
             kwargs["created_at"] = created_at
         if updated_at:
             kwargs["updated_at"] = updated_at
+
         async def _op(session: AsyncSession) -> ConversationV2:
             new_conversation = ConversationV2(
                 user_id=user_id,
@@ -540,6 +541,7 @@ class SQLiteDatabase(BaseDatabase):
         llm_checkpoint_id=None,
     ):
         """Insert a new platform message history record."""
+
         async def _op(session: AsyncSession) -> PlatformMessageHistory:
             new_history = PlatformMessageHistory(
                 platform_id=platform_id,

--- a/astrbot/core/db/sqlite.py
+++ b/astrbot/core/db/sqlite.py
@@ -1,4 +1,6 @@
 import asyncio
+import logging
+import random
 import threading
 import typing as T
 from collections.abc import Awaitable, Callable
@@ -41,6 +43,8 @@ TxResult = T.TypeVar("TxResult")
 CRON_FIELD_NOT_SET = object()
 SQLITE_LOCK_RETRY_ATTEMPTS = 2
 SQLITE_LOCK_RETRY_BASE_DELAY = 0.1
+SQLITE_LOCK_RETRY_MAX_JITTER = 0.05
+logger = logging.getLogger("astrbot")
 
 
 class SQLiteDatabase(BaseDatabase):
@@ -57,7 +61,9 @@ class SQLiteDatabase(BaseDatabase):
         return "database" in message and "locked" in message
 
     async def _sleep_before_locked_retry(self, attempt: int) -> None:
-        await asyncio.sleep(SQLITE_LOCK_RETRY_BASE_DELAY * (2**attempt))
+        delay = SQLITE_LOCK_RETRY_BASE_DELAY * (2**attempt)
+        delay += random.uniform(0, SQLITE_LOCK_RETRY_MAX_JITTER)
+        await asyncio.sleep(delay)
 
     async def initialize(self) -> None:
         """Initialize the database by creating tables if they do not exist."""
@@ -392,15 +398,20 @@ class SQLiteDatabase(BaseDatabase):
         if not values:
             return None
 
-        async def _op(session: AsyncSession) -> None:
+        async def _op(session: AsyncSession) -> ConversationV2 | None:
             query = update(ConversationV2).where(
                 col(ConversationV2.conversation_id) == cid,
             )
             query = query.values(**values)
             await session.execute(query)
+            result = await session.execute(
+                select(ConversationV2).where(
+                    col(ConversationV2.conversation_id) == cid,
+                ),
+            )
+            return result.scalar_one_or_none()
 
-        await self._run_in_tx(_op)
-        return await self.get_conversation_by_id(cid)
+        return await self._run_in_tx(_op)
 
     async def delete_conversation(self, cid) -> None:
         async with self.get_db() as session:
@@ -1311,14 +1322,23 @@ class SQLiteDatabase(BaseDatabase):
                     async with session.begin():
                         return await fn(session)
             except OperationalError as exc:
-                if (
-                    not self._is_sqlite_database_locked_error(exc)
-                    or attempt == SQLITE_LOCK_RETRY_ATTEMPTS - 1
-                ):
+                is_locked = self._is_sqlite_database_locked_error(exc)
+                is_last_attempt = attempt == SQLITE_LOCK_RETRY_ATTEMPTS - 1
+                if not is_locked:
                     raise
+                if is_last_attempt:
+                    logger.warning(
+                        "SQLite database locked after %d attempts; giving up",
+                        SQLITE_LOCK_RETRY_ATTEMPTS,
+                    )
+                    raise
+                logger.debug(
+                    "SQLite database locked on attempt %d; retrying",
+                    attempt + 1,
+                )
                 await self._sleep_before_locked_retry(attempt)
 
-        raise RuntimeError("unreachable sqlite transaction retry state")
+        raise AssertionError("unreachable sqlite transaction retry state")
 
     @staticmethod
     def _apply_updates(model, **updates) -> None:

--- a/tests/unit/test_sqlite_lock_retry.py
+++ b/tests/unit/test_sqlite_lock_retry.py
@@ -130,6 +130,34 @@ async def test_run_in_tx_retries_sqlite_database_table_locked(monkeypatch, tmp_p
 
 
 @pytest.mark.asyncio
+async def test_run_in_tx_reraises_after_sqlite_locked_retries_exhausted(
+    monkeypatch,
+    tmp_path,
+):
+    db = SQLiteDatabase(str(tmp_path / "retry-exhausted.db"))
+    attempts = 0
+    sleep_delays = []
+
+    async def record_sleep(attempt: int) -> None:
+        sleep_delays.append(attempt)
+
+    monkeypatch.setattr(db, "_sleep_before_locked_retry", record_sleep)
+
+    async def op(session):
+        nonlocal attempts
+        attempts += 1
+        raise _operational_error("database is locked")
+
+    with pytest.raises(OperationalError):
+        await db._run_in_tx(op)
+
+    assert attempts == 2
+    assert sleep_delays == [0]
+
+    await db.engine.dispose()
+
+
+@pytest.mark.asyncio
 async def test_run_in_tx_does_not_retry_other_operational_errors(
     monkeypatch,
     tmp_path,
@@ -164,11 +192,9 @@ async def test_update_conversation_uses_retrying_transaction(monkeypatch, tmp_pa
         user_id="webchat:FriendMessage:user-1",
         content=[{"role": "user", "content": "old"}],
     )
-    run_in_tx = AsyncMock(return_value=None)
-    get_conversation_by_id = AsyncMock(return_value=conversation)
+    run_in_tx = AsyncMock(return_value=conversation)
 
     monkeypatch.setattr(db, "_run_in_tx", run_in_tx)
-    monkeypatch.setattr(db, "get_conversation_by_id", get_conversation_by_id)
 
     result = await db.update_conversation(
         "conv-1",
@@ -178,6 +204,5 @@ async def test_update_conversation_uses_retrying_transaction(monkeypatch, tmp_pa
 
     assert result is conversation
     run_in_tx.assert_awaited_once()
-    get_conversation_by_id.assert_awaited_once_with("conv-1")
 
     await db.engine.dispose()

--- a/tests/unit/test_sqlite_lock_retry.py
+++ b/tests/unit/test_sqlite_lock_retry.py
@@ -1,0 +1,183 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.exc import OperationalError
+
+from astrbot.core.db.po import ConversationV2, PlatformMessageHistory
+from astrbot.core.db.sqlite import SQLiteDatabase
+
+
+def _operational_error(message: str) -> OperationalError:
+    return OperationalError("update conversations", {}, Exception(message))
+
+
+@pytest.mark.asyncio
+async def test_run_in_tx_retries_sqlite_database_locked(monkeypatch, tmp_path):
+    db = SQLiteDatabase(str(tmp_path / "retry.db"))
+    attempts = 0
+    sleep_delays = []
+
+    async def record_sleep(attempt: int) -> None:
+        sleep_delays.append(attempt)
+
+    monkeypatch.setattr(db, "_sleep_before_locked_retry", record_sleep)
+
+    async def op(session):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise _operational_error("database is locked")
+        return "ok"
+
+    assert await db._run_in_tx(op) == "ok"
+    assert attempts == 2
+    assert sleep_delays == [0]
+
+    await db.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_update_conversation_noop_returns_none_without_retrying_tx(
+    monkeypatch,
+    tmp_path,
+):
+    db = SQLiteDatabase(str(tmp_path / "noop-update-conversation.db"))
+    run_in_tx = AsyncMock()
+    get_conversation_by_id = AsyncMock()
+
+    monkeypatch.setattr(db, "_run_in_tx", run_in_tx)
+    monkeypatch.setattr(db, "get_conversation_by_id", get_conversation_by_id)
+
+    assert await db.update_conversation("conv-1") is None
+    run_in_tx.assert_not_awaited()
+    get_conversation_by_id.assert_not_awaited()
+
+    await db.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_insert_platform_message_history_uses_retrying_transaction(
+    monkeypatch,
+    tmp_path,
+):
+    db = SQLiteDatabase(str(tmp_path / "platform-message-history.db"))
+    history = PlatformMessageHistory(
+        id=1,
+        platform_id="webchat",
+        user_id="webchat-user",
+        content={"type": "text", "text": "hello"},
+    )
+    run_in_tx = AsyncMock(return_value=history)
+
+    monkeypatch.setattr(db, "_run_in_tx", run_in_tx)
+
+    result = await db.insert_platform_message_history(
+        platform_id="webchat",
+        user_id="webchat-user",
+        content={"type": "text", "text": "hello"},
+    )
+
+    assert result is history
+    run_in_tx.assert_awaited_once()
+
+    await db.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_update_platform_message_history_uses_retrying_transaction(
+    monkeypatch,
+    tmp_path,
+):
+    db = SQLiteDatabase(str(tmp_path / "update-platform-message-history.db"))
+    run_in_tx = AsyncMock(return_value=None)
+
+    monkeypatch.setattr(db, "_run_in_tx", run_in_tx)
+
+    await db.update_platform_message_history(
+        1,
+        content={"type": "text", "text": "updated"},
+    )
+
+    run_in_tx.assert_awaited_once()
+
+    await db.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_run_in_tx_retries_sqlite_database_table_locked(monkeypatch, tmp_path):
+    db = SQLiteDatabase(str(tmp_path / "retry-table.db"))
+    attempts = 0
+
+    async def no_sleep(attempt: int) -> None:
+        return None
+
+    monkeypatch.setattr(db, "_sleep_before_locked_retry", no_sleep)
+
+    async def op(session):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise _operational_error("database table is locked")
+        return SimpleNamespace(value="ok")
+
+    result = await db._run_in_tx(op)
+
+    assert result.value == "ok"
+    assert attempts == 2
+
+    await db.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_run_in_tx_does_not_retry_other_operational_errors(
+    monkeypatch,
+    tmp_path,
+):
+    db = SQLiteDatabase(str(tmp_path / "no-retry.db"))
+    attempts = 0
+
+    async def fail_on_sleep(attempt: int) -> None:
+        raise AssertionError("sleep should not be called")
+
+    monkeypatch.setattr(db, "_sleep_before_locked_retry", fail_on_sleep)
+
+    async def op(session):
+        nonlocal attempts
+        attempts += 1
+        raise _operational_error("no such table: conversations")
+
+    with pytest.raises(OperationalError):
+        await db._run_in_tx(op)
+
+    assert attempts == 1
+
+    await db.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_update_conversation_uses_retrying_transaction(monkeypatch, tmp_path):
+    db = SQLiteDatabase(str(tmp_path / "update-conversation.db"))
+    conversation = ConversationV2(
+        conversation_id="conv-1",
+        platform_id="webchat",
+        user_id="webchat:FriendMessage:user-1",
+        content=[{"role": "user", "content": "old"}],
+    )
+    run_in_tx = AsyncMock(return_value=None)
+    get_conversation_by_id = AsyncMock(return_value=conversation)
+
+    monkeypatch.setattr(db, "_run_in_tx", run_in_tx)
+    monkeypatch.setattr(db, "get_conversation_by_id", get_conversation_by_id)
+
+    result = await db.update_conversation(
+        "conv-1",
+        content=[{"role": "user", "content": "new"}],
+        token_usage=12,
+    )
+
+    assert result is conversation
+    run_in_tx.assert_awaited_once()
+    get_conversation_by_id.assert_awaited_once_with("conv-1")
+
+    await db.engine.dispose()


### PR DESCRIPTION
## Problem / 问题说明

AstrBot 已经在 #8574 中为 internal provider stats 增加了 SQLite `database is locked` 重试，这能解决一部分 agent 处理结束后的后台统计写入问题。

但实际 agent 流程里，还有几条更直接影响用户体验的 SQLite 写入路径没有覆盖。尤其是 agent 完成后保存对话历史时，会走：

```text
InternalAgentSubStage._save_to_history()
-> ConversationManager.update_conversation()
-> SQLiteDatabase.update_conversation()
```

如果这里遇到短暂的 SQLite 写锁，异常会从 agent 主流程冒出，最终表现为：

```text
Error occurred while processing agent:
(sqlite3.OperationalError) database is locked
```

这个错误会让一次已经完成的 agent 请求在最后保存历史时失败。用户看到的是 agent 处理报错，但实际问题不是模型调用失败，而是 SQLite 在多个写入来源并发时短暂锁库。

除了对话历史保存，WebChat 消息历史和 platform stats 也是同一类高频写入点。它们和 agent 保存历史、provider stats、metrics 在同一段事件处理窗口里可能同时写 SQLite。SQLite 只能同时允许一个 writer，所以这些路径需要统一处理短暂锁冲突。

## Root Cause / 原因

当前 SQLite 主库已经设置了 WAL 和 `timeout=30`，这可以缓解不少锁冲突。但在真实使用中，仍然可能出现短时间内多个写事务同时进入的情况，例如：

- agent 结束后保存 conversation history。
- WebChat 保存用户消息、机器人消息或流式消息历史。
- metrics 写入 platform stats。
- provider stats 写入模型调用统计。

已有的 provider stats retry 只覆盖统计写入本身，不能保护 `update_conversation()` 这类主流程写入。一旦这些主流程写入撞到锁，外层 agent 流程仍然会报错。

## Modifications / 改动点

- 在 `SQLiteDatabase` 中增加 SQLite locked 判断和短退避重试。
- 将几个高频写事务迁到统一的 `_run_in_tx()`：
  - `insert_platform_stats()`
  - `create_conversation()`
  - `update_conversation()`
  - `insert_platform_message_history()`
  - `update_platform_message_history()`
- 保持 `insert_provider_stat()` 原有逻辑不变，避免和 #8574 的 provider stats retry 形成双重重试。
- 保留 `update_conversation()` 空更新时返回 `None` 的旧行为，避免行为回归。
- 对返回 ORM 对象的创建类写入补充 `flush()` / `refresh()`，保证事务结束后对象内容可用。
- 新增 SQLite lock retry 单元测试，覆盖：
  - `database is locked`
  - `database table is locked`
  - 非锁类 `OperationalError` 不重试
  - `update_conversation()` 空更新行为
  - WebChat 消息历史写入走统一 retry 事务

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

## Screenshots or Test Results / 运行截图或测试结果

已通过：

```text
python -m pytest -q -s tests/unit/test_sqlite_lock_retry.py tests/unit/test_provider_stats.py
```

结果：

```text
13 passed, 1 warning
```

同时已通过：

```text
python -m py_compile astrbot/core/db/sqlite.py tests/unit/test_sqlite_lock_retry.py
git diff --check -- astrbot/core/db/sqlite.py tests/unit/test_sqlite_lock_retry.py
```

另外跑过真实 SQLite 烟测，覆盖：

- 初始化 SQLite 主库。
- 创建 conversation。
- `update_conversation()` 空更新返回 `None`。
- 更新 conversation history 和 token usage。
- 写入并更新 WebChat platform message history。
- 写入 platform stats。
- 写入 provider stats。

烟测结果：

```text
sqlite smoke ok
```

## Scope / 说明

这个 PR 不改变 agent 流程，也不改变业务数据结构。它只是在 SQLite 短暂锁库时重新开一个事务再尝试一次，用来处理常见的短时间并发写入冲突。

如果数据库被外部进程长时间占用，或者锁超过 SQLite 自身 timeout，这个 PR 仍然会让错误正常暴露出来。它的目标是减少短暂写锁导致的 agent 请求失败，而不是把 SQLite 变成高并发写数据库。

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Add retry handling for transient SQLite lock errors on high-frequency write paths to reduce agent processing failures.

Bug Fixes:
- Prevent agent and web chat operations from failing when conversation or message history updates hit short-lived SQLite write locks.
- Avoid unintended retries for non-lock-related SQLite OperationalError exceptions while preserving existing behavior for no-op conversation updates.

Enhancements:
- Route platform stats, conversation creation/updates, and platform message history writes through a common transactional helper with SQLite lock backoff and retry.
- Ensure ORM objects returned from create conversation and insert platform message history are fully populated after the transaction via flush/refresh.

Tests:
- Add unit tests covering SQLite lock retry behavior, non-retry OperationalError handling, noop conversation update semantics, and use of the retrying transaction helper for web chat history paths.