### PR TITLE
chore: bump version to 4.26.2

### DIFF
--- a/astrbot/__init__.py
+++ b/astrbot/__init__.py
@@ -1,4 +1,4 @@
 import logging
 
-__version__ = "4.26.1"
+__version__ = "4.26.2"
 logger = logging.getLogger("astrbot")

--- a/changelogs/v4.26.2.md
+++ b/changelogs/v4.26.2.md
@@ -1,0 +1,61 @@
+## What's Changed
+
+### Fixes
+
+- Preserve image formats and JPEG quality during media conversion (#9019, #9031)
+- Fix `DashboardRequest` compatibility for dashboard requests, resolving some IM webhook errors (#9021, #9023)
+- Normalize streamed message whitespace and strip trailing buffers before sending (#9029)
+- Prevent plugin detail marketplace mismatches (#9028)
+- Reliably kill shell process trees on Windows timeout (#8822)
+- Guard `_KeyRotator` index bounds (#9040)
+- Track plugin install source for update checks (#9037)
+- Handle MiMo STT audio and reasoning output (#8938)
+- Only show plugin updates for newer market versions
+- Sanitize orphaned `tool_result` blocks in the Anthropic provider (#8952)
+- Preserve assistant messages that contain `reasoning_content` without content or tool calls (#8483)
+- Recognize DeepSeek V4 proxy model names with substring matching (#9015)
+- Clear KV storage when uninstalling plugins and update related i18n text (#8291)
+- Separate plugin and tool activation state (#9048)
+- Keep Tab navigation within reset-password inputs in the account dialog (#9049)
+- Align OpenAI tool message sanitization (#8350)
+- Avoid duplicate `send_message_to_user` replies (#9051)
+
+### Documentation
+
+- Update the Python requirement to 3.12 (#9022)
+- Add the Spanish README (#9020)
+
+### Chores
+
+- Remove the plugin publish issue template (#9050)
+
+## 中文翻译
+
+### 修复
+
+- 在媒体转换过程中保留图片格式和 JPEG 质量 (#9019, #9031)
+- 修复 `DashboardRequest` 对仪表盘请求的兼容性，解决部分 IM webhook 报错问题 (#9021, #9023)
+- 统一流式消息片段中的空白字符处理，并在发送前移除尾部缓存 (#9029)
+- 防止插件详情与插件市场信息不匹配 (#9028)
+- 在 Windows 超时场景下可靠终止 shell 进程树 (#8822)
+- 修复 `_KeyRotator` 索引边界检查 (#9040)
+- 跟踪插件安装来源，用于更新检查 (#9037)
+- 处理 MiMo STT 音频和推理输出 (#8938)
+- 仅在插件市场版本更新时显示插件更新提示
+- 清理 Anthropic 提供商中的孤立 `tool_result` 块 (#8952)
+- 保留只包含 `reasoning_content`、但没有内容或工具调用的 assistant 消息 (#8483)
+- 通过子字符串匹配识别 DeepSeek V4 代理模型名称 (#9015)
+- 卸载插件时清理 KV 存储，并更新相关 i18n 文案 (#8291)
+- 分离插件和工具的启用状态 (#9048)
+- 在账号对话框中，将 Tab 导航限制在重置密码输入框内 (#9049)
+- 对齐 OpenAI 工具消息清理逻辑 (#8350)
+- 避免重复发送 `send_message_to_user` 回复 (#9051)
+
+### 文档
+
+- 将 Python 版本要求更新为 3.12 (#9022)
+- 添加西班牙语 README (#9020)
+
+### 杂项
+
+- 移除插件发布 issue 模板 (#9050)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AstrBot"
-version = "4.26.1"
+version = "4.26.2"
 description = "Easy-to-use multi-platform LLM chatbot and development framework"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }


### PR DESCRIPTION
## Summary

- Bump package version to 4.26.2
- Add the v4.26.2 changelog

## Checks

- uv run ruff format --check .
- uv run ruff check .

## Summary by Sourcery

Bump AstrBot to version 4.26.2 and add the corresponding changelog entry.

Build:
- Update project metadata to version 4.26.2.

Documentation:
- Add changelog for release v4.26.2 describing recent fixes, documentation updates, and chores.