### PR TITLE
fix: deduplicate send_message_t fix: deduplicate send_message_to_user calls to prevent duplicate messages

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -792,6 +792,13 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             await self._complete_with_assistant_response(llm_resp)
 
         # 返回 LLM 结果
+        # 当 LLM 同时返回 completion_text 和 send_message_to_user 工具调用时，
+        # 抑制 completion_text 的 yield，避免 respond 阶段重复发送相同内容。
+        # 这是 mimo 模型的已知问题：它会在同一响应中既输出文本又调用 send_message_to_user。
+        _has_send_message_tool = (
+            llm_resp.tools_call_name
+            and "send_message_to_user" in llm_resp.tools_call_name
+        )
         if llm_resp.reasoning_content:
             yield AgentResponse(
                 type="llm_result",
@@ -802,17 +809,27 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 ),
             )
         if llm_resp.result_chain:
-            yield AgentResponse(
-                type="llm_result",
-                data=AgentResponseData(chain=llm_resp.result_chain),
-            )
+            if _has_send_message_tool:
+                logger.info(
+                    "检测到 send_message_to_user 工具调用，抑制 result_chain 以避免重复发送。"
+                )
+            else:
+                yield AgentResponse(
+                    type="llm_result",
+                    data=AgentResponseData(chain=llm_resp.result_chain),
+                )
         elif llm_resp.completion_text:
-            yield AgentResponse(
-                type="llm_result",
-                data=AgentResponseData(
-                    chain=MessageChain().message(llm_resp.completion_text),
-                ),
-            )
+            if _has_send_message_tool:
+                logger.info(
+                    "检测到 send_message_to_user 工具调用，抑制 completion_text 以避免重复发送。"
+                )
+            else:
+                yield AgentResponse(
+                    type="llm_result",
+                    data=AgentResponseData(
+                        chain=MessageChain().message(llm_resp.completion_text),
+                    ),
+                )
 
         # 如果有工具调用，还需处理工具调用
         if llm_resp.tools_call_name:

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -113,8 +113,8 @@ def _extract_send_message_text(
 ) -> str | None:
     """从 send_message_to_user 工具调用参数中提取纯文本内容。
 
-    用于比对 completion_text 与工具 payload 是否一致，判断是否为重复发送。
-    仅提取 type="plain" 的文本部分。
+    用于比对 completion_text 与工具 payload 是否一致，
+    判断是否为重复发送。仅提取 type="plain" 的文本部分。
     """
     if not tools_call_name or not tools_call_args:
         return None
@@ -819,8 +819,9 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             await self._complete_with_assistant_response(llm_resp)
 
         # 返回 LLM 结果
