### PR TITLE
fix(chat): prevent IME composition character loss at non-terminal cur…

### DIFF
--- a/dashboard/src/components/chat/ChatInput.vue
+++ b/dashboard/src/components/chat/ChatInput.vue
@@ -523,7 +523,14 @@ const filteredCommands = computed(() => {
 
 const localPrompt = computed({
   get: () => props.prompt,
-  set: (value) => emit("update:prompt", value),
+  set: (value) => {
+    // Suppress v-model sync during IME composition to avoid a reactive
+    // feedback loop. Vue's :value binding overwrites the native textarea
+    // DOM state mid-composition, which interferes with IME insertion at
+    // non-terminal cursor positions (alternating character loss).
+    // The final value is synced manually in handleCompositionEnd.
+    if (!isComposing.value) emit("update:prompt", value);
+  },
 });
 
 const sessionPlatformId = computed(
@@ -768,6 +775,17 @@ function handleCompositionStart() {
 function handleCompositionEnd(e: CompositionEvent) {
   lastCompositionEndAt.value = e.timeStamp;
   clearCompositionState({ keepLastEndAt: true });
+
+  // Manually sync the final composited text to the parent component
+  // after the IME commits. The v-model setter is suppressed during
+  // composition (see localPrompt computed), so we must explicitly
+  // propagate the DOM value once composition ends.
+  nextTick(() => {
+    const el = inputField.value;
+    if (el && el.value !== props.prompt) {
+      emit("update:prompt", el.value);
+    }
+  });
 }
 
 function clearCompositionState({ keepLastEndAt = false } = {}) {

--- a/dashboard/src/components/chat/ChatInput.vue
+++ b/dashboard/src/components/chat/ChatInput.vue
@@ -790,13 +790,14 @@ function handleCompositionEnd(e: CompositionEvent) {
     // Only sync if the DOM hasn't been changed externally in the meantime.
     if (el && el.value === endValue && el.value !== props.prompt) {
       emit("update:prompt", el.value);
+      // Re-evaluate command suggestions that were suppressed during IME
+      // composition (handleInput checks isComposing). Only needed when
+      // the value actually changed. Runs in a nested nextTick so
+      // props.prompt reflects the emit above.
+      nextTick(() => {
+        handleInput();
+      });
     }
-    // Re-evaluate command suggestions that were suppressed during IME
-    // composition (handleInput checks isComposing). This runs in a
-    // nested nextTick so props.prompt reflects the emit above.
-    nextTick(() => {
-      handleInput();
-    });
   });
 }
 

--- a/dashboard/src/components/chat/ChatInput.vue
+++ b/dashboard/src/components/chat/ChatInput.vue
@@ -780,11 +780,23 @@ function handleCompositionEnd(e: CompositionEvent) {
   // after the IME commits. The v-model setter is suppressed during
   // composition (see localPrompt computed), so we must explicitly
   // propagate the DOM value once composition ends.
+  //
+  // Capture the DOM value at compositionend to guard against a race
+  // where props.prompt is externally updated between now and nextTick.
+  const endValue = inputField.value?.value;
+
   nextTick(() => {
     const el = inputField.value;
-    if (el && el.value !== props.prompt) {
+    // Only sync if the DOM hasn't been changed externally in the meantime.
+    if (el && el.value === endValue && el.value !== props.prompt) {
       emit("update:prompt", el.value);
     }
+    // Re-evaluate command suggestions that were suppressed during IME
+    // composition (handleInput checks isComposing). This runs in a
+    // nested nextTick so props.prompt reflects the emit above.
+    nextTick(() => {
+      handleInput();
+    });
   });
 }
 


### PR DESCRIPTION
Fixes #8810。修复聊天输入框中 IME 合成在非末尾光标位置时交替丢失字符的 bug。

## Problem / 问题

当使用中文输入法（搜狗拼音 / 微软拼音等）在聊天输入框的**中间位置**输入时，IME 每两次提交就会丢失一次字符：第一次按空格无反应，第二次正常出现，第三次又丢失，如此交替。

### Root Cause / 根因

`dashboard/src/components/chat/ChatInput.vue` 中的 `v-model` 绑定了一个跨组件的 computed 属性：

```javascript
const localPrompt = computed({
  get: () => props.prompt,
  set: (value) => emit("update:prompt", value),
});
```

IME 合成期间，浏览器在 textarea 中间 splice 文本后触发 `input` 事件 → v-model setter emit 到父组件 → computed getter 返回新值 → Vue 用 `:value` 写回 textarea → **覆盖了浏览器原生 IME splice 的 DOM 状态** → 光标位置与 Vue 状态脱同步 → 交替丢失。

末尾位置不受影响是因为只需 append，不存在 splice 被覆盖的问题。

英文不受影响是因为不需 IME 合成阶段。

## Modifications / 改动点

仅修改一个文件：`dashboard/src/components/chat/ChatInput.vue`（共两处改动）

1. **`localPrompt` computed setter**：合成期间 (`isComposing === true`) 禁止 emit，阻断响应式反馈环路。

2. **`handleCompositionEnd`**：合成结束后手动同步 textarea 的最终值到父组件，确保 IME 提交的文本不丢失。

```diff
 const localPrompt = computed({
   get: () => props.prompt,
-  set: (value) => emit("update:prompt", value),
+  set: (value) => {
+    if (!isComposing.value) emit("update:prompt", value);
+  },
 });

 function handleCompositionEnd(e: CompositionEvent) {
   lastCompositionEndAt.value = e.timeStamp;
   clearCompositionState({ keepLastEndAt: true });
+  nextTick(() => {
+    const el = inputField.value;
+    if (el && el.value !== props.prompt) {
+      emit("update:prompt", el.value);
+    }
+  });
 }
```

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

## Verification Steps / 验证步骤

1. 构建 dashboard：`cd dashboard && pnpm build`
2. （Tauri 版本）替换 `D:\Program Files\AstrBot\webui\assets\` 中的构建产物
3. 打开聊天页面
4. 输入一段文字，将光标移动到中间
5. 切换到中文输入法，连续多次输入并确认（按空格）
6. **预期结果**：每次 IME 提交都正常显示，无丢失
7. 额外验证：
   - 光标在末尾输入中文 → 正常（未引入回归）
   - 英文输入 → 正常
   - 命令提示 `/` 触发 → 正常（不会在合成期间错误触发）
   - Enter 发送 → 正常（不会在合成确认时误发送）

## Screenshots or Test Results / 测试结果

修改范围极小，仅增加合成期间的 emit 守卫和合成结束后的手动同步。`ruff format .` 和 `ruff check .` 在 dashboard 目录不适用（前端项目），已验证 TypeScript 类型无误。
### 此为**修复前**
<img width="884" height="227" alt="bug" src="https://github.com/user-attachments/assets/5bea9ad6-ede7-41ab-97a9-67b68593fa5d" />

### 此为**修复后**
<img width="884" height="227" alt="fixed" src="https://github.com/user-attachments/assets/c04d2a23-d2e4-44ee-9f82-98da67468c4d" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Prevent intermittent character loss when using IME composition in the middle of the chat input field by avoiding reactive feedback loops during composition.

## Summary by Sourcery

Fix IME text composition handling in the chat input to prevent character loss and keep suggestions in sync when editing in the middle of the text.

Bug Fixes:
- Prevent intermittent character loss when using IME composition at non-terminal cursor positions in the chat input.
- Ensure the chat input model and DOM stay consistent after IME composition ends, including re-evaluating command suggestions.