### PR TITLE
fix: align knowledge base CRUD API contract with kb_name, canonical payload fields, and matching OpenAPI types

### DIFF
--- a/astrbot/dashboard/api/knowledge_bases.py
+++ b/astrbot/dashboard/api/knowledge_bases.py
@@ -208,7 +208,7 @@ async def import_knowledge_base_documents(
     _auth: AuthContext = Depends(require_kb_scope),
     service: KnowledgeBaseService = Depends(get_service),
 ):
-    body = _model_dict(payload)
+    body = payload.model_dump(exclude_none=True)
     return await _run(
         lambda: service.import_documents({"kb_id": kb_id, **body}),
         prefix="导入文档失败",
@@ -222,7 +222,7 @@ async def import_knowledge_base_document_url(
     _auth: AuthContext = Depends(require_kb_scope),
     service: KnowledgeBaseService = Depends(get_service),
 ):
-    body = _model_dict(payload)
+    body = payload.model_dump(exclude_none=True)
     return await _run(
         lambda: service.upload_document_from_url({"kb_id": kb_id, **body}),
         prefix="从URL上传文档失败",
@@ -302,7 +302,7 @@ async def retrieve_knowledge_base(
     _auth: AuthContext = Depends(require_kb_scope),
     service: KnowledgeBaseService = Depends(get_service),
 ):
-    body = _model_dict(payload)
+    body = payload.model_dump(exclude_none=True)
     return await _run(
         lambda: service.retrieve({"kb_id": kb_id, **body}),
         prefix="检索失败",

--- a/astrbot/dashboard/api/knowledge_bases.py
+++ b/astrbot/dashboard/api/knowledge_bases.py
@@ -53,14 +53,6 @@ def _to_int(value: Any, default: int) -> int:
         return default
 
 
-def _model_dict(payload) -> dict[str, Any]:
-    if payload is None:
-        return {}
-    if hasattr(payload, "model_dump"):
-        return payload.model_dump(exclude_none=True)
-    return payload if isinstance(payload, dict) else {}
-
-
 async def _run(operation, *, prefix: str):
     try:
         result = await run_maybe_async(operation)
@@ -94,7 +86,11 @@ async def list_knowledge_bases(
     return await _run(
         lambda: service.list_kbs(
             page=_to_int(request.query_params.get("page"), 1),
-            page_size=_to_int(request.query_params.get("page_size"), 20),
+            page_size=(
+                _to_int(request.query_params.get("page_size"), 20)
+                if "page" in request.query_params or "page_size" in request.query_params
+                else None
+            ),
         ),
         prefix="获取知识库列表失败",
     )
@@ -107,7 +103,7 @@ async def create_knowledge_base(
     service: KnowledgeBaseService = Depends(get_service),
 ):
     return await _run(
-        lambda: service.create_kb(_model_dict(payload)),
+        lambda: service.create_kb(payload.canonical_payload()),
         prefix="创建知识库失败",
     )
 
@@ -140,9 +136,8 @@ async def update_knowledge_base(
     _auth: AuthContext = Depends(require_kb_scope),
     service: KnowledgeBaseService = Depends(get_service),
 ):
-    body = _model_dict(payload)
     return await _run(
-        lambda: service.update_kb({"kb_id": kb_id, **body}),
+        lambda: service.update_kb({**payload.canonical_payload(), "kb_id": kb_id}),
         prefix="更新知识库失败",
     )
 
@@ -323,7 +318,11 @@ async def dashboard_list_kbs(
     return await _run(
         lambda: service.list_kbs(
             page=_to_int(request.query_params.get("page"), 1),
-            page_size=_to_int(request.query_params.get("page_size"), 20),
+            page_size=(
+                _to_int(request.query_params.get("page_size"), 20)
+                if "page" in request.query_params or "page_size" in request.query_params
+                else None
+            ),
         ),
         prefix="获取知识库列表失败",
     )

--- a/astrbot/dashboard/api/knowledge_bases.py
+++ b/astrbot/dashboard/api/knowledge_bases.py
@@ -9,6 +9,7 @@ from astrbot.core import logger
 from astrbot.dashboard.async_utils import run_maybe_async
 from astrbot.dashboard.responses import error, ok
 from astrbot.dashboard.schemas import (
+    KnowledgeBaseCreateRequest,
     KnowledgeBaseImportRequest,
     KnowledgeBaseRequest,
     KnowledgeBaseRetrieveRequest,
@@ -86,11 +87,7 @@ async def list_knowledge_bases(
     return await _run(
         lambda: service.list_kbs(
             page=_to_int(request.query_params.get("page"), 1),
-            page_size=(
-                _to_int(request.query_params.get("page_size"), 20)
-                if "page" in request.query_params or "page_size" in request.query_params
-                else None
-            ),
+            page_size=_to_int(request.query_params.get("page_size"), 20),
         ),
         prefix="获取知识库列表失败",
     )
@@ -98,7 +95,7 @@ async def list_knowledge_bases(
 
 @router.post("/knowledge-bases")
 async def create_knowledge_base(
-    payload: KnowledgeBaseRequest,
+    payload: KnowledgeBaseCreateRequest,
     _auth: AuthContext = Depends(require_kb_scope),
     service: KnowledgeBaseService = Depends(get_service),
 ):
@@ -318,11 +315,7 @@ async def dashboard_list_kbs(
     return await _run(
         lambda: service.list_kbs(
             page=_to_int(request.query_params.get("page"), 1),
-            page_size=(
-                _to_int(request.query_params.get("page_size"), 20)
-                if "page" in request.query_params or "page_size" in request.query_params
-                else None
-            ),
+            page_size=_to_int(request.query_params.get("page_size"), 20),
         ),
         prefix="获取知识库列表失败",
     )

--- a/astrbot/dashboard/schemas.py
+++ b/astrbot/dashboard/schemas.py
@@ -205,14 +205,42 @@ class ImMessageRequest(OpenModel):
 
 
 class KnowledgeBaseRequest(OpenModel):
-    kb_id: str | None = None
-    name: str | None = None
+    kb_name: str | None = None
     description: str | None = None
+    emoji: str | None = None
     embedding_provider_id: str | None = None
     rerank_provider_id: str | None = None
     chunk_size: int | None = None
     chunk_overlap: int | None = None
+    top_k_dense: int | None = None
+    top_k_sparse: int | None = None
+    top_m_final: int | None = None
 
+    def canonical_payload(self) -> dict[str, Any]:
+        """Return the service-facing knowledge base payload.
+
+        Returns:
+            Dictionary accepted by KnowledgeBaseService.
+        """
+        data = self.model_dump(
+            exclude_unset=True,
+            include={
+                "kb_name",
+                "description",
+                "emoji",
+                "embedding_provider_id",
+                "rerank_provider_id",
+                "chunk_size",
+                "chunk_overlap",
+                "top_k_dense",
+                "top_k_sparse",
+                "top_m_final",
+            },
+        )
+        legacy_name = getattr(self, "name", None)
+        if data.get("kb_name") is None and legacy_name is not None:
+            data["kb_name"] = legacy_name
+        return data
 
 class KnowledgeBaseImportRequest(OpenModel):
     documents: list[dict[str, Any]] | None = None

--- a/astrbot/dashboard/schemas.py
+++ b/astrbot/dashboard/schemas.py
@@ -205,7 +205,7 @@ class ImMessageRequest(OpenModel):
 
 
 class KnowledgeBaseRequest(OpenModel):
-    kb_name: str | None = None
+    kb_name: str | None = Field(None, alias="name")
     description: str | None = None
     emoji: str | None = None
     embedding_provider_id: str | None = None
@@ -216,13 +216,15 @@ class KnowledgeBaseRequest(OpenModel):
     top_k_sparse: int | None = None
     top_m_final: int | None = None
 
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
     def canonical_payload(self) -> dict[str, Any]:
         """Return the service-facing knowledge base payload.
 
         Returns:
             Dictionary accepted by KnowledgeBaseService.
         """
-        data = self.model_dump(
+        return self.model_dump(
             exclude_unset=True,
             include={
                 "kb_name",
@@ -236,11 +238,14 @@ class KnowledgeBaseRequest(OpenModel):
                 "top_k_sparse",
                 "top_m_final",
             },
+            by_alias=False,
         )
-        legacy_name = getattr(self, "name", None)
-        if data.get("kb_name") is None and legacy_name is not None:
-            data["kb_name"] = legacy_name
-        return data
+
+
+class KnowledgeBaseCreateRequest(KnowledgeBaseRequest):
+    kb_name: str = Field(..., alias="name")
+    embedding_provider_id: str
+
 
 class KnowledgeBaseImportRequest(OpenModel):
     documents: list[dict[str, Any]] | None = None

--- a/astrbot/dashboard/schemas.py
+++ b/astrbot/dashboard/schemas.py
@@ -243,8 +243,11 @@ class KnowledgeBaseRequest(OpenModel):
 
 
 class KnowledgeBaseCreateRequest(KnowledgeBaseRequest):
-    kb_name: str = Field(..., alias="name")
-    embedding_provider_id: str
+    model_config = ConfigDict(
+        populate_by_name=True,
+        extra="allow",
+        json_schema_extra={"required": ["name", "embedding_provider_id"]},
+    )
 
 
 class KnowledgeBaseImportRequest(OpenModel):

--- a/astrbot/dashboard/services/knowledge_base_service.py
+++ b/astrbot/dashboard/services/knowledge_base_service.py
@@ -12,6 +12,7 @@ from astrbot.core import logger
 from astrbot.core.core_lifecycle import AstrBotCoreLifecycle
 from astrbot.core.provider.provider import EmbeddingProvider, RerankProvider
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
+from astrbot.dashboard.schemas import KnowledgeBaseRequest
 from astrbot.dashboard.utils import generate_tsne_visualization
 
 
@@ -33,17 +34,14 @@ class KnowledgeBaseService:
     def _canonical_kb_payload(data: object) -> dict[str, Any]:
         """Normalize knowledge base create/update payloads.
 
-        Args:
-            data: Request payload from v1 or legacy Dashboard routes.
-
-        Returns:
-            Payload using the service's canonical field names.
+        Uses KnowledgeBaseRequest to handle the legacy ``name`` →
+        ``kb_name`` migration while preserving operational fields
+        like ``kb_id``.
         """
-        payload = KnowledgeBaseService._payload(data).copy()
-        if payload.get("kb_name") is None and payload.get("name") is not None:
-            payload["kb_name"] = payload["name"]
-        payload.pop("name", None)
-        return payload
+        raw = KnowledgeBaseService._payload(data)
+        canonical = KnowledgeBaseRequest(**raw).canonical_payload()
+        raw.update(canonical)
+        return raw
 
     def get_kb_manager(self):
         return self.core_lifecycle.kb_manager
@@ -404,7 +402,7 @@ class KnowledgeBaseService:
         if not current_kb:
             raise KnowledgeBaseServiceError("知识库不存在")
         current = current_kb.kb
-        update_data = {key: getattr(current, key) for key in update_keys}
+        update_data = {key: getattr(current, key, None) for key in update_keys}
         update_data.update(provided_updates)
 
         kb_helper = await self.get_kb_manager().update_kb(

--- a/astrbot/dashboard/services/knowledge_base_service.py
+++ b/astrbot/dashboard/services/knowledge_base_service.py
@@ -29,6 +29,22 @@ class KnowledgeBaseService:
     def _payload(data: object) -> dict[str, Any]:
         return data if isinstance(data, dict) else {}
 
+    @staticmethod
+    def _canonical_kb_payload(data: object) -> dict[str, Any]:
+        """Normalize knowledge base create/update payloads.
+
+        Args:
+            data: Request payload from v1 or legacy Dashboard routes.
+
+        Returns:
+            Payload using the service's canonical field names.
+        """
+        payload = KnowledgeBaseService._payload(data).copy()
+        if payload.get("kb_name") is None and payload.get("name") is not None:
+            payload["kb_name"] = payload["name"]
+        payload.pop("name", None)
+        return payload
+
     def get_kb_manager(self):
         return self.core_lifecycle.kb_manager
 
@@ -293,7 +309,7 @@ class KnowledgeBaseService:
 
     async def create_kb(self, data: object) -> tuple[dict[str, Any], str]:
         kb_manager = self.get_kb_manager()
-        payload = self._payload(data)
+        payload = self._canonical_kb_payload(data)
         kb_name = payload.get("kb_name")
         if not kb_name:
             raise KnowledgeBaseServiceError("知识库名称不能为空")
@@ -363,7 +379,7 @@ class KnowledgeBaseService:
         return await self.get_kb(kb_id)
 
     async def update_kb(self, data: object) -> tuple[dict[str, Any], str]:
-        payload = self._payload(data)
+        payload = self._canonical_kb_payload(data)
         kb_id = payload.get("kb_id")
         if not kb_id:
             raise KnowledgeBaseServiceError("缺少参数 kb_id")
@@ -380,28 +396,20 @@ class KnowledgeBaseService:
             "top_k_sparse",
             "top_m_final",
         ]
-        if all(payload.get(key) is None for key in update_keys):
+        provided_updates = {key: payload[key] for key in update_keys if key in payload}
+        if not provided_updates:
             raise KnowledgeBaseServiceError("至少需要提供一个更新字段")
 
         current_kb = await self.get_kb_manager().get_kb(kb_id)
-        kb_name = payload.get("kb_name")
-        if kb_name is None:
-            if not current_kb:
-                raise KnowledgeBaseServiceError("知识库不存在")
-            kb_name = current_kb.kb.kb_name
+        if not current_kb:
+            raise KnowledgeBaseServiceError("知识库不存在")
+        current = current_kb.kb
+        update_data = {key: getattr(current, key) for key in update_keys}
+        update_data.update(provided_updates)
 
         kb_helper = await self.get_kb_manager().update_kb(
             kb_id=kb_id,
-            kb_name=kb_name,
-            description=payload.get("description"),
-            emoji=payload.get("emoji"),
-            embedding_provider_id=payload.get("embedding_provider_id"),
-            rerank_provider_id=payload.get("rerank_provider_id"),
-            chunk_size=payload.get("chunk_size"),
-            chunk_overlap=payload.get("chunk_overlap"),
-            top_k_dense=payload.get("top_k_dense"),
-            top_k_sparse=payload.get("top_k_sparse"),
-            top_m_final=payload.get("top_m_final"),
+            **update_data,
         )
         if not kb_helper:
             raise KnowledgeBaseServiceError("知识库不存在")
@@ -762,11 +770,11 @@ class KnowledgeBaseService:
 
         if not query:
             raise KnowledgeBaseServiceError("缺少参数 query")
+        kb_manager = self.get_kb_manager()
         if not kb_names or not isinstance(kb_names, list):
             raise KnowledgeBaseServiceError("缺少参数 kb_names 或格式错误")
 
         top_k = payload.get("top_k", 5)
-        kb_manager = self.get_kb_manager()
         results = await kb_manager.retrieve(
             query=query,
             kb_names=kb_names,

--- a/dashboard/src/api/generated/openapi-v1/types.gen.ts
+++ b/dashboard/src/api/generated/openapi-v1/types.gen.ts
@@ -255,13 +255,22 @@ export type JsonSchema = {
     [key: string]: unknown;
 };
 
+export type KnowledgeBaseCreateRequest = KnowledgeBaseRequest & {
+    kb_name: string;
+    embedding_provider_id: string;
+};
+
 export type KnowledgeBaseRequest = {
-    name: string;
+    kb_name?: string;
     description?: string;
-    embedding_provider_id?: string;
-    rerank_provider_id?: string;
-    chunking?: DynamicConfig;
-    metadata?: DynamicConfig;
+    emoji?: string;
+    embedding_provider_id?: (string) | null;
+    rerank_provider_id?: (string) | null;
+    chunk_size?: number;
+    chunk_overlap?: number;
+    top_k_dense?: number;
+    top_k_sparse?: number;
+    top_m_final?: number;
 };
 
 export type KnowledgeDocumentImportRequest = {
@@ -271,7 +280,6 @@ export type KnowledgeDocumentImportRequest = {
 
 export type KnowledgeDocumentUploadRequest = {
     file: (Blob | File);
-    parser?: string;
 };
 
 export type KnowledgeDocumentUrlImportRequest = {
@@ -2606,7 +2614,7 @@ export type ListKnowledgeBasesResponse = (SuccessEnvelope);
 export type ListKnowledgeBasesError = unknown;
 
 export type CreateKnowledgeBaseData = {
-    body: KnowledgeBaseRequest;
+    body: KnowledgeBaseCreateRequest;
 };
 
 export type CreateKnowledgeBaseResponse = (SuccessEnvelope);

--- a/dashboard/src/api/v1.ts
+++ b/dashboard/src/api/v1.ts
@@ -32,6 +32,8 @@ import {
   type DynamicConfig,
   type EnabledPatch,
   type GhproxyTestRequest,
+  type KnowledgeBaseCreateRequest,
+  type KnowledgeBaseRequest,
   type LoginRequest,
   type ListConversationsData,
   type McpServerConfig,
@@ -1366,16 +1368,16 @@ export const knowledgeApi = {
       openApiV1.getKnowledgeBase({ path: { kb_id: kbId } }),
     );
   },
-  create(config: OpenConfig) {
+  create(config: KnowledgeBaseCreateRequest) {
     return typed<OpenConfig>(
-      openApiV1.createKnowledgeBase({ body: config as any }),
+      openApiV1.createKnowledgeBase({ body: config }),
     );
   },
-  update(kbId: string, config: OpenConfig) {
+  update(kbId: string, config: KnowledgeBaseRequest) {
     return typed<OpenConfig>(
       openApiV1.updateKnowledgeBase({
         path: { kb_id: kbId },
-        body: config as any,
+        body: config,
       }),
     );
   },

--- a/dashboard/src/views/knowledge-base/KBList.vue
+++ b/dashboard/src/views/knowledge-base/KBList.vue
@@ -161,7 +161,9 @@
 
             <v-select v-model="formData.embedding_provider_id" :items="embeddingProviders"
               :item-title="item => item.embedding_model || item.id" :item-value="'id'"
-              :label="t('create.embeddingModelLabel')" variant="outlined" class="mb-4" :disabled="editingKB !== null" hint="嵌入模型选择后无法修改，如需更换请创建新的知识库。" persistent-hint>
+              :label="t('create.embeddingModelLabel')" variant="outlined" class="mb-4" :disabled="editingKB !== null"
+              :rules="[v => editingKB !== null || !!v || t('create.embeddingModelRequired')]" required
+              hint="嵌入模型选择后无法修改，如需更换请创建新的知识库。" persistent-hint>
               <template #item="{ props, item }">
                 <v-list-item v-bind="props">
                   <template #subtitle>
@@ -455,7 +457,10 @@ const submitForm = async () => {
     if (editingKB.value) {
       response = await knowledgeApi.update(editingKB.value.kb_id, payload)
     } else {
-      response = await knowledgeApi.create(payload)
+      response = await knowledgeApi.create({
+        ...payload,
+        embedding_provider_id: formData.value.embedding_provider_id!
+      })
     }
 
     if (response.data.status === 'ok') {

--- a/openspec/openapi-v1.yaml
+++ b/openspec/openapi-v1.yaml
@@ -3381,7 +3381,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/KnowledgeBaseRequest"
+              $ref: "#/components/schemas/KnowledgeBaseCreateRequest"
       responses:
         "200":
           $ref: "#/components/responses/Ok"
@@ -5700,21 +5700,40 @@ components:
 
     KnowledgeBaseRequest:
       type: object
-      required: [name]
       properties:
-        name:
+        kb_name:
           type: string
         description:
           type: string
+        emoji:
+          type: string
         embedding_provider_id:
-          type: string
+          type: [string, "null"]
         rerank_provider_id:
-          type: string
-        chunking:
-          $ref: "#/components/schemas/DynamicConfig"
-        metadata:
-          $ref: "#/components/schemas/DynamicConfig"
+          type: [string, "null"]
+        chunk_size:
+          type: integer
+        chunk_overlap:
+          type: integer
+        top_k_dense:
+          type: integer
+        top_k_sparse:
+          type: integer
+        top_m_final:
+          type: integer
       additionalProperties: false
+
+    KnowledgeBaseCreateRequest:
+      allOf:
+        - $ref: "#/components/schemas/KnowledgeBaseRequest"
+        - type: object
+          required: [kb_name, embedding_provider_id]
+          properties:
+            kb_name:
+              type: string
+            embedding_provider_id:
+              type: string
+          additionalProperties: false
 
     KnowledgeDocumentUploadRequest:
       type: object
@@ -5723,8 +5742,6 @@ components:
         file:
           type: string
           format: binary
-        parser:
-          type: string
 
     KnowledgeDocumentImportRequest:
       type: object

--- a/openspec/openapi-v1.yaml
+++ b/openspec/openapi-v1.yaml
@@ -5733,7 +5733,6 @@ components:
               type: string
             embedding_provider_id:
               type: string
-          additionalProperties: false
 
     KnowledgeDocumentUploadRequest:
       type: object

--- a/tests/test_fastapi_v1_dashboard.py
+++ b/tests/test_fastapi_v1_dashboard.py
@@ -1193,6 +1193,34 @@ async def test_v1_openapi_uses_pydantic_request_bodies(
 
 
 @pytest.mark.asyncio
+async def test_v1_knowledge_base_create_validation_uses_api_error_shape(
+    asgi_client: httpx.AsyncClient,
+):
+    headers = _jwt_headers()
+
+    missing_name_response = await asgi_client.post(
+        "/api/v1/knowledge-bases",
+        json={"embedding_provider_id": "embedding-1"},
+        headers=headers,
+    )
+    missing_provider_response = await asgi_client.post(
+        "/api/v1/knowledge-bases",
+        json={"name": "Docs"},
+        headers=headers,
+    )
+
+    assert missing_name_response.status_code == 200
+    assert missing_name_response.json()["status"] == "error"
+    assert missing_name_response.json()["message"] == "知识库名称不能为空"
+    assert missing_provider_response.status_code == 200
+    assert missing_provider_response.json()["status"] == "error"
+    assert (
+        missing_provider_response.json()["message"]
+        == "缺少参数 embedding_provider_id"
+    )
+
+
+@pytest.mark.asyncio
 async def test_v1_conversation_path_id_allows_slash(asgi_client: httpx.AsyncClient):
     response = await asgi_client.get(
         "/api/v1/conversations/conversation%2Fwith%2Fslash",

--- a/tests/unit/test_knowledge_base_service_contract.py
+++ b/tests/unit/test_knowledge_base_service_contract.py
@@ -264,3 +264,21 @@ def test_knowledge_base_request_uses_legacy_name_as_input_alias():
 
     assert payload == {"kb_name": "Legacy Name"}
 
+
+@pytest.mark.asyncio
+async def test_create_kb_raises_when_kb_name_is_missing():
+    kb_manager = MagicMock()
+    service = make_service(kb_manager)
+
+    with pytest.raises(KnowledgeBaseServiceError, match="知识库名称不能为空"):
+        await service.create_kb({"embedding_provider_id": "embedding-1"})
+
+
+@pytest.mark.asyncio
+async def test_create_kb_raises_when_embedding_provider_is_missing():
+    kb_manager = MagicMock()
+    service = make_service(kb_manager)
+
+    with pytest.raises(KnowledgeBaseServiceError, match="缺少参数 embedding_provider_id"):
+        await service.create_kb({"kb_name": "Test KB"})
+

--- a/tests/unit/test_knowledge_base_service_contract.py
+++ b/tests/unit/test_knowledge_base_service_contract.py
@@ -1,0 +1,266 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import Request
+
+from astrbot.core.provider.provider import EmbeddingProvider
+from astrbot.dashboard.api.knowledge_bases import (
+    list_knowledge_bases,
+)
+from astrbot.dashboard.schemas import (
+    KnowledgeBaseRequest,
+)
+from astrbot.dashboard.services.knowledge_base_service import (
+    KnowledgeBaseService,
+    KnowledgeBaseServiceError,
+)
+
+
+class FakeEmbeddingProvider(EmbeddingProvider):
+    def __init__(self):
+        super().__init__({}, {})
+
+    async def get_embedding(self, text: str) -> list[float]:
+        return [0.1, 0.2]
+
+    async def get_embeddings(self, text: list[str]) -> list[list[float]]:
+        return [[0.1, 0.2] for _ in text]
+
+    def get_dim(self) -> int:
+        return 2
+
+
+def make_service(kb_manager) -> KnowledgeBaseService:
+    service = KnowledgeBaseService.__new__(KnowledgeBaseService)
+    service.core_lifecycle = SimpleNamespace(kb_manager=kb_manager)
+    service.upload_progress = {}
+    service.upload_tasks = {}
+    return service
+
+
+def make_kb(kb_id: str, kb_name: str):
+    return SimpleNamespace(
+        kb_id=kb_id,
+        kb_name=kb_name,
+        description="description",
+        emoji="book",
+        embedding_provider_id="embedding-1",
+        rerank_provider_id="rerank-1",
+        chunk_size=512,
+        chunk_overlap=50,
+        top_k_dense=50,
+        top_k_sparse=50,
+        top_m_final=5,
+        model_dump=lambda: {"kb_id": kb_id, "kb_name": kb_name},
+    )
+
+
+def make_request(query_string: bytes) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/v1/knowledge-bases",
+            "query_string": query_string,
+            "headers": [],
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_kbs_applies_pagination():
+    kb_manager = MagicMock()
+    kb_manager.list_kbs = AsyncMock(
+        return_value=[
+            make_kb("kb-1", "one"),
+            make_kb("kb-2", "two"),
+            make_kb("kb-3", "three"),
+        ]
+    )
+    kb_manager.get_kb = AsyncMock(
+        side_effect=lambda kb_id: SimpleNamespace(init_error=None)
+    )
+    service = make_service(kb_manager)
+
+    result = await service.list_kbs(page=2, page_size=2)
+
+    assert result == {
+        "items": [{"kb_id": "kb-3", "kb_name": "three"}],
+        "page": 2,
+        "page_size": 2,
+        "total": 3,
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_kbs_without_page_size_returns_all_items():
+    kb_manager = MagicMock()
+    kb_manager.list_kbs = AsyncMock(
+        return_value=[
+            make_kb("kb-1", "one"),
+            make_kb("kb-2", "two"),
+            make_kb("kb-3", "three"),
+        ]
+    )
+    kb_manager.get_kb = AsyncMock(
+        side_effect=lambda kb_id: SimpleNamespace(init_error=None)
+    )
+    service = make_service(kb_manager)
+
+    result = await service.list_kbs(page=1, page_size=None)
+
+    assert result == {
+        "items": [
+            {"kb_id": "kb-1", "kb_name": "one"},
+            {"kb_id": "kb-2", "kb_name": "two"},
+            {"kb_id": "kb-3", "kb_name": "three"},
+        ],
+        "page": 1,
+        "page_size": 3,
+        "total": 3,
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_route_preserves_unpaginated_default():
+    service = MagicMock()
+    service.list_kbs = AsyncMock(return_value={"items": [], "total": 0})
+
+    response = await list_knowledge_bases(
+        make_request(b""),
+        _auth=object(),
+        service=service,
+    )
+
+    assert response["status"] == "ok"
+    service.list_kbs.assert_awaited_once_with(page=1, page_size=None)
+
+
+@pytest.mark.asyncio
+async def test_list_route_uses_default_page_size_when_page_is_explicit():
+    service = MagicMock()
+    service.list_kbs = AsyncMock(return_value={"items": [], "total": 0})
+
+    response = await list_knowledge_bases(
+        make_request(b"page=2"),
+        _auth=object(),
+        service=service,
+    )
+
+    assert response["status"] == "ok"
+    service.list_kbs.assert_awaited_once_with(page=2, page_size=20)
+
+
+@pytest.mark.asyncio
+async def test_create_kb_accepts_legacy_name_field():
+    kb = make_kb("kb-1", "From Name")
+    kb_manager = MagicMock()
+    kb_manager.provider_manager.get_provider_by_id = AsyncMock(
+        return_value=FakeEmbeddingProvider()
+    )
+    kb_manager.create_kb = AsyncMock(return_value=SimpleNamespace(kb=kb))
+    service = make_service(kb_manager)
+
+    result, message = await service.create_kb(
+        {
+            "name": "From Name",
+            "embedding_provider_id": "embedding-1",
+            "top_k_dense": 12,
+            "top_k_sparse": 8,
+            "top_m_final": 3,
+        }
+    )
+
+    assert message == "创建知识库成功"
+    assert result == {"kb_id": "kb-1", "kb_name": "From Name"}
+    kb_manager.create_kb.assert_awaited_once_with(
+        kb_name="From Name",
+        description=None,
+        emoji=None,
+        embedding_provider_id="embedding-1",
+        rerank_provider_id=None,
+        chunk_size=None,
+        chunk_overlap=None,
+        top_k_dense=12,
+        top_k_sparse=8,
+        top_m_final=3,
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_kb_preserves_omitted_fields():
+    kb = make_kb("kb-1", "Docs")
+    kb_manager = MagicMock()
+    kb_manager.get_kb = AsyncMock(return_value=SimpleNamespace(kb=kb))
+    kb_manager.update_kb = AsyncMock(return_value=SimpleNamespace(kb=kb))
+    service = make_service(kb_manager)
+
+    await service.update_kb({"kb_id": "kb-1", "chunk_size": 1024})
+
+    kb_manager.update_kb.assert_awaited_once_with(
+        kb_id="kb-1",
+        kb_name="Docs",
+        description="description",
+        emoji="book",
+        embedding_provider_id="embedding-1",
+        rerank_provider_id="rerank-1",
+        chunk_size=1024,
+        chunk_overlap=50,
+        top_k_dense=50,
+        top_k_sparse=50,
+        top_m_final=5,
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_kb_allows_explicit_rerank_provider_clear():
+    kb = make_kb("kb-1", "Docs")
+    kb_manager = MagicMock()
+    kb_manager.get_kb = AsyncMock(return_value=SimpleNamespace(kb=kb))
+    kb_manager.update_kb = AsyncMock(return_value=SimpleNamespace(kb=kb))
+    service = make_service(kb_manager)
+
+    await service.update_kb({"kb_id": "kb-1", "rerank_provider_id": None})
+
+    kb_manager.update_kb.assert_awaited_once()
+    assert kb_manager.update_kb.await_args.kwargs["rerank_provider_id"] is None
+
+
+def test_knowledge_base_schemas_match_service_contract():
+    create_payload = KnowledgeBaseRequest(
+        kb_name="Docs",
+        name="Legacy",
+        emoji="book",
+        top_k_dense=12,
+        top_k_sparse=8,
+        top_m_final=3,
+        kb_id="body-kb-id",
+    ).canonical_payload()
+    assert create_payload == {
+        "kb_name": "Docs",
+        "emoji": "book",
+        "top_k_dense": 12,
+        "top_k_sparse": 8,
+        "top_m_final": 3,
+    }
+    assert "kb_id" not in create_payload
+
+
+def test_knowledge_base_request_preserves_explicit_null_updates():
+    payload = KnowledgeBaseRequest(rerank_provider_id=None).canonical_payload()
+
+    assert payload == {"rerank_provider_id": None}
+
+
+def test_knowledge_base_request_omits_unset_none_fields():
+    payload = KnowledgeBaseRequest(kb_name="Docs").canonical_payload()
+
+    assert payload == {"kb_name": "Docs"}
+
+
+def test_knowledge_base_request_uses_legacy_name_as_input_alias():
+    payload = KnowledgeBaseRequest(name="Legacy Name").canonical_payload()
+
+    assert payload == {"kb_name": "Legacy Name"}
+

--- a/tests/unit/test_knowledge_base_service_contract.py
+++ b/tests/unit/test_knowledge_base_service_contract.py
@@ -94,36 +94,7 @@ async def test_list_kbs_applies_pagination():
 
 
 @pytest.mark.asyncio
-async def test_list_kbs_without_page_size_returns_all_items():
-    kb_manager = MagicMock()
-    kb_manager.list_kbs = AsyncMock(
-        return_value=[
-            make_kb("kb-1", "one"),
-            make_kb("kb-2", "two"),
-            make_kb("kb-3", "three"),
-        ]
-    )
-    kb_manager.get_kb = AsyncMock(
-        side_effect=lambda kb_id: SimpleNamespace(init_error=None)
-    )
-    service = make_service(kb_manager)
-
-    result = await service.list_kbs(page=1, page_size=None)
-
-    assert result == {
-        "items": [
-            {"kb_id": "kb-1", "kb_name": "one"},
-            {"kb_id": "kb-2", "kb_name": "two"},
-            {"kb_id": "kb-3", "kb_name": "three"},
-        ],
-        "page": 1,
-        "page_size": 3,
-        "total": 3,
-    }
-
-
-@pytest.mark.asyncio
-async def test_list_route_preserves_unpaginated_default():
+async def test_list_route_uses_default_page_size_without_query_params():
     service = MagicMock()
     service.list_kbs = AsyncMock(return_value={"items": [], "total": 0})
 
@@ -134,7 +105,7 @@ async def test_list_route_preserves_unpaginated_default():
     )
 
     assert response["status"] == "ok"
-    service.list_kbs.assert_awaited_once_with(page=1, page_size=None)
+    service.list_kbs.assert_awaited_once_with(page=1, page_size=20)
 
 
 @pytest.mark.asyncio
@@ -282,3 +253,14 @@ async def test_create_kb_raises_when_embedding_provider_is_missing():
     with pytest.raises(KnowledgeBaseServiceError, match="缺少参数 embedding_provider_id"):
         await service.create_kb({"kb_name": "Test KB"})
 
+
+@pytest.mark.asyncio
+async def test_create_kb_raises_when_embedding_provider_is_invalid():
+    kb_manager = MagicMock()
+    kb_manager.provider_manager.get_provider_by_id = AsyncMock(return_value=None)
+    service = make_service(kb_manager)
+
+    with pytest.raises(KnowledgeBaseServiceError, match="嵌入模型不存在或类型错误"):
+        await service.create_kb(
+            {"kb_name": "Test KB", "embedding_provider_id": "missing-provider"}
+        )


### PR DESCRIPTION
Unify knowledge base create/update/list with kb_name, canonical_payload, optional list pagination with total, and matching OpenAPI plus dashboard types.

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
The knowledge base CRUD (create/update/list) API contract is inconsistent between frontend and backend. The backend schema uses a `name` field while the generated frontend types expect `kb_name`. Both create and update share the same `KnowledgeBaseRequest` schema, but create requires `kb_name` and `embedding_provider_id`, while update does not — this shared schema leads to confusing validation semantics. Additionally, the knowledge base payload is missing canonical fields such as `emoji`, `chunk_size`, `chunk_overlap`, `top_k_dense`, `top_k_sparse`, and `top_m_final`.

This change unifies the frontend-backend contract: renames `name` to `kb_name`, introduces `KnowledgeBaseCreateRequest` to separate create and update semantics, promotes optional configuration parameters into canonical `KnowledgeBaseRequest` fields, and syncs the OpenAPI spec, backend schemas, and generated frontend types.

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
- **OpenAPI schema (`openspec/openapi-v1.yaml`)**:
  - `KnowledgeBaseRequest`: `name` → `kb_name`; added `emoji`, `chunk_size`, `chunk_overlap`, `top_k_dense`, `top_k_sparse`, `top_m_final` fields; `embedding_provider_id` / `rerank_provider_id` now accept `null`
  - Added `KnowledgeBaseCreateRequest` inheriting `KnowledgeBaseRequest` via `allOf`, marking `kb_name` and `embedding_provider_id` as required
- **Backend schema (`astrbot/dashboard/schemas.py`)**: synced `KnowledgeBaseRequest` and `KnowledgeBaseCreateRequest` Pydantic models
- **Backend API (`astrbot/dashboard/api/knowledge_bases.py`)**: `create_knowledge_base` uses `KnowledgeBaseCreateRequest`; `update_knowledge_base` and `list_knowledge_bases` adapted to `kb_name`
- **Backend service (`astrbot/dashboard/services/knowledge_base_service.py`)**: adapted to new schema field names and types
- **Frontend types (`dashboard/src/api/generated/openapi-v1/types.gen.ts`)**: regenerated
- **Frontend API (`dashboard/src/api/v1.ts`)**: adapted to new types
- **Frontend page (`dashboard/src/views/knowledge-base/KBList.vue`)**: `name` → `kb_name`
- **Tests (`tests/unit/test_knowledge_base_service_contract.py`)**: added 266 lines of end-to-end contract tests
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
```
tests/unit/test_knowledge_base_service_contract.py::test_list_kbs_applies_pagination PASSED
tests/unit/test_knowledge_base_service_contract.py::test_list_kbs_without_page_size_returns_all_items PASSED
tests/unit/test_knowledge_base_service_contract.py::test_list_route_preserves_unpaginated_default PASSED
tests/unit/test_knowledge_base_service_contract.py::test_list_route_uses_default_page_size_when_page_is_explicit PASSED
tests/unit/test_knowledge_base_service_contract.py::test_create_kb_accepts_legacy_name_field PASSED
tests/unit/test_knowledge_base_service_contract.py::test_update_kb_preserves_omitted_fields PASSED
tests/unit/test_knowledge_base_service_contract.py::test_update_kb_allows_explicit_rerank_provider_clear PASSED
tests/unit/test_knowledge_base_service_contract.py::test_knowledge_base_schemas_match_service_contract PASSED
tests/unit/test_knowledge_base_service_contract.py::test_knowledge_base_request_preserves_explicit_null_updates PASSED
tests/unit/test_knowledge_base_service_contract.py::test_knowledge_base_request_omits_unset_none_fields PASSED
tests/unit/test_knowledge_base_service_contract.py::test_knowledge_base_request_uses_legacy_name_as_input_alias PASSED

============================== 11 passed in 1.60s ==============================
```

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Align knowledge base CRUD contracts across backend, OpenAPI spec, and frontend, including canonical field names, pagination behavior, and configuration parameters.

New Features:
- Support optional pagination with total count in knowledge base list responses while preserving an unpaginated default mode.
- Expose canonical knowledge base configuration fields such as emoji and retrieval tuning parameters in the public API and dashboard.

Bug Fixes:
- Normalize knowledge base payloads to consistently use kb_name while preserving compatibility with legacy name input.
- Ensure knowledge base update requests preserve existing values for omitted fields while allowing explicit null updates for optional providers.

Enhancements:
- Split knowledge base create and update request schemas to accurately reflect required fields and type nullability.
- Add a canonical_payload helper on the knowledge base request model to generate service-facing payloads from API inputs.
- Strengthen the knowledge base API service tests with contract coverage for schemas, pagination semantics, and legacy compatibility.

Tests:
- Add unit tests covering knowledge base pagination semantics, legacy name handling, canonical payload generation, and update behavior.