### PR TITLE
fix: fix openapi chat

### DIFF
--- a/astrbot/core/platform/sources/webchat/webchat_adapter.py
+++ b/astrbot/core/platform/sources/webchat/webchat_adapter.py
@@ -202,10 +202,12 @@ class WebChatAdapter(Platform):
 
     async def convert_message(self, data: tuple) -> AstrBotMessage:
         username, cid, payload = data
+        sender_id = str(payload.get("sender_id") or username)
+        sender_name = str(payload.get("sender_name") or username)
 
         abm = AstrBotMessage()
         abm.self_id = "webchat"
-        abm.sender = MessageMember(username, username)
+        abm.sender = MessageMember(sender_id, sender_name)
 
         abm.type = MessageType.FRIEND_MESSAGE
 

--- a/astrbot/dashboard/routes/chat.py
+++ b/astrbot/dashboard/routes/chat.py
@@ -752,6 +752,8 @@ class ChatRoute(Route):
         enable_streaming = post_data.get("enable_streaming", True)
         platform_history_id = post_data.get("_platform_history_id") or "webchat"
         thread_selected_text = post_data.get("_thread_selected_text")
+        sender_id = str(post_data.get("_sender_id") or username)
+        sender_name = str(post_data.get("_sender_name") or username)
 
         if not session_id:
             return Response().error("session_id is empty").__dict__
@@ -1012,6 +1014,8 @@ class ChatRoute(Route):
                     "message_id": message_id,
                     "llm_checkpoint_id": llm_checkpoint_id,
                     "thread_selected_text": thread_selected_text,
+                    "sender_id": sender_id,
+                    "sender_name": sender_name,
                 },
             ),
         )

--- a/astrbot/dashboard/routes/chat.py
+++ b/astrbot/dashboard/routes/chat.py
@@ -752,8 +752,19 @@ class ChatRoute(Route):
         enable_streaming = post_data.get("enable_streaming", True)
         platform_history_id = post_data.get("_platform_history_id") or "webchat"
         thread_selected_text = post_data.get("_thread_selected_text")
-        sender_id = str(post_data.get("_sender_id") or username)
-        sender_name = str(post_data.get("_sender_name") or username)
+        use_internal_sender = request.path.startswith("/api/v1/") and bool(
+            g.get("api_key_id", None)
+        )
+        sender_id = (
+            str(post_data.get("_sender_id") or username)
+            if use_internal_sender
+            else username
+        )
+        sender_name = (
+            str(post_data.get("_sender_name") or username)
+            if use_internal_sender
+            else username
+        )
 
         if not session_id:
             return Response().error("session_id is empty").__dict__

--- a/astrbot/dashboard/routes/open_api.py
+++ b/astrbot/dashboard/routes/open_api.py
@@ -65,6 +65,11 @@ class OpenApiRoute(Route):
             return None, "username is empty"
         return username, None
 
+    @staticmethod
+    def _build_openapi_sender_id(api_key_id: str | None, username: str) -> str:
+        key_id = str(api_key_id or "unknown").strip() or "unknown"
+        return f"openapi:{key_id}:{username}"
+
     def _get_chat_config_list(self) -> list[dict]:
         conf_list = self.core_lifecycle.astrbot_config_mgr.get_conf_list()
 
@@ -170,6 +175,11 @@ class OpenApiRoute(Route):
 
         original_username = g.get("username", "guest")
         g.username = effective_username
+        post_data["_sender_id"] = self._build_openapi_sender_id(
+            g.get("api_key_id", None),
+            effective_username,
+        )
+        post_data["_sender_name"] = effective_username
         if config_id:
             umo = f"webchat:FriendMessage:webchat!{effective_username}!{session_id}"
             try:
@@ -213,10 +223,12 @@ class OpenApiRoute(Route):
             return auth_header.removeprefix("ApiKey ").strip()
         return None
 
-    async def _authenticate_chat_ws_api_key(self) -> tuple[bool, str | None]:
+    async def _authenticate_chat_ws_api_key(
+        self,
+    ) -> tuple[bool, str | None, str | None]:
         raw_key = self._extract_ws_api_key()
         if not raw_key:
