### PR TITLE
test: stabilize route assertions for FastAPI 0.137

### DIFF
--- a/tests/test_fastapi_v1_dashboard.py
+++ b/tests/test_fastapi_v1_dashboard.py
@@ -975,6 +975,10 @@ def _jwt_headers() -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
+def _path_for(app: FastAPI, name: str) -> str:
+    return str(app.url_path_for(name))
+
+
 def test_fastapi_app_adapter_registers_on_app_state():
     app = FastAPI()
     adapter = FastAPIAppAdapter(app)
@@ -1886,9 +1890,10 @@ def test_astrbot_web_request_proxy_exposes_typed_methods():
 
     assert isinstance(plugin_request, PluginRequestProxy)
     assert get_type_hints(type(plugin_request).form)["return"] == PluginMultiDict[str]
-    assert get_type_hints(type(plugin_request).files)["return"] == PluginMultiDict[
-        PluginUploadFile
-    ]
+    assert (
+        get_type_hints(type(plugin_request).files)["return"]
+        == PluginMultiDict[PluginUploadFile]
+    )
 
 
 @pytest.mark.asyncio
@@ -2194,27 +2199,21 @@ async def test_v1_token_file_is_public(
 
 
 def test_v1_openapi_alias_websocket_routes_are_mounted(asgi_app):
-    websocket_paths = {
-        route.path
-        for route in asgi_app.router.routes
-        if "websocket" in route.__class__.__name__.lower()
-    }
-
-    assert "/api/v1/chat/ws" in websocket_paths
-    assert "/api/v1/live-chat/ws" in websocket_paths
-    assert "/api/v1/unified-chat/ws" in websocket_paths
+    assert _path_for(asgi_app, "chat_ws") == "/api/v1/chat/ws"
+    assert _path_for(asgi_app, "live_chat_ws") == "/api/v1/live-chat/ws"
+    assert _path_for(asgi_app, "unified_chat_ws") == "/api/v1/unified-chat/ws"
 
 
 def test_dashboard_config_aliases_are_registered_on_fastapi(asgi_app):
-    http_paths = {
-        route.path
-        for route in asgi_app.router.routes
-        if "route" in route.__class__.__name__.lower()
-    }
-
-    assert "/api/config/platform/list" in http_paths
-    assert "/api/config/provider/list" in http_paths
-    assert "/api/config/provider_sources/update" in http_paths
+    assert _path_for(asgi_app, "dashboard_alias_platform_list") == (
+        "/api/config/platform/list"
+    )
+    assert _path_for(asgi_app, "dashboard_alias_provider_list") == (
+        "/api/config/provider/list"
+    )
+    assert _path_for(asgi_app, "update_dashboard_alias_provider_source") == (
+        "/api/config/provider_sources/update"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The current dependency range allows FastAPI 0.137.0 / Starlette 1.3.1 in CI. With that stack, these two route-registration tests can fail because they inspect `app.router.routes` internals directly: FastAPI now keeps included routers behind `_IncludedRouter`, which has no `path` attribute and can hide routes from the flat list.

The routes themselves are still registered and resolvable through FastAPI's public `url_path_for()` API, so this keeps the tests focused on the intended behavior: the expected aliases are mounted at the expected paths.

### Modifications / 改动点

- Assert the route aliases through `app.url_path_for()` instead of scanning route object class names / `path` attributes directly.
- Keep the change limited to `tests/test_fastapi_v1_dashboard.py`.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Verification run locally:

```text
python -m py_compile tests\test_fastapi_v1_dashboard.py
python -m ruff check tests\test_fastapi_v1_dashboard.py
python -m ruff format --check tests\test_fastapi_v1_dashboard.py
python -m pytest tests\test_fastapi_v1_dashboard.py -q -p no:cacheprovider
uv run python -c "import fastapi, starlette, pytest; print('fastapi', fastapi.__version__); print('starlette', starlette.__version__); print('pytest', pytest.__version__)"
uv run python -m pytest tests\test_fastapi_v1_dashboard.py -q -p no:cacheprovider
```

The `uv run` environment resolved the same relevant versions seen in CI:

```text
fastapi 0.137.0
starlette 1.3.1
pytest 9.1.0
```

Both pytest runs passed:

```text
52 passed
```

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. / No new feature; test compatibility only.
- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 My changes do not introduce malicious code.

## Summary by Sourcery

Stabilize FastAPI v1 dashboard tests against internal routing changes by asserting routes via FastAPI’s public URL resolution API.

Tests:
- Add a helper to resolve route paths via app.url_path_for and update websocket and dashboard alias tests to assert on named routes instead of inspecting router internals.
- Tidy a type-hint assertion in the plugin request proxy tests for consistency.