### PR TITLE
fix: repair onboarding platform and backup upload

### DIFF
--- a/dashboard/src/api/v1.ts
+++ b/dashboard/src/api/v1.ts
@@ -2,10 +2,12 @@ import type { AxiosRequestConfig, AxiosResponse } from 'axios';
 
 import * as openApiV1 from './generated/openapi-v1';
 import {
+  type BackupChunkUploadRequest,
   client as openApiV1Client,
   type BackupExportRequest,
   type BackupRenameRequest,
   type BackupUploadInitRequest,
+  type BackupUploadRequest,
   type BackupUploadSessionRequest,
   type BotConfigRequest,
   type BotRegistrationRequest,
@@ -187,7 +189,21 @@ function generatedQuery<T extends object>(
   return params as (T & Record<string, unknown>) | undefined;
 }
 
-function generatedFormData(formData: FormData) {
+function generatedFormData(formData: FormData | Record<string, unknown>) {
+  if (typeof FormData !== 'undefined' && formData instanceof FormData) {
+    const body: Record<string, unknown> = {};
+    formData.forEach((value, key) => {
+      const existing = body[key];
+      if (existing === undefined) {
+        body[key] = value;
+      } else if (Array.isArray(existing)) {
+        existing.push(value);
+      } else {
+        body[key] = [existing, value];
+      }
+    });
+    return body as any;
+  }
   return formData as any;
 }
 
@@ -586,7 +602,7 @@ export const backupApi = {
       openApiV1.getBackupProgress({ path: { task_id: taskId } }),
     );
   },
-  upload(formData: FormData) {
+  upload(formData: FormData | BackupUploadRequest) {
     return typed<any>(
       openApiV1.uploadBackup({ body: generatedFormData(formData) }),
     );
@@ -594,7 +610,7 @@ export const backupApi = {
   initUpload(payload: BackupUploadInitRequest) {
     return typed<any>(openApiV1.initBackupUpload({ body: payload }));
   },
-  uploadChunk(formData: FormData) {
+  uploadChunk(formData: FormData | BackupChunkUploadRequest) {
     return typed<any>(
       openApiV1.uploadBackupChunk({ body: generatedFormData(formData) }),
     );

--- a/dashboard/src/components/shared/BackupDialog.vue
+++ b/dashboard/src/components/shared/BackupDialog.vue
@@ -574,12 +574,11 @@ const uploadChunksInParallel = async (file, totalChunks, currentUploadId, curren
         const end = Math.min(start + currentChunkSize, file.size)
         const chunk = file.slice(start, end)
 
-        const formData = new FormData()
-        formData.append('upload_id', currentUploadId)
-        formData.append('chunk_index', chunkIndex.toString())
-        formData.append('chunk', chunk)
-
-        const response = await backupApi.uploadChunk(formData)
+        const response = await backupApi.uploadChunk({
+            upload_id: currentUploadId,
+            chunk_index: chunkIndex,
+            chunk
+        })
 
         if (response.data.status !== 'ok') {
             throw new Error(response.data.message)

--- a/dashboard/src/views/WelcomePage.vue
+++ b/dashboard/src/views/WelcomePage.vue
@@ -329,7 +329,7 @@ const greetingText = computed(() => {
 });
 
 async function loadPlatformConfigBase() {
-  const res = await systemConfigApi.get();
+  const res = await systemConfigApi.runtime();
   const payload = (res.data.data || {}) as any;
   platformMetadata.value = payload.metadata || {};
   platformConfigData.value = payload.config || {};


### PR DESCRIPTION
## Summary
- Load onboarding platform setup from runtime config metadata so platform adapter categories are populated.
- Normalize native FormData before passing it to the generated OpenAPI multipart serializer.
- Send backup chunks with the generated client's expected object payload shape.

## Tests
- pnpm typecheck
- pnpm build
- uv run ruff format .
- uv run ruff check .
- Browser smoke: opened dashboard dev server on http://localhost:3001/ and confirmed the app mounted to the login page with no console errors.

## Summary by Sourcery

Load platform configuration from runtime metadata and adjust backup upload handling to match the generated API client's expectations.

Bug Fixes:
- Load onboarding platform configuration from the runtime system config endpoint so platform metadata is correctly populated.
- Normalize FormData bodies into plain objects before passing them to the generated OpenAPI multipart serializer to fix backup uploads.
- Send backup upload and chunk requests using the generated client's expected request payload shape instead of raw FormData.