### PR TITLE
fix(gemini): preserve assistant tool calls during history conversion

### DIFF
--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -290,6 +290,11 @@ class ProviderGoogleGenAI(Provider):
                 else:
                     thinking_config.thinking_level = level
 
+        # If any tools (native or custom function declarations) are active for this request,
+        # we must disable thinking because Gemini API does not support them simultaneously.
+        if tool_list:
+            thinking_config = None
+
         return types.GenerateContentConfig(
             system_instruction=system_instruction,
             temperature=temperature,

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -386,11 +386,10 @@ class ProviderGoogleGenAI(Provider):
                 append_or_extend(gemini_contents, parts, types.UserContent)
 
             elif role == "assistant":
-                if isinstance(content, str):
-                    parts = [types.Part.from_text(text=content)]
-                    append_or_extend(gemini_contents, parts, types.ModelContent)
+                parts = []
+                if isinstance(content, str) and content:
+                    parts.append(types.Part.from_text(text=content))
                 elif isinstance(content, list):
-                    parts = []
                     thinking_signature = None
                     text = ""
                     for part in content:
@@ -415,10 +414,8 @@ class ProviderGoogleGenAI(Provider):
                             thought_signature=thinking_signature,
                         )
                     )
-                    append_or_extend(gemini_contents, parts, types.ModelContent)
 
