### PR TITLE
fix: correct outdated plugin marketplace update prompt

### DIFF
--- a/dashboard/src/components/shared/ExtensionCard.vue
+++ b/dashboard/src/components/shared/ExtensionCard.vue
@@ -269,6 +269,20 @@ const openWebui = () => {
               {{ extension.online_version }}
             </v-chip>
             <v-chip
+              v-else-if="extension?.version_source_ahead && extension?.online_version"
+              color="info"
+              label
+              size="small"
+              variant="outlined"
+            >
+              <v-icon icon="mdi-information-outline" start></v-icon>
+              {{
+                tm("card.status.localVersionAhead", {
+                  version: extension.online_version,
+                })
+              }}
+            </v-chip>
+            <v-chip
               v-for="tag in extension.tags"
               :key="tag"
               :color="tag === 'danger' ? 'error' : 'primary'"

--- a/dashboard/src/i18n/locales/en-US/features/extension.json
+++ b/dashboard/src/i18n/locales/en-US/features/extension.json
@@ -405,6 +405,7 @@
     },
     "status": {
       "hasUpdate": "New version available",
+      "localVersionAhead": "Installed version is newer than the current source (source {version})",
       "disabled": "This extension is disabled",
       "handlersCount": " handlers",
       "supportPlatform": "Supported Platform",

--- a/dashboard/src/i18n/locales/ru-RU/features/extension.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/extension.json
@@ -400,6 +400,7 @@
         },
         "status": {
             "hasUpdate": "Доступно обновление",
+            "localVersionAhead": "Установленная версия новее текущего источника (источник {version})",
             "disabled": "Плагин выключен",
             "handlersCount": "действий",
             "supportPlatform": "Платформы",

--- a/dashboard/src/i18n/locales/zh-CN/features/extension.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/extension.json
@@ -405,6 +405,7 @@
     },
     "status": {
       "hasUpdate": "有新版本可用",
+      "localVersionAhead": "当前插件版本比当前插件源更新（源版本 {version}）",
       "disabled": "该插件已经被禁用",
       "handlersCount": "个行为",
       "supportPlatform": "支持平台",

--- a/dashboard/src/views/extension/useExtensionPage.js
+++ b/dashboard/src/views/extension/useExtensionPage.js
@@ -658,12 +658,20 @@ export const useExtensionPage = () => {
 
       if (matchedPlugin) {
         extension.online_version = matchedPlugin.version;
+        const onlineVersion = String(matchedPlugin.version || "").trim();
+        const versionComparison = comparePluginVersions(
+          extension.version,
+          onlineVersion,
+        );
+
+        extension.version_source_ahead =
+          typeof versionComparison === "number" && versionComparison > 0;
         extension.has_update =
-          extension.version !== matchedPlugin.version &&
-          matchedPlugin.version !== tm("status.unknown");
+          typeof versionComparison === "number" && versionComparison < 0;
       } else {
         extension.online_version = "";
         extension.has_update = false;
+        extension.version_source_ahead = false;
       }
     });
   };
@@ -1283,6 +1291,72 @@ export const useExtensionPage = () => {
   };
 
   const normalizeAstrBotVersionSpec = (value) => String(value || "").trim();
