### PR TITLE
Fix/tool perm bypass

### DIFF
--- a/astrbot/core/astr_agent_tool_exec.py
+++ b/astrbot/core/astr_agent_tool_exec.py
@@ -45,10 +45,21 @@ from astrbot.core.tools.computer_tools import (
     PythonTool,
 )
 from astrbot.core.tools.message_tools import SendMessageToUserTool
+from astrbot.core.tools.registry import get_builtin_tool_name
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
 from astrbot.core.utils.history_saver import persist_agent_history
 from astrbot.core.utils.image_ref_utils import is_supported_image_ref
 from astrbot.core.utils.string_utils import normalize_and_dedupe_strings
+
+
+def _is_builtin_tool_instance(tool: FunctionTool) -> bool:
+    """True if tool is a real instance of a registered builtin tool class.
+
+    Checked by type, not name — an MCP/plugin tool can legally share a
+    builtin tool's name to override it, so a name-based check would skip
+    the permission check below for the wrong tool.
+    """
+    return get_builtin_tool_name(type(tool)) is not None
 
 
 class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
@@ -149,7 +160,19 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
                 yield r
             return
 
-        elif isinstance(tool, MCPTool):
+        if not _is_builtin_tool_instance(tool):
+            ctx = run_context.context.context
+            tool_mgr = (
+                ctx.get_llm_tool_manager()
+                if hasattr(ctx, "get_llm_tool_manager")
+                else llm_tools
+            )
+            if error := await tool_mgr.check_tool_permission(tool.name, run_context):
+                text_content = mcp.types.TextContent(type="text", text=error)
+                yield mcp.types.CallToolResult(content=[text_content])
+                return
+
+        if isinstance(tool, MCPTool):
             async for r in cls._execute_mcp(tool, run_context, **tool_args):
                 yield r
             return
@@ -266,13 +289,8 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
         # "all tools", including runtime computer-use tools.
         if tools is None:
             toolset = ToolSet()
-            handoff_names = {
-                tool.name
-                for tool in tool_mgr.func_list
-                if isinstance(tool, HandoffTool)
-            }
-            for registered_tool in tool_mgr.get_full_tool_set():
-                if registered_tool.name in handoff_names:
+            for registered_tool in tool_mgr.func_list:
+                if isinstance(registered_tool, HandoffTool):
                     continue
                 if registered_tool.active:
                     toolset.add_tool(registered_tool)

--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -210,78 +210,6 @@ async def _quick_test_mcp_connection(config: dict) -> tuple[bool, str]:
         return False, f"{e!s}"
 
 
-class _PermissionGuardedTool(FunctionTool):
-    """Transparent proxy that checks per-tool permissions before delegating.
-
-    Only wraps non-builtin tools. Builtin tools are added to the tool set
-    without wrapping, so their existing hardcoded permission logic
-    (``check_admin_permission`` / ``_is_restricted_env``) is unaffected.
-
-    The ``handler`` field is intentionally kept ``None`` so that
-    ``FunctionToolExecutor._execute_local`` falls through to the
-    ``is_override_call`` branch and invokes our ``call()`` instead of
-    calling the raw handler directly.  This ensures the permission
-    check runs for *every* invocation path.
-    """
-
-    def __init__(
-        self,
-        tool: FunctionTool,
-        manager: FunctionToolManager,
-    ) -> None:
-        # Do NOT pass handler to the parent — keep self.handler = None
-        # so the tool executor always routes through our call().
-        super().__init__(
-            name=tool.name,
-            description=tool.description,
-            parameters=getattr(tool, "parameters", {}),
-        )
-        self._wrapped = tool
-        self._mgr = manager
-        # Mirror mutable state from the underlying tool
-        self.active = getattr(tool, "active", True)
-        self.handler_module_path = getattr(tool, "handler_module_path", None)
-
-    async def call(self, context: Any, **kwargs: Any) -> Any:
-        import inspect as _inspect
-
-        error = self._mgr._check_tool_permission(self.name, context)
-        if error is not None:
-            return error
-
-        # Delegate to handler first (plugin tools).
-        if self._wrapped.handler is not None:
-            result = self._wrapped.handler(context, **kwargs)
-            if _inspect.isasyncgen(result):
-                last: Any = None
-                async for item in result:
-                    last = item
-                return last
-            if _inspect.isawaitable(result):
-                return await result
-            return result
-
-        # Fall back to overridden call() on subclasses (e.g. MCPTool).
-        call_override = getattr(type(self._wrapped), "call", None)
-        if call_override is not None and call_override is not FunctionTool.call:
-            return await self._wrapped.call(context, **kwargs)
-
-        run = getattr(self._wrapped, "run", None)
-        if run is not None:
-            event = context.context.event
-            result = run(event, **kwargs)
-            if _inspect.isasyncgen(result):
-                last: Any = None
-                async for item in result:
-                    last = item
-                return last
-            if _inspect.isawaitable(result):
-                return await result
-            return result
-
-        return "error: tool has no callable handler"
-
-
 class FunctionToolManager:
     def __init__(self) -> None:
         self.func_list: list[FuncTool] = []
