### PR TITLE
fix: normalize shipyard shell exec response

### DIFF
--- a/astrbot/core/computer/booters/shipyard.py
+++ b/astrbot/core/computer/booters/shipyard.py
@@ -61,10 +61,23 @@ class ShipyardShellWrapper:
             cwd=cwd,
         )
         payload = _maybe_model_dump(result)
+        data = payload.get("data")
+        if isinstance(data, dict):
+            payload.update(
+                {key: value for key, value in data.items() if value is not None}
+            )
 
-        stdout = payload.get("output", payload.get("stdout", "")) or ""
-        stderr = payload.get("error", payload.get("stderr", "")) or ""
+        stdout = payload.get("output")
+        if not stdout and payload.get("stdout") is not None:
+            stdout = payload.get("stdout")
+        stdout = stdout or ""
+        stderr = payload.get("error")
+        if not stderr and payload.get("stderr") is not None:
+            stderr = payload.get("stderr")
+        stderr = stderr or ""
         exit_code = payload.get("exit_code")
+        if exit_code is None:
+            exit_code = payload.get("return_code")
         if background:
             pid: int | None = None
             try:

--- a/astrbot/core/computer/booters/shipyard.py
+++ b/astrbot/core/computer/booters/shipyard.py
@@ -67,14 +67,8 @@ class ShipyardShellWrapper:
                 {key: value for key, value in data.items() if value is not None}
             )
 
-        stdout = payload.get("output")
-        if not stdout and payload.get("stdout") is not None:
-            stdout = payload.get("stdout")
-        stdout = stdout or ""
-        stderr = payload.get("error")
-        if not stderr and payload.get("stderr") is not None:
-            stderr = payload.get("stderr")
-        stderr = stderr or ""
+        stdout = payload.get("output") or payload.get("stdout") or ""
+        stderr = payload.get("error") or payload.get("stderr") or ""
         exit_code = payload.get("exit_code")
         if exit_code is None:
             exit_code = payload.get("return_code")

--- a/tests/unit/test_computer.py
+++ b/tests/unit/test_computer.py
@@ -377,6 +377,42 @@ class TestShipyardBooter:
     """Tests for ShipyardBooter."""
 
     @pytest.mark.asyncio
+    async def test_shipyard_shell_unwraps_bay_exec_response(self):
+        """Bay exec responses keep shell output under the data field."""
+        from astrbot.core.computer.booters.shipyard import ShipyardShellWrapper
+
+        raw_shell = AsyncMock()
+        raw_shell.exec = AsyncMock(
+            return_value={
+                "success": True,
+                "data": {
+                    "success": True,
+                    "return_code": 0,
+                    "stdout": "hello_from_shipyard_bay\n/workspace\n",
+                    "stderr": "",
+                    "pid": 16,
+                    "process_id": None,
+                    "error": None,
+                },
+                "error": None,
+            }
+        )
+
+        result = await ShipyardShellWrapper(raw_shell).exec(
+            "echo hello_from_shipyard_bay && pwd"
+        )
+
+        assert result == {
+            "stdout": "hello_from_shipyard_bay\n/workspace\n",
+            "stderr": "",
+            "exit_code": 0,
+            "success": True,
+            "execution_id": None,
+            "execution_time_ms": None,
+            "command": None,
+        }
+
+    @pytest.mark.asyncio
     async def test_shipyard_booter_init(self):
         """Test ShipyardBooter initialization."""
         with patch("astrbot.core.computer.booters.shipyard.ShipyardClient"):

--- a/tests/unit/test_computer.py
+++ b/tests/unit/test_computer.py
@@ -413,6 +413,38 @@ class TestShipyardBooter:
         }
 
     @pytest.mark.asyncio
+    async def test_shipyard_shell_keeps_flat_exec_response_compatible(self):
+        """Flat shell responses remain compatible with ShipyardShellWrapper."""
+        from astrbot.core.computer.booters.shipyard import ShipyardShellWrapper
+
+        raw_shell = AsyncMock()
+        raw_shell.exec = AsyncMock(
+            return_value={
+                "success": True,
+                "stdout": "hello_from_legacy_shell\n/workspace\n",
+                "stderr": "",
+                "exit_code": 0,
+                "execution_id": "exec-legacy",
+                "execution_time_ms": 45,
+                "command": "echo hello_from_legacy_shell && pwd",
+            }
+        )
+
+        result = await ShipyardShellWrapper(raw_shell).exec(
+            "echo hello_from_legacy_shell && pwd"
+        )
+
+        assert result == {
+            "stdout": "hello_from_legacy_shell\n/workspace\n",
+            "stderr": "",
+            "exit_code": 0,
+            "success": True,
+            "execution_id": "exec-legacy",
+            "execution_time_ms": 45,
+            "command": "echo hello_from_legacy_shell && pwd",
+        }
+
+    @pytest.mark.asyncio
     async def test_shipyard_booter_init(self):
         """Test ShipyardBooter initialization."""
         with patch("astrbot.core.computer.booters.shipyard.ShipyardClient"):


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
修复旧版 Shipyard Bay shell 命令实际执行成功，但 AstrBot 返回空 `stdout`、空 `stderr`、`exit_code: null` 的问题。

  旧版 Shipyard `/ship/{ship_id}/exec` API 会把 shell 执行结果包在 `data` 字段中，例如 `data.stdout`、`data.stderr`、`data.return_code`。此前 AstrBot 只读取外层字段，导致命令输出和退出码被丢弃。

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

  - 更新 `astrbot/core/computer/booters/shipyard.py`，兼容 Shipyard Bay `success/data/error` 包装结构。
  - 将 `data.stdout` / `data.stderr` 正确映射为 AstrBot shell 工具输出。
  - 将 `data.return_code` 正确映射为 AstrBot `exit_code`。
  - 在 `tests/unit/test_computer.py` 中增加基于真实 Shipyard Bay 响应结构的回归测试。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
```bash
Ling code/AstrBot ‹master› » uv run pytest tests/unit/test_computer.py::TestShipyardBooter::test_shipyard_shell_unwraps_bay_exec_response
=================================================================================================================== test session starts ====================================================================================================================
platform linux -- Python 3.12.13, pytest-9.1.0, pluggy-1.6.0
rootdir: /home/ling/Documents/code/AstrBot
configfile: pyproject.toml
plugins: anyio-4.14.0, asyncio-1.4.0, cov-7.1.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item                                                                                                                                                                                                                                           

tests/unit/test_computer.py .                                                                                                                                                                                                                        [100%]

==================================================================================================================== 1 passed in 3.66s =====================================================================================================================
```
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Normalize handling of Shipyard Bay shell exec responses so shell command output and exit codes are correctly surfaced by AstrBot.

Bug Fixes:
- Fix missing stdout, stderr, and exit_code when processing nested Shipyard Bay /ship/{ship_id}/exec responses wrapped under a data field.

Tests:
- Add a regression test ensuring ShipyardShellWrapper correctly unwraps Bay exec response payloads and maps them to the standardized shell result format.