### PR TITLE
fix: defer faiss C library import to prevent process hang on startup

### DIFF
--- a/astrbot/core/db/vec_db/faiss_impl/__init__.py
+++ b/astrbot/core/db/vec_db/faiss_impl/__init__.py
@@ -1,3 +1,9 @@
-from .vec_db import FaissVecDB
+def __getattr__(name: str):
+    if name == "FaissVecDB":
+        from .vec_db import FaissVecDB
+
+        return FaissVecDB
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = ["FaissVecDB"]

--- a/astrbot/core/db/vec_db/faiss_impl/embedding_storage.py
+++ b/astrbot/core/db/vec_db/faiss_impl/embedding_storage.py
@@ -7,10 +7,10 @@ class EmbeddingStorage:
     def __init__(self, dimension: int, path: str | None = None) -> None:
         try:
             import faiss
-        except ModuleNotFoundError:
+        except ModuleNotFoundError as e:
             raise ImportError(
                 "faiss 未安装。请使用 'pip install faiss-cpu' 或 'pip install faiss-gpu' 安装。",
-            )
+            ) from e
         self._faiss = faiss
         self.dimension = dimension
         self.path = path

--- a/astrbot/core/db/vec_db/faiss_impl/embedding_storage.py
+++ b/astrbot/core/db/vec_db/faiss_impl/embedding_storage.py
@@ -1,9 +1,3 @@
-try:
-    import faiss
-except ModuleNotFoundError:
-    raise ImportError(
-        "faiss 未安装。请使用 'pip install faiss-cpu' 或 'pip install faiss-gpu' 安装。",
-    )
 import os
 
 import numpy as np
@@ -11,6 +5,13 @@ import numpy as np
 
 class EmbeddingStorage:
     def __init__(self, dimension: int, path: str | None = None) -> None:
+        try:
+            import faiss
+        except ModuleNotFoundError:
+            raise ImportError(
+                "faiss 未安装。请使用 'pip install faiss-cpu' 或 'pip install faiss-gpu' 安装。",
+            )
+        self._faiss = faiss
         self.dimension = dimension
         self.path = path
         self.index = None
@@ -67,7 +68,7 @@ class EmbeddingStorage:
 
         """
         assert self.index is not None, "FAISS index is not initialized."
-        faiss.normalize_L2(vector)
+        self._faiss.normalize_L2(vector)
         distances, indices = self.index.search(vector, k)
         return distances, indices
 
@@ -92,4 +93,4 @@ class EmbeddingStorage:
         """
         if self.index is None:
             return
-        faiss.write_index(self.index, self.path)
+        self._faiss.write_index(self.index, self.path)

--- a/astrbot/core/db/vec_db/faiss_impl/vec_db.py
+++ b/astrbot/core/db/vec_db/faiss_impl/vec_db.py
@@ -9,7 +9,6 @@ from astrbot.core.provider.provider import EmbeddingProvider, RerankProvider
 
 from ..base import BaseVecDB, Result
 from .document_storage import DocumentStorage
-from .embedding_storage import EmbeddingStorage
 
 
 class FaissVecDB(BaseVecDB):
@@ -22,6 +21,8 @@ class FaissVecDB(BaseVecDB):
         embedding_provider: EmbeddingProvider,
         rerank_provider: RerankProvider | None = None,
     ) -> None:
+        from .embedding_storage import EmbeddingStorage
+
         self.doc_store_path = doc_store_path
         self.index_store_path = index_store_path
         self.embedding_provider = embedding_provider

--- a/astrbot/core/db/vec_db/faiss_impl/vec_db.py
+++ b/astrbot/core/db/vec_db/faiss_impl/vec_db.py
@@ -9,6 +9,7 @@ from astrbot.core.provider.provider import EmbeddingProvider, RerankProvider
 
 from ..base import BaseVecDB, Result
 from .document_storage import DocumentStorage
+from .embedding_storage import EmbeddingStorage
 
 
 class FaissVecDB(BaseVecDB):
@@ -21,8 +22,6 @@ class FaissVecDB(BaseVecDB):
         embedding_provider: EmbeddingProvider,
         rerank_provider: RerankProvider | None = None,
     ) -> None:
-        from .embedding_storage import EmbeddingStorage
-
         self.doc_store_path = doc_store_path
         self.index_store_path = index_store_path
         self.embedding_provider = embedding_provider


### PR DESCRIPTION
Fixes #8695

## What happened / 发生了什么

`astrbot/core/db/vec_db/faiss_impl/embedding_storage.py` 顶层执行 `import faiss`，在 faiss-cpu 1.14.2 环境下，C 库的 CPU 指令集检测会永久阻塞（死锁）或触发 SIGILL 非法指令崩溃，导致进程异常退出。

## Modifications / 改动点

1. **`embedding_storage.py`**: 将 `import faiss` 从模块顶层移至 `__init__()` 方法内，存为 `self._faiss`，所有 faiss 调用通过实例属性访问
2. **`vec_db.py`**: 将 `from .embedding_storage import EmbeddingStorage` 从顶层移至 `__init__()` 方法内（局部导入）
3. **`faiss_impl/__init__.py`**: 使用 `__getattr__` 实现懒加载，避免顶层触发导入链

这是 PR #7400 懒加载改造的延续——PR #7400 处理了消费端文件（`kb_helper.py` 等），本次处理 faiss 模块自身的顶层导入。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Verification Steps / 验证步骤

1. 不安装 faiss 的环境下，模块导入不会报错
2. 安装 faiss-cpu 1.14.2 的环境下，启动不再挂死（进程正常退出并报错提示 faiss 不可用）
3. 安装 faiss-cpu 1.13.2 的环境下，功能正常

### Checklist / 检查清单

- [x] 👀 My changes have been well-tested
- [x] 🤓 No new dependencies introduced
- [x] 😮 No malicious code introduced

## Summary by Sourcery

Defer FAISS-related imports and initialization to runtime to avoid startup hangs and crashes when the FAISS C library is unavailable or misconfigured.

Bug Fixes:
- Prevent process hangs or crashes on startup caused by eager importing of the FAISS C library in certain faiss-cpu environments.

Enhancements:
- Lazy-load FAISS within the embedding storage and vector DB modules, routing FAISS usage through an instance attribute and module-level __getattr__ to minimize import-time side effects.