### PR TITLE
fix: handle data URI audio refs in audio preprocessing and truncate warning log

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -357,6 +357,17 @@ class ProviderOpenAIOfficial(Provider):
 
     async def _audio_ref_to_local_path(self, audio_ref: str) -> tuple[str, list[Path]]:
         cleanup_paths: list[Path] = []
+        if audio_ref.startswith("data:"):
+            m = re.match(r"^data:audio/(\w+);base64,(.+)$", audio_ref)
+            if m:
+                suffix = f".{m.group(1)}"
+                audio_bytes = base64.b64decode(m.group(2))
+                temp_dir = Path(get_astrbot_temp_path())
+                temp_dir.mkdir(parents=True, exist_ok=True)
+                target_path = temp_dir / f"provider_audio_{uuid.uuid4().hex}{suffix}"
+                target_path.write_bytes(audio_bytes)
+                cleanup_paths.append(target_path)
+                return str(target_path), cleanup_paths
         if audio_ref.startswith("http"):
             suffix = Path(urlparse(audio_ref).path).suffix or ".wav"
             temp_dir = Path(get_astrbot_temp_path())
@@ -384,7 +395,8 @@ class ProviderOpenAIOfficial(Provider):
                 audio_format = "wav"
             audio_bytes = Path(audio_path).read_bytes()
         except Exception as exc:
-            logger.warning("音频 %s 预处理失败，将忽略。错误: %s", audio_ref, exc)
+            truncated = audio_ref[:256] if len(audio_ref) > 256 else audio_ref
+            logger.warning("音频 %s 预处理失败，将忽略。错误: %s", truncated, exc)
             return None
         finally:
             for cleanup_path in cleanup_paths:

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -358,16 +358,21 @@ class ProviderOpenAIOfficial(Provider):
     async def _audio_ref_to_local_path(self, audio_ref: str) -> tuple[str, list[Path]]:
         cleanup_paths: list[Path] = []
         if audio_ref.startswith("data:"):
-            m = re.match(r"^data:audio/(\w+);base64,(.+)$", audio_ref)
-            if m:
+            try:
+                header, base64_data = audio_ref.split(",", 1)
+                m = re.match(r"^data:audio/(\w+);base64$", header)
+                if not m:
+                    raise ValueError("Invalid audio data URI header format")
                 suffix = f".{m.group(1)}"
-                audio_bytes = base64.b64decode(m.group(2))
+                audio_bytes = base64.b64decode(base64_data)
                 temp_dir = Path(get_astrbot_temp_path())
                 temp_dir.mkdir(parents=True, exist_ok=True)
                 target_path = temp_dir / f"provider_audio_{uuid.uuid4().hex}{suffix}"
                 target_path.write_bytes(audio_bytes)
                 cleanup_paths.append(target_path)
                 return str(target_path), cleanup_paths
+            except Exception as e:
+                raise ValueError(f"Failed to decode audio data URI: {e}") from e
         if audio_ref.startswith("http"):
             suffix = Path(urlparse(audio_ref).path).suffix or ".wav"
             temp_dir = Path(get_astrbot_temp_path())


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
**Problem:** When a user quotes (replies to) a voice message in group chat and @ the bot, the system includes the referenced audio in the LLM request. `_resolve_audio_part` receives a `data:audio/wav;base64,...` data URI for the audio, but `_audio_ref_to_local_path` does not handle the `data:` scheme — it only recognizes `http://` and `file://` prefixes. It falls through to `return audio_ref, cleanup_paths`, and subsequent `Path(data_uri).read_bytes()` crashes because a data URI is not a valid file path. The error handler then logs the full base64 string (potentially megabytes) as a WARNING, flooding the log.

**Fix:**
1. Add a `data:` branch in `_audio_ref_to_local_path` that decodes the base64 payload, writes it to a temp file, and returns the file path for normal processing.
2. Truncate `audio_ref` to 256 characters in the warning log to prevent log pollution.
### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
- **`astrbot/core/provider/sources/openai_source.py`**:
  - `_audio_ref_to_local_path`: added `if audio_ref.startswith("data:")` branch — regex-match `data:audio/\w+;base64,...`, decode base64, write to temp file, return path
  - `_resolve_audio_part`: truncated `audio_ref` to 256 chars in the `logger.warning` call
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
**Before** — full base64 dumped as WARNING (line truncated at 2000 chars, actual data is much longer):
```
[2026-06-10 21:20:06.319] [Core] [DBUG] [runners.tool_loop_agent_runner:614]: [BefCompact] messages -> [16] system,user,assistant,user,...,assistant,user,assistant,user
[2026-06-10 21:20:06.319] [Core] [DBUG] [runners.tool_loop_agent_runner:614]: [AftCompact] messages -> [6] system,user,assistant,user,assistant,user
[2026-06-10 21:20:06.320] [Core][WARN][v4.25.5] [sources.openai_source:387]: 音频 data:audio/wav;base64,IyFBTVIKDFLKPP71zfHMWG……
[2026-06-10 21:20:06.321] [Core][WARN][v4.25.5] [sources.openai_source:387]: 音频 data:audio/wav;base64,IyFBTVIKDGx4RvvXzbvbOW……
```
**After** — `data:` URI is correctly decoded, written to a temp WAV file, and passed to the LLM.
```
[2026-06-10 21:32:35.739] [Core] [DBUG] [pipeline.context_utils:95]: hook(OnLLMRequestEvent) -> astrbot - decorate_llm_req
[2026-06-10 21:32:35.741] [Core] [DBUG] [runners.base:64]: Agent state transition: AgentState.IDLE -> AgentState.RUNNING
[2026-06-10 21:32:35.741] [Core] [DBUG] [runners.tool_loop_agent_runner:614]: [BefCompact] messages -> [10] system,user,assistant,user,assistant,user,assistant,user,assistant,user
[2026-06-10 21:32:35.741] [Core] [DBUG] [runners.tool_loop_agent_runner:614]: [AftCompact] messages -> [6] system,user,assistant,user,assistant,user
[2026-06-10 21:32:42.444] [Core] [DBUG] [sources.openai_source:662]: completion: ChatCompletion(id='chatcmpl-202606101332373016003568268d9d6dRGHgjCB', choices=[Choice(finish_reason='stop', index=0, logprobs=None……
```
---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Handle data URI audio references during audio preprocessing and reduce verbosity of failure logs.

Bug Fixes:
- Decode data:audio/...;base64,... URIs to temporary audio files so referenced voice messages can be processed without crashing.
- Prevent exceptions caused by treating data URI audio references as filesystem paths during audio preprocessing.

Enhancements:
- Truncate long audio reference strings in warning logs to avoid flooding logs with large base64 payloads.