@@ -453,7 +381,7 @@ class FunctionToolManager:
         Builtin tools are never routed through this method."""
         return "member"
 
-    def _check_tool_permission(
+    async def check_tool_permission(
         self,
         tool_name: str,
         context: Any,
@@ -463,11 +391,13 @@ class FunctionToolManager:
         Only non-builtin tools are guarded. Permission is resolved from
         ``tool_permissions`` in SharedPreferences (``_default`` key). When
         no explicit entry exists the tool inherits the fallback
-        ``_default_permission``."""
+        ``_default_permission``.
+
+        Called from ``FunctionToolExecutor.execute()`` — that's the single
+        enforcement point now, not toolset construction.
+        """
         try:
-            perms_raw = sp.get(
-                "tool_permissions", {}, scope="global", scope_id="global"
-            )
+            perms_raw = await sp.get_async("global", "global", "tool_permissions", {})
         except Exception:
             perms_raw = {}
         defaults = perms_raw.get("_default", {}) if isinstance(perms_raw, dict) else {}
@@ -501,13 +431,13 @@ class FunctionToolManager:
         因此，后加载的 inactive 工具不会覆盖已激活的工具；
         同时，MCP 工具在需要时仍可覆盖被禁用的内置工具。
 
-        Non-builtin tools are wrapped with ``_PermissionGuardedTool`` so that
-        every invocation checks the per-tool permission configured via the
-        dashboard.
+        Per-tool permissions are now enforced in
+        ``FunctionToolExecutor.execute()``, not here — tools are returned
+        unwrapped.
         """
         tool_set = ToolSet()
         for tool in self.func_list:
-            tool_set.add_tool(_PermissionGuardedTool(tool, self))
+            tool_set.add_tool(tool)
         return tool_set
 
     @staticmethod

--- a/tests/unit/test_astr_agent_tool_exec.py
+++ b/tests/unit/test_astr_agent_tool_exec.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import mcp
 import pytest
 
+from astrbot.core import astr_agent_tool_exec
 from astrbot.core.agent.agent import Agent
 from astrbot.core.agent.handoff import HandoffTool
 from astrbot.core.agent.run_context import ContextWrapper
