### PR TITLE
Fix: persona edit duplicate ID validation

### DIFF
--- a/dashboard/src/components/shared/PersonaForm.vue
+++ b/dashboard/src/components/shared/PersonaForm.vue
@@ -416,7 +416,7 @@ export default {
             personaIdRules: [
                 v => !!v || this.tm('validation.required'),
                 v => (v && v.length >= 1) || this.tm('validation.minLength', { min: 1 }),
-                v => !this.existingPersonaIds.includes(v) || this.tm('validation.personaIdExists'),
+                v => this.editingPersona?.persona_id === v || !this.existingPersonaIds.includes(v) || this.tm('validation.personaIdExists'),
             ],
             systemPromptRules: [
                 v => !!v || this.tm('validation.required'),


### PR DESCRIPTION
修复 WebUI 人格管理中，新建并保存一个人格后，编辑其他已有人格时保存按钮可能变灰且无法点击的问题

### 改动点

- 修改 `dashboard/src/components/shared/PersonaForm.vue`
- 编辑人格时允许当前人格自己的ID通过重名校验
- 保持新建人格时的重名校验逻辑不变

- [x] 这不是一个破坏性变更。

### 运行截图或测试结果


已检查：

```bash
git diff --check -- dashboard/src/components/shared/PersonaForm.vue
```

---

### 检查清单

- [ ] 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [ ] 我的更改经过了良好的测试，并已在上方提供了“验证步骤”和“运行截图”。

- [x] 我确保没有引入新依赖库，或者引入新依赖库的同时已将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Allow saving edits to an existing persona when its ID matches an already stored ID, instead of incorrectly treating it as a duplicate.