### PR TITLE
feat: 统一 LLM 工具权限控制

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -1043,7 +1043,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                     )
                     continue
 
-                # 统一权限拦截（过滤点 B：双保险）
+                # 统一权限拦截
                 # 即使 LLM 意外获知了受限工具，执行前也会在此被阻断。
                 if getattr(func_tool, "require_admin", False):
                     _caller_event = self.run_context.context.event

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -1043,7 +1043,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                     )
                     continue
 
-                # 统一权限拦截
+                # 权限拦截
                 # 即使 LLM 意外获知了受限工具，执行前也会在此被阻断。
                 if getattr(func_tool, "require_admin", False):
                     _caller_event = self.run_context.context.event
@@ -1065,8 +1065,8 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                             f"error: Permission denied. "
                             f"Tool '{func_tool_name}' requires admin privileges. "
                             f"Your user ID is {sender_id}. "
-                            "Ask the AstrBot admin to grant access via "
-                            "WebUI → 管理行为 → 函数工具 → 权限列.",
+                            "Please ask your AstrBot administrator to grant "
+                            "you access to this tool.",
                         )
                         continue
 

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -1046,7 +1046,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 # 权限拦截
                 # 即使 LLM 意外获知了受限工具，执行前也会在此被阻断。
                 if getattr(func_tool, "require_admin", False):
-                    _caller_event = self.run_context.context.event
+                    _caller_event = getattr(self.run_context.context, "event", None)
                     if getattr(_caller_event, "role", "member") != "admin":
                         sender_id = (
                             _caller_event.get_sender_id()

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -1043,6 +1043,33 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                     )
                     continue
 
+                # 统一权限拦截（过滤点 B：双保险）
+                # 即使 LLM 意外获知了受限工具，执行前也会在此被阻断。
+                if getattr(func_tool, "require_admin", False):
+                    _caller_event = self.run_context.context.event
+                    if getattr(_caller_event, "role", "member") != "admin":
+                        sender_id = (
+                            _caller_event.get_sender_id()
+                            if _caller_event
+                            else "unknown"
+                        )
+                        logger.warning(
+                            "Tool '%s' requires admin, "
+                            "caller role='%s', sender_id='%s'. Blocked.",
+                            func_tool_name,
+                            getattr(_caller_event, "role", "?"),
+                            sender_id,
+                        )
+                        _append_tool_call_result(
+                            func_tool_id,
+                            f"error: Permission denied. "
+                            f"Tool '{func_tool_name}' requires admin privileges. "
+                            f"Your user ID is {sender_id}. "
+                            "Ask the AstrBot admin to grant access via "
+                            "WebUI → 管理行为 → 函数工具 → 权限列.",
+                        )
+                        continue
+
                 valid_params = {}  # 参数过滤：只传递函数实际需要的参数
 
                 # 获取实际的 handler 函数

--- a/astrbot/core/agent/tool.py
+++ b/astrbot/core/agent/tool.py
@@ -58,6 +58,11 @@ class FunctionTool(ToolSchema, Generic[TContext]):
     Whether the tool is active. This field is a special field for AstrBot.
     You can ignore it when integrating with other frameworks.
     """
+    require_admin: bool = False
+    """
+    If True, this tool can only be called by admin users (event.role == 'admin').
+    Default False keeps backward compatibility with existing tools.
+    """
     is_background_task: bool = False
     """
     Declare this tool as a background task. Background tasks return immediately

--- a/astrbot/core/astr_agent_tool_exec.py
+++ b/astrbot/core/astr_agent_tool_exec.py
@@ -266,11 +266,15 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
         # "all tools", including runtime computer-use tools.
         if tools is None:
             toolset = ToolSet()
+            is_admin = getattr(event, "role", "member") == "admin"
             for registered_tool in llm_tools.func_list:
                 if isinstance(registered_tool, HandoffTool):
                     continue
-                if registered_tool.active:
-                    toolset.add_tool(registered_tool)
+                if not registered_tool.active:
+                    continue
+                if not is_admin and getattr(registered_tool, "require_admin", False):
+                    continue
+                toolset.add_tool(registered_tool)
             for runtime_tool in runtime_computer_tools.values():
                 toolset.add_tool(runtime_tool)
             return None if toolset.empty() else toolset
