### PR TITLE
fix: preserve OpenAI embedding API version suffixes

### DIFF
--- a/astrbot/core/provider/sources/openai_embedding_source.py
+++ b/astrbot/core/provider/sources/openai_embedding_source.py
@@ -1,3 +1,5 @@
+import re
+
 import httpx
 from openai import AsyncOpenAI
 
@@ -6,6 +8,15 @@ from astrbot import logger
 from ..entities import ProviderType
 from ..provider import EmbeddingProvider
 from ..register import register_provider_adapter
+
+_API_VERSION_SUFFIX_RE = re.compile(r"/v\d+$")
+
+
+def _normalize_embedding_api_base(api_base: str) -> str:
+    api_base = api_base.strip().removesuffix("/").removesuffix("/embeddings")
+    if api_base and not _API_VERSION_SUFFIX_RE.search(api_base):
+        api_base = api_base + "/v1"
+    return api_base
 
 
 @register_provider_adapter(
@@ -24,15 +35,9 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         if proxy:
             logger.info(f"[OpenAI Embedding] {provider_id} Using proxy: {proxy}")
             http_client = httpx.AsyncClient(proxy=proxy)
-        api_base = (
+        api_base = _normalize_embedding_api_base(
             provider_config.get("embedding_api_base", "https://api.openai.com/v1")
-            .strip()
-            .removesuffix("/")
-            .removesuffix("/embeddings")
         )
-        if api_base and not api_base.endswith("/v1") and not api_base.endswith("/v4"):
-            # /v4 see #5699
-            api_base = api_base + "/v1"
         logger.info(f"[OpenAI Embedding] {provider_id} Using API Base: {api_base}")
         self.client = AsyncOpenAI(
             api_key=provider_config.get("embedding_api_key"),

--- a/astrbot/core/provider/sources/openai_embedding_source.py
+++ b/astrbot/core/provider/sources/openai_embedding_source.py
@@ -12,7 +12,9 @@ from ..register import register_provider_adapter
 _API_VERSION_SUFFIX_RE = re.compile(r"/v\d+$")
 
 
-def _normalize_embedding_api_base(api_base: str) -> str:
+def _normalize_embedding_api_base(api_base: str | None) -> str:
+    if not api_base:
+        return ""
     api_base = api_base.strip().removesuffix("/").removesuffix("/embeddings")
     if api_base and not _API_VERSION_SUFFIX_RE.search(api_base):
         api_base = api_base + "/v1"
@@ -36,7 +38,7 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
             logger.info(f"[OpenAI Embedding] {provider_id} Using proxy: {proxy}")
             http_client = httpx.AsyncClient(proxy=proxy)
         api_base = _normalize_embedding_api_base(
-            provider_config.get("embedding_api_base", "https://api.openai.com/v1")
+            provider_config.get("embedding_api_base") or "https://api.openai.com/v1"
         )
         logger.info(f"[OpenAI Embedding] {provider_id} Using API Base: {api_base}")
         self.client = AsyncOpenAI(

--- a/tests/test_openai_embedding_source.py
+++ b/tests/test_openai_embedding_source.py
@@ -1,0 +1,26 @@
+import pytest
+
+from astrbot.core.provider.sources.openai_embedding_source import (
+    _normalize_embedding_api_base,
+)
+
+
+@pytest.mark.parametrize(
+    ("api_base", "expected"),
+    [
+        ("https://api.openai.com/v1", "https://api.openai.com/v1"),
+        (
+            "https://ark.cn-beijing.volces.com/api/plan/v3",
+            "https://ark.cn-beijing.volces.com/api/plan/v3",
+        ),
+        ("https://example.com/openai/v12/", "https://example.com/openai/v12"),
+        ("https://example.com/openai", "https://example.com/openai/v1"),
+        ("https://example.com/openai/embeddings", "https://example.com/openai/v1"),
+        (
+            " https://example.com/openai/v3/embeddings/ ",
+            "https://example.com/openai/v3",
+        ),
+    ],
+)
+def test_normalize_embedding_api_base(api_base, expected):
+    assert _normalize_embedding_api_base(api_base) == expected

--- a/tests/test_openai_embedding_source.py
+++ b/tests/test_openai_embedding_source.py
@@ -20,6 +20,8 @@ from astrbot.core.provider.sources.openai_embedding_source import (
             " https://example.com/openai/v3/embeddings/ ",
             "https://example.com/openai/v3",
         ),
+        (None, ""),
+        ("", ""),
     ],
 )
 def test_normalize_embedding_api_base(api_base, expected):


### PR DESCRIPTION
## Summary
- normalize OpenAI embedding API base URLs with a generic `/vN` suffix matcher
- preserve compatible endpoints such as Volcengine Ark `/v3` instead of appending `/v1`
- add focused tests for versioned, unversioned, `/embeddings`, and trailing-slash base URLs

Fixes #8732

## Tests
- `PYTHONPATH=. uv run pytest tests/test_openai_embedding_source.py -q`
- `uv run ruff format --check astrbot/core/provider/sources/openai_embedding_source.py tests/test_openai_embedding_source.py`
- `uv run ruff check astrbot/core/provider/sources/openai_embedding_source.py tests/test_openai_embedding_source.py`
- `git diff --check`

## Summary by Sourcery

Normalize OpenAI embedding API base URL handling and add coverage for versioned and unversioned endpoints.

Bug Fixes:
- Ensure embedding API base URLs preserve existing compatible version suffixes instead of incorrectly appending `/v1`.

Tests:
- Add parametrized tests covering normalization of versioned, unversioned, `/embeddings`, and trailing-slash embedding API base URLs.