### PR TITLE
fix: sanitize orphaned tool_result blocks in Anthropic provider

### DIFF
--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -303,6 +303,52 @@ class ProviderAnthropic(Provider):
             else:
                 new_messages.append(message)
 
+        # --- Orphaned tool_result sanitizer ---
+        # After context truncation, tool_result blocks may reference tool_use
+        # IDs that no longer exist. The Anthropic API rejects these with 400.
+        valid_tool_use_ids: set[str] = set()
+        for msg in new_messages:
+            if msg.get("role") == "assistant" and isinstance(msg.get("content"), list):
+                for block in msg["content"]:
+                    if isinstance(block, dict) and block.get("type") == "tool_use":
+                        valid_tool_use_ids.add(block.get("id", ""))
+
+        sanitized: list[dict] = []
+        for msg in new_messages:
+            if msg.get("role") == "user" and isinstance(msg.get("content"), list):
+                cleaned_content = [
+                    block for block in msg["content"]
+                    if not (
+                        isinstance(block, dict)
+                        and block.get("type") == "tool_result"
+                        and block.get("tool_use_id") not in valid_tool_use_ids
+                    )
+                ]
+                if cleaned_content:
+                    sanitized.append({**msg, "content": cleaned_content})
+            else:
+                sanitized.append(msg)
+        new_messages = sanitized
+
+        # --- Merge consecutive same-role messages ---
+        # Stripping orphaned tool_results may leave adjacent messages with the
+        # same role, which violates Anthropic's strict alternation requirement.
+        merged: list[dict] = []
+        for msg in new_messages:
+            if merged and merged[-1].get("role") == msg.get("role"):
+                prev = merged[-1]
+                prev_content = prev.get("content", [])
+                if isinstance(prev_content, str):
+                    prev_content = [{"type": "text", "text": prev_content}]
+                    prev["content"] = prev_content
+                cur_content = msg.get("content", [])
+                if isinstance(cur_content, str):
+                    cur_content = [{"type": "text", "text": cur_content}]
+                prev_content.extend(cur_content)
+            else:
+                merged.append(msg)
+        new_messages = merged
+
         return system_prompt, new_messages
 
     def _extract_usage(self, usage: Usage | None) -> TokenUsage:

--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -306,57 +306,18 @@ class ProviderAnthropic(Provider):
         return system_prompt, new_messages
 
     @staticmethod
-    def _sanitize_assistant_messages(payloads: dict) -> None:
-        """Remove orphaned tool results from Anthropic messages.
+    def _merge_consecutive_anthropic_messages(messages: list[Any]) -> list[Any]:
+        """Merge adjacent Anthropic messages with the same role.
 
         Args:
-            payloads: Anthropic request payload containing a messages list.
+            messages: Anthropic messages to merge.
 
         Returns:
-            None. The messages list is updated in place on ``payloads``.
+            Merged Anthropic messages. When merging user messages, tool result
+            blocks are moved before other blocks to satisfy Anthropic ordering.
         """
-        messages = payloads.get("messages")
-        if not isinstance(messages, list):
-            return
-
-        valid_tool_use_ids: set[str] = set()
-        for msg in messages:
-            if not isinstance(msg, dict) or msg.get("role") != "assistant":
-                continue
-            content = msg.get("content")
-            if not isinstance(content, list):
-                continue
-            for block in content:
-                if isinstance(block, dict) and block.get("type") == "tool_use":
-                    tool_use_id = block.get("id")
-                    if tool_use_id:
-                        valid_tool_use_ids.add(tool_use_id)
-
-        sanitized: list[Any] = []
-        for msg in messages:
-            if not isinstance(msg, dict):
-                sanitized.append(msg)
-                continue
-
-            content = msg.get("content")
-            if msg.get("role") == "user" and isinstance(content, list):
-                cleaned_content = [
-                    block
-                    for block in content
-                    if not (
-                        isinstance(block, dict)
-                        and block.get("type") == "tool_result"
-                        and block.get("tool_use_id") not in valid_tool_use_ids
-                    )
-                ]
-                if cleaned_content:
-                    sanitized.append({**msg, "content": cleaned_content})
-                continue
-
-            sanitized.append(msg)
-
         merged: list[Any] = []
-        for msg in sanitized:
+        for msg in messages:
             if not isinstance(msg, dict):
                 merged.append(msg)
                 continue
@@ -384,11 +345,90 @@ class ProviderAnthropic(Provider):
                 else:
                     cur_content = [cur_content]
 
-                merged[-1] = {**prev, "content": prev_content + cur_content}
+                combined_content = prev_content + cur_content
+                if msg.get("role") == "user":
+                    tool_results = [
+                        block
+                        for block in combined_content
+                        if isinstance(block, dict)
+                        and block.get("type") == "tool_result"
+                    ]
+                    if tool_results:
+                        combined_content = tool_results + [
+                            block
+                            for block in combined_content
+                            if not (
+                                isinstance(block, dict)
+                                and block.get("type") == "tool_result"
+                            )
+                        ]
+
+                merged[-1] = {**prev, "content": combined_content}
             else:
                 merged.append(msg)
 
-        payloads["messages"] = merged
+        return merged
+
+    @staticmethod
+    def _sanitize_assistant_messages(payloads: dict) -> None:
+        """Remove orphaned tool results from Anthropic messages.
+
+        Args:
+            payloads: Anthropic request payload containing a messages list.
+
+        Returns:
+            None. The messages list is updated in place on ``payloads``.
+        """
+        messages = payloads.get("messages")
+        if not isinstance(messages, list):
+            return
+
+        merged = ProviderAnthropic._merge_consecutive_anthropic_messages(messages)
+        sanitized: list[Any] = []
+        pending_tool_use_ids: set[str] = set()
+        for msg in merged:
+            if not isinstance(msg, dict):
+                sanitized.append(msg)
+                pending_tool_use_ids = set()
+                continue
+
+            role = msg.get("role")
+            content = msg.get("content")
+            if role == "assistant":
+                pending_tool_use_ids = set()
+                if isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "tool_use":
+                            tool_use_id = block.get("id")
+                            if tool_use_id:
+                                pending_tool_use_ids.add(tool_use_id)
+                sanitized.append(msg)
+                continue
+
+            if role == "user" and isinstance(content, list):
+                tool_results: list[Any] = []
+                other_blocks: list[Any] = []
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "tool_result":
+                        tool_use_id = block.get("tool_use_id")
+                        if tool_use_id in pending_tool_use_ids:
+                            tool_results.append(block)
+                            pending_tool_use_ids.remove(tool_use_id)
+                        continue
+                    other_blocks.append(block)
+
+                cleaned_content = tool_results + other_blocks
+                if cleaned_content:
+                    sanitized.append({**msg, "content": cleaned_content})
+                pending_tool_use_ids = set()
+                continue
+
+            sanitized.append(msg)
+            pending_tool_use_ids = set()
+
+        payloads["messages"] = ProviderAnthropic._merge_consecutive_anthropic_messages(
+            sanitized
+        )
 
     def _extract_usage(self, usage: Usage | None) -> TokenUsage:
         if usage is None:

--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -337,14 +337,19 @@ class ProviderAnthropic(Provider):
         for msg in new_messages:
             if merged and merged[-1].get("role") == msg.get("role"):
                 prev = merged[-1]
-                prev_content = prev.get("content", [])
+                prev_content = prev.get("content") or []
                 if isinstance(prev_content, str):
                     prev_content = [{"type": "text", "text": prev_content}]
-                    prev["content"] = prev_content
-                cur_content = msg.get("content", [])
+                else:
+                    prev_content = list(prev_content)
+
+                cur_content = msg.get("content") or []
                 if isinstance(cur_content, str):
                     cur_content = [{"type": "text", "text": cur_content}]
-                prev_content.extend(cur_content)
+                else:
+                    cur_content = list(cur_content)
+
+                merged[-1] = {**prev, "content": prev_content + cur_content}
             else:
                 merged.append(msg)
         new_messages = merged

--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -303,21 +303,46 @@ class ProviderAnthropic(Provider):
             else:
                 new_messages.append(message)
 
-        # --- Orphaned tool_result sanitizer ---
-        # After context truncation, tool_result blocks may reference tool_use
-        # IDs that no longer exist. The Anthropic API rejects these with 400.
-        valid_tool_use_ids: set[str] = set()
-        for msg in new_messages:
-            if msg.get("role") == "assistant" and isinstance(msg.get("content"), list):
-                for block in msg["content"]:
-                    if isinstance(block, dict) and block.get("type") == "tool_use":
-                        valid_tool_use_ids.add(block.get("id", ""))
+        return system_prompt, new_messages
 
-        sanitized: list[dict] = []
-        for msg in new_messages:
-            if msg.get("role") == "user" and isinstance(msg.get("content"), list):
+    @staticmethod
+    def _sanitize_assistant_messages(payloads: dict) -> None:
+        """Remove orphaned tool results from Anthropic messages.
+
+        Args:
+            payloads: Anthropic request payload containing a messages list.
+
+        Returns:
+            None. The messages list is updated in place on ``payloads``.
+        """
+        messages = payloads.get("messages")
+        if not isinstance(messages, list):
+            return
+
+        valid_tool_use_ids: set[str] = set()
+        for msg in messages:
+            if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                continue
+            content = msg.get("content")
+            if not isinstance(content, list):
+                continue
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    tool_use_id = block.get("id")
+                    if tool_use_id:
+                        valid_tool_use_ids.add(tool_use_id)
+
+        sanitized: list[Any] = []
+        for msg in messages:
+            if not isinstance(msg, dict):
+                sanitized.append(msg)
+                continue
+
+            content = msg.get("content")
+            if msg.get("role") == "user" and isinstance(content, list):
                 cleaned_content = [
-                    block for block in msg["content"]
+                    block
+                    for block in content
                     if not (
                         isinstance(block, dict)
                         and block.get("type") == "tool_result"
@@ -326,35 +351,44 @@ class ProviderAnthropic(Provider):
                 ]
                 if cleaned_content:
                     sanitized.append({**msg, "content": cleaned_content})
-            else:
-                sanitized.append(msg)
-        new_messages = sanitized
+                continue
 
-        # --- Merge consecutive same-role messages ---
-        # Stripping orphaned tool_results may leave adjacent messages with the
-        # same role, which violates Anthropic's strict alternation requirement.
-        merged: list[dict] = []
-        for msg in new_messages:
-            if merged and merged[-1].get("role") == msg.get("role"):
+            sanitized.append(msg)
+
+        merged: list[Any] = []
+        for msg in sanitized:
+            if not isinstance(msg, dict):
+                merged.append(msg)
+                continue
+
+            if (
+                msg.get("role")
+                and merged
+                and isinstance(merged[-1], dict)
+                and merged[-1].get("role") == msg.get("role")
+            ):
                 prev = merged[-1]
                 prev_content = prev.get("content") or []
                 if isinstance(prev_content, str):
                     prev_content = [{"type": "text", "text": prev_content}]
-                else:
+                elif isinstance(prev_content, list):
                     prev_content = list(prev_content)
+                else:
+                    prev_content = [prev_content]
 
                 cur_content = msg.get("content") or []
                 if isinstance(cur_content, str):
                     cur_content = [{"type": "text", "text": cur_content}]
-                else:
+                elif isinstance(cur_content, list):
                     cur_content = list(cur_content)
+                else:
+                    cur_content = [cur_content]
 
                 merged[-1] = {**prev, "content": prev_content + cur_content}
             else:
                 merged.append(msg)
-        new_messages = merged
 
-        return system_prompt, new_messages
+        payloads["messages"] = merged
 
     def _extract_usage(self, usage: Usage | None) -> TokenUsage:
         if usage is None:
@@ -424,6 +458,7 @@ class ProviderAnthropic(Provider):
         if "max_tokens" not in payloads:
             payloads["max_tokens"] = 65536
         self._apply_thinking_config(payloads)
+        self._sanitize_assistant_messages(payloads)
 
         try:
             completion = await retry_provider_request(
@@ -524,6 +559,7 @@ class ProviderAnthropic(Provider):
         if "max_tokens" not in payloads:
             payloads["max_tokens"] = 65536
         self._apply_thinking_config(payloads)
+        self._sanitize_assistant_messages(payloads)
 
         async with retry_provider_request_context(
             "Anthropic",

--- a/tests/test_anthropic_kimi_code_provider.py
+++ b/tests/test_anthropic_kimi_code_provider.py
@@ -533,6 +533,110 @@ def test_sanitize_assistant_messages_keeps_valid_tool_results_only():
     ]
 
 
+def test_sanitize_assistant_messages_removes_stale_duplicate_tool_result():
+    payloads = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "call_00",
+                        "name": "read_file",
+                        "input": {"path": "/tmp/one.txt"},
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_00",
+                        "content": "one",
+                    }
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Done."}],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_00",
+                        "content": "stale duplicate",
+                    }
+                ],
+            },
+        ]
+    }
+
+    anthropic_source.ProviderAnthropic._sanitize_assistant_messages(payloads)
+
+    assert payloads["messages"] == [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "call_00",
+                    "name": "read_file",
+                    "input": {"path": "/tmp/one.txt"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": "call_00", "content": "one"}
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Done."}],
+        },
+    ]
+
+
+def test_sanitize_assistant_messages_puts_tool_results_before_user_text():
+    payloads = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "call_00",
+                        "name": "read_file",
+                        "input": {"path": "/tmp/one.txt"},
+                    }
+                ],
+            },
+            {"role": "user", "content": "continue"},
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_00",
+                        "content": "one",
+                    }
+                ],
+            },
+        ]
+    }
+
+    anthropic_source.ProviderAnthropic._sanitize_assistant_messages(payloads)
+
+    assert payloads["messages"][1]["content"] == [
+        {"type": "tool_result", "tool_use_id": "call_00", "content": "one"},
+        {"type": "text", "text": "continue"},
+    ]
+
+
 # ---- tool_choice 转换测试 ----
 
 

--- a/tests/test_anthropic_kimi_code_provider.py
+++ b/tests/test_anthropic_kimi_code_provider.py
@@ -451,6 +451,88 @@ def test_prepare_payload_does_not_merge_non_consecutive_tool_results():
     ]
 
 
+def test_sanitize_assistant_messages_removes_orphaned_tool_results_and_merges():
+    payloads = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "First answer."}],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "missing_call",
+                        "content": "stale result",
+                    }
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Second answer."}],
+            },
+        ]
+    }
+
+    anthropic_source.ProviderAnthropic._sanitize_assistant_messages(payloads)
+
+    assert payloads["messages"] == [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "First answer."},
+                {"type": "text", "text": "Second answer."},
+            ],
+        }
+    ]
+
+
+def test_sanitize_assistant_messages_keeps_valid_tool_results_only():
+    payloads = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "call_00",
+                        "name": "read_file",
+                        "input": {"path": "/tmp/one.txt"},
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": "",
+                        "name": "bad_tool",
+                        "input": {},
+                    },
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call_00",
+                        "content": "one",
+                    },
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "",
+                        "content": "empty id should not be valid",
+                    },
+                ],
+            },
+        ]
+    }
+
+    anthropic_source.ProviderAnthropic._sanitize_assistant_messages(payloads)
+
+    assert payloads["messages"][1]["content"] == [
+        {"type": "tool_result", "tool_use_id": "call_00", "content": "one"}
+    ]
+
+
 # ---- tool_choice 转换测试 ----
 
 


### PR DESCRIPTION
Fixes #8951.

After context truncation, `tool_result` blocks in user messages may reference `tool_use_id`s whose corresponding `tool_use` blocks have been truncated away. The Anthropic API rejects these with HTTP 400:

> unexpected `tool_use_id` found in `tool_result` blocks

The OpenAI provider already handles this in `_sanitize_assistant_messages()`, but the Anthropic code path was missing the same safeguard.

### Modifications / 改动点

- **`astrbot/core/provider/sources/anthropic_source.py`** — added two post-processing steps at the end of `_prepare_payload()`:
  1. **Orphaned tool_result sanitizer**: collects all valid `tool_use` IDs from assistant messages, strips `tool_result` blocks referencing unknown IDs, drops user messages left empty after stripping.
  2. **Consecutive message merger**: after stripping, adjacent messages may share the same role (violating Anthropic's strict alternation). Merges them into a single message with combined content blocks.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

Before fix — agent crashes on the turn after a tool call sequence:

Error code: 400 - {'error': {'type': '<nil>', 'message': '***.content.1: unexpected `tool_use_id` found in `tool_result` blocks: 
toolu_01SZebyBwQDqXsddxtcC2twX. Each `tool_result` block must have a corresponding `tool_use` block in the previous message.'}}

After fix — orphaned tool_results are silently stripped, request succeeds. 
The sanitizer is a no-op when all tool_result/tool_use pairs are intact, so normal operation is unaffected.

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Sanitize and normalize Anthropic provider messages after context truncation to keep tool use/result pairs consistent and API-compliant.

Bug Fixes:
- Strip user tool_result blocks that reference missing tool_use IDs to prevent Anthropic 400 errors after context truncation.

Enhancements:
- Merge consecutive messages with the same role after sanitation to preserve Anthropic’s required role alternation and maintain a valid message sequence.