### PR TITLE
fix: inject knowledge base context as temporary user content

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -278,10 +278,11 @@ async def _apply_kb(
             )
             if not kb_result:
                 return
-            if req.system_prompt is not None:
-                req.system_prompt += (
-                    f"\n\n[Related Knowledge Base Results]:\n{kb_result}"
-                )
+            req.extra_user_content_parts.append(
+                TextPart(
+                    text=f"[Related Knowledge Base Results]:\n{kb_result}",
+                ).mark_as_temp()
+            )
         except Exception as exc:  # noqa: BLE001
             logger.error("Error occurred while retrieving knowledge base: %s", exc)
     else:

--- a/tests/unit/test_astr_main_agent.py
+++ b/tests/unit/test_astr_main_agent.py
@@ -8,6 +8,7 @@ import pytest
 
 from astrbot.core import astr_main_agent as ama
 from astrbot.core.agent.mcp_client import MCPTool
+from astrbot.core.agent.message import Message, dump_messages_with_checkpoints
 from astrbot.core.agent.tool import FunctionTool, ToolSet
 from astrbot.core.conversation_mgr import Conversation
 from astrbot.core.message.components import File, Image, Plain, Reply, Video
@@ -377,8 +378,19 @@ class TestApplyKb:
         ):
             await module._apply_kb(mock_event, req, mock_context, config)
 
-        assert "[Related Knowledge Base Results]:" in req.system_prompt
-        assert "KB result" in req.system_prompt
+        assert req.system_prompt == "System prompt"
+        assert len(req.extra_user_content_parts) == 1
+        kb_part = req.extra_user_content_parts[0]
+        assert kb_part.text == "[Related Knowledge Base Results]:\nKB result"
+        assert kb_part._no_save is True
+
+        message = Message.model_validate(await req.assemble_context())
+        assert isinstance(message.content, list)
+        assert message.content[0].text == "test question"
+        assert message.content[1].text == "[Related Knowledge Base Results]:\nKB result"
+        assert dump_messages_with_checkpoints([message]) == [
+            {"role": "user", "content": [{"type": "text", "text": "test question"}]}
+        ]
 
     @pytest.mark.asyncio
     async def test_apply_kb_with_agentic_mode(self, mock_event, mock_context):


### PR DESCRIPTION
## Summary
- inject non-agentic knowledge base results as temporary user content instead of appending to the system prompt
- keep retrieved knowledge available to the current model call without persisting it into conversation history
- update coverage for the non-agentic knowledge base path

## Tests
- uv run ruff format .
- uv run ruff check .
- uv run pytest tests/unit/test_astr_main_agent.py -k apply_kb

## Summary by Sourcery

Inject non-agentic knowledge base results as temporary user content instead of modifying the system prompt, and ensure this context is only used for the current model call without persisting to history.

Bug Fixes:
- Preserve the original system prompt while still providing retrieved knowledge base results to the model as additional user content.

Enhancements:
- Treat knowledge base results as temporary, non-persisted user content parts that participate in context assembly but are excluded from saved conversation history.

Tests:
- Extend non-agentic knowledge base tests to validate temporary user content injection, message assembly ordering, and that saved history excludes the injected knowledge.