-        # 当 send_message_to_user 的 payload 与 completion_text 内容一致时，
-        # 抑制 completion_text 的 yield，避免 respond 阶段重复发送。
+        # 当 send_message_to_user 的 payload 与 completion_text
+        # 内容一致时，抑制 completion_text 的 yield，
+        # 避免 respond 阶段重复发送。
         # 仅在内容匹配时抑制，不影响发到其他会话或内容不同的场景。
         _should_suppress_text = False
         if (

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -107,6 +107,33 @@ class _ToolExecutionInterrupted(Exception):
 ToolExecutorResultT = T.TypeVar("ToolExecutorResultT")
 
 
+def _extract_send_message_text(
+    tools_call_name: list[str] | None,
+    tools_call_args: list[dict] | None,
+) -> str | None:
+    """从 send_message_to_user 工具调用参数中提取纯文本内容。
+
+    用于比对 completion_text 与工具 payload 是否一致，判断是否为重复发送。
+    仅提取 type="plain" 的文本部分。
+    """
+    if not tools_call_name or not tools_call_args:
+        return None
+    for name, args in zip(tools_call_name, tools_call_args):
+        if name == "send_message_to_user" and isinstance(args, dict):
+            messages = args.get("messages")
+            if not isinstance(messages, list):
+                continue
+            texts = []
+            for msg in messages:
+                if isinstance(msg, dict) and msg.get("type") == "plain":
+                    text = msg.get("text", "").strip()
+                    if text:
+                        texts.append(text)
+            if texts:
+                return " ".join(texts)
+    return None
+
+
 class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
     TOOL_RESULT_MAX_ESTIMATED_TOKENS = 27_500
     TOOL_RESULT_PREVIEW_MAX_ESTIMATED_TOKENS = 7000
@@ -792,13 +819,24 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             await self._complete_with_assistant_response(llm_resp)
 
         # 返回 LLM 结果
-        # 当 LLM 同时返回 completion_text 和 send_message_to_user 工具调用时，
-        # 抑制 completion_text 的 yield，避免 respond 阶段重复发送相同内容。
-        # 这是 mimo 模型的已知问题：它会在同一响应中既输出文本又调用 send_message_to_user。
-        _has_send_message_tool = (
+        # 当 send_message_to_user 的 payload 与 completion_text 内容一致时，
+        # 抑制 completion_text 的 yield，避免 respond 阶段重复发送。
+        # 仅在内容匹配时抑制，不影响发到其他会话或内容不同的场景。
+        _should_suppress_text = False
+        if (
             llm_resp.tools_call_name
             and "send_message_to_user" in llm_resp.tools_call_name
-        )
+        ):
+            _tool_text = _extract_send_message_text(
+                llm_resp.tools_call_name, llm_resp.tools_call_args
+            )
+            _completion = (llm_resp.completion_text or "").strip()
+            if _tool_text and _completion and _tool_text == _completion:
+                _should_suppress_text = True
+                logger.info(
+                    "send_message_to_user payload 与 completion_text 一致，"
+                    "抑制以避免重复发送。"
+                )
         if llm_resp.reasoning_content:
             yield AgentResponse(
                 type="llm_result",
@@ -809,21 +847,13 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 ),
             )
         if llm_resp.result_chain:
-            if _has_send_message_tool:
-                logger.info(
-                    "检测到 send_message_to_user 工具调用，抑制 result_chain 以避免重复发送。"
-                )
-            else:
+            if not _should_suppress_text:
                 yield AgentResponse(
                     type="llm_result",
                     data=AgentResponseData(chain=llm_resp.result_chain),
                 )
         elif llm_resp.completion_text:
