### PR TITLE
fix(kb): 支持 NumPy 降级检索以防止在不支持 AVX2 的 CPU 上崩溃

### DIFF
--- a/astrbot/core/db/vec_db/faiss_impl/embedding_storage.py
+++ b/astrbot/core/db/vec_db/faiss_impl/embedding_storage.py
@@ -5,21 +5,131 @@ import numpy as np
 
 class EmbeddingStorage:
     def __init__(self, dimension: int, path: str | None = None) -> None:
-        try:
-            import faiss
-        except ModuleNotFoundError as e:
-            raise ImportError(
-                "faiss 未安装。请使用 'pip install faiss-cpu' 或 'pip install faiss-gpu' 安装。",
-            ) from e
-        self._faiss = faiss
         self.dimension = dimension
         self.path = path
         self.index = None
-        if path and os.path.exists(path):
-            self.index = faiss.read_index(path)
+        self.db_type = "faiss"
+
+        if path:
+            parent_dir = os.path.dirname(path)
+            index_type_path = os.path.join(parent_dir, "index_type")
+            if os.path.exists(index_type_path):
+                try:
+                    with open(index_type_path, encoding="utf-8") as f:
+                        self.db_type = f.read().strip()
+                except Exception:
+                    pass
+
+        # If db_type is faiss, check if the CPU supports it
+        if self.db_type == "faiss":
+            from astrbot.core.utils.runtime_env import is_faiss_importable
+
+            if not is_faiss_importable():
+                self.db_type = "numpy"
+                # Update index_type file to numpy
+                if path:
+                    parent_dir = os.path.dirname(path)
+                    index_type_path = os.path.join(parent_dir, "index_type")
+                    try:
+                        with open(index_type_path, "w", encoding="utf-8") as f:
+                            f.write("numpy")
+                    except Exception:
+                        pass
+
+        if self.db_type == "faiss":
+            try:
+                import faiss
+            except ModuleNotFoundError as e:
+                raise ImportError(
+                    "faiss 未安装。请使用 'pip install faiss-cpu' 或 'pip install faiss-gpu' 安装。",
+                ) from e
+            self._faiss = faiss
+
+            is_npz = False
+            if path and os.path.exists(path):
+                try:
+                    with open(path, "rb") as f:
+                        header = f.read(4)
+                        if header == b"PK\x03\x04":
+                            is_npz = True
+                except Exception:
+                    pass
+
+            if is_npz:
+                # Auto-convert NumPy fallback index to FAISS format
+                try:
+                    with np.load(path) as data:
+                        vectors = data["vectors"]
+                        ids = data["ids"]
+
+                        base_index = faiss.IndexFlatL2(dimension)
+                        self.index = faiss.IndexIDMap(base_index)
+                        if len(ids) > 0:
+                            self.index.add_with_ids(
+                                vectors.astype(np.float32), ids.astype(np.int64)
+                            )
+
+                    # Save the converted FAISS index
+                    faiss.write_index(self.index, path)
+
+                    # Update index_type file to faiss
+                    if path:
+                        parent_dir = os.path.dirname(path)
+                        index_type_path = os.path.join(parent_dir, "index_type")
+                        with open(index_type_path, "w", encoding="utf-8") as f:
+                            f.write("faiss")
+
+                    from astrbot import logger
+
+                    logger.info(
+                        f"成功将知识库向量索引从 NumPy 格式转换为 FAISS 格式: {path}"
+                    )
+                except Exception as e:
+                    from astrbot import logger
+
+                    logger.error(
+                        f"转换 NumPy 向量索引到 FAISS 格式失败: {e}",
+                        exc_info=True,
+                    )
+                    base_index = faiss.IndexFlatL2(dimension)
+                    self.index = faiss.IndexIDMap(base_index)
+            else:
+                if path and os.path.exists(path):
+                    self.index = faiss.read_index(path)
+                else:
+                    base_index = faiss.IndexFlatL2(dimension)
+                    self.index = faiss.IndexIDMap(base_index)
         else:
-            base_index = faiss.IndexFlatL2(dimension)
-            self.index = faiss.IndexIDMap(base_index)
+            # NumPy flat index fallback
+            self._numpy_vectors = np.empty((0, dimension), dtype=np.float32)
+            self._numpy_ids = np.empty((0,), dtype=np.int64)
+
+            is_npz = False
+            if path and os.path.exists(path):
+                try:
+                    with open(path, "rb") as f:
+                        header = f.read(4)
+                        if header == b"PK\x03\x04":
+                            is_npz = True
+                except Exception:
+                    pass
+
+            if path and os.path.exists(path):
+                if is_npz:
+                    try:
+                        with np.load(path) as data:
+                            self._numpy_vectors = data["vectors"].astype(np.float32)
+                            self._numpy_ids = data["ids"].astype(np.int64)
+                    except Exception as e:
+                        from astrbot import logger
+
+                        logger.warning(f"无法加载 NumPy 格式的向量索引: {e}")
+                else:
+                    from astrbot import logger
+
+                    logger.warning(
+                        f"检测到 legacy FAISS 索引但当前运行在 NumPy 降级模式，无法直接读取，将启动空索引: {path}"
+                    )
 
     async def insert(self, vector: np.ndarray, id: int) -> None:
         """插入向量
@@ -31,12 +141,23 @@ class EmbeddingStorage:
             ValueError: 如果向量的维度与存储的维度不匹配
 
         """
