### PR TITLE
fix: preserve At components when sending messages on qq_official plat…

### DIFF
--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -25,7 +25,7 @@ from tenacity import (
 
 from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent, MessageChain
-from astrbot.api.message_components import File, Image, Plain, Record, Video
+from astrbot.api.message_components import At, File, Image, Plain, Record, Video
 from astrbot.api.platform import AstrBotMessage, PlatformMetadata
 from astrbot.core.utils.media_utils import MediaResolver, file_uri_to_path, is_file_uri
 
@@ -747,6 +747,10 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                     file_source = file_path
                 elif i.url:
                     file_source = i.url
+            elif isinstance(i, At):
+                qq_id = getattr(i, "qq", "")
+                if qq_id and qq_id != "all":
+                    plain_text += f"<@{qq_id}>"
             else:
                 logger.debug(f"qq_official 忽略 {i.type}")
         return (


### PR DESCRIPTION
…form

- Add At component handling in _parse_to_qqofficial method
- Convert At(qq=openid) to <@openid> plain_text format
- Maintain original message chain order by appending
- Skip At(qq='all') since QQ Official API may not support it

Closes #8982

修复 QQ 官方机器人 (qq_official) 回复消息无法 @用户 的 bug。在 `_parse_to_qqofficial` 方法中，At 组件之前被 `else` 分支静默丢弃，导致消息链中的 @提及 完全消失。此修复将 At 组件转换为 QQ 官方 API 支持的 `<@openid>` 纯文本格式拼接到 plain_text，同时保持消息链中组件的原始顺序。

### Modifications / 改动点

- `astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py`: 在导入中添加 `At`，在 `_parse_to_qqofficial` 中新增 `At` 组件处理分支，将其转换为 `<@qq_id>` 格式拼接到 plain_text（使用 `plain_text +=` 保持原始顺序）。`qq="all"`（@全体成员）因为 QQ 官方 API 可能不支持，已跳过。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

测试场景：消息链 `[At(qq="user_openid_123"), Plain("\n"), Image(path)]` 在 qq_official 平台下发送后，QQ 群中正确显示 `@用户名\n[图片]`，@提及不再丢失。

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [ ] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [ ] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [ ] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Fix loss of At mentions in qq_official message parsing by converting them to <@openid> format and including them in the plain text output, skipping unsupported @all mentions.