### PR TITLE
fix(waking_check): guard wake-prefix check against empty message chain

### DIFF
--- a/astrbot/core/pipeline/waking_check/stage.py
+++ b/astrbot/core/pipeline/waking_check/stage.py
@@ -107,6 +107,7 @@ class WakingCheckStage(Stage):
             if event.message_str.startswith(wake_prefix):
                 if (
                     not event.is_private_chat()
+                    and messages
                     and isinstance(messages[0], At)
                     and str(messages[0].qq) != str(event.get_self_id())
                     and str(messages[0].qq) != "all"

--- a/tests/unit/test_waking_check_stage.py
+++ b/tests/unit/test_waking_check_stage.py
@@ -1,0 +1,86 @@
+"""Tests for the WakingCheckStage wake-prefix handling."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from astrbot.core.pipeline.context import PipelineContext
+from astrbot.core.pipeline.waking_check.stage import WakingCheckStage
+from astrbot.core.platform.astr_message_event import AstrMessageEvent
+from astrbot.core.platform.astrbot_message import AstrBotMessage, MessageMember
+from astrbot.core.platform.message_type import MessageType
+from astrbot.core.platform.platform_metadata import PlatformMetadata
+
+
+class ConcreteAstrMessageEvent(AstrMessageEvent):
+    """Concrete AstrMessageEvent for testing."""
+
+    async def send(self, message):
+        await super().send(message)
+
+
+def _make_group_event(message_str: str) -> ConcreteAstrMessageEvent:
+    """A group-chat event whose message chain has no components.
+
+    A platform adapter can hand us a message that carries text but an empty
+    component list (for example a forwarded/system payload), so get_messages()
+    returns [].
+    """
+    message = AstrBotMessage()
+    message.type = MessageType.GROUP_MESSAGE
+    message.self_id = "bot123"
+    message.session_id = "group123"
+    message.message_id = "msg123"
+    message.sender = MessageMember(user_id="user123", nickname="TestUser")
+    message.message = []
+    return ConcreteAstrMessageEvent(
+        message_str=message_str,
+        message_obj=message,
+        platform_meta=PlatformMetadata(
+            name="test_platform", description="", id="test_platform_id"
+        ),
+        session_id="group123",
+    )
+
+
+@pytest.fixture
+def stage() -> WakingCheckStage:
+    return WakingCheckStage()
+
+
+async def _init(stage: WakingCheckStage, wake_prefix: list[str]) -> None:
+    ctx = PipelineContext(
+        astrbot_config={
+            "platform_settings": {},
+            "wake_prefix": wake_prefix,
+            "admins_id": [],
+        },
+        plugin_manager=MagicMock(),
+        astrbot_config_id="test",
+    )
+    await stage.initialize(ctx)
+
+
+@pytest.mark.asyncio
+async def test_empty_wake_prefix_with_empty_message_chain_wakes(stage):
+    """An empty wake_prefix matches any text; an empty message chain must not
+    crash the prefix check (it used to index messages[0] unconditionally)."""
+    await _init(stage, wake_prefix=[""])
+    event = _make_group_event("hello there")
+
+    await stage.process(event)
+
+    assert event.is_wake is True
+
+
+@pytest.mark.asyncio
+async def test_wake_prefix_with_empty_message_chain_wakes(stage):
+    """Same edge case with a non-empty prefix: a matching text plus an empty
+    chain should wake and strip the prefix rather than raising IndexError."""
+    await _init(stage, wake_prefix=["/"])
+    event = _make_group_event("/help")
+
+    await stage.process(event)
+
+    assert event.is_wake is True
+    assert event.message_str == "help"


### PR DESCRIPTION
## 问题

`WakingCheckStage` 在群聊里检查 wake-prefix 时，会无条件地访问 `messages[0]`：

```python
for wake_prefix in wake_prefixes:
    if event.message_str.startswith(wake_prefix):
        if (
            not event.is_private_chat()
            and isinstance(messages[0], At)   # messages 为空时 IndexError
            ...
```

当 `messages = event.get_messages()` 为空列表时，这里会抛 `IndexError: list index out of range`。两种常见触发：

- `wake_prefix` 配成了空字符串 `""`（让机器人对任何消息都唤醒），此时 `message_str.startswith("")` 恒为真；
- 平台适配器给出的消息带有文本（`message_str`）但消息段列表为空（例如某些转发 / 系统类负载）。

只要同时满足「群聊 + message_str 命中 wake_prefix + 消息段为空」，唤醒检查就会崩在 `messages[0]`。

## 修复

在 `isinstance(messages[0], At)` 前加一个 `and messages` 短路：消息段为空时不是「@ 了别人」，应当正常唤醒，而不是崩溃。改动只有一行，其余分支行为不变。

## 测试

新增 `tests/unit/test_waking_check_stage.py`，覆盖空 wake-prefix 和非空 wake-prefix 两种情况下消息段为空的场景。两个用例在改动前都会因 `messages[0]` 抛 `IndexError`，改动后通过；`tests/unit/test_astr_message_event.py`（78 个）保持全绿。

```
python -m pytest tests/unit/test_waking_check_stage.py -q   # 2 passed
```

## Summary by Sourcery

Prevent group wake-prefix checking from crashing on events with an empty message chain.

Bug Fixes:
- Guard wake-prefix @-mention checks against empty message lists to avoid IndexError in group chats.

Tests:
- Add unit tests covering wake-prefix handling when the message text is present but the message component list is empty for both empty and non-empty prefixes.