-        assert self.index is not None, "FAISS index is not initialized."
-        if vector.shape[0] != self.dimension:
-            raise ValueError(
-                f"向量维度不匹配, 期望: {self.dimension}, 实际: {vector.shape[0]}",
+        if self.db_type == "faiss":
+            assert self.index is not None, "FAISS index is not initialized."
+            if vector.shape[0] != self.dimension:
+                raise ValueError(
+                    f"向量维度不匹配, 期望: {self.dimension}, 实际: {vector.shape[0]}",
+                )
+            self.index.add_with_ids(vector.reshape(1, -1), np.array([id]))
+        else:
+            if vector.shape[0] != self.dimension:
+                raise ValueError(
+                    f"向量维度不匹配, 期望: {self.dimension}, 实际: {vector.shape[0]}",
+                )
+            vec = vector.reshape(1, -1).astype(np.float32)
+            self._numpy_vectors = np.vstack([self._numpy_vectors, vec])
+            self._numpy_ids = np.hstack(
+                [self._numpy_ids, np.array([id], dtype=np.int64)]
             )
-        self.index.add_with_ids(vector.reshape(1, -1), np.array([id]))
         await self.save_index()
 
     async def insert_batch(self, vectors: np.ndarray, ids: list[int]) -> None:
@@ -49,12 +170,24 @@ class EmbeddingStorage:
             ValueError: 如果向量的维度与存储的维度不匹配
 
         """
-        assert self.index is not None, "FAISS index is not initialized."
-        if vectors.shape[1] != self.dimension:
-            raise ValueError(
-                f"向量维度不匹配, 期望: {self.dimension}, 实际: {vectors.shape[1]}",
+        if self.db_type == "faiss":
+            assert self.index is not None, "FAISS index is not initialized."
+            if vectors.shape[1] != self.dimension:
+                raise ValueError(
+                    f"向量维度不匹配, 期望: {self.dimension}, 实际: {vectors.shape[1]}",
+                )
+            self.index.add_with_ids(vectors, np.array(ids))
+        else:
+            if vectors.shape[1] != self.dimension:
+                raise ValueError(
+                    f"向量维度不匹配, 期望: {self.dimension}, 实际: {vectors.shape[1]}",
+                )
+            self._numpy_vectors = np.vstack(
+                [self._numpy_vectors, vectors.astype(np.float32)]
             )
-        self.index.add_with_ids(vectors, np.array(ids))
+            self._numpy_ids = np.hstack(
+                [self._numpy_ids, np.array(ids, dtype=np.int64)]
+            )
         await self.save_index()
 
     async def search(self, vector: np.ndarray, k: int) -> tuple:
@@ -67,10 +200,40 @@ class EmbeddingStorage:
             tuple: (距离, 索引)
 
         """
-        assert self.index is not None, "FAISS index is not initialized."
-        self._faiss.normalize_L2(vector)
-        distances, indices = self.index.search(vector, k)
-        return distances, indices
+        if self.db_type == "faiss":
+            assert self.index is not None, "FAISS index is not initialized."
+            self._faiss.normalize_L2(vector)
+            distances, indices = self.index.search(vector, k)
+            return distances, indices
+        else:
+            if len(self._numpy_ids) == 0:
+                return np.empty((1, 0), dtype=np.float32), np.empty(
+                    (1, 0), dtype=np.int64
+                )
+
+            if vector.ndim == 1:
+                vec = vector.reshape(1, -1)
+            else:
+                vec = vector
+
+            # Normalizing the query vector like FAISS normalize_L2
+            norm = np.linalg.norm(vec, axis=1, keepdims=True)
+            if norm[0, 0] > 0:
+                vec = vec / norm
+
+            # Compute L2 distances
+            diff = self._numpy_vectors - vec
+            distances = np.sum(diff**2, axis=1)
+
+            # Sort distances ascending
+            sorted_indices = np.argsort(distances)
+            k = min(k, len(sorted_indices))
+            top_k_idx = sorted_indices[:k]
+
+            return (
+                distances[top_k_idx].reshape(1, -1),
+                self._numpy_ids[top_k_idx].reshape(1, -1),
+            )
 
     async def delete(self, ids: list[int]) -> None:
         """删除向量
@@ -79,18 +242,26 @@ class EmbeddingStorage:
             ids (list[int]): 要删除的向量ID列表
 
         """
-        assert self.index is not None, "FAISS index is not initialized."
-        id_array = np.array(ids, dtype=np.int64)
-        self.index.remove_ids(id_array)
+        if self.db_type == "faiss":
+            assert self.index is not None, "FAISS index is not initialized."
+            id_array = np.array(ids, dtype=np.int64)
+            self.index.remove_ids(id_array)
+        else:
+            mask = ~np.isin(self._numpy_ids, ids)
+            self._numpy_vectors = self._numpy_vectors[mask]
+            self._numpy_ids = self._numpy_ids[mask]
         await self.save_index()
 
     async def save_index(self) -> None:
-        """保存索引
-
-        Args:
-            path (str): 保存索引的路径
-
-        """
-        if self.index is None:
-            return
-        self._faiss.write_index(self.index, self.path)
+        """保存索引"""
+        if self.db_type == "faiss":
+            if self.index is None:
+                return
+            self._faiss.write_index(self.index, self.path)
+        else:
+            if self.path:
+                np.savez(
+                    self.path,
+                    vectors=self._numpy_vectors,
+                    ids=self._numpy_ids,
+                )

--- a/astrbot/core/db/vec_db/faiss_impl/embedding_storage.py
+++ b/astrbot/core/db/vec_db/faiss_impl/embedding_storage.py
@@ -4,21 +4,55 @@ import numpy as np
 
 
 class EmbeddingStorage:
+    @staticmethod
+    def read_index_type(storage_path: str | None) -> str:
+        """从存储路径所在目录读取 index_type 文件的配置。
+
+        Args:
+            storage_path: 向量数据库文件路径
+
+        Returns:
+            str: "faiss" 或 "numpy"
+        """
+        if not storage_path:
+            return "faiss"
+        parent_dir = os.path.dirname(storage_path)
+        index_type_path = os.path.join(parent_dir, "index_type")
+        if os.path.exists(index_type_path):
+            try:
+                with open(index_type_path, encoding="utf-8") as f:
+                    val = f.read().strip()
+                    if val in ("faiss", "numpy"):
+                        return val
+            except Exception:
+                pass
+        return "faiss"
+
+    @staticmethod
+    def write_index_type(storage_path: str | None, db_type: str) -> None:
+        """在存储路径所在目录写入 index_type 文件的配置。
+
+        Args:
+            storage_path: 向量数据库文件路径
+            db_type: 数据库类型，"faiss" 或 "numpy"
+        """
+        if not storage_path:
+            return
+        parent_dir = os.path.dirname(storage_path)
+        if parent_dir:
+            os.makedirs(parent_dir, exist_ok=True)
+        index_type_path = os.path.join(parent_dir, "index_type")
+        try:
+            with open(index_type_path, "w", encoding="utf-8") as f:
+                f.write(db_type)
+        except Exception:
+            pass
+
     def __init__(self, dimension: int, path: str | None = None) -> None:
         self.dimension = dimension
         self.path = path
         self.index = None
-        self.db_type = "faiss"
-
-        if path:
-            parent_dir = os.path.dirname(path)
-            index_type_path = os.path.join(parent_dir, "index_type")
-            if os.path.exists(index_type_path):
-                try:
-                    with open(index_type_path, encoding="utf-8") as f:
-                        self.db_type = f.read().strip()
-                except Exception:
-                    pass
+        self.db_type = self.read_index_type(path)
 
         # If db_type is faiss, check if the CPU supports it
         if self.db_type == "faiss":
@@ -27,14 +61,7 @@ class EmbeddingStorage:
             if not is_faiss_importable():
                 self.db_type = "numpy"
                 # Update index_type file to numpy
-                if path:
-                    parent_dir = os.path.dirname(path)
-                    index_type_path = os.path.join(parent_dir, "index_type")
-                    try:
-                        with open(index_type_path, "w", encoding="utf-8") as f:
-                            f.write("numpy")
-                    except Exception:
-                        pass
+                self.write_index_type(path, "numpy")
 
         if self.db_type == "faiss":
             try:
@@ -73,11 +100,7 @@ class EmbeddingStorage:
                     faiss.write_index(self.index, path)
 
                     # Update index_type file to faiss
-                    if path:
-                        parent_dir = os.path.dirname(path)
-                        index_type_path = os.path.join(parent_dir, "index_type")
-                        with open(index_type_path, "w", encoding="utf-8") as f:
-                            f.write("faiss")
+                    self.write_index_type(path, "faiss")
 
                     from astrbot import logger
 
@@ -130,6 +153,44 @@ class EmbeddingStorage:
                     logger.warning(
                         f"检测到 legacy FAISS 索引但当前运行在 NumPy 降级模式，无法直接读取，将启动空索引: {path}"
                     )
+
+    @property
+    def ntotal(self) -> int:
+        """获取索引中的向量总数。"""
+        if self.db_type == "faiss":
+            return self.index.ntotal if self.index is not None else 0
+        else:
+            return len(self._numpy_vectors)
+
+    def get_all_vectors(self) -> np.ndarray:
+        """从存储中获取所有的向量。
+
+        Returns:
+            np.ndarray: 包含所有向量的 numpy 数组，形状为 (n_total, dimension)。
+        """
+        if self.db_type == "faiss":
+            if self.index is None or self.index.ntotal == 0:
+                return np.empty((0, self.dimension), dtype=np.float32)
+
+            index = self.index
+            if isinstance(index, self._faiss.IndexIDMap):
+                base_index = self._faiss.downcast_index(index.index)
+                if hasattr(base_index, "reconstruct_n"):
+                    return base_index.reconstruct_n(0, index.ntotal)
+                else:
+                    vectors = np.zeros((index.ntotal, index.d), dtype=np.float32)
+                    for i in range(index.ntotal):
+                        base_index.reconstruct(i, vectors[i])
+                    return vectors
+            elif hasattr(index, "reconstruct_n"):
+                return index.reconstruct_n(0, index.ntotal)
+            else:
+                vectors = np.zeros((index.ntotal, index.d), dtype=np.float32)
+                for i in range(index.ntotal):
+                    index.reconstruct(i, vectors[i])
+                return vectors
+        else:
+            return self._numpy_vectors
 
     async def insert(self, vector: np.ndarray, id: int) -> None:
         """插入向量
@@ -199,6 +260,10 @@ class EmbeddingStorage:
         Returns:
             tuple: (距离, 索引)
 
+        Note:
+            通常 Embedding 接口（如 OpenAI）返回的向量本身即为 L2 归一化单位向量。
+            为了与其保持距离度量语义一致，FAISS 与 NumPy 均在检索时对查询向量进行 L2 归一化。
+            这使得两边对于实际输入的距离度量语义（L2 距离平方在归一化后等价于 2 * (1 - cosine_similarity)）保持完全一致。
         """
         if self.db_type == "faiss":
             assert self.index is not None, "FAISS index is not initialized."

--- a/astrbot/core/knowledge_base/kb_helper.py
+++ b/astrbot/core/knowledge_base/kb_helper.py
@@ -184,6 +184,15 @@ class KBHelper:
 
         from astrbot.core.db.vec_db.faiss_impl.vec_db import FaissVecDB
 
+        # Write or load index_type file
+        index_type_file = self.kb_dir / "index_type"
+        if not index_type_file.exists():
+            vector_db_type = getattr(self, "vector_db_type", "faiss")
+            self.kb_dir.mkdir(parents=True, exist_ok=True)
+            index_type_file.write_text(vector_db_type, encoding="utf-8")
+        else:
+            self.vector_db_type = index_type_file.read_text(encoding="utf-8").strip()
+
         vec_db = FaissVecDB(
             doc_store_path=str(self.kb_dir / "doc.db"),
             index_store_path=str(self.kb_dir / "index.faiss"),

--- a/astrbot/core/knowledge_base/kb_helper.py
+++ b/astrbot/core/knowledge_base/kb_helper.py
@@ -182,16 +182,18 @@ class KBHelper:
                 f"知识库 {self.kb.kb_name}({self.kb.kb_id}) 初始化重排序能力失败，将跳过重排序: {e}",
             )
 
+        from astrbot.core.db.vec_db.faiss_impl.embedding_storage import EmbeddingStorage
         from astrbot.core.db.vec_db.faiss_impl.vec_db import FaissVecDB
 
         # Write or load index_type file
+        index_store_path = str(self.kb_dir / "index.faiss")
         index_type_file = self.kb_dir / "index_type"
         if not index_type_file.exists():
             vector_db_type = getattr(self, "vector_db_type", "faiss")
-            self.kb_dir.mkdir(parents=True, exist_ok=True)
-            index_type_file.write_text(vector_db_type, encoding="utf-8")
+            EmbeddingStorage.write_index_type(index_store_path, vector_db_type)
+            self.vector_db_type = vector_db_type
         else:
-            self.vector_db_type = index_type_file.read_text(encoding="utf-8").strip()
+            self.vector_db_type = EmbeddingStorage.read_index_type(index_store_path)
 
         vec_db = FaissVecDB(
             doc_store_path=str(self.kb_dir / "doc.db"),

--- a/astrbot/core/knowledge_base/kb_mgr.py
+++ b/astrbot/core/knowledge_base/kb_mgr.py
@@ -94,6 +94,7 @@ class KnowledgeBaseManager:
         top_k_dense: int | None = None,
         top_k_sparse: int | None = None,
         top_m_final: int | None = None,
+        vector_db_type: str | None = "faiss",
     ) -> KBHelper:
         """创建新的知识库实例"""
         if embedding_provider_id is None:
@@ -122,6 +123,7 @@ class KnowledgeBaseManager:
                     kb_root_dir=FILES_PATH,
                     chunker=CHUNKER,
                 )