-            return False, "Missing API key"
+            return False, "Missing API key", None
 
         key_hash = hashlib.pbkdf2_hmac(
             "sha256",
@@ -226,7 +238,7 @@ class OpenApiRoute(Route):
         ).hex()
         api_key = await self.db.get_active_api_key_by_hash(key_hash)
         if not api_key:
-            return False, "Invalid API key"
+            return False, "Invalid API key", None
 
         if isinstance(api_key.scopes, list):
             scopes = api_key.scopes
@@ -234,10 +246,10 @@ class OpenApiRoute(Route):
             scopes = list(ALL_OPEN_API_SCOPES)
 
         if "*" not in scopes and "chat" not in scopes:
-            return False, "Insufficient API key scope"
+            return False, "Insufficient API key scope", None
 
         await self.db.touch_api_key(api_key.key_id)
-        return True, None
+        return True, None, api_key.key_id
 
     async def _send_chat_ws_error(self, message: str, code: str) -> None:
         await websocket.send_json(
@@ -277,7 +289,11 @@ class OpenApiRoute(Route):
             return f"Failed to update chat config route: {e}"
         return None
 
-    async def _handle_chat_ws_send(self, post_data: dict) -> None:
+    async def _handle_chat_ws_send(
+        self,
+        post_data: dict,
+        api_key_id: str | None,
+    ) -> None:
         effective_username, username_err = self._resolve_open_username(
             post_data.get("username")
         )
@@ -331,6 +347,7 @@ class OpenApiRoute(Route):
         selected_provider = post_data.get("selected_provider")
         selected_model = post_data.get("selected_model")
         enable_streaming = post_data.get("enable_streaming", True)
+        sender_id = self._build_openapi_sender_id(api_key_id, effective_username)
 
         back_queue = webchat_queue_mgr.get_or_create_back_queue(message_id, session_id)
         try:
@@ -345,6 +362,8 @@ class OpenApiRoute(Route):
                         "selected_model": selected_model,
                         "enable_streaming": enable_streaming,
                         "message_id": message_id,
+                        "sender_id": sender_id,
+                        "sender_name": effective_username,
                     },
                 )
             )
@@ -493,7 +512,7 @@ class OpenApiRoute(Route):
             webchat_queue_mgr.remove_back_queue(message_id)
 
     async def chat_ws(self) -> None:
-        authed, auth_err = await self._authenticate_chat_ws_api_key()
+        authed, auth_err, api_key_id = await self._authenticate_chat_ws_api_key()
         if not authed:
             await self._send_chat_ws_error(auth_err or "Unauthorized", "UNAUTHORIZED")
             await websocket.close(1008, auth_err or "Unauthorized")
@@ -520,7 +539,7 @@ class OpenApiRoute(Route):
                     )
                     continue
 
-                await self._handle_chat_ws_send(message)
+                await self._handle_chat_ws_send(message, api_key_id)
         except Exception as e:
             logger.debug("Open API WS connection closed: %s", e)
 

--- a/tests/test_api_key_open_api.py
+++ b/tests/test_api_key_open_api.py
@@ -8,6 +8,7 @@ import pytest_asyncio
 from quart import Quart, g, request
 from werkzeug.datastructures import FileStorage
 
+import astrbot.dashboard.routes.chat as chat_module
 import astrbot.dashboard.routes.open_api as open_api_module
 from astrbot.core import LogBroker
 from astrbot.core.config.default import DEFAULT_CONFIG
