### PR TITLE
fix: reject Python MCP stdio script archives

### DIFF
--- a/astrbot/core/agent/mcp_client.py
+++ b/astrbot/core/agent/mcp_client.py
@@ -81,7 +81,17 @@ _DENIED_STDIO_COMMANDS = frozenset(
     }
 )
 _SHELL_META_RE = re.compile(r"[\r\n\x00;&|<>`$]")
+_PYTHON_MODULE_REQUIRED_MSG = (
+    "MCP stdio Python servers must be launched from a module or package; "
+    "local Python script/archive paths are not allowed."
+)
+_PYTHON_INLINE_CODE_DENIED_MSG = (
+    "MCP stdio Python servers must be launched from a module or package; "
+    "inline code flags such as -c are not allowed."
+)
 _PYTHON_INLINE_CODE_FLAGS = frozenset({"-c"})
+_PYTHON_OPTIONS_WITH_VALUE = frozenset({"-W", "-X", "--check-hash-based-pycs"})
+_PYTHON_OPTION_PREFIXES_WITH_VALUE = ("-W", "-X", "--check-hash-based-pycs=")
 _JS_INLINE_CODE_FLAGS = frozenset({"-e", "--eval", "-p", "--print"})
 _DENIED_DOCKER_ARGS = frozenset(
     {
@@ -145,6 +155,50 @@ def _normalize_stdio_command_name(command: str) -> str:
     return command_name
 
 
+def _is_python_option_with_inline_value(arg: str) -> bool:
+    return any(
+        arg.startswith(prefix) and arg != prefix
+        for prefix in _PYTHON_OPTION_PREFIXES_WITH_VALUE
+    )
+
+
+def _ensure_valid_python_module(module_name: str | None) -> None:
+    if not module_name or module_name.startswith("-"):
+        raise ValueError(_PYTHON_MODULE_REQUIRED_MSG)
+
+
+def _validate_python_stdio_args(args: list[str]) -> None:
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--":
+            index += 1
+            break
+        if arg in _PYTHON_OPTIONS_WITH_VALUE:
+            index += 2
+            continue
+        if _is_python_option_with_inline_value(arg):
+            index += 1
+            continue
+        if arg == "-m":
+            module_name = args[index + 1] if index + 1 < len(args) else None
+            _ensure_valid_python_module(module_name)
+            return
+        if arg.startswith("-m") and not arg.startswith("--"):
+            _ensure_valid_python_module(arg[2:])
+            return
+        if arg in _PYTHON_INLINE_CODE_FLAGS or (
+            arg.startswith("-") and not arg.startswith("--") and "c" in arg
+        ):
+            raise ValueError(_PYTHON_INLINE_CODE_DENIED_MSG)
+        if arg.startswith("-"):
+            index += 1
+            continue
+        break
+
+    raise ValueError(_PYTHON_MODULE_REQUIRED_MSG)
+
+
 def _get_stdio_command_allowlist() -> set[str]:
     allowed = set(_DEFAULT_STDIO_COMMAND_ALLOWLIST)
     configured = os.environ.get(_STDIO_ALLOWLIST_ENV, "")
@@ -163,7 +217,10 @@ def _is_stdio_config(config: dict) -> bool:
 
 
 def _validate_stdio_args(command_name: str, args: object) -> None:
+    is_python_command = command_name.startswith("python") or command_name == "py"
     if args is None:
+        if is_python_command:
+            raise ValueError(_PYTHON_MODULE_REQUIRED_MSG)
         return
     if not isinstance(args, list) or not all(isinstance(arg, str) for arg in args):
         raise ValueError("MCP stdio args must be a list of strings.")
@@ -172,15 +229,8 @@ def _validate_stdio_args(command_name: str, args: object) -> None:
         if "\x00" in arg or "\r" in arg or "\n" in arg:
             raise ValueError("MCP stdio args cannot contain control characters.")
 
-    if command_name.startswith("python") or command_name == "py":
-        if any(
-            arg == "-c"
-            or (arg.startswith("-") and not arg.startswith("--") and "c" in arg)
-            for arg in args
-        ):
-            raise ValueError(
-                "MCP stdio Python servers must be launched from a module or file; inline code flags such as -c are not allowed."
-            )
+    if is_python_command:
+        _validate_python_stdio_args(args)
     elif command_name in {"node", "deno", "bun"} or command_name.startswith("node"):
         if any(
             arg in _JS_INLINE_CODE_FLAGS

--- a/astrbot/core/computer/computer_client.py
+++ b/astrbot/core/computer/computer_client.py
@@ -504,10 +504,10 @@ async def _sync_skills_to_sandbox(booter: ComputerBooter) -> None:
             for skill_name, skill_dir in sync_skill_dirs:
                 shutil.copytree(skill_dir, bundle_root / skill_name)
             shutil.make_archive(str(zip_base), "zip", str(bundle_root))
-            remote_zip = Path(SANDBOX_SKILLS_ROOT) / "skills.zip"
+            remote_zip = f"{SANDBOX_SKILLS_ROOT}/skills.zip"
             logger.info("Uploading skills bundle to sandbox...")
             await booter.shell.exec(f"mkdir -p {SANDBOX_SKILLS_ROOT}")
-            upload_result = await booter.upload_file(str(zip_path), str(remote_zip))
+            upload_result = await booter.upload_file(str(zip_path), remote_zip)
             if not upload_result.get("success", False):
                 raise RuntimeError("Failed to upload skills bundle to sandbox.")
         else:

--- a/astrbot/dashboard/services/tools_service.py
+++ b/astrbot/dashboard/services/tools_service.py
@@ -165,7 +165,8 @@ class ToolsService:
                 old_config,
                 active,
             )
-            self._validate_server_config(server_config)
+            if active or not only_update_active:
+                self._validate_server_config(server_config)
 
             if is_rename:
                 config["mcpServers"].pop(old_name)

--- a/tests/unit/test_mcp_client_schema.py
+++ b/tests/unit/test_mcp_client_schema.py
@@ -1,7 +1,13 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from astrbot.core.agent.mcp_client import MCPTool, _normalize_mcp_input_schema
+import pytest
+
+from astrbot.core.agent.mcp_client import (
+    MCPTool,
+    _normalize_mcp_input_schema,
+    validate_mcp_stdio_config,
+)
 
 
 class TestNormalizeMcpInputSchema:
@@ -115,3 +121,92 @@ class TestMCPToolSchemaNormalization:
         assert tool.parameters["required"] == ["stock_code"]
         assert "required" not in tool.parameters["properties"]["stock_code"]
         assert "required" not in tool.parameters["properties"]["market"]
+
+
+class TestValidateMcpStdioConfig:
+    @pytest.mark.parametrize("suffix", [".py", ".pyw", ".pyc", ".pyo", ".pyz"])
+    def test_rejects_python_local_script_targets(self, suffix: str) -> None:
+        config = {"command": "python", "args": [f"./payload{suffix}"]}
+
+        with pytest.raises(ValueError, match="local Python script/archive"):
+            validate_mcp_stdio_config(config)
+
+    def test_rejects_windows_python_archive_target_case_insensitively(self) -> None:
+        config = {
+            "command": "python3",
+            "args": ["-I", "-u", "C:\\Users\\Public\\payload.PYZ"],
+        }
+
+        with pytest.raises(ValueError, match="local Python script/archive"):
+            validate_mcp_stdio_config(config)
+
+    def test_rejects_python_script_target_after_option_separator(self) -> None:
+        config = {"command": "python", "args": ["--", "payload.py"]}
+
+        with pytest.raises(ValueError, match="local Python script/archive"):
+            validate_mcp_stdio_config(config)
+
+    def test_rejects_python_local_target_without_known_suffix(self) -> None:
+        config = {"command": "python", "args": ["./payload"]}
+
+        with pytest.raises(ValueError, match="local Python script/archive"):
+            validate_mcp_stdio_config(config)
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            {"command": "python", "args": ["-m", "mcp_server"]},
+            {"command": "python3", "args": ["-I", "-m", "package.module"]},
+            {"command": "python3", "args": ["-mmcp_server"]},
+            {"command": "py", "args": ["-3.12", "-m", "mcp_server"]},
+            {
+                "command": "python",
+                "args": ["-m", "mcp_server", "--config", "server.py"],
+            },
+            {
+                "mcpServers": {
+                    "demo": {"command": "python", "args": ["-m", "mcp_server"]}
+                }
+            },
+        ],
+    )
+    def test_allows_python_module_launches(self, config: dict) -> None:
+        validate_mcp_stdio_config(config)
+
+    def test_rejects_python_inline_code_flags(self) -> None:
+        config = {"command": "python", "args": ["-c", "print('x')"]}
+
+        with pytest.raises(ValueError, match="inline code flags"):
+            validate_mcp_stdio_config(config)
+
+    def test_rejects_python_compact_inline_code_flags(self) -> None:
+        config = {"command": "python", "args": ["-Ic", "print('x')"]}
+
+        with pytest.raises(ValueError, match="inline code flags"):
+            validate_mcp_stdio_config(config)
+
+    def test_rejects_python_missing_module_name(self) -> None:
+        config = {"command": "python", "args": ["-m"]}
+
+        with pytest.raises(ValueError, match="module or package"):
+            validate_mcp_stdio_config(config)
+
+    def test_rejects_python_option_only_launch(self) -> None:
+        config = {"command": "python", "args": ["-I", "-u"]}
+
+        with pytest.raises(ValueError, match="module or package"):
+            validate_mcp_stdio_config(config)
+
+    def test_rejects_python_launch_without_args(self) -> None:
+        config = {"command": "python"}
+
+        with pytest.raises(ValueError, match="module or package"):
+            validate_mcp_stdio_config(config)
+
+    def test_allows_module_owned_dash_c_argument(self) -> None:
+        config = {
+            "command": "python",
+            "args": ["-m", "mcp_server", "-c", "config.toml"],
+        }
+
+        validate_mcp_stdio_config(config)


