### PR TITLE
feat(ci): allow conventional PR title prefixes

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -21,6 +21,8 @@ jobs:
             // Allow Conventional Commit style PR titles.
             // Examples:
             // feat: xxx
+            // feat(scope): xxx
+            // fix: xxx
             // fix(scope): xxx
             const allowedTypes = "feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert";
             const pattern = new RegExp(`^(${allowedTypes})(\\([a-z0-9-]+\\))?:\\s.+$`, "i");
@@ -39,6 +41,8 @@ jobs:
                       "⚠️ PR title format check failed.",
                       "Required formats:",
                       "- `feat: xxx`",
+                      "- `feat(scope): xxx`",
+                      "- `fix: xxx`",
                       "- `fix(scope): xxx`",
                       "- `chore: xxx`",
                       "",
@@ -56,5 +60,5 @@ jobs:
             }
 
             if (!isValid) {
-              core.setFailed("Invalid PR title. Expected Conventional Commit format, e.g. feat: xxx or fix(scope): xxx.");
+              core.setFailed("Invalid PR title. Expected Conventional Commit format, e.g. feat: xxx, feat(scope): xxx, or fix: xxx.");
             }

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -18,10 +18,12 @@ jobs:
         with:
           script: |
             const title = (context.payload.pull_request.title || "").trim();
-            // allow only:
+            // Allow Conventional Commit style PR titles.
+            // Examples:
             // feat: xxx
-            // feat(scope): xxx
-            const pattern = /^(feat)(\([a-z0-9-]+\))?:\s.+$/i;
+            // fix(scope): xxx
+            const allowedTypes = "feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert";
+            const pattern = new RegExp(`^(${allowedTypes})(\\([a-z0-9-]+\\))?:\\s.+$`, "i");
             const isValid = pattern.test(title);
             const isSameRepo =
               context.payload.pull_request.head.repo.full_name === context.payload.repository.full_name;
@@ -37,7 +39,11 @@ jobs:
                       "⚠️ PR title format check failed.",
                       "Required formats:",
                       "- `feat: xxx`",
-                      "- `feat(scope): xxx`",
+                      "- `fix(scope): xxx`",
+                      "- `chore: xxx`",
+                      "",
+                      "Allowed prefixes:",
+                      "`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`, `revert`",
                       "Please update your PR title and push again."
                     ].join("\n")
                   });
@@ -50,5 +56,5 @@ jobs:
             }
 
             if (!isValid) {
-              core.setFailed("Invalid PR title. Expected format: feat: xxx or feat(scope): xxx.");
+              core.setFailed("Invalid PR title. Expected Conventional Commit format, e.g. feat: xxx or fix(scope): xxx.");
             }


### PR DESCRIPTION
### Modifications / 改动点

This PR aligns the PR title workflow with the repository's CONTRIBUTING guide.

本 PR 将 PR 标题检查 workflow 与仓库 CONTRIBUTING 中的语义化标题规则对齐。

- Allow common Conventional Commit prefixes in `.github/workflows/pr-title-check.yml`: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`, and `revert`.
- Update the failure comment and error message so contributors see the accepted formats.
- Keep the existing `feat: xxx` and `feat(scope): xxx` behavior working.
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Verification:

```text
node -e 'const allowedTypes="feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert"; const pattern=new RegExp("^("+allowedTypes+")(\\([a-z0-9-]+\\))?:\\s.+$","i"); const good=["feat: add thing","fix(core): handle thing","chore: bump deps","perf(provider): reduce calls","Revert: previous change"]; const bad=["update thing","fix(scope) missing colon","feat(scope) : extra space","fix:"]; for (const t of good) if (!pattern.test(t)) throw new Error("expected pass: "+t); for (const t of bad) if (pattern.test(t)) throw new Error("expected fail: "+t); console.log("ok pr-title pattern cases passed");'
ok pr-title pattern cases passed

git diff --check
# no whitespace errors
```

Duplicate check:

```text
gh pr list --repo AstrBotDevs/AstrBot --state open --limit 100 --json number,title,files,url
# No open PR among the first 100 modifies .github/workflows/pr-title-check.yml.
```

### Checklist / 检查清单

- [x] 😊 No user-facing feature is added; this checklist item is N/A.
  / 未新增面向用户的功能；此项不适用。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Align the PR title validation workflow with the repository's Conventional Commit-style title rules.

Enhancements:
- Improve PR title failure messages to clearly document the required Conventional Commit formats and allowed prefixes.

CI:
- Expand the PR title check workflow to accept common Conventional Commit prefixes (feat, fix, docs, style, refactor, perf, test, chore, ci, build, revert).