### PR TITLE
Fix CLI version source

### DIFF
--- a/astrbot/cli/__init__.py
+++ b/astrbot/cli/__init__.py
@@ -1,1 +1,3 @@
-__version__ = "4.25.3"
+from astrbot.core.config.default import VERSION
+
+__version__ = VERSION


### PR DESCRIPTION
## Summary
- use the existing core `VERSION` constant as the CLI version source
- keep `astrbot --version` aligned with the core application version

## Why
In the current master, `pyproject.toml` and `astrbot.core.config.default.VERSION` report `4.25.5`, while `astrbot --version` reports `4.25.3` because the CLI version is hardcoded separately.

Reusing the existing core version constant avoids maintaining another manual version field for the CLI.

## Verification
- `uv run ruff check .`
- `uv run python -m compileall -q astrbot\cli\__init__.py`
- `uv run python -c "from astrbot.cli import __version__; print(__version__)"` returned `4.25.5`