### PR TITLE
fix(dashboard): sync pnpm lockfile overrides

### DIFF
--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  immutable: 4.3.8
+  lodash-es: 4.17.23
+
 importers:
 
   .:
@@ -2066,9 +2070,6 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lodash-es@4.17.21:
-    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
-
   lodash-es@4.17.23:
     resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
 
@@ -3130,12 +3131,12 @@ snapshots:
     dependencies:
       '@chevrotain/gast': 11.0.3
       '@chevrotain/types': 11.0.3
-      lodash-es: 4.17.21
+      lodash-es: 4.17.23
 
   '@chevrotain/gast@11.0.3':
     dependencies:
       '@chevrotain/types': 11.0.3
-      lodash-es: 4.17.21
+      lodash-es: 4.17.23
 
   '@chevrotain/regexp-to-ast@11.0.3': {}
 
@@ -4259,7 +4260,7 @@ snapshots:
       '@chevrotain/regexp-to-ast': 11.0.3
       '@chevrotain/types': 11.0.3
       '@chevrotain/utils': 11.0.3
-      lodash-es: 4.17.21
+      lodash-es: 4.17.23
 
   chokidar@3.6.0:
     dependencies:
@@ -5057,8 +5058,6 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
-
-  lodash-es@4.17.21: {}
 
   lodash-es@4.17.23: {}
 


### PR DESCRIPTION
## Summary

- Regenerate dashboard/pnpm-lock.yaml so it records the pnpm.overrides declared in dashboard/package.json.
- Align the transitive lodash-es lockfile entries with the declared lodash-es@4.17.23 override.

## Evidence from PR scan

- Dashboard CI on master commit 6ae103a24f88a073ee2584d82321d472b04e4954 failed in run 27066032353.
- The same workflow also blocked unrelated Python-only PR #8636 at run 27079164635, job 79921828789.
- Failed job log shows ERR_PNPM_LOCKFILE_CONFIG_MISMATCH during pnpm install --frozen-lockfile: current overrides config did not match the lockfile.
- dashboard/package.json declares pnpm.overrides for immutable and lodash-es, while the previous lockfile lacked top-level overrides.

## Checks

- 
pm exec --yes pnpm@10.28.2 -- install --lockfile-only --ignore-scripts`n- 
pm exec --yes pnpm@10.28.2 -- install --frozen-lockfile --ignore-scripts`n- git diff --check`n
## Notes

- Local full pnpm install --frozen-lockfile progressed past the original lockfile mismatch, then this Windows sandbox blocked the sbuild postinstall child process with spawn EPERM; CI should validate lifecycle scripts on Ubuntu.

## Summary by Sourcery

Regenerate the dashboard pnpm lockfile to sync with the pnpm.overrides configuration and resolve lockfile override mismatches in CI.

Bug Fixes:
- Fix pnpm lockfile configuration mismatch errors during dashboard CI by aligning the lockfile with declared overrides.

Chores:
- Update dashboard/pnpm-lock.yaml to record pnpm.overrides for dependencies such as lodash-es and keep transitive entries consistent with the specified versions.