### PR TITLE
fix: separate plugin and tool activation state

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -461,7 +461,9 @@ class ProviderOpenAIOfficial(Provider):
             if _is_empty(content) and not tool_calls:
                 if not reasoning_content:
                     # 三者全空，真正的垃圾消息，丢弃
-                    logger.debug(f"过滤第 {idx} 条空 assistant 消息 (无 content | tool_calls | reasoning_content)")
+                    logger.debug(
+                        f"过滤第 {idx} 条空 assistant 消息 (无 content | tool_calls | reasoning_content)"
+                    )
                     continue
                 else:
                     # ⭐ 有 reasoning_content 但没有 content 和 tool_calls
@@ -471,7 +473,7 @@ class ProviderOpenAIOfficial(Provider):
                     msg["content"] = ""
 
             elif _is_empty(content) and tool_calls:
-                msg["content"] = None   # 有 tool_calls，按 OpenAI 规范
+                msg["content"] = None  # 有 tool_calls，按 OpenAI 规范
 
             cleaned.append(msg)
 
@@ -881,9 +883,7 @@ class ProviderOpenAIOfficial(Provider):
         llm_response.id = completion.id
 
         llm_response.usage = (
-            self._extract_usage(completion.usage)
-            if completion.usage
-            else TokenUsage()
+            self._extract_usage(completion.usage) if completion.usage else TokenUsage()
         )
 
         return llm_response

--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -11,6 +11,7 @@ import os
 import sys
 import tempfile
 import traceback
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
@@ -815,7 +816,7 @@ class PluginManager:
         self.failed_plugin_info = "\n".join(lines) + "\n"
 
     @staticmethod
-    def _iter_concrete_llm_tools(func_tool: FunctionTool) -> list[FunctionTool]:
+    def _iter_concrete_llm_tools(func_tool: FunctionTool) -> Iterable[FunctionTool]:
         """Return concrete function tools that may belong to a plugin.
 
         Args:
@@ -825,12 +826,13 @@ class PluginManager:
             The concrete function tools to inspect for plugin ownership.
         """
         if isinstance(func_tool, HandoffTool):