+
+  const parsePluginVersion = (value) => {
+    const version = String(value || "").trim().replace(/^v/i, "");
+    const match = version.match(
+      /^([0-9]+(?:\.[0-9]+)*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+(.+))?$/,
+    );
+    if (!match) return null;
+
+    return {
+      parts: match[1].split(".").map((part) => Number.parseInt(part, 10)),
+      prerelease: match[2]
+        ? match[2].split(".").map((part) => {
+            if (/^\d+$/.test(part)) {
+              return Number.parseInt(part, 10);
+            }
+            return part;
+          })
+        : null,
+    };
+  };
+
+  const comparePluginVersions = (left, right) => {
+    const leftVersion = parsePluginVersion(left);
+    const rightVersion = parsePluginVersion(right);
+    if (!leftVersion || !rightVersion) return null;
+
+    const length = Math.max(leftVersion.parts.length, rightVersion.parts.length);
+    for (let i = 0; i < length; i += 1) {
+      const leftPart = leftVersion.parts[i] || 0;
+      const rightPart = rightVersion.parts[i] || 0;
+      if (leftPart > rightPart) return 1;
+      if (leftPart < rightPart) return -1;
+    }
+
+    if (leftVersion.prerelease === null && rightVersion.prerelease !== null) {
+      return 1;
+    }
+    if (leftVersion.prerelease !== null && rightVersion.prerelease === null) {
+      return -1;
+    }
+    if (leftVersion.prerelease === null && rightVersion.prerelease === null) {
+      return 0;
+    }
+
+    const prereleaseLength = Math.max(
+      leftVersion.prerelease.length,
+      rightVersion.prerelease.length,
+    );
+    for (let i = 0; i < prereleaseLength; i += 1) {
+      const leftPart = leftVersion.prerelease[i];
+      const rightPart = rightVersion.prerelease[i];
+
+      if (leftPart === undefined && rightPart !== undefined) return -1;
+      if (leftPart !== undefined && rightPart === undefined) return 1;
+      if (typeof leftPart === "number" && typeof rightPart === "string") {
+        return -1;
+      }
+      if (typeof leftPart === "string" && typeof rightPart === "number") {
+        return 1;
+      }
+      if (leftPart > rightPart) return 1;
+      if (leftPart < rightPart) return -1;
+    }
+
+    return 0;
+  };
 
   const normalizeVersionParts = (value) => {
     const version = String(value || "")

--- a/dashboard/src/views/extension/useExtensionPage.js
+++ b/dashboard/src/views/extension/useExtensionPage.js
@@ -1315,7 +1315,8 @@ export const useExtensionPage = () => {
   const comparePluginVersions = (left, right) => {
     const leftVersion = parsePluginVersion(left);
     const rightVersion = parsePluginVersion(right);
-    if (!leftVersion || !rightVersion) return null;
+    if (!rightVersion) return null;
+    if (!leftVersion) return -1;
 
     const length = Math.max(leftVersion.parts.length, rightVersion.parts.length);
     for (let i = 0; i < length; i += 1) {


### PR DESCRIPTION
优化了一下当前插件市场的版本更新的显示，当当前安装的插件版本高于插件源的版本时，不再显示更新图标，具体修改请看下面的PR内容：

当已安装插件版本高于插件市场或自定义插件源中的版本时，当前面板会把“版本不一致”误判为“有新版本可更新”。例如本地插件版本为 `0.1.5`，插件源版本为 `0.1.4` 时，页面会误提示更新到更旧的 `0.1.4`。

此 PR 修复插件更新状态判断：只有插件源版本高于本地版本时才显示更新提示；当本地插件版本高于当前插件源版本时，插件卡片会显示中性提示，不再展示误导性的更新入口。

### Modifications / 改动点

- 调整已安装插件的更新判断逻辑，不再将任意版本字符串不一致都视为可更新。
- 新增插件版本比较逻辑，支持预发布版本比较，并忽略构建元数据。
- 当本地插件版本高于插件市场或当前插件源版本时，新增本地版本领先状态。
- 在已安装插件卡片上显示“当前插件版本比当前插件源更新”的中性提示。
- 补充 `zh-CN`、`en-US`、`ru-RU` 三种语言下的本地版本领先提示文案。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

本地已执行以下检查：

```text
git diff --check
```

```text
./node_modules/.bin/vue-tsc --noEmit
```

手动代码链路验证：

- 本地版本 `0.1.5`，插件源版本 `0.1.4`：不再显示更新提示，显示本地版本领先提示。
- 本地版本 `0.1.4`，插件源版本 `0.1.5`：仍正常显示更新提示，并保留“更新到 0.1.5”的行为。
- 本地版本与插件源版本一致：不显示更新提示，也不显示本地版本领先提示。
- 批量更新仍基于 `has_update` 判断，本地版本领先的插件不会进入批量更新目标。
- 现有更新和重新安装请求逻辑未发生变化。

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Refine plugin marketplace update status so that update prompts only appear when the marketplace version is newer than the installed version, and show a neutral ahead-of-source state when the local version is more recent.

New Features:
- Add semantic-style plugin version comparison with prerelease support to distinguish newer, older, and equal versions between local and source.
- Display a neutral informational chip on extension cards when the installed plugin version is ahead of the marketplace or source version.

Enhancements:
- Stop treating any version string mismatch as an update, preventing prompts to downgrade plugins.
- Expose local-ahead version state on extensions so bulk update logic can exclude them from update targets.
- Extend i18n strings in zh-CN, en-US, and ru-RU locales for the new local-version-ahead status message.