### PR TITLE
feat(provider): support reset/default subcommands to clear session override

### DIFF
--- a/astrbot/builtin_stars/builtin_commands/commands/provider.py
+++ b/astrbot/builtin_stars/builtin_commands/commands/provider.py
@@ -201,6 +201,7 @@ class ProviderCommands:
                 ret += "\nUse /provider tts <idx> to switch TTS providers."
             if stts:
                 ret += "\nUse /provider stt <idx> to switch STT providers."
+            ret += "\nUse /provider reset to clear session override."
 
             event.set_result(MessageEventResult().message(ret))
         elif idx == "tts":

--- a/astrbot/builtin_stars/builtin_commands/commands/provider.py
+++ b/astrbot/builtin_stars/builtin_commands/commands/provider.py
@@ -198,7 +198,9 @@ class ProviderCommands:
                     f"provider_perf_{ProviderType.TEXT_TO_SPEECH.value}",
                 )
                 event.set_result(
-                    MessageEventResult().message("✅ Successfully reset TTS provider to global default.")
+                    MessageEventResult().message(
+                        "✅ Successfully reset TTS provider to global default."
+                    )
                 )
                 return
             try:
@@ -208,12 +210,13 @@ class ProviderCommands:
                     MessageEventResult().message("❌ Invalid provider index.")
                 )
                 return
-            if idx2_int > len(self.context.get_all_tts_providers()) or idx2_int < 1:
+            providers = list(self.context.get_all_tts_providers())
+            if idx2_int > len(providers) or idx2_int < 1:
                 event.set_result(
                     MessageEventResult().message("❌ Invalid provider index.")
                 )
                 return
-            provider = self.context.get_all_tts_providers()[idx2_int - 1]
+            provider = providers[idx2_int - 1]
             id_ = provider.meta().id
             await self.context.provider_manager.set_provider(
                 provider_id=id_,
@@ -235,7 +238,9 @@ class ProviderCommands:
                     f"provider_perf_{ProviderType.SPEECH_TO_TEXT.value}",
                 )
                 event.set_result(
-                    MessageEventResult().message("✅ Successfully reset STT provider to global default.")
+                    MessageEventResult().message(
+                        "✅ Successfully reset STT provider to global default."
+                    )
                 )
                 return
             try:
@@ -245,12 +250,13 @@ class ProviderCommands:
                     MessageEventResult().message("❌ Invalid provider index.")
                 )
                 return
-            if idx2_int > len(self.context.get_all_stt_providers()) or idx2_int < 1:
+            providers = list(self.context.get_all_stt_providers())
+            if idx2_int > len(providers) or idx2_int < 1:
                 event.set_result(
                     MessageEventResult().message("❌ Invalid provider index.")
                 )
                 return
-            provider = self.context.get_all_stt_providers()[idx2_int - 1]
+            provider = providers[idx2_int - 1]
             id_ = provider.meta().id
             await self.context.provider_manager.set_provider(
                 provider_id=id_,
@@ -266,7 +272,9 @@ class ProviderCommands:
                 f"provider_perf_{ProviderType.CHAT_COMPLETION.value}",
             )
             event.set_result(
-                MessageEventResult().message("✅ Successfully reset Chat Completion provider to global default.")
+                MessageEventResult().message(
+                    "✅ Successfully reset Chat Completion provider to global default."
+                )
             )
         else:
             try:
@@ -276,12 +284,13 @@ class ProviderCommands:
                 is_int = False
 
             if is_int:
-                if idx_int > len(self.context.get_all_providers()) or idx_int < 1:
+                providers = list(self.context.get_all_providers())
+                if idx_int > len(providers) or idx_int < 1:
                     event.set_result(
                         MessageEventResult().message("❌ Invalid provider index.")
                     )
                     return
