### PR TITLE
fix: preserve guarded run-based tools

### DIFF
--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -266,6 +266,19 @@ class _PermissionGuardedTool(FunctionTool):
         if call_override is not None and call_override is not FunctionTool.call:
             return await self._wrapped.call(context, **kwargs)
 
+        run = getattr(self._wrapped, "run", None)
+        if run is not None:
+            event = context.context.event
+            result = run(event, **kwargs)
+            if _inspect.isasyncgen(result):
+                last: Any = None
+                async for item in result:
+                    last = item
+                return last
+            if _inspect.isawaitable(result):
+                return await result
+            return result
+
         return "error: tool has no callable handler"
 
 

--- a/tests/unit/test_tool_permission.py
+++ b/tests/unit/test_tool_permission.py
@@ -255,6 +255,27 @@ async def test_guarded_tool_delegates_to_wrapped_call():
 
 
 @pytest.mark.asyncio
+async def test_guarded_tool_delegates_to_wrapped_run():
+    _clear_tool_permissions()
+    mgr = FunctionToolManager()
+
+    class RunnableTool(FunctionTool):
+        async def run(self, event, **kwargs):
+            return f"from run(): {event.get_sender_id()} {kwargs['value']}"
+
+    wrapped = RunnableTool(
+        name="has_run",
+        description="desc",
+        parameters={},
+    )
+    guarded = _PermissionGuardedTool(wrapped, mgr)
+    context = _make_context(sender_id="runner")
+
+    result = await guarded.call(context, value="ok")
+    assert result == "from run(): runner ok"
+
+
+@pytest.mark.asyncio
 async def test_guarded_tool_handles_async_generator_handler():
     _clear_tool_permissions()
     mgr = FunctionToolManager()


### PR DESCRIPTION
## Summary
- delegate permission-guarded FunctionTool wrappers to underlying run() methods when no handler or overridden call() exists
- keep run() argument semantics aligned with FunctionToolExecutor by passing the event object
- add a regression test for dataclass-style plugin tools that implement run()

Fixes #8788.

## Verification
- uv run pytest tests/unit/test_tool_permission.py -q
- uv run ruff check astrbot/core/provider/func_tool_manager.py tests/unit/test_tool_permission.py
- uv run ruff format --check astrbot/core/provider/func_tool_manager.py tests/unit/test_tool_permission.py
- git diff --check

## Summary by Sourcery

Ensure permission-guarded tools correctly delegate to underlying run-based tools when no custom call handler is defined.

Bug Fixes:
- Fix permission-guarded tools so they invoke the wrapped tool's run() method when no handler or overridden call() exists, returning the final result from sync, async, or async-generator implementations.

Tests:
- Add a regression test verifying that permission-guarded tools delegate to a wrapped tool's run() method and pass through the event context.