-            return [
-                tool
-                for tool in (func_tool.agent.tools or [])
-                if isinstance(tool, FunctionTool)
-            ]
-        return [func_tool]
+            agent = getattr(func_tool, "agent", None)
+            tools = getattr(agent, "tools", None) if agent else None
+            for tool in tools or []:
+                if isinstance(tool, FunctionTool):
+                    yield tool
+            return
+        yield func_tool
 
     @staticmethod
     def _is_plugin_llm_tool(
@@ -846,7 +848,7 @@ class PluginManager:
         Returns:
             Whether the tool belongs to the plugin module.
         """
-        module_path = func_tool.handler_module_path
+        module_path = getattr(func_tool, "handler_module_path", None)
         return bool(
             plugin_module_path
             and module_path
@@ -858,7 +860,7 @@ class PluginManager:
     def _iter_plugin_llm_tools(
         cls,
         plugin_module_path: str | None,
-    ) -> list[FunctionTool]:
+    ) -> Iterable[FunctionTool]:
         """Return registered LLM tools owned by a plugin module.
 
         Args:
@@ -867,12 +869,12 @@ class PluginManager:
         Returns:
             Matching function tools, including sub-tools inside handoff tools.
         """
-        plugin_tools: list[FunctionTool] = []
+        if not plugin_module_path:
+            return
         for func_tool in llm_tools.func_list:
             for concrete_tool in cls._iter_concrete_llm_tools(func_tool):
                 if cls._is_plugin_llm_tool(concrete_tool, plugin_module_path):
-                    plugin_tools.append(concrete_tool)
-        return plugin_tools
+                    yield concrete_tool
 
     async def _migrate_legacy_plugin_tool_inactivation_state(
         self,
@@ -904,6 +906,7 @@ class PluginManager:
                     func_tool.active = not plugin_disabled
 
         if not plugin_tool_names and inactivated_llm_tools:
+            await sp.global_put(PLUGIN_TOOL_STATE_MIGRATION_KEY, True)
             return inactivated_llm_tools
 
         updated_tools = [
@@ -1364,6 +1367,11 @@ class PluginManager:
                     inactivated_plugins,
                 )
             )
+            inactive_tool_names = set(inactivated_llm_tools)
+            for func_tool in llm_tools.func_list:
+                for concrete_tool in self._iter_concrete_llm_tools(func_tool):
+                    if concrete_tool.name in inactive_tool_names:
+                        concrete_tool.active = False
 
         # 清除 pip.main 导致的多余的 logging handlers
         for handler in logging.root.handlers[:]:

--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -852,7 +852,10 @@ class PluginManager:
         return bool(
             plugin_module_path
             and module_path
-            and module_path.startswith(plugin_module_path)
+            and (
+                module_path == plugin_module_path
+                or module_path.startswith(f"{plugin_module_path}.")
+            )
             and not module_path.endswith(("astrbot.builtin_stars", "data.plugins"))
         )
 
@@ -906,7 +909,6 @@ class PluginManager:
                     func_tool.active = not plugin_disabled
 
         if not plugin_tool_names and inactivated_llm_tools:
-            await sp.global_put(PLUGIN_TOOL_STATE_MIGRATION_KEY, True)
             return inactivated_llm_tools
 
         updated_tools = [

--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -94,6 +94,9 @@ class ImportDependencyRecoveryState:
     install_plan: MissingRequirementsPlan | None = None
 
 
+PLUGIN_TOOL_STATE_MIGRATION_KEY = "inactivated_llm_tools_plugin_state_migrated_v1"
+
+
 @contextlib.contextmanager
 def _temporary_filtered_requirements_file(
     *,
@@ -811,6 +814,106 @@ class PluginManager:
 
         self.failed_plugin_info = "\n".join(lines) + "\n"
 
+    @staticmethod
+    def _iter_concrete_llm_tools(func_tool: FunctionTool) -> list[FunctionTool]:
+        """Return concrete function tools that may belong to a plugin.
+
+        Args:
+            func_tool: A registered function tool, possibly a handoff tool.
+
+        Returns:
+            The concrete function tools to inspect for plugin ownership.
+        """
+        if isinstance(func_tool, HandoffTool):
+            return [
+                tool
+                for tool in (func_tool.agent.tools or [])
+                if isinstance(tool, FunctionTool)
+            ]
+        return [func_tool]
+
+    @staticmethod
+    def _is_plugin_llm_tool(
+        func_tool: FunctionTool,
+        plugin_module_path: str | None,
+    ) -> bool:
+        """Check whether a function tool belongs to a plugin module.
+
+        Args:
+            func_tool: Function tool to inspect.
+            plugin_module_path: Plugin module path.
+
+        Returns:
+            Whether the tool belongs to the plugin module.
+        """
+        module_path = func_tool.handler_module_path
+        return bool(
+            plugin_module_path
+            and module_path
+            and module_path.startswith(plugin_module_path)
+            and not module_path.endswith(("astrbot.builtin_stars", "data.plugins"))
+        )
+
+    @classmethod
+    def _iter_plugin_llm_tools(
+        cls,
+        plugin_module_path: str | None,
+    ) -> list[FunctionTool]:
+        """Return registered LLM tools owned by a plugin module.
+
+        Args:
+            plugin_module_path: Plugin module path.
+
+        Returns:
+            Matching function tools, including sub-tools inside handoff tools.
+        """
+        plugin_tools: list[FunctionTool] = []
+        for func_tool in llm_tools.func_list:
+            for concrete_tool in cls._iter_concrete_llm_tools(func_tool):
+                if cls._is_plugin_llm_tool(concrete_tool, plugin_module_path):
+                    plugin_tools.append(concrete_tool)
+        return plugin_tools
+
+    async def _migrate_legacy_plugin_tool_inactivation_state(
+        self,
+        inactivated_llm_tools: list,
+        inactivated_plugins: list,
+    ) -> list:
+        """Remove plugin-owned tools from the legacy manual tool blacklist.
+
+        Args:
+            inactivated_llm_tools: Persisted inactive tool names.
+            inactivated_plugins: Persisted inactive plugin module paths.
+
+        Returns:
+            Updated inactive tool names.
+        """
+        migrated = await sp.global_get(PLUGIN_TOOL_STATE_MIGRATION_KEY, False)
+        if migrated:
+            return inactivated_llm_tools
+
+        plugin_tool_names: set[str] = set()
+        inactive_plugin_paths = set(inactivated_plugins)
+        for star_metadata in star_registry:
+            if not star_metadata.module_path:
+                continue
+            plugin_disabled = star_metadata.module_path in inactive_plugin_paths
+            for func_tool in self._iter_plugin_llm_tools(star_metadata.module_path):
+                plugin_tool_names.add(func_tool.name)
+                if func_tool.name in inactivated_llm_tools:
+                    func_tool.active = not plugin_disabled
+
+        if not plugin_tool_names and inactivated_llm_tools:
+            return inactivated_llm_tools
+
+        updated_tools = [
+            name for name in inactivated_llm_tools if name not in plugin_tool_names
+        ]
+        if updated_tools != inactivated_llm_tools:
+            await sp.global_put("inactivated_llm_tools", updated_tools)
+        await sp.global_put(PLUGIN_TOOL_STATE_MIGRATION_KEY, True)
+        return updated_tools
+
     async def reload_failed_plugin(self, dir_name):
         """
         重新加载未注册（加载失败）的插件
@@ -1089,19 +1192,11 @@ class PluginManager:
                             handler.handler,
                             metadata.star_cls,  # type: ignore
                         )
