### PR TITLE
fix: dispose database engine on shutdown

### DIFF
--- a/astrbot/core/core_lifecycle.py
+++ b/astrbot/core/core_lifecycle.py
@@ -391,6 +391,12 @@ class AstrBotCoreLifecycle:
             except Exception as e:
                 logger.error(f"任务 {task.get_name()} 发生错误: {e}")
 
+        # 释放数据库引擎连接池
+        try:
+            await self.db.engine.dispose()
+        except Exception as e:
+            logger.warning(f"释放数据库引擎失败: {e}")
+
     async def restart(self) -> None:
         """重启 AstrBot 核心生命周期管理类, 终止各个管理器并重新加载平台实例"""
         await self.provider_manager.terminate()


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
After #7724 was reverted (#8638), the SQLite engines use SQLAlchemy's default connection pool again instead of `NullPool`. Each pooled `aiosqlite` connection owns a background worker thread, and `aiosqlite` never marks these threads as daemon, so they inherit the main thread's non-daemon status. `core_lifecycle.stop()` terminates every manager but never disposes the main database engine, so the pool's idle connection threads stay alive and block `threading._shutdown()` at interpreter exit. As a result, a single Ctrl+C hangs instead of shutting down cleanly. `NullPool` had been masking this by closing each connection (and its thread) right after use.
### Modifications / 改动点
- `astrbot/core/core_lifecycle.py`: dispose `self.db.engine` at the end of `stop()` so the connection pool closes idle connections and their `aiosqlite` worker threads exit, letting the process terminate. The knowledge base engine is already disposed in its own `close()`; this aligns the main engine.
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
Before:
<img width="1067" height="162" alt="HapiGo_2026-06-07_07 34 32" src="https://github.com/user-attachments/assets/d794064e-f0e3-4e8f-a36b-ded5d51ecf29" />
After:
<img width="1035" height="95" alt="image" src="https://github.com/user-attachments/assets/58057cfe-cd86-41e4-bacd-d1ebec98fa96" />
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Ensure database engine disposal on shutdown to prevent lingering aiosqlite worker threads from blocking interpreter exit.