### PR TITLE
chore: bump version to 4.26.0

### DIFF
--- a/astrbot/__init__.py
+++ b/astrbot/__init__.py
@@ -1,4 +1,4 @@
 import logging
 
-__version__ = "4.26.0-beta.12"
+__version__ = "4.26.0"
 logger = logging.getLogger("astrbot")

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -136,7 +136,7 @@ DEFAULT_CONFIG = {
         ),
         "llm_compress_keep_recent_ratio": 0.15,
         "llm_compress_provider_id": "",
-        "max_context_length": -1, # 默认不限制
+        "max_context_length": -1,  # 默认不限制
         "dequeue_context_length": 1,
         "streaming_response": False,
         "show_tool_use_status": False,

--- a/changelogs/v4.26.0.md
+++ b/changelogs/v4.26.0.md
@@ -1,3 +1,13 @@
+
+> Note:
+> 1. WebUI “Config -> System Config” has moved to “Settings” at the bottom of the WebUI sidebar.
+> 2. It's recommended to update to v4.25.6 before updating to this version.
+>
+> 提醒：
+> 1. WebUI 的“配置 -> 系统配置”已迁移至 WebUI 侧边栏下方的“设置”。
+> 2. 建议先升级到 v4.25.6 再升级到此版本。
+>
+
 - [更新日志(简体中文)](#chinese)
 - [Changelog(English)](#english)
 
@@ -5,64 +15,158 @@
 
 ## What's Changed
 
-### 新功能
+### ✨ 新功能
 
+- 后端架构从 Quart 迁移至 FastAPI。新增多个 AstrBot OpenAPI。([#8688](https://github.com/AstrBotDevs/AstrBot/pull/8688))
+- 统一全平台消息媒体文件的处理逻辑，提升图片、音频、文件和引用消息媒体的解析一致性，对腾讯系 Silk 格式的语音文件不再使用 pilk 库。([#8764](https://github.com/AstrBotDevs/AstrBot/pull/8764))
+- WebUI 新增函数工具的逐工具权限管理，支持在工具面板中查看和切换工具权限。([#8693](https://github.com/AstrBotDevs/AstrBot/pull/8693))
+- WebUI 新增浅色、深色、跟随系统三种主题模式，并集中处理系统主题同步。([#8648](https://github.com/AstrBotDevs/AstrBot/pull/8648))
+- 重组 WebUI 系统配置页面，将系统配置入口迁移到侧边栏下方的设置区域，并优化相关设置项、自动保存和重启提示体验。([#8777](https://github.com/AstrBotDevs/AstrBot/pull/8777))
+- 新增 QQ 官方机器人 WebSocket 适配器扫码绑定流程，可通过 WebUI 一键扫码获取并回填 AppID 与 Secret，同时将 WebSocket 模板标记为推荐。([#8821](https://github.com/AstrBotDevs/AstrBot/pull/8821))
+- 增强 QQ 官方机器人群聊能力，支持群消息创建类型，并允许 Webhook 适配器在无缓存 `msg_id` 时主动发送群消息。([#8838](https://github.com/AstrBotDevs/AstrBot/pull/8838), [#8841](https://github.com/AstrBotDevs/AstrBot/pull/8841))
+- 为 OpenAI、Gemini、Anthropic 等模型请求加入可配置的重试机制，并新增请求最大重试次数配置，提升临时网络错误与 5xx 服务端错误下的稳定性。([#8893](https://github.com/AstrBotDevs/AstrBot/pull/8893))
+- 现在更新项目时，下载 AstrBot Core 会走 AstrBot 官方托管地址，提高网络稳定性。([#8888](https://github.com/AstrBotDevs/AstrBot/pull/8888))
+- 支持在请求中加载 workspace skills，并加固 workspace skill 发现流程。([#8884](https://github.com/AstrBotDevs/AstrBot/pull/8884))
 - 新增 Exa Web Search 提供商。（[#8973](https://github.com/AstrBotDevs/AstrBot/pull/8973)）
+- 新增 ElevenLabs TTS API Provider。([commit](https://github.com/AstrBotDevs/AstrBot/commit/0b2234936))
+- 新增启动时重置 WebUI 密码的命令行开关，便于无法登录时恢复访问。([commit](https://github.com/AstrBotDevs/AstrBot/commit/4f5075e60))
+- 新增预发布版本可见性开关。([commit](https://github.com/AstrBotDevs/AstrBot/commit/f9d408221))
 - 登录页新增公开版本详情展示。（[#8986](https://github.com/AstrBotDevs/AstrBot/pull/8986)）
+- 备份功能现在会包含 skills 目录。([#8700](https://github.com/AstrBotDevs/AstrBot/pull/8700))
 
-### 安全修复
+### 优化
 
-- 修复知识库上传文件名路径穿越风险。（[#8971](https://github.com/AstrBotDevs/AstrBot/pull/8971)）
-- 修复插件上传文件名路径穿越风险。（[#8968](https://github.com/AstrBotDevs/AstrBot/pull/8968)）
+- 加强未来任务所有者校验，避免越权访问定时任务。([#8881](https://github.com/AstrBotDevs/AstrBot/pull/8881))
+- 优化知识库上传文件名路径穿越风险。（[#8971](https://github.com/AstrBotDevs/AstrBot/pull/8971)）
+- 优化插件上传文件名路径穿越风险。（[#8968](https://github.com/AstrBotDevs/AstrBot/pull/8968)）
+- 在受限本地文件系统工具中拒绝 hardlink 文件，避免通过工作区 hardlink 别名读写允许目录外的文件。
+- 加固沙箱文件传输与 CUA 健康检查流程，降低异常环境下的文件操作风险。([#8840](https://github.com/AstrBotDevs/AstrBot/pull/8840))
+- 消息组件日志输出现在会截断过长的 base64 字段，避免日志中出现大体积内联媒体内容。([#8591](https://github.com/AstrBotDevs/AstrBot/pull/8591))
+- 群聊上下文现在会展示被引用消息的内容。([commit](https://github.com/AstrBotDevs/AstrBot/commit/32cfcbf52))
+- 对话上下文新增当前星期信息。([#8669](https://github.com/AstrBotDevs/AstrBot/pull/8669))
+- 使用原子写入方式保存配置文件，降低写入中断导致配置损坏的概率。([#8793](https://github.com/AstrBotDevs/AstrBot/pull/8793))
+- 新增 GitHub 代理 `gh.dpik.top`，并移除失效代理 `gh.llkk.cc`。([#8772](https://github.com/AstrBotDevs/AstrBot/pull/8772), [#8761](https://github.com/AstrBotDevs/AstrBot/pull/8761))
 
 ### 修复
 
-- 恢复 CLI 初始化 Dashboard 的 monkeypatch hook。
+- 修复 aiocqhttp 平台适配器与消息事件处理器在多处 API 调用中缺少 `self_id` 路由参数的问题。([#8779](https://github.com/AstrBotDevs/AstrBot/pull/8779))
+- 修复生成平台 ID 时可能包含空白字符的问题。([#8768](https://github.com/AstrBotDevs/AstrBot/pull/8768))
+- 修复 Gemini Provider 工具定义没有正确传回模型，导致重复工具调用的问题。([#8833](https://github.com/AstrBotDevs/AstrBot/pull/8833))
+- 修复提供商源修改 ID 后保存被静默还原的问题。（[#8915](https://github.com/AstrBotDevs/AstrBot/pull/8915)）
+- 修复插件 LLM Tools 开关的归属校验问题，避免误操作其他插件的工具配置。([commit](https://github.com/AstrBotDevs/AstrBot/commit/fadada3d6))
+- 完善插件命名模式校验和边界场景处理。([commit](https://github.com/AstrBotDevs/AstrBot/commit/992aea986))
+- 修复插件重装后仓库来源丢失的问题。([commit](https://github.com/AstrBotDevs/AstrBot/commit/a3c25ec2c))
+- 修复子目录工具的 `handler_module_path` 不一致问题。([#8578](https://github.com/AstrBotDevs/AstrBot/pull/8578))
+- 修复 run-based tools 的保护逻辑，避免受保护工具在注册流程中被错误丢失。([#8790](https://github.com/AstrBotDevs/AstrBot/pull/8790))
+- 修复 persona 工具列表场景下系统工具被移除的问题。（[#8908](https://github.com/AstrBotDevs/AstrBot/pull/8908)）
+- 修复人格设定中将工具和 Skills 从指定列表切回“默认使用全部”后不生效的问题。([#8835](https://github.com/AstrBotDevs/AstrBot/pull/8835))
+- 修复人格编辑时重名校验不准确的问题。([#8843](https://github.com/AstrBotDevs/AstrBot/pull/8843))
+- 修复 OpenAPI 文件上传能力，恢复 `/api/v1/file` OpenAPI 暴露、文件范围 API Key 与相关文档/客户端产物。
+- 修复新版 MCP 中 Streamable HTTP client 重命名导致的兼容问题，并保持 `mcp` 依赖小于 2。
+- 修复本地 Python 工具没有在当前 session workspace 中运行的问题。([#8792](https://github.com/AstrBotDevs/AstrBot/pull/8792))
+- 修复上传 skills 时 multipart 请求体生成方式不正确的问题。([commit](https://github.com/AstrBotDevs/AstrBot/commit/898c800c9))
+- 修复静态资源缺失时仍显示 WebUI ready banner 的问题。([#8804](https://github.com/AstrBotDevs/AstrBot/pull/8804))
+- 恢复 WebUI 在接口返回 401 时跳转登录页，避免会话失效后停留在异常状态。([#8903](https://github.com/AstrBotDevs/AstrBot/pull/8903))
+- 保持 Core 版本与 WebUI 静态资源版本同步，修复打包或升级后可能加载旧 dist、资源版本错配的问题。([#8901](https://github.com/AstrBotDevs/AstrBot/pull/8901))
+- 恢复静态资源运行时版本。([commit](https://github.com/AstrBotDevs/AstrBot/commit/d36987dd1))
+- 修复 WebUI 恢复提示文案。([commit](https://github.com/AstrBotDevs/AstrBot/commit/ddc4e142c))
 - 修复 WebUI 刷新时缓存刷新逻辑。
-- 移除样式表链接中冗余的 font family。（[#8942](https://github.com/AstrBotDevs/AstrBot/pull/8942)）
-- 移除未使用的 VoceChat logo，并更新 xmas hat 图片资源。
+- 修复 Dashboard 创建文件夹时按 Enter 无法提交的问题。([#8597](https://github.com/AstrBotDevs/AstrBot/pull/8597))
+- 修复聊天输入框在非末尾位置使用输入法组合输入时可能丢失字符的问题。([#8811](https://github.com/AstrBotDevs/AstrBot/pull/8811))
+- 修复 changelog 弹窗中的锚点链接处理。([#8750](https://github.com/AstrBotDevs/AstrBot/pull/8750))
+- 修复 onboarding 平台配置与备份上传相关问题。([#8834](https://github.com/AstrBotDevs/AstrBot/pull/8834))
+- 将知识库上下文作为临时 user 内容注入，修复模型请求中知识库上下文角色不准确的问题。([#8904](https://github.com/AstrBotDevs/AstrBot/pull/8904))
 - 修复 cron 星期调度规范化问题。（[#8984](https://github.com/AstrBotDevs/AstrBot/pull/8984)）
-- 为 API Keys 增加 data scope。（[#8985](https://github.com/AstrBotDevs/AstrBot/pull/8985)）
-- 修复插件页资源 token fallback。（[#8970](https://github.com/AstrBotDevs/AstrBot/pull/8970)）
 - 修复 QQ 官方平台发送消息时 At 组件被丢失的问题。（[#8983](https://github.com/AstrBotDevs/AstrBot/pull/8983)）
-- 回滚 MCP client 终止会话后的重连改动。（[#8991](https://github.com/AstrBotDevs/AstrBot/pull/8991)）
+- 修复引用图片说明可能重复显示的问题。([#8718](https://github.com/AstrBotDevs/AstrBot/pull/8718))
+- 修复 Embedding API version 后缀被错误截断的问题。([#8736](https://github.com/AstrBotDevs/AstrBot/pull/8736))
+- 延迟导入 FAISS C 库，避免部分环境启动时进程卡住。([#8696](https://github.com/AstrBotDevs/AstrBot/pull/8696))
+- 关闭时主动释放数据库 engine，减少会话和测试环境中的资源残留。([#8650](https://github.com/AstrBotDevs/AstrBot/pull/8650))
+- 修复 CLI 版本来源不正确的问题。([#8692](https://github.com/AstrBotDevs/AstrBot/pull/8692))
+- 恢复 CLI 初始化 Dashboard 的 monkeypatch hook。
+- 修复执行 `astrbot` 命令时不必要地创建数据目录的问题。（[#8932](https://github.com/AstrBotDevs/AstrBot/pull/8932)）
+- 修复 sdist 构建产物路径，确保 Dashboard artifact 可被包含。（[#8933](https://github.com/AstrBotDevs/AstrBot/pull/8933)）
+- 修复插件页资源 token fallback。（[#8970](https://github.com/AstrBotDevs/AstrBot/pull/8970)）
 - 更新 `max_context_length` 与 `dequeue_context_length` 默认值。
-
-### 文档与维护
-
-- 更新 Password Reset 文档。（[#8987](https://github.com/AstrBotDevs/AstrBot/pull/8987)）
-- 更新 GitHub Actions workflow 名称，提升可读性。
-- 升级 github-actions 依赖组中的 `actions/checkout`。（[#8963](https://github.com/AstrBotDevs/AstrBot/pull/8963)）
+- 稳定 FastAPI Dashboard 路由注册测试，兼容 included router 节点。([commit](https://github.com/AstrBotDevs/AstrBot/commit/ad1b64d12))
+- 稳定 Dashboard 路由相关测试，兼容最新 FastAPI 行为。([commit](https://github.com/AstrBotDevs/AstrBot/commit/a2b6aad84))
 
 <a id="english"></a>
 
 ## What's Changed (EN)
 
-### New Features
+### ✨ New Features
 
+- Migrated the backend architecture from Quart to FastAPI and added multiple OpenAPI definitions. ([#8688](https://github.com/AstrBotDevs/AstrBot/pull/8688))
+- Unified media file handling across platforms, improving consistency for images, audio, files, and quoted-message media. Tencent Silk voice files no longer use the pilk library. ([#8764](https://github.com/AstrBotDevs/AstrBot/pull/8764))
+- Added per-tool permission management for function tools in WebUI, with support for viewing and toggling tool permissions from the tools panel. ([#8693](https://github.com/AstrBotDevs/AstrBot/pull/8693))
+- Added light, dark, and system theme modes to WebUI, with centralized system theme synchronization. ([#8648](https://github.com/AstrBotDevs/AstrBot/pull/8648))
+- Reorganized the WebUI system configuration page. The system configuration entry has moved to the Settings area at the bottom of the sidebar, with improved settings, autosave, and restart notices. ([#8777](https://github.com/AstrBotDevs/AstrBot/pull/8777))
+- Added a QR binding flow for the QQ Official Bot WebSocket adapter. WebUI can now fetch and autofill AppID and Secret through one-click QR setup, and the WebSocket template is marked as recommended. ([#8821](https://github.com/AstrBotDevs/AstrBot/pull/8821))
+- Enhanced QQ Official Bot group chat support by adding group message creation types and allowing the Webhook adapter to proactively send group messages without a cached `msg_id`. ([#8838](https://github.com/AstrBotDevs/AstrBot/pull/8838), [#8841](https://github.com/AstrBotDevs/AstrBot/pull/8841))
+- Added configurable retry handling for OpenAI, Gemini, Anthropic, and related model requests, including a maximum request retry setting for better stability during temporary network errors and 5xx server errors. ([#8893](https://github.com/AstrBotDevs/AstrBot/pull/8893))
+- AstrBot Core downloads now use AstrBot's officially hosted source during project updates, improving network stability. ([#8888](https://github.com/AstrBotDevs/AstrBot/pull/8888))
+- Added support for loading workspace skills in requests and hardened workspace skill discovery. ([#8884](https://github.com/AstrBotDevs/AstrBot/pull/8884))
 - Added Exa as a web search provider. ([#8973](https://github.com/AstrBotDevs/AstrBot/pull/8973))
-- Added public version details on the login page. ([#8986](https://github.com/AstrBotDevs/AstrBot/pull/8986))
+- Added the ElevenLabs TTS API provider. ([commit](https://github.com/AstrBotDevs/AstrBot/commit/0b2234936))
+- Added a startup flag to reset the WebUI password, making it easier to recover access when login is unavailable. ([commit](https://github.com/AstrBotDevs/AstrBot/commit/4f5075e60))
+- Added a prerelease visibility toggle. ([commit](https://github.com/AstrBotDevs/AstrBot/commit/f9d408221))
+- Added public version details to the login page. ([#8986](https://github.com/AstrBotDevs/AstrBot/pull/8986))
+- Backups now include the skills directory. ([#8700](https://github.com/AstrBotDevs/AstrBot/pull/8700))
 
-### Security Fixes
+### Improvements
 
-- Fixed a path traversal risk in knowledge base upload filenames. ([#8971](https://github.com/AstrBotDevs/AstrBot/pull/8971))
-- Fixed a path traversal risk in plugin upload filenames. ([#8968](https://github.com/AstrBotDevs/AstrBot/pull/8968))
+- Strengthened Future Task owner checks to prevent unauthorized scheduled-task access. ([#8881](https://github.com/AstrBotDevs/AstrBot/pull/8881))
+- Hardened knowledge base upload filename handling against path traversal risks. ([#8971](https://github.com/AstrBotDevs/AstrBot/pull/8971))
+- Hardened plugin upload filename handling against path traversal risks. ([#8968](https://github.com/AstrBotDevs/AstrBot/pull/8968))
+- Rejected hardlinked files in restricted local filesystem tools to prevent workspace hardlink aliases from reading or writing files outside allowed directories.
+- Hardened sandbox file transfers and CUA health checks to reduce file-operation risks in abnormal environments. ([#8840](https://github.com/AstrBotDevs/AstrBot/pull/8840))
+- Message component logs now truncate long base64 fields to avoid large inline media payloads in logs. ([#8591](https://github.com/AstrBotDevs/AstrBot/pull/8591))
+- Group chat context now includes quoted message content. ([commit](https://github.com/AstrBotDevs/AstrBot/commit/32cfcbf52))
+- Added current weekday information to conversation context. ([#8669](https://github.com/AstrBotDevs/AstrBot/pull/8669))
+- Configuration files are now saved atomically, reducing the chance of corruption during interrupted writes. ([#8793](https://github.com/AstrBotDevs/AstrBot/pull/8793))
+- Added GitHub proxy `gh.dpik.top` and removed the invalid `gh.llkk.cc` proxy. ([#8772](https://github.com/AstrBotDevs/AstrBot/pull/8772), [#8761](https://github.com/AstrBotDevs/AstrBot/pull/8761))
 
 ### Bug Fixes
 
-- Restored the CLI init Dashboard monkeypatch hook.
+- Fixed missing `self_id` routing parameters across multiple aiocqhttp platform adapter and message event API calls. ([#8779](https://github.com/AstrBotDevs/AstrBot/pull/8779))
+- Fixed generated platform IDs potentially containing whitespace characters. ([#8768](https://github.com/AstrBotDevs/AstrBot/pull/8768))
+- Fixed Gemini Provider tool definitions not being passed back to the model correctly, which could cause repeated tool calls. ([#8833](https://github.com/AstrBotDevs/AstrBot/pull/8833))
+- Fixed provider source ID edits being silently restored after saving. ([#8915](https://github.com/AstrBotDevs/AstrBot/pull/8915))
+- Fixed ownership checks when toggling plugin LLM tools to prevent accidental changes to other plugins' tool settings. ([commit](https://github.com/AstrBotDevs/AstrBot/commit/fadada3d6))
+- Improved plugin naming pattern validation and edge-case handling. ([commit](https://github.com/AstrBotDevs/AstrBot/commit/992aea986))
+- Fixed repository source information being lost after reinstalling plugins. ([commit](https://github.com/AstrBotDevs/AstrBot/commit/a3c25ec2c))
+- Fixed inconsistent `handler_module_path` values for tools inside subdirectories. ([#8578](https://github.com/AstrBotDevs/AstrBot/pull/8578))
+- Fixed run-based tool protection so protected tools are not incorrectly dropped during registration. ([#8790](https://github.com/AstrBotDevs/AstrBot/pull/8790))
+- Fixed system tools being removed when persona tool lists are configured. ([#8908](https://github.com/AstrBotDevs/AstrBot/pull/8908))
+- Fixed persona tool and Skill settings not taking effect after switching from selected items back to "use all by default". ([#8835](https://github.com/AstrBotDevs/AstrBot/pull/8835))
+- Fixed inaccurate duplicate-name validation when editing personas. ([#8843](https://github.com/AstrBotDevs/AstrBot/pull/8843))
+- Restored OpenAPI file upload support, including `/api/v1/file` OpenAPI exposure, file-scoped API keys, and related documentation/client artifacts.
+- Fixed compatibility with the renamed Streamable HTTP client in newer MCP versions while keeping the `mcp` dependency below 2.
+- Fixed local Python tools not running inside the current session workspace. ([#8792](https://github.com/AstrBotDevs/AstrBot/pull/8792))
+- Fixed skills uploads by generating multipart request bodies correctly. ([commit](https://github.com/AstrBotDevs/AstrBot/commit/898c800c9))
+- Fixed the WebUI ready banner being shown even when static assets are missing. ([#8804](https://github.com/AstrBotDevs/AstrBot/pull/8804))
+- Restored WebUI login redirects when API requests return 401, preventing expired sessions from staying in an abnormal state. ([#8903](https://github.com/AstrBotDevs/AstrBot/pull/8903))
+- Kept Core and WebUI static asset versions in sync, fixing stale dist loading and asset version mismatches after packaging or upgrades. ([#8901](https://github.com/AstrBotDevs/AstrBot/pull/8901))
+- Restored the static runtime version. ([commit](https://github.com/AstrBotDevs/AstrBot/commit/d36987dd1))
+- Fixed the WebUI recovery hint text. ([commit](https://github.com/AstrBotDevs/AstrBot/commit/ddc4e142c))
 - Fixed WebUI refresh cache-busting behavior.
-- Removed a redundant font family from stylesheet links. ([#8942](https://github.com/AstrBotDevs/AstrBot/pull/8942))
-- Removed the unused VoceChat logo and updated the xmas hat image asset.
+- Fixed Dashboard folder creation not being submitted when pressing Enter. ([#8597](https://github.com/AstrBotDevs/AstrBot/pull/8597))
+- Fixed possible IME composition character loss when typing at a non-terminal cursor position in the chat input. ([#8811](https://github.com/AstrBotDevs/AstrBot/pull/8811))
+- Fixed changelog anchor link handling in the Dashboard dialog. ([#8750](https://github.com/AstrBotDevs/AstrBot/pull/8750))
+- Fixed onboarding platform configuration and backup upload issues. ([#8834](https://github.com/AstrBotDevs/AstrBot/pull/8834))
+- Injected knowledge base context as temporary user content, fixing the role used for knowledge context in model requests. ([#8904](https://github.com/AstrBotDevs/AstrBot/pull/8904))
 - Fixed cron weekday scheduling normalization. ([#8984](https://github.com/AstrBotDevs/AstrBot/pull/8984))
-- Added data scope to API keys. ([#8985](https://github.com/AstrBotDevs/AstrBot/pull/8985))
-- Fixed plugin page asset token fallback. ([#8970](https://github.com/AstrBotDevs/AstrBot/pull/8970))
 - Fixed At components being dropped when sending messages on the QQ Official platform. ([#8983](https://github.com/AstrBotDevs/AstrBot/pull/8983))
-- Reverted the MCP client reconnect-on-terminated-session change. ([#8991](https://github.com/AstrBotDevs/AstrBot/pull/8991))
+- Fixed duplicate captions for quoted images. ([#8718](https://github.com/AstrBotDevs/AstrBot/pull/8718))
+- Fixed Embedding API version suffixes being truncated incorrectly. ([#8736](https://github.com/AstrBotDevs/AstrBot/pull/8736))
+- Deferred FAISS C library imports to avoid startup hangs in some environments. ([#8696](https://github.com/AstrBotDevs/AstrBot/pull/8696))
+- Disposed the database engine on shutdown to reduce resource leftovers in sessions and tests. ([#8650](https://github.com/AstrBotDevs/AstrBot/pull/8650))
+- Fixed the CLI version source. ([#8692](https://github.com/AstrBotDevs/AstrBot/pull/8692))
+- Restored the CLI init Dashboard monkeypatch hook.
+- Fixed unnecessary data directory creation when executing the `astrbot` command. ([#8932](https://github.com/AstrBotDevs/AstrBot/pull/8932))
+- Fixed the sdist build artifact path so the Dashboard artifact can be included. ([#8933](https://github.com/AstrBotDevs/AstrBot/pull/8933))
+- Fixed plugin page asset token fallback. ([#8970](https://github.com/AstrBotDevs/AstrBot/pull/8970))
 - Updated the `max_context_length` and `dequeue_context_length` defaults.
-
-### Documentation and Maintenance
-
-- Updated the Password Reset documentation. ([#8987](https://github.com/AstrBotDevs/AstrBot/pull/8987))
-- Updated GitHub Actions workflow names for readability.
-- Bumped `actions/checkout` in the github-actions dependency group. ([#8963](https://github.com/AstrBotDevs/AstrBot/pull/8963))
+- Stabilized FastAPI Dashboard route registration tests for included router nodes. ([commit](https://github.com/AstrBotDevs/AstrBot/commit/ad1b64d12))
+- Stabilized Dashboard route tests for the latest FastAPI behavior. ([commit](https://github.com/AstrBotDevs/AstrBot/commit/a2b6aad84))

--- a/changelogs/v4.26.0.md
+++ b/changelogs/v4.26.0.md
@@ -1,0 +1,68 @@
+- [更新日志(简体中文)](#chinese)
+- [Changelog(English)](#english)
+
+<a id="chinese"></a>
+
+## What's Changed
+
+### 新功能
+
+- 新增 Exa Web Search 提供商。（[#8973](https://github.com/AstrBotDevs/AstrBot/pull/8973)）
+- 登录页新增公开版本详情展示。（[#8986](https://github.com/AstrBotDevs/AstrBot/pull/8986)）
+
+### 安全修复
+
+- 修复知识库上传文件名路径穿越风险。（[#8971](https://github.com/AstrBotDevs/AstrBot/pull/8971)）
+- 修复插件上传文件名路径穿越风险。（[#8968](https://github.com/AstrBotDevs/AstrBot/pull/8968)）
+
+### 修复
+
+- 恢复 CLI 初始化 Dashboard 的 monkeypatch hook。
+- 修复 WebUI 刷新时缓存刷新逻辑。
+- 移除样式表链接中冗余的 font family。（[#8942](https://github.com/AstrBotDevs/AstrBot/pull/8942)）
+- 移除未使用的 VoceChat logo，并更新 xmas hat 图片资源。
+- 修复 cron 星期调度规范化问题。（[#8984](https://github.com/AstrBotDevs/AstrBot/pull/8984)）
+- 为 API Keys 增加 data scope。（[#8985](https://github.com/AstrBotDevs/AstrBot/pull/8985)）
+- 修复插件页资源 token fallback。（[#8970](https://github.com/AstrBotDevs/AstrBot/pull/8970)）
+- 修复 QQ 官方平台发送消息时 At 组件被丢失的问题。（[#8983](https://github.com/AstrBotDevs/AstrBot/pull/8983)）
+- 回滚 MCP client 终止会话后的重连改动。（[#8991](https://github.com/AstrBotDevs/AstrBot/pull/8991)）
+- 更新 `max_context_length` 与 `dequeue_context_length` 默认值。
+
+### 文档与维护
+
+- 更新 Password Reset 文档。（[#8987](https://github.com/AstrBotDevs/AstrBot/pull/8987)）
+- 更新 GitHub Actions workflow 名称，提升可读性。
+- 升级 github-actions 依赖组中的 `actions/checkout`。（[#8963](https://github.com/AstrBotDevs/AstrBot/pull/8963)）
+
+<a id="english"></a>
+
+## What's Changed (EN)
+
+### New Features
+
+- Added Exa as a web search provider. ([#8973](https://github.com/AstrBotDevs/AstrBot/pull/8973))
+- Added public version details on the login page. ([#8986](https://github.com/AstrBotDevs/AstrBot/pull/8986))
+
+### Security Fixes
+
+- Fixed a path traversal risk in knowledge base upload filenames. ([#8971](https://github.com/AstrBotDevs/AstrBot/pull/8971))
+- Fixed a path traversal risk in plugin upload filenames. ([#8968](https://github.com/AstrBotDevs/AstrBot/pull/8968))
+
+### Bug Fixes
+
+- Restored the CLI init Dashboard monkeypatch hook.
+- Fixed WebUI refresh cache-busting behavior.
+- Removed a redundant font family from stylesheet links. ([#8942](https://github.com/AstrBotDevs/AstrBot/pull/8942))
+- Removed the unused VoceChat logo and updated the xmas hat image asset.
+- Fixed cron weekday scheduling normalization. ([#8984](https://github.com/AstrBotDevs/AstrBot/pull/8984))
+- Added data scope to API keys. ([#8985](https://github.com/AstrBotDevs/AstrBot/pull/8985))
+- Fixed plugin page asset token fallback. ([#8970](https://github.com/AstrBotDevs/AstrBot/pull/8970))
+- Fixed At components being dropped when sending messages on the QQ Official platform. ([#8983](https://github.com/AstrBotDevs/AstrBot/pull/8983))
+- Reverted the MCP client reconnect-on-terminated-session change. ([#8991](https://github.com/AstrBotDevs/AstrBot/pull/8991))
+- Updated the `max_context_length` and `dequeue_context_length` defaults.
+
+### Documentation and Maintenance
+
+- Updated the Password Reset documentation. ([#8987](https://github.com/AstrBotDevs/AstrBot/pull/8987))
+- Updated GitHub Actions workflow names for readability.
+- Bumped `actions/checkout` in the github-actions dependency group. ([#8963](https://github.com/AstrBotDevs/AstrBot/pull/8963))

--- a/changelogs/v4.26.0.md
+++ b/changelogs/v4.26.0.md
@@ -60,17 +60,9 @@
 - 修复 run-based tools 的保护逻辑，避免受保护工具在注册流程中被错误丢失。([#8790](https://github.com/AstrBotDevs/AstrBot/pull/8790))
 - 修复 persona 工具列表场景下系统工具被移除的问题。（[#8908](https://github.com/AstrBotDevs/AstrBot/pull/8908)）
 - 修复人格设定中将工具和 Skills 从指定列表切回“默认使用全部”后不生效的问题。([#8835](https://github.com/AstrBotDevs/AstrBot/pull/8835))
-- 修复人格编辑时重名校验不准确的问题。([#8843](https://github.com/AstrBotDevs/AstrBot/pull/8843))
-- 修复 OpenAPI 文件上传能力，恢复 `/api/v1/file` OpenAPI 暴露、文件范围 API Key 与相关文档/客户端产物。
 - 修复新版 MCP 中 Streamable HTTP client 重命名导致的兼容问题，并保持 `mcp` 依赖小于 2。
 - 修复本地 Python 工具没有在当前 session workspace 中运行的问题。([#8792](https://github.com/AstrBotDevs/AstrBot/pull/8792))
-- 修复上传 skills 时 multipart 请求体生成方式不正确的问题。([commit](https://github.com/AstrBotDevs/AstrBot/commit/898c800c9))
 - 修复静态资源缺失时仍显示 WebUI ready banner 的问题。([#8804](https://github.com/AstrBotDevs/AstrBot/pull/8804))
-- 恢复 WebUI 在接口返回 401 时跳转登录页，避免会话失效后停留在异常状态。([#8903](https://github.com/AstrBotDevs/AstrBot/pull/8903))
-- 保持 Core 版本与 WebUI 静态资源版本同步，修复打包或升级后可能加载旧 dist、资源版本错配的问题。([#8901](https://github.com/AstrBotDevs/AstrBot/pull/8901))
-- 恢复静态资源运行时版本。([commit](https://github.com/AstrBotDevs/AstrBot/commit/d36987dd1))
-- 修复 WebUI 恢复提示文案。([commit](https://github.com/AstrBotDevs/AstrBot/commit/ddc4e142c))
-- 修复 WebUI 刷新时缓存刷新逻辑。
 - 修复 Dashboard 创建文件夹时按 Enter 无法提交的问题。([#8597](https://github.com/AstrBotDevs/AstrBot/pull/8597))
 - 修复聊天输入框在非末尾位置使用输入法组合输入时可能丢失字符的问题。([#8811](https://github.com/AstrBotDevs/AstrBot/pull/8811))
 - 修复 changelog 弹窗中的锚点链接处理。([#8750](https://github.com/AstrBotDevs/AstrBot/pull/8750))
@@ -78,13 +70,12 @@
 - 将知识库上下文作为临时 user 内容注入，修复模型请求中知识库上下文角色不准确的问题。([#8904](https://github.com/AstrBotDevs/AstrBot/pull/8904))
 - 修复 cron 星期调度规范化问题。（[#8984](https://github.com/AstrBotDevs/AstrBot/pull/8984)）
 - 修复 QQ 官方平台发送消息时 At 组件被丢失的问题。（[#8983](https://github.com/AstrBotDevs/AstrBot/pull/8983)）
-- 修复引用图片说明可能重复显示的问题。([#8718](https://github.com/AstrBotDevs/AstrBot/pull/8718))
+- 修复引用消息中的 image caption 可能重复显示的问题。([#8718](https://github.com/AstrBotDevs/AstrBot/pull/8718))
 - 修复 Embedding API version 后缀被错误截断的问题。([#8736](https://github.com/AstrBotDevs/AstrBot/pull/8736))
 - 延迟导入 FAISS C 库，避免部分环境启动时进程卡住。([#8696](https://github.com/AstrBotDevs/AstrBot/pull/8696))
 - 关闭时主动释放数据库 engine，减少会话和测试环境中的资源残留。([#8650](https://github.com/AstrBotDevs/AstrBot/pull/8650))
 - 修复 CLI 版本来源不正确的问题。([#8692](https://github.com/AstrBotDevs/AstrBot/pull/8692))
-- 恢复 CLI 初始化 Dashboard 的 monkeypatch hook。
-- 修复执行 `astrbot` 命令时不必要地创建数据目录的问题。（[#8932](https://github.com/AstrBotDevs/AstrBot/pull/8932)）
+- 修复执行 `astrbot` 命令时不必要地创建 data 目录的问题。（[#8932](https://github.com/AstrBotDevs/AstrBot/pull/8932)）
 - 修复 sdist 构建产物路径，确保 Dashboard artifact 可被包含。（[#8933](https://github.com/AstrBotDevs/AstrBot/pull/8933)）
 - 修复插件页资源 token fallback。（[#8970](https://github.com/AstrBotDevs/AstrBot/pull/8970)）
 - 更新 `max_context_length` 与 `dequeue_context_length` 默认值。
@@ -140,17 +131,9 @@
 - Fixed run-based tool protection so protected tools are not incorrectly dropped during registration. ([#8790](https://github.com/AstrBotDevs/AstrBot/pull/8790))
 - Fixed system tools being removed when persona tool lists are configured. ([#8908](https://github.com/AstrBotDevs/AstrBot/pull/8908))
 - Fixed persona tool and Skill settings not taking effect after switching from selected items back to "use all by default". ([#8835](https://github.com/AstrBotDevs/AstrBot/pull/8835))
-- Fixed inaccurate duplicate-name validation when editing personas. ([#8843](https://github.com/AstrBotDevs/AstrBot/pull/8843))
-- Restored OpenAPI file upload support, including `/api/v1/file` OpenAPI exposure, file-scoped API keys, and related documentation/client artifacts.
 - Fixed compatibility with the renamed Streamable HTTP client in newer MCP versions while keeping the `mcp` dependency below 2.
 - Fixed local Python tools not running inside the current session workspace. ([#8792](https://github.com/AstrBotDevs/AstrBot/pull/8792))
-- Fixed skills uploads by generating multipart request bodies correctly. ([commit](https://github.com/AstrBotDevs/AstrBot/commit/898c800c9))
 - Fixed the WebUI ready banner being shown even when static assets are missing. ([#8804](https://github.com/AstrBotDevs/AstrBot/pull/8804))
-- Restored WebUI login redirects when API requests return 401, preventing expired sessions from staying in an abnormal state. ([#8903](https://github.com/AstrBotDevs/AstrBot/pull/8903))
-- Kept Core and WebUI static asset versions in sync, fixing stale dist loading and asset version mismatches after packaging or upgrades. ([#8901](https://github.com/AstrBotDevs/AstrBot/pull/8901))
-- Restored the static runtime version. ([commit](https://github.com/AstrBotDevs/AstrBot/commit/d36987dd1))
-- Fixed the WebUI recovery hint text. ([commit](https://github.com/AstrBotDevs/AstrBot/commit/ddc4e142c))
-- Fixed WebUI refresh cache-busting behavior.
 - Fixed Dashboard folder creation not being submitted when pressing Enter. ([#8597](https://github.com/AstrBotDevs/AstrBot/pull/8597))
 - Fixed possible IME composition character loss when typing at a non-terminal cursor position in the chat input. ([#8811](https://github.com/AstrBotDevs/AstrBot/pull/8811))
 - Fixed changelog anchor link handling in the Dashboard dialog. ([#8750](https://github.com/AstrBotDevs/AstrBot/pull/8750))
@@ -163,7 +146,6 @@
 - Deferred FAISS C library imports to avoid startup hangs in some environments. ([#8696](https://github.com/AstrBotDevs/AstrBot/pull/8696))
 - Disposed the database engine on shutdown to reduce resource leftovers in sessions and tests. ([#8650](https://github.com/AstrBotDevs/AstrBot/pull/8650))
 - Fixed the CLI version source. ([#8692](https://github.com/AstrBotDevs/AstrBot/pull/8692))
-- Restored the CLI init Dashboard monkeypatch hook.
 - Fixed unnecessary data directory creation when executing the `astrbot` command. ([#8932](https://github.com/AstrBotDevs/AstrBot/pull/8932))
 - Fixed the sdist build artifact path so the Dashboard artifact can be included. ([#8933](https://github.com/AstrBotDevs/AstrBot/pull/8933))
 - Fixed plugin page asset token fallback. ([#8970](https://github.com/AstrBotDevs/AstrBot/pull/8970))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AstrBot"
-version = "4.26.0-beta.12"
+version = "4.26.0"
 description = "Easy-to-use multi-platform LLM chatbot and development framework"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }


### PR DESCRIPTION
## Summary
- Bump AstrBot from 4.26.0-beta.12 to 4.26.0
- Add the v4.26.0 changelog
- Apply Ruff formatting required by release validation

## Validation
- uv run ruff format --check .
- uv run ruff check .

## Summary by Sourcery

Release AstrBot 4.26.0 as a stable version and add its accompanying changelog.

New Features:
- Publish AstrBot version 4.26.0 as the new stable release.

Enhancements:
- Add the v4.26.0 changelog documenting new features, fixes, and maintenance updates.
- Apply Ruff formatting adjustments required by the release validation tooling.

Build:
- Update the project version metadata to 4.26.0 in package and project configuration.