+                    plugin_disabled = metadata.module_path in inactivated_plugins
+
                     # 绑定 llm_tool handler
                     for func_tool in llm_tools.func_list:
-                        if isinstance(func_tool, HandoffTool):
-                            need_apply = []
-                            sub_tools = func_tool.agent.tools
-                            if sub_tools:
-                                for sub_tool in sub_tools:
-                                    if isinstance(sub_tool, FunctionTool):
-                                        need_apply.append(sub_tool)
-                        else:
-                            need_apply = [func_tool]
-
-                        for ft in need_apply:
+                        for ft in self._iter_concrete_llm_tools(func_tool):
                             if (
                                 ft.handler
                                 and ft.handler.__module__ == metadata.module_path
@@ -1111,8 +1206,11 @@ class PluginManager:
                                     ft.handler,
                                     metadata.star_cls,  # type: ignore
                                 )
-                            if ft.name in inactivated_llm_tools:
-                                ft.active = False
+                            if self._is_plugin_llm_tool(ft, metadata.module_path):
+                                ft.active = (
+                                    not plugin_disabled
+                                    and ft.name not in inactivated_llm_tools
+                                )
 
                 else:
                     # v3.4.0 以前的方式注册插件
@@ -1258,6 +1356,14 @@ class PluginManager:
                     )
                 )
                 self._cleanup_plugin_state(root_dir_name, reserved)
+
+        if not specified_module_path and not specified_dir_name:
+            inactivated_llm_tools = (
+                await self._migrate_legacy_plugin_tool_inactivation_state(
+                    inactivated_llm_tools,
+                    inactivated_plugins,
+                )
+            )
 
         # 清除 pip.main 导致的多余的 logging handlers
         for handler in logging.root.handlers[:]:
