### PR TITLE
fix: align knowledge base API contracts

### DIFF
--- a/astrbot/dashboard/api/knowledge_bases.py
+++ b/astrbot/dashboard/api/knowledge_bases.py
@@ -53,14 +53,6 @@ def _to_int(value: Any, default: int) -> int:
         return default
 
 
-def _model_dict(payload) -> dict[str, Any]:
-    if payload is None:
-        return {}
-    if hasattr(payload, "model_dump"):
-        return payload.model_dump(exclude_none=True)
-    return payload if isinstance(payload, dict) else {}
-
-
 async def _run(operation, *, prefix: str):
     try:
         result = await run_maybe_async(operation)
@@ -94,7 +86,11 @@ async def list_knowledge_bases(
     return await _run(
         lambda: service.list_kbs(
             page=_to_int(request.query_params.get("page"), 1),
-            page_size=_to_int(request.query_params.get("page_size"), 20),
+            page_size=(
+                _to_int(request.query_params.get("page_size"), 20)
+                if "page" in request.query_params or "page_size" in request.query_params
+                else None
+            ),
         ),
         prefix="获取知识库列表失败",
     )
@@ -107,7 +103,7 @@ async def create_knowledge_base(
     service: KnowledgeBaseService = Depends(get_service),
 ):
     return await _run(
-        lambda: service.create_kb(_model_dict(payload)),
+        lambda: service.create_kb(payload.canonical_payload()),
         prefix="创建知识库失败",
     )
 
@@ -140,9 +136,8 @@ async def update_knowledge_base(
     _auth: AuthContext = Depends(require_kb_scope),
     service: KnowledgeBaseService = Depends(get_service),
 ):
-    body = _model_dict(payload)
     return await _run(
-        lambda: service.update_kb({"kb_id": kb_id, **body}),
+        lambda: service.update_kb({**payload.canonical_payload(), "kb_id": kb_id}),
         prefix="更新知识库失败",
     )
 
@@ -212,9 +207,10 @@ async def import_knowledge_base_documents(
     _auth: AuthContext = Depends(require_kb_scope),
     service: KnowledgeBaseService = Depends(get_service),
 ):
-    body = _model_dict(payload)
     return await _run(
-        lambda: service.import_documents({"kb_id": kb_id, **body}),
+        lambda: service.import_documents(
+            {**payload.canonical_payload(), "kb_id": kb_id}
+        ),
         prefix="导入文档失败",
     )
 
@@ -226,9 +222,10 @@ async def import_knowledge_base_document_url(
     _auth: AuthContext = Depends(require_kb_scope),
     service: KnowledgeBaseService = Depends(get_service),
 ):
-    body = _model_dict(payload)
     return await _run(
-        lambda: service.upload_document_from_url({"kb_id": kb_id, **body}),
+        lambda: service.upload_document_from_url(
+            {**payload.canonical_payload(), "kb_id": kb_id}
+        ),
         prefix="从URL上传文档失败",
     )
 
@@ -306,9 +303,14 @@ async def retrieve_knowledge_base(
     _auth: AuthContext = Depends(require_kb_scope),
     service: KnowledgeBaseService = Depends(get_service),
 ):
-    body = _model_dict(payload)
+    async def _operation():
+        kb = await service.get_kb(kb_id)
+        return await service.retrieve(
+            payload.canonical_payload(kb_name=kb["kb_name"]),
+        )
+
     return await _run(
-        lambda: service.retrieve({"kb_id": kb_id, **body}),
+        _operation,
         prefix="检索失败",
     )
 
@@ -322,7 +324,11 @@ async def dashboard_list_kbs(
     return await _run(
         lambda: service.list_kbs(
             page=_to_int(request.query_params.get("page"), 1),
-            page_size=_to_int(request.query_params.get("page_size"), 20),
+            page_size=(
+                _to_int(request.query_params.get("page_size"), 20)
+                if "page" in request.query_params or "page_size" in request.query_params
+                else None
+            ),
         ),
         prefix="获取知识库列表失败",
     )

--- a/astrbot/dashboard/api/knowledge_bases.py
+++ b/astrbot/dashboard/api/knowledge_bases.py
@@ -305,8 +305,11 @@ async def retrieve_knowledge_base(
 ):
     async def _operation():
         kb = await service.get_kb(kb_id)
+        kb_name = kb.get("kb_name") if isinstance(kb, dict) else None
+        if not kb_name:
+            raise KnowledgeBaseServiceError("知识库不存在")
         return await service.retrieve(
-            payload.canonical_payload(kb_name=kb["kb_name"]),
+            payload.canonical_payload(kb_name=kb_name),
         )
 
     return await _run(

--- a/astrbot/dashboard/schemas.py
+++ b/astrbot/dashboard/schemas.py
@@ -222,23 +222,23 @@ class KnowledgeBaseRequest(OpenModel):
         Returns:
             Dictionary accepted by KnowledgeBaseService.
         """
-        field_names = {
-            "kb_name",
-            "description",
-            "emoji",
-            "embedding_provider_id",
-            "rerank_provider_id",
-            "chunk_size",
-            "chunk_overlap",
-            "top_k_dense",
-            "top_k_sparse",
-            "top_m_final",
-        }
         data = self.model_dump(
-            include=self.model_fields_set & field_names,
+            exclude_unset=True,
+            include={
+                "kb_name",
+                "description",
+                "emoji",
+                "embedding_provider_id",
+                "rerank_provider_id",
+                "chunk_size",
+                "chunk_overlap",
+                "top_k_dense",
+                "top_k_sparse",
+                "top_m_final",
+            },
         )
         legacy_name = getattr(self, "name", None)
-        if self.kb_name is None and legacy_name is not None:
+        if data.get("kb_name") is None and legacy_name is not None:
             data["kb_name"] = legacy_name
         return data
 

--- a/astrbot/dashboard/schemas.py
+++ b/astrbot/dashboard/schemas.py
@@ -205,13 +205,42 @@ class ImMessageRequest(OpenModel):
 
 
 class KnowledgeBaseRequest(OpenModel):
-    kb_id: str | None = None
-    name: str | None = None
+    kb_name: str | None = None
     description: str | None = None
+    emoji: str | None = None
     embedding_provider_id: str | None = None
     rerank_provider_id: str | None = None
     chunk_size: int | None = None
     chunk_overlap: int | None = None
+    top_k_dense: int | None = None
+    top_k_sparse: int | None = None
+    top_m_final: int | None = None
+
+    def canonical_payload(self) -> dict[str, Any]:
+        """Return the service-facing knowledge base payload.
+
+        Returns:
+            Dictionary accepted by KnowledgeBaseService.
+        """
+        field_names = {
+            "kb_name",
+            "description",
+            "emoji",
+            "embedding_provider_id",
+            "rerank_provider_id",
+            "chunk_size",
+            "chunk_overlap",
+            "top_k_dense",
+            "top_k_sparse",
+            "top_m_final",
+        }
+        data = self.model_dump(
+            include=self.model_fields_set & field_names,
+        )
+        legacy_name = getattr(self, "name", None)
+        if self.kb_name is None and legacy_name is not None:
+            data["kb_name"] = legacy_name
+        return data
 
 
 class KnowledgeBaseImportRequest(OpenModel):
@@ -220,22 +249,69 @@ class KnowledgeBaseImportRequest(OpenModel):
     tasks_limit: int | None = None
     max_retries: int | None = None
 
+    def canonical_payload(self) -> dict[str, Any]:
+        """Return the service-facing document import payload.
+
+        Returns:
+            Dictionary accepted by KnowledgeBaseService.import_documents.
+        """
+        return self.model_dump(
+            exclude_none=True,
+            include={"documents", "batch_size", "tasks_limit", "max_retries"},
+        )
+
 
 class KnowledgeBaseUrlImportRequest(OpenModel):
     url: str | None = None
-    urls: list[str] | None = None
     chunk_size: int | None = None
     chunk_overlap: int | None = None
     batch_size: int | None = None
     tasks_limit: int | None = None
     max_retries: int | None = None
+    enable_cleaning: bool | None = None
+    cleaning_provider_id: str | None = None
+
+    def canonical_payload(self) -> dict[str, Any]:
+        """Return the service-facing URL import payload.
+
+        Returns:
+            Dictionary accepted by KnowledgeBaseService.upload_document_from_url.
+        """
+        return self.model_dump(
+            exclude_none=True,
+            include={
+                "url",
+                "chunk_size",
+                "chunk_overlap",
+                "batch_size",
+                "tasks_limit",
+                "max_retries",
+                "enable_cleaning",
+                "cleaning_provider_id",
+            },
+        )
 
 
 class KnowledgeBaseRetrieveRequest(OpenModel):
     query: str | None = None
     top_k: int | None = None
-    threshold: float | None = None
-    rerank: bool | None = None
+    debug: bool | None = None
+
+    def canonical_payload(self, *, kb_name: str) -> dict[str, Any]:
+        """Return the service-facing retrieve payload.
+
+        Args:
+            kb_name: Knowledge base name resolved from the route path.
+
+        Returns:
+            Dictionary accepted by KnowledgeBaseService.retrieve.
+        """
+        data = self.model_dump(
+            exclude_none=True,
+            include={"query", "top_k", "debug"},
+        )
+        data["kb_names"] = [kb_name]
+        return data
 
 
 class ToolEnabledRequest(BaseModel):

--- a/astrbot/dashboard/services/knowledge_base_service.py
+++ b/astrbot/dashboard/services/knowledge_base_service.py
@@ -29,6 +29,22 @@ class KnowledgeBaseService:
     def _payload(data: object) -> dict[str, Any]:
         return data if isinstance(data, dict) else {}
 
+    @staticmethod
+    def _canonical_kb_payload(data: object) -> dict[str, Any]:
+        """Normalize knowledge base create/update payloads.
+
+        Args:
+            data: Request payload from v1 or legacy Dashboard routes.
+
+        Returns:
+            Payload using the service's canonical field names.
+        """
+        payload = KnowledgeBaseService._payload(data).copy()
+        if payload.get("kb_name") is None and payload.get("name") is not None:
+            payload["kb_name"] = payload["name"]
+        payload.pop("name", None)
+        return payload
+
     def get_kb_manager(self):
         return self.core_lifecycle.kb_manager
 
@@ -263,19 +279,30 @@ class KnowledgeBaseService:
             logger.error(traceback.format_exc())
             self.set_task_result(task_id, "failed", error=str(exc))
 
-    async def list_kbs(self, *, page: int, page_size: int) -> dict[str, Any]:
+    async def list_kbs(self, *, page: int, page_size: int | None) -> dict[str, Any]:
         kb_manager = self.get_kb_manager()
         kbs = await kb_manager.list_kbs()
 
         kb_list = []
-        for kb in kbs:
+        selected_kbs = kbs
+        if page_size is not None:
+            start = max(page - 1, 0) * page_size
+            end = start + page_size
+            selected_kbs = kbs[start:end]
+
+        for kb in selected_kbs:
             kb_dict = kb.model_dump()
             kb_helper = await kb_manager.get_kb(kb.kb_id)
             if kb_helper and kb_helper.init_error:
                 kb_dict["init_error"] = kb_helper.init_error
             kb_list.append(kb_dict)
 
-        return {"items": kb_list, "page": page, "page_size": page_size}
+        return {
+            "items": kb_list,
+            "page": page,
+            "page_size": page_size if page_size is not None else len(kbs),
+            "total": len(kbs),
+        }
 
     async def list_kbs_from_dashboard_query(self, *, page, page_size) -> dict[str, Any]:
         return await self.list_kbs(
@@ -285,7 +312,7 @@ class KnowledgeBaseService:
 
     async def create_kb(self, data: object) -> tuple[dict[str, Any], str]:
         kb_manager = self.get_kb_manager()
-        payload = self._payload(data)
+        payload = self._canonical_kb_payload(data)
         kb_name = payload.get("kb_name")
         if not kb_name:
             raise KnowledgeBaseServiceError("知识库名称不能为空")
@@ -355,7 +382,7 @@ class KnowledgeBaseService:
         return await self.get_kb(kb_id)
 
     async def update_kb(self, data: object) -> tuple[dict[str, Any], str]:
-        payload = self._payload(data)
+        payload = self._canonical_kb_payload(data)
         kb_id = payload.get("kb_id")
         if not kb_id:
             raise KnowledgeBaseServiceError("缺少参数 kb_id")
@@ -372,28 +399,32 @@ class KnowledgeBaseService:
             "top_k_sparse",
             "top_m_final",
         ]
-        if all(payload.get(key) is None for key in update_keys):
+        if all(key not in payload for key in update_keys):
             raise KnowledgeBaseServiceError("至少需要提供一个更新字段")
 
         current_kb = await self.get_kb_manager().get_kb(kb_id)
-        kb_name = payload.get("kb_name")
-        if kb_name is None:
-            if not current_kb:
-                raise KnowledgeBaseServiceError("知识库不存在")
-            kb_name = current_kb.kb.kb_name
+        if not current_kb:
+            raise KnowledgeBaseServiceError("知识库不存在")
+        current = current_kb.kb
 
         kb_helper = await self.get_kb_manager().update_kb(
             kb_id=kb_id,
-            kb_name=kb_name,
-            description=payload.get("description"),
-            emoji=payload.get("emoji"),
-            embedding_provider_id=payload.get("embedding_provider_id"),
-            rerank_provider_id=payload.get("rerank_provider_id"),
-            chunk_size=payload.get("chunk_size"),
-            chunk_overlap=payload.get("chunk_overlap"),
-            top_k_dense=payload.get("top_k_dense"),
-            top_k_sparse=payload.get("top_k_sparse"),
-            top_m_final=payload.get("top_m_final"),
+            kb_name=payload.get("kb_name", current.kb_name),
+            description=payload.get("description", current.description),
+            emoji=payload.get("emoji", current.emoji),
+            embedding_provider_id=payload.get(
+                "embedding_provider_id",
+                current.embedding_provider_id,
+            ),
+            rerank_provider_id=payload.get(
+                "rerank_provider_id",
+                current.rerank_provider_id,
+            ),
+            chunk_size=payload.get("chunk_size", current.chunk_size),
+            chunk_overlap=payload.get("chunk_overlap", current.chunk_overlap),
+            top_k_dense=payload.get("top_k_dense", current.top_k_dense),
+            top_k_sparse=payload.get("top_k_sparse", current.top_k_sparse),
+            top_m_final=payload.get("top_m_final", current.top_m_final),
         )
         if not kb_helper:
             raise KnowledgeBaseServiceError("知识库不存在")
@@ -736,11 +767,11 @@ class KnowledgeBaseService:
 
         if not query:
             raise KnowledgeBaseServiceError("缺少参数 query")
+        kb_manager = self.get_kb_manager()
         if not kb_names or not isinstance(kb_names, list):
             raise KnowledgeBaseServiceError("缺少参数 kb_names 或格式错误")
 
         top_k = payload.get("top_k", 5)
-        kb_manager = self.get_kb_manager()
         results = await kb_manager.retrieve(
             query=query,
             kb_names=kb_names,

--- a/astrbot/dashboard/services/knowledge_base_service.py
+++ b/astrbot/dashboard/services/knowledge_base_service.py
@@ -399,32 +399,20 @@ class KnowledgeBaseService:
             "top_k_sparse",
             "top_m_final",
         ]
-        if all(key not in payload for key in update_keys):
+        provided_updates = {key: payload[key] for key in update_keys if key in payload}
+        if not provided_updates:
             raise KnowledgeBaseServiceError("至少需要提供一个更新字段")
 
         current_kb = await self.get_kb_manager().get_kb(kb_id)
         if not current_kb:
             raise KnowledgeBaseServiceError("知识库不存在")
         current = current_kb.kb
+        update_data = {key: getattr(current, key) for key in update_keys}
+        update_data.update(provided_updates)
 
         kb_helper = await self.get_kb_manager().update_kb(
             kb_id=kb_id,
-            kb_name=payload.get("kb_name", current.kb_name),
-            description=payload.get("description", current.description),
-            emoji=payload.get("emoji", current.emoji),
-            embedding_provider_id=payload.get(
-                "embedding_provider_id",
-                current.embedding_provider_id,
-            ),
-            rerank_provider_id=payload.get(
-                "rerank_provider_id",
-                current.rerank_provider_id,
-            ),
-            chunk_size=payload.get("chunk_size", current.chunk_size),
-            chunk_overlap=payload.get("chunk_overlap", current.chunk_overlap),
-            top_k_dense=payload.get("top_k_dense", current.top_k_dense),
-            top_k_sparse=payload.get("top_k_sparse", current.top_k_sparse),
-            top_m_final=payload.get("top_m_final", current.top_m_final),
+            **update_data,
         )
         if not kb_helper:
             raise KnowledgeBaseServiceError("知识库不存在")

--- a/dashboard/src/api/generated/openapi-v1/types.gen.ts
+++ b/dashboard/src/api/generated/openapi-v1/types.gen.ts
@@ -86,6 +86,9 @@ export type ChatProjectRequest = {
 };
 
 export type ChatRequest = {
+    /**
+     * Caller-declared WebChat sender/session owner. This value is used as the message sender identity and may participate in sender-ID-based command permission checks. Treat chat-scoped API keys as trusted backend credentials and map or validate usernames before accepting end-user input.
+     */
     username?: string;
     session_id?: string;
     /**
@@ -252,34 +255,54 @@ export type JsonSchema = {
     [key: string]: unknown;
 };
 
+export type KnowledgeBaseCreateRequest = KnowledgeBaseRequest & {
+    kb_name: string;
+    embedding_provider_id: string;
+};
+
 export type KnowledgeBaseRequest = {
-    name: string;
+    kb_name?: string;
     description?: string;
-    embedding_provider_id?: string;
-    rerank_provider_id?: string;
-    chunking?: DynamicConfig;
-    metadata?: DynamicConfig;
+    emoji?: string;
+    embedding_provider_id?: (string) | null;
+    rerank_provider_id?: (string) | null;
+    chunk_size?: number;
+    chunk_overlap?: number;
+    top_k_dense?: number;
+    top_k_sparse?: number;
+    top_m_final?: number;
 };
 
 export type KnowledgeDocumentImportRequest = {
-    paths: Array<(string)>;
-    parser?: string;
+    documents: Array<{
+        file_name: string;
+        chunks: Array<(string)>;
+        [key: string]: unknown | string;
+    }>;
+    batch_size?: number;
+    tasks_limit?: number;
+    max_retries?: number;
 };
 
 export type KnowledgeDocumentUploadRequest = {
     file: (Blob | File);
-    parser?: string;
 };
 
 export type KnowledgeDocumentUrlImportRequest = {
     url: string;
-    parser?: string;
+    chunk_size?: number;
+    chunk_overlap?: number;
+    batch_size?: number;
+    tasks_limit?: number;
+    max_retries?: number;
+    enable_cleaning?: boolean;
+    cleaning_provider_id?: (string) | null;
 };
 
 export type KnowledgeRetrieveRequest = {
     query: string;
     top_k?: number;
-    score_threshold?: number;
+    debug?: boolean;
 };
 
 export type LoginRequest = {
@@ -2566,7 +2589,7 @@ export type ListKnowledgeBasesResponse = (SuccessEnvelope);
 export type ListKnowledgeBasesError = unknown;
 
 export type CreateKnowledgeBaseData = {
-    body: KnowledgeBaseRequest;
+    body: KnowledgeBaseCreateRequest;
 };
 
 export type CreateKnowledgeBaseResponse = (SuccessEnvelope);

--- a/dashboard/src/api/v1.ts
+++ b/dashboard/src/api/v1.ts
@@ -32,6 +32,10 @@ import {
   type DynamicConfig,
   type EnabledPatch,
   type GhproxyTestRequest,
+  type KnowledgeBaseCreateRequest,
+  type KnowledgeBaseRequest,
+  type KnowledgeDocumentUrlImportRequest,
+  type KnowledgeRetrieveRequest,
   type LoginRequest,
   type ListConversationsData,
   type McpServerConfig,
@@ -1345,16 +1349,16 @@ export const knowledgeApi = {
       openApiV1.getKnowledgeBase({ path: { kb_id: kbId } }),
     );
   },
-  create(config: OpenConfig) {
+  create(config: KnowledgeBaseCreateRequest) {
     return typed<OpenConfig>(
-      openApiV1.createKnowledgeBase({ body: config as any }),
+      openApiV1.createKnowledgeBase({ body: config }),
     );
   },
-  update(kbId: string, config: OpenConfig) {
+  update(kbId: string, config: KnowledgeBaseRequest) {
     return typed<OpenConfig>(
       openApiV1.updateKnowledgeBase({
         path: { kb_id: kbId },
-        body: config as any,
+        body: config,
       }),
     );
   },
@@ -1379,11 +1383,11 @@ export const knowledgeApi = {
       }),
     );
   },
-  importDocumentFromUrl(kbId: string, payload: OpenConfig) {
+  importDocumentFromUrl(kbId: string, payload: KnowledgeDocumentUrlImportRequest) {
     return typed<any>(
       openApiV1.importKnowledgeDocumentFromUrl({
         path: { kb_id: kbId },
-        body: payload as any,
+        body: payload,
       }),
     );
   },
@@ -1425,11 +1429,11 @@ export const knowledgeApi = {
       }),
     );
   },
-  retrieve(kbId: string, payload: OpenConfig) {
+  retrieve(kbId: string, payload: KnowledgeRetrieveRequest) {
     return typed<any>(
       openApiV1.retrieveKnowledgeBase({
         path: { kb_id: kbId },
-        body: payload as any,
+        body: payload,
       }),
     );
   },

--- a/dashboard/src/i18n/locales/en-US/features/knowledge-base/index.json
+++ b/dashboard/src/i18n/locales/en-US/features/knowledge-base/index.json
@@ -33,7 +33,8 @@
     "rerankProviderInfo": "Provider: {id}",
     "cancel": "Cancel",
     "submit": "Create",
-    "nameRequired": "Please enter knowledge base name"
+    "nameRequired": "Please enter knowledge base name",
+    "embeddingModelRequired": "Please select an embedding model"
   },
   "edit": {
     "title": "Edit Knowledge Base",

--- a/dashboard/src/i18n/locales/ru-RU/features/knowledge-base/index.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/knowledge-base/index.json
@@ -33,7 +33,8 @@
         "rerankProviderInfo": "Провайдер: {id}",
         "cancel": "Отмена",
         "submit": "Создать",
-        "nameRequired": "Введите название базы знаний"
+        "nameRequired": "Введите название базы знаний",
+        "embeddingModelRequired": "Выберите embedding модель"
     },
     "edit": {
         "title": "Редактирование",

--- a/dashboard/src/i18n/locales/zh-CN/features/knowledge-base/index.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/knowledge-base/index.json
@@ -33,7 +33,8 @@
     "rerankProviderInfo": "提供商: {id}",
     "cancel": "取消",
     "submit": "创建",
-    "nameRequired": "请输入知识库名称"
+    "nameRequired": "请输入知识库名称",
+    "embeddingModelRequired": "请选择嵌入模型"
   },
   "edit": {
     "title": "编辑知识库",

--- a/dashboard/src/views/knowledge-base/KBList.vue
+++ b/dashboard/src/views/knowledge-base/KBList.vue
@@ -152,7 +152,9 @@
 
             <v-select v-model="formData.embedding_provider_id" :items="embeddingProviders"
               :item-title="item => item.embedding_model || item.id" :item-value="'id'"
-              :label="t('create.embeddingModelLabel')" variant="outlined" class="mb-4" :disabled="editingKB !== null" hint="嵌入模型选择后无法修改，如需更换请创建新的知识库。" persistent-hint>
+              :label="t('create.embeddingModelLabel')" variant="outlined" class="mb-4" :disabled="editingKB !== null"
+              :rules="[v => editingKB || !!v || t('create.embeddingModelRequired')]" required
+              hint="嵌入模型选择后无法修改，如需更换请创建新的知识库。" persistent-hint>
               <template #item="{ props, item }">
                 <v-list-item v-bind="props">
                   <template #subtitle>
@@ -441,7 +443,10 @@ const submitForm = async () => {
     if (editingKB.value) {
       response = await knowledgeApi.update(editingKB.value.kb_id, payload)
     } else {
-      response = await knowledgeApi.create(payload)
+      response = await knowledgeApi.create({
+        ...payload,
+        embedding_provider_id: formData.value.embedding_provider_id!
+      })
     }
 
     if (response.data.status === 'ok') {

--- a/dashboard/src/views/knowledge-base/KBList.vue
+++ b/dashboard/src/views/knowledge-base/KBList.vue
@@ -153,7 +153,7 @@
             <v-select v-model="formData.embedding_provider_id" :items="embeddingProviders"
               :item-title="item => item.embedding_model || item.id" :item-value="'id'"
               :label="t('create.embeddingModelLabel')" variant="outlined" class="mb-4" :disabled="editingKB !== null"
-              :rules="[v => editingKB || !!v || t('create.embeddingModelRequired')]" required
+              :rules="[v => editingKB !== null || !!v || t('create.embeddingModelRequired')]" required
               hint="嵌入模型选择后无法修改，如需更换请创建新的知识库。" persistent-hint>
               <template #item="{ props, item }">
                 <v-list-item v-bind="props">

--- a/dashboard/src/views/knowledge-base/components/DocumentsTab.vue
+++ b/dashboard/src/views/knowledge-base/components/DocumentsTab.vue
@@ -480,7 +480,6 @@ const uploadFromUrl = async () => {
 
   try {
     const payload: any = {
-      kb_id: props.kbId,
       url: uploadUrl.value,
       batch_size: uploadSettings.value.batch_size,
       tasks_limit: uploadSettings.value.tasks_limit,

--- a/dashboard/src/views/knowledge-base/components/RetrievalTab.vue
+++ b/dashboard/src/views/knowledge-base/components/RetrievalTab.vue
@@ -162,7 +162,6 @@ const performRetrieval = async () => {
   try {
     const response = await knowledgeApi.retrieve(props.kbId, {
       query: query.value,
-      kb_names: [props.kbName],
       top_k: topK.value,
       debug: debugMode.value
     })

--- a/openspec/openapi-v1.yaml
+++ b/openspec/openapi-v1.yaml
@@ -3347,7 +3347,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/KnowledgeBaseRequest"
+              $ref: "#/components/schemas/KnowledgeBaseCreateRequest"
       responses:
         "200":
           $ref: "#/components/responses/Ok"
@@ -5613,21 +5613,40 @@ components:
 
     KnowledgeBaseRequest:
       type: object
-      required: [name]
       properties:
-        name:
+        kb_name:
           type: string
         description:
           type: string
+        emoji:
+          type: string
         embedding_provider_id:
-          type: string
+          type: [string, "null"]
         rerank_provider_id:
-          type: string
-        chunking:
-          $ref: "#/components/schemas/DynamicConfig"
-        metadata:
-          $ref: "#/components/schemas/DynamicConfig"
+          type: [string, "null"]
+        chunk_size:
+          type: integer
+        chunk_overlap:
+          type: integer
+        top_k_dense:
+          type: integer
+        top_k_sparse:
+          type: integer
+        top_m_final:
+          type: integer
       additionalProperties: false
+
+    KnowledgeBaseCreateRequest:
+      allOf:
+        - $ref: "#/components/schemas/KnowledgeBaseRequest"
+        - type: object
+          required: [kb_name, embedding_provider_id]
+          properties:
+            kb_name:
+              type: string
+            embedding_provider_id:
+              type: string
+          additionalProperties: false
 
     KnowledgeDocumentUploadRequest:
       type: object
@@ -5636,19 +5655,30 @@ components:
         file:
           type: string
           format: binary
-        parser:
-          type: string
 
     KnowledgeDocumentImportRequest:
       type: object
-      required: [paths]
+      required: [documents]
       properties:
-        paths:
+        documents:
           type: array
           items:
-            type: string
-        parser:
-          type: string
+            type: object
+            required: [file_name, chunks]
+            properties:
+              file_name:
+                type: string
+              chunks:
+                type: array
+                items:
+                  type: string
+            additionalProperties: true
+        batch_size:
+          type: integer
+        tasks_limit:
+          type: integer
+        max_retries:
+          type: integer
       additionalProperties: false
 
     KnowledgeDocumentUrlImportRequest:
@@ -5658,8 +5688,20 @@ components:
         url:
           type: string
           format: uri
-        parser:
-          type: string
+        chunk_size:
+          type: integer
+        chunk_overlap:
+          type: integer
+        batch_size:
+          type: integer
+        tasks_limit:
+          type: integer
+        max_retries:
+          type: integer
+        enable_cleaning:
+          type: boolean
+        cleaning_provider_id:
+          type: [string, "null"]
       additionalProperties: false
 
     KnowledgeRetrieveRequest:
@@ -5671,8 +5713,8 @@ components:
         top_k:
           type: integer
           default: 5
-        score_threshold:
-          type: number
+        debug:
+          type: boolean
       additionalProperties: false
 
     PersonaRequest:

--- a/tests/unit/test_knowledge_base_service_contract.py
+++ b/tests/unit/test_knowledge_base_service_contract.py
@@ -314,6 +314,12 @@ def test_knowledge_base_request_preserves_explicit_null_updates():
     assert payload == {"rerank_provider_id": None}
 
 
+def test_knowledge_base_request_omits_unset_none_fields():
+    payload = KnowledgeBaseRequest(kb_name="Docs").canonical_payload()
+
+    assert payload == {"kb_name": "Docs"}
+
+
 def test_knowledge_base_request_uses_legacy_name_as_input_alias():
     payload = KnowledgeBaseRequest(name="Legacy Name").canonical_payload()
 
@@ -359,3 +365,21 @@ async def test_retrieve_route_resolves_path_kb_id_to_canonical_kb_names():
             "kb_names": ["Route KB"],
         }
     )
+
+
+@pytest.mark.asyncio
+async def test_retrieve_route_requires_resolved_kb_name():
+    service = MagicMock()
+    service.get_kb = AsyncMock(return_value={})
+    service.retrieve = AsyncMock()
+
+    response = await retrieve_knowledge_base(
+        "route-kb-id",
+        KnowledgeBaseRetrieveRequest(query="hello"),
+        _auth=object(),
+        service=service,
+    )
+
+    assert response["status"] == "error"
+    assert response["message"] == "知识库不存在"
+    service.retrieve.assert_not_awaited()

--- a/tests/unit/test_knowledge_base_service_contract.py
+++ b/tests/unit/test_knowledge_base_service_contract.py
@@ -1,0 +1,361 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import Request
+
+from astrbot.core.provider.provider import EmbeddingProvider
+from astrbot.dashboard.api.knowledge_bases import (
+    list_knowledge_bases,
+    retrieve_knowledge_base,
+)
+from astrbot.dashboard.schemas import (
+    KnowledgeBaseRequest,
+    KnowledgeBaseRetrieveRequest,
+    KnowledgeBaseUrlImportRequest,
+)
+from astrbot.dashboard.services.knowledge_base_service import (
+    KnowledgeBaseService,
+    KnowledgeBaseServiceError,
+)
+
+
+class FakeEmbeddingProvider(EmbeddingProvider):
+    def __init__(self):
+        super().__init__({}, {})
+
+    async def get_embedding(self, text: str) -> list[float]:
+        return [0.1, 0.2]
+
+    async def get_embeddings(self, text: list[str]) -> list[list[float]]:
+        return [[0.1, 0.2] for _ in text]
+
+    def get_dim(self) -> int:
+        return 2
+
+
+def make_service(kb_manager) -> KnowledgeBaseService:
+    service = KnowledgeBaseService.__new__(KnowledgeBaseService)
+    service.core_lifecycle = SimpleNamespace(kb_manager=kb_manager)
+    service.upload_progress = {}
+    service.upload_tasks = {}
+    return service
+
+
+def make_kb(kb_id: str, kb_name: str):
+    return SimpleNamespace(
+        kb_id=kb_id,
+        kb_name=kb_name,
+        description="description",
+        emoji="book",
+        embedding_provider_id="embedding-1",
+        rerank_provider_id="rerank-1",
+        chunk_size=512,
+        chunk_overlap=50,
+        top_k_dense=50,
+        top_k_sparse=50,
+        top_m_final=5,
+        model_dump=lambda: {"kb_id": kb_id, "kb_name": kb_name},
+    )
+
+
+def make_request(query_string: bytes) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/v1/knowledge-bases",
+            "query_string": query_string,
+            "headers": [],
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_kbs_applies_pagination():
+    kb_manager = MagicMock()
+    kb_manager.list_kbs = AsyncMock(
+        return_value=[
+            make_kb("kb-1", "one"),
+            make_kb("kb-2", "two"),
+            make_kb("kb-3", "three"),
+        ]
+    )
+    kb_manager.get_kb = AsyncMock(
+        side_effect=lambda kb_id: SimpleNamespace(init_error=None)
+    )
+    service = make_service(kb_manager)
+
+    result = await service.list_kbs(page=2, page_size=2)
+
+    assert result == {
+        "items": [{"kb_id": "kb-3", "kb_name": "three"}],
+        "page": 2,
+        "page_size": 2,
+        "total": 3,
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_kbs_without_page_size_returns_all_items():
+    kb_manager = MagicMock()
+    kb_manager.list_kbs = AsyncMock(
+        return_value=[
+            make_kb("kb-1", "one"),
+            make_kb("kb-2", "two"),
+            make_kb("kb-3", "three"),
+        ]
+    )
+    kb_manager.get_kb = AsyncMock(
+        side_effect=lambda kb_id: SimpleNamespace(init_error=None)
+    )
+    service = make_service(kb_manager)
+
+    result = await service.list_kbs(page=1, page_size=None)
+
+    assert result == {
+        "items": [
+            {"kb_id": "kb-1", "kb_name": "one"},
+            {"kb_id": "kb-2", "kb_name": "two"},
+            {"kb_id": "kb-3", "kb_name": "three"},
+        ],
+        "page": 1,
+        "page_size": 3,
+        "total": 3,
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_route_preserves_unpaginated_default():
+    service = MagicMock()
+    service.list_kbs = AsyncMock(return_value={"items": [], "total": 0})
+
+    response = await list_knowledge_bases(
+        make_request(b""),
+        _auth=object(),
+        service=service,
+    )
+
+    assert response["status"] == "ok"
+    service.list_kbs.assert_awaited_once_with(page=1, page_size=None)
+
+
+@pytest.mark.asyncio
+async def test_list_route_uses_default_page_size_when_page_is_explicit():
+    service = MagicMock()
+    service.list_kbs = AsyncMock(return_value={"items": [], "total": 0})
+
+    response = await list_knowledge_bases(
+        make_request(b"page=2"),
+        _auth=object(),
+        service=service,
+    )
+
+    assert response["status"] == "ok"
+    service.list_kbs.assert_awaited_once_with(page=2, page_size=20)
+
+
+@pytest.mark.asyncio
+async def test_create_kb_accepts_legacy_name_field():
+    kb = make_kb("kb-1", "From Name")
+    kb_manager = MagicMock()
+    kb_manager.provider_manager.get_provider_by_id = AsyncMock(
+        return_value=FakeEmbeddingProvider()
+    )
+    kb_manager.create_kb = AsyncMock(return_value=SimpleNamespace(kb=kb))
+    service = make_service(kb_manager)
+
+    result, message = await service.create_kb(
+        {
+            "name": "From Name",
+            "embedding_provider_id": "embedding-1",
+            "top_k_dense": 12,
+            "top_k_sparse": 8,
+            "top_m_final": 3,
+        }
+    )
+
+    assert message == "创建知识库成功"
+    assert result == {"kb_id": "kb-1", "kb_name": "From Name"}
+    kb_manager.create_kb.assert_awaited_once_with(
+        kb_name="From Name",
+        description=None,
+        emoji=None,
+        embedding_provider_id="embedding-1",
+        rerank_provider_id=None,
+        chunk_size=None,
+        chunk_overlap=None,
+        top_k_dense=12,
+        top_k_sparse=8,
+        top_m_final=3,
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_kb_preserves_omitted_fields():
+    kb = make_kb("kb-1", "Docs")
+    kb_manager = MagicMock()
+    kb_manager.get_kb = AsyncMock(return_value=SimpleNamespace(kb=kb))
+    kb_manager.update_kb = AsyncMock(return_value=SimpleNamespace(kb=kb))
+    service = make_service(kb_manager)
+
+    await service.update_kb({"kb_id": "kb-1", "chunk_size": 1024})
+
+    kb_manager.update_kb.assert_awaited_once_with(
+        kb_id="kb-1",
+        kb_name="Docs",
+        description="description",
+        emoji="book",
+        embedding_provider_id="embedding-1",
+        rerank_provider_id="rerank-1",
+        chunk_size=1024,
+        chunk_overlap=50,
+        top_k_dense=50,
+        top_k_sparse=50,
+        top_m_final=5,
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_kb_allows_explicit_rerank_provider_clear():
+    kb = make_kb("kb-1", "Docs")
+    kb_manager = MagicMock()
+    kb_manager.get_kb = AsyncMock(return_value=SimpleNamespace(kb=kb))
+    kb_manager.update_kb = AsyncMock(return_value=SimpleNamespace(kb=kb))
+    service = make_service(kb_manager)
+
+    await service.update_kb({"kb_id": "kb-1", "rerank_provider_id": None})
+
+    kb_manager.update_kb.assert_awaited_once()
+    assert kb_manager.update_kb.await_args.kwargs["rerank_provider_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_retrieve_uses_canonical_kb_names():
+    kb_manager = MagicMock()
+    kb_manager.retrieve = AsyncMock(
+        return_value={"results": [{"chunk_id": "chunk-1"}], "context_text": "text"}
+    )
+    service = make_service(kb_manager)
+
+    result = await service.retrieve(
+        {"kb_names": ["Docs"], "query": "hello", "top_k": 2}
+    )
+
+    assert result == {
+        "results": [{"chunk_id": "chunk-1"}],
+        "total": 1,
+        "query": "hello",
+    }
+    kb_manager.retrieve.assert_awaited_once_with(
+        query="hello",
+        kb_names=["Docs"],
+        top_m_final=2,
+    )
+
+
+@pytest.mark.asyncio
+async def test_retrieve_requires_canonical_kb_names():
+    kb_manager = MagicMock()
+    service = make_service(kb_manager)
+
+    with pytest.raises(KnowledgeBaseServiceError, match="缺少参数 kb_names"):
+        await service.retrieve({"kb_id": "missing", "query": "hello"})
+
+
+def test_knowledge_base_schemas_match_service_contract():
+    create_payload = KnowledgeBaseRequest(
+        kb_name="Docs",
+        name="Legacy",
+        emoji="book",
+        top_k_dense=12,
+        top_k_sparse=8,
+        top_m_final=3,
+        kb_id="body-kb-id",
+    ).canonical_payload()
+    retrieve_payload = KnowledgeBaseRetrieveRequest(
+        query="hello",
+        top_k=2,
+        debug=True,
+        kb_names=["Wrong"],
+    ).canonical_payload(kb_name="Docs")
+    url_payload = KnowledgeBaseUrlImportRequest(
+        url="https://example.com",
+        urls=["https://unused.example.com"],
+        enable_cleaning=True,
+        cleaning_provider_id="llm-1",
+    ).canonical_payload()
+
+    assert create_payload == {
+        "kb_name": "Docs",
+        "emoji": "book",
+        "top_k_dense": 12,
+        "top_k_sparse": 8,
+        "top_m_final": 3,
+    }
+    assert retrieve_payload == {
+        "query": "hello",
+        "kb_names": ["Docs"],
+        "top_k": 2,
+        "debug": True,
+    }
+    assert url_payload == {
+        "url": "https://example.com",
+        "enable_cleaning": True,
+        "cleaning_provider_id": "llm-1",
+    }
+    assert "urls" not in url_payload
+    assert "kb_id" not in create_payload
+
+
+def test_knowledge_base_request_preserves_explicit_null_updates():
+    payload = KnowledgeBaseRequest(rerank_provider_id=None).canonical_payload()
+
+    assert payload == {"rerank_provider_id": None}
+
+
+def test_knowledge_base_request_uses_legacy_name_as_input_alias():
+    payload = KnowledgeBaseRequest(name="Legacy Name").canonical_payload()
+
+    assert payload == {"kb_name": "Legacy Name"}
+
+
+def test_retrieve_request_can_use_route_kb_name_as_default():
+    payload = KnowledgeBaseRetrieveRequest(query="hello").canonical_payload(
+        kb_name="Route KB"
+    )
+
+    assert payload == {"query": "hello", "kb_names": ["Route KB"]}
+
+
+@pytest.mark.asyncio
+async def test_retrieve_route_resolves_path_kb_id_to_canonical_kb_names():
+    service = MagicMock()
+    service.get_kb = AsyncMock(return_value={"kb_name": "Route KB"})
+    service.retrieve = AsyncMock(return_value={"results": [], "total": 0})
+    payload = KnowledgeBaseRetrieveRequest(
+        query="hello",
+        kb_names=["Wrong"],
+        debug=False,
+    )
+
+    response = await retrieve_knowledge_base(
+        "route-kb-id",
+        payload,
+        _auth=object(),
+        service=service,
+    )
+
+    assert response == {
+        "status": "ok",
+        "message": None,
+        "data": {"results": [], "total": 0},
+    }
+    service.get_kb.assert_awaited_once_with("route-kb-id")
+    service.retrieve.assert_awaited_once_with(
+        {
+            "query": "hello",
+            "debug": False,
+            "kb_names": ["Route KB"],
+        }
+    )


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
Align the knowledge base dashboard API, service payload handling, OpenAPI schema, and generated frontend client types so the contract matches the actual backend behavior.

This fixes several knowledge base issues:
- Listing knowledge bases without pagination now returns all items instead of only the first 20.
- Partial updates preserve omitted fields, including `rerank_provider_id`.
- Explicit `rerank_provider_id: null` still clears the rerank provider.
- Retrieve requests now resolve the target knowledge base from the route `kb_id` instead of trusting body-level `kb_names`.
- OpenAPI and generated frontend types now reflect the real create/update/retrieve/import request contracts.

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
- Updated knowledge base schemas to canonicalize service-facing payloads.
- Updated knowledge base API routes to preserve unpaginated list behavior and canonicalize retrieve requests.
- Updated knowledge base service update logic to preserve omitted fields.
- Added unit tests for pagination, partial update behavior, retrieve canonicalization, legacy `name` support, and schema filtering.
- Updated `openspec/openapi-v1.yaml` and regenerated dashboard API client types.
- Updated dashboard knowledge base API usage to rely on generated request types.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
```bash
uv run ruff check .
uv run pytest tests/unit/test_knowledge_base_service_contract.py tests/test_kb_import.py
cd dashboard && pnpm typecheck
```
Results:
```bash
ruff check: passed
pytest: 17 passed, 1 warning
pnpm typecheck: passed
```
---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Align knowledge base dashboard API contracts, backend service payload handling, OpenAPI schemas, and generated frontend client types with the actual backend behavior.

Bug Fixes:
- Ensure listing knowledge bases without explicit pagination returns all items and includes total counts.
- Preserve existing knowledge base fields on partial updates while allowing explicit clearing of rerank providers.
- Resolve retrieve requests using the route knowledge base ID and canonical kb_name instead of trusting body-provided kb_names.

Enhancements:
- Introduce canonical payload helpers for knowledge base create/update/import/retrieve requests across dashboard schemas and services.
- Refine knowledge base listing responses to support optional pagination and expose total item counts.
- Regenerate OpenAPI v1 schemas and dashboard client types for knowledge base operations and tighten frontend type usage accordingly.

Tests:
- Add unit tests covering pagination behavior, partial update semantics, retrieve canonicalization, legacy name support, and schema filtering for knowledge base services and routes.