-                elif not native_tool_enabled and "tool_calls" in message:
-                    parts = []
+                if not native_tool_enabled and "tool_calls" in message:
                     for tool in message["tool_calls"]:
                         part = types.Part.from_function_call(
                             name=tool["function"]["name"],
@@ -436,15 +433,16 @@ class ProviderGoogleGenAI(Provider):
                             if ts_bs64:
                                 part.thought_signature = base64.b64decode(ts_bs64)
                         parts.append(part)
-                    append_or_extend(gemini_contents, parts, types.ModelContent)
-                else:
+
+                if not parts:
                     logger.warning("assistant 角色的消息内容为空，已添加空格占位")
                     if native_tool_enabled and "tool_calls" in message:
                         logger.warning(
                             "检测到启用Gemini原生工具，且上下文中存在函数调用，建议使用 /reset 重置上下文",
                         )
                     parts = [types.Part.from_text(text=" ")]
-                    append_or_extend(gemini_contents, parts, types.ModelContent)
+
+                append_or_extend(gemini_contents, parts, types.ModelContent)
 
             elif role == "tool" and not native_tool_enabled:
                 func_name = message.get("name", message["tool_call_id"])

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -292,7 +292,8 @@ class ProviderGoogleGenAI(Provider):
 
         # If any tools (native or custom function declarations) are active for this request,
         # we must disable thinking because Gemini API does not support them simultaneously.
-        if tool_list:
+        if tool_list and thinking_config:
+            logger.warning("[Gemini] Thinking config is automatically disabled because tools are active for this request.")
             thinking_config = None
 
         return types.GenerateContentConfig(

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -293,7 +293,10 @@ class ProviderGoogleGenAI(Provider):
         # If any tools (native or custom function declarations) are active for this request,
         # we must disable thinking because Gemini API does not support them simultaneously.
         if tool_list and thinking_config:
-            logger.warning("[Gemini] Thinking config is automatically disabled because tools are active for this request.")
+            if getattr(thinking_config, "thinking_budget", None) != 0:
+                logger.warning(
+                    "[Gemini] Thinking config is automatically disabled because tools are active for this request."
+                )
             thinking_config = None
 
         return types.GenerateContentConfig(

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -290,15 +290,6 @@ class ProviderGoogleGenAI(Provider):
                 else:
                     thinking_config.thinking_level = level
 
-        # If any tools (native or custom function declarations) are active for this request,
-        # we must disable thinking because Gemini API does not support them simultaneously.
-        if tool_list and thinking_config:
-            if getattr(thinking_config, "thinking_budget", None) != 0:
-                logger.warning(
-                    "[Gemini] Thinking config is automatically disabled because tools are active for this request."
-                )
-            thinking_config = None
-
         return types.GenerateContentConfig(
             system_instruction=system_instruction,
             temperature=temperature,
@@ -415,8 +406,9 @@ class ProviderGoogleGenAI(Provider):
                         )
                     )
 
-                if not native_tool_enabled and "tool_calls" in message:
-                    for tool in message["tool_calls"]:
+                tool_calls = message.get("tool_calls") or []
+                if not native_tool_enabled and tool_calls:
+                    for tool in tool_calls:
                         part = types.Part.from_function_call(
                             name=tool["function"]["name"],
                             args=json.loads(tool["function"]["arguments"]),

--- a/tests/test_gemini_source.py
+++ b/tests/test_gemini_source.py
@@ -1,3 +1,5 @@
+import base64
+
 import pytest
 
 from astrbot.core.exceptions import EmptyModelOutputError
@@ -27,3 +29,103 @@ def test_gemini_reasoning_only_output_is_allowed():
         response_id="resp_reasoning",
         finish_reason="STOP",
     )
+
+
+def _make_gemini_provider_for_conversation():
+    provider = object.__new__(ProviderGoogleGenAI)
+    provider.provider_config = {
+        "gm_native_coderunner": False,
+        "gm_native_search": False,
+    }
+    return provider
+
+
+def _assistant_tool_call_message(content):
+    return {
+        "role": "assistant",
+        "content": content,
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "get_pull_request_files",
+                    "arguments": '{"owner":"AstrBotDevs","repo":"AstrBot","pull_number":8742}',
+                },
+            },
+        ],
+    }
+
+
+def _first_model_parts(gemini_contents):
+    model_content = next(
+        content
+        for content in gemini_contents
+        if content.__class__.__name__ == "ModelContent"
+    )
+    return model_content.parts or []
+
+
+def test_prepare_conversation_keeps_assistant_text_and_tool_calls():
+    provider = _make_gemini_provider_for_conversation()
+    payloads = {
+        "messages": [
+            {"role": "user", "content": "summarize this PR"},
+            _assistant_tool_call_message("I will inspect the changed files first."),
+        ]
+    }
+
+    parts = _first_model_parts(provider._prepare_conversation(payloads))
+
+    assert any(part.text == "I will inspect the changed files first." for part in parts)
+    assert [
+        part.function_call.name
+        for part in parts
+        if getattr(part, "function_call", None)
+    ] == ["get_pull_request_files"]
+
+
+def test_prepare_conversation_keeps_assistant_list_content_and_tool_calls():
+    provider = _make_gemini_provider_for_conversation()
+    payloads = {
+        "messages": [
+            {"role": "user", "content": "summarize this PR"},
+            _assistant_tool_call_message(
+                [
+                    {
+                        "type": "think",
+                        "encrypted": base64.b64encode(b"signature").decode("utf-8"),
+                    },
+                    {"type": "text", "text": "I will inspect the changed files first."},
+                ]
+            ),
+        ]
+    }
+
+    parts = _first_model_parts(provider._prepare_conversation(payloads))
+
+    assert any(part.text == "I will inspect the changed files first." for part in parts)
+    assert [
+        part.function_call.name
+        for part in parts
+        if getattr(part, "function_call", None)
+    ] == ["get_pull_request_files"]
+
+
+def test_prepare_conversation_ignores_null_tool_calls():
+    provider = _make_gemini_provider_for_conversation()
+    payloads = {
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": "hello back",
+                "tool_calls": None,
+            },
+        ]
+    }
+
+    parts = _first_model_parts(provider._prepare_conversation(payloads))
+
+    assert [part.text for part in parts] == ["hello back"]
+    assert not any(getattr(part, "function_call", None) for part in parts)


### PR DESCRIPTION
## Summary

This PR fixes Gemini history conversion when an assistant message contains both normal content and `tool_calls`.

Previously, `_prepare_conversation()` handled assistant messages with mutually exclusive `if / elif / elif` branches. If an assistant message had text content, or list content such as a think/text part, the `tool_calls` branch was skipped. The next Gemini request could then contain a tool response without the corresponding assistant function-call part, which can make Gemini repeat the same tool call or request invalid tool names in later turns.

## Changes

- Preserve assistant text/list content and function calls in the same `ModelContent.parts` list.
- Treat `tool_calls: null` as empty, so OpenAI-style assistant messages with a null field do not crash local conversion.
- Add regression tests for:
  - assistant text content + `tool_calls`
  - assistant list/think content + `tool_calls`
  - `tool_calls: null`

## Notes

This PR was narrowed after re-checking the evidence. The earlier wording about a universal Gemini `thinking_config` + tools incompatibility was too broad, so that part has been removed from the patch and from the main claim here. This PR now focuses on the confirmed serialization bug.

## Verification

```bash
uv run python -m pytest tests/test_gemini_source.py -q
uv run ruff check astrbot/core/provider/sources/gemini_source.py tests/test_gemini_source.py
```