-                provider = self.context.get_all_providers()[idx_int - 1]
+                provider = providers[idx_int - 1]
                 id_ = provider.meta().id
                 await self.context.provider_manager.set_provider(
                     provider_id=id_,

--- a/astrbot/builtin_stars/builtin_commands/commands/provider.py
+++ b/astrbot/builtin_stars/builtin_commands/commands/provider.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 
 from astrbot import logger
-from astrbot.api import star
+from astrbot.api import sp, star
 from astrbot.api.event import AstrMessageEvent, MessageEventResult
 from astrbot.core.provider.entities import ProviderType
 from astrbot.core.utils.error_redaction import safe_error
@@ -112,7 +112,7 @@ class ProviderCommands:
         self,
         event: AstrMessageEvent,
         idx: str | int | None = None,
-        idx2: int | None = None,
+        idx2: str | int | None = None,
     ) -> None:
         """查看或者切换 LLM Provider"""
         umo = event.unified_msg_origin
@@ -192,12 +192,28 @@ class ProviderCommands:
                     MessageEventResult().message("Please enter the index.")
                 )
                 return
-            if idx2 > len(self.context.get_all_tts_providers()) or idx2 < 1:
+            if idx2 in ("default", "reset", "clear"):
+                await sp.session_remove(
+                    umo,
+                    f"provider_perf_{ProviderType.TEXT_TO_SPEECH.value}",
+                )
+                event.set_result(
+                    MessageEventResult().message("✅ Successfully reset TTS provider to global default.")
+                )
+                return
+            try:
+                idx2_int = int(idx2)
+            except ValueError:
                 event.set_result(
                     MessageEventResult().message("❌ Invalid provider index.")
                 )
                 return
-            provider = self.context.get_all_tts_providers()[idx2 - 1]
+            if idx2_int > len(self.context.get_all_tts_providers()) or idx2_int < 1:
+                event.set_result(
+                    MessageEventResult().message("❌ Invalid provider index.")
+                )
+                return
+            provider = self.context.get_all_tts_providers()[idx2_int - 1]
             id_ = provider.meta().id
             await self.context.provider_manager.set_provider(
                 provider_id=id_,
@@ -213,12 +229,28 @@ class ProviderCommands:
                     MessageEventResult().message("Please enter the index.")
                 )
                 return
-            if idx2 > len(self.context.get_all_stt_providers()) or idx2 < 1:
+            if idx2 in ("default", "reset", "clear"):
+                await sp.session_remove(
+                    umo,
+                    f"provider_perf_{ProviderType.SPEECH_TO_TEXT.value}",
+                )
+                event.set_result(
+                    MessageEventResult().message("✅ Successfully reset STT provider to global default.")
+                )
+                return
+            try:
+                idx2_int = int(idx2)
+            except ValueError:
                 event.set_result(
                     MessageEventResult().message("❌ Invalid provider index.")
                 )
                 return