@@ -279,10 +283,15 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
             return None
 
         toolset = ToolSet()
+        is_admin = getattr(event, "role", "member") == "admin"
         for tool_name_or_obj in tools:
             if isinstance(tool_name_or_obj, str):
                 registered_tool = llm_tools.get_func(tool_name_or_obj)
                 if registered_tool and registered_tool.active:
+                    if not is_admin and getattr(
+                        registered_tool, "require_admin", False
+                    ):
+                        continue
                     toolset.add_tool(registered_tool)
                     continue
                 runtime_tool = runtime_computer_tools.get(tool_name_or_obj)

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -958,6 +958,29 @@ def _plugin_tool_fix(event: AstrMessageEvent, req: ProviderRequest) -> None:
         req.func_tool = new_tool_set
 
 
+def _filter_tools_by_role(event: AstrMessageEvent, req: ProviderRequest) -> None:
+    """从 req.func_tool 中移除当前用户无权调用的工具。
+
+    require_admin=True 的工具对非管理员用户不可见，
+    LLM 不会感知到这些工具的存在。
+    """
+    if not req.func_tool:
+        return
+    if getattr(event, "role", "member") == "admin":
+        return
+    new_tool_set = ToolSet()
+    for tool in req.func_tool.tools:
+        if getattr(tool, "require_admin", False):
+            logger.debug(
+                "Hiding tool '%s' from non-admin user (sender_id=%s).",
+                tool.name,
+                event.get_sender_id(),
+            )
+            continue
+        new_tool_set.add_tool(tool)
+    req.func_tool = new_tool_set
+
+
 async def _handle_webchat(
     event: AstrMessageEvent, req: ProviderRequest, prov: Provider
 ) -> None:
@@ -1446,6 +1469,7 @@ async def build_main_agent(
         req.session_id = event.unified_msg_origin
 
     _plugin_tool_fix(event, req)
+    _filter_tools_by_role(event, req)
     await _apply_web_search_tools(event, req, plugin_context)
 
     if config.llm_safety_mode:

--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -901,21 +901,16 @@ class FunctionToolManager:
 
         func_tool.require_admin = require
 
-        require_admin_tools: list = sp.get(
-            "tool_require_admin_list",
-            [],
+        require_admin_map: dict = sp.get(
+            "tool_require_admin_map",
+            {},
             scope="global",
             scope_id="global",
         )
-        if require:
-            if name not in require_admin_tools:
-                require_admin_tools.append(name)
-        else:
-            if name in require_admin_tools:
-                require_admin_tools.remove(name)
+        require_admin_map[name] = require
         sp.put(
-            "tool_require_admin_list",
-            require_admin_tools,
+            "tool_require_admin_map",
+            require_admin_map,
             scope="global",
             scope_id="global",
         )
@@ -926,14 +921,15 @@ class FunctionToolManager:
 
         应在 MCP 客户端初始化完成后、插件工具注册完成后调用。
         """
-        require_admin_tools: list = sp.get(
-            "tool_require_admin_list",
-            [],
+        require_admin_map: dict = sp.get(
+            "tool_require_admin_map",
+            {},
             scope="global",
             scope_id="global",
         )
         for tool in self.func_list:
-            tool.require_admin = tool.name in require_admin_tools
+            if tool.name in require_admin_map:
+                tool.require_admin = require_admin_map[tool.name]
 
     @property
     def mcp_config_path(self):

--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -680,6 +680,7 @@ class FunctionToolManager:
             self.func_list.append(func_tool)
 
         logger.info(f"Connected to MCP server {name}, Tools: {tool_names}")
+        self._restore_tool_permissions()
         return mcp_client
 
     async def _terminate_mcp_client(self, name: str) -> None:

--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -516,6 +516,8 @@ class FunctionToolManager:
             if raise_on_all_failed:
                 raise MCPAllServicesFailedError(msg)
             logger.error(msg)
+
+        self._restore_tool_permissions()
         return summary
 
     async def _start_mcp_server(
@@ -886,6 +888,52 @@ class FunctionToolManager:
 
             return True
         return False
+
+    def set_tool_require_admin(self, name: str, require: bool) -> bool:
+        """设置某工具是否仅管理员可调用，并持久化。
+
+        Returns:
+            如果没找到工具，会返回 False
+        """
+        func_tool = self.get_func(name)
+        if func_tool is None:
+            return False
+
+        func_tool.require_admin = require
+
+        require_admin_tools: list = sp.get(
+            "tool_require_admin_list",
+            [],
+            scope="global",
+            scope_id="global",
+        )
+        if require:
+            if name not in require_admin_tools:
+                require_admin_tools.append(name)
+        else:
+            if name in require_admin_tools:
+                require_admin_tools.remove(name)
+        sp.put(
+            "tool_require_admin_list",
+            require_admin_tools,
+            scope="global",
+            scope_id="global",
+        )
+        return True
+
+    def _restore_tool_permissions(self) -> None:
+        """从持久化存储恢复 require_admin 状态到已注册的工具。
+
+        应在 MCP 客户端初始化完成后、插件工具注册完成后调用。
+        """
+        require_admin_tools: list = sp.get(
+            "tool_require_admin_list",
+            [],
+            scope="global",
+            scope_id="global",
+        )
+        for tool in self.func_list:
+            tool.require_admin = tool.name in require_admin_tools
 
     @property
     def mcp_config_path(self):

--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -1269,6 +1269,8 @@ class PluginManager:
             logger.error(traceback.format_exc())
 
         self._rebuild_failed_plugin_info()
+        # 插件工具注册完成后恢复权限配置
+        llm_tools._restore_tool_permissions()
         if has_load_error:
             return False, self.failed_plugin_info
         return True, None

--- a/astrbot/dashboard/routes/tools.py
+++ b/astrbot/dashboard/routes/tools.py
@@ -55,6 +55,7 @@ class ToolsRoute(Route):
             "/tools/mcp/test": ("POST", self.test_mcp_connection),
             "/tools/list": ("GET", self.get_tool_list),
             "/tools/toggle-tool": ("POST", self.toggle_tool),
+            "/tools/set-permission": ("POST", self.set_tool_permission),
             "/tools/mcp/sync-provider": ("POST", self.sync_provider),
         }
         self.register_routes()
@@ -498,6 +499,7 @@ class ToolsRoute(Route):
                     "description": tool.description,
                     "parameters": tool.parameters,
                     "active": tool.active,
+                    "require_admin": getattr(tool, "require_admin", False),
                     "origin": origin,
                     "origin_name": origin_name,
                     "readonly": readonly,
@@ -550,6 +552,42 @@ class ToolsRoute(Route):
         except Exception as e:
             logger.error(traceback.format_exc())
             return Response().error(f"Failed to operate tool: {e!s}").__dict__
+
+    async def set_tool_permission(self):
+        """Set require_admin flag for a specified tool."""
+        try:
+            data = await request.json
+            tool_name = data.get("name")
+            require_admin = data.get("require_admin")
+
+            if not tool_name or require_admin is None:
+                return (
+                    Response()
+                    .error("Missing required parameters: name or require_admin")
+                    .__dict__
+                )
+
+            if self.tool_mgr.is_builtin_tool(tool_name):
+                return (
+                    Response()
+                    .error(
+                        f"Tool {tool_name} is a builtin tool and its permission cannot be changed."
+                    )
+                    .__dict__
+                )
+
+            ok = self.tool_mgr.set_tool_require_admin(tool_name, bool(require_admin))
+            if ok:
+                return Response().ok(None, "Permission updated.").__dict__
+            return (
+                Response()
+                .error(f"Tool {tool_name} does not exist or the operation failed.")
+                .__dict__
+            )
+
+        except Exception as e:
+            logger.error(traceback.format_exc())
+            return Response().error(f"Failed to set tool permission: {e!s}").__dict__
 
     async def sync_provider(self):
         """Sync MCP provider configuration."""

--- a/dashboard/src/components/extension/componentPanel/components/ToolTable.vue
+++ b/dashboard/src/components/extension/componentPanel/components/ToolTable.vue
@@ -12,6 +12,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'toggle-tool', tool: ToolItem): void;
+  (e: 'update-permission', tool: ToolItem, permission: 'admin' | 'everyone'): void;
 }>();
 
 const toolHeaders = computed(() => [
@@ -19,6 +20,7 @@ const toolHeaders = computed(() => [
   { title: tmTool('functionTools.description'), key: 'description' },
   { title: tmTool('functionTools.table.origin'), key: 'origin', sortable: false, width: '120px' },
   { title: tmTool('functionTools.table.originName'), key: 'origin_name', sortable: false, width: '160px' },
+  { title: tmTool('functionTools.table.permission'), key: 'permission', sortable: false, width: '120px' },
   { title: tmTool('functionTools.table.actions'), key: 'actions', sortable: false, width: '120px' }
 ]);
 
@@ -68,6 +70,16 @@ const formatCondition = (condition: ToolConfigCondition) => {
 const enabledConfigTags = (tool: ToolItem): BuiltinToolConfigTag[] => {
   if (tool.origin !== 'builtin') return [];
   return (tool.builtin_config_tags || []).filter(tag => tag.enabled);
+};
+
+const getPermissionColor = (permission: string): string => {
+  return permission === 'admin' ? 'error' : 'success';
+};
+
+const getPermissionLabel = (permission: string): string => {
+  return permission === 'admin'
+    ? tmTool('functionTools.permission.admin')
+    : tmTool('functionTools.permission.everyone');
 };
 </script>
 
@@ -136,6 +148,41 @@ const enabledConfigTags = (tool: ToolItem): BuiltinToolConfigTag[] => {
         <div class="text-body-2 text-medium-emphasis" style="max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;" :title="item.origin_name">
           {{ item.origin_name || '-' }}
         </div>
+      </template>
+
+      <!-- 权限列 -->
+      <template #item.permission="{ item }">
+        <span v-if="item.readonly" class="text-medium-emphasis">-</span>
+        <v-menu v-else location="bottom">
+          <template #activator="{ props: menuProps }">
+            <v-chip
+              v-bind="menuProps"
+              :color="getPermissionColor(item.require_admin ? 'admin' : 'everyone')"
+              size="small"
+              class="font-weight-medium cursor-pointer"
+              link
+            >
+              {{ getPermissionLabel(item.require_admin ? 'admin' : 'everyone') }}
+              <v-icon end size="14">mdi-chevron-down</v-icon>
+            </v-chip>
+          </template>
+          <v-list density="compact">
+            <v-list-item
+              value="everyone"
+              :active="!item.require_admin"
+              @click="emit('update-permission', item, 'everyone')"
+            >
+              <v-list-item-title>{{ tmTool('functionTools.permission.everyone') }}</v-list-item-title>
+            </v-list-item>
+            <v-list-item
+              value="admin"
+              :active="item.require_admin"
+              @click="emit('update-permission', item, 'admin')"
+            >
+              <v-list-item-title>{{ tmTool('functionTools.permission.admin') }}</v-list-item-title>
+            </v-list-item>
+          </v-list>
+        </v-menu>
       </template>
 
       <template #item.actions="{ item }">
@@ -224,5 +271,9 @@ const enabledConfigTags = (tool: ToolItem): BuiltinToolConfigTag[] => {
 .tool-config-tooltip :deep(.text-medium-emphasis),
 .tool-config-tooltip :deep(.font-weight-medium) {
   color: inherit !important;
+}
+
+.cursor-pointer {
+  cursor: pointer;
 }
 </style>

--- a/dashboard/src/components/extension/componentPanel/index.vue
+++ b/dashboard/src/components/extension/componentPanel/index.vue
@@ -125,6 +125,26 @@ const handleToggleTool = async (tool: ToolItem) => {
   }
 };
 
+const handleUpdateToolPermission = async (tool: ToolItem, permission: 'admin' | 'everyone') => {
+  const previous = tool.require_admin;
+  tool.require_admin = permission === 'admin';
+  try {
+    const res = await axios.post('/api/tools/set-permission', {
+      name: tool.name,
+      require_admin: tool.require_admin
+    });
+    if (res.data.status === 'ok') {
+      toast(tmTool('messages.updatePermissionSuccess'));
+    } else {
+      tool.require_admin = previous;
+      toast(res.data.message || tmTool('messages.updatePermissionError', { error: '' }), 'error');
+    }
+  } catch (error: any) {
+    tool.require_admin = previous;
+    toast(error?.response?.data?.message || error?.message || tmTool('messages.updatePermissionError', { error: '' }), 'error');
+  }
+};
+
 // 处理确认重命名
 const handleConfirmRename = async () => {
   await confirmRename(tm('messages.renameSuccess'), tm('messages.renameFailed'));
@@ -274,6 +294,7 @@ watch(viewMode, async (mode) => {
               :items="filteredTools"
               :loading="toolsLoading"
               @toggle-tool="handleToggleTool"
+              @update-permission="handleUpdateToolPermission"
             />
           </div>
         </v-card-text>

--- a/dashboard/src/components/extension/componentPanel/types.ts
+++ b/dashboard/src/components/extension/componentPanel/types.ts
@@ -112,6 +112,7 @@ export interface ToolItem {
   description: string;
   active: boolean;
   readonly?: boolean;
+  require_admin?: boolean;
   parameters?: {
     properties?: Record<string, ToolParameter>;
   };

--- a/dashboard/src/i18n/locales/en-US/features/tool-use.json
+++ b/dashboard/src/i18n/locales/en-US/features/tool-use.json
@@ -47,7 +47,8 @@
       "origin": "Origin",
       "originName": "Origin Name",
       "readonly": "Read-only",
-      "actions": "Actions"
+      "actions": "Actions",
+      "permission": "Permission"
     },
     "configTags": {
       "tooltipTitle": "This tool is enabled in config file {config} because:",
@@ -57,6 +58,10 @@
         "in": "{key} matched {expected}",
         "fallback": "{key} is currently {actual}"
       }
+    },
+    "permission": {
+      "everyone": "Everyone",
+      "admin": "Admin only"
     }
   },
   "marketplace": {
@@ -167,6 +172,8 @@
     "toggleToolSuccess": "Tool status toggled successfully!",
     "toggleToolReadonly": "Builtin tools are read-only and cannot be enabled or disabled.",
     "toggleToolError": "Failed to toggle tool status: {error}",
-    "testError": "Test connection failed: {error}"
+    "testError": "Test connection failed: {error}",
+    "updatePermissionSuccess": "Permission updated successfully!",
+    "updatePermissionError": "Failed to update permission: {error}"
   }
 }

--- a/dashboard/src/i18n/locales/ru-RU/features/tool-use.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/tool-use.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "title": "Инструменты и функции",
     "subtitle": "Управление MCP-серверами и доступными функциями",
     "tooltip": {
@@ -47,7 +47,8 @@
             "origin": "Источник",
             "originName": "Имя источника",
             "readonly": "Только чтение",
-            "actions": "Действия"
+            "actions": "Действия",
+            "permission": "Права доступа"
         },
         "configTags": {
             "tooltipTitle": "Этот инструмент включен в файле конфигурации {config}, потому что:",
@@ -57,6 +58,10 @@
                 "in": "{key} соответствует {expected}",
                 "fallback": "Текущее значение {key}: {actual}"
             }
+        },
+        "permission": {
+            "everyone": "Все",
+            "admin": "Только администратор"
         }
     },
     "marketplace": {
@@ -167,7 +172,9 @@
         "toggleToolSuccess": "Статус инструмента изменен!",
         "toggleToolReadonly": "Встроенные инструменты доступны только для чтения и не могут быть включены или выключены.",
         "toggleToolError": "Не удалось изменить статус: {error}",
-        "testError": "Ошибка теста связи: {error}"
+        "testError": "Ошибка теста связи: {error}",
+        "updatePermissionSuccess": "Права доступа обновлены!",
+        "updatePermissionError": "Ошибка обновления прав: {error}"
     },
     "syncProvider": {
         "title": "Синхронизация серверов MCP",

--- a/dashboard/src/i18n/locales/zh-CN/features/tool-use.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/tool-use.json
@@ -47,7 +47,8 @@
       "origin": "来源",
       "originName": "来源名称",
       "readonly": "只读",
-      "actions": "操作"
+      "actions": "操作",
+      "permission": "权限"
     },
     "configTags": {
       "tooltipTitle": "该工具在配置文件 {config} 中启用，因为：",
@@ -57,6 +58,10 @@
         "in": "{key} 命中了 {expected}",
         "fallback": "{key} 当前值为 {actual}"
       }
+    },
+    "permission": {
+      "everyone": "所有人",
+      "admin": "管理员"
     }
   },
   "marketplace": {
@@ -167,6 +172,8 @@
     "toggleToolSuccess": "工具状态切换成功!",
     "toggleToolReadonly": "内置工具为只读，无法进行启用或停用操作。",
     "toggleToolError": "工具状态切换失败: {error}",
-    "testError": "测试连接失败: {error}"
+    "testError": "测试连接失败: {error}",
+    "updatePermissionSuccess": "权限更新成功!",
+    "updatePermissionError": "权限更新失败: {error}"
   }
 }


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
Related  #8511 短期实现

### Modifications / 改动点

- `astrbot/core/agent/tool.py`：`FunctionTool` 新增 `require_admin: bool = False` 字段，默认值保持向后兼容
- `astrbot/core/provider/func_tool_manager.py`：新增 `set_tool_require_admin()` 持久化权限配置（存储为 map，仅覆盖用户明确配置的工具）；新增 `_restore_tool_permissions()` 恢复权限状态；在 `init_mcp_clients()` 末尾和 `_init_mcp_client()` 末尾分别调用，覆盖批量初始化和动态启动/重连场景
- `astrbot/core/star/star_manager.py`：`load()` 末尾调用 `_restore_tool_permissions()`，确保插件工具注册完成后权限正确恢复（含热重载）
- `astrbot/core/astr_agent_tool_exec.py`：`_build_handoff_toolset()` 两个分支均加入 `require_admin` 过滤，覆盖 Handoff 子 Agent 路径（该路径绕过主对话的组装流程）
- `astrbot/core/astr_main_agent.py`：新增 `_filter_tools_by_role()`，在 `_plugin_tool_fix` 之后、`AgentRunner.reset()` 之前过滤非管理员无权调用的工具，LLM 不会感知受限工具的存在
- `astrbot/core/agent/runners/tool_loop_agent_runner.py`：`_handle_function_tools()` 中 `execute()` 前插入权限二次拦截，作为兜底保障
- `astrbot/dashboard/routes/tools.py`：`get_tool_list` 返回 `require_admin` 字段；新增 `POST /tools/set-permission` 接口，内置工具不可修改
- `dashboard/src/components/extension/componentPanel/components/ToolTable.vue`：函数工具列表新增"权限"列，`readonly` 工具显示 `-`，其他工具显示可点击下拉，与指令管理页风格一致
- `dashboard/src/components/extension/componentPanel/index.vue`：新增 `handleUpdateToolPermission`，绑定 `@update-permission` 事件
- `dashboard/src/components/extension/componentPanel/types.ts`：`ToolItem` 新增 `require_admin?: boolean`
- `dashboard/src/i18n/locales/zh-CN/features/tool-use.json`：新增权限相关翻译 key
- `dashboard/src/i18n/locales/en-US/features/tool-use.json`：新增权限相关翻译 key
- `dashboard/src/i18n/locales/ru-RU/features/tool-use.json`：新增权限相关翻译 key
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
<img width="1507" height="304" alt="image" src="https://github.com/user-attachments/assets/71cf38d0-2b54-4849-9378-52968c5ae5d0" />


<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x]  👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Introduce role-based tool permissions that restrict certain tools to admin users and expose permission management in the web dashboard.

New Features:
- Allow marking individual function tools as admin-only and persist their permission state across restarts.
- Add server-side APIs and web UI controls to view and update each tool's permission (admin-only vs everyone) from the dashboard.
- Hide admin-only tools from non-admin users during tool selection and execution, with centralized permission checks blocking unauthorized tool calls.

Enhancements:
- Restore tool permission configuration after MCP and plugin tools are initialized to keep runtime state consistent.
- Extend tool metadata and localization to surface tool permission information in the dashboard tool table.

## Summary by Sourcery

Introduce role-based admin-only restrictions for function tools and surface their permissions in both backend APIs and the dashboard UI.

New Features:
- Allow marking function tools as admin-only via a persisted require_admin flag exposed on FunctionTool and managed by the function tool manager.
- Add backend API and dashboard controls to view and update each tool's permission, including a new permission column and selector in the tools table.
- Hide admin-only tools from non-admin users during tool selection and execution, with centralized runtime checks blocking unauthorized calls.

Enhancements:
- Restore stored tool permission configuration after MCP and plugin tool initialization to keep runtime tool state consistent.
- Extend tool metadata, responses, and localization entries to include permission information for display in the dashboard.