### PR TITLE
fix: skip cron knowledge base injection

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -271,6 +271,8 @@ async def _apply_kb(
     config: MainAgentBuildConfig,
 ) -> None:
     if not config.kb_agentic_mode:
+        if event.get_platform_name() == "cron":
+            return
         if req.prompt is None or not req.prompt.strip():
             return
         try:

--- a/tests/unit/test_astr_main_agent.py
+++ b/tests/unit/test_astr_main_agent.py
@@ -392,6 +392,24 @@ class TestApplyKb:
         ]
 
     @pytest.mark.asyncio
+    async def test_apply_kb_skips_cron_events(self, mock_event, mock_context):
+        """Test scheduled tasks do not inject KB results as user content."""
+        module = ama
+        mock_event.get_platform_name.return_value = "cron"
+        req = ProviderRequest(prompt="scheduled task", system_prompt="System prompt")
+        config = module.MainAgentBuildConfig(
+            tool_call_timeout=60, kb_agentic_mode=False
+        )
+        retrieve = AsyncMock(return_value="KB result")
+
+        with patch("astrbot.core.astr_main_agent.retrieve_knowledge_base", retrieve):
+            await module._apply_kb(mock_event, req, mock_context, config)
+
+        retrieve.assert_not_awaited()
+        assert req.system_prompt == "System prompt"
+        assert req.extra_user_content_parts == []
+
+    @pytest.mark.asyncio
     async def test_apply_kb_with_agentic_mode(self, mock_event, mock_context):
         """Test applying knowledge base in agentic mode."""
         module = ama


### PR DESCRIPTION
## Summary
- Skip non-agentic automatic knowledge-base injection for scheduled cron events.
- Add a regression test proving cron-triggered requests do not call `retrieve_knowledge_base()` or append KB results as user content.

## Evidence
- Issue #9018 reports scheduled tasks treating knowledge-base injections as recent user dialogue.
- PR #8904 changed KB results to temporary user content, which is appropriate for user messages but misleading for synthetic cron prompts.
- `astrbot/core/cron/manager.py` builds cron requests with a fixed scheduled-task prompt, so automatic KB lookup uses the scheduler prompt rather than a real user utterance.

## Verification
- `uv run pytest tests/unit/test_astr_main_agent.py -k "apply_kb" -v`: 8 passed.
- `uv run ruff check astrbot/core/astr_main_agent.py tests/unit/test_astr_main_agent.py`: passed.
- `uv run ruff format --check astrbot/core/astr_main_agent.py tests/unit/test_astr_main_agent.py`: passed.
- `uv run astrbot --help`: passed.
- `bunx pnpm@10.28.2 install --frozen-lockfile && bunx pnpm@10.28.2 run build` in `dashboard/`: passed.
- `uv run pytest -q`: 1648 passed, 28 failed locally on Windows in unrelated path/CRLF/file-uri/local-shell/config-directory tests.
- `tests/test_code_quality_typing.py`: absent on current master.

## Notes
- Full ruff over the zipball copy scanned `.venv` because this was not a normal git checkout; source-file checks passed for the changed files.

## Summary by Sourcery

Prevent knowledge-base injection from running for cron-triggered events and add coverage to ensure scheduled tasks do not treat KB results as user content.

Bug Fixes:
- Skip non-agentic knowledge-base lookup when handling cron platform events to avoid injecting KB results into synthetic scheduled-task prompts.

Tests:
- Add an async unit test verifying that _apply_kb does not call retrieve_knowledge_base or append extra user content for cron events.