### PR TITLE
fix: skip unavailable WebUI startup

### DIFF
--- a/astrbot/core/initial_loader.py
+++ b/astrbot/core/initial_loader.py
@@ -37,7 +37,11 @@ class InitialLoader:
         core_task = core_lifecycle.start()
 
         if not self.webui_available:
-            await core_task
+            try:
+                await core_task
+            except asyncio.CancelledError:
+                logger.info("🌈 正在关闭 AstrBot...")
+                await core_lifecycle.stop()
             return
 
         webui_dir = self.webui_dir

--- a/astrbot/core/initial_loader.py
+++ b/astrbot/core/initial_loader.py
@@ -22,6 +22,7 @@ class InitialLoader:
         self.logger = logger
         self.log_broker = log_broker
         self.webui_dir: str | None = None
+        self.webui_available = True
 
     async def start(self) -> None:
         core_lifecycle = AstrBotCoreLifecycle(self.log_broker, self.db)
@@ -34,6 +35,10 @@ class InitialLoader:
             return
 
         core_task = core_lifecycle.start()
+
+        if not self.webui_available:
+            await core_task
+            return
 
         webui_dir = self.webui_dir
 

--- a/main.py
+++ b/main.py
@@ -130,6 +130,7 @@ async def main_async(webui_dir_arg: str | None) -> None:
 
     core_lifecycle = InitialLoader(db, log_broker)
     core_lifecycle.webui_dir = webui_dir
+    core_lifecycle.webui_available = webui_dir is not None
     await core_lifecycle.start()
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import sys
 from pathlib import Path
@@ -301,3 +302,24 @@ async def test_initial_loader_skips_unavailable_webui():
     core_lifecycle.initialize.assert_awaited_once()
     core_lifecycle.start.assert_awaited_once()
     mock_dashboard.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_initial_loader_stops_core_when_unavailable_webui_is_cancelled():
+    from astrbot.core.initial_loader import InitialLoader
+
+    core_lifecycle = mock.MagicMock()
+    core_lifecycle.initialize = mock.AsyncMock()
+    core_lifecycle.start = mock.AsyncMock(side_effect=asyncio.CancelledError)
+    core_lifecycle.stop = mock.AsyncMock()
+
+    with mock.patch(
+        "astrbot.core.initial_loader.AstrBotCoreLifecycle",
+        return_value=core_lifecycle,
+    ):
+        loader = InitialLoader(mock.MagicMock(), mock.MagicMock())
+        loader.webui_available = False
+
+        await loader.start()
+
+    core_lifecycle.stop.assert_awaited_once()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -257,3 +257,47 @@ async def test_check_dashboard_files_with_webui_dir_arg(monkeypatch):
             assert result == valid_dir
             mock_download.assert_not_called()
             mock_get_version.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_main_async_disables_webui_when_dashboard_check_fails():
+    with mock.patch(
+        "main.check_dashboard_files",
+        mock.AsyncMock(return_value=None),
+    ):
+        with mock.patch("main.log_broker", create=True):
+            with mock.patch("main.InitialLoader") as mock_loader:
+                mock_loader.return_value.start = mock.AsyncMock()
+
+                from main import main_async
+
+                await main_async(None)
+
+    assert mock_loader.return_value.webui_dir is None
+    assert mock_loader.return_value.webui_available is False
+    mock_loader.return_value.start.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_initial_loader_skips_unavailable_webui():
+    from astrbot.core.initial_loader import InitialLoader
+
+    core_lifecycle = mock.MagicMock()
+    core_lifecycle.initialize = mock.AsyncMock()
+    core_lifecycle.start = mock.AsyncMock()
+
+    with mock.patch(
+        "astrbot.core.initial_loader.AstrBotCoreLifecycle",
+        return_value=core_lifecycle,
+    ):
+        with mock.patch(
+            "astrbot.core.initial_loader.AstrBotDashboard",
+        ) as mock_dashboard:
+            loader = InitialLoader(mock.MagicMock(), mock.MagicMock())
+            loader.webui_available = False
+
+            await loader.start()
+
+    core_lifecycle.initialize.assert_awaited_once()
+    core_lifecycle.start.assert_awaited_once()
+    mock_dashboard.assert_not_called()


### PR DESCRIPTION
Fixes #8795

### Modifications / 改动点

- Stop the dashboard server from starting when the startup WebUI file check or download fails.
- Keep the core lifecycle running normally when WebUI is unavailable.
- Add regressions for propagating the unavailable state and skipping dashboard construction.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```text
python -m pytest tests\test_main.py -q -p no:cacheprovider
13 passed

python -m ruff check main.py astrbot\core\initial_loader.py tests\test_main.py
All checks passed!
```

The broader `tests/test_dashboard.py` collection is currently blocked on this Windows environment by an existing `ModuleNotFoundError: tests.fixtures`; the focused startup tests are green.

---

### Checklist / 检查清单

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。
- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure the application continues core startup while cleanly disabling the WebUI when dashboard startup checks fail.

Bug Fixes:
- Prevent the dashboard server from starting when the WebUI startup checks fail by propagating an unavailable state through the loader.
- Ensure the core lifecycle initializes and starts normally even when the WebUI is unavailable.

Tests:
- Add async tests verifying that a failed dashboard file check disables WebUI startup but still runs the core lifecycle.
- Add tests confirming that the initial loader skips dashboard construction when WebUI is marked unavailable.