### PR TITLE
chore: bump version to 4.26.0-beta.10

### DIFF
--- a/changelogs/v4.26.0-beta.10.md
+++ b/changelogs/v4.26.0-beta.10.md
@@ -1,0 +1,22 @@
+- [更新日志(简体中文)](#chinese)
+- [Changelog(English)](#english)
+
+<a id="chinese"></a>
+
+## What's Changed
+
+### 修复
+
+- 恢复 WebUI 在接口返回 401 时跳转登录页，避免会话失效后停留在异常状态。([#8903](https://github.com/AstrBotDevs/AstrBot/pull/8903))
+- 保持 Core 版本与 WebUI 静态资源版本同步，修复打包或升级后可能加载旧 dist、资源版本错配的问题。([#8901](https://github.com/AstrBotDevs/AstrBot/pull/8901))
+- 将知识库上下文作为临时 user 内容注入，修复模型请求中知识库上下文角色不准确的问题。([#8904](https://github.com/AstrBotDevs/AstrBot/pull/8904))
+
+<a id="english"></a>
+
+## What's Changed (EN)
+
+### Bug Fixes
+
+- Restored the WebUI login redirect when API requests return 401, preventing expired sessions from staying in a broken state. ([#8903](https://github.com/AstrBotDevs/AstrBot/pull/8903))
+- Kept Core and WebUI static asset versions in sync, fixing stale dist loading and asset version mismatches after packaging or upgrades. ([#8901](https://github.com/AstrBotDevs/AstrBot/pull/8901))
+- Injected knowledge base context as temporary user content, fixing the role used for knowledge context in model requests. ([#8904](https://github.com/AstrBotDevs/AstrBot/pull/8904))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AstrBot"
-version = "4.26.0-beta.9"
+version = "4.26.0-beta.10"
 description = "Easy-to-use multi-platform LLM chatbot and development framework"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }


### PR DESCRIPTION
## Summary
- Bump AstrBot version to 4.26.0-beta.10
- Add bilingual changelog for v4.26.0-beta.10

## Validation
- `uv run ruff format .`
- `uv run ruff check .`