### PR TITLE
fix: write config files atomically

### DIFF
--- a/astrbot/core/config/astrbot_config.py
+++ b/astrbot/core/config/astrbot_config.py
@@ -226,7 +226,6 @@ class AstrBotConfig(dict):
             dir=directory,
             prefix=f".{os.path.basename(self.config_path)}.",
             suffix=".tmp",
-            text=True,
         )
         try:
             with os.fdopen(fd, "w", encoding="utf-8-sig") as f:

--- a/astrbot/core/config/astrbot_config.py
+++ b/astrbot/core/config/astrbot_config.py
@@ -2,6 +2,7 @@ import enum
 import json
 import logging
 import os
+import tempfile
 
 from astrbot.core.utils.astrbot_path import get_astrbot_data_path
 from astrbot.core.utils.auth_password import (
@@ -53,9 +54,9 @@ class AstrBotConfig(dict):
 
         if not self.check_exist():
             """不存在时载入默认配置"""
-            with open(config_path, "w", encoding="utf-8-sig") as f:
-                json.dump(default_config, f, indent=4, ensure_ascii=False)
-                object.__setattr__(self, "first_deploy", True)  # 标记第一次部署
+            self.update(default_config)
+            self.save_config(indent=4)
+            object.__setattr__(self, "first_deploy", True)  # 标记第一次部署
 
         with open(config_path, encoding="utf-8-sig") as f:
             conf_str = f.read()
@@ -211,15 +212,34 @@ class AstrBotConfig(dict):
 
         return has_new
 
-    def save_config(self, replace_config: dict | None = None) -> None:
+    def save_config(
+        self, replace_config: dict | None = None, *, indent: int = 2
+    ) -> None:
         """将配置写入文件
 
         如果传入 replace_config，则将配置替换为 replace_config
         """
         if replace_config:
             self.update(replace_config)
-        with open(self.config_path, "w", encoding="utf-8-sig") as f:
-            json.dump(self, f, indent=2, ensure_ascii=False)
+        directory = os.path.dirname(os.path.abspath(self.config_path)) or "."
+        fd, temp_path = tempfile.mkstemp(
+            dir=directory,
+            prefix=f".{os.path.basename(self.config_path)}.",
+            suffix=".tmp",
+            text=True,
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8-sig") as f:
+                json.dump(self, f, indent=indent, ensure_ascii=False)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(temp_path, self.config_path)
+        except Exception:
+            try:
+                os.unlink(temp_path)
+            except FileNotFoundError:
+                pass
+            raise
 
     def __getattr__(self, item):
         try:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -529,6 +529,38 @@ class TestConfigHotReload:
         # Original fields are preserved because update merges
         assert "platform_settings" in loaded_config
 
+    def test_save_config_preserves_existing_file_when_write_fails(
+        self, temp_config_path, minimal_default_config, monkeypatch
+    ):
+        """Config saves should not corrupt the existing file on write failure."""
+        config = AstrBotConfig(
+            config_path=temp_config_path, default_config=minimal_default_config
+        )
+        with open(temp_config_path, encoding="utf-8-sig") as f:
+            original_content = f.read()
+
+        def failing_dump(*args, **kwargs):
+            file_obj = args[1]
+            file_obj.write("{")
+            raise RuntimeError("simulated interrupted write")
+
+        config.new_field = "new_value"
+        monkeypatch.setattr(
+            "astrbot.core.config.astrbot_config.json.dump",
+            failing_dump,
+        )
+
+        with pytest.raises(RuntimeError, match="simulated interrupted write"):
+            config.save_config()
+
+        with open(temp_config_path, encoding="utf-8-sig") as f:
+            assert f.read() == original_content
+        assert [
+            entry.name
+            for entry in os.scandir(os.path.dirname(temp_config_path))
+            if entry.name != os.path.basename(temp_config_path)
+        ] == []
+
     def test_modification_persists_after_reload(
         self, temp_config_path, minimal_default_config
     ):


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Summary
- write AstrBot config files through a same-directory temporary file followed by atomic replace
- fsync the temporary file before replacement so interrupted writes keep either the old complete config or the new complete config
- use the same atomic path when creating the initial config file
- add a regression test proving a failed write leaves the existing config intact and cleans temporary files

Fixes #8298.

## Verification
- uv run pytest tests/unit/test_config.py -q
- uv run ruff check astrbot/core/config/astrbot_config.py tests/unit/test_config.py
- uv run ruff format --check astrbot/core/config/astrbot_config.py tests/unit/test_config.py
- git diff --check

## Summary by Sourcery

Write AstrBot configuration files atomically to avoid corrupting existing configs on write failures.

Bug Fixes:
- Ensure saving configuration writes through a temporary file and atomic replace so interrupted writes do not corrupt the existing config file.

Enhancements:
- Initialize new config files using the same atomic save path and allow configuring JSON indentation when saving configs.

Tests:
- Add a regression test verifying that failed config writes leave the original file intact and do not leave temporary files behind.