### PR TITLE
fix: prevent path traversal vulnerability in knowledge base upload filenames

### DIFF
--- a/astrbot/dashboard/services/knowledge_base_service.py
+++ b/astrbot/dashboard/services/knowledge_base_service.py
@@ -495,7 +495,9 @@ class KnowledgeBaseService:
 
         files_to_upload = []
         for file in file_list:
-            file_name = file.filename
+            file_name = Path(str(file.filename or "document").replace("\\", "/")).name
+            if file_name in {"", ".", ".."}:
+                file_name = "document"
             temp_file_path = (
                 Path(get_astrbot_temp_path()) / f"kb_upload_{uuid.uuid4()}_{file_name}"
             )


### PR DESCRIPTION
This PR fixes a path traversal vulnerability caused by using an unvalidated, user-controlled multipart filename when constructing a temporary knowledge base upload path.

## What Problem This Solves

After checking the codebase again with Codex, I found a similar vulnerability in another upload path, so I am submitting this fix as well.

`upload_document()` has a path traversal / directory traversal vulnerability (CWE-22: Improper Limitation of a Pathname to a Restricted Directory / CWE-73: External Control of File Name or Path). The issue is caused by the backend directly using an unvalidated, user-controlled upload filename to construct a temporary filesystem path, allowing crafted path separators to influence filesystem path resolution.

The vulnerable path was built with the raw multipart filename:

```py
Path(get_astrbot_temp_path()) / f"kb_upload_{uuid.uuid4()}_{file_name}"
```

where `file_name` came directly from `file.filename`.

Multipart filenames are client-controlled. A crafted filename can contain path separators such as `../` or Windows-style `..\`. If that value is used directly while building a filesystem path, the filesystem path parser can resolve the temporary upload target outside the intended AstrBot temp directory.

## Change

Normalize the uploaded knowledge base document filename before constructing the temporary file path:

- convert Windows path separators to forward slashes
- keep only the basename
- fall back to `document` when the filename is missing, empty, or resolves to a special basename such as `.` or `..`

This keeps the knowledge base upload flow unchanged while preventing crafted filename path segments from affecting the destination path.

## Evidence

A crafted multipart filename can demonstrate the issue:

```text
../../../evil.txt
..\..\..\evil.txt
```

Before this fix, a path like this could be constructed:

```text
C:\Temp\astrbot-temp\kb_upload_<uuid>_../../../evil.txt
```

which can resolve outside the intended temporary directory. After this fix, both payloads are reduced to the basename and saved as:

```text
kb_upload_<uuid>_evil.txt
```

inside the configured AstrBot temp directory.

Special path-only basenames such as `.`, `..`, `/`, and `../../` now fall back to:

```text
kb_upload_<uuid>_document
```

<table>
  <tr>
    <td><img src="https://img.vectorpeak.cn/obsidian/2026/05-06/20260623234228206.png?imageSlim" /></td>
    <td><img src="https://img.vectorpeak.cn/obsidian/2026/05-06/20260623234145480.png?imageSlim" /></td>
  </tr>
  <tr>
    <td><img src="https://img.vectorpeak.cn/obsidian/2026/05-06/20260623234309410.png?imageSlim" /></td>
    <td><img src="https://img.vectorpeak.cn/obsidian/2026/05-06/20260623234352853.png?imageSlim" /></td>
  </tr>
</table>

## Possible call chain / impact

The affected path is the Dashboard knowledge base document upload flow:

```text
astrbot/dashboard/api/knowledge_bases.py
  -> upload_knowledge_base_document(...)
    -> KnowledgeBaseService.upload_document(...)
      -> file.save(temp_file_path)
      -> aiofiles.open(temp_file_path, "rb")
```

This PR only changes the temporary filename used for uploaded knowledge base documents. It does not change document parsing, embedding, indexing, knowledge base permissions, or successful upload behavior.

## Testing

- `uvx ruff format --check astrbot/dashboard/services/knowledge_base_service.py`
- `uvx ruff check astrbot/dashboard/services/knowledge_base_service.py`
- `uv run python -m py_compile astrbot/dashboard/services/knowledge_base_service.py`
- Local console path-resolution reproduction for `../../../evil.txt`, `..\..\..\evil.txt`, `.`, `..`, `/`, and `../../`

## Summary by Sourcery

Bug Fixes:
- Normalize uploaded document filenames to prevent crafted path segments from escaping the AstrBot temporary directory.