@@ -248,7 +249,8 @@ async def test_open_chat_send_auto_session_id_and_username(
             json={
                 "message": "hello",
                 "username": "astrbot",
-                "_sender_id": "astrbot",
+                "_sender_id": "evil-admin",
+                "_sender_name": "evil-admin",
                 "enable_streaming": False,
             },
             headers={"X-API-Key": raw_key},
@@ -435,6 +437,64 @@ async def test_open_chat_ws_send_uses_openapi_sender_id(
     assert queued_payload["sender_id"] not in DEFAULT_CONFIG["admins_id"]
     assert queued_payload["sender_name"] == "astrbot"
     assert any(message["type"] == "session_id" for message in websocket_messages)
+
+
+@pytest.mark.asyncio
+async def test_dashboard_chat_send_ignores_internal_sender_fields(
+    app: Quart,
+    authenticated_header: dict,
+    core_lifecycle_td: AstrBotCoreLifecycle,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    test_client = app.test_client()
+    session_id = f"dashboard_sender_{uuid.uuid4().hex[:8]}"
+    chat_queue_items = []
+
+    class CaptureQueue:
+        async def put(self, item):
+            chat_queue_items.append(item)
+
+    def fake_back_queue(*_args, **_kwargs):
+        queue = asyncio.Queue()
+        queue.put_nowait({"type": "end", "data": ""})
+        return queue
+
+    monkeypatch.setattr(
+        chat_module.webchat_queue_mgr,
+        "get_or_create_back_queue",
+        fake_back_queue,
+    )
+    monkeypatch.setattr(
+        chat_module.webchat_queue_mgr,
+        "get_or_create_queue",
+        lambda *_args, **_kwargs: CaptureQueue(),
+    )
+    monkeypatch.setattr(
+        chat_module.webchat_queue_mgr,
+        "remove_back_queue",
+        lambda *_args, **_kwargs: None,
+    )
+
+    send_res = await test_client.post(
+        "/api/chat/send",
+        json={
+            "message": "hello",
+            "session_id": session_id,
+            "_sender_id": "astrbot",
+            "_sender_name": "astrbot",
+        },
+        headers=authenticated_header,
+    )
+
+    assert send_res.status_code == 200
+    body = await send_res.get_data(as_text=True)
+    assert '"type": "session_id"' in body
+    assert len(chat_queue_items) == 1
+    queued_username, queued_session_id, queued_payload = chat_queue_items[0]
+    assert queued_username == core_lifecycle_td.astrbot_config["dashboard"]["username"]
+    assert queued_session_id == session_id
+    assert queued_payload["sender_id"] == queued_username
+    assert queued_payload["sender_name"] == queued_username
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_key_open_api.py
+++ b/tests/test_api_key_open_api.py
@@ -8,9 +8,17 @@ import pytest_asyncio
 from quart import Quart, g, request
 from werkzeug.datastructures import FileStorage
 
+import astrbot.dashboard.routes.open_api as open_api_module
 from astrbot.core import LogBroker
+from astrbot.core.config.default import DEFAULT_CONFIG
 from astrbot.core.core_lifecycle import AstrBotCoreLifecycle
 from astrbot.core.db.sqlite import SQLiteDatabase
+from astrbot.core.pipeline.context import PipelineContext
+from astrbot.core.pipeline.waking_check.stage import WakingCheckStage
+from astrbot.core.platform import AstrBotMessage, MessageMember, MessageType
+from astrbot.core.platform.platform_metadata import PlatformMetadata
+from astrbot.core.platform.sources.webchat.webchat_adapter import WebChatAdapter
+from astrbot.core.platform.sources.webchat.webchat_event import WebChatMessageEvent
 from astrbot.core.utils.auth_password import (
     hash_dashboard_password,
     hash_legacy_dashboard_password,
@@ -208,7 +216,7 @@ async def test_open_chat_send_auto_session_id_and_username(
 ):
     test_client = app.test_client()
 
-    raw_key, _ = await _create_api_key(
+    raw_key, key_id = await _create_api_key(
         app,
         authenticated_header,
         scopes=["chat"],
@@ -226,6 +234,8 @@ async def test_open_chat_send_auto_session_id_and_username(
                 data={
                     "session_id": payload.get("session_id"),
                     "creator": g.get("username"),
+                    "sender_id": payload.get("_sender_id"),
+                    "sender_name": payload.get("_sender_name"),
                 }
             )
             .__dict__
@@ -237,7 +247,8 @@ async def test_open_chat_send_auto_session_id_and_username(
             "/api/v1/chat",
             json={
                 "message": "hello",
-                "username": "alice_auto_session",
+                "username": "astrbot",
+                "_sender_id": "astrbot",
                 "enable_streaming": False,
             },
             headers={"X-API-Key": raw_key},
@@ -251,12 +262,15 @@ async def test_open_chat_send_auto_session_id_and_username(
     created_session_id = send_data["data"]["session_id"]
     assert isinstance(created_session_id, str)
     uuid.UUID(created_session_id)
-    assert send_data["data"]["creator"] == "alice_auto_session"
+    assert send_data["data"]["creator"] == "astrbot"
+    assert send_data["data"]["sender_id"] == f"openapi:{key_id}:astrbot"
+    assert send_data["data"]["sender_id"] not in DEFAULT_CONFIG["admins_id"]
+    assert send_data["data"]["sender_name"] == "astrbot"
     created_session = await core_lifecycle_td.db.get_platform_session_by_id(
         created_session_id
     )
     assert created_session is not None
-    assert created_session.creator == "alice_auto_session"
+    assert created_session.creator == "astrbot"
     assert created_session.platform_id == "webchat"
 
     await core_lifecycle_td.db.create_platform_session(
@@ -289,6 +303,138 @@ async def test_open_chat_send_auto_session_id_and_username(
     missing_username_data = await missing_username_res.get_json()
     assert missing_username_data["status"] == "error"
     assert missing_username_data["message"] == "Missing key: username"
+
+
+@pytest.mark.asyncio
+async def test_openapi_sender_id_is_used_for_webchat_event_identity():
+    adapter = WebChatAdapter({}, {}, asyncio.Queue())
+    message = await adapter.convert_message(
+        (
+            "astrbot",
+            "openapi-repro-session",
+            {
+                "message": [{"type": "plain", "text": "/provider"}],
+                "message_id": "openapi-repro-message",
+                "sender_id": "openapi:key-123:astrbot",
+                "sender_name": "astrbot",
+            },
+        )
+    )
+
+    assert message.sender.user_id == "openapi:key-123:astrbot"
+    assert message.sender.user_id not in DEFAULT_CONFIG["admins_id"]
+    assert message.sender.nickname == "astrbot"
+    assert message.session_id == "webchat!astrbot!openapi-repro-session"
+
+
+@pytest.mark.asyncio
+async def test_openapi_sender_id_does_not_match_default_admin_in_waking_stage():
+    stage = WakingCheckStage()
+    await stage.initialize(
+        PipelineContext(
+            astrbot_config={
+                "admins_id": DEFAULT_CONFIG["admins_id"],
+                "wake_prefix": ["/"],
+                "platform_settings": {"friend_message_needs_wake_prefix": True},
+                "disable_builtin_commands": False,
+            },
+            plugin_manager=None,
+            astrbot_config_id="test",
+        )
+    )
+    platform_meta = PlatformMetadata(
+        name="webchat",
+        description="webchat",
+        id="webchat",
+    )
+
+    async def role_for(sender_id: str) -> str:
+        message_obj = AstrBotMessage()
+        message_obj.type = MessageType.FRIEND_MESSAGE
+        message_obj.self_id = "webchat"
+        message_obj.sender = MessageMember(sender_id, "astrbot")
+        message_obj.message = []
+        message_obj.message_str = "hello"
+        message_obj.session_id = "webchat!astrbot!waking-repro"
+        event = WebChatMessageEvent(
+            message_str="hello",
+            message_obj=message_obj,
+            platform_meta=platform_meta,
+            session_id=message_obj.session_id,
+        )
+        await stage.process(event)
+        return event.role
+
+    assert await role_for("astrbot") == "admin"
+    assert await role_for("openapi:key-123:astrbot") == "member"
+
+
+@pytest.mark.asyncio
+async def test_open_chat_ws_send_uses_openapi_sender_id(
+    app: Quart,
+    authenticated_header: dict,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    open_api_route = _get_open_api_route(app)
+    session_id = f"openapi_ws_sender_{uuid.uuid4().hex[:8]}"
+    message_id = f"openapi-ws-message-{uuid.uuid4().hex[:8]}"
+    chat_queue_items = []
+    websocket_messages = []
+
+    class CaptureQueue:
+        async def put(self, item):
+            chat_queue_items.append(item)
+
+    back_queue = asyncio.Queue()
+    await back_queue.put(
+        {
+            "type": "end",
+            "data": "",
+            "message_id": message_id,
+        }
+    )
+
+    class FakeWebsocket:
+        async def send_json(self, payload):
+            websocket_messages.append(payload)
+
+    monkeypatch.setattr(
+        open_api_module.webchat_queue_mgr,
+        "get_or_create_back_queue",
+        lambda *_args, **_kwargs: back_queue,
+    )
+    monkeypatch.setattr(
+        open_api_module.webchat_queue_mgr,
+        "get_or_create_queue",
+        lambda *_args, **_kwargs: CaptureQueue(),
+    )
+    monkeypatch.setattr(
+        open_api_module.webchat_queue_mgr,
+        "remove_back_queue",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(open_api_module, "websocket", FakeWebsocket())
+
+    await open_api_route._handle_chat_ws_send(
+        {
+            "message": "hello",
+            "username": "astrbot",
+            "session_id": session_id,
+            "message_id": message_id,
+            "enable_streaming": False,
+            "sender_id": "astrbot",
+        },
+        "ws-key-123",
+    )
+
+    assert len(chat_queue_items) == 1
+    queued_username, queued_session_id, queued_payload = chat_queue_items[0]
+    assert queued_username == "astrbot"
+    assert queued_session_id == session_id
+    assert queued_payload["sender_id"] == "openapi:ws-key-123:astrbot"
+    assert queued_payload["sender_id"] not in DEFAULT_CONFIG["admins_id"]
+    assert queued_payload["sender_name"] == "astrbot"
+    assert any(message["type"] == "session_id" for message in websocket_messages)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
修复 OpenAPI chat 中一个可能导致权限提升的问题。

目前 `/api/v1/chat` 和 `/api/v1/chat/ws` 会接收外部系统传入的 `username`，后续 WebChat 消息进入消息管线时，这个 `username` 又会被当成事件的 sender id 使用。管理员权限判断依赖 `event.get_sender_id()` 是否命中 `admins_id`，而默认配置里包含 `astrbot`。

这会导致一个实际风险：如果管理员给外部系统创建了带 `chat` scope 的 API key，例如接入自建 chat 平台、智能客服或其他第三方入口，外部用户只要把自己的 `username` 设置为 `astrbot`，这条消息进入插件、命令和工具权限判断时就可能被当成管理员。这样会绕过原本 API key 只允许 chat 调用的权限边界，也可能影响 admin-only 命令和需要管理员权限的工具调用。

这个问题不需要修改全局管理员判断逻辑，更合适的修复点是在 OpenAPI chat 入口把“外部展示用户名”和“内部权限身份”分开。

### Modifications / 改动点

- OpenAPI chat HTTP 路径现在会为消息生成内部 sender id，格式类似 `openapi:<api_key_id>:<username>`，不再直接用外部传入的 `username` 做权限身份。
- OpenAPI chat WebSocket 路径现在会在鉴权后保留 `api_key_id`，并使用同样的内部 sender id 进入 WebChat 队列。
- WebChatAdapter 支持从 payload 中读取内部 `sender_id` / `sender_name`，事件权限判断使用内部 sender id。
- 原有 `username` 仍然保留给会话创建、会话归属、历史展示和配置路由使用，避免破坏现有 OpenAPI chat 调用方式。
- 增加回归测试，覆盖 HTTP、WebSocket、WebChatAdapter 转换，以及最终 waking 阶段的管理员身份判断。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```bash
/tmp/astrbot-p1-review-venv/bin/python -m pytest -q --capture=no tests/test_api_key_open_api.py
```

结果：

```text
15 passed, 2 warnings in 8.57s
```

测试覆盖点：

- `/api/v1/chat` 中传入 `username=astrbot` 时，内部 sender id 会变成 `openapi:<key_id>:astrbot`。
- 调用方即使传入 `_sender_id=astrbot`，也会被服务端覆盖。
- `/api/v1/chat/ws` 入队 payload 使用 `openapi:<key_id>:astrbot`，不会采信客户端传入的 `sender_id`。
- 普通 dashboard `/api/chat/send` 即使传入 `_sender_id=astrbot`，也会强制使用当前登录用户作为内部 sender。
- WebChatAdapter 会把内部 sender id 用作事件 sender id，同时保持原有 session id 结构。
- WakingCheckStage 中，原始 `astrbot` 会命中管理员，但 `openapi:<key_id>:astrbot` 不会命中默认管理员 ID。

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。
