### PR TITLE
feat(core): show weekday in datetime prompt

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -115,6 +115,15 @@ from astrbot.core.utils.quoted_message_parser import (
 from astrbot.core.utils.string_utils import normalize_and_dedupe_strings
 
 LLM_ERROR_MESSAGE_EXTRA_KEY = "_llm_error_message"
+WEEKDAY_NAMES = (
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+    "Sunday",
+)
 WEB_SEARCH_CITATION_TOOL_NAMES = frozenset(
     {
         "web_search_baidu",
@@ -874,18 +883,17 @@ def _append_system_reminders(
                 system_parts.append(f"Group name: {group_name}")
 
     if cfg.get("datetime_system_prompt"):
-        current_time = None
+        now = None
         if timezone:
             try:
                 now = datetime.datetime.now(zoneinfo.ZoneInfo(timezone))
-                current_time = now.strftime("%Y-%m-%d %H:%M (%Z)")
             except Exception as exc:  # noqa: BLE001
                 logger.error("时区设置错误: %s, 使用本地时区", exc)
-        if not current_time:
-            current_time = (
-                datetime.datetime.now().astimezone().strftime("%Y-%m-%d %H:%M (%Z)")
-            )
-        system_parts.append(f"Current datetime: {current_time}")
+        if now is None:
+            now = datetime.datetime.now().astimezone()
+        current_time = now.strftime("%Y-%m-%d %H:%M (%Z)")
+        weekday = WEEKDAY_NAMES[now.weekday()]
+        system_parts.append(f"Current datetime: {current_time}, Weekday: {weekday}")
 
     if system_parts:
         system_content = (

--- a/tests/unit/test_astr_main_agent.py
+++ b/tests/unit/test_astr_main_agent.py
@@ -1,5 +1,6 @@
 """Tests for astr_main_agent module."""
 
+import datetime
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -132,6 +133,39 @@ def _setup_conversation_for_build(conv_mgr, cid: str = "conv-id") -> MagicMock:
     conversation = _new_mock_conversation(cid=cid)
     conv_mgr.get_conversation = AsyncMock(return_value=conversation)
     return conversation
+
+
+def test_append_system_reminders_includes_weekday(mock_event):
+    """Test datetime reminder includes weekday information."""
+    req = ProviderRequest(prompt="Hello")
+    fixed_now = datetime.datetime(
+        2026,
+        6,
+        8,
+        12,
+        34,
+        tzinfo=datetime.timezone.utc,
+    )
+
+    class FixedDateTime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            if tz:
+                return fixed_now.astimezone(tz)
+            return fixed_now
+
+    with patch("astrbot.core.astr_main_agent.datetime.datetime", FixedDateTime):
+        ama._append_system_reminders(
+            mock_event,
+            req,
+            {"datetime_system_prompt": True},
+            "UTC",
+        )
+
+    assert [part.text for part in req.extra_user_content_parts] == [
+        "<system_reminder>Current datetime: "
+        "2026-06-08 12:34 (UTC), Weekday: Monday</system_reminder>"
+    ]
 
 
 class TestMainAgentBuildConfig:


### PR DESCRIPTION
当前 AstrBot 在开启“现实世界时间感知”后，会向模型补充当前日期、时间和时区信息，但不会直接提供“今天是星期几”。

这会让模型在处理日程、提醒、周期性安排、相对日期理解等场景时，需要自行根据日期推算星期，增加出错概率。本 PR 在现有时间提示中追加 Weekday 字段，让模型可以直接感知当前星期信息。

### Modifications / 改动点

- 在 `astrbot/core/astr_main_agent.py` 中，将现实世界时间感知提示从 `Current datetime: YYYY-MM-DD HH:MM (TZ)` 扩展为 `Current datetime: YYYY-MM-DD HH:MM (TZ), Weekday: Monday`。
- 使用固定英文星期表和 `now.weekday()` 生成 Weekday，避免依赖系统 locale 导致不同运行环境输出不一致。
- 保持原有时区逻辑不变：优先使用配置时区，配置错误时继续回退到本地时区。
- 在 `tests/unit/test_astr_main_agent.py` 中新增单测，覆盖时间提示中包含 Weekday 的输出格式。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

已执行以下测试：

```bash
PYTHONPATH=. pytest -s tests/unit/test_astr_main_agent.py -q
```

结果：

```text
87 passed, 1 warning in 2.36s
```

同时执行：

```bash
git diff --check
PYTHONPATH=. python -m compileall -q astrbot/core/astr_main_agent.py tests/unit/test_astr_main_agent.py
```

以上检查均通过。

补充说明：当前环境没有安装 `uv`，因此未使用 `uv run pytest` 执行测试；本地改用 `PYTHONPATH=.` 方式运行目标单测文件。

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Include weekday information in the datetime system reminder prompt for AstrBot and add corresponding tests.

New Features:
- Expose the current weekday alongside date, time, and timezone in the system datetime prompt to the model.

Tests:
- Add a unit test to verify that the datetime system reminder includes the weekday with a fixed datetime context.