### PR TITLE
chore: bump version to 4.26.0-beta.12

### DIFF
--- a/astrbot/__init__.py
+++ b/astrbot/__init__.py
@@ -1,4 +1,4 @@
 import logging
 
-__version__ = "4.26.0-beta.11"
+__version__ = "4.26.0-beta.12"
 logger = logging.getLogger("astrbot")

--- a/changelogs/v4.26.0-beta.12.md
+++ b/changelogs/v4.26.0-beta.12.md
@@ -1,0 +1,7 @@
+## What's Changed
+
+<!-- Review, group, and polish these entries before publishing. -->
+
+- fix: 修复提供商源修改 ID 后保存被静默还原的问题 (#8915) (42ca89d6c)
+- fix: created unnecessary data dir when executing astrbot command (#8932) (39d425316)
+- fix: add sdist build artifact path to allow dashboard artifact to be included (#8933) (05148dfdd)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AstrBot"
-version = "4.26.0-beta.11"
+version = "4.26.0-beta.12"
 description = "Easy-to-use multi-platform LLM chatbot and development framework"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }


### PR DESCRIPTION
## Summary
- Bump AstrBot to 4.26.0-beta.12
- Add changelog for changes since v4.26.0-beta.11

## Validation
- uv run ruff format --check .
- uv run ruff check .

## Summary by Sourcery

Bump AstrBot project version to 4.26.0-beta.12 and document the changes included in this beta release.

Bug Fixes:
- Document fixes for provider source ID persistence, unwanted data directory creation, and inclusion of dashboard artifacts in sdist builds.

Build:
- Update project version metadata to 4.26.0-beta.12 in packaging configuration.

Documentation:
- Add changelog entry describing changes for version 4.26.0-beta.12.