### PR TITLE
fix: add data scope to api keys

### DIFF
--- a/astrbot/dashboard/services/auth_service.py
+++ b/astrbot/dashboard/services/auth_service.py
@@ -54,6 +54,7 @@ ALL_OPEN_API_SCOPES = (
     "im",
     "config",
     "chat",
+    "data",
     "file",
     "plugin",
     "mcp",

--- a/dashboard/src/api/generated/openapi-v1/types.gen.ts
+++ b/dashboard/src/api/generated/openapi-v1/types.gen.ts
@@ -86,6 +86,9 @@ export type ChatProjectRequest = {
 };
 
 export type ChatRequest = {
+    /**
+     * Caller-declared WebChat sender/session owner. This value is used as the message sender identity and may participate in sender-ID-based command permission checks. Treat chat-scoped API keys as trusted backend credentials and map or validate usernames before accepting end-user input.
+     */
     username?: string;
     session_id?: string;
     /**
@@ -191,7 +194,7 @@ export type ConversationRef = {
 
 export type CreateApiKeyRequest = {
     name: string;
-    scopes?: Array<('bot' | 'provider' | 'persona' | 'im' | 'config' | 'chat' | 'file' | 'plugin' | 'mcp' | 'skill')>;
+    scopes?: Array<('bot' | 'provider' | 'persona' | 'im' | 'config' | 'chat' | 'data' | 'file' | 'plugin' | 'mcp' | 'skill')>;
     expires_at?: string;
     expires_in_days?: number;
 };

--- a/dashboard/src/views/Settings.vue
+++ b/dashboard/src/views/Settings.vue
@@ -513,6 +513,7 @@ const availableScopes = [
     { value: 'im', label: 'im' },
     { value: 'config', label: 'config' },
     { value: 'chat', label: 'chat' },
+    { value: 'data', label: 'data' },
     { value: 'file', label: 'file' },
     { value: 'plugin', label: 'plugin' },
     { value: 'mcp', label: 'mcp' },

--- a/openspec/openapi-v1.yaml
+++ b/openspec/openapi-v1.yaml
@@ -8,7 +8,7 @@ info:
     JSON objects because their schemas are provided at runtime by template
     endpoints.
     Developer API keys currently support these scopes only: bot, provider,
-    persona, im, config, chat, file, plugin, mcp, skill. The config scope also
+    persona, im, config, chat, data, file, plugin, mcp, skill. The config scope also
     grants bot and provider access.
 servers:
   - url: http://localhost:6185
@@ -5127,8 +5127,8 @@ components:
           type: array
           items:
             type: string
-            enum: [bot, provider, persona, im, config, chat, file, plugin, mcp, skill]
-          example: [bot, provider, persona, im, config, chat, file, plugin, mcp, skill]
+            enum: [bot, provider, persona, im, config, chat, data, file, plugin, mcp, skill]
+          example: [bot, provider, persona, im, config, chat, data, file, plugin, mcp, skill]
         expires_at:
           type: string
           format: date-time


### PR DESCRIPTION
## Summary
- add the data scope to allowed developer API key scopes
- document data in the OpenAPI create-key scope enum and example
- expose data in the dashboard API key scope picker and regenerated client types

## Tests
- ruff format .
- ruff check .
- pnpm typecheck

## Summary by Sourcery

Add support for the `data` scope in developer API keys across backend, OpenAPI specification, and dashboard UI.

New Features:
- Allow developer API keys to use a new `data` scope in the authentication service.
- Expose the `data` scope option in the dashboard API key scope picker.
- Document the `data` scope in the OpenAPI specification and regenerate corresponding client types.