@@ -180,6 +181,45 @@ async def test_execute_skips_permission_check_for_real_builtin_tool(
 
     assert calls == []
     assert results[0].content[0].text == "stubbed-output"
+
+
+@pytest.mark.asyncio
+async def test_execute_falls_back_to_global_llm_tools_when_ctx_lacks_manager(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Covers the llm_tools fallback when ctx has no get_llm_tool_manager."""
+    calls = []
+
+    async def _recording_check(name, ctx):
+        calls.append(name)
+        return f"error: Permission denied for {name}"
+
+    fake_global_manager = SimpleNamespace(check_tool_permission=_recording_check)
+    monkeypatch.setattr(astr_agent_tool_exec, "llm_tools", fake_global_manager)
+
+    event = _DummyEvent()
+    ctx = SimpleNamespace()  # no get_llm_tool_manager
+    run_context = ContextWrapper(context=SimpleNamespace(event=event, context=ctx))
+
+    called = False
+
+    async def handler(ctx, **kw):
+        nonlocal called
+        called = True
+        return "should not run"
+
+    tool = FunctionTool(
+        name="plugin_tool",
+        description="d",
+        parameters={"type": "object", "properties": {}},
+        handler=handler,
+    )
+
+    results = [r async for r in FunctionToolExecutor.execute(tool, run_context)]
+
+    assert calls == ["plugin_tool"]
+    assert not called
+    assert "Permission denied" in results[0].content[0].text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_astr_agent_tool_exec.py
+++ b/tests/unit/test_astr_agent_tool_exec.py
@@ -7,12 +7,13 @@ from astrbot.core.agent.agent import Agent
 from astrbot.core.agent.handoff import HandoffTool
 from astrbot.core.agent.run_context import ContextWrapper
 from astrbot.core.agent.tool import FunctionTool
-from astrbot.core.astr_agent_tool_exec import FunctionToolExecutor
-from astrbot.core.message.components import Image
-from astrbot.core.provider.func_tool_manager import (
-    FunctionToolManager,
-    _PermissionGuardedTool,
+from astrbot.core.astr_agent_tool_exec import (
+    FunctionToolExecutor,
+    _is_builtin_tool_instance,
 )
+from astrbot.core.message.components import Image
+from astrbot.core.provider.func_tool_manager import FunctionToolManager
+from astrbot.core.tools.computer_tools import ExecuteShellTool
 
 
 class _DummyEvent:
@@ -36,7 +37,8 @@ def _build_run_context(message_components: list[object] | None = None):
     return ContextWrapper(context=ctx)
 
 
-def test_build_handoff_toolset_keeps_permission_guards_for_default_tools():
+def test_build_handoff_toolset_includes_plain_tools_excludes_handoffs():
+    """Permission checks now happen in execute(), not here."""
     mgr = FunctionToolManager()
     plugin_tool = FunctionTool(
         name="admin_only_mcp",
@@ -58,8 +60,176 @@ def test_build_handoff_toolset_keeps_permission_guards_for_default_tools():
     toolset = FunctionToolExecutor._build_handoff_toolset(run_context, tools=None)
 
     assert toolset is not None
-    assert isinstance(toolset.get_tool("admin_only_mcp"), _PermissionGuardedTool)
+    assert toolset.get_tool("admin_only_mcp") is plugin_tool
     assert toolset.get_tool("transfer_to_child") is None
+
+
+def test_is_builtin_tool_instance_true_for_real_builtin_tool():
+    assert _is_builtin_tool_instance(ExecuteShellTool()) is True
+
+
+def test_is_builtin_tool_instance_false_for_plain_tool():
+    tool = FunctionTool(
+        name="my_plugin_tool",
+        description="d",
+        parameters={"type": "object", "properties": {}},
+    )
+    assert _is_builtin_tool_instance(tool) is False
+
+
+def test_is_builtin_tool_instance_false_for_name_collision_with_builtin():
+    """Same name as a builtin tool, different class — must not be treated
+    as builtin."""
+    impostor = FunctionTool(
+        name="astrbot_execute_shell",
+        description="not actually the builtin shell tool",
+        parameters={"type": "object", "properties": {}},
+    )
+    assert _is_builtin_tool_instance(impostor) is False
+
+
+def _build_execute_run_context(tool_mgr) -> ContextWrapper:
+    event = _DummyEvent()
+    context = SimpleNamespace(get_llm_tool_manager=lambda: tool_mgr)
+    return ContextWrapper(context=SimpleNamespace(event=event, context=context))
+
+
+@pytest.mark.asyncio
+async def test_execute_denies_tool_when_permission_check_fails():
+    async def _denying_check(name, ctx):
+        return f"error: Permission denied for {name}"
+
+    tool_mgr = SimpleNamespace(check_tool_permission=_denying_check)
+    run_context = _build_execute_run_context(tool_mgr)
+
+    called = False
+
+    async def handler(ctx, **kw):
+        nonlocal called
+        called = True
+        return "should not run"
+
+    tool = FunctionTool(
+        name="dangerous_tool",
+        description="d",
+        parameters={"type": "object", "properties": {}},
+        handler=handler,
+    )
+
+    results = [r async for r in FunctionToolExecutor.execute(tool, run_context)]
+
+    assert not called
+    assert len(results) == 1
+    assert isinstance(results[0], mcp.types.CallToolResult)
+    assert "Permission denied" in results[0].content[0].text
+
+
+@pytest.mark.asyncio
+async def test_execute_invokes_permission_check_and_runs_tool_when_allowed():
+    calls = []
+
+    async def _allowing_check(name, ctx):
+        calls.append(name)
+        return None
+
+    tool_mgr = SimpleNamespace(check_tool_permission=_allowing_check)
+    run_context = _build_execute_run_context(tool_mgr)
+
+    async def handler(ctx, **kw):
+        return "ok"
+
+    tool = FunctionTool(
+        name="plugin_tool",
+        description="d",
+        parameters={"type": "object", "properties": {}},
+        handler=handler,
+    )
+
+    results = [r async for r in FunctionToolExecutor.execute(tool, run_context)]
+
+    assert calls == ["plugin_tool"]
+    assert len(results) == 1
+    assert results[0].content[0].text == "ok"
+
+
+@pytest.mark.asyncio
+async def test_execute_skips_permission_check_for_real_builtin_tool(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls = []
+
+    async def _recording_check(name, ctx):
+        calls.append(name)
+        return None
+
+    tool_mgr = SimpleNamespace(check_tool_permission=_recording_check)
+    run_context = _build_execute_run_context(tool_mgr)
+
+    async def _fake_call(self, ctx, **kwargs):
+        return "stubbed-output"
+
+    monkeypatch.setattr(ExecuteShellTool, "call", _fake_call)
+    tool = ExecuteShellTool()
+
+    results = [
+        r
+        async for r in FunctionToolExecutor.execute(
+            tool, run_context, command="echo hi"
+        )
+    ]
+
+    assert calls == []
+    assert results[0].content[0].text == "stubbed-output"
+
+
+@pytest.mark.asyncio
+async def test_execute_end_to_end_denies_admin_tool_for_member_with_real_manager():
+    """Same as above but with a real FunctionToolManager + sp config,
+    not a mocked check_tool_permission."""
+    from astrbot.core import sp
+
+    mgr = FunctionToolManager()
+    called = False
+
+    async def handler(ctx, **kw):
+        nonlocal called
+        called = True
+        return "should not run"
+
+    tool = FunctionTool(
+        name="real_admin_tool",
+        description="d",
+        parameters={"type": "object", "properties": {}},
+        handler=handler,
+    )
+    mgr.func_list = [tool]
+
+    sp.put(
+        "tool_permissions",
+        {"_default": {"real_admin_tool": "admin"}},
+        scope="global",
+        scope_id="global",
+    )
+    try:
+
+        class _FakeMemberEvent:
+            def is_admin(self) -> bool:
+                return False
+
+            def get_sender_id(self) -> str:
+                return "member_1"
+
+        context = SimpleNamespace(get_llm_tool_manager=lambda: mgr)
+        run_context = ContextWrapper(
+            context=SimpleNamespace(event=_FakeMemberEvent(), context=context)
+        )
+
+        results = [r async for r in FunctionToolExecutor.execute(tool, run_context)]
+
+        assert not called
+        assert "Permission denied" in results[0].content[0].text
+    finally:
+        sp.put("tool_permissions", {}, scope="global", scope_id="global")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_tool_conflict_resolution.py
+++ b/tests/unit/test_tool_conflict_resolution.py
@@ -178,20 +178,15 @@ class TestFunctionToolManagerGetFullToolSet:
         assert web_search is not None
         assert web_search.active is True
 
-    def test_wrapping_preserves_tool_name_and_description(self):
-        """_PermissionGuardedTool wrapping should preserve name and description."""
-        from astrbot.core.provider.func_tool_manager import _PermissionGuardedTool
-
+    def test_get_full_tool_set_preserves_tool_identity(self):
+        """Permission checks happen in execute() now, not via a wrapper here."""
         manager = FunctionToolManager()
         tool = make_tool("web_search")
         manager.func_list = [tool]
 
         toolset = manager.get_full_tool_set()
 
-        wrapped = toolset.tools[0]
-        assert wrapped.name == "web_search"
-        assert wrapped.description == "Test tool web_search"
-        assert isinstance(wrapped, _PermissionGuardedTool)
+        assert toolset.tools[0] is tool
 
     def test_mcp_tool_overrides_disabled_builtin(self):
         """

--- a/tests/unit/test_tool_permission.py
+++ b/tests/unit/test_tool_permission.py
@@ -6,10 +6,7 @@ import pytest
 
 from astrbot.core import sp
 from astrbot.core.agent.tool import FunctionTool
-from astrbot.core.provider.func_tool_manager import (
-    FunctionToolManager,
-    _PermissionGuardedTool,
-)
+from astrbot.core.provider.func_tool_manager import FunctionToolManager
 from astrbot.dashboard.services.tools_service import ToolsService, ToolsServiceError
 
 # ── helpers ──────────────────────────────────────────────────────────
@@ -91,7 +88,7 @@ async def test_check_permission_passes_when_no_config():
     mgr = FunctionToolManager()
     context = _make_context(role="member")
 
-    error = mgr._check_tool_permission("no_such_tool", context)
+    error = await mgr.check_tool_permission("no_such_tool", context)
     assert error is None
 
 
@@ -106,7 +103,7 @@ async def test_check_permission_passes_for_admin_with_admin_tool():
     try:
         mgr = FunctionToolManager()
         context = _make_context(role="admin", sender_id="admin_001")
-        error = mgr._check_tool_permission("dangerous_tool", context)
+        error = await mgr.check_tool_permission("dangerous_tool", context)
         assert error is None
     finally:
         _clear_tool_permissions()
@@ -123,7 +120,7 @@ async def test_check_permission_denies_member_for_admin_tool():
     try:
         mgr = FunctionToolManager()
         context = _make_context(role="member", sender_id="user_999")
-        error = mgr._check_tool_permission("dangerous_tool", context)
+        error = await mgr.check_tool_permission("dangerous_tool", context)
         assert error is not None
         assert "dangerous_tool" in str(error)
         assert "admin" in str(error).lower()
@@ -146,7 +143,7 @@ async def test_check_permission_denies_when_no_event():
         class FakeWrapper:
             pass  # no .context.event
 
-        error = mgr._check_tool_permission("dangerous_tool", FakeWrapper())
+        error = await mgr.check_tool_permission("dangerous_tool", FakeWrapper())
         assert error is not None
         assert "admin" in str(error).lower()
     finally:
@@ -164,139 +161,14 @@ async def test_check_permission_passes_for_member_when_configured_member():
     try:
         mgr = FunctionToolManager()
         context = _make_context(role="member")
-        error = mgr._check_tool_permission("safe_tool", context)
+        error = await mgr.check_tool_permission("safe_tool", context)
         assert error is None
     finally:
         _clear_tool_permissions()
 
 
-# ── _PermissionGuardedTool ───────────────────────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_guarded_tool_delegates_when_permission_passes():
-    _clear_tool_permissions()
-    mgr = FunctionToolManager()
-
-    called = False
-
-    async def handler(ctx, **kw):
-        nonlocal called
-        called = True
-        return "ok"
-
-    wrapped = FunctionTool(
-        name="delegated",
-        description="desc",
-        parameters={},
-        handler=handler,
-    )
-    guarded = _PermissionGuardedTool(wrapped, mgr)
-    context = _make_context(role="member")
-
-    result = await guarded.call(context)
-    assert called
-    assert result == "ok"
-
-
-@pytest.mark.asyncio
-async def test_guarded_tool_blocks_when_permission_denied():
-    sp.put(
-        "tool_permissions",
-        {"_default": {"blocked_tool": "admin"}},
-        scope="global",
-        scope_id="global",
-    )
-    try:
-        mgr = FunctionToolManager()
-        called = False
-
-        async def handler(ctx, **kw):
-            nonlocal called
-            called = True
-            return "should not reach"
-
-        wrapped = FunctionTool(
-            name="blocked_tool",
-            description="desc",
-            parameters={},
-            handler=handler,
-        )
-        guarded = _PermissionGuardedTool(wrapped, mgr)
-        context = _make_context(role="member")
-
-        result = await guarded.call(context)
-        assert not called
-        assert isinstance(result, str)
-        assert "Permission denied" in result
-    finally:
-        _clear_tool_permissions()
-
-
-@pytest.mark.asyncio
-async def test_guarded_tool_delegates_to_wrapped_call():
-    _clear_tool_permissions()
-    mgr = FunctionToolManager()
-
-    class CallableTool(FunctionTool):
-        async def call(self, context, **kwargs):
-            return "from call()"
-
-    wrapped = CallableTool(
-        name="has_call",
-        description="desc",
-        parameters={},
-    )
-    guarded = _PermissionGuardedTool(wrapped, mgr)
-    context = _make_context()
-
-    result = await guarded.call(context)
-    assert result == "from call()"
-
-
-@pytest.mark.asyncio
-async def test_guarded_tool_delegates_to_wrapped_run():
-    _clear_tool_permissions()
-    mgr = FunctionToolManager()
-
-    class RunnableTool(FunctionTool):
-        async def run(self, event, **kwargs):
-            return f"from run(): {event.get_sender_id()} {kwargs['value']}"
-
-    wrapped = RunnableTool(
-        name="has_run",
-        description="desc",
-        parameters={},
-    )
-    guarded = _PermissionGuardedTool(wrapped, mgr)
-    context = _make_context(sender_id="runner")
-
-    result = await guarded.call(context, value="ok")
-    assert result == "from run(): runner ok"
-
-
-@pytest.mark.asyncio
-async def test_guarded_tool_handles_async_generator_handler():
-    _clear_tool_permissions()
-    mgr = FunctionToolManager()
-
-    async def gen_handler(ctx, **kw):  # type: ignore[misc]
-        yield "A"
-        yield "B"
-        yield "C"
-
-    wrapped = FunctionTool(
-        name="gen_tool",
-        description="desc",
-        parameters={},
-        handler=gen_handler,
-    )
-    guarded = _PermissionGuardedTool(wrapped, mgr)
-    context = _make_context()
-
-    result = await guarded.call(context)
-    # should return the last yielded value
-    assert result == "C"
+# Permission enforcement for tool execution now runs in
+# FunctionToolExecutor.execute() — see test_astr_agent_tool_exec.py.
 
 
 # ── get_full_tool_set ────────────────────────────────────────────────
@@ -314,18 +186,17 @@ def test_get_full_tool_set_excludes_builtin_tools():
     assert "astrbot_execute_shell" not in names
 
 
-def test_get_full_tool_set_wraps_non_builtin():
+def test_get_full_tool_set_returns_unwrapped_non_builtin_tools():
+    """Tools come back as-is now; permission checks happen in execute()."""
     mgr = FunctionToolManager()
     _clear_tool_permissions()
 
-    mgr.func_list.append(_dummy_tool("my_plugin_tool"))
+    dummy = _dummy_tool("my_plugin_tool")
+    mgr.func_list.append(dummy)
     tool_set = mgr.get_full_tool_set()
 
     plugin_tools = [t for t in tool_set.tools if t.name == "my_plugin_tool"]
-    assert plugin_tools
-    assert isinstance(plugin_tools[0], _PermissionGuardedTool), (
-        "non-builtin tools must be wrapped"
-    )
+    assert plugin_tools == [dummy]
 
 
 # ── API: get_tool_list permission fields ──────────────────────────────


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
子代理（subagent/handoff）显式指定工具列表、主代理 persona 显式工具白名单这两条路径，在构建 `ToolSet` 时是直接从 `func_list`/`get_func()` 拿原始工具对象加进去的，没有经过 `_PermissionGuardedTool` 包装。结果是：管理员在 dashboard 上把某个工具设置成仅 admin 可用后，只要这个工具被分配给了某个子代理、或者出现在某个人格的显式工具列表里，普通成员依然可以绕过权限限制直接调用它，权限检查0作用。
### Modifications / 改动点
把权限检查从逐个包装，改成在执行入口统一检查一次：
 - `astr_agent_tool_exec.py`：把权限检查从"构建工具集时包装"改成"`execute()` 里统一检查一次"，覆盖所有构建路径；新增 `_is_builtin_tool_instance()` 按类型（非按名字）判断内置工具，避免同名碰撞绕过检查。
- `func_tool_manager.py`：删除 `_PermissionGuardedTool`；`get_full_tool_set()` 简化为直接返回未包装工具；`check_tool_permission` 改为公开异步方法，内部改用 `sp.get_async` 避免阻塞事件循环。
- 三个测试文件：删掉测包装类本身的旧测试，改为针对 `execute()` 的行为测试，并补了同名碰撞和真实 manager 端到端测试。
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Enforce per-tool permission checks at execution time rather than during toolset construction to prevent permission bypass via subagents or persona-specific tool lists.

Bug Fixes:
- Ensure non-builtin tools respect dashboard-configured permissions even when assigned to subagents or persona-specific tool lists by checking permissions in FunctionToolExecutor.execute().
- Avoid permission bypass through name collisions by identifying builtin tools by their class type instead of their registered name.

Enhancements:
- Simplify FunctionToolManager by returning unwrapped tools from get_full_tool_set() and exposing an async check_tool_permission API that uses non-blocking shared preference access.

Tests:
- Replace wrapper-focused tests with execution-path permission tests, including builtin detection, denial/allow flows, and an end-to-end scenario using a real FunctionToolManager and shared permission config.