### PR TITLE
[codex] fix event bus task retention

### DIFF
--- a/astrbot/core/event_bus.py
+++ b/astrbot/core/event_bus.py
@@ -33,6 +33,7 @@ class EventBus:
         # abconf uuid -> scheduler
         self.pipeline_scheduler_mapping = pipeline_scheduler_mapping
         self.astrbot_config_mgr = astrbot_config_mgr
+        self._pending_tasks: set[asyncio.Task[None]] = set()
 
     async def dispatch(self) -> None:
         while True:
@@ -47,7 +48,21 @@ class EventBus:
                     f"PipelineScheduler not found for id: {conf_id}, event ignored."
                 )
                 continue
-            asyncio.create_task(scheduler.execute(event))
+            task = asyncio.create_task(scheduler.execute(event))
+            self._pending_tasks.add(task)
+            task.add_done_callback(self._on_task_done)
+
+    def _on_task_done(self, task: asyncio.Task[None]) -> None:
+        self._pending_tasks.discard(task)
+        if task.cancelled():
+            return
+
+        exc = task.exception()
+        if exc is not None:
+            logger.error(
+                "Pipeline task execution failed.",
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
 
     def _print_event(self, event: AstrMessageEvent, conf_name: str) -> None:
         """用于记录事件信息

--- a/tests/unit/test_event_bus.py
+++ b/tests/unit/test_event_bus.py
@@ -57,6 +57,7 @@ class TestEventBusInit:
         assert bus.event_queue == event_queue
         assert bus.pipeline_scheduler_mapping == {"test": mock_pipeline_scheduler}
         assert bus.astrbot_config_mgr == mock_config_manager
+        assert bus._pending_tasks == set()
 
 
 class TestEventBusDispatch:
@@ -100,6 +101,76 @@ class TestEventBusDispatch:
         mock_config_manager.get_conf_info.assert_called_once_with(
             "test-platform:group:123"
         )
+        assert not event_bus._pending_tasks
+
+    @pytest.mark.asyncio
+    async def test_dispatch_keeps_pending_task_reference(
+        self, event_bus, event_queue, mock_pipeline_scheduler
+    ):
+        """Dispatch should retain pipeline tasks until they complete."""
+        started = asyncio.Event()
+        release = asyncio.Event()
+        finished = asyncio.Event()
+
+        async def execute_and_wait(event):  # noqa: ARG001
+            started.set()
+            await release.wait()
+            finished.set()
+
+        mock_pipeline_scheduler.execute.side_effect = execute_and_wait
+
+        mock_event = MagicMock()
+        mock_event.unified_msg_origin = "test-platform:group:123"
+        mock_event.get_platform_id.return_value = "test-platform"
+        mock_event.get_platform_name.return_value = "Test Platform"
+        mock_event.get_sender_name.return_value = "TestUser"
+        mock_event.get_sender_id.return_value = "user123"
+        mock_event.get_message_outline.return_value = "Hello"
+
+        await event_queue.put(mock_event)
+
+        dispatch_task = asyncio.create_task(event_bus.dispatch())
+        try:
+            await asyncio.wait_for(started.wait(), timeout=1.0)
+            assert len(event_bus._pending_tasks) == 1
+
+            release.set()
+            await asyncio.wait_for(finished.wait(), timeout=1.0)
+            await asyncio.sleep(0)
+        finally:
+            dispatch_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await dispatch_task
+
+        assert not event_bus._pending_tasks
+
+    @pytest.mark.asyncio
+    async def test_pipeline_task_exception_logs_traceback_tuple(self, event_bus):
+        """Task exceptions should log the original traceback."""
+
+        async def fail_pipeline():
+            raise RuntimeError("pipeline failed")
+
+        with patch("astrbot.core.event_bus.logger") as mock_logger:
+            task = asyncio.create_task(fail_pipeline())
+            callback_done = asyncio.Event()
+
+            def on_task_done(task: asyncio.Task[None]) -> None:
+                event_bus._on_task_done(task)
+                callback_done.set()
+
+            event_bus._pending_tasks.add(task)
+            task.add_done_callback(on_task_done)
+
+            await asyncio.wait_for(callback_done.wait(), timeout=1.0)
+
+        assert task not in event_bus._pending_tasks
+        mock_logger.error.assert_called_once()
+        exc_info = mock_logger.error.call_args.kwargs["exc_info"]
+        assert exc_info[0] is RuntimeError
+        assert isinstance(exc_info[1], RuntimeError)
+        assert str(exc_info[1]) == "pipeline failed"
+        assert exc_info[2] is exc_info[1].__traceback__
 
     @pytest.mark.asyncio
     async def test_dispatch_handles_missing_scheduler(


### PR DESCRIPTION
## Summary

- Keep strong references to EventBus pipeline tasks until they complete.
- Log completed task exceptions with their original traceback tuple.
- Add unit coverage for pending-task retention and traceback logging.

## Evidence from PR scan

- Recent PR #8618 (`973c3f82d9ae05add07640de9583c2e672dcc375`) addresses lost pipeline task references, but its review points out `logger.error(..., exc_info=exc)` loses the task traceback because `exc_info` needs a boolean or `(type, exc, traceback)` tuple.
- Current `master` still dispatches via a bare `asyncio.create_task(scheduler.execute(event))` in `astrbot/core/event_bus.py`, so the base branch still has the original task-retention issue.

## Checks

- `C:\Users\zacza\Desktop\x\ABD\.venv\Scripts\python.exe -m pytest tests/unit/test_event_bus.py -q` (`18 passed`; pytest cache warning only)
- `C:\Users\zacza\Desktop\x\ABD\.venv\Scripts\ruff.exe format --check astrbot/core/event_bus.py tests/unit/test_event_bus.py`
- `C:\Users\zacza\Desktop\x\ABD\.venv\Scripts\ruff.exe check astrbot/core/event_bus.py tests/unit/test_event_bus.py`
- `python -m py_compile astrbot/core/event_bus.py tests/unit/test_event_bus.py`

## Notes

- `uv run pytest tests/test_code_quality_typing.py -v` could not be run because that file is not present on current `master`.

## Summary by Sourcery

Ensure EventBus retains and tracks pipeline tasks until completion and logs failures with full traceback information.

Bug Fixes:
- Keep strong references to dispatched pipeline tasks to prevent them from being prematurely garbage-collected or lost while pending.
- Log pipeline task exceptions using the original exception and traceback tuple so that stack traces are preserved.

Tests:
- Add unit tests verifying that EventBus tracks pending pipeline tasks until they complete and clears them afterward.
- Add unit tests verifying that pipeline task failures log an error with a full (type, exception, traceback) exc_info tuple.