### PR TITLE
test: cover POSIX file URI root preservation

### DIFF
--- a/tests/test_media_utils.py
+++ b/tests/test_media_utils.py
@@ -446,6 +446,12 @@ def test_file_uri_to_path_supports_standard_and_legacy_posix_file_uris(tmp_path)
         assert media_utils.file_uri_to_path(legacy_file_uri) == str(media_path)
 
 
+def test_file_uri_to_path_preserves_posix_root_for_container_paths():
+    assert media_utils.file_uri_to_path("file:///AstrBot/data/cache/image.png") == (
+        "/AstrBot/data/cache/image.png"
+    )
+
+
 def test_from_file_system_uses_pathlib_file_uri(tmp_path):
     media_path = tmp_path / "media file.bin"
     media_path.write_bytes(b"media")

--- a/tests/test_media_utils.py
+++ b/tests/test_media_utils.py
@@ -447,9 +447,10 @@ def test_file_uri_to_path_supports_standard_and_legacy_posix_file_uris(tmp_path)
 
 
 def test_file_uri_to_path_preserves_posix_root_for_container_paths():
-    assert media_utils.file_uri_to_path("file:///AstrBot/data/cache/image.png") == (
-        "/AstrBot/data/cache/image.png"
-    )
+    if os.name != "nt":
+        assert media_utils.file_uri_to_path("file:///AstrBot/data/cache/image.png") == (
+            "/AstrBot/data/cache/image.png"
+        )
 
 
 def test_from_file_system_uses_pathlib_file_uri(tmp_path):


### PR DESCRIPTION
## Summary

Adds a regression test for POSIX absolute file URIs such as `file:///AstrBot/data/cache/image.png`.

This guards against accidentally dropping the root slash when normalizing local file URIs, which would turn `/AstrBot/...` into the relative path `AstrBot/...` in container deployments.

## Testing

- `uv run pytest tests/test_media_utils.py -k "file_uri_to_path"`