### PR TITLE
fix: preserve embedding api version suffixes

### DIFF
--- a/astrbot/core/provider/sources/openai_embedding_source.py
+++ b/astrbot/core/provider/sources/openai_embedding_source.py
@@ -1,3 +1,5 @@
+import re
+
 import httpx
 from openai import AsyncOpenAI
 
@@ -6,6 +8,13 @@ from astrbot import logger
 from ..entities import ProviderType
 from ..provider import EmbeddingProvider
 from ..register import register_provider_adapter
+
+
+def _normalize_api_base(api_base: str) -> str:
+    api_base = api_base.strip().removesuffix("/").removesuffix("/embeddings")
+    if api_base and not re.search(r"/v\d+$", api_base):
+        api_base = api_base + "/v1"
+    return api_base
 
 
 @register_provider_adapter(
@@ -24,15 +33,9 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         if proxy:
             logger.info(f"[OpenAI Embedding] {provider_id} Using proxy: {proxy}")
             http_client = httpx.AsyncClient(proxy=proxy)
-        api_base = (
+        api_base = _normalize_api_base(
             provider_config.get("embedding_api_base", "https://api.openai.com/v1")
-            .strip()
-            .removesuffix("/")
-            .removesuffix("/embeddings")
         )
-        if api_base and not api_base.endswith("/v1") and not api_base.endswith("/v4"):
-            # /v4 see #5699
-            api_base = api_base + "/v1"
         logger.info(f"[OpenAI Embedding] {provider_id} Using API Base: {api_base}")
         self.client = AsyncOpenAI(
             api_key=provider_config.get("embedding_api_key"),

--- a/tests/test_openai_embedding_source.py
+++ b/tests/test_openai_embedding_source.py
@@ -1,0 +1,18 @@
+from astrbot.core.provider.sources.openai_embedding_source import _normalize_api_base
+
+
+def test_openai_embedding_api_base_keeps_version_suffixes():
+    assert (
+        _normalize_api_base("https://ark.cn-beijing.volces.com/api/plan/v3")
+        == "https://ark.cn-beijing.volces.com/api/plan/v3"
+    )
+    assert _normalize_api_base("https://example.test/v4") == "https://example.test/v4"
+
+
+def test_openai_embedding_api_base_adds_default_version():
+    assert _normalize_api_base("https://example.test/openai") == (
+        "https://example.test/openai/v1"
+    )
+    assert _normalize_api_base("https://example.test/v1/embeddings") == (
+        "https://example.test/v1"
+    )


### PR DESCRIPTION
## Summary
- preserve any `/vN` suffix when normalizing OpenAI-compatible embedding API bases
- keep the existing fallback that appends `/v1` when a base URL has no version suffix
- add regression coverage for `/v3`, `/v4`, unversioned bases, and `/embeddings` suffix trimming

## Why
Fixes #8732. Providers such as Volcengine Ark can use embedding endpoints ending in `/v3`. The old check only recognized `/v1` and `/v4`, so `https://.../v3` became `https://.../v3/v1` and returned 404.

## Verified
- `python -m py_compile astrbot\core\provider\sources\openai_embedding_source.py tests\test_openai_embedding_source.py`
- `.\.venv\Scripts\python.exe -m ruff check astrbot\core\provider\sources\openai_embedding_source.py tests\test_openai_embedding_source.py`
- `git diff --check`
- direct helper behavior check covering `/v3`, `/v4`, unversioned base URLs, and `/v1/embeddings`

I also tried `.\.venv\Scripts\python.exe -m pytest tests\test_openai_embedding_source.py -q` in a minimal local venv. Collection reached the shared `tests/conftest.py` dependency chain and stopped on missing full AstrBot runtime dependencies; I did not install the whole application dependency set just for this small provider normalization check.

## Summary by Sourcery

Preserve and centralize normalization of OpenAI-compatible embedding API base URLs while ensuring a sensible default version is applied.

Bug Fixes:
- Fix incorrect normalization that appended '/v1' to embedding API bases already using other version suffixes like '/v3', which could cause 404 responses.

Enhancements:
- Extract API base URL normalization into a reusable helper that trims trailing slashes and '/embeddings' while respecting existing version suffixes.

Tests:
- Add regression tests covering versioned embedding API bases (including '/v3' and '/v4'), unversioned bases, and '/embeddings' suffix trimming behavior.