### PR TITLE
fix: Prevent duplicate web search citation prompts from being repeatedly appended to the system message after multiple tool invocations in a single interaction

### DIFF
--- a/astrbot/core/astr_agent_hooks.py
+++ b/astrbot/core/astr_agent_hooks.py
@@ -3,7 +3,6 @@ from typing import Any
 from mcp.types import CallToolResult
 
 from astrbot.core.agent.hooks import BaseAgentRunHooks
-from astrbot.core.agent.message import Message
 from astrbot.core.agent.run_context import ContextWrapper
 from astrbot.core.agent.tool import FunctionTool
 from astrbot.core.astr_agent_context import AstrAgentContext
@@ -69,37 +68,6 @@ class MainAgentHooks(BaseAgentRunHooks[AstrAgentContext]):
             tool_args,
             tool_result,
         )
-
-        # special handle web_search_tavily
-        platform_name = run_context.context.event.get_platform_name()
-        if (
-            platform_name == "webchat"
-            and tool.name
-            in [
-                "web_search_baidu",
-                "web_search_tavily",
-                "web_search_bocha",
-                "web_search_brave",
-            ]
-            and len(run_context.messages) > 0
-            and tool_result
-            and len(tool_result.content)
-        ):
-            # inject system prompt
-            first_part = run_context.messages[0]
-            if (
-                isinstance(first_part, Message)
-                and first_part.role == "system"
-                and first_part.content
-                and isinstance(first_part.content, str)
-            ):
-                # we assume system part is str
-                first_part.content += (
-                    "Always cite web search results you rely on. "
-                    "Index is a unique identifier for each search result. "
-                    "Use the exact citation format <ref>index</ref> (e.g. <ref>abcd.3</ref>) "
-                    "after the sentence that uses the information. Do not invent citations."
-                )
 
 
 class EmptyAgentHooks(BaseAgentRunHooks[AstrAgentContext]):

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -115,6 +115,20 @@ from astrbot.core.utils.quoted_message_parser import (
 from astrbot.core.utils.string_utils import normalize_and_dedupe_strings
 
 LLM_ERROR_MESSAGE_EXTRA_KEY = "_llm_error_message"
+WEB_SEARCH_CITATION_TOOL_NAMES = frozenset(
+    {
+        "web_search_baidu",
+        "web_search_tavily",
+        "web_search_bocha",
+        "web_search_brave",
+    }
+)
+WEB_SEARCH_CITATION_PROMPT = (
+    "Always cite web search results you rely on. "
+    "Index is a unique identifier for each search result. "
+    "Use the exact citation format <ref>index</ref> (e.g. <ref>abcd.3</ref>) "
+    "after the sentence that uses the information. Do not invent citations."
+)
 
 
 @dataclass(slots=True)
@@ -1149,6 +1163,23 @@ async def _apply_web_search_tools(
         req.func_tool.add_tool(tool_mgr.get_builtin_tool(BaiduWebSearchTool))
 
 
+def _apply_web_search_citation_prompt(
+    event: AstrMessageEvent,
+    req: ProviderRequest,
+) -> None:
+    if event.get_platform_name() != "webchat" or not req.func_tool:
+        return
+
+    if not any(req.func_tool.get_tool(name) for name in WEB_SEARCH_CITATION_TOOL_NAMES):
+        return
+
+    system_prompt = req.system_prompt or ""
+    if WEB_SEARCH_CITATION_PROMPT in system_prompt:
+        return
+
+    req.system_prompt = f"{system_prompt}\n{WEB_SEARCH_CITATION_PROMPT}\n"
+
+
 def _get_compress_provider(
     config: MainAgentBuildConfig,
     plugin_context: Context,
@@ -1519,6 +1550,8 @@ async def build_main_agent(
     action_type = event.get_extra("action_type")
     if action_type == "live":
         req.system_prompt += f"\n{LIVE_MODE_SYSTEM_PROMPT}\n"
+
+    _apply_web_search_citation_prompt(event, req)
 
     reset_coro = agent_runner.reset(
         provider=provider,

--- a/tests/unit/test_astr_main_agent.py
+++ b/tests/unit/test_astr_main_agent.py
@@ -476,6 +476,46 @@ class TestBuiltinToolInjection:
         assert req.func_tool.get_tool("web_search_firecrawl") is search_tool
         assert req.func_tool.get_tool("firecrawl_extract_web_page") is extract_tool
 
+    def test_apply_web_search_citation_prompt_for_webchat(self, mock_event):
+        module = ama
+        req = ProviderRequest(system_prompt="base")
+        search_tool = MagicMock(spec=FunctionTool)
+        search_tool.name = "web_search_tavily"
+        req.func_tool = ToolSet()
+        req.func_tool.add_tool(search_tool)
+        mock_event.get_platform_name.return_value = "webchat"
+
+        module._apply_web_search_citation_prompt(mock_event, req)
+
+        assert module.WEB_SEARCH_CITATION_PROMPT in req.system_prompt
+
+    def test_apply_web_search_citation_prompt_is_idempotent(self, mock_event):
+        module = ama
+        req = ProviderRequest(system_prompt="")
+        search_tool = MagicMock(spec=FunctionTool)
+        search_tool.name = "web_search_tavily"
+        req.func_tool = ToolSet()
+        req.func_tool.add_tool(search_tool)
+        mock_event.get_platform_name.return_value = "webchat"
+
+        module._apply_web_search_citation_prompt(mock_event, req)
+        module._apply_web_search_citation_prompt(mock_event, req)
+
+        assert req.system_prompt.count(module.WEB_SEARCH_CITATION_PROMPT) == 1
+
+    def test_apply_web_search_citation_prompt_requires_webchat(self, mock_event):
+        module = ama
+        req = ProviderRequest(system_prompt="")
+        search_tool = MagicMock(spec=FunctionTool)
+        search_tool.name = "web_search_tavily"
+        req.func_tool = ToolSet()
+        req.func_tool.add_tool(search_tool)
+        mock_event.get_platform_name.return_value = "test_platform"
+
+        module._apply_web_search_citation_prompt(mock_event, req)
+
+        assert module.WEB_SEARCH_CITATION_PROMPT not in req.system_prompt
+
     def test_proactive_cron_job_tools_uses_builtin_tool_manager(self, mock_context):
         """Test cron tool injection through the builtin tool manager."""
         module = ama


### PR DESCRIPTION
fix: #8414

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [ ] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [ ] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [ ] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure web search citation guidance is injected once at agent build time instead of on every tool invocation.

Bug Fixes:
- Prevent duplicate web search citation prompts from being appended to the system message during multiple tool runs in a single interaction.

Enhancements:
- Centralize web search citation prompt injection in the main agent build flow using a shared helper and constant prompt text.

Tests:
- Add unit tests to verify citation prompt injection only for webchat, idempotency of the helper, and absence on non-webchat platforms.