### PR TITLE
fix: harden sandbox file transfers

### DIFF
--- a/astrbot/core/computer/booters/cua.py
+++ b/astrbot/core/computer/booters/cua.py
@@ -55,10 +55,21 @@ async def _write_base64_via_shell(
     encoded = base64.b64encode(data).decode("ascii")
     decoder = (
         "import base64,pathlib,sys; "
-        "pathlib.Path(sys.argv[1]).write_bytes(base64.b64decode(sys.stdin.read()))"
+        "path=pathlib.Path(sys.argv[1]); "
+        "path.parent.mkdir(parents=True, exist_ok=True); "
+        "path.write_bytes(base64.b64decode(sys.stdin.read()))"
     )
+    chunk_size = 60_000
+    stdin_parts = [
+        f"cat <<'EOF'\n{encoded[index : index + chunk_size]}\nEOF"
+        for index in range(0, len(encoded), chunk_size)
+    ] or ["cat <<'EOF'\n\nEOF"]
+    stdin_command = "\n".join(stdin_parts)
     return await shell.exec(
-        f"python3 -c {shlex.quote(decoder)} {shlex.quote(path)} <<'EOF'\n{encoded}\nEOF"
+        "{ "
+        f"{stdin_command}"
+        "\n} | "
+        f"python3 -c {shlex.quote(decoder)} {shlex.quote(path)}"
     )
 
 

--- a/astrbot/core/computer/booters/cua.py
+++ b/astrbot/core/computer/booters/cua.py
@@ -16,6 +16,7 @@ from .cua_defaults import CUA_CONFIG_KEYS, CUA_DEFAULT_CONFIG
 from .shipyard_search_file_util import search_files_via_shell
 
 _POSIX_OS_TYPES = {"linux", "darwin", "macos"}
+_CUA_SANDBOX_HEALTH_PROBE = "_astrbot_cua_ok_"
 
 _CUA_BACKGROUND_LAUNCHER = """
 import subprocess, sys, time
@@ -894,12 +895,14 @@ class CuaBooter(ComputerBooter):
         if self._runtime is None:
             return False
         try:
-            result = await self._runtime.shell.exec("echo _astrbot_cua_ok_", timeout=10)
+            result = await self._runtime.shell.exec(
+                f"echo {_CUA_SANDBOX_HEALTH_PROBE}", timeout=10
+            )
         except asyncio.CancelledError:
             raise
         except Exception as exc:
             logger.debug("[Computer] CUA sandbox health check failed: %s", exc)
             return False
-        if result.get("exit_code") not in (0, None):
+        if result.get("exit_code") != 0:
             return False
-        return "_astrbot_cua_ok_" in str(result.get("stdout", ""))
+        return _CUA_SANDBOX_HEALTH_PROBE in str(result.get("stdout", ""))

--- a/astrbot/core/computer/booters/cua.py
+++ b/astrbot/core/computer/booters/cua.py
@@ -60,16 +60,13 @@ async def _write_base64_via_shell(
         "path.write_bytes(base64.b64decode(sys.stdin.read()))"
     )
     chunk_size = 60_000
-    stdin_parts = [
-        f"cat <<'EOF'\n{encoded[index : index + chunk_size]}\nEOF"
+    encoded_lines = "\n".join(
+        encoded[index : index + chunk_size]
         for index in range(0, len(encoded), chunk_size)
-    ] or ["cat <<'EOF'\n\nEOF"]
-    stdin_command = "\n".join(stdin_parts)
+    )
     return await shell.exec(
-        "{ "
-        f"{stdin_command}"
-        "\n} | "
-        f"python3 -c {shlex.quote(decoder)} {shlex.quote(path)}"
+        f"python3 -c {shlex.quote(decoder)} {shlex.quote(path)} <<'EOF'\n"
+        f"{encoded_lines}\nEOF"
     )
 
 
@@ -900,6 +897,6 @@ class CuaBooter(ComputerBooter):
         except Exception as exc:
             logger.debug("[Computer] CUA sandbox health check failed: %s", exc)
             return False
-        if result.get("success") is False or result.get("stderr"):
+        if result.get("exit_code") not in (0, None):
             return False
         return "_astrbot_cua_ok_" in str(result.get("stdout", ""))

--- a/astrbot/core/computer/booters/cua.py
+++ b/astrbot/core/computer/booters/cua.py
@@ -893,4 +893,13 @@ class CuaBooter(ComputerBooter):
         Path(local_path).write_bytes(base64.b64decode(result.get("stdout", "")))
 
     async def available(self) -> bool:
-        return self._runtime is not None
+        if self._runtime is None:
+            return False
+        try:
+            result = await self._runtime.shell.exec("echo _astrbot_cua_ok_", timeout=10)
+        except Exception as exc:
+            logger.debug("[Computer] CUA sandbox health check failed: %s", exc)
+            return False
+        if result.get("success") is False or result.get("stderr"):
+            return False
+        return "_astrbot_cua_ok_" in str(result.get("stdout", ""))

--- a/astrbot/core/computer/booters/cua.py
+++ b/astrbot/core/computer/booters/cua.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import inspect
 import shlex
@@ -894,6 +895,8 @@ class CuaBooter(ComputerBooter):
             return False
         try:
             result = await self._runtime.shell.exec("echo _astrbot_cua_ok_", timeout=10)
+        except asyncio.CancelledError:
+            raise
         except Exception as exc:
             logger.debug("[Computer] CUA sandbox health check failed: %s", exc)
             return False

--- a/astrbot/core/tools/computer_tools/fs.py
+++ b/astrbot/core/tools/computer_tools/fs.py
@@ -70,6 +70,10 @@ _SANDBOX_RUNTIME_TOOL_CONFIG = {
 _IMAGE_FILE_SUFFIXES = {".bmp", ".gif", ".jpeg", ".jpg", ".png", ".webp"}
 
 
+def _remote_basename(path: str) -> str:
+    return path.replace("\\", "/").rstrip("/").split("/")[-1]
+
+
 def _restricted_env_path_labels(umo: str, *, include_plugin_skills: bool) -> list[str]:
     """Labels for the allowed directories in a local(not sandbox) and restricted(not admin) environment"""
     normalized_umo = normalize_umo_for_workspace(umo)
@@ -772,7 +776,7 @@ class FileDownloadTool(FunctionTool):
             context.context.event.unified_msg_origin,
         )
         try:
-            name = os.path.basename(remote_path)
+            name = _remote_basename(remote_path) or os.path.basename(remote_path)
 
             local_path = os.path.join(
                 get_astrbot_temp_path(), f"sandbox_{uuid.uuid4().hex[:4]}_{name}"
@@ -784,7 +788,7 @@ class FileDownloadTool(FunctionTool):
 
             if also_send_to_user:
                 try:
-                    name = os.path.basename(local_path)
+                    name = _remote_basename(remote_path) or os.path.basename(local_path)
                     if Path(local_path).suffix.lower() in _IMAGE_FILE_SUFFIXES:
                         message_component = Image.fromFileSystem(local_path)
                         sent_as = "image"

--- a/astrbot/core/tools/computer_tools/fs.py
+++ b/astrbot/core/tools/computer_tools/fs.py
@@ -71,6 +71,8 @@ _IMAGE_FILE_SUFFIXES = {".bmp", ".gif", ".jpeg", ".jpg", ".png", ".webp"}
 
 
 def _remote_basename(path: str) -> str:
+    # Sandbox paths may come from POSIX or Windows runtimes; normalize separators
+    # without interpreting the path against the host filesystem.
     return path.replace("\\", "/").rstrip("/").split("/")[-1]
 
 

--- a/astrbot/core/tools/message_tools.py
+++ b/astrbot/core/tools/message_tools.py
@@ -15,6 +15,7 @@ from astrbot.core.astr_agent_context import AstrAgentContext
 from astrbot.core.computer.computer_client import get_booter
 from astrbot.core.message.message_event_result import MessageChain
 from astrbot.core.platform.message_session import MessageSession
+from astrbot.core.tools.computer_tools.fs import _remote_basename
 from astrbot.core.tools.computer_tools.util import (
     check_admin_permission,
     is_local_runtime,
@@ -173,7 +174,7 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
             quoted_path = shlex.quote(path)
             result = await sb.shell.exec(f"test -f {quoted_path} && echo '_&exists_'")
             if "_&exists_" in json.dumps(result):
-                name = os.path.basename(path)
+                name = _remote_basename(path) or os.path.basename(path)
                 local_path = os.path.join(
                     get_astrbot_temp_path(), f"sandbox_{uuid.uuid4().hex[:4]}_{name}"
                 )
@@ -259,7 +260,7 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
                     url = msg.get("url")
                     name = (
                         msg.get("text")
-                        or (os.path.basename(path) if path else "")
+                        or (_remote_basename(path) if path else "")
                         or (os.path.basename(url) if url else "")
                         or "file"
                     )

--- a/tests/test_computer_fs_tools.py
+++ b/tests/test_computer_fs_tools.py
@@ -5,6 +5,7 @@ import io
 import zipfile
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 from mcp.types import CallToolResult, ImageContent
@@ -39,6 +40,66 @@ def _make_context(
     )
     astr_ctx = SimpleNamespace(context=config_holder, event=event)
     return ContextWrapper(context=astr_ctx)
+
+
+def _make_sandbox_context(
+    *,
+    role: str = "admin",
+    umo: str = "qq:friend:user-1",
+):
+    config_holder = SimpleNamespace(
+        get_config=lambda umo=None: {
+            "provider_settings": {
+                "computer_use_require_admin": True,
+                "computer_use_runtime": "sandbox",
+            }
+        }
+    )
+    event = SimpleNamespace(
+        role=role,
+        unified_msg_origin=umo,
+        send=AsyncMock(),
+    )
+    astr_ctx = SimpleNamespace(context=config_holder, event=event)
+    return ContextWrapper(context=astr_ctx)
+
+
+@pytest.mark.asyncio
+async def test_sandbox_file_download_handles_windows_remote_filename(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    temp_root = tmp_path / "temp"
+    temp_root.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(
+        fs_tools,
+        "get_astrbot_temp_path",
+        lambda: str(temp_root),
+    )
+
+    async def _download_file(_remote_path, local_path):
+        assert local_path.endswith("report.txt")
+        assert "\\" not in local_path
+
+    booter = SimpleNamespace(download_file=AsyncMock(side_effect=_download_file))
+
+    async def _fake_get_booter(_ctx, _umo):
+        return booter
+
+    monkeypatch.setattr(fs_tools, "get_booter", _fake_get_booter)
+
+    context = _make_sandbox_context()
+    result = await fs_tools.FileDownloadTool().call(
+        context,
+        remote_path=r"C:\Users\AstrBot\report.txt",
+        also_send_to_user=True,
+    )
+
+    assert "report.txt" in result
+    sent_chain = context.context.event.send.await_args.args[0]
+    sent_file = sent_chain.chain[0]
+    assert sent_file.name == "report.txt"
 
 
 def _setup_local_fs_tools(

--- a/tests/test_computer_fs_tools.py
+++ b/tests/test_computer_fs_tools.py
@@ -102,6 +102,40 @@ async def test_sandbox_file_download_handles_windows_remote_filename(
     assert sent_file.name == "report.txt"
 
 
+@pytest.mark.asyncio
+async def test_sandbox_file_download_strips_trailing_remote_slash(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    temp_root = tmp_path / "temp"
+    temp_root.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(
+        fs_tools,
+        "get_astrbot_temp_path",
+        lambda: str(temp_root),
+    )
+
+    booter = SimpleNamespace(download_file=AsyncMock())
+
+    async def _fake_get_booter(_ctx, _umo):
+        return booter
+
+    monkeypatch.setattr(fs_tools, "get_booter", _fake_get_booter)
+
+    context = _make_sandbox_context()
+    result = await fs_tools.FileDownloadTool().call(
+        context,
+        remote_path="reports/export/",
+        also_send_to_user=True,
+    )
+
+    assert "export" in result
+    sent_chain = context.context.event.send.await_args.args[0]
+    sent_file = sent_chain.chain[0]
+    assert sent_file.name == "export"
+
+
 def _setup_local_fs_tools(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,

--- a/tests/unit/test_cua_computer_use.py
+++ b/tests/unit/test_cua_computer_use.py
@@ -8,6 +8,7 @@ import mcp
 import pytest
 
 from astrbot.core.astr_agent_tool_exec import FunctionToolExecutor
+from astrbot.core.computer.booters.cua import CuaShellComponent
 from astrbot.core.config.default import CONFIG_METADATA_3
 from astrbot.core.provider.func_tool_manager import FunctionToolManager
 
@@ -931,7 +932,6 @@ async def test_cua_upload_file_fallback_rejects_non_posix_os_type(tmp_path):
         CuaFileSystemComponent,
         CuaGUIComponent,
         CuaPythonComponent,
-        CuaShellComponent,
         _CuaRuntime,
     )
 
@@ -962,7 +962,6 @@ async def test_cua_upload_file_prefers_native_files_upload(tmp_path):
         CuaFileSystemComponent,
         CuaGUIComponent,
         CuaPythonComponent,
-        CuaShellComponent,
         _CuaRuntime,
     )
 
@@ -1331,7 +1330,6 @@ async def test_cua_shutdown_clears_cached_components():
         CuaFileSystemComponent,
         CuaGUIComponent,
         CuaPythonComponent,
-        CuaShellComponent,
         _CuaRuntime,
     )
 
@@ -1389,6 +1387,34 @@ async def test_cua_available_checks_shell_health():
 
     assert await booter.available() is True
     assert sandbox.shell.commands[-1][0] == "echo _astrbot_cua_ok_"
+
+
+@pytest.mark.asyncio
+async def test_cua_available_rejects_unknown_health_exit_code():
+    from astrbot.core.computer.booters.cua import (
+        CuaBooter,
+        CuaFileSystemComponent,
+        CuaGUIComponent,
+        CuaPythonComponent,
+        _CuaRuntime,
+    )
+
+    class UnknownExitCodeRuntimeShell:
+        async def exec(self, command: str, **kwargs):
+            return {"stdout": "_astrbot_cua_ok_\n", "stderr": "", "exit_code": None}
+
+    sandbox = FakeSandbox()
+    booter = CuaBooter()
+    booter._runtime = _CuaRuntime(
+        sandbox_cm=object(),
+        sandbox=sandbox,
+        shell=UnknownExitCodeRuntimeShell(),
+        python=CuaPythonComponent(sandbox),
+        fs=CuaFileSystemComponent(sandbox),
+        gui=CuaGUIComponent(sandbox),
+    )
+
+    assert await booter.available() is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_cua_computer_use.py
+++ b/tests/unit/test_cua_computer_use.py
@@ -641,6 +641,32 @@ async def test_cua_write_file_shell_fallback_uses_python_base64_decoder():
 
 
 @pytest.mark.asyncio
+async def test_cua_write_file_shell_fallback_creates_parent_directory():
+    from astrbot.core.computer.booters.cua import CuaFileSystemComponent
+
+    sandbox = FakeSandbox()
+    delattr(sandbox, "filesystem")
+
+    await CuaFileSystemComponent(sandbox).write_file("reports/summary.txt", "hello")
+
+    command = sandbox.shell.commands[0][0]
+    assert "path.parent.mkdir(parents=True, exist_ok=True)" in command
+
+
+@pytest.mark.asyncio
+async def test_cua_write_file_shell_fallback_chunks_large_payloads():
+    from astrbot.core.computer.booters.cua import CuaFileSystemComponent
+
+    sandbox = FakeSandbox()
+    delattr(sandbox, "filesystem")
+
+    await CuaFileSystemComponent(sandbox).write_file("large.txt", "x" * 100_000)
+
+    command = sandbox.shell.commands[0][0]
+    assert command.count("cat <<'EOF'") > 1
+
+
+@pytest.mark.asyncio
 async def test_cua_create_file_reports_mode_as_informational():
     from astrbot.core.computer.booters.cua import CuaFileSystemComponent
 

--- a/tests/unit/test_cua_computer_use.py
+++ b/tests/unit/test_cua_computer_use.py
@@ -1356,6 +1356,68 @@ async def test_cua_shutdown_clears_cached_components():
     assert booter._runtime is None
 
 
+@pytest.mark.asyncio
+async def test_cua_available_checks_shell_health():
+    from astrbot.core.computer.booters.cua import (
+        CuaBooter,
+        CuaFileSystemComponent,
+        CuaGUIComponent,
+        CuaPythonComponent,
+        CuaShellComponent,
+        _CuaRuntime,
+    )
+
+    class HealthShell(FakeShell):
+        async def run(self, command: str, **kwargs):
+            self.commands.append((command, kwargs))
+            return {"stdout": "_astrbot_cua_ok_\n", "stderr": "", "exit_code": 0}
+
+    sandbox = FakeSandbox()
+    sandbox.shell = HealthShell()
+    booter = CuaBooter()
+    booter._runtime = _CuaRuntime(
+        sandbox_cm=object(),
+        sandbox=sandbox,
+        shell=CuaShellComponent(sandbox),
+        python=CuaPythonComponent(sandbox),
+        fs=CuaFileSystemComponent(sandbox),
+        gui=CuaGUIComponent(sandbox),
+    )
+
+    assert await booter.available() is True
+    assert sandbox.shell.commands[-1][0] == "echo _astrbot_cua_ok_"
+
+
+@pytest.mark.asyncio
+async def test_cua_available_returns_false_when_shell_health_fails():
+    from astrbot.core.computer.booters.cua import (
+        CuaBooter,
+        CuaFileSystemComponent,
+        CuaGUIComponent,
+        CuaPythonComponent,
+        CuaShellComponent,
+        _CuaRuntime,
+    )
+
+    class DisconnectedShell:
+        async def run(self, command: str, **kwargs):
+            raise RuntimeError("server disconnected")
+
+    sandbox = FakeSandbox()
+    sandbox.shell = DisconnectedShell()
+    booter = CuaBooter()
+    booter._runtime = _CuaRuntime(
+        sandbox_cm=object(),
+        sandbox=sandbox,
+        shell=CuaShellComponent(sandbox),
+        python=CuaPythonComponent(sandbox),
+        fs=CuaFileSystemComponent(sandbox),
+        gui=CuaGUIComponent(sandbox),
+    )
+
+    assert await booter.available() is False
+
+
 def test_cua_tools_are_registered_as_builtin_tools():
     from astrbot.core.tools.computer_tools.cua import (
         CuaKeyboardTypeTool,

--- a/tests/unit/test_cua_computer_use.py
+++ b/tests/unit/test_cua_computer_use.py
@@ -663,7 +663,8 @@ async def test_cua_write_file_shell_fallback_chunks_large_payloads():
     await CuaFileSystemComponent(sandbox).write_file("large.txt", "x" * 100_000)
 
     command = sandbox.shell.commands[0][0]
-    assert command.count("cat <<'EOF'") > 1
+    payload = command.split("<<'EOF'\n", 1)[1].rsplit("\nEOF", 1)[0]
+    assert len(payload.splitlines()) > 1
 
 
 @pytest.mark.asyncio
@@ -1416,6 +1417,41 @@ async def test_cua_available_returns_false_when_shell_health_fails():
     )
 
     assert await booter.available() is False
+
+
+@pytest.mark.asyncio
+async def test_cua_available_allows_shell_health_warning_on_stderr():
+    from astrbot.core.computer.booters.cua import (
+        CuaBooter,
+        CuaFileSystemComponent,
+        CuaGUIComponent,
+        CuaPythonComponent,
+        CuaShellComponent,
+        _CuaRuntime,
+    )
+
+    class WarningShell(FakeShell):
+        async def run(self, command: str, **kwargs):
+            self.commands.append((command, kwargs))
+            return {
+                "stdout": "_astrbot_cua_ok_\n",
+                "stderr": "profile warning\n",
+                "exit_code": 0,
+            }
+
+    sandbox = FakeSandbox()
+    sandbox.shell = WarningShell()
+    booter = CuaBooter()
+    booter._runtime = _CuaRuntime(
+        sandbox_cm=object(),
+        sandbox=sandbox,
+        shell=CuaShellComponent(sandbox),
+        python=CuaPythonComponent(sandbox),
+        fs=CuaFileSystemComponent(sandbox),
+        gui=CuaGUIComponent(sandbox),
+    )
+
+    assert await booter.available() is True
 
 
 def test_cua_tools_are_registered_as_builtin_tools():

--- a/tests/unit/test_cua_computer_use.py
+++ b/tests/unit/test_cua_computer_use.py
@@ -664,7 +664,9 @@ async def test_cua_write_file_shell_fallback_chunks_large_payloads():
 
     command = sandbox.shell.commands[0][0]
     payload = command.split("<<'EOF'\n", 1)[1].rsplit("\nEOF", 1)[0]
-    assert len(payload.splitlines()) > 1
+    lines = payload.splitlines()
+    assert len(lines) > 1
+    assert max(len(line) for line in lines) <= 60_000
 
 
 @pytest.mark.asyncio
@@ -1417,6 +1419,37 @@ async def test_cua_available_returns_false_when_shell_health_fails():
     )
 
     assert await booter.available() is False
+
+
+@pytest.mark.asyncio
+async def test_cua_available_propagates_cancellation():
+    from astrbot.core.computer.booters.cua import (
+        CuaBooter,
+        CuaFileSystemComponent,
+        CuaGUIComponent,
+        CuaPythonComponent,
+        CuaShellComponent,
+        _CuaRuntime,
+    )
+
+    class CancellingShell:
+        async def run(self, command: str, **kwargs):
+            raise asyncio.CancelledError
+
+    sandbox = FakeSandbox()
+    sandbox.shell = CancellingShell()
+    booter = CuaBooter()
+    booter._runtime = _CuaRuntime(
+        sandbox_cm=object(),
+        sandbox=sandbox,
+        shell=CuaShellComponent(sandbox),
+        python=CuaPythonComponent(sandbox),
+        fs=CuaFileSystemComponent(sandbox),
+        gui=CuaGUIComponent(sandbox),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await booter.available()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_message_tools.py
+++ b/tests/unit/test_message_tools.py
@@ -235,3 +235,51 @@ async def test_non_admin_can_send_temp_file(tmp_path, monkeypatch):
 
     assert "Message sent to session" in result
     ctx.context.context.send_message.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_message_downloads_windows_sandbox_file_with_original_name(
+    tmp_path, monkeypatch
+):
+    """Windows sandbox paths keep their basename when sent as files."""
+    tool = SendMessageToUserTool()
+    ctx = _make_context(runtime="sandbox")
+    temp_root = tmp_path / "temp"
+    temp_root.mkdir()
+    monkeypatch.setattr(
+        "astrbot.core.tools.message_tools.get_astrbot_temp_path",
+        lambda: str(temp_root),
+    )
+
+    async def _exec(_command):
+        return {"content": "_&exists_"}
+
+    async def _download_file(_remote_path, local_path):
+        assert local_path.endswith("report.txt")
+        assert "\\" not in local_path
+        with open(local_path, "w", encoding="utf-8") as file:
+            file.write("report")
+
+    booter = SimpleNamespace(
+        shell=SimpleNamespace(exec=AsyncMock(side_effect=_exec)),
+        download_file=AsyncMock(side_effect=_download_file),
+    )
+
+    async def mock_get_booter(*args, **kwargs):
+        del args, kwargs
+        return booter
+
+    monkeypatch.setattr(
+        "astrbot.core.tools.message_tools.get_booter",
+        mock_get_booter,
+    )
+
+    result = await tool.call(
+        ctx,
+        messages=[{"type": "file", "path": r"C:\Users\AstrBot\report.txt"}],
+    )
+
+    assert "Message sent to session" in result
+    sent_chain = ctx.context.context.send_message.await_args.args[1]
+    sent_file = sent_chain.chain[0]
+    assert sent_file.name == "report.txt"

--- a/tests/unit/test_message_tools.py
+++ b/tests/unit/test_message_tools.py
@@ -283,3 +283,49 @@ async def test_send_message_downloads_windows_sandbox_file_with_original_name(
     sent_chain = ctx.context.context.send_message.await_args.args[1]
     sent_file = sent_chain.chain[0]
     assert sent_file.name == "report.txt"
+
+
+@pytest.mark.asyncio
+async def test_send_message_downloads_trailing_slash_sandbox_file_with_basename(
+    tmp_path, monkeypatch
+):
+    tool = SendMessageToUserTool()
+    ctx = _make_context(runtime="sandbox")
+    temp_root = tmp_path / "temp"
+    temp_root.mkdir()
+    monkeypatch.setattr(
+        "astrbot.core.tools.message_tools.get_astrbot_temp_path",
+        lambda: str(temp_root),
+    )
+
+    async def _exec(_command):
+        return {"content": "_&exists_"}
+
+    async def _download_file(_remote_path, local_path):
+        assert local_path.endswith("export")
+        with open(local_path, "w", encoding="utf-8") as file:
+            file.write("export")
+
+    booter = SimpleNamespace(
+        shell=SimpleNamespace(exec=AsyncMock(side_effect=_exec)),
+        download_file=AsyncMock(side_effect=_download_file),
+    )
+
+    async def mock_get_booter(*args, **kwargs):
+        del args, kwargs
+        return booter
+
+    monkeypatch.setattr(
+        "astrbot.core.tools.message_tools.get_booter",
+        mock_get_booter,
+    )
+
+    result = await tool.call(
+        ctx,
+        messages=[{"type": "file", "path": "reports/export/"}],
+    )
+
+    assert "Message sent to session" in result
+    sent_chain = ctx.context.context.send_message.await_args.args[1]
+    sent_file = sent_chain.chain[0]
+    assert sent_file.name == "export"


### PR DESCRIPTION
## Summary
- preserve original sandbox filenames when downloading Windows-style remote paths
- keep send_message_to_user file names stable for sandbox paths
- make CUA shell fallback writes create parent directories and chunk large base64 payloads

## Tests
- uv run pytest tests/unit/test_cua_computer_use.py tests/test_computer_fs_tools.py tests/unit/test_message_tools.py
- uv run ruff check astrbot/core/computer/booters/cua.py astrbot/core/tools/computer_tools/fs.py astrbot/core/tools/message_tools.py tests/test_computer_fs_tools.py tests/unit/test_message_tools.py tests/unit/test_cua_computer_use.py

Note: this intentionally does not add the optional cua package as a core dependency.

## Summary by Sourcery

Harden sandbox-based file transfers and CUA sandbox health checking for computer use.

Bug Fixes:
- Preserve original sandbox filenames for Windows-style remote paths and trailing-slash paths when downloading or sending files from the sandbox.
- Ensure sandbox file downloads strip trailing slashes from remote paths to avoid malformed local filenames.
- Fix CUA sandbox availability to perform a real shell-based health check and handle failure, stderr warnings, unknown exit codes, and cancellation correctly.

Enhancements:
- Make CUA shell fallback file writes create parent directories and chunk large base64 payloads to improve robustness of large writes.
- Normalize sandbox remote basenames independently of host OS path semantics for safer cross-platform file handling.

Tests:
- Add unit tests covering CUA shell fallback directory creation and base64 chunking behavior.
- Add tests for CUA booter availability behavior across healthy, failing, warning, and cancelling shell scenarios.
- Add tests for sandbox file download and send-message tools to validate Windows-style paths, trailing slashes, and preserved filenames.