### PR TITLE
fix(computer): support 'idle' status for shipyard_neo booter

### DIFF
--- a/astrbot/core/computer/booters/shipyard_neo.py
+++ b/astrbot/core/computer/booters/shipyard_neo.py
@@ -478,7 +478,7 @@ class ShipyardNeoBooter(ComputerBooter):
             await sandbox.refresh()
             status = getattr(sandbox.status, "value", str(sandbox.status))
 
-            if status == "ready":
+            if status in {"ready", "idle"}:
                 logger.info(
                     "[Computer] Sandbox %s is ready (profile=%s)",
                     sandbox_id,


### PR DESCRIPTION
This PR fixes 120-second execution timeout issues when using the `shipyard_neo` booter in AstrBot. 
Newer versions of Shipyard Neo return an `idle` status instead of `ready` once the sandbox container is initialized. AstrBot previously kept polling indefinitely until it hit a 120s timeout.

### Modifications / 改动点

- `astrbot/core/computer/booters/shipyard_neo.py`: Updated the `_wait_until_ready` logic to white-list both `ready` and `idle` statuses for successful sandbox initialization.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

```
[2026-06-15 22:24:52.372] [Core] [INFO] [computer.computer_client:607]: [Computer] Shipyard Neo config: endpoint=http://bay:8114, profile=python-default, ttl=3600
[2026-06-15 22:24:52.380] [Core] [INFO] [booters.shipyard_neo:551]: [Computer] Using user-specified profile: python-default
[2026-06-15 22:24:52.416] [Core] [INFO] [booters.shipyard_neo:482]: [Computer] Sandbox sandbox-70d4cec0d67c is ready (profile=python-default)
[2026-06-15 22:24:52.417] [Core] [INFO] [booters.shipyard_neo:456]: Got Shipyard Neo sandbox: sandbox-70d4cec0d67c (profile=python-default, capabilities=['filesystem', 'shell', 'python'], auto=False)
[2026-06-15 22:24:52.417] [Core] [INFO] [computer.computer_client:634]: [Computer] Sandbox booted successfully: type=shipyard_neo, session=default:FriendMessage:<id>
```

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Prevent Shipyard Neo booted sandboxes that report an idle status from causing 120-second execution timeouts by accepting idle as a ready state.