### PR TITLE
refactor(core): restructure initialization logic in `__init__.py` for…

### DIFF
--- a/astrbot/core/__init__.py
+++ b/astrbot/core/__init__.py
@@ -25,23 +25,76 @@ from astrbot.core.utils.t2i.renderer import HtmlRenderer
 from .log import LogBroker, LogManager  # noqa
 from .utils.astrbot_path import get_astrbot_data_path
 
-# 初始化数据存储文件夹
-os.makedirs(get_astrbot_data_path(), exist_ok=True)
-
 DEMO_MODE = os.getenv("DEMO_MODE", "False").strip().lower() in ("true", "1", "t")
 
-astrbot_config = AstrBotConfig()
-t2i_base_url = astrbot_config.get("t2i_endpoint", "https://t2i.soulter.top/text2img")
-html_renderer = HtmlRenderer(t2i_base_url)
-logger = LogManager.GetLogger(log_name="astrbot")
-LogManager.configure_logger(logger, astrbot_config)
-LogManager.configure_trace_logger(astrbot_config)
-db_helper = SQLiteDatabase(DB_PATH)
-# 简单的偏好设置存储, 这里后续应该存储到数据库中, 一些部分可以存储到配置中
-sp = SharedPreferences(db_helper=db_helper)
-# 文件令牌服务
-file_token_service = FileTokenService()
-pip_installer = PipInstaller(
-    astrbot_config.get("pip_install_arg", ""),
-    astrbot_config.get("pypi_index_url", None),
-)
+_initialized = False
+
+
+def _bootstrap():
+    """
+    internal initialization function, triggered only on first access to global instances.
+    Do not call this function directly from outside.
+    """
+    global _initialized
+    if _initialized:
+        return
+    _initialized = True
+
+    global \
+        astrbot_config, \
+        t2i_base_url, \
+        html_renderer, \
+        logger, \
+        db_helper, \
+        sp, \
+        file_token_service, \
+        pip_installer
+
+    # 初始化数据存储文件夹
+    os.makedirs(get_astrbot_data_path(), exist_ok=True)
+
+    astrbot_config = AstrBotConfig()
+    t2i_base_url = astrbot_config.get(
+        "t2i_endpoint", "https://t2i.soulter.top/text2img"
+    )
+    html_renderer = HtmlRenderer(t2i_base_url)
+    logger = LogManager.GetLogger(log_name="astrbot")
+    LogManager.configure_logger(logger, astrbot_config)
+    LogManager.configure_trace_logger(astrbot_config)
+    db_helper = SQLiteDatabase(DB_PATH)
+    # 简单的偏好设置存储, 这里后续应该存储到数据库中, 一些部分可以存储到配置中
+    sp = SharedPreferences(db_helper=db_helper)
+    # 文件令牌服务
+    file_token_service = FileTokenService()
+    pip_installer = PipInstaller(
+        astrbot_config.get("pip_install_arg", ""),
+        astrbot_config.get("pypi_index_url", None),
+    )
+
+
+# PEP 562 module-level __getattr__ and __dir__ for lazy loading of global instances
+_lazy_attrs = {
+    "astrbot_config",
+    "t2i_base_url",
+    "html_renderer",
+    "logger",
+    "db_helper",
+    "sp",
+    "file_token_service",
+    "pip_installer",
+}
+
+
+def __getattr__(name: str):
+    """lazy load global instances on first access"""
+    if name in _lazy_attrs:
+        _bootstrap()
+        return globals()[name]
+    raise AttributeError(f"module 'astrbot.core' has no attribute {name!r}")
+
+
+def __dir__():
+    """make sure dir() and IDE completion can discover lazy-loaded attributes"""
+    # auto-collect all public symbols in the module __dict__ that do not start with an underscore
+    public_api = [k for k in globals() if not k.startswith("_")]
+    return public_api + list(_lazy_attrs)

--- a/astrbot/core/__init__.py
+++ b/astrbot/core/__init__.py
@@ -1,5 +1,4 @@
 import os
-import threading
 from typing import TYPE_CHECKING
 
 from astrbot.core.config import AstrBotConfig
@@ -29,7 +28,6 @@ from .utils.astrbot_path import get_astrbot_data_path
 
 DEMO_MODE = os.getenv("DEMO_MODE", "False").strip().lower() in ("true", "1", "t")
 
-_bootstrap_lock = threading.Lock()
 _initialized = False
 
 if TYPE_CHECKING:
