### PR TITLE
fix: retry sqlite preference reads on lock

### DIFF
--- a/astrbot/core/db/__init__.py
+++ b/astrbot/core/db/__init__.py
@@ -30,18 +30,7 @@ from astrbot.core.db.po import (
     UmoAlias,
     WebChatThread,
 )
-
-
-def _configure_sqlite_connection(dbapi_connection, connection_record) -> None:
-    cursor = dbapi_connection.cursor()
-    try:
-        cursor.execute("PRAGMA busy_timeout=30000")
-        cursor.execute("PRAGMA synchronous=NORMAL")
-        cursor.execute("PRAGMA cache_size=20000")
-        cursor.execute("PRAGMA temp_store=MEMORY")
-        cursor.execute("PRAGMA mmap_size=134217728")
-    finally:
-        cursor.close()
+from astrbot.core.db.sqlite_pragmas import configure_sqlite_connection
 
 
 @dataclass
@@ -77,7 +66,7 @@ class BaseDatabase(abc.ABC):
             event.listen(
                 self.engine.sync_engine,
                 "connect",
-                _configure_sqlite_connection,
+                configure_sqlite_connection,
             )
         self.AsyncSessionLocal = async_sessionmaker(
             self.engine,

--- a/astrbot/core/db/__init__.py
+++ b/astrbot/core/db/__init__.py
@@ -35,12 +35,11 @@ from astrbot.core.db.po import (
 def _configure_sqlite_connection(dbapi_connection, connection_record) -> None:
     cursor = dbapi_connection.cursor()
     try:
-        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.execute("PRAGMA busy_timeout=30000")
         cursor.execute("PRAGMA synchronous=NORMAL")
         cursor.execute("PRAGMA cache_size=20000")
         cursor.execute("PRAGMA temp_store=MEMORY")
         cursor.execute("PRAGMA mmap_size=134217728")
-        cursor.execute("PRAGMA optimize")
     finally:
         cursor.close()
 

--- a/astrbot/core/db/sqlite.py
+++ b/astrbot/core/db/sqlite.py
@@ -45,7 +45,7 @@ SQLITE_LOCK_RETRY_BASE_DELAY = 0.2
 
 
 def _is_sqlite_database_locked_error(exc: OperationalError) -> bool:
-    raw = getattr(exc, "orig", exc)
+    raw = getattr(exc, "orig", None) or exc
     message = str(raw).lower()
     return "database" in message and "locked" in message
 
@@ -57,14 +57,16 @@ class SQLiteDatabase(BaseDatabase):
         self.inited = False
         super().__init__()
 
-    async def _run_with_sqlite_lock_retry(
+    async def _with_session_and_sqlite_lock_retry(
         self,
-        operation: Callable[[], Awaitable[TxResult]],
+        operation: Callable[[AsyncSession], Awaitable[TxResult]],
     ) -> TxResult:
         for attempt in range(SQLITE_LOCK_RETRY_ATTEMPTS):
             last_attempt = attempt == SQLITE_LOCK_RETRY_ATTEMPTS - 1
             try:
-                return await operation()
+                async with self.get_db() as session:
+                    session: AsyncSession
+                    return await operation(session)
             except asyncio.CancelledError:
                 raise
             except OperationalError as exc:
@@ -1255,34 +1257,30 @@ class SQLiteDatabase(BaseDatabase):
     async def get_preference(self, scope, scope_id, key):
         """Get a preference by key."""
 
-        async def _get_preference() -> Preference | None:
-            async with self.get_db() as session:
-                session: AsyncSession
-                query = select(Preference).where(
-                    Preference.scope == scope,
-                    Preference.scope_id == scope_id,
-                    Preference.key == key,
-                )
-                result = await session.execute(query)
-                return result.scalar_one_or_none()
+        async def _get_preference(session: AsyncSession) -> Preference | None:
+            query = select(Preference).where(
+                Preference.scope == scope,
+                Preference.scope_id == scope_id,
+                Preference.key == key,
+            )
+            result = await session.execute(query)
+            return result.scalar_one_or_none()
 
-        return await self._run_with_sqlite_lock_retry(_get_preference)
+        return await self._with_session_and_sqlite_lock_retry(_get_preference)
 
     async def get_preferences(self, scope, scope_id=None, key=None):
         """Get all preferences for a specific scope ID or key."""
 
-        async def _get_preferences() -> list[Preference]:
-            async with self.get_db() as session:
-                session: AsyncSession
-                query = select(Preference).where(Preference.scope == scope)
-                if scope_id is not None:
-                    query = query.where(Preference.scope_id == scope_id)
-                if key is not None:
-                    query = query.where(Preference.key == key)
-                result = await session.execute(query)
-                return result.scalars().all()
+        async def _get_preferences(session: AsyncSession) -> list[Preference]:
+            query = select(Preference).where(Preference.scope == scope)
+            if scope_id is not None:
+                query = query.where(Preference.scope_id == scope_id)
+            if key is not None:
+                query = query.where(Preference.key == key)
+            result = await session.execute(query)
+            return result.scalars().all()
 
-        return await self._run_with_sqlite_lock_retry(_get_preferences)
+        return await self._with_session_and_sqlite_lock_retry(_get_preferences)
 
     async def remove_preference(self, scope, scope_id, key) -> None:
         """Remove a preference by scope ID and key."""

--- a/astrbot/core/db/sqlite.py
+++ b/astrbot/core/db/sqlite.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import threading
 import typing as T
 from collections.abc import Awaitable, Callable
@@ -42,6 +43,7 @@ TxResult = T.TypeVar("TxResult")
 CRON_FIELD_NOT_SET = object()
 SQLITE_LOCK_RETRY_ATTEMPTS = 3
 SQLITE_LOCK_RETRY_BASE_DELAY = 0.2
+logger = logging.getLogger(__name__)
 
 
 def _is_sqlite_database_locked_error(exc: OperationalError) -> bool:
@@ -51,18 +53,30 @@ def _is_sqlite_database_locked_error(exc: OperationalError) -> bool:
 
 
 class SQLiteDatabase(BaseDatabase):
-    def __init__(self, db_path: str) -> None:
+    def __init__(
+        self,
+        db_path: str,
+        sqlite_lock_retry_attempts: int = SQLITE_LOCK_RETRY_ATTEMPTS,
+        sqlite_lock_retry_base_delay: float = SQLITE_LOCK_RETRY_BASE_DELAY,
+    ) -> None:
+        if sqlite_lock_retry_attempts < 1:
+            raise ValueError("sqlite_lock_retry_attempts must be at least 1")
+        if sqlite_lock_retry_base_delay < 0:
+            raise ValueError("sqlite_lock_retry_base_delay must be non-negative")
+
         self.db_path = db_path
         self.DATABASE_URL = f"sqlite+aiosqlite:///{db_path}"
         self.inited = False
+        self.sqlite_lock_retry_attempts = sqlite_lock_retry_attempts
+        self.sqlite_lock_retry_base_delay = sqlite_lock_retry_base_delay
         super().__init__()
 
     async def _with_session_and_sqlite_lock_retry(
         self,
         operation: Callable[[AsyncSession], Awaitable[TxResult]],
     ) -> TxResult:
-        for attempt in range(SQLITE_LOCK_RETRY_ATTEMPTS):
-            last_attempt = attempt == SQLITE_LOCK_RETRY_ATTEMPTS - 1
+        for attempt in range(self.sqlite_lock_retry_attempts):
+            last_attempt = attempt == self.sqlite_lock_retry_attempts - 1
             try:
                 async with self.get_db() as session:
                     session: AsyncSession
@@ -70,9 +84,22 @@ class SQLiteDatabase(BaseDatabase):
             except asyncio.CancelledError:
                 raise
             except OperationalError as exc:
-                if not _is_sqlite_database_locked_error(exc) or last_attempt:
+                if not _is_sqlite_database_locked_error(exc):
                     raise
-                await asyncio.sleep(SQLITE_LOCK_RETRY_BASE_DELAY * (2**attempt))
+                if last_attempt:
+                    logger.warning(
+                        "SQLite database lock retry exhausted after %s attempts",
+                        self.sqlite_lock_retry_attempts,
+                    )
+                    raise
+                delay = self.sqlite_lock_retry_base_delay * (2**attempt)
+                logger.debug(
+                    "SQLite database locked; retrying in %.3f seconds (attempt %s/%s)",
+                    delay,
+                    attempt + 1,
+                    self.sqlite_lock_retry_attempts,
+                )
+                await asyncio.sleep(delay)
 
         raise RuntimeError("unreachable sqlite lock retry state")
 

--- a/astrbot/core/db/sqlite.py
+++ b/astrbot/core/db/sqlite.py
@@ -5,6 +5,7 @@ from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import CursorResult, Row
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, delete, desc, func, or_, select, text, update
 
@@ -39,6 +40,14 @@ from astrbot.core.sentinels import NOT_GIVEN
 
 TxResult = T.TypeVar("TxResult")
 CRON_FIELD_NOT_SET = object()
+SQLITE_LOCK_RETRY_ATTEMPTS = 3
+SQLITE_LOCK_RETRY_BASE_DELAY = 0.2
+
+
+def _is_sqlite_database_locked_error(exc: OperationalError) -> bool:
+    raw = getattr(exc, "orig", exc)
+    message = str(raw).lower()
+    return "database" in message and "locked" in message
 
 
 class SQLiteDatabase(BaseDatabase):
@@ -47,6 +56,23 @@ class SQLiteDatabase(BaseDatabase):
         self.DATABASE_URL = f"sqlite+aiosqlite:///{db_path}"
         self.inited = False
         super().__init__()
+
+    async def _run_with_sqlite_lock_retry(
+        self,
+        operation: Callable[[], Awaitable[TxResult]],
+    ) -> TxResult:
+        for attempt in range(SQLITE_LOCK_RETRY_ATTEMPTS):
+            last_attempt = attempt == SQLITE_LOCK_RETRY_ATTEMPTS - 1
+            try:
+                return await operation()
+            except asyncio.CancelledError:
+                raise
+            except OperationalError as exc:
+                if not _is_sqlite_database_locked_error(exc) or last_attempt:
+                    raise
+                await asyncio.sleep(SQLITE_LOCK_RETRY_BASE_DELAY * (2**attempt))
+
+        raise RuntimeError("unreachable sqlite lock retry state")
 
     async def initialize(self) -> None:
         """Initialize the database by creating tables if they do not exist."""
@@ -1228,27 +1254,35 @@ class SQLiteDatabase(BaseDatabase):
 
     async def get_preference(self, scope, scope_id, key):
         """Get a preference by key."""
-        async with self.get_db() as session:
-            session: AsyncSession
-            query = select(Preference).where(
-                Preference.scope == scope,
-                Preference.scope_id == scope_id,
-                Preference.key == key,
-            )
-            result = await session.execute(query)
-            return result.scalar_one_or_none()
+
+        async def _get_preference() -> Preference | None:
+            async with self.get_db() as session:
+                session: AsyncSession
+                query = select(Preference).where(
+                    Preference.scope == scope,
+                    Preference.scope_id == scope_id,
+                    Preference.key == key,
+                )
+                result = await session.execute(query)
+                return result.scalar_one_or_none()
+
+        return await self._run_with_sqlite_lock_retry(_get_preference)
 
     async def get_preferences(self, scope, scope_id=None, key=None):
         """Get all preferences for a specific scope ID or key."""
-        async with self.get_db() as session:
-            session: AsyncSession
-            query = select(Preference).where(Preference.scope == scope)
-            if scope_id is not None:
-                query = query.where(Preference.scope_id == scope_id)
-            if key is not None:
-                query = query.where(Preference.key == key)
-            result = await session.execute(query)
-            return result.scalars().all()
+
+        async def _get_preferences() -> list[Preference]:
+            async with self.get_db() as session:
+                session: AsyncSession
+                query = select(Preference).where(Preference.scope == scope)
+                if scope_id is not None:
+                    query = query.where(Preference.scope_id == scope_id)
+                if key is not None:
+                    query = query.where(Preference.key == key)
+                result = await session.execute(query)
+                return result.scalars().all()
+
+        return await self._run_with_sqlite_lock_retry(_get_preferences)
 
     async def remove_preference(self, scope, scope_id, key) -> None:
         """Remove a preference by scope ID and key."""

--- a/astrbot/core/db/sqlite_pragmas.py
+++ b/astrbot/core/db/sqlite_pragmas.py
@@ -1,0 +1,17 @@
+SQLITE_BUSY_TIMEOUT_MS = 30000
+SQLITE_CONNECT_PRAGMAS = (
+    f"PRAGMA busy_timeout={SQLITE_BUSY_TIMEOUT_MS}",
+    "PRAGMA synchronous=NORMAL",
+    "PRAGMA cache_size=20000",
+    "PRAGMA temp_store=MEMORY",
+    "PRAGMA mmap_size=134217728",
+)
+
+
+def configure_sqlite_connection(dbapi_connection, connection_record) -> None:
+    cursor = dbapi_connection.cursor()
+    try:
+        for statement in SQLITE_CONNECT_PRAGMAS:
+            cursor.execute(statement)
+    finally:
+        cursor.close()

--- a/astrbot/core/knowledge_base/kb_db_sqlite.py
+++ b/astrbot/core/knowledge_base/kb_db_sqlite.py
@@ -8,6 +8,7 @@ from sqlalchemy.pool import NullPool
 from sqlmodel import col, desc
 
 from astrbot.core import logger
+from astrbot.core.db.sqlite_pragmas import configure_sqlite_connection
 from astrbot.core.knowledge_base.models import (
     BaseKBModel,
     KBDocument,
@@ -18,18 +19,6 @@ from astrbot.core.utils.astrbot_path import get_astrbot_knowledge_base_path
 
 if TYPE_CHECKING:
     from astrbot.core.db.vec_db.faiss_impl import FaissVecDB
-
-
-def _configure_sqlite_connection(dbapi_connection, connection_record) -> None:
-    cursor = dbapi_connection.cursor()
-    try:
-        cursor.execute("PRAGMA busy_timeout=30000")
-        cursor.execute("PRAGMA synchronous=NORMAL")
-        cursor.execute("PRAGMA cache_size=20000")
-        cursor.execute("PRAGMA temp_store=MEMORY")
-        cursor.execute("PRAGMA mmap_size=134217728")
-    finally:
-        cursor.close()
 
 
 class KBSQLiteDatabase:
@@ -59,7 +48,7 @@ class KBSQLiteDatabase:
         event.listen(
             self.engine.sync_engine,
             "connect",
-            _configure_sqlite_connection,
+            configure_sqlite_connection,
         )
 
         # 创建会话工厂

--- a/astrbot/core/knowledge_base/kb_db_sqlite.py
+++ b/astrbot/core/knowledge_base/kb_db_sqlite.py
@@ -23,12 +23,11 @@ if TYPE_CHECKING:
 def _configure_sqlite_connection(dbapi_connection, connection_record) -> None:
     cursor = dbapi_connection.cursor()
     try:
-        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.execute("PRAGMA busy_timeout=30000")
         cursor.execute("PRAGMA synchronous=NORMAL")
         cursor.execute("PRAGMA cache_size=20000")
         cursor.execute("PRAGMA temp_store=MEMORY")
         cursor.execute("PRAGMA mmap_size=134217728")
-        cursor.execute("PRAGMA optimize")
     finally:
         cursor.close()
 
@@ -55,6 +54,7 @@ class KBSQLiteDatabase:
             self.DATABASE_URL,
             echo=False,
             poolclass=NullPool,
+            connect_args={"timeout": 30},
         )
         event.listen(
             self.engine.sync_engine,

--- a/tests/unit/test_sqlite_lock_retry.py
+++ b/tests/unit/test_sqlite_lock_retry.py
@@ -1,0 +1,122 @@
+from collections.abc import Sequence
+
+import pytest
+from sqlalchemy.exc import OperationalError
+
+from astrbot.core.db import sqlite
+from astrbot.core.db.po import Preference
+
+
+class _ScalarResult:
+    def __init__(self, value):
+        self.value = value
+
+    def scalar_one_or_none(self):
+        return self.value
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self.value
+
+
+class _SessionContext:
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _LockedOnceSession:
+    def __init__(self, value, message: str = "database is locked"):
+        self.value = value
+        self.message = message
+        self.attempts = 0
+
+    async def execute(self, query):
+        self.attempts += 1
+        if self.attempts == 1:
+            raise OperationalError(
+                "select from preferences", {}, Exception(self.message)
+            )
+        return _ScalarResult(self.value)
+
+
+@pytest.mark.asyncio
+async def test_get_preference_retries_sqlite_database_lock(
+    temp_db,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    preference = Preference(
+        scope="global",
+        scope_id="global",
+        key="migration_done",
+        value={"val": True},
+    )
+    session = _LockedOnceSession(preference)
+    sleep_delays = []
+
+    async def record_sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(temp_db, "get_db", lambda: _SessionContext(session))
+    monkeypatch.setattr(sqlite.asyncio, "sleep", record_sleep)
+
+    result = await temp_db.get_preference("global", "global", "migration_done")
+
+    assert result == preference
+    assert session.attempts == 2
+    assert sleep_delays == [sqlite.SQLITE_LOCK_RETRY_BASE_DELAY]
+
+
+@pytest.mark.asyncio
+async def test_get_preferences_retries_sqlite_database_lock(
+    temp_db,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    preferences: Sequence[Preference] = [
+        Preference(
+            scope="global",
+            scope_id="global",
+            key="migration_done",
+            value={"val": True},
+        ),
+    ]
+    session = _LockedOnceSession(preferences, "database table is locked")
+
+    async def no_sleep(delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(temp_db, "get_db", lambda: _SessionContext(session))
+    monkeypatch.setattr(sqlite.asyncio, "sleep", no_sleep)
+
+    result = await temp_db.get_preferences("global")
+
+    assert result == preferences
+    assert session.attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_get_preference_does_not_retry_other_operational_errors(
+    temp_db,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    session = _LockedOnceSession(None, "no such table: preferences")
+    sleep_delays = []
+
+    async def record_sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(temp_db, "get_db", lambda: _SessionContext(session))
+    monkeypatch.setattr(sqlite.asyncio, "sleep", record_sleep)
+
+    with pytest.raises(OperationalError):
+        await temp_db.get_preference("global", "global", "migration_done")
+
+    assert session.attempts == 1
+    assert sleep_delays == []

--- a/tests/unit/test_sqlite_lock_retry.py
+++ b/tests/unit/test_sqlite_lock_retry.py
@@ -3,8 +3,12 @@ from collections.abc import Sequence
 import pytest
 from sqlalchemy.exc import OperationalError
 
+from astrbot.core.db import _configure_sqlite_connection as configure_main_sqlite
 from astrbot.core.db import sqlite
 from astrbot.core.db.po import Preference
+from astrbot.core.knowledge_base.kb_db_sqlite import (
+    _configure_sqlite_connection as configure_kb_sqlite,
+)
 
 
 class _ScalarResult:
@@ -45,6 +49,40 @@ class _LockedOnceSession:
                 "select from preferences", {}, Exception(self.message)
             )
         return _ScalarResult(self.value)
+
+
+class _AlwaysLockedSession:
+    def __init__(self, message: str = "database is locked"):
+        self.message = message
+        self.attempts = 0
+        self.last_error: OperationalError | None = None
+
+    async def execute(self, query):
+        self.attempts += 1
+        self.last_error = OperationalError(
+            "select from preferences", {}, Exception(self.message)
+        )
+        raise self.last_error
+
+
+class _RecordingCursor:
+    def __init__(self):
+        self.statements = []
+        self.closed = False
+
+    def execute(self, statement: str) -> None:
+        self.statements.append(statement)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _RecordingConnection:
+    def __init__(self):
+        self.cursor_instance = _RecordingCursor()
+
+    def cursor(self):
+        return self.cursor_instance
 
 
 @pytest.mark.asyncio
@@ -120,3 +158,56 @@ async def test_get_preference_does_not_retry_other_operational_errors(
 
     assert session.attempts == 1
     assert sleep_delays == []
+
+
+@pytest.mark.asyncio
+async def test_get_preference_propagates_operational_error_after_retry_exhaustion(
+    temp_db,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    session = _AlwaysLockedSession()
+    sleep_delays = []
+
+    async def record_sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(temp_db, "get_db", lambda: _SessionContext(session))
+    monkeypatch.setattr(sqlite.asyncio, "sleep", record_sleep)
+
+    with pytest.raises(OperationalError) as exc_info:
+        await temp_db.get_preference("global", "global", "migration_done")
+
+    expected_sleep_delays = [
+        sqlite.SQLITE_LOCK_RETRY_BASE_DELAY * (2**attempt)
+        for attempt in range(sqlite.SQLITE_LOCK_RETRY_ATTEMPTS - 1)
+    ]
+    assert session.attempts == sqlite.SQLITE_LOCK_RETRY_ATTEMPTS
+    assert sleep_delays == expected_sleep_delays
+    assert exc_info.value is session.last_error
+
+
+def test_sqlite_lock_detection_falls_back_when_orig_is_none():
+    error = OperationalError("database is locked", {}, None)
+
+    assert sqlite._is_sqlite_database_locked_error(error)
+
+
+@pytest.mark.parametrize(
+    "configure_sqlite",
+    [configure_main_sqlite, configure_kb_sqlite],
+)
+def test_sqlite_connect_hook_uses_only_lightweight_connection_pragmas(
+    configure_sqlite,
+):
+    connection = _RecordingConnection()
+
+    configure_sqlite(connection, None)
+
+    assert connection.cursor_instance.closed
+    assert connection.cursor_instance.statements == [
+        "PRAGMA busy_timeout=30000",
+        "PRAGMA synchronous=NORMAL",
+        "PRAGMA cache_size=20000",
+        "PRAGMA temp_store=MEMORY",
+        "PRAGMA mmap_size=134217728",
+    ]

--- a/tests/unit/test_sqlite_lock_retry.py
+++ b/tests/unit/test_sqlite_lock_retry.py
@@ -3,11 +3,11 @@ from collections.abc import Sequence
 import pytest
 from sqlalchemy.exc import OperationalError
 
-from astrbot.core.db import _configure_sqlite_connection as configure_main_sqlite
 from astrbot.core.db import sqlite
 from astrbot.core.db.po import Preference
-from astrbot.core.knowledge_base.kb_db_sqlite import (
-    _configure_sqlite_connection as configure_kb_sqlite,
+from astrbot.core.db.sqlite_pragmas import (
+    SQLITE_CONNECT_PRAGMAS,
+    configure_sqlite_connection,
 )
 
 
@@ -98,18 +98,25 @@ async def test_get_preference_retries_sqlite_database_lock(
     )
     session = _LockedOnceSession(preference)
     sleep_delays = []
+    debug_logs = []
 
     async def record_sleep(delay: float) -> None:
         sleep_delays.append(delay)
 
     monkeypatch.setattr(temp_db, "get_db", lambda: _SessionContext(session))
     monkeypatch.setattr(sqlite.asyncio, "sleep", record_sleep)
+    monkeypatch.setattr(
+        sqlite.logger,
+        "debug",
+        lambda *args, **kwargs: debug_logs.append((args, kwargs)),
+    )
 
     result = await temp_db.get_preference("global", "global", "migration_done")
 
     assert result == preference
     assert session.attempts == 2
     assert sleep_delays == [sqlite.SQLITE_LOCK_RETRY_BASE_DELAY]
+    assert len(debug_logs) == 1
 
 
 @pytest.mark.asyncio
@@ -167,12 +174,18 @@ async def test_get_preference_propagates_operational_error_after_retry_exhaustio
 ):
     session = _AlwaysLockedSession()
     sleep_delays = []
+    warning_logs = []
 
     async def record_sleep(delay: float) -> None:
         sleep_delays.append(delay)
 
     monkeypatch.setattr(temp_db, "get_db", lambda: _SessionContext(session))
     monkeypatch.setattr(sqlite.asyncio, "sleep", record_sleep)
+    monkeypatch.setattr(
+        sqlite.logger,
+        "warning",
+        lambda *args, **kwargs: warning_logs.append((args, kwargs)),
+    )
 
     with pytest.raises(OperationalError) as exc_info:
         await temp_db.get_preference("global", "global", "migration_done")
@@ -184,6 +197,30 @@ async def test_get_preference_propagates_operational_error_after_retry_exhaustio
     assert session.attempts == sqlite.SQLITE_LOCK_RETRY_ATTEMPTS
     assert sleep_delays == expected_sleep_delays
     assert exc_info.value is session.last_error
+    assert len(warning_logs) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_preference_uses_configured_sqlite_lock_retry_settings(
+    temp_db,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    temp_db.sqlite_lock_retry_attempts = 2
+    temp_db.sqlite_lock_retry_base_delay = 0.05
+    session = _AlwaysLockedSession()
+    sleep_delays = []
+
+    async def record_sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(temp_db, "get_db", lambda: _SessionContext(session))
+    monkeypatch.setattr(sqlite.asyncio, "sleep", record_sleep)
+
+    with pytest.raises(OperationalError):
+        await temp_db.get_preference("global", "global", "migration_done")
+
+    assert session.attempts == 2
+    assert sleep_delays == [0.05]
 
 
 def test_sqlite_lock_detection_falls_back_when_orig_is_none():
@@ -192,22 +229,10 @@ def test_sqlite_lock_detection_falls_back_when_orig_is_none():
     assert sqlite._is_sqlite_database_locked_error(error)
 
 
-@pytest.mark.parametrize(
-    "configure_sqlite",
-    [configure_main_sqlite, configure_kb_sqlite],
-)
-def test_sqlite_connect_hook_uses_only_lightweight_connection_pragmas(
-    configure_sqlite,
-):
+def test_sqlite_connect_hook_uses_only_lightweight_connection_pragmas():
     connection = _RecordingConnection()
 
-    configure_sqlite(connection, None)
+    configure_sqlite_connection(connection, None)
 
     assert connection.cursor_instance.closed
-    assert connection.cursor_instance.statements == [
-        "PRAGMA busy_timeout=30000",
-        "PRAGMA synchronous=NORMAL",
-        "PRAGMA cache_size=20000",
-        "PRAGMA temp_store=MEMORY",
-        "PRAGMA mmap_size=134217728",
-    ]
+    assert connection.cursor_instance.statements == list(SQLITE_CONNECT_PRAGMAS)


### PR DESCRIPTION
## Summary
- add SQLite lock retry handling inside `SQLiteDatabase`
- apply the retry path to `get_preference` and `get_preferences`
- keep SQLite connect hooks lightweight by moving `journal_mode=WAL` and `PRAGMA optimize` out of the high-frequency connect path
- centralize SQLite connection PRAGMA tuning in `astrbot.core.db.sqlite_pragmas`
- make SQLite lock retry attempts/base delay configurable through `SQLiteDatabase` constructor defaults
- add lightweight retry/exhaustion logging for sqlite lock contention
- apply the same connect-hook cleanup to the knowledge base SQLite database
- add regression tests for locked preference reads, retry exhaustion, `orig is None` fallback, configurable retry settings, logging, and connect-hook PRAGMA behavior

## Context
Follow-up to https://github.com/AstrBotDevs/AstrBot/commit/1ad2b2c385f07c3e3171347ec19c359a017f80e7 and https://github.com/AstrBotDevs/AstrBot/pull/7724. Provider stats already retried sqlite lock errors, but shared preference reads could still fail with `database is locked`. The connect hook also ran maintenance PRAGMA statements on every new SQLite connection under `NullPool`, which could increase lock contention.

## Tests
- `uv run pytest tests/unit/test_sqlite_lock_retry.py tests/unit/test_provider_stats.py tests/unit/test_kb_manager_resilience.py`
- `uv run ruff check astrbot/core/db/__init__.py astrbot/core/db/sqlite.py astrbot/core/db/sqlite_pragmas.py astrbot/core/knowledge_base/kb_db_sqlite.py tests/unit/test_sqlite_lock_retry.py`