### PR TITLE
fix: prevent path traversal vulnerability in plugin upload filenames

### DIFF
--- a/astrbot/dashboard/services/plugin_service.py
+++ b/astrbot/dashboard/services/plugin_service.py
@@ -872,9 +872,10 @@ class PluginService:
     ) -> tuple[dict, str]:
         self._ensure_not_demo()
         logger.info(f"正在安装用户上传的插件 {upload_file.filename}")
+        filename = str(upload_file.filename or "plugin.zip").replace("\\", "/")
         file_path = os.path.join(
             get_astrbot_temp_path(),
-            f"plugin_upload_{upload_file.filename}",
+            f"plugin_upload_{os.path.basename(filename) or 'plugin.zip'}",
         )
         await upload_file.save(file_path)
         try:


### PR DESCRIPTION
This PR fixes a path traversal vulnerability caused by using an unvalidated, user-controlled multipart filename when constructing a filesystem path.

## What Problem This Solves

`install_plugin_upload()` has a path traversal / directory traversal vulnerability (CWE-22: Improper Limitation of a Pathname to a Restricted Directory / CWE-73: External Control of File Name or Path). The issue is caused by the backend directly using an unvalidated, user-controlled upload filename to construct a temporary filesystem path, allowing crafted path separators to influence filesystem path resolution.

`install_plugin_upload()` saves a user-uploaded plugin archive to AstrBot's temporary directory before passing it to the plugin installer.

The current path was built with the raw multipart filename:

```py
f"plugin_upload_{upload_file.filename}"
```

Multipart filenames are client-controlled. A crafted filename can contain path separators such as `../` or Windows-style `..\`. If that value is used directly while building a filesystem path, the filesystem path parser can resolve the resulting save target outside the intended temporary directory.

Even though the upload endpoint requires Dashboard access, the server should still treat multipart filenames as untrusted input before using them in filesystem paths.

The same codebase already applies this defensive pattern in other upload flows, for example skill uploads normalize the uploaded filename with `os.path.basename(...)` before saving it.

## Change

Normalize the uploaded plugin filename before constructing the temporary file path:

- convert Windows path separators to forward slashes
- keep only the basename
- fall back to `plugin.zip` when the filename is empty

This keeps the plugin upload flow unchanged while preventing crafted filename path segments from affecting the destination path.

## Evidence

![image.png](https://img.vectorpeak.cn/obsidian/2026/05-06/20260623183054746.png?imageSlim)

A crafted multipart filename can demonstrate the issue without requiring special zip contents:

```text
../../../evil.zip
..\..\..\evil.zip
```

Before this fix, a path like this could be constructed:

```text
C:\Temp\astrbot-temp\plugin_upload_../../../evil.zip
```

which can resolve outside the intended temporary directory. After this fix, both payloads are reduced to the basename and saved as:

```text
plugin_upload_evil.zip
```

inside the configured AstrBot temp directory.

## Possible call chain / impact

The affected path is the Dashboard plugin upload flow:

```text
astrbot/dashboard/api/plugins.py
  -> install_plugin_from_upload(...)
    -> _install_plugin_upload(...)
      -> PluginService.install_plugin_upload_from_dashboard_form(...)
        -> PluginService.install_plugin_upload(...)
          -> upload_file.save(file_path)
          -> plugin_manager.install_plugin_from_file(file_path)
```

This PR only changes the temporary filename used for uploaded plugin archives. It does not change plugin archive parsing, plugin version checks, plugin installation behavior, or Dashboard authentication.

## Testing

- `uvx ruff format --check astrbot/dashboard/services/plugin_service.py`
- `uvx ruff check astrbot/dashboard/services/plugin_service.py`
- `uv run python -m py_compile astrbot/dashboard/services/plugin_service.py`

## Summary by Sourcery

Bug Fixes:
- Prevent path traversal vulnerability in plugin uploads by normalizing the multipart filename and restricting it to a safe basename before saving the archive.