### PR TITLE
feat: show quoted message content in group chat context

### DIFF
--- a/astrbot/builtin_stars/astrbot/group_chat_context.py
+++ b/astrbot/builtin_stars/astrbot/group_chat_context.py
@@ -7,7 +7,18 @@ from collections import defaultdict, deque
 from astrbot import logger
 from astrbot.api import star
 from astrbot.api.event import AstrMessageEvent
-from astrbot.api.message_components import At, AtAll, Face, File, Forward, Image, Plain, Record, Reply, Video
+from astrbot.api.message_components import (
+    At,
+    AtAll,
+    Face,
+    File,
+    Forward,
+    Image,
+    Plain,
+    Record,
+    Reply,
+    Video,
+)
 from astrbot.api.platform import MessageType
 from astrbot.api.provider import Provider, ProviderRequest
 from astrbot.core.agent.message import TextPart
@@ -221,9 +232,7 @@ class GroupChatContext:
                     )
                 elif comp.chain:
                     chain_desc = _describe_chain(comp.chain)
-                    parts.append(
-                        f" [Quote({comp.sender_nickname}: {chain_desc})]"
-                    )
+                    parts.append(f" [Quote({comp.sender_nickname}: {chain_desc})]")
                 else:
                     parts.append(" [Quote]")
 
@@ -234,7 +243,7 @@ _MAX_REPLY_TEXT_LENGTH = 200
 
 
 def _describe_chain(chain: list) -> str:
-    """简要描述消息链内容，用于引用消息的展示"""
+    """Summarize message chain content for quoted reply display."""
     desc = []
     for c in chain:
         if isinstance(c, Plain) and getattr(c, "text", None):
@@ -264,7 +273,7 @@ def _describe_chain(chain: list) -> str:
 
 
 def _truncate_reply_text(text: str) -> str:
-    """截断过长的引用文本"""
+    """Truncate overly long quoted reply text."""
     if len(text) <= _MAX_REPLY_TEXT_LENGTH:
         return text
     return text[:_MAX_REPLY_TEXT_LENGTH] + "..."

--- a/astrbot/builtin_stars/astrbot/group_chat_context.py
+++ b/astrbot/builtin_stars/astrbot/group_chat_context.py
@@ -7,7 +7,7 @@ from collections import defaultdict, deque
 from astrbot import logger
 from astrbot.api import star
 from astrbot.api.event import AstrMessageEvent
-from astrbot.api.message_components import At, File, Image, Plain, Record, Reply, Video
+from astrbot.api.message_components import At, AtAll, Face, File, Forward, Image, Plain, Record, Reply, Video
 from astrbot.api.platform import MessageType
 from astrbot.api.provider import Provider, ProviderRequest
 from astrbot.core.agent.message import TextPart
@@ -250,6 +250,12 @@ def _describe_chain(chain: list) -> str:
             desc.append("[Video]")
         elif isinstance(c, File):
             desc.append(f"[File: {getattr(c, 'name', '') or ''}]")
+        elif isinstance(c, Forward):
+            desc.append("[Forward]")
+        elif isinstance(c, AtAll):
+            desc.append("[At: All]")
+        elif isinstance(c, Face):
+            desc.append(f"[Sticker: {getattr(c, 'id', '')}]")
         elif isinstance(c, Reply):
             desc.append("[Quote]")
         else:

--- a/astrbot/builtin_stars/astrbot/group_chat_context.py
+++ b/astrbot/builtin_stars/astrbot/group_chat_context.py
@@ -7,7 +7,7 @@ from collections import defaultdict, deque
 from astrbot import logger
 from astrbot.api import star
 from astrbot.api.event import AstrMessageEvent
-from astrbot.api.message_components import At, Image, Plain
+from astrbot.api.message_components import At, Image, Plain, Reply
 from astrbot.api.platform import MessageType
 from astrbot.api.provider import Provider, ProviderRequest
 from astrbot.core.agent.message import TextPart
@@ -214,8 +214,43 @@ class GroupChatContext:
                 if is_at_self:
                     parts.insert(1, "⚠️[DIRECTED AT YOU] ")
                 parts.append(f" [At: {comp.name}]")
+            elif isinstance(comp, Reply):
+                if comp.message_str:
+                    parts.append(
+                        f" [引用消息({comp.sender_nickname}: {comp.message_str})]"
+                    )
+                elif comp.chain:
+                    chain_desc = _describe_chain(comp.chain)
+                    parts.append(
+                        f" [引用消息({comp.sender_nickname}: {chain_desc})]"
+                    )
+                else:
+                    parts.append(" [引用消息]")
 
         return "".join(parts)
+
+
+def _describe_chain(chain: list) -> str:
+    """简要描述消息链内容，用于引用消息的展示"""
+    desc = []
+    for c in chain:
+        cls_name = c.__class__.__name__
+        if cls_name == "Plain" and getattr(c, "text", None):
+            desc.append(c.text)
+        elif cls_name == "Image":
+            desc.append("[图片]")
+        elif cls_name == "At":
+            name = getattr(c, "name", "") or getattr(c, "qq", "")
+            desc.append(f"[At: {name}]")
+        elif cls_name == "Record":
+            desc.append("[语音]")
+        elif cls_name == "Video":
+            desc.append("[视频]")
+        elif cls_name == "File":
+            desc.append(f"[文件: {getattr(c, 'name', '') or ''}]")
+        else:
+            desc.append(f"[{cls_name}]")
+    return "".join(desc) or "[未知内容]"
 
 
 def _positive_int(value, fallback: int) -> int:

--- a/astrbot/builtin_stars/astrbot/group_chat_context.py
+++ b/astrbot/builtin_stars/astrbot/group_chat_context.py
@@ -7,7 +7,7 @@ from collections import defaultdict, deque
 from astrbot import logger
 from astrbot.api import star
 from astrbot.api.event import AstrMessageEvent
-from astrbot.api.message_components import At, Image, Plain, Reply
+from astrbot.api.message_components import At, File, Image, Plain, Record, Reply, Video
 from astrbot.api.platform import MessageType
 from astrbot.api.provider import Provider, ProviderRequest
 from astrbot.core.agent.message import TextPart
@@ -217,40 +217,51 @@ class GroupChatContext:
             elif isinstance(comp, Reply):
                 if comp.message_str:
                     parts.append(
-                        f" [引用消息({comp.sender_nickname}: {comp.message_str})]"
+                        f" [Quote({comp.sender_nickname}: {_truncate_reply_text(comp.message_str)})]"
                     )
                 elif comp.chain:
                     chain_desc = _describe_chain(comp.chain)
                     parts.append(
-                        f" [引用消息({comp.sender_nickname}: {chain_desc})]"
+                        f" [Quote({comp.sender_nickname}: {chain_desc})]"
                     )
                 else:
-                    parts.append(" [引用消息]")
+                    parts.append(" [Quote]")
 
         return "".join(parts)
+
+
+_MAX_REPLY_TEXT_LENGTH = 200
 
 
 def _describe_chain(chain: list) -> str:
     """简要描述消息链内容，用于引用消息的展示"""
     desc = []
     for c in chain:
-        cls_name = c.__class__.__name__
-        if cls_name == "Plain" and getattr(c, "text", None):
+        if isinstance(c, Plain) and getattr(c, "text", None):
             desc.append(c.text)
-        elif cls_name == "Image":
-            desc.append("[图片]")
-        elif cls_name == "At":
+        elif isinstance(c, Image):
+            desc.append("[Image]")
+        elif isinstance(c, At):
             name = getattr(c, "name", "") or getattr(c, "qq", "")
             desc.append(f"[At: {name}]")
-        elif cls_name == "Record":
-            desc.append("[语音]")
-        elif cls_name == "Video":
-            desc.append("[视频]")
-        elif cls_name == "File":
-            desc.append(f"[文件: {getattr(c, 'name', '') or ''}]")
+        elif isinstance(c, Record):
+            desc.append("[Voice]")
+        elif isinstance(c, Video):
+            desc.append("[Video]")
+        elif isinstance(c, File):
+            desc.append(f"[File: {getattr(c, 'name', '') or ''}]")
+        elif isinstance(c, Reply):
+            desc.append("[Quote]")
         else:
-            desc.append(f"[{cls_name}]")
-    return "".join(desc) or "[未知内容]"
+            desc.append(f"[{c.__class__.__name__}]")
+    return "".join(desc) or "[Unknown]"
+
+
+def _truncate_reply_text(text: str) -> str:
+    """截断过长的引用文本"""
+    if len(text) <= _MAX_REPLY_TEXT_LENGTH:
+        return text
+    return text[:_MAX_REPLY_TEXT_LENGTH] + "..."
 
 
 def _positive_int(value, fallback: int) -> int:


### PR DESCRIPTION
Include Reply component content in _format_message so the LLM can see what message was quoted when someone replies to the bot.

## Problem

群聊中，当有人引用（Reply）机器人的消息时，`group_chat_context.py` 的 `_format_message()` 方法只处理 Plain、Image、At 三种消息段，跳过了 Reply。虽然 Reply 组件通过 OneBot API 已经拿到了被引用消息的完整信息（`sender_nickname`、`message_str`、`chain` 等），但这些内容没有传递给 LLM。

结果：LLM 知道有人回复了我，但不知道被引用的消息具体说了什么。

## Solution

在 `_format_message` 中新增 Reply 消息段的处理：

- **文本引用**：展示 `[引用消息(发送者: 文本内容)]`
- **非文本引用**（图片、语音等）：通过 `_describe_chain()` 辅助函数描述引用内容

Before:
```
[小明/14:30:20]: 再解释一下
```

After:
```
[小明/14:30:20]:  [引用消息(机器人: 今天天气怎么样)] 再解释一下
```

## Modifications

- [x] This is NOT a breaking change.

仅修改一个文件：`astrbot/builtin_stars/astrbot/group_chat_context.py`
- import 添加 `Reply`
- `_format_message()`: 新增 `elif isinstance(comp, Reply)` 分支
- 新增 `_describe_chain()` 辅助函数

## Test Results

```
引用纯文本: 今天天气怎么样
引用图片: [图片]
引用混合: 看这个图[图片]
测试通过
```

## Summary by Sourcery

Include quoted reply message content in formatted group chat context so the LLM can see what was replied to.

New Features:
- Display quoted reply message content, including sender and text or a summarized description of non-text content, in formatted group chat messages for LLM context.

Enhancements:
- Introduce a helper to generate concise descriptions of mixed-content message chains when showing quoted replies in group chats.