### PR TITLE
chore: bump version to 4.26.0-beta.9

### DIFF
--- a/changelogs/v4.26.0-beta.9.md
+++ b/changelogs/v4.26.0-beta.9.md
@@ -1,0 +1,54 @@
+- [更新日志(简体中文)](#chinese)
+- [Changelog(English)](#english)
+
+<a id="chinese"></a>
+
+## What's Changed
+
+### 重点更新
+
+- 为 OpenAI、Gemini、Anthropic 等模型请求加入可配置的重试机制，并新增请求最大重试次数配置，提升临时网络错误与 5xx 服务端错误下的稳定性。([#8893](https://github.com/AstrBotDevs/AstrBot/pull/8893))
+- 新增托管 Core 包下载能力，并加强 Core 与 Dashboard 包下载归档校验。([#8888](https://github.com/AstrBotDevs/AstrBot/pull/8888))
+- 支持在请求中加载 workspace skills，并加固 workspace skill 发现流程。([#8884](https://github.com/AstrBotDevs/AstrBot/pull/8884))
+
+### 修复
+
+- 修复 OpenAPI 文件上传能力，恢复 `/api/v1/file` OpenAPI 暴露、文件范围 API Key 与相关文档/客户端产物。
+- 修复新版 MCP 中 Streamable HTTP client 重命名导致的兼容问题，并保持 `mcp` 依赖小于 2。
+- 加固人格工具边界，确保人格限定的工具范围在主 Agent 请求中正确生效。([#8786](https://github.com/AstrBotDevs/AstrBot/pull/8786))
+- 加强 Future Task 所有者校验，避免越权访问定时任务。([#8881](https://github.com/AstrBotDevs/AstrBot/pull/8881))
+- 在受限本地文件系统工具中拒绝 hardlink 文件，避免通过工作区 hardlink 别名读写允许目录外的文件。
+
+### 发布流程
+
+- 新增 `scripts/prepare_release.py`，统一 release 分支、版本号、changelog 与校验流程。([#8891](https://github.com/AstrBotDevs/AstrBot/pull/8891))
+
+### 文档
+
+- 明确 OpenAPI Chat 中 `username` 字段的身份含义。([#8880](https://github.com/AstrBotDevs/AstrBot/pull/8880))
+
+<a id="english"></a>
+
+## What's Changed (EN)
+
+### Highlights
+
+- Added configurable retry handling for OpenAI, Gemini, Anthropic, and related provider requests, including a maximum request retry setting to improve stability for transient network failures and 5xx server errors. ([#8893](https://github.com/AstrBotDevs/AstrBot/pull/8893))
+- Added hosted Core package downloads and strengthened archive validation for hosted Core and Dashboard packages. ([#8888](https://github.com/AstrBotDevs/AstrBot/pull/8888))
+- Added workspace skills support in requests and hardened workspace skill discovery. ([#8884](https://github.com/AstrBotDevs/AstrBot/pull/8884))
+
+### Bug Fixes
+
+- Restored OpenAPI file uploads by exposing `/api/v1/file`, enabling file-scoped API keys, and regenerating docs/client artifacts.
+- Fixed compatibility with the renamed MCP Streamable HTTP client while keeping the `mcp` dependency below 2.
+- Hardened persona tool boundaries so persona-restricted tool scopes are enforced correctly in main Agent requests. ([#8786](https://github.com/AstrBotDevs/AstrBot/pull/8786))
+- Enforced Future Task owner checks to prevent unauthorized scheduled-task access. ([#8881](https://github.com/AstrBotDevs/AstrBot/pull/8881))
+- Rejected hardlinked files in restricted local filesystem tools to prevent workspace hardlink aliases from reading or overwriting files outside allowed directories.
+
+### Release Process
+
+- Added `scripts/prepare_release.py` to standardize release branches, version bumps, changelog generation, and validation. ([#8891](https://github.com/AstrBotDevs/AstrBot/pull/8891))
+
+### Docs
+
+- Clarified the identity semantics of the `username` field in OpenAPI Chat. ([#8880](https://github.com/AstrBotDevs/AstrBot/pull/8880))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AstrBot"
-version = "4.26.0-beta.8"
+version = "4.26.0-beta.9"
 description = "Easy-to-use multi-platform LLM chatbot and development framework"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }


### PR DESCRIPTION
## Summary
- Bump project version to 4.26.0-beta.9
- Add changelog for v4.26.0-beta.9

## Validation
- uv run python scripts/prepare_release.py 4.26.0-beta.9
- uv run ruff format --check .
- uv run ruff check .

## Summary by Sourcery

Bump the AstrBot package version for a new beta release and add the corresponding release changelog document.

Enhancements:
- Introduce a detailed bilingual changelog entry describing highlights, bug fixes, release process updates, and documentation changes for version 4.26.0-beta.9.

Build:
- Update the project version in pyproject.toml to 4.26.0-beta.9.

Documentation:
- Add a new bilingual changelog file for version 4.26.0-beta.9.