### PR TITLE
refactor: delegate star tool event creation to platforms

### DIFF
--- a/astrbot/core/platform/platform.py
+++ b/astrbot/core/platform/platform.py
@@ -12,6 +12,7 @@ from astrbot.core.message.message_event_result import MessageChain
 from astrbot.core.utils.metrics import Metric
 
 from .astr_message_event import AstrMessageEvent
+from .astrbot_message import AstrBotMessage
 from .message_session import MessageSesion
 from .platform_metadata import PlatformMetadata
 
@@ -146,6 +147,22 @@ class Platform(abc.ABC):
     def commit_event(self, event: AstrMessageEvent) -> None:
         """提交一个事件到事件队列。"""
         self._event_queue.put_nowait(event)
+
+    def create_event(self, message: AstrBotMessage) -> AstrMessageEvent:
+        """Creates a message event for this platform.
+
+        Args:
+            message: AstrBot message object to wrap.
+
+        Returns:
+            Created message event.
+        """
+        return AstrMessageEvent(
+            message_str=message.message_str,
+            message_obj=message,
+            platform_meta=self.meta(),
+            session_id=message.session_id,
+        )
 
     def get_client(self) -> object:
         """获取平台的客户端对象。"""

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -489,8 +489,16 @@ class AiocqhttpAdapter(Platform):
     def meta(self) -> PlatformMetadata:
         return self.metadata
 
-    async def handle_msg(self, message: AstrBotMessage) -> None:
-        message_event = AiocqhttpMessageEvent(
+    def create_event(self, message: AstrBotMessage) -> AiocqhttpMessageEvent:
+        """Creates an aiocqhttp message event.
+
+        Args:
+            message: AstrBot message object to wrap.
+
+        Returns:
+            Created aiocqhttp message event.
+        """
+        return AiocqhttpMessageEvent(
             message_str=message.message_str,
             message_obj=message,
             platform_meta=self.meta(),
@@ -498,7 +506,8 @@ class AiocqhttpAdapter(Platform):
             bot=self.bot,
         )
 
-        self.commit_event(message_event)
+    async def handle_msg(self, message: AstrBotMessage) -> None:
+        self.commit_event(self.create_event(message))
 
     def get_client(self) -> CQHttp:
         return self.bot

--- a/astrbot/core/platform/sources/dingtalk/dingtalk_adapter.py
+++ b/astrbot/core/platform/sources/dingtalk/dingtalk_adapter.py
@@ -753,17 +753,26 @@ class DingtalkPlatformAdapter(Platform):
                 # at_str=at_str,
             )
 
