### PR TITLE
Implement time tracking for image caption requests

### DIFF
--- a/astrbot/builtin_stars/astrbot/group_chat_context.py
+++ b/astrbot/builtin_stars/astrbot/group_chat_context.py
@@ -106,7 +106,8 @@ class GroupChatContext:
         # 记录图片转述模型的调用统计
         if event is not None:
             try:
-                provider_model = provider.get_model() if provider.get_model() else None
+                model = provider.get_model()
+                provider_model = model or None
                 usage_dict: dict = {}
                 if response.usage:
                     usage_dict = {

--- a/astrbot/builtin_stars/astrbot/group_chat_context.py
+++ b/astrbot/builtin_stars/astrbot/group_chat_context.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import random
+import time
 import uuid
 from collections import defaultdict, deque
 
@@ -10,6 +11,7 @@ from astrbot.api.event import AstrMessageEvent
 from astrbot.api.message_components import At, Image, Plain
 from astrbot.api.platform import MessageType
 from astrbot.api.provider import Provider, ProviderRequest
+from astrbot.core import db_helper
 from astrbot.core.agent.message import TextPart
 from astrbot.core.astrbot_config_mgr import AstrBotConfigManager
 
@@ -79,21 +81,64 @@ class GroupChatContext:
         image_url: str,
         image_caption_provider_id: str,
         image_caption_prompt: str,
+        event: AstrMessageEvent | None = None,
     ) -> str:
+        provider_id = image_caption_provider_id
         if not image_caption_provider_id:
             provider = self.context.get_using_provider()
+            provider_id = provider.meta().id if hasattr(provider, 'meta') else ""
         else:
             provider = self.context.get_provider_by_id(image_caption_provider_id)
             if not provider:
                 raise Exception(f"没有找到 ID 为 {image_caption_provider_id} 的提供商")
         if not isinstance(provider, Provider):
             raise Exception(f"提供商类型错误({type(provider)})，无法获取图片描述")
+
+        start_time = time.time()
         response = await provider.text_chat(
             prompt=image_caption_prompt,
             session_id=uuid.uuid4().hex,
             image_urls=[image_url],
             persist=False,
         )
+        end_time = time.time()
+
+        # 记录图片转述模型的调用统计
+        if event is not None:
+            try:
+                provider_model = (
+                    provider.get_model() if provider.get_model() else None
+                )
+                usage_dict: dict = {}
+                if response.usage:
+                    usage_dict = {
+                        "input_other": response.usage.input_other,
+                        "input_cached": response.usage.input_cached,
+                        "output": response.usage.output,
+                    }
+
+                await db_helper.insert_provider_stat(
+                    umo=event.unified_msg_origin,
+                    provider_id=provider_id,
+                    provider_model=provider_model,
+                    conversation_id=None,
+                    status="completed"
+                    if response.role != "err"
+                    else "error",
+                    stats={
+                        "token_usage": usage_dict,
+                        "start_time": start_time,
+                        "end_time": end_time,
+                        "time_to_first_token": 0.0,
+                    },
+                    agent_type="internal",
+                )
+            except Exception:
+                logger.debug(
+                    "Failed to record group chat image caption provider stat",
+                    exc_info=True,
+                )
+
         return response.completion_text
 
     async def need_active_reply(self, event: AstrMessageEvent) -> bool:
@@ -200,6 +245,7 @@ class GroupChatContext:
                             url,
                             cfg["image_caption_provider_id"],
                             cfg["image_caption_prompt"],
+                            event=event,
                         )
                         parts.append(f" [Image: {caption}]")
                     except Exception as e:

--- a/astrbot/builtin_stars/astrbot/group_chat_context.py
+++ b/astrbot/builtin_stars/astrbot/group_chat_context.py
@@ -11,7 +11,6 @@ from astrbot.api.event import AstrMessageEvent
 from astrbot.api.message_components import At, Image, Plain
 from astrbot.api.platform import MessageType
 from astrbot.api.provider import Provider, ProviderRequest
-from astrbot.core import db_helper
 from astrbot.core.agent.message import TextPart
 from astrbot.core.astrbot_config_mgr import AstrBotConfigManager
 
@@ -105,36 +104,14 @@ class GroupChatContext:
 
         # 记录图片转述模型的调用统计
         if event is not None:
