### PR TITLE
fix: preserve fallback models for future tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,6 @@ astrbot.lock
 # Other
 chroma
 venv/*
-test.md
 pytest.ini
 AGENTS.md
 IFLOW.md

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ astrbot.lock
 # Other
 chroma
 venv/*
+test.md
 pytest.ini
 AGENTS.md
 IFLOW.md

--- a/astrbot/core/cron/manager.py
+++ b/astrbot/core/cron/manager.py
@@ -416,13 +416,13 @@ class CronJobManager:
         if cron_payload.get("origin", "tool") == "api":
             cron_event.role = "admin"
 
-        tool_call_timeout = cfg.get("provider_settings", {}).get(
-            "tool_call_timeout", 120
-        )
+        provider_settings = cfg.get("provider_settings", {}) or {}
+        tool_call_timeout = provider_settings.get("tool_call_timeout", 120)
         config = MainAgentBuildConfig(
             tool_call_timeout=tool_call_timeout,
             llm_safety_mode=False,
             streaming_response=False,
+            provider_settings=provider_settings,
         )
         req = ProviderRequest()
         conv = await _get_session_conv(event=cron_event, plugin_context=self.ctx)

--- a/tests/unit/test_cron_manager.py
+++ b/tests/unit/test_cron_manager.py
@@ -534,6 +534,72 @@ class TestRunBasicJob:
             await cron_manager._run_basic_job(sample_cron_job)
 
 
+class TestRunActiveAgentJob:
+    """Tests for active agent cron job execution."""
+
+    @pytest.mark.asyncio
+    async def test_woke_main_agent_passes_provider_settings(self, cron_manager):
+        """Test active cron agent keeps fallback chat model settings."""
+        provider_settings = {
+            "tool_call_timeout": 77,
+            "fallback_chat_models": ["fallback-provider"],
+        }
+        ctx = MagicMock()
+        ctx.get_config.return_value = {
+            "admins_id": [],
+            "provider_settings": provider_settings,
+        }
+        cron_manager.ctx = ctx
+
+        conv = MagicMock()
+        conv.history = "[]"
+
+        class FakeRunner:
+            def step_until_done(self, max_step):
+                async def gen():
+                    if False:
+                        yield None
+
+                return gen()
+
+            def get_final_llm_resp(self):
+                return None
+
+        captured = {}
+
+        async def fake_build_main_agent(*, event, plugin_context, config, req):
+            captured["config"] = config
+            return MagicMock(agent_runner=FakeRunner())
+
+        async def fake_persist_agent_history(*args, **kwargs):
+            return None
+
+        with (
+            patch(
+                "astrbot.core.astr_main_agent._get_session_conv",
+                AsyncMock(return_value=conv),
+            ),
+            patch(
+                "astrbot.core.astr_main_agent.build_main_agent",
+                side_effect=fake_build_main_agent,
+            ),
+            patch(
+                "astrbot.core.cron.manager.persist_agent_history",
+                side_effect=fake_persist_agent_history,
+            ),
+        ):
+            await cron_manager._woke_main_agent(
+                message="run scheduled task",
+                session_str="test:FriendMessage:user123",
+                extras={"cron_job": {"id": "job-1"}, "cron_payload": {}},
+            )
+
+        config = captured["config"]
+        assert config.tool_call_timeout == 77
+        assert config.provider_settings is provider_settings
+        assert config.provider_settings["fallback_chat_models"] == ["fallback-provider"]
+
+
 class TestGetNextRunTime:
     """Tests for _get_next_run_time method."""
 


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

Closes #8996 

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- 修复未来任务触发主 Agent 时未传递 `provider_settings` 的问题。
- 让未来任务路径能够正确读取 `fallback_chat_models`，主模型请求失败后可继续切换到备选模型。
- 增加回归测试，验证 active cron/future task 唤醒 Agent 时会保留 fallback 模型配置。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

- 修复前，未来任务在主模型不可用的情况下不会自动切到备用模型：
<img width="1656" height="374" alt="0cb75e17a7674924d52f4b0b591517da" src="https://github.com/user-attachments/assets/49fb9dac-a636-4fd9-a256-fb116d73ba77" />
<img width="1632" height="101" alt="00da39ba3a40772124d611560618afac" src="https://github.com/user-attachments/assets/75a888a8-38e3-48f2-85fd-5507dc823557" />

- 修复后，未来任务能够在主模型不可用的情况下自动切到备用模型：

<img width="1671" height="307" alt="c59bfb847a81af40dace4a4e56649672" src="https://github.com/user-attachments/assets/0ac5212a-7ccc-4006-b113-79a1c92ceca6" />
<img width="1658" height="133" alt="17ab4f9f46fb44aa83c626cd1f71db55" src="https://github.com/user-attachments/assets/10fbb5c9-cd39-4ac1-90f6-f98e5b123b00" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure cron-triggered agent executions preserve provider settings, including fallback models, when waking the main agent.

Bug Fixes:
- Preserve provider settings, including tool_call_timeout and fallback_chat_models, when running the main agent from active cron or future tasks so fallback models continue to work if the primary model fails.

Tests:
- Add unit test verifying that waking the main agent from an active cron job passes through provider_settings and retains fallback_chat_models in the agent build configuration.