@@ -64,46 +62,41 @@ def _bootstrap():
     """
     global _initialized
 
-    # double-checked locking to avoid unnecessary locking after initialization is done
     if _initialized:
         return
 
-    with _bootstrap_lock:
-        if _initialized:
-            return
+    global \
+        astrbot_config, \
+        t2i_base_url, \
+        html_renderer, \
+        logger, \
+        db_helper, \
+        sp, \
+        file_token_service, \
+        pip_installer
 
-        global \
-            astrbot_config, \
-            t2i_base_url, \
-            html_renderer, \
-            logger, \
-            db_helper, \
-            sp, \
-            file_token_service, \
-            pip_installer
+    # 初始化数据存储文件夹
+    os.makedirs(get_astrbot_data_path(), exist_ok=True)
 
-        # 初始化数据存储文件夹
-        os.makedirs(get_astrbot_data_path(), exist_ok=True)
+    astrbot_config = AstrBotConfig()
+    t2i_base_url = astrbot_config.get(
+        "t2i_endpoint", "https://t2i.soulter.top/text2img"
+    )
+    html_renderer = HtmlRenderer(t2i_base_url)
+    logger = LogManager.GetLogger(log_name="astrbot")
+    LogManager.configure_logger(logger, astrbot_config)
+    LogManager.configure_trace_logger(astrbot_config)
+    db_helper = SQLiteDatabase(DB_PATH)
+    # 简单的偏好设置存储, 这里后续应该存储到数据库中, 一些部分可以存储到配置中
+    sp = SharedPreferences(db_helper=db_helper)
+    # 文件令牌服务
+    file_token_service = FileTokenService()
+    pip_installer = PipInstaller(
+        astrbot_config.get("pip_install_arg", ""),
+        astrbot_config.get("pypi_index_url", None),
+    )
 
-        astrbot_config = AstrBotConfig()
-        t2i_base_url = astrbot_config.get(
-            "t2i_endpoint", "https://t2i.soulter.top/text2img"
-        )
-        html_renderer = HtmlRenderer(t2i_base_url)
-        logger = LogManager.GetLogger(log_name="astrbot")
-        LogManager.configure_logger(logger, astrbot_config)
-        LogManager.configure_trace_logger(astrbot_config)
-        db_helper = SQLiteDatabase(DB_PATH)
-        # 简单的偏好设置存储, 这里后续应该存储到数据库中, 一些部分可以存储到配置中
-        sp = SharedPreferences(db_helper=db_helper)
-        # 文件令牌服务
-        file_token_service = FileTokenService()
-        pip_installer = PipInstaller(
-            astrbot_config.get("pip_install_arg", ""),
-            astrbot_config.get("pypi_index_url", None),
-        )
-
-        _initialized = True
+    _initialized = True
 
 
 def __getattr__(name: str):
@@ -117,6 +110,5 @@ def __getattr__(name: str):
 def __dir__():
     """make sure dir() and IDE completion can discover lazy-loaded attributes"""
     # auto-collect all public symbols in the module __dict__ that do not start with an underscore
-    with _bootstrap_lock:
-        public_api = {k for k in globals() if not k.startswith("_")}
+    public_api = {k for k in globals() if not k.startswith("_")}
     return sorted(public_api | _lazy_attrs)

--- a/astrbot/core/__init__.py
+++ b/astrbot/core/__init__.py
@@ -1,5 +1,6 @@
 import os
 import threading
+from typing import TYPE_CHECKING
 
 from astrbot.core.config import AstrBotConfig
 from astrbot.core.config.default import DB_PATH
@@ -30,6 +31,30 @@ DEMO_MODE = os.getenv("DEMO_MODE", "False").strip().lower() in ("true", "1", "t"
 
 _bootstrap_lock = threading.Lock()
 _initialized = False
+
+if TYPE_CHECKING:
+    import logging
+
+    astrbot_config: AstrBotConfig
+    t2i_base_url: str
+    html_renderer: HtmlRenderer
+    logger: logging.Logger
+    db_helper: SQLiteDatabase
+    sp: SharedPreferences
+    file_token_service: FileTokenService
+    pip_installer: PipInstaller
+
+# PEP 562 module-level __getattr__ and __dir__ for lazy loading of global instances
+_lazy_attrs = {
+    "astrbot_config",
+    "t2i_base_url",
+    "html_renderer",
+    "logger",
+    "db_helper",
+    "sp",
+    "file_token_service",
+    "pip_installer",
+}
 
 
 def _bootstrap():
@@ -79,19 +104,6 @@ def _bootstrap():
         )
 
         _initialized = True
-
-
-# PEP 562 module-level __getattr__ and __dir__ for lazy loading of global instances
-_lazy_attrs = {
-    "astrbot_config",
-    "t2i_base_url",
-    "html_renderer",
-    "logger",
-    "db_helper",
-    "sp",
-    "file_token_service",
-    "pip_installer",
-}
 
 
 def __getattr__(name: str):

--- a/astrbot/core/__init__.py
+++ b/astrbot/core/__init__.py
@@ -105,5 +105,6 @@ def __getattr__(name: str):
 def __dir__():
     """make sure dir() and IDE completion can discover lazy-loaded attributes"""
     # auto-collect all public symbols in the module __dict__ that do not start with an underscore
-    public_api = {k for k in globals() if not k.startswith("_")}
+    with _bootstrap_lock:
+        public_api = {k for k in globals() if not k.startswith("_")}
     return sorted(public_api | _lazy_attrs)

--- a/astrbot/core/__init__.py
+++ b/astrbot/core/__init__.py
@@ -1,4 +1,5 @@
 import os
+import threading
 
 from astrbot.core.config import AstrBotConfig
 from astrbot.core.config.default import DB_PATH
@@ -27,6 +28,7 @@ from .utils.astrbot_path import get_astrbot_data_path
 
 DEMO_MODE = os.getenv("DEMO_MODE", "False").strip().lower() in ("true", "1", "t")
 
+_bootstrap_lock = threading.Lock()
 _initialized = False
 
 
@@ -36,41 +38,47 @@ def _bootstrap():
     Do not call this function directly from outside.
     """
     global _initialized