-            try:
-                model = provider.get_model()
-                provider_model = model or None
-                usage_dict: dict = {}
-                if response.usage:
-                    usage_dict = {
-                        "input_other": response.usage.input_other,
-                        "input_cached": response.usage.input_cached,
-                        "output": response.usage.output,
-                    }
-
-                await db_helper.insert_provider_stat(
-                    umo=event.unified_msg_origin,
-                    provider_id=provider_id,
-                    provider_model=provider_model,
-                    conversation_id=None,
-                    status="completed" if response.role != "err" else "error",
-                    stats={
-                        "token_usage": usage_dict,
-                        "start_time": start_time,
-                        "end_time": end_time,
-                        "time_to_first_token": 0.0,
-                    },
-                    agent_type="internal",
-                )
-            except Exception:
-                logger.debug(
-                    "Failed to record group chat image caption provider stat",
-                    exc_info=True,
-                )
+            await provider.record_image_caption_stat(
+                umo=event.unified_msg_origin,
+                provider_id=provider_id,
+                conversation_id=None,
+                start_time=start_time,
+                end_time=end_time,
+                response=response,
+            )
 
         return response.completion_text
 

--- a/astrbot/builtin_stars/astrbot/group_chat_context.py
+++ b/astrbot/builtin_stars/astrbot/group_chat_context.py
@@ -86,7 +86,7 @@ class GroupChatContext:
         provider_id = image_caption_provider_id
         if not image_caption_provider_id:
             provider = self.context.get_using_provider()
-            provider_id = provider.meta().id if hasattr(provider, 'meta') else ""
+            provider_id = provider.meta().id if hasattr(provider, "meta") else ""
         else:
             provider = self.context.get_provider_by_id(image_caption_provider_id)
             if not provider:
@@ -106,9 +106,7 @@ class GroupChatContext:
         # 记录图片转述模型的调用统计
         if event is not None:
             try:
-                provider_model = (
-                    provider.get_model() if provider.get_model() else None
-                )
+                provider_model = provider.get_model() if provider.get_model() else None
                 usage_dict: dict = {}
                 if response.usage:
                     usage_dict = {
@@ -122,9 +120,7 @@ class GroupChatContext:
                     provider_id=provider_id,
                     provider_model=provider_model,
                     conversation_id=None,
-                    status="completed"
-                    if response.role != "err"
-                    else "error",
+                    status="completed" if response.role != "err" else "error",
                     stats={
                         "token_usage": usage_dict,
                         "start_time": start_time,

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -661,9 +661,7 @@ async def _request_img_caption(
                 agent_type="internal",
             )
         except Exception:
-            logger.debug(
-                "Failed to record image caption provider stat", exc_info=True
-            )
+            logger.debug("Failed to record image caption provider stat", exc_info=True)
 
     return llm_resp.completion_text
 

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -12,7 +12,7 @@ from collections.abc import Coroutine
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from astrbot.core import db_helper, logger
+from astrbot.core import logger
 from astrbot.core.agent.handoff import HandoffTool
 from astrbot.core.agent.mcp_client import MCPTool
 from astrbot.core.agent.message import TextPart
@@ -633,35 +633,15 @@ async def _request_img_caption(
     )
     end_time = time.time()
 
-    # 记录图片转述模型的调用统计
     if event is not None:
-        try:
-            model = prov.get_model()
-            provider_model = model or None
-            usage_dict: dict = {}
-            if llm_resp.usage:
-                usage_dict = {
-                    "input_other": llm_resp.usage.input_other,
-                    "input_cached": llm_resp.usage.input_cached,
-                    "output": llm_resp.usage.output,
-                }
-
-            await db_helper.insert_provider_stat(
-                umo=event.unified_msg_origin,
-                provider_id=provider_id,
-                provider_model=provider_model,
-                conversation_id=conversation_id,
-                status="completed" if llm_resp.role != "err" else "error",
-                stats={
-                    "token_usage": usage_dict,
-                    "start_time": start_time,
-                    "end_time": end_time,
-                    "time_to_first_token": 0.0,
-                },
-                agent_type="internal",
-            )
-        except Exception:
-            logger.debug("Failed to record image caption provider stat", exc_info=True)
+        await prov.record_image_caption_stat(
+            umo=event.unified_msg_origin,
+            provider_id=provider_id,
+            conversation_id=conversation_id,
+            start_time=start_time,
+            end_time=end_time,
+            response=llm_resp,
+        )
 
     return llm_resp.completion_text
 

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -6,12 +6,11 @@ import datetime
 import json
 import os
 import platform
+import time
 import zoneinfo
 from collections.abc import Coroutine
 from dataclasses import dataclass, field
 from pathlib import Path
-
-import time
 
 from astrbot.core import db_helper, logger
 from astrbot.core.agent.handoff import HandoffTool

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -11,7 +11,9 @@ from collections.abc import Coroutine
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from astrbot.core import logger
+import time
+
+from astrbot.core import db_helper, logger
 from astrbot.core.agent.handoff import HandoffTool
 from astrbot.core.agent.mcp_client import MCPTool
 from astrbot.core.agent.message import TextPart
@@ -606,6 +608,8 @@ async def _request_img_caption(
     cfg: dict,
     image_urls: list[str],
     plugin_context: Context,
+    event: AstrMessageEvent | None = None,
+    conversation_id: str | None = None,
 ) -> str:
     prov = plugin_context.get_provider_by_id(provider_id)
     if prov is None:
@@ -622,10 +626,45 @@ async def _request_img_caption(
         "Please describe the image.",
     )
     logger.debug("Processing image caption with provider: %s", provider_id)
+
+    start_time = time.time()
     llm_resp = await prov.text_chat(
         prompt=img_cap_prompt,
         image_urls=image_urls,
     )
+    end_time = time.time()
+
+    # 记录图片转述模型的调用统计
+    if event is not None:
+        try:
+            provider_model = prov.get_model() if prov.get_model() else None
+            usage_dict: dict = {}
+            if llm_resp.usage:
+                usage_dict = {
+                    "input_other": llm_resp.usage.input_other,
+                    "input_cached": llm_resp.usage.input_cached,
+                    "output": llm_resp.usage.output,
+                }
+
+            await db_helper.insert_provider_stat(
+                umo=event.unified_msg_origin,
+                provider_id=provider_id,
+                provider_model=provider_model,
+                conversation_id=conversation_id,
+                status="completed" if llm_resp.role != "err" else "error",
+                stats={
+                    "token_usage": usage_dict,
+                    "start_time": start_time,
+                    "end_time": end_time,
+                    "time_to_first_token": 0.0,
+                },
+                agent_type="internal",
+            )
+        except Exception:
+            logger.debug(
+                "Failed to record image caption provider stat", exc_info=True
+            )
+
     return llm_resp.completion_text
 
 
@@ -648,6 +687,8 @@ async def _ensure_img_caption(
             cfg,
             compressed_urls,
             plugin_context,
+            event=event,
+            conversation_id=req.conversation.cid if req.conversation else None,
         )
         if caption:
             req.extra_user_content_parts.append(

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -636,7 +636,8 @@ async def _request_img_caption(
     # 记录图片转述模型的调用统计
     if event is not None:
         try:
-            provider_model = prov.get_model() if prov.get_model() else None
+            model = prov.get_model()
+            provider_model = model or None
             usage_dict: dict = {}
             if llm_resp.usage:
                 usage_dict = {

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -62,6 +62,50 @@ class AbstractProvider(abc.ABC):
         """
         ...
 
+    async def record_image_caption_stat(
+        self,
+        *,
+        umo: str,
+        provider_id: str,
+        conversation_id: str | None,
+        start_time: float,
+        end_time: float,
+        response: LLMResponse,
+    ) -> None:
+        """记录图片转述模型调用统计，由子类调用。"""
+        try:
+            from astrbot.core import db_helper, logger
+        except ImportError:
+            return
+
+        try:
+            model = self.get_model()
+            provider_model = model or None
+            usage_dict: dict = {}
+            if response.usage:
+                usage_dict = {
+                    "input_other": response.usage.input_other,
+                    "input_cached": response.usage.input_cached,
+                    "output": response.usage.output,
+                }
+
+            await db_helper.insert_provider_stat(
+                umo=umo,
+                provider_id=provider_id,
+                provider_model=provider_model,
+                conversation_id=conversation_id,
+                status="completed" if response.role != "err" else "error",
+                stats={
+                    "token_usage": usage_dict,
+                    "start_time": start_time,
+                    "end_time": end_time,
+                    "time_to_first_token": 0.0,
+                },
+                agent_type="internal",
+            )
+        except Exception:
+            logger.debug("Failed to record image caption provider stat", exc_info=True)
+
 
 class Provider(AbstractProvider):
     """Chat Provider"""


### PR DESCRIPTION
Added time tracking for image caption provider usage and logging.

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Track and record provider usage and timing for image caption generation in group chats.

New Features:
- Add time-based usage tracking for image caption provider calls, including token usage and status logging for group chat images.

Enhancements:
- Propagate the message event into image caption requests to support storing unified message origin metadata with provider statistics.