### PR TITLE
fix: restore star context typing

### DIFF
--- a/astrbot/core/star/base.py
+++ b/astrbot/core/star/base.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any
 
 from astrbot.core import html_renderer
 from astrbot.core.utils.command_parser import CommandParserMixin
 from astrbot.core.utils.plugin_kv_store import PluginKVStoreMixin
 
 from .star import StarMetadata, star_map, star_registry
+
+if TYPE_CHECKING:
+    from .context import Context
 
 logger = logging.getLogger("astrbot")
 
@@ -17,11 +20,9 @@ class Star(CommandParserMixin, PluginKVStoreMixin):
 
     author: str
     name: str
+    context: Context
 
-    class _ContextLike(Protocol):
-        def get_config(self, umo: str | None = None) -> Any: ...
-
-    def __init__(self, context: _ContextLike, config: dict | None = None) -> None:
+    def __init__(self, context: Context, config: dict | None = None) -> None:
         self.context = context
 
     def _get_context_config(self) -> Any:


### PR DESCRIPTION
## Summary
- remove the local _ContextLike protocol from Star
- type Star.context and Star.__init__ with the real Context under TYPE_CHECKING
- keep runtime imports unchanged to avoid reintroducing the circular dependency fixed by #5353

## Tests
- uv run pytest tests/unit/test_star_base.py
- uv run ruff format astrbot/core/star/base.py
- uv run ruff check astrbot/core/star/base.py

## Summary by Sourcery

Restore Star context attribute and constructor typing to use the real Context type while preserving existing runtime import behavior.

Bug Fixes:
- Align Star.context and Star.__init__ type annotations with the actual Context type to prevent incorrect or incomplete typing of the Star context.

Enhancements:
- Remove the local _ContextLike protocol in favor of the concrete Context type under TYPE_CHECKING for clearer and more accurate static typing.