### PR TITLE
fix: sanitize Lark platform id suffixes

### DIFF
--- a/dashboard/src/components/platform/AddNewPlatform.vue
+++ b/dashboard/src/components/platform/AddNewPlatform.vue
@@ -1409,6 +1409,13 @@ export default {
       return suffix;
     },
 
+    sanitizePlatformIdPart(value) {
+      return String(value || "")
+        .trim()
+        .replace(/\s+/g, "")
+        .replace(/[!:]/g, "_");
+    },
+
     handlePlatformRegistrationCreated(data) {
       if (!this.selectedPlatformConfig || !data) {
         return;
@@ -1420,18 +1427,14 @@ export default {
       }
 
       let suffix = "";
-      const explicitSuffix = String(data.platform_id_suffix || "")
-        .trim()
-        .replace(/[!:]/g, "_");
+      const explicitSuffix = this.sanitizePlatformIdPart(data.platform_id_suffix);
       if (explicitSuffix) {
         suffix =
           explicitSuffix.startsWith("_") || explicitSuffix.startsWith("-")
             ? explicitSuffix
             : `_${explicitSuffix}`;
       } else if (data.bot_name) {
-        const safeBotName = String(data.bot_name || "")
-          .trim()
-          .replace(/[!:]/g, "_");
+        const safeBotName = this.sanitizePlatformIdPart(data.bot_name);
         if (safeBotName) {
           suffix = `-${safeBotName}`;
         }
@@ -1459,7 +1462,7 @@ export default {
       if (!id) {
         return false;
       }
-      return !/[!:]/.test(id);
+      return !/[!:\s]/.test(id);
     },
 
     // 获取该平台适配器使用的所有配置文件（新版本：直接操作路由表）


### PR DESCRIPTION
Fixes #8726.

### Modifications / 改动点

- Sanitize generated platform ID suffixes with the same path for explicit suffixes and registered bot names.
- Strip whitespace from the generated Lark bot-name suffix, so a bot name like `藤田琴音 Bot` produces `lark-藤田琴音Bot` instead of an ID containing spaces around or inside the suffix.
- Reject whitespace in manually edited platform IDs, matching the routing path that later resolves UMOs by exact `platform.meta().id`.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Verification run locally:

```text
git diff --check
npm run typecheck
npm run build
```

`npm run build` completed successfully and regenerated the dashboard bundle locally. No generated assets or dependency files are included in this PR.

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure platform IDs generated and edited in the dashboard use a consistently sanitized suffix and reject invalid characters.

Bug Fixes:
- Normalize whitespace and special characters in generated Lark platform ID suffixes so bot names cannot produce IDs with spaces or disallowed punctuation.
- Disallow whitespace in manually edited platform IDs to match the routing logic that resolves platforms by exact ID.

Enhancements:
- Centralize platform ID suffix sanitization into a shared helper used for both explicit suffixes and bot-name-derived suffixes.