### PR TITLE
fix(cron): trigger llm request hooks before resetting main agent

### DIFF
--- a/astrbot/core/cron/manager.py
+++ b/astrbot/core/cron/manager.py
@@ -14,9 +14,11 @@ from astrbot.core.agent.tool import ToolSet
 from astrbot.core.cron.events import CronMessageEvent
 from astrbot.core.db import BaseDatabase
 from astrbot.core.db.po import CronJob
+from astrbot.core.pipeline.context_utils import call_event_hook
 from astrbot.core.platform.message_session import MessageSession
 from astrbot.core.platform.message_type import MessageType
 from astrbot.core.provider.entites import ProviderRequest
+from astrbot.core.star.star_handler import EventType
 from astrbot.core.utils.history_saver import persist_agent_history
 
 if TYPE_CHECKING:
@@ -377,14 +379,31 @@ class CronJobManager:
                 self.ctx.get_llm_tool_manager().get_builtin_tool(SendMessageToUserTool)
             )
 
+        await call_event_hook(cron_event, EventType.OnWaitingLLMRequestEvent)
+
         result = await build_main_agent(
-            event=cron_event, plugin_context=self.ctx, config=config, req=req
+            event=cron_event,
+            plugin_context=self.ctx,
+            config=config,
+            req=req,
+            apply_reset=False,
         )
         if not result:
             logger.error("Failed to build main agent for cron job.")
             return
 
         runner = result.agent_runner
+        req = result.provider_request
+        reset_coro = result.reset_coro
+
+        if await call_event_hook(cron_event, EventType.OnLLMRequestEvent, req):
+            if reset_coro:
+                reset_coro.close()
+            return
+
+        if reset_coro:
+            await reset_coro
+
         async for _ in runner.step_until_done(30):
             # agent will send message to user via using tools
             pass

--- a/tests/unit/test_cron_manager.py
+++ b/tests/unit/test_cron_manager.py
@@ -5,8 +5,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from astrbot.core.astr_main_agent import MainAgentBuildResult
 from astrbot.core.cron.manager import CronJobManager, CronJobSchedulingError
 from astrbot.core.db.po import CronJob
+from astrbot.core.platform.message_session import MessageSession
+from astrbot.core.platform.message_type import MessageType
+from astrbot.core.provider.entities import ProviderRequest
 
 
 @pytest.fixture
@@ -503,3 +507,80 @@ class TestGetNextRunTime:
         next_run = cron_manager._get_next_run_time("non-existent")
 
         assert next_run is None
+
+
+class TestWokeMainAgent:
+    """Tests for cron-triggered main-agent wake flow."""
+
+    @pytest.mark.asyncio
+    async def test_woke_main_agent_calls_llm_request_hook_before_reset(
+        self, cron_manager, mock_context
+    ):
+        """Test cron path mirrors the normal request-hook timing."""
+
+        async def reset_stub():
+            return None
+
+        async def empty_steps(*args, **kwargs):
+            if False:
+                yield None
+
+        cron_manager.ctx = mock_context
+        mock_context.get_config.return_value = {
+            "admins_id": [],
+            "provider_settings": {"tool_call_timeout": 120},
+        }
+        mock_context.conversation_manager.get_curr_conversation_id = AsyncMock(
+            return_value="conv-id"
+        )
+        mock_context.conversation_manager.get_conversation = AsyncMock(
+            return_value=MagicMock(history="[]", cid="conv-id", persona_id=None)
+        )
+        mock_context.get_llm_tool_manager.return_value = MagicMock()
+
+        req = ProviderRequest(prompt="scheduled")
+        runner = MagicMock()
+        runner.step_until_done = empty_steps
+        runner.get_final_llm_resp.return_value = None
+        build_result = MainAgentBuildResult(
+            agent_runner=runner,
+            provider_request=req,
+            provider=MagicMock(),
+            reset_coro=reset_stub(),
+        )
+
+        with (
+            patch(
+                "astrbot.core.astr_main_agent.build_main_agent",
+                AsyncMock(return_value=build_result),
+            ) as mock_build_main_agent,
+            patch(
+                "astrbot.core.cron.manager.call_event_hook",
+                AsyncMock(side_effect=[False, True]),
+                create=True,
+            ) as mock_call_event_hook,
+            patch(
+                "astrbot.core.cron.manager.persist_agent_history",
+                AsyncMock(),
+            ),
+        ):
+            await cron_manager._woke_main_agent(
+                message="hello",
+                session_str=MessageSession(
+                    platform_name="cron",
+                    message_type=MessageType.OTHER_MESSAGE,
+                    session_id="test-session",
+                ),
+                extras={"cron_job": {}, "cron_payload": {}},
+            )
+
+        assert mock_build_main_agent.await_args.kwargs["apply_reset"] is False
+        assert (
+            mock_call_event_hook.await_args_list[0].args[1].name
+            == "OnWaitingLLMRequestEvent"
+        )
+        assert (
+            mock_call_event_hook.await_args_list[1].args[1].name
+            == "OnLLMRequestEvent"
+        )
+        assert mock_call_event_hook.await_args_list[1].args[2] is req


### PR DESCRIPTION
Align cron-triggered main-agent wake flow with the normal LLM request path.

Closes #8701

Fixes the inconsistency where cron-triggered main-agent requests did not follow the same hook semantics as normal LLM requests. Previously, plugins relying on `OnWaitingLLMRequestEvent` or `OnLLMRequestEvent` could work in regular conversations but not in cron-triggered proactive tasks.

This change limits its scope to the `cron` path only. It does not alter the hook behavior of background-task result callbacks or other internal wake flows.

- trigger `OnWaitingLLMRequestEvent` before building the main agent
- build the cron main agent with `apply_reset=False`
- trigger `OnLLMRequestEvent` before awaiting `reset_coro`
- preserve hook-based interception by closing `reset_coro` when stopped
- add a regression test for cron hook timing

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

- Updated `astrbot/core/cron/manager.py`
  - added `OnWaitingLLMRequestEvent` before the cron main-agent build flow
  - switched cron main-agent construction to `apply_reset=False`
  - added `OnLLMRequestEvent` before awaiting `reset_coro`
  - preserved early interception behavior by closing `reset_coro` when the hook stops the event

- Updated `tests/unit/test_cron_manager.py`
  - added a regression test to verify cron-triggered main-agent requests call LLM request hooks before reset
  - verified the cron path aligns with the normal LLM request timing model

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

Verification steps executed locally:

```text
.\.venv\Scripts\python.exe -m pytest tests/unit/test_cron_manager.py -q
.\.venv\Scripts\python.exe -m ruff check astrbot/core/cron/manager.py tests/unit/test_cron_manager.py
.\.venv\Scripts\python.exe -m py_compile astrbot/core/cron/manager.py tests/unit/test_cron_manager.py
```

Results:

```text
tests/unit/test_cron_manager.py: 33 passed
ruff check: All checks passed!
py_compile: passed
```
---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Align cron-triggered main-agent wake flow with standard LLM request hook behavior for proactive tasks.

Bug Fixes:
- Ensure cron-triggered main-agent requests fire waiting and main LLM request hooks in the same order and timing as normal LLM requests, including proper handling of reset coroutines when hooks intercept execution.

Tests:
- Add a regression test verifying cron-triggered main-agent wakes invoke LLM request hooks before agent reset and mirror the normal request timing model.