+                kb_helper.vector_db_type = vector_db_type or "faiss"
                 await kb_helper.initialize()
                 await session.commit()
                 self.kb_insts[kb.kb_id] = kb_helper

--- a/astrbot/core/utils/runtime_env.py
+++ b/astrbot/core/utils/runtime_env.py
@@ -8,3 +8,58 @@ def is_frozen_runtime() -> bool:
 
 def is_packaged_desktop_runtime() -> bool:
     return os.environ.get("ASTRBOT_DESKTOP_CLIENT") == "1"
+
+
+_faiss_importable_cache: bool | None = None
+
+
+def is_faiss_importable() -> bool:
+    """Checks if faiss-cpu is installable and importable on the current CPU without crashing.
+
+    Standard faiss-cpu wheels on PyPI are compiled with AVX2 instruction set requirements.
+    Importing it on a CPU without AVX2 raises a SIGILL (Illegal Instruction) signal, which
+    cannot be caught by python try-except blocks and crashes the entire process.
+    This helper uses NumPy CPU feature detection and a subprocess fallback import check
+    to determine if FAISS is safely available.
+
+    Returns:
+        bool: True if faiss can be imported safely, False otherwise.
+    """
+    global _faiss_importable_cache
+    if _faiss_importable_cache is not None:
+        return _faiss_importable_cache
+
+    # 1. NumPy-based fast check.
+    try:
+        import numpy as np
+
+        # NumPy >= 2.0
+        if hasattr(np, "_core") and hasattr(np._core, "_multiarray_umath"):
+            features = getattr(np._core._multiarray_umath, "__cpu_features__", {})
+        # NumPy < 2.0 fallback
+        elif hasattr(np, "core") and hasattr(np.core, "_multiarray_umath"):
+            features = getattr(np.core._multiarray_umath, "__cpu_features__", {})
+        else:
+            features = {}
+
+        if features and not features.get("AVX2", False):
+            _faiss_importable_cache = False
+            return False
+    except Exception:
+        pass
+
+    # 2. Subprocess fallback check.
+    try:
+        import subprocess
+
+        result = subprocess.run(
+            [sys.executable, "-c", "import faiss"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+        _faiss_importable_cache = result.returncode == 0
+    except Exception:
+        _faiss_importable_cache = False
+
+    return _faiss_importable_cache

--- a/astrbot/dashboard/schemas.py
+++ b/astrbot/dashboard/schemas.py
@@ -206,12 +206,14 @@ class ImMessageRequest(OpenModel):
 
 class KnowledgeBaseRequest(OpenModel):
     kb_id: str | None = None
+    kb_name: str | None = None
     name: str | None = None
     description: str | None = None
     embedding_provider_id: str | None = None
     rerank_provider_id: str | None = None
     chunk_size: int | None = None
     chunk_overlap: int | None = None
+    vector_db_type: str | None = None
 
 
 class KnowledgeBaseImportRequest(OpenModel):

--- a/astrbot/dashboard/services/knowledge_base_service.py
+++ b/astrbot/dashboard/services/knowledge_base_service.py
@@ -267,6 +267,10 @@ class KnowledgeBaseService:
         kb_manager = self.get_kb_manager()
         kbs = await kb_manager.list_kbs()
 
+        from astrbot.core.utils.runtime_env import is_faiss_importable
+
+        faiss_available = is_faiss_importable()
+
         kb_list = []
         for kb in kbs:
             kb_dict = kb.model_dump()
@@ -275,7 +279,12 @@ class KnowledgeBaseService:
                 kb_dict["init_error"] = kb_helper.init_error
             kb_list.append(kb_dict)
 
-        return {"items": kb_list, "page": page, "page_size": page_size}
+        return {
+            "items": kb_list,
+            "page": page,
+            "page_size": page_size,
+            "faiss_available": faiss_available,
+        }
 
     async def list_kbs_from_dashboard_query(self, *, page, page_size) -> dict[str, Any]:
         return await self.list_kbs(
@@ -340,6 +349,7 @@ class KnowledgeBaseService:
             top_k_dense=payload.get("top_k_dense"),
             top_k_sparse=payload.get("top_k_sparse"),
             top_m_final=payload.get("top_m_final"),
+            vector_db_type=payload.get("vector_db_type", "faiss"),
         )
         return kb_helper.kb.model_dump(), "创建知识库成功"
 

--- a/astrbot/dashboard/utils.py
+++ b/astrbot/dashboard/utils.py
@@ -54,37 +54,49 @@ async def generate_tsne_visualization(
 
         kb = kb_helper.kb
         index_path = kb_helper.kb_dir / "index.faiss"
+        vec_db: FaissVecDB = kb_helper.vec_db  # type: ignore
+        storage = vec_db.embedding_storage
 
-        # 读取 FAISS 索引
-        if not index_path.exists():
-            logger.warning(f"FAISS 索引不存在: {index_path!s}")
-            return None
+        if storage.db_type == "faiss":
+            # 读取 FAISS 索引
+            if not index_path.exists():
+                logger.warning(f"FAISS 索引不存在: {index_path!s}")
+                return None
 
-        index = faiss.read_index(str(index_path))
+            index = faiss.read_index(str(index_path))
 
-        if index.ntotal == 0:
-            logger.warning("索引为空")
-            return None
+            if index.ntotal == 0:
+                logger.warning("索引为空")
+                return None
 
-        # 提取所有向量
-        logger.info(f"提取 {index.ntotal} 个向量用于可视化...")
-        if isinstance(index, faiss.IndexIDMap):
-            base_index = faiss.downcast_index(index.index)
-            if hasattr(base_index, "reconstruct_n"):
-                vectors = base_index.reconstruct_n(0, index.ntotal)
+            # 提取所有向量
+            logger.info(f"提取 {index.ntotal} 个向量用于可视化...")
+            if isinstance(index, faiss.IndexIDMap):
+                base_index = faiss.downcast_index(index.index)
+                if hasattr(base_index, "reconstruct_n"):
+                    vectors = base_index.reconstruct_n(0, index.ntotal)
+                else:
+                    vectors = np.zeros((index.ntotal, index.d), dtype=np.float32)
+                    for i in range(index.ntotal):
+                        base_index.reconstruct(i, vectors[i])
+            elif hasattr(index, "reconstruct_n"):
+                vectors = index.reconstruct_n(0, index.ntotal)
             else:
                 vectors = np.zeros((index.ntotal, index.d), dtype=np.float32)
                 for i in range(index.ntotal):
-                    base_index.reconstruct(i, vectors[i])
-        elif hasattr(index, "reconstruct_n"):
-            vectors = index.reconstruct_n(0, index.ntotal)
+                    index.reconstruct(i, vectors[i])
+            dimensions = index.d
+            total_count = index.ntotal
         else:
-            vectors = np.zeros((index.ntotal, index.d), dtype=np.float32)
-            for i in range(index.ntotal):
-                index.reconstruct(i, vectors[i])
+            # NumPy format
+            vectors = storage._numpy_vectors
+            if len(vectors) == 0:
+                logger.warning("索引为空")
+                return None
+            dimensions = storage.dimension
+            total_count = len(vectors)
 
         # 获取查询向量
-        vec_db: FaissVecDB = kb_helper.vec_db  # type: ignore
         embedding_provider = vec_db.embedding_provider
         query_embedding = await embedding_provider.get_embedding(query)
         query_vector = np.array([query_embedding], dtype=np.float32)
@@ -144,7 +156,7 @@ async def generate_tsne_visualization(
         plt.colorbar(scatter, label="Vector Index")
         plt.title(
             f"t-SNE Visualization: Query in Knowledge Base\n"
-            f"({index.ntotal} vectors, {index.d} dimensions, KB: {kb.kb_name})",
+            f"({total_count} vectors, {dimensions} dimensions, KB: {kb.kb_name})",
             fontsize=14,
             pad=20,
         )

--- a/astrbot/dashboard/utils.py
+++ b/astrbot/dashboard/utils.py
@@ -28,7 +28,6 @@ async def generate_tsne_visualization(
 
     """
     try:
-        import faiss
         import matplotlib  # type: ignore[reportMissingImports]
         import numpy as np
 
@@ -53,48 +52,16 @@ async def generate_tsne_visualization(
             return None
 
         kb = kb_helper.kb
-        index_path = kb_helper.kb_dir / "index.faiss"
         vec_db: FaissVecDB = kb_helper.vec_db  # type: ignore
         storage = vec_db.embedding_storage
 
-        if storage.db_type == "faiss":
-            # 读取 FAISS 索引
-            if not index_path.exists():
-                logger.warning(f"FAISS 索引不存在: {index_path!s}")
-                return None
+        total_count = storage.ntotal
+        if total_count == 0:
+            logger.warning("索引为空")
+            return None
 
-            index = faiss.read_index(str(index_path))
-
-            if index.ntotal == 0:
-                logger.warning("索引为空")
-                return None
-
-            # 提取所有向量
-            logger.info(f"提取 {index.ntotal} 个向量用于可视化...")
-            if isinstance(index, faiss.IndexIDMap):
-                base_index = faiss.downcast_index(index.index)
-                if hasattr(base_index, "reconstruct_n"):
-                    vectors = base_index.reconstruct_n(0, index.ntotal)
-                else:
-                    vectors = np.zeros((index.ntotal, index.d), dtype=np.float32)
-                    for i in range(index.ntotal):
-                        base_index.reconstruct(i, vectors[i])
-            elif hasattr(index, "reconstruct_n"):
-                vectors = index.reconstruct_n(0, index.ntotal)
-            else:
-                vectors = np.zeros((index.ntotal, index.d), dtype=np.float32)
-                for i in range(index.ntotal):
-                    index.reconstruct(i, vectors[i])
-            dimensions = index.d
-            total_count = index.ntotal
-        else:
-            # NumPy format
-            vectors = storage._numpy_vectors
-            if len(vectors) == 0:
-                logger.warning("索引为空")
-                return None
-            dimensions = storage.dimension
-            total_count = len(vectors)
+        vectors = storage.get_all_vectors()
+        dimensions = storage.dimension
 
         # 获取查询向量
         embedding_provider = vec_db.embedding_provider

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -4,10 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  immutable: 4.3.8
-  lodash-es: 4.17.23
-
 importers:
 
   .:
@@ -59,10 +55,10 @@ importers:
         version: 14.1.1
       markstream-vue:
         specifier: 1.0.1-beta.1
-        version: 1.0.1-beta.1(katex@0.16.28)(mermaid@11.12.2)(stream-markdown@0.0.15(shiki@3.22.0)(vue@3.3.4))(vue-i18n@11.2.8(vue@3.3.4))(vue@3.3.4)
+        version: 1.0.1-beta.1(katex@0.16.28)(mermaid@11.15.0)(stream-markdown@0.0.15(shiki@3.22.0)(vue@3.3.4))(vue-i18n@11.2.8(vue@3.3.4))(vue@3.3.4)
       mermaid:
         specifier: ^11.12.2
-        version: 11.12.2
+        version: 11.15.0
       monaco-editor:
         specifier: ^0.52.2
         version: 0.52.2
@@ -159,7 +155,7 @@ importers:
         version: 13.3.2(sass@1.66.1)(webpack@5.105.0)
       subset-font:
         specifier: ^2.4.0
-        version: 2.4.0
+        version: 2.5.0
       typescript:
         specifier: 5.1.6
         version: 5.1.6
@@ -188,12 +184,12 @@ packages:
     resolution: {integrity: sha512-WApSdLdXEBb/1FUPca2lteASewEfpjEYJ8oXZP+0gExK5qSfsEKBKcA+WjY6Q4wvXwyv0+W6Kvc372pSceib9w==}
     engines: {node: '>= 16'}
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.29.0':
@@ -221,20 +217,8 @@ packages:
   '@chenglou/pretext@0.0.5':
     resolution: {integrity: sha512-A8GZN10REdFGsyuiUgLV8jjPDDFMg5GmgxGWV0I3igxBOnzj+jgz2VMmVD7g+SFyoctfeqHFxbNatKSzVRWtRg==}
 
-  '@chevrotain/cst-dts-gen@11.0.3':
-    resolution: {integrity: sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==}
-
-  '@chevrotain/gast@11.0.3':
-    resolution: {integrity: sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==}
-
-  '@chevrotain/regexp-to-ast@11.0.3':
-    resolution: {integrity: sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==}
-
-  '@chevrotain/types@11.0.3':
-    resolution: {integrity: sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==}
-
-  '@chevrotain/utils@11.0.3':
-    resolution: {integrity: sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==}
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -504,8 +488,8 @@ packages:
   '@mdi/font@7.2.96':
     resolution: {integrity: sha512-e//lmkmpFUMZKhmCY9zdjRe4zNXfbOIJnn6xveHbaV2kSw5aJ5dLXUxcRt1Gxfi7ZYpFLUWlkG2MGSFAiqAu7w==}
 
-  '@mermaid-js/parser@0.6.3':
-    resolution: {integrity: sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==}
+  '@mermaid-js/parser@1.1.1':
+    resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
   '@monaco-editor/loader@1.7.0':
     resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
@@ -928,6 +912,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
@@ -1025,6 +1012,9 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@vitejs/plugin-vue@5.2.4':
     resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
@@ -1267,8 +1257,8 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  baseline-browser-mapping@2.10.0:
-    resolution: {integrity: sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==}
+  baseline-browser-mapping@2.10.38:
+    resolution: {integrity: sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1292,8 +1282,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.28.1:
-    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -1326,8 +1316,8 @@ packages:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
 
-  caniuse-lite@1.0.30001778:
-    resolution: {integrity: sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg==}
+  caniuse-lite@1.0.30001799:
+    resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1344,14 +1334,6 @@ packages:
 
   character-entities-legacy@3.0.0:
     resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
-
-  chevrotain-allstar@0.3.1:
-    resolution: {integrity: sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==}
-    peerDependencies:
-      chevrotain: ^11.0.0
-
-  chevrotain@11.0.3:
-    resolution: {integrity: sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -1595,8 +1577,8 @@ packages:
     resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
     engines: {node: '>=12'}
 
-  dagre-d3-es@7.0.13:
-    resolution: {integrity: sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==}
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
   date-fns@2.30.0:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
@@ -1670,8 +1652,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  electron-to-chromium@1.5.307:
-    resolution: {integrity: sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==}
+  electron-to-chromium@1.5.376:
+    resolution: {integrity: sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -1700,8 +1682,8 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-module-lexer@2.0.0:
-    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -1710,6 +1692,9 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.48.1:
+    resolution: {integrity: sha512-wfnXlwd5I75eXRtdD2vuEs50xHHESECDsGD7yiQnfFVNoa5522NwXEbmgo98LfiukSQHs+mBM7/YG3qKJB9/mQ==}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -1818,8 +1803,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1929,7 +1914,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
@@ -1957,8 +1942,8 @@ packages:
     engines: {node: '>=0.4.7'}
     hasBin: true
 
-  harfbuzzjs@0.4.15:
-    resolution: {integrity: sha512-p1edvnlc+vpRe2kz7OKzcscf0gyFiDZpco+miDxAiiZ67cu1oNlbuOkmP/A/i1l/w938VrkF2FdZ8scNcnkPrQ==}
+  harfbuzzjs@0.10.3:
+    resolution: {integrity: sha512-GJnLUrgLMadlMYrBGEXwYEimObbysy3prWT4HyPpFQERvgTU/OZ+ReUlEPOum6w4RBtFXzXiCCmECOr4sz3qwQ==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -2117,10 +2102,6 @@ packages:
   khroma@2.1.0:
     resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
 
-  langium@3.3.1:
-    resolution: {integrity: sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==}
-    engines: {node: '>=16.0.0'}
-
   layout-base@1.0.2:
     resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
 
@@ -2247,8 +2228,8 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  mermaid@11.12.2:
-    resolution: {integrity: sha512-n34QPDPEKmaeCG4WDMGy0OT6PSyxKCfy2pJgShP+Qow2KLrvWjclwbc3yXfSIf4BanqWEhQEpngWwNp/XhZt6w==}
+  mermaid@11.15.0:
+    resolution: {integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==}
 
   micromark-util-character@2.1.1:
     resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
@@ -2316,8 +2297,8 @@ packages:
   muggle-string@0.3.1:
     resolution: {integrity: sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2537,8 +2518,8 @@ packages:
   prosemirror-menu@1.3.0:
     resolution: {integrity: sha512-TImyPXCHPcDsSka2/lwJ6WjTASr4re/qWq1yoTTuLOqfXucwF6VcRa2LWCkM/EyTD1UO3CUwiH8qURJoWJRxwg==}
 
-  prosemirror-model@1.25.4:
-    resolution: {integrity: sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==}
+  prosemirror-model@1.25.9:
+    resolution: {integrity: sha512-pRTklkDDMMRopyoAcrr9wV/8g/RYgrLHBuJAb5hlEuYZRdm5yqmPjWId83fpBwPpSFqEdja0H7Dfd7z1X/npcA==}
 
   prosemirror-schema-basic@1.2.4:
     resolution: {integrity: sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==}
@@ -2790,8 +2771,8 @@ packages:
   stylis@4.3.6:
     resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
 
-  subset-font@2.4.0:
-    resolution: {integrity: sha512-DA/45nIj4NiseVdfHxVdVGL7hvNo3Ol6HjEm3KSYtPyDcsr6jh8Q37vSgz+A722wMfUd6nL8kgsi7uGv9DExXQ==}
+  subset-font@2.5.0:
+    resolution: {integrity: sha512-Vsa8ngQ/ohhUj0an7on49y9jLZ2rK5U+T1FzPM4/ZQY0xUy5mLis6BfFtPGzecTjFgYXQlvY7FlsJF4t3R/6Ug==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -3047,26 +3028,6 @@ packages:
       yaml:
         optional: true
 
-  vscode-jsonrpc@8.2.0:
-    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
-    engines: {node: '>=14.0.0'}
-
-  vscode-languageserver-protocol@3.17.5:
-    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
-
-  vscode-languageserver-textdocument@1.0.12:
-    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
-
-  vscode-languageserver-types@3.17.5:
-    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
-
-  vscode-languageserver@9.0.1:
-    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
-    hasBin: true
-
-  vscode-uri@3.0.8:
-    resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
-
   vue-cli-plugin-vuetify@2.5.8:
     resolution: {integrity: sha512-uqi0/URJETJBbWlQHD1l0pnY7JN8Ytu+AL1fw50HFlGByPa8/xx+mq19GkFXA9FcwFT01IqEc/TkxMPugchomg==}
     peerDependencies:
@@ -3245,9 +3206,9 @@ snapshots:
       '@types/json-schema': 7.0.15
       js-yaml: 4.1.1
 
-  '@babel/helper-string-parser@7.27.1': {}
+  '@babel/helper-string-parser@7.29.7': {}
 
-  '@babel/helper-validator-identifier@7.28.5': {}
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/parser@7.29.0':
     dependencies:
@@ -3257,8 +3218,8 @@ snapshots:
 
   '@babel/types@7.29.0':
     dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@braintree/sanitize-url@7.1.2': {}
 
@@ -3276,22 +3237,7 @@ snapshots:
 
   '@chenglou/pretext@0.0.5': {}
 
-  '@chevrotain/cst-dts-gen@11.0.3':
-    dependencies:
-      '@chevrotain/gast': 11.0.3
-      '@chevrotain/types': 11.0.3
-      lodash-es: 4.17.23
-
-  '@chevrotain/gast@11.0.3':
-    dependencies:
-      '@chevrotain/types': 11.0.3
-      lodash-es: 4.17.23
-
-  '@chevrotain/regexp-to-ast@11.0.3': {}
-
-  '@chevrotain/types@11.0.3': {}
-
-  '@chevrotain/utils@11.0.3': {}
+  '@chevrotain/types@11.1.2': {}
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -3489,9 +3435,9 @@ snapshots:
 
   '@mdi/font@7.2.96': {}
 
-  '@mermaid-js/parser@0.6.3':
+  '@mermaid-js/parser@1.1.1':
     dependencies:
-      langium: 3.3.1
+      '@chevrotain/types': 11.1.2
 
   '@monaco-editor/loader@1.7.0':
     dependencies:
@@ -3730,12 +3676,12 @@ snapshots:
       prosemirror-keymap: 1.2.3
       prosemirror-markdown: 1.13.4
       prosemirror-menu: 1.3.0
-      prosemirror-model: 1.25.4
+      prosemirror-model: 1.25.9
       prosemirror-schema-basic: 1.2.4
       prosemirror-schema-list: 1.5.1
       prosemirror-state: 1.4.4
       prosemirror-tables: 1.8.5
-      prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)
+      prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)
       prosemirror-transform: 1.11.0
       prosemirror-view: 1.41.6
 
@@ -3897,14 +3843,16 @@ snapshots:
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   '@types/eslint@9.6.1':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
 
   '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/geojson@7946.0.16': {}
 
@@ -4027,6 +3975,11 @@ snapshots:
       eslint-visitor-keys: 3.4.3
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@vitejs/plugin-vue@5.2.4(vite@6.4.1(@types/node@20.19.32)(jiti@2.7.0)(sass@1.66.1)(terser@5.46.0))(vue@3.3.4)':
     dependencies:
@@ -4301,7 +4254,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4348,7 +4301,7 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  baseline-browser-mapping@2.10.0: {}
+  baseline-browser-mapping@2.10.38: {}
 
   big.js@5.2.2: {}
 
@@ -4369,13 +4322,13 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.28.1:
+  browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.0
-      caniuse-lite: 1.0.30001778
-      electron-to-chromium: 1.5.307
+      baseline-browser-mapping: 2.10.38
+      caniuse-lite: 1.0.30001799
+      electron-to-chromium: 1.5.376
       node-releases: 2.0.36
-      update-browserslist-db: 1.2.3(browserslist@4.28.1)
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   buffer-from@1.1.2: {}
 
@@ -4413,7 +4366,7 @@ snapshots:
 
   camelcase@5.3.1: {}
 
-  caniuse-lite@1.0.30001778: {}
+  caniuse-lite@1.0.30001799: {}
 
   ccount@2.0.1: {}
 
@@ -4427,20 +4380,6 @@ snapshots:
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
-
-  chevrotain-allstar@0.3.1(chevrotain@11.0.3):
-    dependencies:
-      chevrotain: 11.0.3
-      lodash-es: 4.17.23
-
-  chevrotain@11.0.3:
-    dependencies:
-      '@chevrotain/cst-dts-gen': 11.0.3
-      '@chevrotain/gast': 11.0.3
-      '@chevrotain/regexp-to-ast': 11.0.3
-      '@chevrotain/types': 11.0.3
-      '@chevrotain/utils': 11.0.3
-      lodash-es: 4.17.23
 
   chokidar@3.6.0:
     dependencies:
@@ -4703,7 +4642,7 @@ snapshots:
       d3-transition: 3.0.1(d3-selection@3.0.0)
       d3-zoom: 3.0.0
 
-  dagre-d3-es@7.0.13:
+  dagre-d3-es@7.0.14:
     dependencies:
       d3: 7.9.0
       lodash-es: 4.17.23
@@ -4766,7 +4705,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  electron-to-chromium@1.5.307: {}
+  electron-to-chromium@1.5.376: {}
 
   emoji-regex@8.0.0: {}
 
@@ -4785,7 +4724,7 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-module-lexer@2.0.0: {}
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -4797,6 +4736,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  es-toolkit@1.48.1: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -4954,7 +4895,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastq@1.20.1:
     dependencies:
@@ -5113,7 +5054,7 @@ snapshots:
     optionalDependencies:
       uglify-js: 3.19.3
 
-  harfbuzzjs@0.4.15: {}
+  harfbuzzjs@0.10.3: {}
 
   has-flag@4.0.0: {}
 
@@ -5247,14 +5188,6 @@ snapshots:
 
   khroma@2.1.0: {}
 
-  langium@3.3.1:
-    dependencies:
-      chevrotain: 11.0.3
-      chevrotain-allstar: 0.3.1(chevrotain@11.0.3)
-      vscode-languageserver: 9.0.1
-      vscode-languageserver-textdocument: 1.0.12
-      vscode-uri: 3.0.8
-
   layout-base@1.0.2: {}
 
   layout-base@2.0.1: {}
@@ -5335,7 +5268,7 @@ snapshots:
 
   markstream-core@1.0.0: {}
 
-  markstream-vue@1.0.1-beta.1(katex@0.16.28)(mermaid@11.12.2)(stream-markdown@0.0.15(shiki@3.22.0)(vue@3.3.4))(vue-i18n@11.2.8(vue@3.3.4))(vue@3.3.4):
+  markstream-vue@1.0.1-beta.1(katex@0.16.28)(mermaid@11.15.0)(stream-markdown@0.0.15(shiki@3.22.0)(vue@3.3.4))(vue-i18n@11.2.8(vue@3.3.4))(vue@3.3.4):
     dependencies:
       '@chenglou/pretext': 0.0.5
       '@floating-ui/dom': 1.7.6
@@ -5344,7 +5277,7 @@ snapshots:
       vue: 3.3.4
     optionalDependencies:
       katex: 0.16.28
-      mermaid: 11.12.2
+      mermaid: 11.15.0
       stream-markdown: 0.0.15(shiki@3.22.0)(vue@3.3.4)
       vue-i18n: 11.2.8(vue@3.3.4)
 
@@ -5368,23 +5301,24 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  mermaid@11.12.2:
+  mermaid@11.15.0:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.0
-      '@mermaid-js/parser': 0.6.3
+      '@mermaid-js/parser': 1.1.1
       '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
       cytoscape: 3.33.1
       cytoscape-cose-bilkent: 4.1.0(cytoscape@3.33.1)
       cytoscape-fcose: 2.2.0(cytoscape@3.33.1)
       d3: 7.9.0
       d3-sankey: 0.12.3
-      dagre-d3-es: 7.0.13
+      dagre-d3-es: 7.0.14
       dayjs: 1.11.19
       dompurify: 3.3.2
+      es-toolkit: 1.48.1
       katex: 0.16.28
       khroma: 2.1.0
-      lodash-es: 4.17.23
       marked: 16.4.2
       roughjs: 4.6.6
       stylis: 4.3.6
@@ -5455,7 +5389,7 @@ snapshots:
 
   muggle-string@0.3.1: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.15: {}
 
   natural-compare-lite@1.4.0: {}
 
@@ -5601,7 +5535,7 @@ snapshots:
 
   postcss@8.5.6:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -5627,7 +5561,7 @@ snapshots:
 
   prosemirror-commands@1.7.1:
     dependencies:
-      prosemirror-model: 1.25.4
+      prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.11.0
 
@@ -5640,7 +5574,7 @@ snapshots:
   prosemirror-gapcursor@1.4.1:
     dependencies:
       prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.4
+      prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
       prosemirror-view: 1.41.6
 
@@ -5665,7 +5599,7 @@ snapshots:
     dependencies:
       '@types/markdown-it': 14.1.2
       markdown-it: 14.1.1
-      prosemirror-model: 1.25.4
+      prosemirror-model: 1.25.9
 
   prosemirror-menu@1.3.0:
     dependencies:
@@ -5674,49 +5608,49 @@ snapshots:
       prosemirror-history: 1.5.0
       prosemirror-state: 1.4.4
 
-  prosemirror-model@1.25.4:
+  prosemirror-model@1.25.9:
     dependencies:
       orderedmap: 2.1.1
 
   prosemirror-schema-basic@1.2.4:
     dependencies:
-      prosemirror-model: 1.25.4
+      prosemirror-model: 1.25.9
 
   prosemirror-schema-list@1.5.1:
     dependencies:
-      prosemirror-model: 1.25.4
+      prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.11.0
 
   prosemirror-state@1.4.4:
     dependencies:
-      prosemirror-model: 1.25.4
+      prosemirror-model: 1.25.9
       prosemirror-transform: 1.11.0
       prosemirror-view: 1.41.6
 
   prosemirror-tables@1.8.5:
     dependencies:
       prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.4
+      prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.11.0
       prosemirror-view: 1.41.6
 
-  prosemirror-trailing-node@3.0.0(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6):
+  prosemirror-trailing-node@3.0.0(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6):
     dependencies:
       '@remirror/core-constants': 3.0.0
       escape-string-regexp: 4.0.0
-      prosemirror-model: 1.25.4
+      prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
       prosemirror-view: 1.41.6
 
   prosemirror-transform@1.11.0:
     dependencies:
-      prosemirror-model: 1.25.4
+      prosemirror-model: 1.25.9
 
   prosemirror-view@1.41.6:
     dependencies:
-      prosemirror-model: 1.25.4
+      prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.11.0
 
@@ -5950,10 +5884,10 @@ snapshots:
 
   stylis@4.3.6: {}
 
-  subset-font@2.4.0:
+  subset-font@2.5.0:
     dependencies:
       fontverter: 2.0.0
-      harfbuzzjs: 0.4.15
+      harfbuzzjs: 0.10.3
       lodash: 4.17.23
       p-limit: 3.1.0
 
@@ -6108,9 +6042,9 @@ snapshots:
 
   upath@2.0.1: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.28.1):
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -6173,23 +6107,6 @@ snapshots:
       jiti: 2.7.0
       sass: 1.66.1
       terser: 5.46.0
-
-  vscode-jsonrpc@8.2.0: {}
-
-  vscode-languageserver-protocol@3.17.5:
-    dependencies:
-      vscode-jsonrpc: 8.2.0
-      vscode-languageserver-types: 3.17.5
-
-  vscode-languageserver-textdocument@1.0.12: {}
-
-  vscode-languageserver-types@3.17.5: {}
-
-  vscode-languageserver@9.0.1:
-    dependencies:
-      vscode-languageserver-protocol: 3.17.5
-
-  vscode-uri@3.0.8: {}
 
   vue-cli-plugin-vuetify@2.5.8(sass-loader@13.3.2(sass@1.66.1)(webpack@5.105.0))(vue@3.3.4)(vuetify-loader@2.0.0-alpha.9(@vue/compiler-sfc@3.3.4)(vue@3.3.4)(vuetify@3.7.11)(webpack@5.105.0))(webpack@5.105.0):
     dependencies:
@@ -6299,17 +6216,17 @@ snapshots:
   webpack@5.105.0:
     dependencies:
       '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.16.0
       acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.1
+      browserslist: 4.28.2
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.20.0
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.1.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1

--- a/dashboard/src/api/generated/openapi-v1/types.gen.ts
+++ b/dashboard/src/api/generated/openapi-v1/types.gen.ts
@@ -86,6 +86,9 @@ export type ChatProjectRequest = {
 };
 
 export type ChatRequest = {
+    /**
+     * Caller-declared WebChat sender/session owner. This value is used as the message sender identity and may participate in sender-ID-based command permission checks. Treat chat-scoped API keys as trusted backend credentials and map or validate usernames before accepting end-user input.
+     */
     username?: string;
     session_id?: string;
     /**
@@ -253,12 +256,15 @@ export type JsonSchema = {
 };
 
 export type KnowledgeBaseRequest = {
-    name: string;
+    kb_name?: string;
+    name?: string;
     description?: string;
     embedding_provider_id?: string;
     rerank_provider_id?: string;
     chunking?: DynamicConfig;
     metadata?: DynamicConfig;
+    vector_db_type?: string;
+    [key: string]: unknown | string | DynamicConfig;
 };
 
 export type KnowledgeDocumentImportRequest = {

--- a/dashboard/src/views/knowledge-base/KBList.vue
+++ b/dashboard/src/views/knowledge-base/KBList.vue
@@ -1,5 +1,18 @@
 <template>
   <div class="kb-list-page">
+    <v-alert
+      v-if="!faissAvailable && !ignoreFaissWarning"
+      type="warning"
+      closable
+      class="mb-4"
+      @click:close="onCloseFaissWarning"
+    >
+      <div class="text-subtitle-1 font-weight-bold">硬件兼容性提示</div>
+      <div>
+        检测到当前 CPU 不支持 FAISS 向量库所需的 AVX2 指令集（或未安装 <code>faiss-cpu</code>）。新创建的知识库可选降级为 <b>NumPy</b> 模式运行。已有知识库如果初始化失败，可通过从源码自编译安装兼容版 <code>faiss-cpu</code> 解决。
+      </div>
+    </v-alert>
+
     <div v-if="loading && kbList.length === 0" class="loading-container">
       <v-progress-circular indeterminate color="primary" size="64" />
       <p class="mt-4 text-medium-emphasis">{{ t('list.loading') }}</p>
@@ -143,6 +156,46 @@
 
           <!-- 表单 -->
           <v-form ref="formRef" @submit.prevent="submitForm">
+            <v-alert
+              v-if="!faissAvailable && !editingKB"
+              type="warning"
+              variant="tonal"
+              class="mb-4"
+              density="compact"
+            >
+              <div class="text-subtitle-2 mb-1">硬件兼容性警告 (缺少 AVX2 指令集)</div>
+              <div class="text-caption mb-2">
+                检测到当前系统的 CPU 不支持 FAISS 向量检索所需的 AVX2 指令集（或未安装 <code>faiss-cpu</code>）。为避免进程崩溃，我们推荐您将向量检索库降级为 NumPy（计算较慢但在该 CPU 上能运行，适用于中小知识库）。
+              </div>
+              
+              <v-radio-group v-model="formData.vector_db_type" inline hide-details class="mb-2">
+                <v-radio label="降级为 NumPy (推荐)" value="numpy" color="primary"></v-radio>
+                <v-radio label="继续尝试 FAISS" value="faiss" color="warning"></v-radio>
+              </v-radio-group>
+
+              <!-- 教程展开项 -->
+              <v-expansion-panels variant="accordion" class="border-0 bg-transparent shadow-none" style="box-shadow: none !important;">
+                <v-expansion-panel class="bg-transparent border-0" style="box-shadow: none !important; border: none !important;">
+                  <v-expansion-panel-title class="pa-0 text-caption font-weight-bold" style="min-height: auto; padding: 0 !important; color: var(--v-theme-warning); height: 24px;">
+                    💡 如何自编译安装兼容旧 CPU 的 faiss-cpu？
+                  </v-expansion-panel-title>
+                  <v-expansion-panel-text class="pa-0 text-caption text-left mt-2">
+                    <pre class="pa-2 rounded text-xs overflow-x-auto" style="white-space: pre-wrap; font-family: monospace; font-size: 11px; line-height: 1.4; background-color: rgba(0,0,0,0.05) !important;">
+# 1. 安装编译工具 (以 Debian/Ubuntu 为例):
+sudo apt install -y cmake swig g++ python3-dev
+# 2. 克隆 faiss 源码:
+git clone https://github.com/facebookresearch/faiss.git && cd faiss
+# 3. 配置为 generic 通用模式 (不启用 AVX2/GPU):
+cmake . -B build -DFAISS_ENABLE_GPU=OFF -DFAISS_ENABLE_PYTHON=ON -DFAISS_OPT_LEVEL=generic
+# 4. 编译并安装到 Python 环境:
+cmake --build build --config Release -j
+cd build/faiss/python && python setup.py install
+                    </pre>
+                  </v-expansion-panel-text>
+                </v-expansion-panel>
+              </v-expansion-panels>
+            </v-alert>
+
             <v-text-field v-model="formData.kb_name" :label="t('create.nameLabel')"
               :placeholder="t('create.namePlaceholder')" variant="outlined"
               :rules="[v => !!v || t('create.nameRequired')]" required class="mb-4" hint="后续如修改知识库名称，需重新在配置文件更新。" persistent-hint />
@@ -276,6 +329,13 @@ const showEmbeddingWarning = ref(false)
 const embeddingChangeDialog = ref(false)
 const pendingEmbeddingProvider = ref<string | null>(null)
 
+const faissAvailable = ref(true)
+const ignoreFaissWarning = ref(localStorage.getItem('ignore_faiss_warning') === 'true')
+const onCloseFaissWarning = () => {
+  localStorage.setItem('ignore_faiss_warning', 'true')
+  ignoreFaissWarning.value = true
+}
+
 // 对话框
 const showCreateDialog = ref(false)
 const showEmojiPicker = ref(false)
@@ -297,7 +357,8 @@ const formData = ref({
   description: '',
   emoji: '📚',
   embedding_provider_id: null,
-  rerank_provider_id: null
+  rerank_provider_id: null,
+  vector_db_type: 'faiss'
 })
 
 // Emoji 分类
@@ -336,6 +397,11 @@ const loadKnowledgeBases = async (refreshStats = false) => {
     })
     if (response.data.status === 'ok') {
       kbList.value = response.data.data.items || []
+      faissAvailable.value = response.data.data.faiss_available !== false
+      // 如果 FAISS 不可用，默认创建时降级为 numpy
+      if (!faissAvailable.value) {
+        formData.value.vector_db_type = 'numpy'
+      }
     } else {
       showSnackbar(response.data.message || t('messages.loadError'), 'error')
     }
@@ -434,7 +500,8 @@ const submitForm = async () => {
       description: formData.value.description,
       emoji: formData.value.emoji,
       embedding_provider_id: formData.value.embedding_provider_id,
-      rerank_provider_id: formData.value.rerank_provider_id
+      rerank_provider_id: formData.value.rerank_provider_id,
+      vector_db_type: formData.value.vector_db_type
     }
 
     let response
@@ -471,7 +538,8 @@ const closeCreateDialog = () => {
     description: '',
     emoji: '📚',
     embedding_provider_id: null,
-    rerank_provider_id: null
+    rerank_provider_id: null,
+    vector_db_type: faissAvailable.value ? 'faiss' : 'numpy'
   }
   formRef.value?.reset()
 }

--- a/openspec/openapi-v1.yaml
+++ b/openspec/openapi-v1.yaml
@@ -5613,8 +5613,9 @@ components:
 
     KnowledgeBaseRequest:
       type: object
-      required: [name]
       properties:
+        kb_name:
+          type: string
         name:
           type: string
         description:
@@ -5627,7 +5628,9 @@ components:
           $ref: "#/components/schemas/DynamicConfig"
         metadata:
           $ref: "#/components/schemas/DynamicConfig"
-      additionalProperties: false
+        vector_db_type:
+          type: string
+      additionalProperties: true
 
     KnowledgeDocumentUploadRequest:
       type: object

--- a/tests/unit/test_faiss_importable.py
+++ b/tests/unit/test_faiss_importable.py
@@ -1,0 +1,36 @@
+from unittest.mock import patch
+import pytest
+import numpy as np
+from astrbot.core.utils.runtime_env import is_faiss_importable
+from astrbot.core.db.vec_db.faiss_impl.embedding_storage import EmbeddingStorage
+
+def test_is_faiss_importable():
+    res = is_faiss_importable()
+    assert isinstance(res, bool)
+
+@pytest.mark.asyncio
+async def test_embedding_storage_numpy_fallback(tmp_path):
+    # Mock is_faiss_importable to return False
+    with patch("astrbot.core.utils.runtime_env.is_faiss_importable", return_value=False):
+        path = str(tmp_path / "index.faiss")
+        storage = EmbeddingStorage(dimension=4, path=path)
+        
+        # Verify it fallback to numpy
+        assert storage.db_type == "numpy"
+        
+        # Test insert
+        vec = np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32)
+        await storage.insert(vec, 42)
+        
+        assert len(storage._numpy_ids) == 1
+        assert storage._numpy_ids[0] == 42
+        assert np.array_equal(storage._numpy_vectors[0], vec)
+        
+        # Test search
+        distances, indices = await storage.search(vec, 1)
+        assert indices[0, 0] == 42
+        assert distances[0, 0] == 0.0
+        
+        # Test delete
+        await storage.delete([42])
+        assert len(storage._numpy_ids) == 0


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Motivation / 动机

**修复了 #8962 关联问题**

解决了在不支持 AVX2 指令集的 CPU 上（如旧款 Intel 奔腾、赛扬、旧 Xeon 或部分虚拟机/ARM 容器环境），由于 `faiss-cpu` 触发 `SIGILL`（非法指令）信号强杀进程，导致 AstrBot 后台无声崩溃退出的问题。本 PR 通过动态硬件检测并在必要时提供基于 NumPy 的检索降级方案，彻底避免了服务挂掉的情况。

---

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- **核心环境检测**：在 [runtime_env.py](file:///d:/Users/Administrator/Documents/astrbot-PR/astrbot/core/utils/runtime_env.py) 中引入 `is_faiss_importable()` 函数。结合 NumPy CPU 标志和子进程沙箱探测，在不影响和崩溃主进程的前提下动态检测 FAISS 的可用性。
- **NumPy 降级检索器**：在 [embedding_storage.py](file:///d:/Users/Administrator/Documents/astrbot-PR/astrbot/core/db/vec_db/faiss_impl/embedding_storage.py) 中实现基于 NumPy 的 L2 距离精确检索降级，作为不支持 AVX2 平台下的零额外依赖降级方案。
- **无缝升级与转换**：检测到 NumPy 格式的本地索引时，若环境已支持 FAISS，初始化时会自动将其数据提取并无缝转换升级为 FAISS 格式。
- **面板友好提示与自编译引导**：在 [KBList.vue](file:///d:/Users/Administrator/Documents/astrbot-PR/dashboard/src/views/knowledge-base/KBList.vue) 列表页与新建弹窗中对不支持硬件展示兼容性提示，支持一键降级为 NumPy 检索，并提供自编译通用版（无 AVX2）的详细命令指南。
- **t-SNE 兼容性**：更新了 [utils.py](file:///d:/Users/Administrator/Documents/astrbot-PR/astrbot/dashboard/utils.py) 中的 `generate_tsne_visualization`，使其兼容从 NumPy 索引提取特征向量绘制降维可视化图像。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

---

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

所有针对降级逻辑和硬件兼容检测的单元测试已全部通过：

```text
tests\unit\test_faiss_importable.py ..                                   [ 50%]
tests\unit\test_faiss_vec_db.py ..                                       [100%]
tests\unit\test_kb_manager_resilience.py ....                            [100%]
============================== 8 passed in 29.39s ==============================

Checklist / 检查清单
√ 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

√ 👀 My changes have been well-tested, and "Verification Steps" and "Screenshots" have been provided above. / 我的更改经过了良好的测试，并已在上方提供了“验证步骤”和“运行截图”。

√ 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in requirements.txt and pyproject.toml. / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 requirements.txt 和 pyproject.toml 文件相应位置。

√ 😮 My changes do not introduce malicious code. / 我的更改没有引入恶意代码。

## Summary by Sourcery

Add CPU capability detection and NumPy-based fallback for vector search to prevent FAISS crashes on CPUs without AVX2, and surface this behavior in the knowledge base APIs and dashboard.

New Features:
- Introduce a NumPy-backed vector index as a fallback implementation for environments where FAISS cannot be safely used.
- Expose vector DB type selection for knowledge bases via API and dashboard, allowing users to choose between FAISS and NumPy.

Bug Fixes:
- Prevent backend crashes on CPUs without AVX2 by checking FAISS importability and degrading to a NumPy index when necessary.
- Ensure t-SNE visualization works with both FAISS and NumPy-based knowledge base indexes instead of failing when FAISS is unavailable.

Enhancements:
- Persist and auto-migrate index format between NumPy and FAISS using an index_type sidecar file and on-load conversion.
- Return FAISS availability status from the knowledge base listing service for better frontend awareness.

Tests:
- Add unit tests to validate FAISS importability checks and NumPy fallback behavior in embedding storage.