### PR TITLE
fix: upload skills with generated multipart body

### DIFF
--- a/dashboard/src/api/v1.ts
+++ b/dashboard/src/api/v1.ts
@@ -1322,9 +1322,9 @@ export const skillApi = {
   list(params?: { enabled?: boolean; source?: string }) {
     return typed<any>(openApiV1.listSkills({ query: params }));
   },
-  uploadBatch(formData: FormData) {
+  uploadBatch(files: File[]) {
     return typed<any>(
-      openApiV1.uploadSkillsBatch({ body: generatedFormData(formData) }),
+      openApiV1.uploadSkillsBatch({ body: { files } }),
     );
   },
   setEnabled(skillName: string, enabled: boolean) {

--- a/dashboard/src/components/extension/SkillsSection.vue
+++ b/dashboard/src/components/extension/SkillsSection.vue
@@ -1195,12 +1195,9 @@ export default {
       }
 
       try {
-        const formData = new FormData();
-        for (const item of attemptedItems) {
-          formData.append("files", item.file);
-        }
-
-        const res = await skillApi.uploadBatch(formData);
+        const res = await skillApi.uploadBatch(
+          attemptedItems.map((item) => item.file),
+        );
 
         const payload = res?.data?.data || {};
         applyUploadResults(attemptedItems, payload);


### PR DESCRIPTION
## Summary
- pass skill batch uploads to the generated client as a typed files array
- let the client serialize repeated multipart files so the backend receives the files field

Fixes #8794

## Testing
- ruff format .
- ruff check .
- cd dashboard && pnpm install
- cd dashboard && pnpm typecheck
- cd dashboard && pnpm build

## Summary by Sourcery

Update skill batch upload to pass files directly to the generated API client for proper multipart serialization.

Bug Fixes:
- Ensure skill batch uploads send the files field correctly by letting the generated client build the multipart body.

Enhancements:
- Simplify the skill batch upload API by accepting a typed files array instead of a pre-built FormData.