### PR TITLE
fix(truncator): keep an all-system context in the system half

### DIFF
--- a/astrbot/core/agent/context/truncator.py
+++ b/astrbot/core/agent/context/truncator.py
@@ -21,7 +21,9 @@ class ContextTruncator:
         Returns:
             tuple: (system_messages, non_system_messages)
         """
-        first_non_system = 0
+        # Default to the end so an all-system list lands entirely in the system
+        # half; otherwise the loop never breaks and the split would be reversed.
+        first_non_system = len(messages)
         for i, msg in enumerate(messages):
             if msg.role != "system":
                 first_non_system = i

--- a/tests/agent/test_truncator.py
+++ b/tests/agent/test_truncator.py
@@ -376,6 +376,29 @@ class TestContextTruncator:
         if len(result) > 0:
             assert all(msg.role == "system" for msg in result)
 
+    def test_split_system_rest_with_only_system_messages(self):
+        """All-system input must land entirely in the system half, not the rest."""
+        truncator = ContextTruncator()
+        messages = [
+            self.create_message("system", "System 1"),
+            self.create_message("system", "System 2"),
+        ]
+
+        system_messages, non_system_messages = truncator._split_system_rest(messages)
+
+        assert len(system_messages) == 2
+        assert non_system_messages == []
+
+    def test_halving_keeps_all_system_messages(self):
+        """Halving must never drop system messages, even with no turns present."""
+        truncator = ContextTruncator()
+        messages = [self.create_message("system", f"System {i}") for i in range(4)]
+
+        result = truncator.truncate_by_halving(messages)
+
+        assert len(result) == 4
+        assert all(msg.role == "system" for msg in result)
+
     # ==================== #6196: 长 tool chain 只有一条 user 消息 ====================
 
     def _build_tool_chain(self, tool_rounds: int = 20) -> list[Message]:


### PR DESCRIPTION
## What

`ContextTruncator._split_system_rest` splits a message list into `(system_messages, rest)`. It initialized `first_non_system = 0` and only updated it when it found a non-system message. When **every** message is a system message the loop never breaks, so `first_non_system` stays `0` and the split is reversed — the system messages end up in the `rest` half and the system half is empty.

The truncation strategies then treat those system messages as droppable turns. For example `truncate_by_halving` on four system messages returns only two:

```python
msgs = [Message(role="system", content=f"S{i}") for i in range(4)]
ContextTruncator().truncate_by_halving(msgs)
# before: 2 messages (two system messages dropped)
# after:  4 messages (all preserved)
```

System messages must never be dropped by truncation. The fix defaults `first_non_system` to `len(messages)`, so an all-system list stays entirely in the system half. Mixed inputs (the loop still breaks at the first non-system message) and empty inputs are unchanged.

## Test plan

Added two tests in `tests/agent/test_truncator.py`:

- `test_split_system_rest_with_only_system_messages` — all-system input puts everything in the system half.
- `test_halving_keeps_all_system_messages` — `truncate_by_halving` keeps all four system messages.

Both fail on `master` and pass with this change.

```
python -m pytest tests/agent/test_truncator.py
# 37 passed
```

`ruff check` and `ruff format --check` pass on the changed files.

## Summary by Sourcery

Ensure context truncation never drops system messages when splitting or halving message histories.

Bug Fixes:
- Correct splitting of message lists so all-system inputs are fully retained in the system portion instead of being misclassified as non-system messages.

Tests:
- Add tests verifying that all-system message lists remain entirely in the system half and that halving truncation preserves all system messages.