### PR TITLE
fix(path_util): guard path_Mapping against IndexError on short relative targets

### DIFF
--- a/astrbot/core/utils/path_util.py
+++ b/astrbot/core/utils/path_util.py
@@ -54,10 +54,11 @@ def path_Mapping(mappings, srcPath: str) -> str:
                 has_replaced_processed = False
                 if srcPath.startswith("."):
                     # 相对路径处理。如果是相对路径，可能是Linux路径，也可能是Windows路径
-                    sign = srcPath[1]
+                    # 映射目标可能短到只是 "." 或 ".."，此时没有后续字符，按需取以免越界
+                    sign = srcPath[1] if len(srcPath) > 1 else ""
                     # 处理两个点的情况
                     if sign == ".":
-                        sign = srcPath[2]
+                        sign = srcPath[2] if len(srcPath) > 2 else ""
                     if sign == "/":
                         srcPath = srcPath.replace("\\", "/")
                         has_replaced_processed = True

--- a/tests/test_path_util.py
+++ b/tests/test_path_util.py
@@ -1,0 +1,19 @@
+from astrbot.core.utils.path_util import path_Mapping
+
+
+def test_path_mapping_target_single_dot_does_not_crash():
+    # A mapping whose target is "." reduces srcPath to "." (one character).
+    # The relative-path branch indexed srcPath[1] unconditionally and raised
+    # IndexError. path_Mapping is reachable from the respond stage, so a user
+    # configuring such a rule could crash message handling.
+    assert path_Mapping(["somepath:."], "somepath") == "."
+
+
+def test_path_mapping_target_double_dot_does_not_crash():
+    # ".." is two characters, so the inner srcPath[2] access also overran.
+    assert path_Mapping(["somepath:.."], "somepath") == ".."
+
+
+def test_path_mapping_relative_target_still_normalized():
+    # Regression: a normal relative target keeps its existing behaviour.
+    assert path_Mapping(["somepath:./sub"], "somepath") == "./sub"


### PR DESCRIPTION
### Problem

`path_Mapping` indexes the relative-path branch unconditionally:

```python
if srcPath.startswith("."):
    sign = srcPath[1]          # IndexError when srcPath == "."
    if sign == ".":
        sign = srcPath[2]      # IndexError when srcPath == ".."
```

A mapping rule whose target is `.` or `..` reduces `srcPath` to a one- or two-character string, so these accesses raise `IndexError: string index out of range`.

This is reachable in normal operation: `respond/stage.py` runs file component paths through `path_Mapping`, so a user-configured rule like `from:.` crashes message handling.

```python
path_Mapping(["somepath:."], "somepath")   # IndexError
path_Mapping(["somepath:.."], "somepath")  # IndexError
```

### Fix

Read those characters defensively (`srcPath[1] if len(srcPath) > 1 else ""`) and fall through to the existing default normalization when they are absent, so `.` / `..` targets are returned as-is instead of crashing.

### Tests

Added `tests/test_path_util.py` covering the `.` and `..` targets (which raised `IndexError` before this change) plus a regression check that a normal `./sub` target is still normalized. `python -m pytest tests/test_path_util.py` passes; `ruff check` and `ruff format --check` are clean.

## Summary by Sourcery

Guard relative-path handling in path_Mapping against short targets and add regression tests for edge cases.

Bug Fixes:
- Prevent IndexError in path_Mapping when mapping targets reduce srcPath to "." or "..".

Tests:
- Add unit tests covering "." and ".." mapping targets and confirming normal relative targets like "./sub" remain correctly handled.