### PR TITLE
fix: _KeyRotator index bounds check

### DIFF
--- a/astrbot/core/tools/web_search_tools.py
+++ b/astrbot/core/tools/web_search_tools.py
@@ -73,6 +73,8 @@ class _KeyRotator:
             )
 
         async with self.lock:
+            if self.index >= len(keys):
+                self.index = 0
             key = keys[self.index]
             self.index = (self.index + 1) % len(keys)
             return key


### PR DESCRIPTION
[Bug] _KeyRotator IndexError when key list shrinks

## What
`_KeyRotator.get()` in `astrbot/core/tools/web_search_tools.py` raises `IndexError` when the configured key list has fewer entries than the internal `index` counter expects.

Same bug affects all four rotators: `_TAVILY_KEY_ROTATOR`, `_BOCHA_KEY_ROTATOR`, `_BRAVE_KEY_ROTATOR`, `_FIRECRAWL_KEY_ROTATOR`.

## Why
`_KeyRotator` is a module-level singleton. `self.index` persists across calls but only resets on bot restart. If someone configures 2 keys (index advances to 1), then later removes one (1 key left), the `if not keys` guard passes but `keys[self.index]` still blows up.

## Fix
One-line bounds check before accessing `keys[self.index]`:

```python
async with self.lock:
    if self.index >= len(keys):
        self.index = 0
    key = keys[self.index]
    ...
```

## Tested
- `index=1, keys=["a"]` → was IndexError, now returns "a" and resets index to 0
- Normal rotation with 2 keys still works correctly
- Single key with index=0 unchanged

Closes #9039

## Summary by Sourcery

Bug Fixes:
- Prevent IndexError in key rotator when the internal index exceeds the current number of configured keys.