### PR TITLE
fix: keep strong refs to pipeline tasks to prevent GC

### DIFF
--- a/astrbot/core/event_bus.py
+++ b/astrbot/core/event_bus.py
@@ -33,6 +33,8 @@ class EventBus:
         # abconf uuid -> scheduler
         self.pipeline_scheduler_mapping = pipeline_scheduler_mapping
         self.astrbot_config_mgr = astrbot_config_mgr
+        # 持有正在执行的 pipeline 任务的强引用, 防止 task 在 pending 状态被 GC 回收
+        self._pending_tasks: set[asyncio.Task] = set()
 
     async def dispatch(self) -> None:
         while True:
@@ -47,7 +49,18 @@ class EventBus:
                     f"PipelineScheduler not found for id: {conf_id}, event ignored."
                 )
                 continue
-            asyncio.create_task(scheduler.execute(event))
+            task = asyncio.create_task(scheduler.execute(event))
+            self._pending_tasks.add(task)
+            task.add_done_callback(self._on_task_done)
+
+    def _on_task_done(self, task: asyncio.Task) -> None:
+        """pipeline 任务结束回调: 移除强引用并暴露未捕获的异常"""
+        self._pending_tasks.discard(task)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.error("pipeline 任务执行异常", exc_info=exc)
 
     def _print_event(self, event: AstrMessageEvent, conf_name: str) -> None:
         """用于记录事件信息


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
EventBus dispatched every incoming event with a bare `asyncio.create_task(scheduler.execute(event))` whose return value was discarded. Because asyncio only holds weak references to tasks, a suspended pipeline task could be garbage-collected while still pending whenever it lost the reference to the future it was awaiting — for example when an underlying platform/network connection was dropped mid-handler. The result was a recurring `Task was destroyed but it is pending!` warning followed by a cascade of `aclose(): asynchronous generator is already running` errors, as the GC tried to finalize the nested suspended async generators of the onion-model pipeline. The work itself usually completed, but the noise masked real failures and exceptions were silently swallowed (`Task exception was never retrieved`).
<img width="3308" height="904" alt="18e16e0c2d72de861828ce880d3f0dc0" src="https://github.com/user-attachments/assets/8aba7ecf-1dfb-49ce-a030-de6b134a99fd" />
### Modifications / 改动点
- `astrbot/core/event_bus.py`: Hold a strong reference to each dispatched pipeline task in a `set` for the duration of its execution, preventing premature GC. A `_on_task_done` callback removes the task when finished and logs any uncaught exception via `logger.error(..., exc_info=exc)`, so pipeline failures now surface as a real log entry instead of being lost.
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [ ] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure event pipeline tasks remain alive for the duration of their execution so their failures are surfaced instead of being silently discarded.

Bug Fixes:
- Prevent dispatched pipeline tasks from being garbage-collected while still pending by keeping strong references until completion.
- Log uncaught exceptions from pipeline task execution so previously hidden task failures are now visible in logs.