@@ -1706,7 +1812,7 @@ class PluginManager:
         """禁用一个插件。
         调用插件的 terminate() 方法，
         将插件的 module_path 加入到 data/shared_preferences.json 的 inactivated_plugins 列表中。
-        并且同时将插件启用的 llm_tool 禁用。
+        Disables the plugin's LLM tools only for the current runtime state.
         """
         async with self._pm_lock:
             plugin = self.context.get_registered_star(plugin_name)
@@ -1721,25 +1827,10 @@ class PluginManager:
             if plugin.module_path not in inactivated_plugins:
                 inactivated_plugins.append(plugin.module_path)
 
-            inactivated_llm_tools: list = list(
-                set(await sp.global_get("inactivated_llm_tools", [])),
-            )  # 后向兼容
-
-            # 禁用插件启用的 llm_tool
-            for func_tool in llm_tools.func_list:
-                mp = func_tool.handler_module_path
-                if (
-                    plugin.module_path
-                    and mp
-                    and mp.startswith(plugin.module_path)
-                    and not mp.endswith(("astrbot.builtin_stars", "data.plugins"))
-                ):
-                    func_tool.active = False
-                    if func_tool.name not in inactivated_llm_tools:
-                        inactivated_llm_tools.append(func_tool.name)
+            for func_tool in self._iter_plugin_llm_tools(plugin.module_path):
+                func_tool.active = False
 
             await sp.global_put("inactivated_plugins", inactivated_plugins)
-            await sp.global_put("inactivated_llm_tools", inactivated_llm_tools)
 
             plugin.activated = False
 
@@ -1800,19 +1891,8 @@ class PluginManager:
             inactivated_plugins.remove(plugin.module_path)
         await sp.global_put("inactivated_plugins", inactivated_plugins)
 
