### PR TITLE
fix: updates the aiocqhttp platform adapter and message event handler to include self_id routing parameters across multiple API calls

### DIFF
--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_message_event.py
@@ -99,11 +99,22 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
         session_id_int = (
             int(session_id) if session_id and session_id.isdigit() else None
         )
+        routing_params = {}
+        if isinstance(event, Event) and event.get("self_id"):
+            routing_params["self_id"] = event["self_id"]
 
         if is_group and isinstance(session_id_int, int):
-            await bot.send_group_msg(group_id=session_id_int, message=messages)
+            await bot.send_group_msg(
+                group_id=session_id_int,
+                message=messages,
+                **routing_params,
+            )
         elif not is_group and isinstance(session_id_int, int):
-            await bot.send_private_msg(user_id=session_id_int, message=messages)
+            await bot.send_private_msg(
+                user_id=session_id_int,
+                message=messages,
+                **routing_params,
+            )
         elif isinstance(event, Event):  # 最后兜底
             await bot.send(event=event, message=messages)
         else:
@@ -151,9 +162,13 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
 
                 if is_group:
                     payload["group_id"] = session_id
+                    if isinstance(event, Event) and event.get("self_id"):
+                        payload["self_id"] = event["self_id"]
                     await bot.call_action("send_group_forward_msg", **payload)
                 else:
                     payload["user_id"] = session_id
+                    if isinstance(event, Event) and event.get("self_id"):
+                        payload["self_id"] = event["self_id"]
                     await bot.call_action("send_private_forward_msg", **payload)
             elif isinstance(seg, File):
                 d = await cls._from_segment_to_dict(seg)
@@ -225,14 +240,20 @@ class AiocqhttpMessageEvent(AstrMessageEvent):
         else:
             return None
 
+        routing_params = {}
+        if getattr(self.message_obj, "self_id", None):
+            routing_params["self_id"] = self.message_obj.self_id
+
         info: dict = await self.bot.call_action(
             "get_group_info",
             group_id=group_id,
+            **routing_params,
         )
 
         members: list[dict] = await self.bot.call_action(
             "get_group_member_list",
             group_id=group_id,
+            **routing_params,
         )
 
         owner_id = None

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -396,10 +396,7 @@ class AiocqhttpAdapter(Platform):
 
                 message_str += "".join(at_parts)
             elif t == "mface":
-                for m in m_group:
-                    name = str(m["data"].get("name") or "[动画表情]")
-                    abm.message.append(Plain(text=name))
-                    message_str += name
+                continue
             elif t == "markdown":
                 for m in m_group:
                     text = m["data"].get("markdown") or m["data"].get("content", "")

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -239,6 +239,7 @@ class AiocqhttpAdapter(Platform):
             raise ValueError(err)
 
         # 按消息段类型类型适配
+        routing_params = {"self_id": event.self_id} if event.self_id else {}
         for t, m_group in itertools.groupby(event.message, key=lambda x: x["type"]):
             a = None
             if t == "text":
@@ -272,11 +273,13 @@ class AiocqhttpAdapter(Platform):
                                     action="get_group_file_url",
                                     file_id=event.message[0]["data"]["file_id"],
                                     group_id=event.group_id,
+                                    **routing_params,
                                 )
                             elif abm.type == MessageType.FRIEND_MESSAGE:
                                 ret = await self.bot.call_action(
                                     action="get_private_file_url",
                                     file_id=event.message[0]["data"]["file_id"],
+                                    **routing_params,
                                 )
                             if ret and "url" in ret:
                                 file_url = ret["url"]  # https
@@ -307,6 +310,7 @@ class AiocqhttpAdapter(Platform):
                             reply_event_data = await self.bot.call_action(
                                 action="get_msg",
                                 message_id=int(m["data"]["id"]),
+                                **routing_params,
                             )
                             # 添加必要的 post_type 字段，防止 Event.from_payload 报错
                             reply_event_data["post_type"] = "message"
@@ -353,6 +357,7 @@ class AiocqhttpAdapter(Platform):
                             group_id=event.group_id,
                             user_id=int(m["data"]["qq"]),
                             no_cache=False,
+                            **routing_params,
                         )
                         if at_info:
                             nickname = at_info.get("card", "")
@@ -361,6 +366,7 @@ class AiocqhttpAdapter(Platform):
                                     action="get_stranger_info",
                                     user_id=int(m["data"]["qq"]),
                                     no_cache=False,
+                                    **routing_params,
                                 )
                                 nickname = at_info.get("nick", "") or at_info.get(
                                     "nickname",
@@ -389,6 +395,11 @@ class AiocqhttpAdapter(Platform):
                         logger.error(f"获取 @ 用户信息失败: {e}，此消息段将被忽略。")
 
                 message_str += "".join(at_parts)
+            elif t == "mface":
+                for m in m_group:
+                    name = str(m["data"].get("name") or "[动画表情]")
+                    abm.message.append(Plain(text=name))
+                    message_str += name
             elif t == "markdown":
                 for m in m_group:
                     text = m["data"].get("markdown") or m["data"].get("content", "")


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
本 PR 改进 AstrBot 的 aiocqhttp / OneBot V11 适配兼容性。
在部分 OneBot 实现，例如 SnowLuma，在反向 WebSocket 场景下可能存在多个连接或 API 连接上下文不明确的情况。
  - 在通过 aiocqhttp 调用 OneBot API 时传递 `self_id`
  - 修复反向 WebSocket API 连接存在歧义时可能出现的 `ApiNotAvailable`
  - 对 `mface` 消息段进行静默兼容处理，避免标准外扩展段产生 warning
### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
  - 在消息发送相关 API 调用中携带事件的 self_id
  - 在引用消息、@ 用户信息、文件 URL 等 API 查询中携带 self_id
  - 对 mface 消息段增加静默处理
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<img width="1125" height="221" alt="image" src="https://github.com/user-attachments/assets/57aa2a8b-0807-445a-bc86-1b2d9f2a6a3b" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。