-            if _has_send_message_tool:
-                logger.info(
-                    "检测到 send_message_to_user 工具调用，抑制 completion_text 以避免重复发送。"
-                )
-            else:
+            if not _should_suppress_text:
                 yield AgentResponse(
                     type="llm_result",
                     data=AgentResponseData(

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -107,17 +107,37 @@ class _ToolExecutionInterrupted(Exception):
 ToolExecutorResultT = T.TypeVar("ToolExecutorResultT")
 
 
-def _extract_send_message_text(
+def _normalize_text(text: str) -> str:
+    """标准化文本用于比对：strip + 合并连续空白。"""
+    return " ".join(text.strip().split())
+
+
+def _extract_text_from_chain(chain) -> str | None:
+    """从 MessageChain 中提取纯文本内容。"""
+    if not chain or not hasattr(chain, "chain") or not chain.chain:
+        return None
+    texts = []
+    for comp in chain.chain:
+        if hasattr(comp, "text"):
+            text = comp.text.strip()
+            if text:
+                texts.append(text)
+    return " ".join(texts) if texts else None
+
+
+def _extract_send_message_texts(
     tools_call_name: list[str] | None,
     tools_call_args: list[dict] | None,
-) -> str | None:
-    """从 send_message_to_user 工具调用参数中提取纯文本内容。
+) -> list[str]:
+    """从所有 send_message_to_user 调用中提取纯文本。
 
-    用于比对 completion_text 与工具 payload 是否一致，
-    判断是否为重复发送。仅提取 type="plain" 的文本部分。
+    用于比对 completion_text / result_chain 与工具 payload
+    是否一致，判断是否为重复发送。
+    仅提取 type="plain" 的文本部分。
     """
     if not tools_call_name or not tools_call_args:
-        return None
+        return []
+    results = []
     for name, args in zip(tools_call_name, tools_call_args):
         if name == "send_message_to_user" and isinstance(args, dict):
             messages = args.get("messages")
@@ -130,8 +150,8 @@ def _extract_send_message_text(
                     if text:
                         texts.append(text)
             if texts:
-                return " ".join(texts)
-    return None
+                results.append(" ".join(texts))
+    return results
 
 
 class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
@@ -820,7 +840,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
 
         # 返回 LLM 结果
         # 当 send_message_to_user 的 payload 与 completion_text
-        # 内容一致时，抑制 completion_text 的 yield，
+        # 或 result_chain 内容一致时，抑制 yield，
         # 避免 respond 阶段重复发送。
         # 仅在内容匹配时抑制，不影响发到其他会话或内容不同的场景。
         _should_suppress_text = False
@@ -828,16 +848,27 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             llm_resp.tools_call_name
             and "send_message_to_user" in llm_resp.tools_call_name
         ):
-            _tool_text = _extract_send_message_text(
+            _tool_texts = _extract_send_message_texts(
                 llm_resp.tools_call_name, llm_resp.tools_call_args
             )
-            _completion = (llm_resp.completion_text or "").strip()
-            if _tool_text and _completion and _tool_text == _completion:
-                _should_suppress_text = True
-                logger.info(
-                    "send_message_to_user payload 与 completion_text 一致，"
-                    "抑制以避免重复发送。"
+            if _tool_texts:
+                _completion = _normalize_text(
+                    llm_resp.completion_text or ""
                 )
+                _chain_text = _normalize_text(
+                    _extract_text_from_chain(llm_resp.result_chain) or ""
+                )
+                for _tt in _tool_texts:
+                    _nt = _normalize_text(_tt)
+                    if (_nt and _completion and _nt == _completion) or (
+                        _nt and _chain_text and _nt == _chain_text
+                    ):
+                        _should_suppress_text = True
+                        logger.info(
+                            "send_message_to_user payload 与响应文本一致，"
+                            f"抑制以避免重复发送。 text={_tt[:50]!r}"
+                        )
+                        break
         if llm_resp.reasoning_content:
             yield AgentResponse(
                 type="llm_result",

--- a/astrbot/core/tools/message_tools.py
+++ b/astrbot/core/tools/message_tools.py
@@ -325,11 +325,10 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
             messages, ensure_ascii=False, sort_keys=True
         )
         fingerprint = hashlib.md5(dedup_key.encode()).hexdigest()
-        sent_fingerprints = context.context.event.get_extra(
+        existing = context.context.event.get_extra(
             "_send_message_fingerprints"
         )
-        if sent_fingerprints is None:
-            sent_fingerprints = set()
+        sent_fingerprints = set(existing) if existing else set()
         if fingerprint in sent_fingerprints:
             logger.info(
                 f"[send_message_to_user] 当前事件内重复发送，已跳过。"
@@ -338,7 +337,9 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
             )
             return f"Message skipped (duplicate), session={target_session}"
         sent_fingerprints.add(fingerprint)
-        context.context.event.set_extra("_send_message_fingerprints", sent_fingerprints)
+        context.context.event.set_extra(
+            "_send_message_fingerprints", sent_fingerprints
+        )
 
         await context.context.context.send_message(
             target_session,

--- a/astrbot/core/tools/message_tools.py
+++ b/astrbot/core/tools/message_tools.py
@@ -1,6 +1,8 @@
+import hashlib
 import json
 import os
 import shlex
+import time
 import uuid
 from pathlib import Path
 
@@ -25,6 +27,13 @@ from astrbot.core.utils.astrbot_path import (
     get_astrbot_system_tmp_path,
     get_astrbot_temp_path,
 )
+
+# 消息发送去重：防止 LLM 在同一 agent run 中重复调用 send_message_to_user 发送相同内容。
+# 已知触发模型：mimo（会在同一响应中同时返回 completion_text 和 send_message_to_user 工具调用，
+# 或在连续多次响应中重复调用同一工具）。
+# 指纹 = md5(session + 序列化后的 messages)，在时间窗口内相同则跳过。
+_recent_sends: dict[str, float] = {}
+_DEDUP_WINDOW_SECONDS = 30.0
 
 
 def _file_send_allowed_roots(umo: str | None) -> tuple[Path, ...]:
@@ -315,6 +324,24 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
                     return f"error: invalid session: {session}"
             else:
                 return f"error: invalid session: {session}"
+
+        # 去重：计算消息指纹，跳过短时间内重复发送的相同内容
+        global _recent_sends
+        now = time.time()
+        _recent_sends = {
+            k: v for k, v in _recent_sends.items()
+            if now - v < _DEDUP_WINDOW_SECONDS
+        }
+        fingerprint = hashlib.md5(
+            (str(session) + json.dumps(messages, ensure_ascii=False, sort_keys=True)).encode()
+        ).hexdigest()
+        if fingerprint in _recent_sends:
+            logger.info(
+                f"[send_message_to_user] 检测到重复发送，已跳过。"
+                f" session={session}, fingerprint={fingerprint[:8]}"
+            )
+            return f"Message skipped (duplicate), session={target_session}"
+        _recent_sends[fingerprint] = now
 
         await context.context.context.send_message(
             target_session,

--- a/astrbot/core/tools/message_tools.py
+++ b/astrbot/core/tools/message_tools.py
@@ -1,3 +1,4 @@
+import asyncio
 import hashlib
 import json
 import os
@@ -31,8 +32,10 @@ from astrbot.core.utils.astrbot_path import (
 # 消息发送去重：防止 LLM 在同一 agent run 中重复调用 send_message_to_user 发送相同内容。
 # 已知触发模型：mimo（会在同一响应中同时返回 completion_text 和 send_message_to_user 工具调用，
 # 或在连续多次响应中重复调用同一工具）。
-# 指纹 = md5(session + 序列化后的 messages)，在时间窗口内相同则跳过。
+# 指纹 = md5(target_session + sender_id + platform_id + 序列化后的 messages)，
+# 在时间窗口内相同则跳过。使用 asyncio.Lock 保证并发安全。
 _recent_sends: dict[str, float] = {}
+_recent_sends_lock = asyncio.Lock()
 _DEDUP_WINDOW_SECONDS = 30.0
 
 
@@ -325,23 +328,32 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
             else:
                 return f"error: invalid session: {session}"
 
-        # 去重：计算消息指纹，跳过短时间内重复发送的相同内容
-        global _recent_sends
+        # 去重：计算消息指纹，跳过短时间内重复发送的相同内容。
+        # 使用 target_session（已解析的规范会话标识）而非原始 session 字符串，
+        # 并加入 sender_id 和 platform_id 以区分不同来源的相同消息内容。
+        global _recent_sends, _recent_sends_lock
         now = time.time()
-        _recent_sends = {
-            k: v for k, v in _recent_sends.items()
-            if now - v < _DEDUP_WINDOW_SECONDS
-        }
-        fingerprint = hashlib.md5(
-            (str(session) + json.dumps(messages, ensure_ascii=False, sort_keys=True)).encode()
-        ).hexdigest()
-        if fingerprint in _recent_sends:
-            logger.info(
-                f"[send_message_to_user] 检测到重复发送，已跳过。"
-                f" session={session}, fingerprint={fingerprint[:8]}"
-            )
-            return f"Message skipped (duplicate), session={target_session}"
-        _recent_sends[fingerprint] = now
+        event = context.context.event
+        dedup_key = "|".join([
+            str(target_session),
+            str(getattr(event, "sender_id", "")),
+            str(getattr(event, "platform_id", "")),
+            json.dumps(messages, ensure_ascii=False, sort_keys=True),
+        ])
+        fingerprint = hashlib.md5(dedup_key.encode()).hexdigest()
+        async with _recent_sends_lock:
+            _recent_sends = {
+                k: v for k, v in _recent_sends.items()
+                if now - v < _DEDUP_WINDOW_SECONDS
+            }
+            if fingerprint in _recent_sends:
+                logger.info(
+                    f"[send_message_to_user] 检测到重复发送，已跳过。"
+                    f" session={session}, target_session={target_session},"
+                    f" fingerprint={fingerprint[:8]}"
+                )
+                return f"Message skipped (duplicate), session={target_session}"
+            _recent_sends[fingerprint] = now
 
         await context.context.context.send_message(
             target_session,

--- a/astrbot/core/tools/message_tools.py
+++ b/astrbot/core/tools/message_tools.py
@@ -1,9 +1,7 @@
-import asyncio
 import hashlib
 import json
 import os
 import shlex
-import time
 import uuid
 from pathlib import Path
 
@@ -29,14 +27,6 @@ from astrbot.core.utils.astrbot_path import (
     get_astrbot_temp_path,
 )
 
-# 消息发送去重：防止 LLM 在同一 agent run 中重复调用 send_message_to_user 发送相同内容。
-# 已知触发模型：mimo（会在同一响应中同时返回 completion_text 和 send_message_to_user 工具调用，
-# 或在连续多次响应中重复调用同一工具）。
-# 指纹 = md5(target_session + sender_id + platform_id + 序列化后的 messages)，
-# 在时间窗口内相同则跳过。使用 asyncio.Lock 保证并发安全。
-_recent_sends: dict[str, float] = {}
-_recent_sends_lock = asyncio.Lock()
-_DEDUP_WINDOW_SECONDS = 30.0
 
 
 def _file_send_allowed_roots(umo: str | None) -> tuple[Path, ...]:
@@ -328,32 +318,23 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
             else:
                 return f"error: invalid session: {session}"
 
-        # 去重：计算消息指纹，跳过短时间内重复发送的相同内容。
-        # 使用 target_session（已解析的规范会话标识）而非原始 session 字符串，
-        # 并加入 sender_id 和 platform_id 以区分不同来源的相同消息内容。
-        global _recent_sends, _recent_sends_lock
-        now = time.time()
-        event = context.context.event
-        dedup_key = "|".join([
-            str(target_session),
-            str(getattr(event, "sender_id", "")),
-            str(getattr(event, "platform_id", "")),
-            json.dumps(messages, ensure_ascii=False, sort_keys=True),
-        ])
-        fingerprint = hashlib.md5(dedup_key.encode()).hexdigest()
-        async with _recent_sends_lock:
-            _recent_sends = {
-                k: v for k, v in _recent_sends.items()
-                if now - v < _DEDUP_WINDOW_SECONDS
-            }
-            if fingerprint in _recent_sends:
-                logger.info(
-                    f"[send_message_to_user] 检测到重复发送，已跳过。"
-                    f" session={session}, target_session={target_session},"
-                    f" fingerprint={fingerprint[:8]}"
-                )
-                return f"Message skipped (duplicate), session={target_session}"
-            _recent_sends[fingerprint] = now
+        # 去重：按事件作用域记录已发送的消息指纹，拦截同一 agent run 内的重复调用。
+        # 作用域限定在当前事件，不影响其他事件的合法重复发送。
+        fingerprint = hashlib.md5(
+            (str(target_session) + json.dumps(messages, ensure_ascii=False, sort_keys=True)).encode()
+        ).hexdigest()
+        sent_fingerprints = context.context.event.get_extra("_send_message_fingerprints")
+        if sent_fingerprints is None:
+            sent_fingerprints = set()
+        if fingerprint in sent_fingerprints:
+            logger.info(
+                f"[send_message_to_user] 当前事件内重复发送，已跳过。"
+                f" session={session}, target_session={target_session},"
+                f" fingerprint={fingerprint[:8]}"
+            )
+            return f"Message skipped (duplicate), session={target_session}"
+        sent_fingerprints.add(fingerprint)
+        context.context.event.set_extra("_send_message_fingerprints", sent_fingerprints)
 
         await context.context.context.send_message(
             target_session,

--- a/astrbot/core/tools/message_tools.py
+++ b/astrbot/core/tools/message_tools.py
@@ -318,12 +318,16 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
             else:
                 return f"error: invalid session: {session}"
 
-        # 去重：按事件作用域记录已发送的消息指纹，拦截同一 agent run 内的重复调用。
+        # 去重：按事件作用域记录已发送的消息指纹，
+        # 拦截同一 agent run 内的重复调用。
         # 作用域限定在当前事件，不影响其他事件的合法重复发送。
-        fingerprint = hashlib.md5(
-            (str(target_session) + json.dumps(messages, ensure_ascii=False, sort_keys=True)).encode()
-        ).hexdigest()
-        sent_fingerprints = context.context.event.get_extra("_send_message_fingerprints")
+        dedup_key = str(target_session) + json.dumps(
+            messages, ensure_ascii=False, sort_keys=True
+        )
+        fingerprint = hashlib.md5(dedup_key.encode()).hexdigest()
+        sent_fingerprints = context.context.event.get_extra(
+            "_send_message_fingerprints"
+        )
         if sent_fingerprints is None:
             sent_fingerprints = set()
         if fingerprint in sent_fingerprints:

--- a/tests/unit/test_message_tools.py
+++ b/tests/unit/test_message_tools.py
@@ -8,6 +8,24 @@ import pytest
 from astrbot.core.tools.message_tools import SendMessageToUserTool
 
 
+class _MockEvent:
+    """Minimal event mock with get_extra/set_extra support."""
+
+    def __init__(self, unified_msg_origin, role):
+        self.unified_msg_origin = unified_msg_origin
+        self.role = role
+        self._extras: dict = {}
+
+    def get_sender_id(self):
+        return "user-1"
+
+    def get_extra(self, key, default=None):
+        return self._extras.get(key, default)
+
+    def set_extra(self, key, value):
+        self._extras[key] = value
+
+
 def _make_context(
     current_session="feishu:GroupMessage:oc_xxx",
     role="admin",
@@ -23,11 +41,7 @@ def _make_context(
     }
     return SimpleNamespace(
         context=SimpleNamespace(
-            event=SimpleNamespace(
-                unified_msg_origin=current_session,
-                role=role,
-                get_sender_id=lambda: "user-1",
-            ),
+            event=_MockEvent(current_session, role),
             context=SimpleNamespace(
                 get_config=lambda umo: cfg,
                 send_message=AsyncMock(),


### PR DESCRIPTION
问题
某些 LLM（已知触发模型：mimo）在同一响应中同时返回 `completion_text` 和 `send_message_to_user`
工具调用，或在连续多次响应中重复调用 `send_message_to_user`，导致用户收到重复消息。
复现
1. 使用 mimo 模型
2. 在群聊中 @机器人
3. 机器人偶尔会发送两条完全相同的消息
修复方案
1. `tool_loop_agent_runner.py`（根因修复）
当 LLM 响应中包含 `send_message_to_user` 工具调用时，抑制 `completion_text` / `result_chain` 的 yield，防止
RespondStage 重复发送相同内容。
2. `message_tools.py`（指纹去重）
在 `send_message_to_user` 工具内部，计算消息指纹（md5），30 秒内相同内容直接跳过，防止跨响应的重复调用。
测试
日志中看到 `检测到 send_message_to_user 工具调用，抑制 completion_text` 说明根因修复生效
日志中看到 `[send_message_to_user] 检测到重复发送，已跳过` 说明指纹去重生效

## Summary by Sourcery

Prevent duplicate user-visible messages when LLMs return both text and send_message_to_user tool calls or repeatedly invoke the tool across responses.

Bug Fixes:
- Suppress completion_text/result_chain output when a send_message_to_user tool call is present in the LLM response to avoid double-sending the same content.
- Deduplicate send_message_to_user calls within a short time window using a message fingerprint to skip repeated sends across responses.

Enhancements:
- Add logging around suppression and deduplication paths to aid in diagnosing duplicate message behavior.