### PR TITLE
fix: 修复提供商源修改 ID 后保存被静默还原的问题

### DIFF
--- a/astrbot/dashboard/schemas.py
+++ b/astrbot/dashboard/schemas.py
@@ -418,11 +418,10 @@ class ProviderSourceRequest(OpenModel):
             self.config
             or self.model_dump(exclude={"source_id", "config"}, exclude_none=True)
         )
-        if "id" not in config or not config.get("id"):
-            if self.id:
-                config["id"] = self.id
-            elif fallback_id:
-                config["id"] = fallback_id
+        if not config.get("id"):
+            # 不覆盖已有 id；self.id（显式指定）优先于 fallback_id（旧值兜底）
+            if fallback := (self.id or fallback_id):
+                config["id"] = fallback
         return config
 
 

--- a/astrbot/dashboard/schemas.py
+++ b/astrbot/dashboard/schemas.py
@@ -418,10 +418,11 @@ class ProviderSourceRequest(OpenModel):
             self.config
             or self.model_dump(exclude={"source_id", "config"}, exclude_none=True)
         )
-        if fallback_id:
-            config["id"] = fallback_id
-        elif self.id and "id" not in config:
-            config["id"] = self.id
+        if "id" not in config or not config.get("id"):
+            if self.id:
+                config["id"] = self.id
+            elif fallback_id:
+                config["id"] = fallback_id
         return config
 
 


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
fix #8872 修复提供商源（Provider Source）修改 ID 后保存无效的问题

感谢 @Evernight275 在 issue 中帮忙定位到这处代码。
### Modifications / 改动点
- `astrbot/dashboard/schemas.py`： 将覆盖逻辑改为仅当 `config` 中不存在有效的 `id` 时，才使用 `self.id` 或 `fallback_id` 作为兜底值，不再无条件覆盖已存在的 id。
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Respect existing provider source IDs in config so that manually edited IDs are preserved on save instead of being silently reset.