### PR TITLE
chore: bump version to 4.26.1

### DIFF
--- a/astrbot/__init__.py
+++ b/astrbot/__init__.py
@@ -1,4 +1,4 @@
 import logging
 
-__version__ = "4.26.0"
+__version__ = "4.26.1"
 logger = logging.getLogger("astrbot")

--- a/changelogs/v4.26.1.md
+++ b/changelogs/v4.26.1.md
@@ -1,0 +1,30 @@
+- [更新日志(简体中文)](#chinese)
+- [Changelog(English)](#english)
+
+<a id="chinese"></a>
+
+## What's Changed
+
+### 修复
+
+- 修复插件注册的 LLM Tool 在受保护工具权限处理场景下可能无法正常调用的问题。([#9001](https://github.com/AstrBotDevs/AstrBot/pull/9001))
+- 修复等待 LLM 请求事件在获取会话锁前未及时处理停止信号的问题。([#8935](https://github.com/AstrBotDevs/AstrBot/pull/8935))
+- 回滚 QQ 官方平台发送消息时保留 At 组件的相关变更，避免引入兼容性问题。([#9004](https://github.com/AstrBotDevs/AstrBot/pull/9004))
+
+### 其他
+
+- 补充 Cloudflare Workers 静态资源相关配置。([commit](https://github.com/AstrBotDevs/AstrBot/commit/44df70d2e), [commit](https://github.com/AstrBotDevs/AstrBot/commit/348fe8172))
+
+<a id="english"></a>
+
+## What's Changed (EN)
+
+### Bug Fixes
+
+- Fixed a case where plugin-registered LLM tools could fail to invoke when guarded tool permission handling was applied. ([#9001](https://github.com/AstrBotDevs/AstrBot/pull/9001))
+- Fixed waiting LLM request events so stop signals are checked before acquiring the session lock. ([#8935](https://github.com/AstrBotDevs/AstrBot/pull/8935))
+- Reverted the QQ Official platform At component preservation change to avoid compatibility regressions. ([#9004](https://github.com/AstrBotDevs/AstrBot/pull/9004))
+
+### Other
+
+- Added Cloudflare Workers static asset configuration. ([commit](https://github.com/AstrBotDevs/AstrBot/commit/44df70d2e), [commit](https://github.com/AstrBotDevs/AstrBot/commit/348fe8172))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AstrBot"
-version = "4.26.0"
+version = "4.26.1"
 description = "Easy-to-use multi-platform LLM chatbot and development framework"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }


### PR DESCRIPTION
## Summary
- Bump AstrBot to 4.26.1.
- Add release notes for plugin-registered LLM tool invocation fixes and related changes.

## Validation
- uv run ruff format --check .
- uv run ruff check .

## Summary by Sourcery

Bump AstrBot to version 4.26.1 and document the associated fixes and changes for this release.

Bug Fixes:
- Document fixes for plugin-registered LLM tool invocation under guarded tool permissions.
- Document fixes to ensure waiting LLM request events respect stop signals before acquiring session locks.
- Document reversion of QQ Official platform At component preservation to avoid compatibility issues.

Documentation:
- Add bilingual (Chinese and English) changelog for the 4.26.1 release, covering bug fixes and Cloudflare Workers static asset configuration changes.