-            provider = self.context.get_all_stt_providers()[idx2 - 1]
+            if idx2_int > len(self.context.get_all_stt_providers()) or idx2_int < 1:
+                event.set_result(
+                    MessageEventResult().message("❌ Invalid provider index.")
+                )
+                return
+            provider = self.context.get_all_stt_providers()[idx2_int - 1]
             id_ = provider.meta().id
             await self.context.provider_manager.set_provider(
                 provider_id=id_,
@@ -228,21 +260,36 @@ class ProviderCommands:
             event.set_result(
                 MessageEventResult().message(f"✅ Successfully switched to {id_}.")
             )
-        elif isinstance(idx, int):
-            if idx > len(self.context.get_all_providers()) or idx < 1:
-                event.set_result(
-                    MessageEventResult().message("❌ Invalid provider index.")
-                )
-                return
-            provider = self.context.get_all_providers()[idx - 1]
-            id_ = provider.meta().id
-            await self.context.provider_manager.set_provider(
-                provider_id=id_,
-                provider_type=ProviderType.CHAT_COMPLETION,
-                umo=umo,
+        elif idx in ("default", "reset", "clear"):
+            await sp.session_remove(
+                umo,
+                f"provider_perf_{ProviderType.CHAT_COMPLETION.value}",
             )
             event.set_result(
-                MessageEventResult().message(f"✅ Successfully switched to {id_}.")
+                MessageEventResult().message("✅ Successfully reset Chat Completion provider to global default.")
             )
         else:
-            event.set_result(MessageEventResult().message("❌ Invalid parameter."))
+            try:
+                idx_int = int(idx)
+                is_int = True
+            except (ValueError, TypeError):
+                is_int = False
+
+            if is_int:
+                if idx_int > len(self.context.get_all_providers()) or idx_int < 1:
+                    event.set_result(
+                        MessageEventResult().message("❌ Invalid provider index.")
+                    )
+                    return
+                provider = self.context.get_all_providers()[idx_int - 1]
+                id_ = provider.meta().id
+                await self.context.provider_manager.set_provider(
+                    provider_id=id_,
+                    provider_type=ProviderType.CHAT_COMPLETION,
+                    umo=umo,
+                )
+                event.set_result(
+                    MessageEventResult().message(f"✅ Successfully switched to {id_}.")
+                )
+            else:
+                event.set_result(MessageEventResult().message("❌ Invalid parameter."))

--- a/astrbot/builtin_stars/builtin_commands/commands/provider.py
+++ b/astrbot/builtin_stars/builtin_commands/commands/provider.py
@@ -13,6 +13,23 @@ class ProviderCommands:
     def __init__(self, context: star.Context) -> None:
         self.context = context
 
+    async def _reset_provider_override(
+        self,
+        event: AstrMessageEvent,
+        umo: str,
+        provider_type: ProviderType,
+        display_name: str,
+    ) -> None:
+        await sp.session_remove(
+            umo,
+            f"provider_perf_{provider_type.value}",
+        )
+        event.set_result(
+            MessageEventResult().message(
+                f"✅ Successfully reset {display_name} provider to global default."
+            )
+        )
+
     def _log_reachability_failure(
         self,
         provider,
@@ -193,14 +210,8 @@ class ProviderCommands:
                 )
                 return
             if idx2 in ("default", "reset", "clear"):
-                await sp.session_remove(
-                    umo,
-                    f"provider_perf_{ProviderType.TEXT_TO_SPEECH.value}",
-                )
-                event.set_result(
-                    MessageEventResult().message(
-                        "✅ Successfully reset TTS provider to global default."
-                    )
+                await self._reset_provider_override(
+                    event, umo, ProviderType.TEXT_TO_SPEECH, "TTS"
                 )
                 return
             try:
@@ -233,14 +244,8 @@ class ProviderCommands:
                 )
                 return
             if idx2 in ("default", "reset", "clear"):
-                await sp.session_remove(
-                    umo,
-                    f"provider_perf_{ProviderType.SPEECH_TO_TEXT.value}",
-                )
-                event.set_result(
-                    MessageEventResult().message(
-                        "✅ Successfully reset STT provider to global default."
-                    )
+                await self._reset_provider_override(
+                    event, umo, ProviderType.SPEECH_TO_TEXT, "STT"
                 )
                 return
             try:
@@ -267,14 +272,8 @@ class ProviderCommands:
                 MessageEventResult().message(f"✅ Successfully switched to {id_}.")
             )
         elif idx in ("default", "reset", "clear"):
-            await sp.session_remove(
-                umo,
-                f"provider_perf_{ProviderType.CHAT_COMPLETION.value}",
-            )
-            event.set_result(
-                MessageEventResult().message(
-                    "✅ Successfully reset Chat Completion provider to global default."
-                )
+            await self._reset_provider_override(
+                event, umo, ProviderType.CHAT_COMPLETION, "Chat Completion"
             )
         else:
             try:

--- a/astrbot/builtin_stars/builtin_commands/main.py
+++ b/astrbot/builtin_stars/builtin_commands/main.py
@@ -67,7 +67,7 @@ class Main(star.Star):
         self,
         event: AstrMessageEvent,
         idx: str | int | None = None,
-        idx2: int | None = None,
+        idx2: str | int | None = None,
     ) -> None:
         """View or switch LLM Provider"""
         await self.provider_c.provider(event, idx, idx2)

--- a/tests/unit/test_provider_commands.py
+++ b/tests/unit/test_provider_commands.py
@@ -1,0 +1,56 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from astrbot.builtin_stars.builtin_commands.commands.provider import ProviderCommands
+from astrbot.api.event import AstrMessageEvent, MessageEventResult
+from astrbot.core.provider.entities import ProviderType
+
+@pytest.mark.asyncio
+async def test_provider_reset_chat_completion():
+    context = MagicMock()
+    cmd = ProviderCommands(context)
+    event = MagicMock(spec=AstrMessageEvent)
+    event.unified_msg_origin = "session-123"
+
+    with patch("astrbot.builtin_stars.builtin_commands.commands.provider.sp.session_remove", new_callable=AsyncMock) as mock_remove:
+        await cmd.provider(event, idx="reset")
+        mock_remove.assert_called_once_with(
+            "session-123",
+            f"provider_perf_{ProviderType.CHAT_COMPLETION.value}",
+        )
+        event.set_result.assert_called_once()
+        res = event.set_result.call_args[0][0]
+        assert "reset Chat Completion provider" in res.get_plain_text()
+
+@pytest.mark.asyncio
+async def test_provider_reset_tts():
+    context = MagicMock()
+    cmd = ProviderCommands(context)
+    event = MagicMock(spec=AstrMessageEvent)
+    event.unified_msg_origin = "session-123"
+
+    with patch("astrbot.builtin_stars.builtin_commands.commands.provider.sp.session_remove", new_callable=AsyncMock) as mock_remove:
+        await cmd.provider(event, idx="tts", idx2="reset")
+        mock_remove.assert_called_once_with(
+            "session-123",
+            f"provider_perf_{ProviderType.TEXT_TO_SPEECH.value}",
+        )
+        event.set_result.assert_called_once()
+        res = event.set_result.call_args[0][0]
+        assert "reset TTS provider" in res.get_plain_text()
+
+@pytest.mark.asyncio
+async def test_provider_reset_stt():
+    context = MagicMock()
+    cmd = ProviderCommands(context)
+    event = MagicMock(spec=AstrMessageEvent)
+    event.unified_msg_origin = "session-123"
+
+    with patch("astrbot.builtin_stars.builtin_commands.commands.provider.sp.session_remove", new_callable=AsyncMock) as mock_remove:
+        await cmd.provider(event, idx="stt", idx2="reset")
+        mock_remove.assert_called_once_with(
+            "session-123",
+            f"provider_perf_{ProviderType.SPEECH_TO_TEXT.value}",
+        )
+        event.set_result.assert_called_once()
+        res = event.set_result.call_args[0][0]
+        assert "reset STT provider" in res.get_plain_text()

--- a/tests/unit/test_provider_commands.py
+++ b/tests/unit/test_provider_commands.py
@@ -1,7 +1,9 @@
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from astrbot.api.event import AstrMessageEvent
 from astrbot.builtin_stars.builtin_commands.commands.provider import ProviderCommands
-from astrbot.api.event import AstrMessageEvent, MessageEventResult
 from astrbot.core.provider.entities import ProviderType
 
 

--- a/tests/unit/test_provider_commands.py
+++ b/tests/unit/test_provider_commands.py
@@ -4,6 +4,7 @@ from astrbot.builtin_stars.builtin_commands.commands.provider import ProviderCom
 from astrbot.api.event import AstrMessageEvent, MessageEventResult
 from astrbot.core.provider.entities import ProviderType
 
+
 @pytest.mark.asyncio
 async def test_provider_reset_chat_completion():
     context = MagicMock()
@@ -11,7 +12,10 @@ async def test_provider_reset_chat_completion():
     event = MagicMock(spec=AstrMessageEvent)
     event.unified_msg_origin = "session-123"
 
-    with patch("astrbot.builtin_stars.builtin_commands.commands.provider.sp.session_remove", new_callable=AsyncMock) as mock_remove:
+    with patch(
+        "astrbot.builtin_stars.builtin_commands.commands.provider.sp.session_remove",
+        new_callable=AsyncMock,
+    ) as mock_remove:
         await cmd.provider(event, idx="reset")
         mock_remove.assert_called_once_with(
             "session-123",
@@ -21,6 +25,7 @@ async def test_provider_reset_chat_completion():
         res = event.set_result.call_args[0][0]
         assert "reset Chat Completion provider" in res.get_plain_text()
 
+
 @pytest.mark.asyncio
 async def test_provider_reset_tts():
     context = MagicMock()
@@ -28,7 +33,10 @@ async def test_provider_reset_tts():
     event = MagicMock(spec=AstrMessageEvent)
     event.unified_msg_origin = "session-123"
 
-    with patch("astrbot.builtin_stars.builtin_commands.commands.provider.sp.session_remove", new_callable=AsyncMock) as mock_remove:
+    with patch(
+        "astrbot.builtin_stars.builtin_commands.commands.provider.sp.session_remove",
+        new_callable=AsyncMock,
+    ) as mock_remove:
         await cmd.provider(event, idx="tts", idx2="reset")
         mock_remove.assert_called_once_with(
             "session-123",
@@ -38,6 +46,7 @@ async def test_provider_reset_tts():
         res = event.set_result.call_args[0][0]
         assert "reset TTS provider" in res.get_plain_text()
 
+
 @pytest.mark.asyncio
 async def test_provider_reset_stt():
     context = MagicMock()
@@ -45,7 +54,10 @@ async def test_provider_reset_stt():
     event = MagicMock(spec=AstrMessageEvent)
     event.unified_msg_origin = "session-123"
 
-    with patch("astrbot.builtin_stars.builtin_commands.commands.provider.sp.session_remove", new_callable=AsyncMock) as mock_remove:
+    with patch(
+        "astrbot.builtin_stars.builtin_commands.commands.provider.sp.session_remove",
+        new_callable=AsyncMock,
+    ) as mock_remove:
         await cmd.provider(event, idx="stt", idx2="reset")
         mock_remove.assert_called_once_with(
             "session-123",


### PR DESCRIPTION
## Description

Currently, when an administrator runs `/provider <idx>` in a session, the session-level provider override is persisted in the database under `provider_perf_<type>`. 
However, there was no command or method to clear/delete this session-level preference once it was set. As a result, even if the administrator changes the default model or provider in the global WebUI configuration, the session remains locked/stuck on the old overridden provider.

This PR implements `default`, `reset`, and `clear` subcommands for:
- `/provider` (e.g. `/provider reset` or `/provider default`)
- `/provider tts` (e.g. `/provider tts reset` or `/provider tts default`)
- `/provider stt` (e.g. `/provider stt reset` or `/provider stt default`)

When executed, it removes the session override preference using `sp.session_remove(...)` so that the session correctly falls back to the default configuration.

## Proposed Changes
- Change signature of `idx2` in `provider` command to `str | int | None` to support string commands.
- Check for subcommands `("default", "reset", "clear")` for Chat, TTS, and STT providers.
- Call `sp.session_remove` to delete the preference override keys.
- Robustly parse provider index input as both string digits and integers.
- Add unit tests for the newly added reset features in `tests/unit/test_provider_commands.py`.

## Validation
All 3 new tests in `tests/unit/test_provider_commands.py` pass:
- `test_provider_reset_chat_completion`
- `test_provider_reset_tts`
- `test_provider_reset_stt`

## Summary by Sourcery

Add support for resetting session-level provider overrides back to the global defaults for chat, TTS, and STT providers.

New Features:
- Allow /provider, /provider tts, and /provider stt commands to accept default/reset/clear subcommands to remove session-specific provider overrides.

Enhancements:
- Relax provider command parameter types and parsing to handle both integer indices and string subcommands for provider selection.

Tests:
- Add unit tests covering reset behavior for chat completion, TTS, and STT provider commands.