### PR TITLE
fix: 修复 DeepSeek 推理模型截断导致的 400 错误

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -191,9 +191,16 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             )
         if llm_resp.completion_text:
             parts.append(TextPart(text=llm_resp.completion_text))
-        if len(parts) == 0:
-            logger.warning("LLM returned empty assistant message with no tool calls.")
-        self.run_context.messages.append(Message(role="assistant", content=parts))
+
+        # 只有 ThinkPart、没有正文/工具调用的消息，发出去时 content 会变空，
+        # 会被下游服务端拒收，因此不存。
+        has_real_content = any(not isinstance(p, ThinkPart) for p in parts)
+        if not has_real_content:
+            logger.warning(
+                "LLM response has no text/tool_calls, only reasoning; skipping this turn."
+            )
+        else:
+            self.run_context.messages.append(Message(role="assistant", content=parts))
 
         try:
             await self.agent_hooks.on_agent_done(self.run_context, llm_resp)

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -440,6 +440,7 @@ class ProviderOpenAIOfficial(Provider):
         ``content`` 和 ``tool_calls`` 时返回 400。把 ``""`` / ``None`` / ``[]``
         都视作空内容：无 tool_calls 时整条过滤掉；有 tool_calls 时将 content
         设为 ``None`` 以符合 OpenAI 规范。就地修改 ``payloads["messages"]``。
+        reasoning_content 不算数，不能替代 content/tool_calls。
         """
         messages = payloads.get("messages")
         if not isinstance(messages, list):
@@ -456,9 +457,8 @@ class ProviderOpenAIOfficial(Provider):
 
             content = msg.get("content")
             tool_calls = msg.get("tool_calls")
-            reasoning_content = msg.get("reasoning_content")
 
-            if _is_empty(content) and not tool_calls and not reasoning_content:
+            if _is_empty(content) and not tool_calls:
                 logger.warning(f"过滤第 {idx} 条空 assistant 消息 (无工具调用)")
                 continue
 


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
fix #9035 
### Modifications / 改动点
- tool_loop_agent_runner.py: _complete_with_assistant_response原本无条件 append 消息（len(parts)==0 只控制是否打日志，不影响是否存储）。改为仅在 parts 含有除 ThinkPart 之外的真实内容时才存入历史。

- openai_source.py: _sanitize_assistant_messages原判空条件把 reasoning_content 也当作"非空"依据，但reasoning_content 不能替代 content/tool_calls。去掉这个条件，只看 content 和 tool_calls 是否同时为空。

与 #8483 的区别：保留残缺消息，把 content 设为 "" 占位，靠空字符串通过校验。
本 PR：直接丢弃残缺消息，不存入历史。

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Avoid persisting assistant turns that contain only internal reasoning and no user-visible content or tool calls, ensuring only valid messages are sent downstream and stored in history.

Bug Fixes:
- Skip storing assistant messages that consist solely of reasoning parts to prevent downstream rejection of empty content.
- Treat assistant messages as empty unless they include content or tool_calls, ignoring reasoning_content when filtering invalid OpenAI payloads.