### PR TITLE
fix: prevent plugin detail marketplace mismatches

### DIFF
--- a/dashboard/src/views/ExtensionPage.vue
+++ b/dashboard/src/views/ExtensionPage.vue
@@ -181,16 +181,30 @@ const selectedInstalledPlugin = computed(() => {
   return data.find((plugin) => plugin.name === selectedPluginId.value) || null;
 });
 
+const normalizeRepoUrl = (value) =>
+  String(value || "")
+    .trim()
+    .replace(/\/+$/, "")
+    .toLowerCase()
+    .replace(/\.git$/, "");
+
 const selectedMarketPlugin = computed(() => {
   const market = Array.isArray(pluginMarketData.value)
     ? pluginMarketData.value
     : [];
   const installedPlugin = selectedInstalledPlugin.value;
-  const repo = installedPlugin?.repo?.toLowerCase();
+  const marketNameMatch =
+    market.find((item) => item.name === selectedPluginId.value) || null;
+
+  if (selectedDetailTab.value === "market" || !installedPlugin) {
+    return marketNameMatch;
+  }
+
+  const repo = normalizeRepoUrl(installedPlugin.repo);
+  if (!repo) return null;
+
   return (
-    market.find((item) => item.name === selectedPluginId.value) ||
-    market.find((item) => repo && item.repo?.toLowerCase() === repo) ||
-    null
+    market.find((item) => normalizeRepoUrl(item?.repo) === repo) || null
   );
 });
 


### PR DESCRIPTION
### Modifications / Changes

Fixes #9026.

- Match an installed plugin to marketplace metadata by normalized repository URL instead of plugin name.
- Keep name-based marketplace lookup for marketplace detail pages, so browsing the marketplace still works.
- Avoid mixing same-name marketplace fields into installed plugin details when the local plugin has no matching repository.

- [x] This is NOT a breaking change.

### Screenshots or Test Results

```
corepack pnpm@10.24.0 build
```

The dashboard build passed. The build emitted existing warnings about missing MDI icon names and a Google Fonts download timeout, but Vite completed successfully.

---

### Checklist

- [x] My changes have been tested.
- [x] I have ensured that no new dependencies are introduced.
- [x] My changes do not introduce malicious code.

## Summary by Sourcery

Improve plugin marketplace matching logic to prevent incorrect marketplace details from being shown for installed plugins.

Bug Fixes:
- Resolve mismatches between installed plugins and marketplace metadata by matching on normalized repository URLs instead of plugin names when viewing installed plugin details.
- Ensure marketplace tab browsing still uses name-based lookup while avoiding mixing same-name marketplace metadata into installed plugin details when no matching repository exists.