### PR TITLE
fix:plugin uninstall file handle leak

### DIFF
--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -1616,6 +1616,7 @@ class PluginManager:
         plugin.star_cls_type = None
 
         plugin_dir_norm = os.path.normcase(os.path.normpath(plugin_dir))
+        self_locals_id = id(locals())
         for obj in gc.get_objects():
             if not isinstance(obj, ImageFont.FreeTypeFont):
                 continue
@@ -1626,8 +1627,9 @@ class PluginManager:
                 plugin_dir_norm + os.sep
             ):
                 continue
+            logger.debug(f"释放字体句柄: {font_path}")
             for referrer in gc.get_referrers(obj):
-                if not isinstance(referrer, dict):
+                if not isinstance(referrer, dict) or id(referrer) == self_locals_id:
                     continue
                 for k in [k for k, v in referrer.items() if v is obj]:
                     referrer[k] = None

--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -1549,6 +1549,11 @@ class PluginManager:
 
             await self._unbind_plugin(plugin_name, plugin.module_path)
 
+            plugin_module_prefix = plugin.module_path.rsplit(".", 1)[0]
+            plugin_dir = os.path.join(ppath, root_dir_name)
+            await self._cancel_plugin_tasks(plugin_module_prefix)
+            self._release_plugin_font_handles(plugin, plugin_dir)
+
             # 删除插件文件夹
             try:
                 remove_dir(os.path.join(ppath, root_dir_name))
@@ -1563,6 +1568,71 @@ class PluginManager:
                 delete_config=delete_config,
                 delete_data=delete_data,
             )
+
+    async def _cancel_plugin_tasks(self, plugin_module_prefix: str) -> None:
+        """取消并等待属于指定插件模块的所有 asyncio tasks。"""
+        plugin_tasks = []
+        for task in asyncio.all_tasks():
+            if task.done():
+                continue
+            coro = task.get_coro()
+            frame = getattr(coro, "cr_frame", None)
+            if frame is None:
+                continue
+            mod_name = frame.f_globals.get("__name__", "")
+            if mod_name == plugin_module_prefix or mod_name.startswith(
+                plugin_module_prefix + "."
+            ):
+                plugin_tasks.append(task)
+
+        if not plugin_tasks:
+            return
+
+        logger.debug(
+            f"取消插件 {plugin_module_prefix} 的 {len(plugin_tasks)} 个 asyncio tasks"
+        )
+        for task in plugin_tasks:
+            task.cancel()
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*plugin_tasks, return_exceptions=True),
+                timeout=5.0,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"插件 {plugin_module_prefix} 的部分 tasks 在 5 秒内未能取消，"
+                "可能导致文件句柄未释放。"
+            )
+        await asyncio.sleep(0)
+
+    def _release_plugin_font_handles(self, plugin, plugin_dir: str) -> None:
+        """释放插件目录下字体文件的句柄，确保删除目录前文件不被占用。"""
+        import gc
+
+        from PIL import ImageFont
+
+        plugin.star_cls = None
+        plugin.module = None
+        plugin.star_cls_type = None
+
+        plugin_dir_norm = os.path.normcase(os.path.normpath(plugin_dir))
+        for obj in gc.get_objects():
+            if not isinstance(obj, ImageFont.FreeTypeFont):
+                continue
+            font_path = getattr(obj, "path", None)
+            if not isinstance(font_path, str):
+                continue
+            if not os.path.normcase(os.path.normpath(font_path)).startswith(
+                plugin_dir_norm + os.sep
+            ):
+                continue
+            for referrer in gc.get_referrers(obj):
+                if not isinstance(referrer, dict):
+                    continue
+                for k in [k for k, v in referrer.items() if v is obj]:
+                    referrer[k] = None
+
+        gc.collect()
 
     async def uninstall_failed_plugin(
         self,

--- a/astrbot/core/utils/io.py
+++ b/astrbot/core/utils/io.py
@@ -33,13 +33,63 @@ def on_error(func, path, exc_info) -> None:
         raise exc_info[1]
 
 
+def _force_remove_file_windows(path: str, retries: int = 5, delay: float = 0.1) -> None:
+    """在 Windows 上强制删除被占用的文件，带重试。"""
+    import stat
+
+    try:
+        os.chmod(path, stat.S_IWUSR | stat.S_IRUSR)
+    except Exception:
+        pass
+
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            os.remove(path)
+            return
+        except PermissionError as e:
+            last_exc = e
+            if attempt < retries - 1:
+                time.sleep(delay)
+        except FileNotFoundError:
+            return
+
+    raise PermissionError(
+        f"无法删除文件（已重试 {retries} 次），文件可能仍被其他进程占用: {path}"
+    ) from last_exc
+
+
+def _on_error_windows(func, path, exc_info) -> None:
+    """rmtree 的 Windows 错误回调，对被锁定的文件做重试。"""
+    import stat
+
+    exc = exc_info[1]
+    win_error = getattr(exc, "winerror", None)
+    if win_error in (5, 32) and func is os.unlink:
+        _force_remove_file_windows(path)
+        return
+
+    if not os.access(path, os.W_OK):
+        os.chmod(path, stat.S_IWUSR)
+        func(path)
+    else:
+        raise exc
+
+
 def remove_dir(file_path: str) -> bool:
     if not os.path.lexists(file_path):
         return True
     if os.path.isfile(file_path) or os.path.islink(file_path):
-        os.remove(file_path)
+        try:
+            os.remove(file_path)
+        except PermissionError:
+            if os.name == "nt":
+                _force_remove_file_windows(file_path)
+            else:
+                raise
     else:
-        shutil.rmtree(file_path, onerror=on_error)
+        error_handler = _on_error_windows if os.name == "nt" else on_error
+        shutil.rmtree(file_path, onerror=error_handler)
     return True
 
 


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

在 Windows 上卸载含有字体文件（如 `.ttc`）的插件时，字体文件句柄未被释放，导致 `shutil.rmtree` 删除目录时触发 `[WinError 5] 拒绝访问`，卸载失败。

### Modifications / 改动点
 
`astrbot/core/utils/io.py`
 
- 新增 `_force_remove_file_windows`：对被占用的文件带重试地强制删除
- 新增 `_on_error_windows`：`rmtree` 的 Windows 错误回调，对 `WinError 5/32` 的文件走重试，目录走原有权限修复逻辑
- `remove_dir` 在 Windows 上使用上述增强回调

`astrbot/core/star/star_manager.py`
 
- 新增 `_cancel_plugin_tasks`：卸载前取消插件创建的 asyncio tasks，防止协程帧持有插件实例进而持有字体对象
- 新增 `_release_plugin_font_handles`：断开 `StarMetadata` 上的已知引用链（`star_cls` / `module` / `star_cls_type`），并用 `gc.get_objects()` 扫描所有存活的 `FreeTypeFont` 对象，找出路径在插件目录下的，通过 `gc.get_referrers` 强制断开引用，触发 GC 释放文件句柄
- `uninstall_plugin` 在删除目录前依次调用上述两个方法
 
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure Windows plugin uninstallation can delete font files by releasing font handles and hardening directory removal.

Bug Fixes:
- Fix Windows plugin uninstall failures caused by locked font files by cancelling plugin tasks and releasing font handles before directory removal.
- Improve directory removal on Windows by retrying deletion of locked files and handling permission errors for shutil.rmtree.