+
+    # double-checked locking to avoid unnecessary locking after initialization is done
     if _initialized:
         return
 
-    global \
-        astrbot_config, \
-        t2i_base_url, \
-        html_renderer, \
-        logger, \
-        db_helper, \
-        sp, \
-        file_token_service, \
-        pip_installer
+    with _bootstrap_lock:
+        if _initialized:
+            return
 
-    # 初始化数据存储文件夹
-    os.makedirs(get_astrbot_data_path(), exist_ok=True)
+        global \
+            astrbot_config, \
+            t2i_base_url, \
+            html_renderer, \
+            logger, \
+            db_helper, \
+            sp, \
+            file_token_service, \
+            pip_installer
 
-    astrbot_config = AstrBotConfig()
-    t2i_base_url = astrbot_config.get(
-        "t2i_endpoint", "https://t2i.soulter.top/text2img"
-    )
-    html_renderer = HtmlRenderer(t2i_base_url)
-    logger = LogManager.GetLogger(log_name="astrbot")
-    LogManager.configure_logger(logger, astrbot_config)
-    LogManager.configure_trace_logger(astrbot_config)
-    db_helper = SQLiteDatabase(DB_PATH)
-    # 简单的偏好设置存储, 这里后续应该存储到数据库中, 一些部分可以存储到配置中
-    sp = SharedPreferences(db_helper=db_helper)
-    # 文件令牌服务
-    file_token_service = FileTokenService()
-    pip_installer = PipInstaller(
-        astrbot_config.get("pip_install_arg", ""),
-        astrbot_config.get("pypi_index_url", None),
-    )
+        # 初始化数据存储文件夹
+        os.makedirs(get_astrbot_data_path(), exist_ok=True)
 
-    _initialized = True
+        astrbot_config = AstrBotConfig()
+        t2i_base_url = astrbot_config.get(
+            "t2i_endpoint", "https://t2i.soulter.top/text2img"
+        )
+        html_renderer = HtmlRenderer(t2i_base_url)
+        logger = LogManager.GetLogger(log_name="astrbot")
+        LogManager.configure_logger(logger, astrbot_config)
+        LogManager.configure_trace_logger(astrbot_config)
+        db_helper = SQLiteDatabase(DB_PATH)
+        # 简单的偏好设置存储, 这里后续应该存储到数据库中, 一些部分可以存储到配置中
+        sp = SharedPreferences(db_helper=db_helper)
+        # 文件令牌服务
+        file_token_service = FileTokenService()
+        pip_installer = PipInstaller(
+            astrbot_config.get("pip_install_arg", ""),
+            astrbot_config.get("pypi_index_url", None),
+        )
+
+        _initialized = True
 
 
 # PEP 562 module-level __getattr__ and __dir__ for lazy loading of global instances

--- a/astrbot/core/__init__.py
+++ b/astrbot/core/__init__.py
@@ -38,7 +38,6 @@ def _bootstrap():
     global _initialized
     if _initialized:
         return
-    _initialized = True
 
     global \
         astrbot_config, \
@@ -71,6 +70,8 @@ def _bootstrap():
         astrbot_config.get("pypi_index_url", None),
     )
 
+    _initialized = True
+
 
 # PEP 562 module-level __getattr__ and __dir__ for lazy loading of global instances
 _lazy_attrs = {
@@ -96,5 +97,5 @@ def __getattr__(name: str):
 def __dir__():
     """make sure dir() and IDE completion can discover lazy-loaded attributes"""
     # auto-collect all public symbols in the module __dict__ that do not start with an underscore
-    public_api = [k for k in globals() if not k.startswith("_")]
-    return public_api + list(_lazy_attrs)
+    public_api = {k for k in globals() if not k.startswith("_")}
+    return sorted(public_api | _lazy_attrs)


### PR DESCRIPTION
… global instances

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
fix #8953，为core模块的__init__.py添加懒加载机制

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
对`astrbot/core/__init__.py`进行修改，副作用代码改为懒加载

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
导入core库，不在创建多余data目录

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
本地通过`make pr-test-full`测试
<img width="692" height="138" alt="image" src="https://github.com/user-attachments/assets/9f72d382-73b8-4e99-a7ae-a0c4c22bee61" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Refactor the core module’s initialization to lazily create and configure global instances only on first access, reducing side effects at import time.

Bug Fixes:
- Avoid creating the data directory and other side effects when merely importing the core module by deferring initialization until first attribute access.

Enhancements:
- Introduce an internal bootstrap routine and PEP 562-based lazy attribute access in astrbot.core to centralize and defer setup of configuration, logging, database, and related services.