### PR TITLE
fix: run local python in session workspace

### DIFF
--- a/astrbot/core/computer/booters/local.py
+++ b/astrbot/core/computer/booters/local.py
@@ -143,13 +143,16 @@ class LocalPythonComponent(PythonComponent):
         kernel_id: str | None = None,
         timeout: int = 30,
         silent: bool = False,
+        cwd: str | None = None,
     ) -> dict[str, Any]:
         def _run() -> dict[str, Any]:
             try:
+                working_dir = os.path.abspath(cwd) if cwd else get_astrbot_root()
                 result = subprocess.run(
                     [os.environ.get("PYTHON", sys.executable), "-c", code],
                     timeout=timeout,
                     capture_output=True,
+                    cwd=working_dir,
                 )
                 stdout = "" if silent else _decode_shell_output(result.stdout)
                 stderr = (

--- a/astrbot/core/computer/olayer/python.py
+++ b/astrbot/core/computer/olayer/python.py
@@ -14,6 +14,7 @@ class PythonComponent(Protocol):
         kernel_id: str | None = None,
         timeout: int = 30,
         silent: bool = False,
+        cwd: str | None = None,
     ) -> dict[str, Any]:
         """Execute Python code"""
         ...

--- a/astrbot/core/tools/computer_tools/python.py
+++ b/astrbot/core/tools/computer_tools/python.py
@@ -11,7 +11,7 @@ from astrbot.core.computer.computer_client import get_booter, get_local_booter
 from astrbot.core.message.message_event_result import MessageChain
 
 from ..registry import builtin_tool
-from .util import check_admin_permission
+from .util import check_admin_permission, workspace_root
 
 _OS_NAME = platform.system()
 _SANDBOX_PYTHON_TOOL_CONFIG = {
@@ -137,10 +137,15 @@ class LocalPythonTool(FunctionTool):
             else context.tool_call_timeout
         )
         try:
+            current_workspace_root = workspace_root(
+                context.context.event.unified_msg_origin
+            )
+            current_workspace_root.mkdir(parents=True, exist_ok=True)
             result = await sb.python.exec(
                 code,
                 timeout=effective_timeout,
                 silent=silent,
+                cwd=str(current_workspace_root),
             )
             return await handle_result(result, context.context.event)
         except Exception as e:

--- a/tests/unit/test_python_tools.py
+++ b/tests/unit/test_python_tools.py
@@ -1,5 +1,10 @@
 import platform
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
+import pytest
+
+from astrbot.core.agent.run_context import ContextWrapper
 from astrbot.core.tools.computer_tools.python import LocalPythonTool, PythonTool
 
 
@@ -18,3 +23,48 @@ def test_local_python_tool_description_contains_os():
     assert current_os in tool.description
     assert "Python environment" in tool.description
     assert "system-compatible" in tool.description
+
+
+@pytest.mark.asyncio
+async def test_local_python_tool_uses_session_workspace(tmp_path, monkeypatch):
+    """Local Python execution should use the same workspace as local shell."""
+    tool = LocalPythonTool()
+    python_exec = AsyncMock(
+        return_value={"data": {"output": {"text": "ok", "images": []}, "error": ""}}
+    )
+    monkeypatch.setattr(
+        "astrbot.core.tools.computer_tools.python.get_local_booter",
+        lambda: SimpleNamespace(python=SimpleNamespace(exec=python_exec)),
+    )
+    monkeypatch.setattr(
+        "astrbot.core.tools.computer_tools.python.workspace_root",
+        lambda umo: tmp_path / umo.replace(":", "_"),
+    )
+
+    event = SimpleNamespace(
+        unified_msg_origin="onebot:GroupMessage:12345",
+        role="admin",
+        get_platform_name=lambda: "onebot",
+    )
+    context = ContextWrapper(
+        context=SimpleNamespace(
+            event=event,
+            context=SimpleNamespace(
+                get_config=lambda **_kwargs: {
+                    "provider_settings": {"computer_use_require_admin": True}
+                }
+            ),
+        ),
+        tool_call_timeout=60,
+    )
+
+    await tool.call(context, code="print('ok')", timeout=30)
+
+    workspace = tmp_path / "onebot_GroupMessage_12345"
+    assert workspace.is_dir()
+    python_exec.assert_awaited_once_with(
+        "print('ok')",
+        timeout=30,
+        silent=False,
+        cwd=str(workspace.resolve(strict=False)),
+    )


### PR DESCRIPTION
## Summary
- run local Python tool code from the same per-session workspace used by local shell commands
- add optional cwd support to the local Python computer component
- add a regression test that verifies LocalPythonTool passes the normalized UMO workspace as cwd

Fixes #8730.

## Verification
- uv run pytest tests/unit/test_python_tools.py tests/unit/test_computer.py -q
- uv run ruff check astrbot/core/computer/olayer/python.py astrbot/core/computer/booters/local.py astrbot/core/tools/computer_tools/python.py tests/unit/test_python_tools.py
- uv run ruff format --check astrbot/core/computer/olayer/python.py astrbot/core/computer/booters/local.py astrbot/core/tools/computer_tools/python.py tests/unit/test_python_tools.py
- git diff --check

## Summary by Sourcery

Ensure local Python tool execution uses the same per-session workspace as local shell commands and support passing a working directory to the local Python executor.

New Features:
- Allow specifying an optional working directory (cwd) for local Python execution in the computer component.

Bug Fixes:
- Align LocalPythonTool execution with the per-session workspace used by local shell commands so Python runs in the correct session-specific directory.

Tests:
- Add a regression test verifying that LocalPythonTool passes the normalized unified message origin workspace as cwd to the Python executor.