### PR TITLE
fix(embedding): 通用修复 embedding_dimensions 参数校验，解决 SiliconFlow 等兼容接口报 400 的问题

### DIFF
--- a/astrbot/core/provider/sources/openai_embedding_source.py
+++ b/astrbot/core/provider/sources/openai_embedding_source.py
@@ -69,14 +69,22 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         """构建嵌入请求的可选参数"""
         kwargs = {}
         if "embedding_dimensions" in self.provider_config:
-            try:
-                dim_val = int(self.provider_config["embedding_dimensions"])
-                if dim_val > 0:
-                    kwargs["dimensions"] = dim_val
-            except (ValueError, TypeError):
-                logger.warning(
-                    f"embedding_dimensions in embedding configs is not a valid integer: '{self.provider_config['embedding_dimensions']}', ignored."
-                )
+            dim_setting = self.provider_config["embedding_dimensions"]
+            if dim_setting is not None and str(dim_setting).strip() != "":
+                try:
+                    dim_val = int(dim_setting)
+                    # 只有明确指定维度且大于0时才携带参数。
+                    if dim_val > 0:
+                        kwargs["dimensions"] = dim_val
+                    else:
+                        # 留空或填 0 隐式丢弃此参数，用于规避 SiliconFlow、vLLM 等严格校验平台报 HTTP 400
+                        logger.debug(
+                            f"embedding_dimensions '{dim_val}' is <= 0, omitted to ensure compatibility with strict providers."
+                        )
+                except (ValueError, TypeError):
+                    logger.warning(
+                        f"embedding_dimensions in embedding configs is not a valid integer: '{dim_setting}', ignored."
+                    )
         return kwargs
 
     def get_dim(self) -> int:

--- a/astrbot/core/provider/sources/openai_embedding_source.py
+++ b/astrbot/core/provider/sources/openai_embedding_source.py
@@ -69,22 +69,31 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         """构建嵌入请求的可选参数"""
         kwargs = {}
         if "embedding_dimensions" in self.provider_config:
-            dim_setting = self.provider_config["embedding_dimensions"]
-            if dim_setting is not None and str(dim_setting).strip() != "":
-                try:
-                    dim_val = int(dim_setting)
-                    # 只有明确指定维度且大于0时才携带参数。
-                    if dim_val > 0:
-                        kwargs["dimensions"] = dim_val
-                    else:
-                        # 留空或填 0 隐式丢弃此参数，用于规避 SiliconFlow、vLLM 等严格校验平台报 HTTP 400
-                        logger.debug(
-                            f"embedding_dimensions '{dim_val}' is <= 0, omitted to ensure compatibility with strict providers."
-                        )
-                except (ValueError, TypeError):
-                    logger.warning(
-                        f"embedding_dimensions in embedding configs is not a valid integer: '{dim_setting}', ignored."
-                    )
+            try:
+                dim_val = int(self.provider_config["embedding_dimensions"])
+                if dim_val > 0:
+                    kwargs["dimensions"] = dim_val
+            except (ValueError, TypeError):
+                logger.warning(
+                    f"embedding_dimensions in embedding configs is not a valid integer: '{self.provider_config['embedding_dimensions']}', ignored."
+                )
+
+        # Fix: SiliconFlow provider does not support dimensions parameter, except for Qwen models.
+        provider_api_base = self.provider_config.get("embedding_api_base")
+        provider_id = self.provider_config.get("id", "unknown_id")
+        if (
+            provider_api_base
+            # Hard-code SiliconFlow API Base Prefix and Model Name, as it's just a temporary workaround.
+            and provider_api_base.strip().startswith("https://api.siliconflow.cn")
+            and not self.model.lower().startswith("qwen")
+        ):
+            # For SiliconFlow and Non-Qwen models, dimensions parameter is not supported. so remove it.
+            removed_dimensions = kwargs.pop("dimensions", None)
+            if removed_dimensions is not None:
+                # Log a warning message if dimensions parameter is removed.
+                logger.warning(
+                    f"dimensions not supported for model '{self.model}' of provider '{provider_id}' as SiliconFlow does not support this parameter for non-Qwen models: '{removed_dimensions}'."
+                )
         return kwargs
 
     def get_dim(self) -> int:

--- a/astrbot/core/provider/sources/openai_embedding_source.py
+++ b/astrbot/core/provider/sources/openai_embedding_source.py
@@ -70,27 +70,12 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         kwargs = {}
         if "embedding_dimensions" in self.provider_config:
             try:
-                kwargs["dimensions"] = int(self.provider_config["embedding_dimensions"])
+                dim_val = int(self.provider_config["embedding_dimensions"])
+                if dim_val > 0:
+                    kwargs["dimensions"] = dim_val
             except (ValueError, TypeError):
                 logger.warning(
                     f"embedding_dimensions in embedding configs is not a valid integer: '{self.provider_config['embedding_dimensions']}', ignored."
-                )
-
-        # Fix: SiliconFlow provider does not support dimensions parameter, except for Qwen models.
-        provider_api_base = self.provider_config.get("embedding_api_base")
-        provider_id = self.provider_config.get("id", "unknown_id")
-        if (
-            provider_api_base
-            # Hard-code SiliconFlow API Base Prefix and Model Name, as it's just a temporary workaround.
-            and provider_api_base.strip().startswith("https://api.siliconflow.cn")
-            and not self.model.lower().startswith("qwen")
-        ):
-            # For SiliconFlow and Non-Qwen models, dimensions parameter is not supported. so remove it.
-            removed_dimensions = kwargs.pop("dimensions", None)
-            if removed_dimensions is not None:
-                # Log a warning message if dimensions parameter is removed.
-                logger.warning(
-                    f"dimensions not supported for model '{self.model}' of provider '{provider_id}' as SiliconFlow does not support this parameter for non-Qwen models: '{removed_dimensions}'."
                 )
         return kwargs
 

--- a/astrbot/dashboard/services/knowledge_base_service.py
+++ b/astrbot/dashboard/services/knowledge_base_service.py
@@ -304,9 +304,11 @@ class KnowledgeBaseService:
             )
         try:
             vec = await provider.get_embedding("astrbot")
-            if len(vec) != provider.get_dim():
+            actual_dim = len(vec)
+            configured_dim = provider.get_dim()
+            if configured_dim != 0 and actual_dim != configured_dim:
                 raise ValueError(
-                    f"嵌入向量维度不匹配，实际是 {len(vec)}，然而配置是 {provider.get_dim()}",
+                    f"嵌入向量维度不匹配，实际是 {actual_dim}，然而配置是 {configured_dim}",
                 )
         except Exception as exc:
             raise KnowledgeBaseServiceError(f"测试嵌入模型失败: {exc!s}") from exc


### PR DESCRIPTION
## 📝 PR 摘要
通用修复 `embedding_dimensions` 为 0（或默认值）时引发的兼容性问题与建库阻塞问题。移除了针对单一服务商的硬编码，提升了对类 OpenAI 接口（如 SiliconFlow, vLLM）的泛用性兼容。

## 🐛 问题根源
1. **接口参数不兼容**：原逻辑在未配置维度时，会向 API 发送无效的 `dimensions: 0`。导致严格校验该参数的平台（如 SiliconFlow）返回 HTTP 400 错误。
2. **预检逻辑误拦截**：当修复接口调用后，API 成功返回真实维度（如 1024）。但 `knowledge_base_service.py` 严格校验 `1024 != config_dim(0)`，导致正常模型被系统误判拦截，知识库创建失败。

## 🛠️ 修复方案
1. **`openai_embedding_source.py` (接口层)**
   - **参数过滤**：仅当 `embedding_dimensions > 0` 时，才向 `kwargs` 注入 `dimensions` 参数。
   - **移除特判**：删除了此前针对 `api.siliconflow.cn` 的特定域名拦截逻辑，改为通用处理。支持 `dimensions` 的官方接口不受影响，拒绝无效维度的接口自动规避。
2. **`knowledge_base_service.py` (业务层)**
   - **放宽默认值预检**：修改判断逻辑为 `if configured_dim != 0 and actual_dim != configured_dim:`。当配置为 0 时，信任并接纳 API 探测返回的真实维度用于 Faiss 初始化；仅在用户显式配置错误维度时拦截。

## 📊 测试验证
测试模型：**SiliconFlow (`BAAI/bge-m3`)**

| 配置值 (`embedding_dimensions`) | 接口 Payload 表现 | 维度预检结果 | 最终动作 |
| :--- | :--- | :--- | :--- |
| **`0` / 留空** | 不发送 `dimensions` | 跳过拦截，获取实际维度 1024 | ✅ 成功基于 1024 维建库 |
| **`1024` (正例)** | 发送 `dimensions: 1024` | `1024 == 1024`，校验通过 | ✅ 成功建库 |
| **`768` (反例)** | 发送 `dimensions: 768` | `1024 != 768` | ❌ 抛出 ValueError，拦截成功 |