### PR DESCRIPTION
Fixes #8860

### Modifications / 改动点

- Reject Python MCP stdio configs that execute local Python script/archive targets instead of module/package launch patterns.
- Preserve module-based MCP server launches such as `python -m mcp_server`, including module-owned argv values after `-m`.
- Avoid validating disabled MCP server config when only toggling it off, while still validating active configs and config edits.
- Keep sandbox upload paths POSIX-style so the recommended PR validation script passes on Windows.
- Add unit tests for rejected Python script/archive targets, inline code flags, missing module launches, and allowed module launch patterns.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```bash
uv run pytest tests/unit/test_mcp_client_schema.py tests/test_computer_skill_sync.py::test_sync_skills_uses_managed_strategy_instead_of_wiping_all tests/test_computer_skill_sync.py::test_sync_skills_includes_plugin_provided_skills -q
# 27 passed in 4.35s

uv run ruff format --check astrbot/core/agent/mcp_client.py astrbot/core/computer/computer_client.py astrbot/dashboard/services/tools_service.py tests/unit/test_mcp_client_schema.py
# 4 files already formatted

uv run ruff check astrbot/core/agent/mcp_client.py astrbot/core/computer/computer_client.py astrbot/dashboard/services/tools_service.py tests/unit/test_mcp_client_schema.py
# All checks passed!

uv run python -m compileall -q astrbot tests
# passed

uv build
# Successfully built dist\astrbot-4.26.0b12.tar.gz
# Successfully built dist\astrbot-4.26.0b12-py3-none-any.whl

bash scripts/pr_test_env.sh --profile neo
# 12 passed in 15.52s
# Smoke test passed
# PR checks completed successfully
```

Note: `make pr-test-neo` could not run in my Windows Git Bash environment because `make` is not installed, so I ran the underlying repository script directly: `bash scripts/pr_test_env.sh --profile neo`.

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Enforce safer MCP stdio configuration handling for Python servers and sandbox skill uploads.

Bug Fixes:
- Reject Python MCP stdio configurations that launch local scripts/archives or use inline code flags instead of module- or package-based entry points.
- Ensure MCP stdio Python commands without module specifications are treated as invalid configurations.
- Fix sandbox skills bundle upload to always use POSIX-style remote paths for compatibility across platforms.
- Avoid re-validating disabled MCP server configurations when only toggling their active state.

Tests:
- Add unit tests covering accepted Python module-based MCP stdio launches and rejected script/archive, inline-code, and invalid argument patterns in MCP stdio configurations.