### PR TITLE
fix: avoid WebUI ready banner when assets missing

### DIFF
--- a/astrbot/dashboard/server.py
+++ b/astrbot/dashboard/server.py
@@ -545,7 +545,13 @@ class AstrBotDashboard:
 
             raise Exception(f"端口 {port} 已被占用")
 
-        parts = [f"\n ✨✨✨\n  AstrBot v{VERSION} WebUI is ready\n\n"]
+        if (Path(self.data_path) / "index.html").is_file():
+            webui_status = "WebUI is ready"
+        else:
+            webui_status = (
+                f"WebUI is NOT ready: static files are missing at {self.data_path}"
+            )
+        parts = [f"\n ✨✨✨\n  AstrBot v{VERSION} {webui_status}\n\n"]
         parts.append(f"   ➜  Local: {scheme}://localhost:{port}\n")
         for ip in ip_addr:
             parts.append(f"   ➜  Network: {scheme}://{ip}:{port}\n")


### PR DESCRIPTION
## Summary
- Check dashboard static entry files before printing the WebUI ready banner
- Log a clear warning and start only the web backend/API path when WebUI assets are missing
- Add regression coverage for missing WebUI static files

Fixes #8795

## Tests
- uv run ruff format .
- uv run ruff check .
- uv run pytest tests/test_dashboard.py::test_dashboard_ssl_missing_cert_and_key_falls_back_to_http tests/test_dashboard.py::test_dashboard_run_skips_ready_banner_when_static_files_missing

## Summary by Sourcery

Guard the WebUI startup flow against missing static assets and adjust logging and readiness output accordingly.

Bug Fixes:
- Avoid printing the WebUI ready banner and implying a functional frontend when required static files are missing, while still starting the backend APIs.

Tests:
- Extend dashboard SSL fallback test to run with an explicit WebUI directory containing minimal assets.
- Add a regression test verifying that dashboard run logs a warning, starts only the web backend, and skips the WebUI ready banner when static files are missing.