### PR TITLE
fix: skip plugin reload for deactivated plugins to preserve their tools

### DIFF
--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -860,6 +860,18 @@ class PluginManager:
                         specified_module_path = smd.module_path
                         break
 
+            if specified_module_path:
+                inactivated_plugins = await sp.global_get("inactivated_plugins", [])
+                if specified_module_path in inactivated_plugins:
+                    # 已停用插件没有实例，无需重载；此处若继续执行 _unbind_plugin，
+                    # 会将其在 __init__ 中通过 add_llm_tools 注册的工具从
+                    # func_list 中移除且无法恢复（load 会跳过停用插件的实例化）。
+                    # 新配置会在重新启用插件时由完整的 reload 流程应用。见 #8582。
+                    logger.info(
+                        f"插件 {specified_plugin_name} 处于禁用状态，跳过重载。",
+                    )
+                    return True, None
+
             # 终止插件
             if not specified_module_path:
                 # 重载所有插件

--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -861,7 +861,9 @@ class PluginManager:
                         break
 
             if specified_module_path:
-                inactivated_plugins = await sp.global_get("inactivated_plugins", [])
+                inactivated_plugins = (
+                    await sp.global_get("inactivated_plugins", [])
+                ) or []
                 if specified_module_path in inactivated_plugins:
                     # 已停用插件没有实例，无需重载；此处若继续执行 _unbind_plugin，
                     # 会将其在 __init__ 中通过 add_llm_tools 注册的工具从

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -596,6 +596,120 @@ async def test_turn_plugin_toggles_llm_tools_from_plugin_child_module(
 
 
 @pytest.mark.asyncio
+async def test_reload_skips_deactivated_plugin(
+    plugin_manager_pm: PluginManager, monkeypatch
+):
+    """Reloading a deactivated plugin must not unbind it (#8582).
+
+    _terminate_plugin short-circuits for deactivated plugins, but
+    _unbind_plugin still removed their tools from func_list while load()
+    skipped re-instantiation, losing every tool registered via
+    add_llm_tools() in the plugin's __init__.
+    """
+    _clear_star_runtime_state()
+    plugin_name = "plugin_one"
+    module_path = f"data.plugins.{plugin_name}.main"
+    metadata = star_manager_module.StarMetadata(
+        name=plugin_name,
+        root_dir_name=plugin_name,
+        module_path=module_path,
+        activated=False,
+    )
+    star_manager_module.star_map[module_path] = metadata
+    star_manager_module.star_registry.append(metadata)
+
+    calls = []
+
+    async def mock_global_get(key, default=None):
+        if key == "inactivated_plugins":
+            return [module_path]
+        return default
+
+    async def mock_terminate(plugin):
+        calls.append(("terminate", plugin.name))
+
+    async def mock_unbind(plugin_name, plugin_module_path):
+        calls.append(("unbind", plugin_name))
+
+    async def mock_load(
+        specified_module_path=None,
+        specified_dir_name=None,
+        ignore_version_check=False,
+    ):
+        calls.append(("load", specified_module_path))
+        return True, None
+
+    monkeypatch.setattr(star_manager_module.sp, "global_get", mock_global_get)
+    monkeypatch.setattr(plugin_manager_pm, "_terminate_plugin", mock_terminate)
+    monkeypatch.setattr(plugin_manager_pm, "_unbind_plugin", mock_unbind)
+    monkeypatch.setattr(plugin_manager_pm, "load", mock_load)
+
+    try:
+        result = await plugin_manager_pm.reload(plugin_name)
+        assert result == (True, None)
+        assert calls == []
+        assert module_path in star_manager_module.star_map
+        assert any(smd.name == plugin_name for smd in star_manager_module.star_registry)
+    finally:
+        _clear_star_runtime_state()
+
+
+@pytest.mark.asyncio
+async def test_reload_runs_full_cycle_for_activated_plugin(
+    plugin_manager_pm: PluginManager, monkeypatch
+):
+    """Activated plugins keep the full terminate -> unbind -> load cycle."""
+    _clear_star_runtime_state()
+    plugin_name = "plugin_one"
+    module_path = f"data.plugins.{plugin_name}.main"
+    metadata = star_manager_module.StarMetadata(
+        name=plugin_name,
+        root_dir_name=plugin_name,
+        module_path=module_path,
+    )
+    star_manager_module.star_map[module_path] = metadata
+    star_manager_module.star_registry.append(metadata)
+
+    calls = []
+
+    async def mock_global_get(key, default=None):
+        if key == "inactivated_plugins":
+            return []
+        return default
+
+    async def mock_terminate(plugin):
+        calls.append(("terminate", plugin.name))
+
+    async def mock_unbind(plugin_name, plugin_module_path):
+        calls.append(("unbind", plugin_name))
+        star_manager_module.star_map.pop(plugin_module_path, None)
+
+    async def mock_load(
+        specified_module_path=None,
+        specified_dir_name=None,
+        ignore_version_check=False,
+    ):
+        calls.append(("load", specified_module_path))
+        return True, None
+
+    monkeypatch.setattr(star_manager_module.sp, "global_get", mock_global_get)
+    monkeypatch.setattr(plugin_manager_pm, "_terminate_plugin", mock_terminate)
+    monkeypatch.setattr(plugin_manager_pm, "_unbind_plugin", mock_unbind)
+    monkeypatch.setattr(plugin_manager_pm, "load", mock_load)
+
+    try:
+        result = await plugin_manager_pm.reload(plugin_name)
+        assert result == (True, None)
+        assert calls == [
+            ("terminate", plugin_name),
+            ("unbind", plugin_name),
+            ("load", module_path),
+        ]
+    finally:
+        _clear_star_runtime_state()
+
+
+@pytest.mark.asyncio
 async def test_load_reports_unregistered_plugin_without_index_error(
     plugin_manager_pm: PluginManager, monkeypatch
 ):

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -710,6 +710,61 @@ async def test_reload_runs_full_cycle_for_activated_plugin(
 
 
 @pytest.mark.asyncio
+async def test_reload_treats_none_inactivated_plugins_as_empty(
+    plugin_manager_pm: PluginManager, monkeypatch
+):
+    """A corrupted null preference should not crash targeted reload."""
+    _clear_star_runtime_state()
+    plugin_name = "plugin_one"
+    module_path = f"data.plugins.{plugin_name}.main"
+    metadata = star_manager_module.StarMetadata(
+        name=plugin_name,
+        root_dir_name=plugin_name,
+        module_path=module_path,
+    )
+    star_manager_module.star_map[module_path] = metadata
+    star_manager_module.star_registry.append(metadata)
+
+    calls = []
+
+    async def mock_global_get(key, default=None):
+        if key == "inactivated_plugins":
+            return None
+        return default
+
+    async def mock_terminate(plugin):
+        calls.append(("terminate", plugin.name))
+
+    async def mock_unbind(plugin_name, plugin_module_path):
+        calls.append(("unbind", plugin_name))
+        star_manager_module.star_map.pop(plugin_module_path, None)
+
+    async def mock_load(
+        specified_module_path=None,
+        specified_dir_name=None,
+        ignore_version_check=False,
+    ):
+        calls.append(("load", specified_module_path))
+        return True, None
+
+    monkeypatch.setattr(star_manager_module.sp, "global_get", mock_global_get)
+    monkeypatch.setattr(plugin_manager_pm, "_terminate_plugin", mock_terminate)
+    monkeypatch.setattr(plugin_manager_pm, "_unbind_plugin", mock_unbind)
+    monkeypatch.setattr(plugin_manager_pm, "load", mock_load)
+
+    try:
+        result = await plugin_manager_pm.reload(plugin_name)
+        assert result == (True, None)
+        assert calls == [
+            ("terminate", plugin_name),
+            ("unbind", plugin_name),
+            ("load", module_path),
+        ]
+    finally:
+        _clear_star_runtime_state()
+
+
+@pytest.mark.asyncio
 async def test_load_reports_unregistered_plugin_without_index_error(
     plugin_manager_pm: PluginManager, monkeypatch
 ):


### PR DESCRIPTION
Fixes #8582

Saving the config of a **deactivated** plugin in the WebUI calls `plugin_manager.reload(plugin_name)` unconditionally (`dashboard/routes/config.py`). For a deactivated plugin, `_terminate_plugin` short-circuits, but `_unbind_plugin` still removes the plugin from `star_map`/`star_registry` and deletes all of its tools from `llm_tools.func_list`, while the subsequent `load()` skips instantiation (the plugin path is in `inactivated_plugins`). Tools registered via `context.add_llm_tools()` in the plugin's `__init__` are therefore never re-added: they disappear from `func_list` until the plugin is re-enabled, and stale `inactivated_llm_tools` blacklist entries are left behind.

### Modifications / 改动点

- `astrbot/core/star/star_manager.py`: `reload()` now returns early when the specified plugin is listed in the persisted `inactivated_plugins` preference. A deactivated plugin has no instance to re-apply config to; the new config is picked up by the full reload that `turn_on_plugin` triggers when the plugin is re-enabled.
  - The guard intentionally checks the `inactivated_plugins` preference instead of `metadata.activated`: `turn_on_plugin` removes the entry from the preference *before* calling `reload()`, while the stale metadata still has `activated=False` at that moment, so checking the flag would break plugin re-enabling.
  - Fixing inside `reload()` covers every caller (config save, WebUI reload button, `update_plugin`), not just the config-save route.
- `tests/test_plugin_manager.py`: regression tests for both paths — a deactivated plugin is left untouched (no terminate/unbind/load, stays in `star_map`/`star_registry`), and an activated plugin still goes through the full terminate → unbind → load cycle.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```
$ uv run pytest tests/test_plugin_manager.py -q
.......................................                                  [100%]
39 passed in 2.43s
```

(includes the two new regression tests; `test_reload_skips_deactivated_plugin` fails on master and passes with this change)

```
$ make pr-test-neo
==> Running Ruff format check
435 files already formatted
==> Running Ruff lint check
All checks passed!
==> Running pytest
............                                                             [100%]
12 passed in 3.83s
==> Starting smoke test on http://localhost:6185
==> Smoke test passed
==> PR checks completed successfully
```

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Guard plugin reload against deactivated plugins so their tools remain registered and configuration is applied only when re-enabled.

Bug Fixes:
- Prevent reloading deactivated plugins from unbinding them and removing their registered LLM tools while skipping re-instantiation.

Tests:
- Add regression tests ensuring reload is skipped for deactivated plugins and still performs the full terminate–unbind–load cycle for activated plugins.