### PR TITLE
docs: fix LM Studio public IP typo

### DIFF
--- a/docs/zh/providers/provider-lmstudio.md
+++ b/docs/zh/providers/provider-lmstudio.md
@@ -26,8 +26,8 @@ API Base URL 填写 `http://localhost:1234/v1`
 
 API Key 填写 `lm-studio`
 
-> 对于 Mac/Windows 使用 Docker Desktop 部署 AstrBot 部署的用户，API Base URL 请填写为 `http://host.docker.internal:1234/v1`。
-> 对于 Linux 使用 Docker 部署 AstrBot 部署的用户，API Base URL 请填写为 `http://172.17.0.1:1234/v1`，或者将 `172.17.0.1` 替换为你的公网 IP（确保宿主机系统放行了 1234 端口）。
+> 对于 Mac/Windows 使用 Docker Desktop 部署 AstrBot 的用户，API Base URL 请填写为 `http://host.docker.internal:1234/v1`。
+> 对于 Linux 使用 Docker 部署 AstrBot 的用户，API Base URL 请填写为 `http://172.17.0.1:1234/v1`，或者将 `172.17.0.1` 替换为你的公网 IP（确保宿主机系统放行了 1234 端口）。
 
 如果 LM Studio 使用了 Docker 部署，请确保 1234 端口已经映射到宿主机。
 

--- a/docs/zh/providers/provider-lmstudio.md
+++ b/docs/zh/providers/provider-lmstudio.md
@@ -27,7 +27,7 @@ API Base URL 填写 `http://localhost:1234/v1`
 API Key 填写 `lm-studio`
 
 > 对于 Mac/Windows 使用 Docker Desktop 部署 AstrBot 部署的用户，API Base URL 请填写为 `http://host.docker.internal:1234/v1`。
-> 对于 Linux 使用 Docker 部署 AstrBot 部署的用户，API Base URL 请填写为 `http://172.17.0.1:1234/v1`，或者将 `172.17.0.1` 替换为你的公网 IP IP（确保宿主机系统放行了 1234 端口）。
+> 对于 Linux 使用 Docker 部署 AstrBot 部署的用户，API Base URL 请填写为 `http://172.17.0.1:1234/v1`，或者将 `172.17.0.1` 替换为你的公网 IP（确保宿主机系统放行了 1234 端口）。
 
 如果 LM Studio 使用了 Docker 部署，请确保 1234 端口已经映射到宿主机。
 


### PR DESCRIPTION
Changes:
- Fixed a duplicated "IP" in the Chinese LM Studio provider documentation.

Validation:
- Ran git diff --check.
- No code changes.

## Summary by Sourcery

Documentation:
- Correct a duplicated wording issue in the Chinese LM Studio provider guide when describing public IP configuration for Linux Docker setups.