-        # 启用插件启用的 llm_tool
-        for func_tool in llm_tools.func_list:
-            mp = func_tool.handler_module_path
-            if (
-                plugin.module_path
-                and mp
-                and mp.startswith(plugin.module_path)
-                and not mp.endswith(("astrbot.builtin_stars", "data.plugins"))
-                and func_tool.name in inactivated_llm_tools
-            ):
-                inactivated_llm_tools.remove(func_tool.name)
-                func_tool.active = True
-        await sp.global_put("inactivated_llm_tools", inactivated_llm_tools)
+        for func_tool in self._iter_plugin_llm_tools(plugin.module_path):
+            func_tool.active = func_tool.name not in inactivated_llm_tools
 
         await self.reload(plugin_name)
 

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -582,7 +582,7 @@ async def test_turn_plugin_toggles_llm_tools_from_plugin_child_module(
         assert plugin_tool.active is False
         assert other_tool.active is True
         assert preferences["inactivated_plugins"] == [plugin.module_path]
-        assert preferences["inactivated_llm_tools"] == [plugin_tool.name]
+        assert preferences["inactivated_llm_tools"] == []
         assert plugin.activated is False
 
         await plugin_manager_pm.turn_on_plugin(plugin.root_dir_name)
@@ -593,6 +593,135 @@ async def test_turn_plugin_toggles_llm_tools_from_plugin_child_module(
         assert preferences["inactivated_llm_tools"] == []
     finally:
         llm_tools.func_list = original_func_list
+
+
+@pytest.mark.asyncio
+async def test_turn_plugin_preserves_user_disabled_llm_tools(
+    plugin_manager_pm: PluginManager,
+    monkeypatch,
+):
+    plugin = star_manager_module.StarMetadata(
+        name="demo_plugin",
+        root_dir_name="demo_plugin",
+        module_path="data.plugins.demo_plugin.main",
+    )
+    cast(Any, plugin_manager_pm.context).stars.append(plugin)
+    plugin_tool = star_manager_module.FunctionTool(
+        name="plugin_search",
+        description="plugin search",
+        parameters={"type": "object", "properties": {}},
+        handler_module_path="data.plugins.demo_plugin.main.tools.search",
+    )
+    llm_tools = cast(Any, star_manager_module.llm_tools)
+    original_func_list = llm_tools.func_list
+    llm_tools.func_list = [plugin_tool]
+    preferences = {
+        "inactivated_plugins": [],
+        "inactivated_llm_tools": [plugin_tool.name],
+    }
+
+    async def mock_global_get(key, default=None):
+        return preferences.get(key, default)
+
+    async def mock_global_put(key, value):
+        preferences[key] = value
+
+    async def mock_terminate(star_metadata):
+        assert star_metadata is plugin
+
+    async def mock_reload(plugin_name):
+        assert plugin_name == plugin.root_dir_name
+        return True, None
+
+    monkeypatch.setattr(star_manager_module.sp, "global_get", mock_global_get)
+    monkeypatch.setattr(star_manager_module.sp, "global_put", mock_global_put)
+    monkeypatch.setattr(plugin_manager_pm, "_terminate_plugin", mock_terminate)
+    monkeypatch.setattr(plugin_manager_pm, "reload", mock_reload)
+
+    try:
+        await plugin_manager_pm.turn_off_plugin(plugin.root_dir_name)
+        await plugin_manager_pm.turn_on_plugin(plugin.root_dir_name)
+
+        assert plugin_tool.active is False
+        assert preferences["inactivated_plugins"] == []
+        assert preferences["inactivated_llm_tools"] == [plugin_tool.name]
+    finally:
+        llm_tools.func_list = original_func_list
+
+
+@pytest.mark.asyncio
+async def test_migrate_legacy_plugin_tool_inactivation_state(
+    plugin_manager_pm: PluginManager,
+    monkeypatch,
+):
+    active_plugin = star_manager_module.StarMetadata(
+        name="active_plugin",
+        module_path="data.plugins.active_plugin.main",
+    )
+    inactive_plugin = star_manager_module.StarMetadata(
+        name="inactive_plugin",
+        module_path="data.plugins.inactive_plugin.main",
+    )
+    star_manager_module.star_registry.extend([active_plugin, inactive_plugin])
+    active_tool = star_manager_module.FunctionTool(
+        name="active_plugin_search",
+        description="active plugin search",
+        parameters={"type": "object", "properties": {}},
+        handler_module_path="data.plugins.active_plugin.main.tools.search",
+    )
+    inactive_tool = star_manager_module.FunctionTool(
+        name="inactive_plugin_search",
+        description="inactive plugin search",
+        parameters={"type": "object", "properties": {}},
+        handler_module_path="data.plugins.inactive_plugin.main.tools.search",
+    )
+    user_tool = star_manager_module.FunctionTool(
+        name="user_disabled_builtin",
+        description="user disabled builtin",
+        parameters={"type": "object", "properties": {}},
+        handler_module_path="astrbot.core.tools.user_disabled_builtin",
+    )
+    active_tool.active = False
+    inactive_tool.active = False
+    user_tool.active = False
+    llm_tools = cast(Any, star_manager_module.llm_tools)
+    original_func_list = llm_tools.func_list
+    llm_tools.func_list = [active_tool, inactive_tool, user_tool]
+    preferences = {
+        "inactivated_llm_tools": [
+            active_tool.name,
+            inactive_tool.name,
+            user_tool.name,
+        ],
+        star_manager_module.PLUGIN_TOOL_STATE_MIGRATION_KEY: False,
+    }
+
+    async def mock_global_get(key, default=None):
+        return preferences.get(key, default)
+
+    async def mock_global_put(key, value):
+        preferences[key] = value
+
+    monkeypatch.setattr(star_manager_module.sp, "global_get", mock_global_get)
+    monkeypatch.setattr(star_manager_module.sp, "global_put", mock_global_put)
+
+    try:
+        updated_tools = (
+            await plugin_manager_pm._migrate_legacy_plugin_tool_inactivation_state(
+                preferences["inactivated_llm_tools"],
+                [inactive_plugin.module_path],
+            )
+        )
+
+        assert updated_tools == [user_tool.name]
+        assert preferences["inactivated_llm_tools"] == [user_tool.name]
+        assert preferences[star_manager_module.PLUGIN_TOOL_STATE_MIGRATION_KEY] is True
+        assert active_tool.active is True
+        assert inactive_tool.active is False
+        assert user_tool.active is False
+    finally:
+        llm_tools.func_list = original_func_list
+        _clear_star_runtime_state()
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -596,6 +596,37 @@ async def test_turn_plugin_toggles_llm_tools_from_plugin_child_module(
         cast(Any, plugin_manager_pm.context).stars.remove(plugin)
 
 
+def test_is_plugin_llm_tool_requires_module_boundary():
+    plugin_module_path = "data.plugins.weather.main"
+    plugin_tool = star_manager_module.FunctionTool(
+        name="weather",
+        description="weather",
+        parameters={"type": "object", "properties": {}},
+        handler_module_path=plugin_module_path,
+    )
+    child_module_tool = star_manager_module.FunctionTool(
+        name="weather_child",
+        description="weather child",
+        parameters={"type": "object", "properties": {}},
+        handler_module_path="data.plugins.weather.main.tools.search",
+    )
+    prefixed_module_tool = star_manager_module.FunctionTool(
+        name="weather_prefixed",
+        description="weather prefixed",
+        parameters={"type": "object", "properties": {}},
+        handler_module_path="data.plugins.weather.main_extra.tools.search",
+    )
+
+    assert PluginManager._is_plugin_llm_tool(plugin_tool, plugin_module_path) is True
+    assert (
+        PluginManager._is_plugin_llm_tool(child_module_tool, plugin_module_path) is True
+    )
+    assert (
+        PluginManager._is_plugin_llm_tool(prefixed_module_tool, plugin_module_path)
+        is False
+    )
+
+
 @pytest.mark.asyncio
 async def test_turn_plugin_preserves_user_disabled_llm_tools(
     plugin_manager_pm: PluginManager,
@@ -727,6 +758,44 @@ async def test_migrate_legacy_plugin_tool_inactivation_state(
 
 
 @pytest.mark.asyncio
+async def test_migrate_legacy_plugin_tool_inactivation_state_defers_without_loaded_plugin_tools(
+    plugin_manager_pm: PluginManager,
+    monkeypatch,
+):
+    llm_tools = cast(Any, star_manager_module.llm_tools)
+    original_func_list = llm_tools.func_list
+    llm_tools.func_list = []
+    preferences = {
+        "inactivated_llm_tools": ["legacy_plugin_tool"],
+        star_manager_module.PLUGIN_TOOL_STATE_MIGRATION_KEY: False,
+    }
+
+    async def mock_global_get(key, default=None):
+        return preferences.get(key, default)
+
+    async def mock_global_put(key, value):
+        preferences[key] = value
+
+    monkeypatch.setattr(star_manager_module.sp, "global_get", mock_global_get)
+    monkeypatch.setattr(star_manager_module.sp, "global_put", mock_global_put)
+
+    try:
+        updated_tools = (
+            await plugin_manager_pm._migrate_legacy_plugin_tool_inactivation_state(
+                preferences["inactivated_llm_tools"],
+                [],
+            )
+        )
+
+        assert updated_tools == ["legacy_plugin_tool"]
+        assert preferences["inactivated_llm_tools"] == ["legacy_plugin_tool"]
+        assert preferences[star_manager_module.PLUGIN_TOOL_STATE_MIGRATION_KEY] is False
+    finally:
+        llm_tools.func_list = original_func_list
+        _clear_star_runtime_state()
+
+
+@pytest.mark.asyncio
 async def test_load_applies_manual_inactivation_to_non_plugin_tools(
     plugin_manager_pm: PluginManager,
     monkeypatch,
@@ -772,7 +841,7 @@ async def test_load_applies_manual_inactivation_to_non_plugin_tools(
         assert error is None
         assert manual_tool.active is False
         assert preferences["inactivated_llm_tools"] == [manual_tool.name]
-        assert preferences[star_manager_module.PLUGIN_TOOL_STATE_MIGRATION_KEY] is True
+        assert preferences[star_manager_module.PLUGIN_TOOL_STATE_MIGRATION_KEY] is False
     finally:
         llm_tools.func_list = original_func_list
 

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -593,6 +593,7 @@ async def test_turn_plugin_toggles_llm_tools_from_plugin_child_module(
         assert preferences["inactivated_llm_tools"] == []
     finally:
         llm_tools.func_list = original_func_list
+        cast(Any, plugin_manager_pm.context).stars.remove(plugin)
 
 
 @pytest.mark.asyncio
@@ -647,6 +648,7 @@ async def test_turn_plugin_preserves_user_disabled_llm_tools(
         assert preferences["inactivated_llm_tools"] == [plugin_tool.name]
     finally:
         llm_tools.func_list = original_func_list
+        cast(Any, plugin_manager_pm.context).stars.remove(plugin)
 
 
 @pytest.mark.asyncio
@@ -722,6 +724,57 @@ async def test_migrate_legacy_plugin_tool_inactivation_state(
     finally:
         llm_tools.func_list = original_func_list
         _clear_star_runtime_state()
+
+
+@pytest.mark.asyncio
+async def test_load_applies_manual_inactivation_to_non_plugin_tools(
+    plugin_manager_pm: PluginManager,
+    monkeypatch,
+):
+    manual_tool = star_manager_module.FunctionTool(
+        name="manual_tool",
+        description="manual tool",
+        parameters={"type": "object", "properties": {}},
+        handler_module_path="external.tools.manual",
+    )
+    llm_tools = cast(Any, star_manager_module.llm_tools)
+    original_func_list = llm_tools.func_list
+    llm_tools.func_list = [manual_tool]
+    preferences = {
+        "inactivated_plugins": [],
+        "inactivated_llm_tools": [manual_tool.name],
+        "alter_cmd": {},
+        star_manager_module.PLUGIN_TOOL_STATE_MIGRATION_KEY: False,
+    }
+
+    async def mock_global_get(key, default=None):
+        return preferences.get(key, default)
+
+    async def mock_global_put(key, value):
+        preferences[key] = value
+
+    async def mock_sync_command_configs():
+        return None
+
+    monkeypatch.setattr(star_manager_module.sp, "global_get", mock_global_get)
+    monkeypatch.setattr(star_manager_module.sp, "global_put", mock_global_put)
+    monkeypatch.setattr(plugin_manager_pm, "_get_plugin_modules", lambda: [])
+    monkeypatch.setattr(
+        star_manager_module,
+        "sync_command_configs",
+        mock_sync_command_configs,
+    )
+
+    try:
+        success, error = await plugin_manager_pm.load()
+
+        assert success is True
+        assert error is None
+        assert manual_tool.active is False
+        assert preferences["inactivated_llm_tools"] == [manual_tool.name]
+        assert preferences[star_manager_module.PLUGIN_TOOL_STATE_MIGRATION_KEY] is True
+    finally:
+        llm_tools.func_list = original_func_list
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- stop persisting plugin-disable side effects into the manual `inactivated_llm_tools` blacklist
- compute plugin tool availability from both plugin activation state and user-disabled tool state during load
- add a one-time legacy cleanup for plugin-owned tool names previously stored in `inactivated_llm_tools`
- add regression tests for plugin toggles, user-disabled tools, and legacy migration

Fixes #8584.

## Tests
- `uv run pytest tests/test_plugin_manager.py tests/unit/test_func_tool_manager.py`
- `uv run ruff format astrbot/core/star/star_manager.py tests/test_plugin_manager.py`
- `uv run ruff check .`
- `git diff --check`