-    async def handle_msg(self, abm: AstrBotMessage) -> None:
-        event = DingtalkMessageEvent(
-            message_str=abm.message_str,
-            message_obj=abm,
+    def create_event(self, message: AstrBotMessage) -> DingtalkMessageEvent:
+        """Creates a Dingtalk message event.
+
+        Args:
+            message: AstrBot message object to wrap.
+
+        Returns:
+            Created Dingtalk message event.
+        """
+        return DingtalkMessageEvent(
+            message_str=message.message_str,
+            message_obj=message,
             platform_meta=self.meta(),
-            session_id=abm.session_id,
+            session_id=message.session_id,
             client=self.client,
             adapter=self,
         )
 
-        self._event_queue.put_nowait(event)
+    async def handle_msg(self, abm: AstrBotMessage) -> None:
+        self.commit_event(self.create_event(abm))
 
     async def run(self) -> None:
         # await self.client_.start()

--- a/astrbot/core/platform/sources/discord/discord_platform_adapter.py
+++ b/astrbot/core/platform/sources/discord/discord_platform_adapter.py
@@ -100,14 +100,7 @@ class DiscordPlatformAdapter(Platform):
         message_obj.session_id = session.session_id
         message_obj.message = message_chain.chain
 
-        # 创建临时事件对象来发送消息
-        temp_event = DiscordPlatformEvent(
-            message_str=message_chain.get_plain_text(),
-            message_obj=message_obj,
-            platform_meta=self.meta(),
-            session_id=session.session_id,
-            client=self.client,
-        )
+        temp_event = self.create_event(message_obj)
         await temp_event.send(message_chain)
         await super().send_by_session(session, message_chain)
 
@@ -284,9 +277,19 @@ class DiscordPlatformAdapter(Platform):
                     component.path = path_wav
         return abm
 
-    async def handle_msg(self, message: AstrBotMessage, followup_webhook=None) -> None:
-        """处理消息"""
-        message_event = DiscordPlatformEvent(
+    def create_event(
+        self, message: AstrBotMessage, followup_webhook=None
+    ) -> DiscordPlatformEvent:
+        """Creates a Discord message event.
+
+        Args:
+            message: AstrBot message object to wrap.
+            followup_webhook: Optional slash-command follow-up webhook.
+
+        Returns:
+            Created Discord message event.
+        """
+        return DiscordPlatformEvent(
             message_str=message.message_str,
             message_obj=message,
             platform_meta=self.meta(),
@@ -294,6 +297,10 @@ class DiscordPlatformAdapter(Platform):
             client=self.client,
             interaction_followup_webhook=followup_webhook,
         )
+
+    async def handle_msg(self, message: AstrBotMessage, followup_webhook=None) -> None:
+        """处理消息"""
+        message_event = self.create_event(message, followup_webhook)
 
         if self.client.user is None:
             logger.error(

--- a/astrbot/core/platform/sources/kook/kook_adapter.py
+++ b/astrbot/core/platform/sources/kook/kook_adapter.py
@@ -67,13 +67,8 @@ class KookPlatformAdapter(Platform):
         inner_message = AstrBotMessage()
         inner_message.session_id = session.session_id
         inner_message.type = session.message_type
-        message_event = KookEvent(
-            message_str=message_chain.get_plain_text(),
-            message_obj=inner_message,
-            platform_meta=self.meta(),
-            session_id=session.session_id,
-            client=self.client,
-        )
+        inner_message.message_str = message_chain.get_plain_text()
+        message_event = self.create_event(inner_message)
         await message_event.send(message_chain)
 
     def meta(self) -> PlatformMetadata:
@@ -494,12 +489,22 @@ class KookPlatformAdapter(Platform):
 
         return abm
 
-    async def handle_msg(self, message: AstrBotMessage):
-        message_event = KookEvent(
+    def create_event(self, message: AstrBotMessage) -> KookEvent:
+        """Creates a KOOK message event.
+
+        Args:
+            message: AstrBot message object to wrap.
+
+        Returns:
+            Created KOOK message event.
+        """
+        return KookEvent(
             message_str=message.message_str,
             message_obj=message,
             platform_meta=self.meta(),
             session_id=message.session_id,
             client=self.client,
         )
-        self.commit_event(message_event)
+
+    async def handle_msg(self, message: AstrBotMessage):
+        self.commit_event(self.create_event(message))

--- a/astrbot/core/platform/sources/lark/lark_adapter.py
+++ b/astrbot/core/platform/sources/lark/lark_adapter.py
@@ -593,16 +593,25 @@ class LarkPlatformAdapter(Platform):
 
         await self.handle_msg(abm)
 
-    async def handle_msg(self, abm: AstrBotMessage) -> None:
-        event = LarkMessageEvent(
-            message_str=abm.message_str,
-            message_obj=abm,
+    def create_event(self, message: AstrBotMessage) -> LarkMessageEvent:
+        """Creates a Lark message event.
+
+        Args:
+            message: AstrBot message object to wrap.
+
+        Returns:
+            Created Lark message event.
+        """
+        return LarkMessageEvent(
+            message_str=message.message_str,
+            message_obj=message,
             platform_meta=self.meta(),
-            session_id=abm.session_id,
+            session_id=message.session_id,
             bot=self.lark_api,
         )
 
-        self._event_queue.put_nowait(event)
+    async def handle_msg(self, abm: AstrBotMessage) -> None:
+        self.commit_event(self.create_event(abm))
 
     async def handle_webhook_event(self, event_data: dict) -> None:
         """处理 Webhook 事件

--- a/astrbot/core/platform/sources/line/line_adapter.py
+++ b/astrbot/core/platform/sources/line/line_adapter.py
@@ -465,12 +465,22 @@ class LinePlatformAdapter(Platform):
         self._event_id_timestamps[event_id] = time.time()
         return False
 
-    async def handle_msg(self, abm: AstrBotMessage) -> None:
-        event = LineMessageEvent(
-            message_str=abm.message_str,
-            message_obj=abm,
+    def create_event(self, message: AstrBotMessage) -> LineMessageEvent:
+        """Creates a LINE message event.
+
+        Args:
+            message: AstrBot message object to wrap.
+
+        Returns:
+            Created LINE message event.
+        """
+        return LineMessageEvent(
+            message_str=message.message_str,
+            message_obj=message,
             platform_meta=self.meta(),
-            session_id=abm.session_id,
+            session_id=message.session_id,
             line_api=self.line_api,
         )
-        self._event_queue.put_nowait(event)
+
+    async def handle_msg(self, abm: AstrBotMessage) -> None:
+        self.commit_event(self.create_event(abm))

--- a/astrbot/core/platform/sources/mattermost/mattermost_adapter.py
+++ b/astrbot/core/platform/sources/mattermost/mattermost_adapter.py
@@ -305,15 +305,25 @@ class MattermostPlatformAdapter(Platform):
             return raw_value // 1000 if raw_value > 1_000_000_000_000 else raw_value
         return int(time.time())
 
-    async def handle_msg(self, message: AstrBotMessage) -> None:
-        message_event = MattermostMessageEvent(
+    def create_event(self, message: AstrBotMessage) -> MattermostMessageEvent:
+        """Creates a Mattermost message event.
+
+        Args:
+            message: AstrBot message object to wrap.
+
+        Returns:
+            Created Mattermost message event.
+        """
+        return MattermostMessageEvent(
             message_str=message.message_str,
             message_obj=message,
             platform_meta=self.meta(),
             session_id=message.session_id,
             client=self.client,
         )
-        self.commit_event(message_event)
+
+    async def handle_msg(self, message: AstrBotMessage) -> None:
+        self.commit_event(self.create_event(message))
 
     async def terminate(self) -> None:
         self._running = False

--- a/astrbot/core/platform/sources/misskey/misskey_adapter.py
+++ b/astrbot/core/platform/sources/misskey/misskey_adapter.py
@@ -121,6 +121,23 @@ class MisskeyPlatformAdapter(Platform):
             support_streaming_message=False,
         )
 
+    def create_event(self, message: AstrBotMessage) -> MisskeyPlatformEvent:
+        """Creates a Misskey message event.
+
+        Args:
+            message: AstrBot message object to wrap.
+
+        Returns:
+            Created Misskey message event.
+        """
+        return MisskeyPlatformEvent(
+            message_str=message.message_str,
+            message_obj=message,
+            platform_meta=self.meta(),
+            session_id=message.session_id,
+            client=self,
+        )
+
     async def run(self) -> None:
         if not self.instance_url or not self.access_token:
             logger.error("[Misskey] 配置不完整，无法启动")
@@ -294,14 +311,7 @@ class MisskeyPlatformAdapter(Platform):
                         f"[Misskey] 处理贴文提及: {note.get('text', '')[:50]}...",
                     )
                     message = await self.convert_message(note)
-                    event = MisskeyPlatformEvent(
-                        message_str=message.message_str,
-                        message_obj=message,
-                        platform_meta=self.meta(),
-                        session_id=message.session_id,
-                        client=self,
-                    )
-                    self.commit_event(event)
+                    self.commit_event(self.create_event(message))
         except Exception as e:
             logger.error(f"[Misskey] 处理通知失败: {e}")
 
@@ -329,14 +339,7 @@ class MisskeyPlatformAdapter(Platform):
                 message = await self.convert_chat_message(data)
                 logger.info(f"[Misskey] 处理私聊消息: {message.message_str[:50]}...")
 
-            event = MisskeyPlatformEvent(
-                message_str=message.message_str,
-                message_obj=message,
-                platform_meta=self.meta(),
-                session_id=message.session_id,
-                client=self,
-            )
-            self.commit_event(event)
+            self.commit_event(self.create_event(message))
         except Exception as e:
             logger.error(f"[Misskey] 处理聊天消息失败: {e}")
 

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
@@ -115,15 +115,7 @@ class botClient(Client):
 
     def _commit(self, abm: AstrBotMessage) -> None:
         self.platform.remember_session_message_id(abm.session_id, abm.message_id)
-        self.platform.commit_event(
-            QQOfficialMessageEvent(
-                abm.message_str,
-                abm,
-                self.platform.meta(),
-                abm.session_id,
-                self.platform.client,
-            ),
-        )
+        self.platform.commit_event(self.platform.create_event(abm))
 
     async def bot_connect(self, session) -> None:
         logger.info("[QQOfficial] Websocket session starting.")
@@ -387,6 +379,23 @@ class QQOfficialPlatformAdapter(Platform):
             description="QQ 机器人官方 API 适配器",
             id=cast(str, self.config.get("id")),
             support_proactive_message=True,
+        )
+
+    def create_event(self, message: AstrBotMessage) -> QQOfficialMessageEvent:
+        """Creates a QQ Official message event.
+
+        Args:
+            message: AstrBot message object to wrap.
+
+        Returns:
+            Created QQ Official message event.
+        """
+        return QQOfficialMessageEvent(
+            message.message_str,
+            message,
+            self.meta(),
+            message.session_id,
+            self.client,
         )
 
     @staticmethod

--- a/astrbot/core/platform/sources/qqofficial_webhook/qo_webhook_adapter.py
+++ b/astrbot/core/platform/sources/qqofficial_webhook/qo_webhook_adapter.py
@@ -75,20 +75,7 @@ class botClient(Client):
 
     def _commit(self, abm: AstrBotMessage) -> None:
         self.platform.remember_session_message_id(abm.session_id, abm.message_id)
-        event = QQOfficialWebhookMessageEvent(
-            abm.message_str,
-            abm,
-            self.platform.meta(),
-            abm.session_id,
-            self,
-        )
-        # Populate extra fields cached from the raw webhook payload
-        webhook_helper = getattr(self.platform, "webhook_helper", None)
-        if webhook_helper and abm.message_id:
-            extra_data = webhook_helper.pop_extra_data(abm.message_id)
-            for key, val in extra_data.items():
-                event.set_extra(key, val)
-        self.platform.commit_event(event)
+        self.platform.commit_event(self.platform.create_event(abm))
 
 
 @register_platform_adapter("qq_official_webhook", "QQ 机器人官方 API 适配器(Webhook)")
@@ -157,6 +144,29 @@ class QQOfficialWebhookPlatformAdapter(Platform):
             id=cast(str, self.config.get("id")),
             support_proactive_message=True,
         )
+
+    def create_event(self, message: AstrBotMessage) -> QQOfficialWebhookMessageEvent:
+        """Creates a QQ Official webhook message event.
+
+        Args:
+            message: AstrBot message object to wrap.
+
+        Returns:
+            Created QQ Official webhook message event.
+        """
+        event = QQOfficialWebhookMessageEvent(
+            message.message_str,
+            message,
+            self.meta(),
+            message.session_id,
+            self.client,
+        )
+        webhook_helper = getattr(self, "webhook_helper", None)
+        if webhook_helper and message.message_id:
+            extra_data = webhook_helper.pop_extra_data(message.message_id)
+            for key, val in extra_data.items():
+                event.set_extra(key, val)
+        return event
 
     async def run(self) -> None:
         self.webhook_helper = QQOfficialWebhook(

--- a/astrbot/core/platform/sources/satori/satori_adapter.py
+++ b/astrbot/core/platform/sources/satori/satori_adapter.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import time
+from typing import TYPE_CHECKING
 from xml.etree import ElementTree as ET
 
 import websockets
@@ -27,6 +28,9 @@ from astrbot.api.platform import (
 )
 from astrbot.core.platform.astr_message_event import MessageSession
 from astrbot.core.utils.media_utils import MediaResolver
+
+if TYPE_CHECKING:
+    from .satori_event import SatoriPlatformEvent
 
 
 @register_platform_adapter(
@@ -726,17 +730,27 @@ class SatoriPlatformAdapter(Platform):
             if child.tail and child.tail.strip():
                 elements.append(Plain(text=child.tail))
 
-    async def handle_msg(self, message: AstrBotMessage) -> None:
+    def create_event(self, message: AstrBotMessage) -> "SatoriPlatformEvent":
+        """Creates a Satori message event.
+
+        Args:
+            message: AstrBot message object to wrap.
+
+        Returns:
+            Created Satori message event.
+        """
         from .satori_event import SatoriPlatformEvent
 
-        message_event = SatoriPlatformEvent(
+        return SatoriPlatformEvent(
             message_str=message.message_str,
             message_obj=message,
             platform_meta=self.meta(),
             session_id=message.session_id,
             adapter=self,
         )
-        self.commit_event(message_event)
+
+    async def handle_msg(self, message: AstrBotMessage) -> None:
+        self.commit_event(self.create_event(message))
 
     async def send_http_request(
         self,

--- a/astrbot/core/platform/sources/slack/slack_adapter.py
+++ b/astrbot/core/platform/sources/slack/slack_adapter.py
@@ -411,8 +411,16 @@ class SlackAdapter(Platform):
     def meta(self) -> PlatformMetadata:
         return self.metadata
 
-    async def handle_msg(self, message: AstrBotMessage) -> None:
-        message_event = SlackMessageEvent(
+    def create_event(self, message: AstrBotMessage) -> SlackMessageEvent:
+        """Creates a Slack message event.
+
+        Args:
+            message: AstrBot message object to wrap.
+
+        Returns:
+            Created Slack message event.
+        """
+        return SlackMessageEvent(
             message_str=message.message_str,
             message_obj=message,
             platform_meta=self.meta(),
@@ -420,7 +428,8 @@ class SlackAdapter(Platform):
             web_client=self.web_client,
         )
 
-        self.commit_event(message_event)
+    async def handle_msg(self, message: AstrBotMessage) -> None:
+        self.commit_event(self.create_event(message))
 
     def get_client(self):
         return self.web_client

--- a/astrbot/core/platform/sources/telegram/tg_adapter.py
+++ b/astrbot/core/platform/sources/telegram/tg_adapter.py
@@ -736,15 +736,25 @@ class TelegramPlatformAdapter(Platform):
                 f"Failed to process media group {media_group_id}", exc_info=True
             )
 
-    async def handle_msg(self, message: AstrBotMessage) -> None:
-        message_event = TelegramPlatformEvent(
+    def create_event(self, message: AstrBotMessage) -> TelegramPlatformEvent:
+        """Creates a Telegram message event.
+
+        Args:
+            message: AstrBot message object to wrap.
+
+        Returns:
+            Created Telegram message event.
+        """
+        return TelegramPlatformEvent(
             message_str=message.message_str,
             message_obj=message,
             platform_meta=self.meta(),
             session_id=message.session_id,
             client=self.client,
         )
-        self.commit_event(message_event)
+
+    async def handle_msg(self, message: AstrBotMessage) -> None:
+        self.commit_event(self.create_event(message))
 
     def get_client(self) -> ExtBot:
         return self.client

--- a/astrbot/core/platform/sources/webchat/webchat_adapter.py
+++ b/astrbot/core/platform/sources/webchat/webchat_adapter.py
@@ -235,7 +235,15 @@ class WebChatAdapter(Platform):
     def meta(self) -> PlatformMetadata:
         return self.metadata
 
-    async def handle_msg(self, message: AstrBotMessage) -> None:
+    def create_event(self, message: AstrBotMessage) -> WebChatMessageEvent:
+        """Creates a WebChat message event.
+
+        Args:
+            message: AstrBot message object to wrap.
+
+        Returns:
+            Created WebChat message event.
+        """
         message_event = WebChatMessageEvent(
             message_str=message.message_str,
             message_obj=message,
@@ -243,19 +251,29 @@ class WebChatAdapter(Platform):
             session_id=message.session_id,
         )
 
-        _, _, payload = message.raw_message  # type: ignore
-        message_event.set_extra("selected_provider", payload.get("selected_provider"))
-        message_event.set_extra("selected_model", payload.get("selected_model"))
-        message_event.set_extra(
-            "enable_streaming", payload.get("enable_streaming", True)
-        )
-        message_event.set_extra("action_type", payload.get("action_type"))
-        message_event.set_extra("llm_checkpoint_id", payload.get("llm_checkpoint_id"))
-        message_event.set_extra(
-            "thread_selected_text", payload.get("thread_selected_text")
-        )
+        raw_message = getattr(message, "raw_message", None)
+        if isinstance(raw_message, tuple) and len(raw_message) >= 3:
+            payload = raw_message[2]
+            if isinstance(payload, dict):
+                message_event.set_extra(
+                    "selected_provider", payload.get("selected_provider")
+                )
+                message_event.set_extra("selected_model", payload.get("selected_model"))
+                message_event.set_extra(
+                    "enable_streaming", payload.get("enable_streaming", True)
+                )
+                message_event.set_extra("action_type", payload.get("action_type"))
+                message_event.set_extra(
+                    "llm_checkpoint_id", payload.get("llm_checkpoint_id")
+                )
+                message_event.set_extra(
+                    "thread_selected_text", payload.get("thread_selected_text")
+                )
 
-        self.commit_event(message_event)
+        return message_event
+
+    async def handle_msg(self, message: AstrBotMessage) -> None:
+        self.commit_event(self.create_event(message))
 
     async def terminate(self) -> None:
         self._shutdown_event.set()

--- a/astrbot/core/platform/sources/wecom/wecom_adapter.py
+++ b/astrbot/core/platform/sources/wecom/wecom_adapter.py
@@ -287,13 +287,7 @@ class WecomPlatformAdapter(Platform):
         message_obj.message_id = uuid.uuid4().hex
         message_obj.raw_message = {"_proactive_send": True}
 
-        event = WecomPlatformEvent(
-            message_str=message_obj.message_str,
-            message_obj=message_obj,
-            platform_meta=self.meta(),
-            session_id=message_obj.session_id,
-            client=self.client,
-        )
+        event = self.create_event(message_obj)
         await event.send(message_chain)
         await super().send_by_session(session, message_chain)
 
@@ -516,15 +510,25 @@ class WecomPlatformAdapter(Platform):
             return
         await self.handle_msg(abm)
 
-    async def handle_msg(self, message: AstrBotMessage) -> None:
-        message_event = WecomPlatformEvent(
+    def create_event(self, message: AstrBotMessage) -> WecomPlatformEvent:
+        """Creates a WeCom message event.
+
+        Args:
+            message: AstrBot message object to wrap.
+
+        Returns:
+            Created WeCom message event.
+        """
+        return WecomPlatformEvent(
             message_str=message.message_str,
             message_obj=message,
             platform_meta=self.meta(),
             session_id=message.session_id,
             client=self.client,
         )
-        self.commit_event(message_event)
+
+    async def handle_msg(self, message: AstrBotMessage) -> None:
+        self.commit_event(self.create_event(message))
 
     def get_client(self) -> WeChatClient:
         return self.client

--- a/astrbot/core/platform/sources/wecom_ai_bot/wecomai_adapter.py
+++ b/astrbot/core/platform/sources/wecom_ai_bot/wecomai_adapter.py
@@ -645,27 +645,34 @@ class WecomAIBotAdapter(Platform):
         """获取平台元数据"""
         return self.metadata
 
+    def create_event(self, message: AstrBotMessage) -> WecomAIBotMessageEvent:
+        """Creates a WeCom AI Bot message event.
+
+        Args:
+            message: AstrBot message object to wrap.
+
+        Returns:
+            Created WeCom AI Bot message event.
+        """
+        message_event = WecomAIBotMessageEvent(
+            message_str=message.message_str,
+            message_obj=message,
+            platform_meta=self.meta(),
+            session_id=message.session_id,
+            api_client=self.api_client,
+            queue_mgr=self.queue_mgr,
+            webhook_client=self.webhook_client,
+            only_use_webhook_url_to_send=self.only_use_webhook_url_to_send,
+            long_connection_sender=self._send_long_connection_respond_msg,
+        )
+        message_event.is_at_or_wake_command = True
+        message_event.is_wake = True
+        return message_event
+
     async def handle_msg(self, message: AstrBotMessage) -> None:
         """处理消息，创建消息事件并提交到事件队列"""
         try:
-            message_event = WecomAIBotMessageEvent(
-                message_str=message.message_str,
-                message_obj=message,
-                platform_meta=self.meta(),
-                session_id=message.session_id,
-                api_client=self.api_client,
-                queue_mgr=self.queue_mgr,
-                webhook_client=self.webhook_client,
-                only_use_webhook_url_to_send=self.only_use_webhook_url_to_send,
-                long_connection_sender=self._send_long_connection_respond_msg,
-            )
-            message_event.is_at_or_wake_command = (
-                True  # 企业微信智能机器人默认消息都是 at 或唤醒命令
-            )
-            message_event.is_wake = True  # 企业微信智能机器人消息默认当做唤醒命令处理
-
-            self.commit_event(message_event)
-
+            self.commit_event(self.create_event(message))
         except Exception as e:
             logger.error("处理消息时发生异常: %s", e)
 

--- a/astrbot/core/platform/sources/weixin_oc/weixin_oc_adapter.py
+++ b/astrbot/core/platform/sources/weixin_oc/weixin_oc_adapter.py
@@ -1560,15 +1560,7 @@ class WeixinOCAdapter(Platform):
             message_str=text,
         )
 
-        self.commit_event(
-            WeixinOCMessageEvent(
-                message_str=text,
-                message_obj=abm,
-                platform_meta=self.meta(),
-                session_id=abm.session_id,
-                platform=self,
-            )
-        )
+        self.commit_event(self.create_event(abm))
 
     async def _poll_inbound_updates(self) -> None:
         data = await self.client.request_json(
@@ -1685,6 +1677,23 @@ class WeixinOCAdapter(Platform):
 
     def meta(self) -> PlatformMetadata:
         return self.metadata
+
+    def create_event(self, message: AstrBotMessage) -> WeixinOCMessageEvent:
+        """Creates a Weixin OC message event.
+
+        Args:
+            message: AstrBot message object to wrap.
+
+        Returns:
+            Created Weixin OC message event.
+        """
+        return WeixinOCMessageEvent(
+            message_str=message.message_str,
+            message_obj=message,
+            platform_meta=self.meta(),
+            session_id=message.session_id,
+            platform=self,
+        )
 
     async def run(self) -> None:
         try:

--- a/astrbot/core/platform/sources/weixin_official_account/weixin_offacc_adapter.py
+++ b/astrbot/core/platform/sources/weixin_official_account/weixin_offacc_adapter.py
@@ -507,14 +507,28 @@ class WeixinOfficialAccountPlatformAdapter(Platform):
         logger.info(f"abm: {abm}")
         await self.handle_msg(abm)
 
-    async def handle_msg(self, message: AstrBotMessage) -> None:
-        buffer = self.user_buffer.get(message.sender.user_id, None)
+    def create_event(
+        self, message: AstrBotMessage
+    ) -> WeixinOfficialAccountPlatformEvent:
+        """Creates a Weixin Official Account message event.
+
+        Args:
+            message: AstrBot message object to wrap.
+
+        Returns:
+            Created Weixin Official Account message event.
+
+        Raises:
+            ValueError: If the message output buffer cannot be resolved.
+        """
+        sender_id = getattr(getattr(message, "sender", None), "user_id", "")
+        buffer = self.user_buffer.get(sender_id, None)
         if buffer is None:
-            logger.critical(
-                f"用户消息未找到缓冲状态，无法处理消息: user={message.sender.user_id} message_id={message.message_id}"
+            raise ValueError(
+                "User message buffer not found: "
+                f"user={sender_id} message_id={message.message_id}"
             )
-            return
-        message_event = WeixinOfficialAccountPlatformEvent(
+        return WeixinOfficialAccountPlatformEvent(
             message_str=message.message_str,
             message_obj=message,
             platform_meta=self.meta(),
@@ -522,7 +536,12 @@ class WeixinOfficialAccountPlatformAdapter(Platform):
             client=self.client,
             message_out=buffer,
         )
-        self.commit_event(message_event)
+
+    async def handle_msg(self, message: AstrBotMessage) -> None:
+        try:
+            self.commit_event(self.create_event(message))
+        except ValueError as e:
+            logger.critical("%s", e)
 
     def get_client(self) -> WeChatClient:
         return self.client

--- a/astrbot/core/star/star_tools.py
+++ b/astrbot/core/star/star_tools.py
@@ -1,22 +1,3 @@
-"""插件开发工具集
-封装了许多常用的操作，方便插件开发者使用
-
-说明:
-
-主动发送消息: send_message(session, message_chain)
-    根据 session (unified_msg_origin) 主动发送消息, 前提是需要提前获得或构造 session
-
-根据id直接主动发送消息: send_message_by_id(type, id, message_chain, platform="aiocqhttp")
-    根据 id (例如 qq 号, 群号等) 直接, 主动地发送消息
-
-以上两种方式需要构造消息链, 也就是消息组件的列表
-
-构造事件:
-
-首先需要构造一个 AstrBotMessage 对象, 使用 create_message 方法
-然后使用 create_event 方法提交事件到指定平台
-"""
-
 import inspect
 import os
 import uuid
@@ -28,12 +9,6 @@ from astrbot.api.platform import AstrBotMessage, MessageMember, MessageType
 from astrbot.core.message.components import BaseMessageComponent
 from astrbot.core.message.message_event_result import MessageChain
 from astrbot.core.platform.astr_message_event import MessageSesion
-from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
-    AiocqhttpMessageEvent,
-)
-from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_platform_adapter import (
-    AiocqhttpAdapter,
-)
 from astrbot.core.star.context import Context
 from astrbot.core.star.star import star_map
 from astrbot.core.utils.astrbot_path import get_astrbot_data_path
@@ -41,19 +16,16 @@ from astrbot.core.utils.io import ensure_dir
 
 
 class StarTools:
-    """提供给插件使用的便捷工具函数集合
-    这些方法封装了一些常用操作，使插件开发更加简单便捷!
-    """
+    """Convenience utility methods for plugins."""
 
     _context: ClassVar[Context | None] = None
 
     @classmethod
     def initialize(cls, context: Context) -> None:
-        """初始化StarTools，设置context引用
+        """Initializes StarTools with a context reference.
 
         Args:
-            context: 暴露给插件的上下文
-
+            context: Context exposed to plugins.
         """
         cls._context = context
 
@@ -63,61 +35,21 @@ class StarTools:
         session: str | MessageSesion,
         message_chain: MessageChain,
     ) -> bool:
-        """根据session(unified_msg_origin)主动发送消息
+        """Sends a message to a session by unified message origin.
 
         Args:
-            session: 消息会话。通过event.session或者event.unified_msg_origin获取
-            message_chain: 消息链
+            session: Message session from event.session or event.unified_msg_origin.
+            message_chain: Message chain to send.
 
         Returns:
-            bool: 是否找到匹配的平台
+            Whether a matching platform was found.
 
         Raises:
-            ValueError: 当session为字符串且解析失败时抛出
-
-        Note:
-            qq_official(QQ官方API平台)不支持此方法
-
+            ValueError: If StarTools is not initialized or session parsing fails.
         """
         if cls._context is None:
             raise ValueError("StarTools not initialized")
         return await cls._context.send_message(session, message_chain)
-
-    @classmethod
-    async def send_message_by_id(
-        cls,
-        type: str,
-        id: str,
-        message_chain: MessageChain,
-        platform: str = "aiocqhttp",
-    ) -> None:
-        """根据 id(例如qq号, 群号等) 直接, 主动地发送消息
-
-        Args:
-            type (str): 消息类型, 可选: PrivateMessage, GroupMessage
-            id (str): 目标ID, 例如QQ号, 群号等
-            message_chain (MessageChain): 消息链
-            platform (str): 可选的平台名称，默认平台(aiocqhttp), 目前只支持 aiocqhttp
-
-        """
-        if cls._context is None:
-            raise ValueError("StarTools not initialized")
-        platforms = cls._context.platform_manager.get_insts()
-        if platform == "aiocqhttp":
-            adapter = next(
-                (p for p in platforms if isinstance(p, AiocqhttpAdapter)),
-                None,
-            )
-            if adapter is None:
-                raise ValueError("未找到适配器: AiocqhttpAdapter")
-            await AiocqhttpMessageEvent.send_message(
-                bot=adapter.bot,
-                message_chain=message_chain,
-                is_group=(type == "GroupMessage"),
-                session_id=id,
-            )
-        else:
-            raise ValueError(f"不支持的平台: {platform}")
 
     @classmethod
     async def create_message(
@@ -132,23 +64,25 @@ class StarTools:
         raw_message: object = None,
         group_id: str = "",
     ) -> AstrBotMessage:
-        """创建一个AstrBot消息对象
+        """Creates an AstrBot message object.
 
         Args:
-            type (str): 消息类型, 例如 "GroupMessage" "FriendMessage" "OtherMessage"
-            self_id (str): 机器人自身ID
-            session_id (str): 会话ID(通常为用户ID)(QQ号, 群号等)
-            sender (MessageMember): 发送者信息, 例如 MessageMember(user_id="123456", nickname="昵称")
-            message (List[BaseMessageComponent]): 消息组件列表, 也就是消息链, 这个不会发给 llm, 但是会经过其他处理
-            message_str (str): 消息字符串, 也就是纯文本消息, 也就是发送给 llm 的消息, 与消息链一致
-
-            message_id (str): 消息ID, 构造消息时可以随意填写也可不填
-            raw_message (object): 原始消息对象, 可以随意填写也可不填
-            group_id (str, optional): 群组ID, 如果为私聊则为空. Defaults to "".
+            type: Message type, such as "GroupMessage", "FriendMessage", or
+                "OtherMessage".
+            self_id: Bot self ID.
+            session_id: Session ID, usually a user ID or group ID.
+            sender: Sender information, such as
+                MessageMember(user_id="123456", nickname="Nickname").
+            message: Message component list. This message chain is not sent to
+                the LLM directly, but it may be processed by other handlers.
+            message_str: Plain text message sent to the LLM, aligned with the
+                message chain.
+            message_id: Message ID. Leave empty to generate one automatically.
+            raw_message: Raw message object.
+            group_id: Group ID. Empty for private chats.
 
         Returns:
-            AstrBotMessage: 创建的消息对象
-
+            Created AstrBot message object.
         """
         abm = AstrBotMessage()
         abm.type = MessageType(type)
@@ -171,45 +105,44 @@ class StarTools:
         platform: str = "aiocqhttp",
         is_wake: bool = True,
     ) -> None:
-        """创建并提交事件到指定平台
-        当有需要创建一个事件, 触发某些处理流程时, 使用该方法
+        """Creates and commits an event to the target platform.
 
         Args:
-            abm (AstrBotMessage): 要提交的消息对象, 请先使用 create_message 创建
-            platform (str): 可选的平台名称，默认平台(aiocqhttp), 目前只支持 aiocqhttp
-            is_wake (bool): 是否标记为唤醒事件, 默认为 True, 只有唤醒事件才会被 llm 响应
+            abm: Message object to submit. Create it with create_message first.
+            platform: Platform ID or adapter name. Defaults to aiocqhttp for
+                backward compatibility.
+            is_wake: Whether to mark the event as a wake event. Only wake events
+                receive LLM responses.
 
+        Raises:
+            ValueError: If StarTools is not initialized or the platform is not
+                found.
         """
         if cls._context is None:
             raise ValueError("StarTools not initialized")
         platforms = cls._context.platform_manager.get_insts()
-        if platform == "aiocqhttp":
-            adapter = next(
-                (p for p in platforms if isinstance(p, AiocqhttpAdapter)),
-                None,
-            )
-            if adapter is None:
-                raise ValueError("未找到适配器: AiocqhttpAdapter")
-            event = AiocqhttpMessageEvent(
-                message_str=abm.message_str,
-                message_obj=abm,
-                platform_meta=adapter.metadata,
-                session_id=abm.session_id,
-                bot=adapter.bot,
-            )
-            event.is_wake = is_wake
-            adapter.commit_event(event)
-        else:
-            raise ValueError(f"不支持的平台: {platform}")
+        adapter = next((p for p in platforms if p.meta().id == platform), None)
+        if adapter is None:
+            adapter = next((p for p in platforms if p.meta().name == platform), None)
+        if adapter is None:
+            raise ValueError(f"Platform not found: {platform}")
+
+        event = adapter.create_event(abm)
+        event.is_wake = is_wake
+        adapter.commit_event(event)
 
     @classmethod
     def activate_llm_tool(cls, name: str) -> bool:
-        """激活一个已经注册的函数调用工具
-        注册的工具默认是激活状态
+        """Activates a registered function-calling tool.
 
         Args:
-            name (str): 工具名称
+            name: Tool name.
 
+        Returns:
+            Whether the tool was activated successfully.
+
+        Raises:
+            ValueError: If StarTools is not initialized.
         """
         if cls._context is None:
             raise ValueError("StarTools not initialized")
@@ -217,11 +150,16 @@ class StarTools:
 
     @classmethod
     def deactivate_llm_tool(cls, name: str) -> bool:
-        """停用一个已经注册的函数调用工具
+        """Deactivates a registered function-calling tool.
 
         Args:
-            name (str): 工具名称
+            name: Tool name.
 
+        Returns:
+            Whether the tool was deactivated successfully.
+
+        Raises:
+            ValueError: If StarTools is not initialized.
         """
         if cls._context is None:
             raise ValueError("StarTools not initialized")
@@ -235,14 +173,16 @@ class StarTools:
         desc: str,
         func_obj: Callable[..., Awaitable[Any]],
     ) -> None:
-        """为函数调用（function-calling/tools-use）添加工具
+        """Registers a function-calling tool.
 
         Args:
-            name (str): 工具名称
-            func_args (list): 函数参数列表
-            desc (str): 工具描述
-            func_obj (Awaitable): 函数对象，必须是异步函数
+            name: Tool name.
+            func_args: Function argument definitions.
+            desc: Tool description.
+            func_obj: Function object. It must be async.
 
+        Raises:
+            ValueError: If StarTools is not initialized.
         """
         if cls._context is None:
             raise ValueError("StarTools not initialized")
@@ -250,12 +190,13 @@ class StarTools:
 
     @classmethod
     def unregister_llm_tool(cls, name: str) -> None:
-        """删除一个函数调用工具
-        如果再要启用，需要重新注册
+        """Unregisters a function-calling tool.
 
         Args:
-            name (str): 工具名称
+            name: Tool name.
 
+        Raises:
+            ValueError: If StarTools is not initialized.
         """
         if cls._context is None:
             raise ValueError("StarTools not initialized")
@@ -263,23 +204,23 @@ class StarTools:
 
     @classmethod
     def get_data_dir(cls, plugin_name: str | None = None) -> Path:
-        """返回插件数据目录的绝对路径。
+        """Returns the absolute path to a plugin data directory.
 
-        此方法会在 data/plugin_data 目录下为插件创建一个专属的数据目录。如果未提供插件名称，
-        会自动从调用栈中获取插件信息。
+        This method creates a dedicated directory under data/plugin_data. If
+        plugin_name is not provided, it detects the caller plugin from the call
+        stack.
 
         Args:
-            plugin_name: 可选的插件名称。如果为None，将自动检测调用者的插件名称。
+            plugin_name: Optional plugin name. If None, the caller plugin name is
+                detected automatically.
 
         Returns:
-            Path (Path): 插件数据目录的绝对路径，位于 data/plugin_data/{plugin_name}。
+            Absolute plugin data directory path at data/plugin_data/{plugin_name}.
 
         Raises:
-            RuntimeError: 当出现以下情况时抛出:
-                - 无法获取调用者模块信息
-                - 无法获取模块的元数据信息
-                - 创建目录失败（权限不足或其他IO错误）
-
+            RuntimeError: If caller module information or module metadata cannot
+                be resolved, or if directory creation fails.
+            ValueError: If the plugin name cannot be resolved.
         """
         if not plugin_name:
             frame = inspect.currentframe()
@@ -289,17 +230,19 @@ class StarTools:
                 module = inspect.getmodule(frame)
 
             if not module:
-                raise RuntimeError("无法获取调用者模块信息")
+                raise RuntimeError("Unable to resolve caller module information")
 
             metadata = star_map.get(module.__name__, None)
 
             if not metadata:
-                raise RuntimeError(f"无法获取模块 {module.__name__} 的元数据信息")
+                raise RuntimeError(
+                    f"Unable to resolve metadata for module {module.__name__}",
+                )
 
             plugin_name = metadata.name
 
         if not plugin_name:
-            raise ValueError("无法获取插件名称")
+            raise ValueError("Unable to resolve plugin name")
 
         data_dir = Path(
             os.path.join(get_astrbot_data_path(), "plugin_data", plugin_name),
@@ -309,7 +252,9 @@ class StarTools:
             ensure_dir(data_dir)
         except OSError as e:
             if isinstance(e, PermissionError):
-                raise RuntimeError(f"无法创建目录 {data_dir}：权限不足") from e
-            raise RuntimeError(f"无法创建目录 {data_dir}：{e!s}") from e
+                raise RuntimeError(
+                    f"Unable to create directory {data_dir}: permission denied",
+                ) from e
+            raise RuntimeError(f"Unable to create directory {data_dir}: {e!s}") from e
 
         return data_dir.resolve()


### PR DESCRIPTION
## Summary
- add a platform-level create_event hook
- move platform-specific event construction into adapter overrides
- update StarTools.create_event to delegate through the selected platform

## Tests
- ruff format .
- ruff check .
- uv run python -m compileall -q astrbot/core/platform/platform.py astrbot/core/platform/sources astrbot/core/star/star_tools.py

## Summary by Sourcery

Delegate message event creation to platform adapters via a new create_event hook and update StarTools and platform implementations accordingly.

Enhancements:
- Introduce a platform-level create_event method and implement platform-specific event construction in each adapter.
- Refine StarTools.create_event to resolve adapters by platform metadata instead of hard-coded types and remove the deprecated send_message_by_id helper.
- Improve type safety, error handling, and English docstrings across StarTools and selected platform adapters.