### PR TITLE
style: standardize dashboard dialog styling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ ruff check .
 6. For path handling, use `pathlib.Path` instead of string paths, and use `astrbot.core.utils.path_utils` to get the AstrBot data and temp directory.
 7. When backend API routes, request/response schemas, or OpenAPI definitions change, regenerate the frontend API client by running `cd dashboard && pnpm generate:api`.
 8. When updating the project version, keep `[project].version` in `pyproject.toml` and `__version__` in `astrbot/__init__.py` in sync. `VERSION` in `astrbot/core/config/default.py` should derive from `astrbot.__version__` instead of hardcoding a separate version string.
+9. When designing WebUI dialogs, use `text-h3 pa-4 pb-0 pl-6` as the base class for dialog titles, and use `variant="text"` or `variant="tonal"` for dialog buttons.
 
 ### KISS and First Principles
 

--- a/dashboard/src/components/ConfirmDialog.vue
+++ b/dashboard/src/components/ConfirmDialog.vue
@@ -1,12 +1,12 @@
 <template>
   <v-dialog v-model="isOpen" max-width="400">
     <v-card>
-      <v-card-title class="text-h3 pl-6 pt-4">{{ title }}</v-card-title>
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{ title }}</v-card-title>
       <v-card-text>{{ message }}</v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="gray" @click="handleCancel">{{ t('core.common.dialog.cancelButton') }}</v-btn>
-        <v-btn color="red" @click="handleConfirm">{{ t('core.common.dialog.confirmButton') }}</v-btn>
+        <v-btn color="gray" variant="text" @click="handleCancel">{{ t('core.common.dialog.cancelButton') }}</v-btn>
+        <v-btn color="red" variant="tonal" @click="handleConfirm">{{ t('core.common.dialog.confirmButton') }}</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/dashboard/src/components/chat/Chat.vue
+++ b/dashboard/src/components/chat/Chat.vue
@@ -445,7 +445,7 @@
     />
     <v-dialog v-model="sessionTitleDialogOpen" max-width="420">
       <v-card>
-        <v-card-title class="text-h6">
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6">
           {{ tm("conversation.editDisplayName") }}
         </v-card-title>
         <v-card-text>
@@ -466,6 +466,7 @@
           </v-btn>
           <v-btn
             color="primary"
+            variant="tonal"
             :loading="savingSessionTitle"
             @click="saveSessionTitleDialog"
           >

--- a/dashboard/src/components/chat/ConfigSelector.vue
+++ b/dashboard/src/components/chat/ConfigSelector.vue
@@ -22,7 +22,7 @@
 
         <v-dialog v-model="dialog" max-width="480">
             <v-card>
-                <v-card-title class="d-flex align-center justify-space-between">
+                <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center justify-space-between">
                     <span>选择配置文件</span>
                     <v-btn icon variant="text" @click="closeDialog">
                         <v-icon>mdi-close</v-icon>
@@ -60,6 +60,7 @@
                     <v-btn variant="text" @click="closeDialog">取消</v-btn>
                     <v-btn
                         color="primary"
+                        variant="tonal"
                         @click="confirmSelection"
                         :disabled="!tempSelectedConfig"
                         :loading="saving"

--- a/dashboard/src/components/chat/ProjectDialog.vue
+++ b/dashboard/src/components/chat/ProjectDialog.vue
@@ -1,7 +1,7 @@
 <template>
     <v-dialog v-model="isOpen" max-width="500" @update:model-value="handleDialogChange">
         <v-card>
-            <v-card-title class="dialog-title">
+            <v-card-title class="text-h3 pa-4 pb-0 pl-6">
                 {{ isEditing ? tm('project.edit') : tm('project.create') }}
             </v-card-title>
             <v-card-text>

--- a/dashboard/src/components/config/UnsavedChangesConfirmDialog.vue
+++ b/dashboard/src/components/config/UnsavedChangesConfirmDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <v-dialog v-model="isOpen" max-width="480" persistent>
     <v-card>
-      <v-card-title class="dialog-title d-flex align-center justify-space-between">
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center justify-space-between">
         <span>{{ title }}</span>
         <v-btn icon="mdi-close" variant="text" @click="handleClose"></v-btn>
       </v-card-title>
@@ -15,8 +15,8 @@
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="gray" @click="handleCancel">{{ t('core.common.dialog.cancelButton') }}</v-btn>
-        <v-btn color="red" @click="handleConfirm" class="confirm-button">{{ t('core.common.dialog.confirmButton') }}</v-btn>
+        <v-btn color="gray" variant="text" @click="handleCancel">{{ t('core.common.dialog.cancelButton') }}</v-btn>
+        <v-btn color="red" variant="tonal" @click="handleConfirm" class="confirm-button">{{ t('core.common.dialog.confirmButton') }}</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/dashboard/src/components/extension/McpServersSection.vue
+++ b/dashboard/src/components/extension/McpServersSection.vue
@@ -48,7 +48,7 @@
                 </template>
                 <template v-slot:default="{ isActive }">
                   <v-card style="padding: 16px;">
-                    <v-card-title class="d-flex align-center">
+                    <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
                       <span>{{ tm('mcpServers.status.availableTools') }}</span>
                     </v-card-title>
                     <v-card-text>
@@ -164,7 +164,7 @@
     <!-- 添加/编辑 MCP 服务器对话框 -->
     <v-dialog v-model="showMcpServerDialog" max-width="750px">
       <v-card>
-        <v-card-title class="pa-4 pl-6">
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6">
           <v-icon class="me-2">{{ isEditMode ? 'mdi-pencil' : 'mdi-plus' }}</v-icon>
           <span>{{ isEditMode ? tm('dialogs.addServer.editTitle') : tm('dialogs.addServer.title') }}</span>
         </v-card-title>
@@ -228,7 +228,7 @@
           <v-btn variant="text" @click="testServerConnection" :disabled="loading">
             {{ tm('dialogs.addServer.buttons.testConnection') }}
           </v-btn>
-          <v-btn color="primary" @click="saveServer" :loading="loading" :disabled="!isServerFormValid">
+          <v-btn color="primary" variant="tonal" @click="saveServer" :loading="loading" :disabled="!isServerFormValid">
             {{ tm('dialogs.addServer.buttons.save') }}
           </v-btn>
         </v-card-actions>
@@ -238,7 +238,7 @@
     <!-- 同步 MCP 服务器对话框 -->
     <v-dialog v-model="showSyncMcpServerDialog" max-width="500px" persistent>
       <v-card>
-        <v-card-title class="bg-primary text-white py-3">
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6">
           <span>同步外部平台 MCP 服务器</span>
         </v-card-title>
 
@@ -284,7 +284,7 @@
           <v-btn variant="text" @click="showSyncMcpServerDialog = false" :disabled="loading">
             {{ tm('dialogs.addServer.buttons.cancel') }}
           </v-btn>
-          <v-btn color="primary" @click="syncMcpServers" :loading="loading" :disabled="loading">
+          <v-btn color="primary" variant="tonal" @click="syncMcpServers" :loading="loading" :disabled="loading">
             {{ tm('dialogs.addServer.buttons.sync') }}
           </v-btn>
         </v-card-actions>

--- a/dashboard/src/components/extension/SkillsSection.vue
+++ b/dashboard/src/components/extension/SkillsSection.vue
@@ -372,9 +372,9 @@
 
     <v-dialog v-model="uploadDialog" max-width="880px" :persistent="uploading">
       <v-card class="skills-upload-dialog">
-        <v-card-title class="skills-upload-dialog__header px-6 pt-6 pb-2">
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6 skills-upload-dialog__header">
           <div class="skills-upload-dialog__heading">
-            <div class="text-h4 font-weight-medium">
+            <div>
               {{ tm("skills.uploadDialogTitle") }}
             </div>
           </div>
@@ -565,7 +565,7 @@
           </v-btn>
           <v-btn
             class="skills-upload-dialog__action-btn"
-            variant="flat"
+            variant="tonal"
             color="primary"
             :loading="uploading"
             :disabled="!hasUploadableItems"
@@ -579,13 +579,13 @@
 
     <v-dialog v-model="deleteDialog" max-width="400px">
       <v-card>
-        <v-card-title>{{ tm("skills.deleteTitle") }}</v-card-title>
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{ tm("skills.deleteTitle") }}</v-card-title>
         <v-card-text>{{ tm("skills.deleteMessage") }}</v-card-text>
         <v-card-actions class="d-flex justify-end">
           <v-btn variant="text" @click="deleteDialog = false">{{
             tm("skills.cancel")
           }}</v-btn>
-          <v-btn color="error" :loading="deleting" @click="deleteSkill">
+          <v-btn color="error" variant="tonal" :loading="deleting" @click="deleteSkill">
             {{ t("core.common.itemCard.delete") }}
           </v-btn>
         </v-card-actions>
@@ -598,9 +598,9 @@
       :persistent="editorDialog.saving"
     >
       <v-card class="skill-editor-dialog">
-        <v-card-title class="skill-editor-dialog__header">
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6 skill-editor-dialog__header">
           <div>
-            <div class="text-h3 font-weight-bold">
+            <div>
               {{ editorDialog.skillName }}
             </div>
           </div>
@@ -713,7 +713,7 @@
           </v-btn>
           <v-btn
             color="primary"
-            variant="flat"
+            variant="tonal"
             :loading="editorDialog.saving"
             :disabled="
               !editorDialog.filePath ||
@@ -730,7 +730,7 @@
 
     <v-dialog v-model="payloadDialog.show" max-width="820px">
       <v-card>
-        <v-card-title>{{ tm("skills.neoPayloadTitle") }}</v-card-title>
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{ tm("skills.neoPayloadTitle") }}</v-card-title>
         <v-card-text>
           <pre class="payload-preview">{{ payloadDialog.content }}</pre>
         </v-card-text>
@@ -1892,7 +1892,6 @@ export default {
   display: flex;
   justify-content: space-between;
   gap: 16px;
-  padding: 18px 22px 14px;
 }
 
 .skill-editor-dialog__body {

--- a/dashboard/src/components/extension/componentPanel/components/DetailsDialog.vue
+++ b/dashboard/src/components/extension/componentPanel/components/DetailsDialog.vue
@@ -48,7 +48,7 @@ const getPermissionLabel = (permission: string): string => {
 <template>
   <v-dialog :model-value="show" @update:model-value="emit('update:show', $event)" max-width="500">
     <v-card v-if="command">
-      <v-card-title class="text-h5">{{ tm('dialogs.details.title') }}</v-card-title>
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{ tm('dialogs.details.title') }}</v-card-title>
       <v-card-text>
         <v-list density="compact">
           <v-list-item>

--- a/dashboard/src/components/extension/componentPanel/components/RenameDialog.vue
+++ b/dashboard/src/components/extension/componentPanel/components/RenameDialog.vue
@@ -59,7 +59,7 @@ watch(showAliasEditor, (open) => {
 <template>
   <v-dialog :model-value="show" @update:model-value="emit('update:show', $event)" max-width="500">
     <v-card>
-      <v-card-title class="text-h5">{{ tm('dialogs.rename.title') }}</v-card-title>
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{ tm('dialogs.rename.title') }}</v-card-title>
       <v-card-text>
         <v-text-field
           :model-value="newName"
@@ -99,7 +99,7 @@ watch(showAliasEditor, (open) => {
               </div>
               <v-btn
                 prepend-icon="mdi-plus"
-                variant="outlined"
+                variant="tonal"
                 color="primary"
                 block
                 size="small"
@@ -119,7 +119,7 @@ watch(showAliasEditor, (open) => {
         </v-btn>
         <v-btn
           color="primary"
-          variant="text"
+          variant="tonal"
           :loading="loading"
           @click="emit('confirm')"
         >

--- a/dashboard/src/components/folder/BaseCreateFolderDialog.vue
+++ b/dashboard/src/components/folder/BaseCreateFolderDialog.vue
@@ -1,7 +1,7 @@
 <template>
     <v-dialog v-model="showDialog" max-width="450px">
         <v-card>
-            <v-card-title>
+            <v-card-title class="text-h3 pa-4 pb-0 pl-6">
                 <v-icon class="mr-2">mdi-folder-plus</v-icon>
                 {{ labels.title }}
             </v-card-title>
@@ -20,7 +20,7 @@
                 <v-btn variant="text" @click="closeDialog">
                     {{ labels.cancelButton }}
                 </v-btn>
-                <v-btn color="primary" variant="flat" @click="submitForm" :loading="loading" :disabled="!formValid">
+                <v-btn color="primary" variant="tonal" @click="submitForm" :loading="loading" :disabled="!formValid">
                     {{ labels.createButton }}
                 </v-btn>
             </v-card-actions>

--- a/dashboard/src/components/folder/BaseFolderItemSelector.vue
+++ b/dashboard/src/components/folder/BaseFolderItemSelector.vue
@@ -20,7 +20,7 @@
             :min-width="isCompactLayout ? undefined : '800px'"
         >
             <v-card class="selector-dialog-card">
-                <v-card-title class="dialog-title d-flex align-center" :class="isCompactLayout ? 'py-3 px-4' : 'py-4 px-5'">
+                <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
                     <v-icon class="mr-3" color="primary">mdi-account-circle</v-icon>
                     <span>{{ labels.dialogTitle || '选择项目' }}</span>
                 </v-card-title>
@@ -171,7 +171,7 @@
                     </v-btn>
                     <v-spacer></v-spacer>
                     <v-btn variant="text" @click="cancelSelection">{{ labels.cancelButton || '取消' }}</v-btn>
-                    <v-btn color="primary" @click="confirmSelection" :disabled="!selectedItemId">
+                    <v-btn color="primary" variant="tonal" @click="confirmSelection" :disabled="!selectedItemId">
                         {{ labels.confirmButton || '确认' }}
                     </v-btn>
                 </v-card-actions>

--- a/dashboard/src/components/folder/BaseMoveToFolderDialog.vue
+++ b/dashboard/src/components/folder/BaseMoveToFolderDialog.vue
@@ -1,7 +1,7 @@
 <template>
     <v-dialog v-model="showDialog" max-width="500px" persistent>
         <v-card>
-            <v-card-title>
+            <v-card-title class="text-h3 pa-4 pb-0 pl-6">
                 <v-icon class="mr-2">mdi-folder-move</v-icon>
                 {{ labels.title }}
             </v-card-title>
@@ -41,7 +41,7 @@
                 <v-btn variant="text" @click="closeDialog">
                     {{ labels.cancelButton }}
                 </v-btn>
-                <v-btn color="primary" variant="flat" @click="submitMove" :loading="loading">
+                <v-btn color="primary" variant="tonal" @click="submitMove" :loading="loading">
                     {{ labels.moveButton }}
                 </v-btn>
             </v-card-actions>

--- a/dashboard/src/components/platform/AddNewPlatform.vue
+++ b/dashboard/src/components/platform/AddNewPlatform.vue
@@ -5,15 +5,16 @@
     max-height="90%"
     @after-enter="prepareData"
   >
-    <v-card
-      :title="
-        updatingMode
-          ? `${tm('dialog.edit')} ${updatingPlatformConfig.id} ${tm(
-              'dialog.adapter',
-            )}`
-          : tm('dialog.addPlatform')
-      "
-    >
+    <v-card>
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6">
+        {{
+          updatingMode
+            ? `${tm('dialog.edit')} ${updatingPlatformConfig.id} ${tm(
+                'dialog.adapter',
+              )}`
+            : tm('dialog.addPlatform')
+        }}
+      </v-card-title>
       <v-card-text
         ref="dialogScrollContainer"
         class="pa-4 ml-2"
@@ -315,7 +316,7 @@
               </div>
               <div>
                 <v-btn
-                  variant="plain"
+                  variant="text"
                   icon
                   @click="toggleConfigSection"
                   class="mt-2"
@@ -670,10 +671,11 @@
 
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn text @click="closeDialog">{{ tm("dialog.cancel") }}</v-btn>
+        <v-btn variant="text" @click="closeDialog">{{ tm("dialog.cancel") }}</v-btn>
         <v-btn
           :disabled="!canSave"
           color="primary"
+          variant="tonal"
           v-if="!updatingMode"
           @click="newPlatform"
           :loading="loading"
@@ -682,6 +684,7 @@
         <v-btn
           :disabled="!selectedAbConfId"
           color="primary"
+          variant="tonal"
           v-else
           @click="newPlatform"
           :loading="loading"
@@ -694,7 +697,7 @@
   <!-- ID冲突确认对话框 -->
   <v-dialog v-model="showIdConflictDialog" max-width="450" persistent>
     <v-card>
-      <v-card-title class="text-h6 bg-warning d-flex align-center">
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
         <v-icon start class="me-2">mdi-alert-circle-outline</v-icon>
         {{ tm("dialog.idConflict.title") }}
       </v-card-title>
@@ -716,7 +719,7 @@
   <!-- 安全警告对话框 -->
   <v-dialog v-model="showOneBotEmptyTokenWarnDialog" max-width="600" persistent>
     <v-card>
-      <v-card-title>
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6">
         {{ tm("dialog.securityWarning.title") }}
       </v-card-title>
       <v-card-text class="py-4">
@@ -733,12 +736,14 @@
         <v-spacer></v-spacer>
         <v-btn
           color="error"
+          variant="tonal"
           @click="handleOneBotEmptyTokenWarningDismiss(true)"
         >
           {{ tm("createDialog.warningContinue") }}
         </v-btn>
         <v-btn
           color="primary"
+          variant="text"
           @click="handleOneBotEmptyTokenWarningDismiss(false)"
         >
           {{ tm("createDialog.warningEditAgain") }}

--- a/dashboard/src/components/provider/AddNewProvider.vue
+++ b/dashboard/src/components/provider/AddNewProvider.vue
@@ -1,6 +1,7 @@
 <template>
     <v-dialog v-model="showDialog" max-width="1000px" >
-        <v-card :title="tm('dialogs.addProvider.title')">
+        <v-card>
+            <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{ tm('dialogs.addProvider.title') }}</v-card-title>
             <v-card-text style="overflow-y: auto;">
                 <v-tabs v-model="activeProviderTab" grow>
                     <v-tab value="agent_runner" class="font-weight-medium px-3">
@@ -63,7 +64,7 @@
             </v-card-text>
             <v-card-actions>
                 <v-spacer></v-spacer>
-                <v-btn text @click="closeDialog">{{ tm('dialogs.config.cancel') }}</v-btn>
+                <v-btn variant="text" @click="closeDialog">{{ tm('dialogs.config.cancel') }}</v-btn>
             </v-card-actions>
         </v-card>
     </v-dialog>

--- a/dashboard/src/components/provider/ProviderChatCompletionPanel.vue
+++ b/dashboard/src/components/provider/ProviderChatCompletionPanel.vue
@@ -112,7 +112,10 @@
     </div>
 
     <v-dialog v-model="showManualModelDialog" max-width="400">
-      <v-card :title="tm('models.manualDialogTitle')">
+      <v-card>
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6">
+          {{ tm('models.manualDialogTitle') }}
+        </v-card-title>
         <v-card-text class="py-4">
           <v-text-field
             v-model="manualModelId"
@@ -134,13 +137,16 @@
         <v-card-actions class="pa-4">
           <v-spacer></v-spacer>
           <v-btn variant="text" @click="showManualModelDialog = false">取消</v-btn>
-          <v-btn color="primary" @click="confirmManualModel">添加</v-btn>
+          <v-btn color="primary" variant="tonal" @click="confirmManualModel">添加</v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>
 
     <v-dialog v-model="showProviderEditDialog" width="800">
-      <v-card :title="providerEditDialogTitle">
+      <v-card>
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6">
+          {{ providerEditDialogTitle }}
+        </v-card-title>
         <v-card-text class="py-4">
           <AstrBotConfig
             v-if="providerEditData"
@@ -161,6 +167,7 @@
           </v-btn>
           <v-btn
             color="primary"
+            variant="tonal"
             :loading="savingProviders.includes(providerEditData?.id)"
             @click="saveEditedProvider"
           >

--- a/dashboard/src/components/shared/BackupDialog.vue
+++ b/dashboard/src/components/shared/BackupDialog.vue
@@ -1,7 +1,7 @@
 <template>
     <v-dialog v-model="isOpen" persistent max-width="700" scrollable>
         <v-card>
-            <v-card-title class="d-flex align-center">
+            <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
                 <v-icon class="mr-2">mdi-backup-restore</v-icon>
                 {{ t('features.settings.backup.dialog.title') }}
             </v-card-title>
@@ -36,7 +36,7 @@
                                 </template>
                                 {{ t('features.settings.backup.export.includes') }}
                             </v-alert>
-                            <v-btn color="primary" size="large" @click="startExport" :loading="exportStatus === 'processing'">
+                            <v-btn color="primary" variant="tonal" size="large" @click="startExport" :loading="exportStatus === 'processing'">
                                 <v-icon class="mr-2">mdi-export</v-icon>
                                 {{ t('features.settings.backup.export.button') }}
                             </v-btn>
@@ -53,7 +53,7 @@
                             <v-icon size="64" color="success" class="mb-4">mdi-check-circle</v-icon>
                             <h3 class="mb-4">{{ t('features.settings.backup.export.completed') }}</h3>
                             <p class="mb-4">{{ exportResult?.filename }}</p>
-                            <v-btn color="primary" @click="downloadBackup(exportResult?.filename)" class="mr-2">
+                            <v-btn color="primary" variant="tonal" @click="downloadBackup(exportResult?.filename)" class="mr-2">
                                 <v-icon class="mr-2">mdi-download</v-icon>
                                 {{ t('features.settings.backup.export.download') }}
                             </v-btn>
@@ -68,7 +68,7 @@
                             <v-alert type="error" variant="tonal" class="mb-4">
                                 {{ exportError }}
                             </v-alert>
-                            <v-btn color="primary" @click="resetExport">
+                            <v-btn color="primary" variant="tonal" @click="resetExport">
                                 {{ t('features.settings.backup.export.retry') }}
                             </v-btn>
                         </div>
@@ -97,6 +97,7 @@
                             <div class="d-flex justify-center">
                                 <v-btn
                                     color="primary"
+                                    variant="tonal"
                                     size="large"
                                     @click="uploadAndCheck"
                                     :disabled="!importFile"
@@ -184,7 +185,7 @@
                             <div class="d-flex justify-center align-center mt-4" style="gap: 16px;">
                                 <v-btn
                                     color="grey-darken-1"
-                                    variant="outlined"
+                                    variant="text"
                                     size="large"
                                     @click="resetImport"
                                 >
@@ -195,7 +196,7 @@
                                     v-if="checkResult?.can_import"
                                     color="error"
                                     size="large"
-                                    variant="flat"
+                                    variant="tonal"
                                     @click="confirmImport"
                                 >
                                     <v-icon class="mr-2">mdi-alert</v-icon>
@@ -218,7 +219,7 @@
                             <v-alert type="info" variant="tonal" class="mb-4">
                                 {{ t('features.settings.backup.import.restartRequired') }}
                             </v-alert>
-                            <v-btn color="primary" @click="restartAstrBot" class="mr-2">
+                            <v-btn color="primary" variant="tonal" @click="restartAstrBot" class="mr-2">
                                 <v-icon class="mr-2">mdi-restart</v-icon>
                                 {{ t('features.settings.backup.import.restartNow') }}
                             </v-btn>
@@ -233,7 +234,7 @@
                             <v-alert type="error" variant="tonal" class="mb-4">
                                 {{ importError }}
                             </v-alert>
-                            <v-btn color="primary" @click="resetImport">
+                            <v-btn color="primary" variant="tonal" @click="resetImport">
                                 {{ t('features.settings.backup.import.retry') }}
                             </v-btn>
                         </div>
@@ -322,7 +323,7 @@
     <!-- 重命名对话框 -->
     <v-dialog v-model="renameDialogOpen" max-width="450" persistent>
         <v-card>
-            <v-card-title>
+            <v-card-title class="text-h3 pa-4 pb-0 pl-6">
                 <v-icon class="mr-2">mdi-pencil</v-icon>
                 {{ t('features.settings.backup.list.renameTitle') }}
             </v-card-title>
@@ -352,7 +353,7 @@
                 </v-btn>
                 <v-btn
                     color="primary"
-                    variant="flat"
+                    variant="tonal"
                     @click="confirmRename"
                     :loading="renameLoading"
                     :disabled="!renameNewName || !!renameError"

--- a/dashboard/src/components/shared/ChangelogDialog.vue
+++ b/dashboard/src/components/shared/ChangelogDialog.vue
@@ -161,9 +161,9 @@ getCurrentVersion();
     max-width="1000"
   >
     <v-card>
-      <v-card-title class="d-flex justify-space-between align-center">
-        <span class="text-h3">{{ t('core.navigation.changelogDialog.title') }}</span>
-        <v-btn icon @click="dialog = false" flat>
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex justify-space-between align-center">
+        <span>{{ t('core.navigation.changelogDialog.title') }}</span>
+        <v-btn icon @click="dialog = false" variant="text">
           <v-icon>mdi-close</v-icon>
         </v-btn>
       </v-card-title>

--- a/dashboard/src/components/shared/DashboardTotpManageDialog.vue
+++ b/dashboard/src/components/shared/DashboardTotpManageDialog.vue
@@ -5,7 +5,7 @@
     @update:model-value="val => emit('update:modelValue', val)"
   >
     <v-card>
-      <v-card-title class="d-flex align-center pa-4">
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
         {{ tm('system_group.system.dashboard.totp.configuration') }}
         <v-spacer></v-spacer>
         <v-btn icon variant="text" size="small" @click="emit('update:modelValue', false)">

--- a/dashboard/src/components/shared/DashboardTotpRecoveryDialog.vue
+++ b/dashboard/src/components/shared/DashboardTotpRecoveryDialog.vue
@@ -6,7 +6,7 @@
     @update:model-value="val => emit('update:modelValue', val)"
   >
     <v-card>
-      <v-card-title class="d-flex align-center pa-4">
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
         {{ tm('system_group.system.dashboard.totp.recoveryTitle') }}
         <v-spacer></v-spacer>
       </v-card-title>

--- a/dashboard/src/components/shared/DashboardTotpSetupDialog.vue
+++ b/dashboard/src/components/shared/DashboardTotpSetupDialog.vue
@@ -6,7 +6,7 @@
     @click:outside="onCancel"
   >
     <v-card>
-      <v-card-title class="d-flex align-center pa-4">
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
         {{ cardTitle }}
         <v-spacer></v-spacer>
         <v-btn icon variant="text" size="small" @click="onCancel">

--- a/dashboard/src/components/shared/DashboardTwoFactorDialog.vue
+++ b/dashboard/src/components/shared/DashboardTwoFactorDialog.vue
@@ -6,7 +6,7 @@
     @click:outside="onCancel"
   >
     <v-card>
-      <v-card-title class="d-flex align-center pa-4">
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
         {{ tm('system_group.system.dashboard.totp.configSaveTitle') }}
         <v-spacer></v-spacer>
         <v-btn icon variant="text" size="small" @click="onCancel">

--- a/dashboard/src/components/shared/FileConfigItem.vue
+++ b/dashboard/src/components/shared/FileConfigItem.vue
@@ -11,8 +11,8 @@
 
     <v-dialog v-model="dialog" max-width="700">
       <v-card class="file-dialog-card" variant="flat">
-        <v-card-title class="d-flex align-center">
-          <span class="text-h3">{{ tm('fileUpload.dialogTitle') }}</span>
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
+          <span>{{ tm('fileUpload.dialogTitle') }}</span>
           <v-spacer />
           <v-btn icon="mdi-close" variant="text" @click="dialog = false" />
         </v-card-title>
@@ -63,7 +63,7 @@
 
         <v-card-actions class="file-dialog-actions">
           <v-spacer />
-          <v-btn color="primary" variant="elevated" @click="dialog = false">
+          <v-btn color="primary" variant="tonal" @click="dialog = false">
             {{ tm('fileUpload.done') }}
           </v-btn>
         </v-card-actions>

--- a/dashboard/src/components/shared/KnowledgeBaseSelector.vue
+++ b/dashboard/src/components/shared/KnowledgeBaseSelector.vue
@@ -27,7 +27,7 @@
   <!-- Knowledge Base Selection Dialog -->
   <v-dialog v-model="dialog" max-width="600px">
     <v-card>
-      <v-card-title class="text-h3 py-4" style="font-weight: normal;">
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6">
         {{ tm('knowledgeBaseSelector.dialogTitle') }}
       </v-card-title>
       
@@ -84,6 +84,7 @@
         <v-btn variant="text" @click="cancelSelection">{{ tm('knowledgeBaseSelector.cancelSelection') }}</v-btn>
         <v-btn 
           color="primary" 
+          variant="tonal"
           @click="confirmSelection">
           {{ tm('knowledgeBaseSelector.confirmSelection') }}
         </v-btn>

--- a/dashboard/src/components/shared/ListConfigItem.vue
+++ b/dashboard/src/components/shared/ListConfigItem.vue
@@ -30,7 +30,7 @@
   <!-- List Management Dialog -->
   <v-dialog v-model="dialog" max-width="600px">
     <v-card>
-      <v-card-title class="text-h3 py-4" style="font-weight: normal;">
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6">
         {{ dialogTitle || t('core.common.list.editTitle') }}
       </v-card-title>
       
@@ -92,18 +92,18 @@
             
             <template v-slot:append>
               <div class="d-flex">
-                <v-btn 
+                <v-btn
                   v-if="editIndex === index"
                   @click.stop="saveEdit" 
-                  variant="plain" 
+                  variant="text"
                   color="success" 
                   icon 
                   size="small">
                   <v-icon>mdi-check</v-icon>
                 </v-btn>
-                <v-btn 
+                <v-btn
                   @click.stop="editIndex === index ? cancelEdit() : removeItem(index)" 
-                  variant="plain" 
+                  variant="text"
                   :color="editIndex === index ? 'error' : 'default'"
                   icon 
                   size="small">
@@ -123,7 +123,7 @@
       <v-card-actions class="pa-4">
         <v-spacer></v-spacer>
         <v-btn variant="text" @click="cancelDialog">{{ t('core.common.cancel') }}</v-btn>
-        <v-btn color="primary" @click="confirmDialog">{{ t('core.common.confirm') }}</v-btn>
+        <v-btn color="primary" variant="tonal" @click="confirmDialog">{{ t('core.common.confirm') }}</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -131,7 +131,7 @@
   <!-- Batch Import Dialog -->
   <v-dialog v-model="showBatchImport" max-width="600px">
     <v-card>
-      <v-card-title class="text-h3 py-4" style="font-weight: normal;">
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6">
         {{ t('core.common.list.batchImportTitle') }}
       </v-card-title>
       
@@ -150,7 +150,7 @@
       <v-card-actions class="pa-4">
         <v-spacer></v-spacer>
         <v-btn variant="text" @click="cancelBatchImport">{{ t('core.common.cancel') }}</v-btn>
-        <v-btn color="primary" @click="confirmBatchImport">
+        <v-btn color="primary" variant="tonal" @click="confirmBatchImport">
           {{ t('core.common.list.batchImportButton', { count: batchImportPreviewCount }) }}
         </v-btn>
       </v-card-actions>

--- a/dashboard/src/components/shared/ObjectEditor.vue
+++ b/dashboard/src/components/shared/ObjectEditor.vue
@@ -21,7 +21,7 @@
   <!-- Key-Value Management Dialog -->
   <v-dialog v-model="dialog" max-width="600px">
     <v-card>
-      <v-card-title class="text-h3 py-4" style="font-weight: normal;">
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6">
         {{ resolveDialogTitle }}
       </v-card-title>
 
@@ -213,7 +213,7 @@
       <v-card-actions class="pa-4">
         <v-spacer></v-spacer>
         <v-btn variant="text" @click="cancelDialog">{{ t('core.common.cancel') }}</v-btn>
-        <v-btn color="primary" @click="confirmDialog">{{ t('core.common.confirm') }}</v-btn>
+        <v-btn color="primary" variant="tonal" @click="confirmDialog">{{ t('core.common.confirm') }}</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/dashboard/src/components/shared/PersonaForm.vue
+++ b/dashboard/src/components/shared/PersonaForm.vue
@@ -1,7 +1,7 @@
 <template>
     <v-dialog v-model="showDialog" :max-width="$vuetify.display.smAndDown ? undefined : '1200px'" scrollable>
         <v-card class="persona-form-card" :class="{ 'persona-form-card-mobile': $vuetify.display.smAndDown }">
-            <v-card-title class="persona-form-title text-h2 px-6 pt-6 pl-6">
+            <v-card-title class="persona-form-title text-h3 pa-4 pb-0 pl-6">
                 {{ editingPersona ? tm('dialog.edit.title') : tm('dialog.create.title') }}
             </v-card-title>
 
@@ -331,7 +331,7 @@
                                     </v-textarea>
                                 </div>
 
-                                <v-btn variant="outlined" prepend-icon="mdi-plus" @click="addDialogPair" block>
+                                <v-btn variant="tonal" prepend-icon="mdi-plus" @click="addDialogPair" block>
                                     {{ tm('buttons.addDialogPair') }}
                                 </v-btn>
                             </v-expansion-panel-text>
@@ -350,7 +350,7 @@
                 <v-btn color="grey" variant="text" @click="closeDialog">
                     {{ tm('buttons.cancel') }}
                 </v-btn>
-                <v-btn color="primary" variant="flat" @click="savePersona" :loading="saving" :disabled="!formValid">
+                <v-btn color="primary" variant="tonal" @click="savePersona" :loading="saving" :disabled="!formValid">
                     {{ tm('buttons.save') }}
                 </v-btn>
             </v-card-actions>
@@ -883,10 +883,6 @@ export default {
     overflow-y: auto;
 }
 
-.persona-form-title {
-    line-height: 1.3;
-}
-
 .persona-form-actions {
     position: sticky;
     bottom: 0;
@@ -936,11 +932,6 @@ export default {
     .persona-basic-col,
     .persona-panels-col {
         padding-top: 0 !important;
-    }
-
-    .persona-form-title {
-        font-size: 1.15rem !important;
-        padding: 12px 16px !important;
     }
 
     .selected-config-area {

--- a/dashboard/src/components/shared/PluginSetSelector.vue
+++ b/dashboard/src/components/shared/PluginSetSelector.vue
@@ -22,7 +22,7 @@
   <!-- Plugin Set Selection Dialog -->
   <v-dialog v-model="dialog" max-width="700px">
     <v-card>
-      <v-card-title class="text-h3 py-4" style="font-weight: normal;">
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6">
         {{ tm('pluginSetSelector.dialogTitle') }}
       </v-card-title>
       
@@ -93,6 +93,7 @@
         <v-btn variant="text" @click="cancelSelection">{{ tm('pluginSetSelector.cancelSelection') }}</v-btn>
         <v-btn 
           color="primary" 
+          variant="tonal"
           @click="confirmSelection">
           {{ tm('pluginSetSelector.confirmSelection') }}
         </v-btn>

--- a/dashboard/src/components/shared/ProviderSelector.vue
+++ b/dashboard/src/components/shared/ProviderSelector.vue
@@ -34,8 +34,7 @@
   <v-dialog v-model="dialog" max-width="600px">
     <v-card>
       <v-card-title
-        class="text-h3 py-4 d-flex align-center justify-space-between gap-4 flex-wrap"
-        style="font-weight: normal;"
+        class="text-h3 pa-4 pb-0 pl-6 d-flex align-center justify-space-between gap-4 flex-wrap"
       >
         <span>{{ tm('providerSelector.dialogTitle') }}</span>
         <v-btn
@@ -146,6 +145,7 @@
         <v-btn variant="text" @click="cancelSelection">{{ tm('providerSelector.cancelSelection') }}</v-btn>
         <v-btn 
           color="primary" 
+          variant="tonal"
           @click="confirmSelection">
           {{ tm('providerSelector.confirmSelection') }}
         </v-btn>

--- a/dashboard/src/components/shared/ReadmeDialog.vue
+++ b/dashboard/src/components/shared/ReadmeDialog.vue
@@ -411,8 +411,8 @@ const showActionArea = computed(() => {
 <template>
   <v-dialog v-model="_show" width="800">
     <v-card>
-      <v-card-title class="d-flex justify-space-between align-center">
-        <span class="text-h2 pa-2">{{ modeConfig.title }}</span>
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex justify-space-between align-center">
+        <span>{{ modeConfig.title }}</span>
         <v-btn icon @click="_show = false" variant="text">
           <v-icon>mdi-close</v-icon>
         </v-btn>
@@ -422,6 +422,7 @@ const showActionArea = computed(() => {
           <v-btn
             v-if="modeConfig.showGithubButton && repoUrl"
             color="primary"
+            variant="tonal"
             prepend-icon="mdi-github"
             @click="openExternalLink(repoUrl)"
           >
@@ -430,6 +431,7 @@ const showActionArea = computed(() => {
           <v-btn
             v-if="modeConfig.showRefreshButton"
             color="secondary"
+            variant="tonal"
             prepend-icon="mdi-refresh"
             @click="fetchContent"
           >

--- a/dashboard/src/components/shared/SidebarCustomizer.vue
+++ b/dashboard/src/components/shared/SidebarCustomizer.vue
@@ -12,7 +12,7 @@
 
     <v-dialog v-model="dialog" max-width="700px">
       <v-card>
-        <v-card-title class="d-flex justify-space-between align-center">
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex justify-space-between align-center">
           <span>{{ t('features.settings.sidebar.customize.title') }}</span>
           <v-btn
             icon="mdi-close"

--- a/dashboard/src/components/shared/T2ITemplateEditor.vue
+++ b/dashboard/src/components/shared/T2ITemplateEditor.vue
@@ -17,7 +17,7 @@
     </template>
     
     <v-card class="t2i-template-editor">
-      <v-card-title class="d-flex align-center justify-space-between">
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center justify-space-between">
         <span>{{ tm('t2iTemplateEditor.dialogTitle') }}</span>
         <v-spacer></v-spacer>
         <div class="d-flex align-center gap-2" style="width: 60%">
@@ -199,13 +199,13 @@
     <!-- 确认重置对话框 -->
     <v-dialog v-model="resetDialog" max-width="400px">
       <v-card>
-        <v-card-title>{{ tm('t2iTemplateEditor.confirmReset') }}</v-card-title>
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{ tm('t2iTemplateEditor.confirmReset') }}</v-card-title>
         <v-card-text>
           {{ tm('t2iTemplateEditor.confirmResetMessage') }}
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn text @click="resetDialog = false">{{ t('core.common.cancel') }}</v-btn>
+          <v-btn variant="text" @click="resetDialog = false">{{ t('core.common.cancel') }}</v-btn>
           <v-btn color="warning" variant="tonal" @click="confirmReset" :loading="resetLoading">{{ tm('t2iTemplateEditor.confirmResetButton') }}</v-btn>
         </v-card-actions>
       </v-card>
@@ -214,13 +214,13 @@
     <!-- 删除确认对话框 -->
     <v-dialog v-model="deleteDialog" max-width="400px">
       <v-card>
-        <v-card-title>{{ tm('t2iTemplateEditor.confirmDelete') }}</v-card-title>
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{ tm('t2iTemplateEditor.confirmDelete') }}</v-card-title>
         <v-card-text>
           {{ tm('t2iTemplateEditor.confirmDeleteMessage', { name: selectedTemplate }) }}
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn text @click="deleteDialog = false">{{ t('core.common.cancel') }}</v-btn>
+          <v-btn variant="text" @click="deleteDialog = false">{{ t('core.common.cancel') }}</v-btn>
           <v-btn color="error" variant="tonal" @click="confirmDelete" :loading="saveLoading">{{ tm('t2iTemplateEditor.confirmDeleteButton') }}</v-btn>
         </v-card-actions>
       </v-card>
@@ -229,13 +229,13 @@
     <!-- 保存并应用确认对话框 -->
     <v-dialog v-model="applyAndCloseDialog" max-width="500px">
       <v-card>
-        <v-card-title>{{ tm('t2iTemplateEditor.confirmAction') }}</v-card-title>
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{ tm('t2iTemplateEditor.confirmAction') }}</v-card-title>
         <v-card-text>
           {{ tm('t2iTemplateEditor.confirmApplyMessage', { name: selectedTemplate }) }}
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn text @click="applyAndCloseDialog = false">{{ t('core.common.cancel') }}</v-btn>
+          <v-btn variant="text" @click="applyAndCloseDialog = false">{{ t('core.common.cancel') }}</v-btn>
           <v-btn color="primary" variant="tonal" @click="confirmApplyAndClose" :loading="saveLoading">{{ t('core.common.confirm') }}</v-btn>
         </v-card-actions>
       </v-card>

--- a/dashboard/src/components/shared/UninstallConfirmDialog.vue
+++ b/dashboard/src/components/shared/UninstallConfirmDialog.vue
@@ -6,7 +6,7 @@
     @keydown.esc="handleCancel"
   >
     <v-card>
-      <v-card-title class="text-h5">
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6">
         {{ tm('dialogs.uninstall.title') }}
       </v-card-title>
       
@@ -77,7 +77,7 @@
         </v-btn>
         <v-btn
           color="error"
-          variant="elevated"
+          variant="tonal"
           @click="handleConfirm"
         >
           {{ t('core.common.confirm') }}

--- a/dashboard/src/components/shared/UpgradeRecoveryDialog.vue
+++ b/dashboard/src/components/shared/UpgradeRecoveryDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <v-dialog v-model="visible" max-width="520" :persistent="blockingRecovery || restarting">
     <v-card>
-      <v-card-title class="upgrade-recovery-title">
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6">
         <span>{{ t('core.common.upgradeRecovery.title') }}</span>
       </v-card-title>
 
@@ -35,7 +35,7 @@
         </v-btn>
         <v-btn
           color="primary"
-          variant="flat"
+          variant="tonal"
           prepend-icon="mdi-restart"
           :loading="restarting"
           @click="restartCore"

--- a/dashboard/src/components/shared/WaitingForRestart.vue
+++ b/dashboard/src/components/shared/WaitingForRestart.vue
@@ -1,7 +1,7 @@
 <template>
     <v-dialog v-model="visible" persistent max-width="400">
         <v-card>
-            <v-card-title>{{ t('core.common.restart.waiting') }}</v-card-title>
+            <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{ t('core.common.restart.waiting') }}</v-card-title>
             <v-card-text>
                 <v-progress-linear indeterminate color="primary"></v-progress-linear>
             </v-card-text>

--- a/dashboard/src/layouts/full/vertical-header/VerticalHeader.vue
+++ b/dashboard/src/layouts/full/vertical-header/VerticalHeader.vue
@@ -1308,13 +1308,14 @@ onMounted(async () => {
       :fullscreen="$vuetify.display.xs"
     >
       <v-card>
-        <v-card-title class="mobile-card-title">
-          <span class="text-h3 pa-4">{{
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6 mobile-card-title">
+          <span>{{
             t("core.header.updateDialog.title")
           }}</span>
           <v-btn
             v-if="$vuetify.display.xs"
             icon
+            variant="text"
             @click="updateStatusDialog = false"
           >
             <v-icon>mdi-close</v-icon>
@@ -1368,7 +1369,7 @@ onMounted(async () => {
                 </div>
                 <v-btn
                   color="success"
-                  variant="elevated"
+                  variant="tonal"
                   size="small"
                   @click="reloadAfterUpdate"
                 >
@@ -1661,7 +1662,7 @@ onMounted(async () => {
     <!-- Release Notes Modal -->
     <v-dialog v-model="releaseNotesDialog" max-width="800">
       <v-card>
-        <v-card-title class="text-h3 pa-4">
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6">
           {{ t("core.header.updateDialog.releaseNotes.title") }}:
           {{ selectedReleaseTag }}
         </v-card-title>
@@ -1689,7 +1690,7 @@ onMounted(async () => {
 
     <v-dialog v-model="desktopUpdateDialog" max-width="460">
       <v-card>
-        <v-card-title class="text-h3 pa-4 pl-6 pb-0">
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6">
           {{ t("core.header.updateDialog.desktopApp.title") }}
         </v-card-title>
         <v-card-text>
@@ -1731,7 +1732,7 @@ onMounted(async () => {
           </v-btn>
           <v-btn
             color="primary"
-            variant="flat"
+            variant="tonal"
             @click="confirmDesktopUpdate"
             :loading="desktopUpdateInstalling"
             :disabled="
@@ -1886,6 +1887,7 @@ onMounted(async () => {
           </v-btn>
           <v-btn
             color="primary"
+            variant="tonal"
             @click="accountEdit"
             :loading="accountEditStatus.loading"
             :disabled="!formValid"

--- a/dashboard/src/views/ConfigPage.vue
+++ b/dashboard/src/views/ConfigPage.vue
@@ -88,15 +88,15 @@
   <v-dialog v-model="codeEditorDialog" fullscreen transition="dialog-bottom-transition" scrollable>
     <v-card>
       <v-toolbar color="primary" dark>
-        <v-btn icon @click="codeEditorDialog = false">
+        <v-btn icon variant="text" @click="codeEditorDialog = false">
           <v-icon>mdi-close</v-icon>
         </v-btn>
         <v-toolbar-title>{{ tm('codeEditor.title') }}</v-toolbar-title>
         <v-spacer></v-spacer>
         <v-toolbar-items style="display: flex; align-items: center;">
-          <v-btn style="margin-left: 16px;" size="small" @click="configToString()">{{
+          <v-btn style="margin-left: 16px;" size="small" variant="text" @click="configToString()">{{
             tm('editor.revertCode') }}</v-btn>
-          <v-btn v-if="config_data_has_changed" style="margin-left: 16px;" size="small" @click="applyStrConfig()">{{
+          <v-btn v-if="config_data_has_changed" style="margin-left: 16px;" size="small" variant="tonal" @click="applyStrConfig()">{{
             tm('editor.applyConfig') }}</v-btn>
           <small style="margin-left: 16px;">💡 {{ tm('editor.applyTip') }}</small>
         </v-toolbar-items>
@@ -112,8 +112,8 @@
   <!-- Config Management Dialog -->
   <v-dialog v-model="configManageDialog" max-width="800px">
     <v-card>
-      <v-card-title class="d-flex align-center justify-space-between">
-        <span class="text-h4">{{ tm('configManagement.title') }}</span>
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center justify-space-between">
+        <span>{{ tm('configManagement.title') }}</span>
         <v-btn icon="mdi-close" variant="text" @click="configManageDialog = false"></v-btn>
       </v-card-title>
 
@@ -156,7 +156,7 @@
 
           <div class="d-flex justify-end mt-4" style="gap: 8px;">
             <v-btn variant="text" @click="cancelConfigForm">{{ tm('buttons.cancel') }}</v-btn>
-            <v-btn color="primary" @click="saveConfigForm"
+            <v-btn color="primary" variant="tonal" @click="saveConfigForm"
               :disabled="isConfigFormSaveDisabled">
               {{ isEditingConfig ? tm('buttons.update') : tm('buttons.create') }}
             </v-btn>

--- a/dashboard/src/views/ConsolePage.vue
+++ b/dashboard/src/views/ConsolePage.vue
@@ -28,11 +28,11 @@ const { tm } = useModuleI18n('features/console');
         ></v-switch>
         <v-dialog v-model="pipDialog" width="400">
           <template v-slot:activator="{ props }">
-            <v-btn variant="plain" v-bind="props">{{ tm('pipInstall.button') }}</v-btn>
+            <v-btn variant="text" v-bind="props">{{ tm('pipInstall.button') }}</v-btn>
           </template>
           <v-card>
-            <v-card-title>
-              <span class="text-h5">{{ tm('pipInstall.dialogTitle') }}</span>
+            <v-card-title class="text-h3 pa-4 pb-0 pl-6">
+              <span>{{ tm('pipInstall.dialogTitle') }}</span>
             </v-card-title>
             <v-card-text>
               <v-text-field v-model="pipInstallPayload.package" :label="tm('pipInstall.packageLabel')" variant="outlined"></v-text-field>

--- a/dashboard/src/views/ConversationPage.vue
+++ b/dashboard/src/views/ConversationPage.vue
@@ -206,7 +206,7 @@
         <!-- 对话详情对话框 -->
         <v-dialog v-model="dialogView" max-width="900px" scrollable>
             <v-card class="conversation-detail-card">
-                <v-card-title class="ml-2 mt-2 conversation-detail-title">
+                <v-card-title class="text-h3 pa-4 pb-0 pl-6 conversation-detail-title">
                     <div class="conversation-detail-heading">
                         <span class="text-truncate">{{ selectedConversation?.title || tm('status.noTitle') }}</span>
                         <UmoDisplay v-if="selectedConversation?.user_id && hasConversationUmoReadableName(selectedConversation)"
@@ -280,8 +280,8 @@
         <!-- 编辑对话框 -->
         <v-dialog v-model="dialogEdit" max-width="500px">
             <v-card>
-                <v-card-title class="bg-primary text-white py-3">
-                    <v-icon color="white" class="me-2">mdi-pencil</v-icon>
+                <v-card-title class="text-h3 pa-4 pb-0 pl-6">
+                    <v-icon color="primary" class="me-2">mdi-pencil</v-icon>
                     <span>{{ tm('dialogs.edit.title') }}</span>
                 </v-card-title>
 
@@ -300,7 +300,7 @@
                     <v-btn variant="text" @click="dialogEdit = false" :disabled="loading">
                         {{ tm('dialogs.edit.cancel') }}
                     </v-btn>
-                    <v-btn color="primary" @click="saveConversation" :loading="loading">
+                    <v-btn color="primary" variant="tonal" @click="saveConversation" :loading="loading">
                         {{ tm('dialogs.edit.save') }}
                     </v-btn>
                 </v-card-actions>
@@ -310,8 +310,8 @@
         <!-- 删除确认对话框 -->
         <v-dialog v-model="dialogDelete" max-width="500px">
             <v-card>
-                <v-card-title class="bg-error text-white py-3">
-                    <v-icon color="white" class="me-2">mdi-alert</v-icon>
+                <v-card-title class="text-h3 pa-4 pb-0 pl-6">
+                    <v-icon color="error" class="me-2">mdi-alert</v-icon>
                     <span>{{ tm('dialogs.delete.title') }}</span>
                 </v-card-title>
 
@@ -327,7 +327,7 @@
                     <v-btn variant="text" @click="dialogDelete = false" :disabled="loading">
                         {{ tm('dialogs.delete.cancel') }}
                     </v-btn>
-                    <v-btn color="error" @click="deleteConversation" :loading="loading">
+                    <v-btn color="error" variant="tonal" @click="deleteConversation" :loading="loading">
                         {{ tm('dialogs.delete.confirm') }}
                     </v-btn>
                 </v-card-actions>
@@ -337,8 +337,8 @@
         <!-- 批量删除确认对话框 -->
         <v-dialog v-model="dialogBatchDelete" max-width="600px">
             <v-card>
-                <v-card-title class="bg-error text-white py-3">
-                    <v-icon color="white" class="me-2">mdi-delete</v-icon>
+                <v-card-title class="text-h3 pa-4 pb-0 pl-6">
+                    <v-icon color="error" class="me-2">mdi-delete</v-icon>
                     <span>{{ tm('dialogs.batchDelete.title') }}</span>
                 </v-card-title>
 
@@ -369,7 +369,7 @@
                     <v-btn variant="text" @click="dialogBatchDelete = false" :disabled="loading">
                         {{ tm('dialogs.batchDelete.cancel') }}
                     </v-btn>
-                    <v-btn color="error" @click="batchDeleteConversations" :loading="loading">
+                    <v-btn color="error" variant="tonal" @click="batchDeleteConversations" :loading="loading">
                         {{ tm('dialogs.batchDelete.confirm') }}
                     </v-btn>
                 </v-card-actions>

--- a/dashboard/src/views/CronJobPage.vue
+++ b/dashboard/src/views/CronJobPage.vue
@@ -188,7 +188,7 @@
 
         <v-dialog v-model="platformDialog" max-width="520">
           <v-card class="dashboard-dialog-card">
-            <v-card-title class="text-h3 pt-5 px-5">
+            <v-card-title class="text-h3 pa-4 pb-0 pl-6">
               {{ tm("platformDialog.title") }}
             </v-card-title>
             <v-card-text class="px-5 pb-2">
@@ -229,7 +229,7 @@
 
         <v-dialog v-model="createDialog" max-width="620">
           <v-card class="dashboard-dialog-card">
-            <v-card-title class="text-h3 pt-5 px-5">{{
+            <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{
               dialogTitle
             }}</v-card-title>
             <v-card-text class="px-5 pb-2">

--- a/dashboard/src/views/ExtensionPage.vue
+++ b/dashboard/src/views/ExtensionPage.vue
@@ -427,7 +427,7 @@ const updateDialogPluginLogo = computed(() => {
   <!-- 配置对话框 -->
   <v-dialog v-model="configDialog" max-width="900">
     <v-card>
-      <v-card-title class="text-h2 pa-4 pl-6 pb-0">{{
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{
         tm("dialogs.config.title")
       }}</v-card-title>
       <v-card-text>
@@ -461,7 +461,7 @@ const updateDialogPluginLogo = computed(() => {
   <!-- 加载对话框 -->
   <v-dialog v-model="loadingDialog.show" width="700" persistent>
     <v-card>
-      <v-card-title class="text-h5">{{ loadingDialog.title }}</v-card-title>
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{ loadingDialog.title }}</v-card-title>
       <v-card-text style="max-height: calc(100vh - 200px); overflow-y: auto">
         <v-progress-linear
           v-if="loadingDialog.statusCode === 0"
@@ -541,7 +541,7 @@ const updateDialogPluginLogo = computed(() => {
   <!-- 更新全部插件确认对话框 -->
   <v-dialog v-model="updateAllConfirmDialog.show" max-width="420">
     <v-card class="rounded-lg">
-      <v-card-title class="d-flex align-center pa-4">
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
         <v-icon color="warning" class="mr-2">mdi-update</v-icon>
         {{ tm("dialogs.updateAllConfirm.title") }}
       </v-card-title>
@@ -559,7 +559,7 @@ const updateDialogPluginLogo = computed(() => {
         <v-btn variant="text" @click="cancelUpdateAll">{{
           tm("buttons.cancel")
         }}</v-btn>
-        <v-btn color="warning" variant="flat" @click="confirmUpdateAll">{{
+        <v-btn color="warning" variant="tonal" @click="confirmUpdateAll">{{
           tm("dialogs.updateAllConfirm.confirm")
         }}</v-btn>
       </v-card-actions>
@@ -569,7 +569,7 @@ const updateDialogPluginLogo = computed(() => {
   <!-- 指令冲突提示对话框 -->
   <v-dialog v-model="conflictDialog.show" max-width="420">
     <v-card class="rounded-lg">
-      <v-card-title class="d-flex align-center pa-4">
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
         <v-icon color="warning" class="mr-2">mdi-alert-circle</v-icon>
         {{ tm("conflicts.title") }}
       </v-card-title>
@@ -597,7 +597,7 @@ const updateDialogPluginLogo = computed(() => {
         <v-btn variant="text" @click="conflictDialog.show = false">{{
           tm("conflicts.later")
         }}</v-btn>
-        <v-btn color="warning" variant="flat" @click="handleConflictConfirm">
+        <v-btn color="warning" variant="tonal" @click="handleConflictConfirm">
           {{ tm("conflicts.goToManage") }}
         </v-btn>
       </v-card-actions>
@@ -607,7 +607,7 @@ const updateDialogPluginLogo = computed(() => {
   <!-- 危险插件确认对话框 -->
   <v-dialog v-model="dangerConfirmDialog" width="500" persistent>
     <v-card>
-      <v-card-title class="text-h5 d-flex align-center">
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
         <v-icon color="warning" class="mr-2">mdi-alert-circle</v-icon>
         {{ tm("dialogs.danger_warning.title") }}
       </v-card-title>
@@ -616,10 +616,10 @@ const updateDialogPluginLogo = computed(() => {
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="grey" @click="cancelDangerInstall">
+        <v-btn color="grey" variant="text" @click="cancelDangerInstall">
           {{ tm("dialogs.danger_warning.cancel") }}
         </v-btn>
-        <v-btn color="warning" @click="confirmDangerInstall">
+        <v-btn color="warning" variant="tonal" @click="confirmDangerInstall">
           {{ tm("dialogs.danger_warning.confirm") }}
         </v-btn>
       </v-card-actions>
@@ -629,7 +629,7 @@ const updateDialogPluginLogo = computed(() => {
   <!-- 版本不兼容警告对话框 -->
   <v-dialog v-model="versionSupportDialog.show" width="520" persistent>
     <v-card>
-      <v-card-title class="text-h5 d-flex align-center">
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
         <v-icon color="warning" class="mr-2">mdi-alert</v-icon>
         {{ tm("dialogs.versionSupport.title") }}
       </v-card-title>
@@ -641,10 +641,10 @@ const updateDialogPluginLogo = computed(() => {
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="grey" @click="cancelInstallOnVersionWarning">
+        <v-btn color="grey" variant="text" @click="cancelInstallOnVersionWarning">
           {{ tm("dialogs.versionSupport.cancel") }}
         </v-btn>
-        <v-btn color="warning" @click="continueInstallIgnoringVersionWarning">
+        <v-btn color="warning" variant="tonal" @click="continueInstallIgnoringVersionWarning">
           {{ tm("dialogs.versionSupport.confirm") }}
         </v-btn>
       </v-card-actions>
@@ -788,10 +788,10 @@ const updateDialogPluginLogo = computed(() => {
 
                 <v-btn
                   color="primary"
+                  variant="tonal"
                   size="large"
                   prepend-icon="mdi-upload"
                   @click="$refs.fileInput.click()"
-                  elevation="2"
                 >
                   {{ tm("buttons.selectFile") }}
                 </v-btn>
@@ -968,7 +968,7 @@ const updateDialogPluginLogo = computed(() => {
   <!-- 插件源管理对话框 -->
   <v-dialog v-model="showSourceManagerDialog" width="640">
     <v-card>
-      <v-card-title class="text-h3 pa-4 pl-6">{{
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{
         tm("market.sourceManagement")
       }}</v-card-title>
       <v-card-text>
@@ -1057,7 +1057,7 @@ const updateDialogPluginLogo = computed(() => {
   <!-- 添加/编辑自定义插件源对话框 -->
   <v-dialog v-model="showSourceDialog" width="500">
     <v-card>
-      <v-card-title class="text-h5">{{
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{
         editingSource ? tm("market.editSource") : tm("market.addSource")
       }}</v-card-title>
       <v-card-text>
@@ -1115,7 +1115,7 @@ const updateDialogPluginLogo = computed(() => {
         }}</v-btn>
         <v-btn
           color="primary"
-          variant="text"
+          variant="tonal"
           :loading="sourceResolving"
           :disabled="
             sourceResolving || (!sourceResolveCurrent && !sourceUrl.trim())
@@ -1134,7 +1134,7 @@ const updateDialogPluginLogo = computed(() => {
   <!-- 删除插件源确认对话框 -->
   <v-dialog v-model="showRemoveSourceDialog" width="400">
     <v-card>
-      <v-card-title class="text-h5 d-flex align-center">
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
         <v-icon color="warning" class="mr-2">mdi-alert-circle</v-icon>
         {{ tm("dialogs.uninstall.title") }}
       </v-card-title>
@@ -1153,7 +1153,7 @@ const updateDialogPluginLogo = computed(() => {
           @click="showRemoveSourceDialog = false"
           >{{ tm("buttons.cancel") }}</v-btn
         >
-        <v-btn color="error" variant="text" @click="confirmRemoveSource">{{
+        <v-btn color="error" variant="tonal" @click="confirmRemoveSource">{{
           tm("buttons.deleteSource")
         }}</v-btn>
       </v-card-actions>
@@ -1233,7 +1233,7 @@ const updateDialogPluginLogo = computed(() => {
         </v-btn>
         <v-btn
           color="primary"
-          variant="flat"
+          variant="tonal"
           @click="confirmUpdatePlugin"
         >
           {{ tm("dialogs.update.confirm") }}
@@ -1245,7 +1245,7 @@ const updateDialogPluginLogo = computed(() => {
   <!-- 强制更新确认对话框 -->
   <v-dialog v-model="forceUpdateDialog.show" max-width="420">
     <v-card class="rounded-lg">
-      <v-card-title class="text-h6 d-flex align-center">
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
         <v-icon color="info" class="mr-2">mdi-information-outline</v-icon>
         {{ tm("dialogs.forceUpdate.title") }}
       </v-card-title>
@@ -1257,7 +1257,7 @@ const updateDialogPluginLogo = computed(() => {
         <v-btn variant="text" @click="forceUpdateDialog.show = false">{{
           tm("buttons.cancel")
         }}</v-btn>
-        <v-btn color="primary" variant="flat" @click="confirmForceUpdate">{{
+        <v-btn color="primary" variant="tonal" @click="confirmForceUpdate">{{
           tm("dialogs.forceUpdate.confirm")
         }}</v-btn>
       </v-card-actions>

--- a/dashboard/src/views/PlatformPage.vue
+++ b/dashboard/src/views/PlatformPage.vue
@@ -120,7 +120,7 @@
     <!-- Webhook URL 对话框 -->
     <v-dialog v-model="showWebhookDialog" max-width="600">
       <v-card>
-        <v-card-title class="d-flex align-center pa-4">
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
           <v-icon class="me-2" color="primary">mdi-webhook</v-icon>
           {{ tm('webhookDialog.title') }}
         </v-card-title>
@@ -156,7 +156,7 @@
 
     <v-dialog v-model="showQrDialog" max-width="480">
       <v-card>
-        <v-card-title class="d-flex align-center pa-4">
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
           <v-icon class="me-2">mdi-qrcode</v-icon>
           {{ tm('platformQr.title') }}
         </v-card-title>
@@ -181,7 +181,7 @@
     <!-- 错误详情对话框 -->
     <v-dialog v-model="showErrorDialog" max-width="700">
       <v-card>
-        <v-card-title class="d-flex align-center pa-4">
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
           <v-icon class="me-2" color="error">mdi-alert-circle</v-icon>
           {{ tm('errorDialog.title') }}
         </v-card-title>

--- a/dashboard/src/views/ProviderPage.vue
+++ b/dashboard/src/views/ProviderPage.vue
@@ -216,7 +216,10 @@
     />
 
     <v-dialog v-model="showManualModelDialog" max-width="400">
-      <v-card :title="tm('models.manualDialogTitle')">
+      <v-card>
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6">
+          {{ tm('models.manualDialogTitle') }}
+        </v-card-title>
         <v-card-text class="py-4">
           <v-text-field
             v-model="manualModelId"
@@ -238,15 +241,16 @@
         <v-card-actions class="pa-4">
           <v-spacer></v-spacer>
           <v-btn variant="text" @click="showManualModelDialog = false">取消</v-btn>
-          <v-btn color="primary" @click="confirmManualModel">添加</v-btn>
+          <v-btn color="primary" variant="tonal" @click="confirmManualModel">添加</v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>
 
     <v-dialog v-model="showProviderCfg" width="900" persistent>
-      <v-card
-        :title="updatingMode ? tm('dialogs.config.editTitle') : tm('dialogs.config.addTitle') + ` ${newSelectedProviderName} ` + tm('dialogs.config.provider')"
-      >
+      <v-card>
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6">
+          {{ updatingMode ? tm('dialogs.config.editTitle') : tm('dialogs.config.addTitle') + ` ${newSelectedProviderName} ` + tm('dialogs.config.provider') }}
+        </v-card-title>
         <v-card-text class="py-4">
           <AstrBotConfig
             :iterable="newSelectedProviderConfig"
@@ -263,7 +267,7 @@
           <v-btn variant="text" :disabled="loading" @click="showProviderCfg = false">
             {{ tm('dialogs.config.cancel') }}
           </v-btn>
-          <v-btn color="primary" :loading="loading" @click="newProvider">
+          <v-btn color="primary" variant="tonal" :loading="loading" @click="newProvider">
             {{ tm('dialogs.config.save') }}
           </v-btn>
         </v-card-actions>
@@ -271,7 +275,10 @@
     </v-dialog>
 
     <v-dialog v-model="showProviderEditDialog" width="800">
-      <v-card :title="providerEditDialogTitle">
+      <v-card>
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6">
+          {{ providerEditDialogTitle }}
+        </v-card-title>
         <v-card-text class="py-4">
           <AstrBotConfig
             v-if="providerEditData"
@@ -292,6 +299,7 @@
           </v-btn>
           <v-btn
             color="primary"
+            variant="tonal"
             :loading="savingProviders.includes(providerEditData?.id)"
             @click="saveEditedProvider"
           >
@@ -307,7 +315,7 @@
 
     <v-dialog v-model="showAgentRunnerDialog" max-width="520" persistent>
       <v-card>
-        <v-card-title class="text-h3 d-flex align-center">
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
           <v-icon start class="me-2">mdi-information</v-icon>
           请前往「配置文件」页测试 Agent 执行器
         </v-card-title>
@@ -323,7 +331,7 @@
         <v-card-actions>
           <v-spacer></v-spacer>
           <v-btn color="grey" variant="text" @click="showAgentRunnerDialog = false">好的</v-btn>
-          <v-btn color="primary" variant="flat" @click="goToConfigPage">点击前往</v-btn>
+          <v-btn color="primary" variant="tonal" @click="goToConfigPage">点击前往</v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>

--- a/dashboard/src/views/SessionManagementPage.vue
+++ b/dashboard/src/views/SessionManagementPage.vue
@@ -253,7 +253,7 @@
       <!-- 分组编辑对话框 -->
       <v-dialog v-model="groupDialog" max-width="800" @after-enter="loadAvailableUmos">
         <v-card>
-          <v-card-title class="py-3 px-4">
+          <v-card-title class="text-h3 pa-4 pb-0 pl-6">
             {{ groupDialogMode === 'create' ? tm('groups.create') : tm('groups.edit') }}
           </v-card-title>
           <v-card-text>
@@ -360,7 +360,7 @@
       <!-- 添加规则对话框 - 选择 UMO -->
       <v-dialog v-model="addRuleDialog" max-width="600">
         <v-card>
-          <v-card-title class="py-3 px-4" style="display: flex; align-items: center">
+          <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
             <span>{{ tm('addRule.title') }}</span>
             <v-spacer></v-spacer>
             <v-btn icon variant="text" @click="addRuleDialog = false">
@@ -407,7 +407,7 @@
       <!-- 规则编辑对话框 -->
       <v-dialog v-model="ruleDialog" max-width="550" scrollable>
         <v-card v-if="selectedUmo" class="d-flex flex-column" height="600">
-          <v-card-title class="py-3 px-6 d-flex align-center border-b">
+          <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center border-b">
             <span>{{ tm('ruleEditor.title') }}</span>
             <v-chip size="x-small" class="ml-2 font-weight-regular" variant="outlined">
               {{ selectedUmo.umo }}
@@ -613,7 +613,7 @@
       <!-- 确认删除对话框 -->
       <v-dialog v-model="deleteDialog" max-width="400">
         <v-card>
-          <v-card-title class="text-h6">{{ tm('deleteConfirm.title') }}</v-card-title>
+          <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{ tm('deleteConfirm.title') }}</v-card-title>
           <v-card-text>
             {{ tm('deleteConfirm.message') }}
             <br /><br />
@@ -630,7 +630,7 @@
       <!-- 批量删除确认对话框 -->
       <v-dialog v-model="batchDeleteDialog" max-width="500">
         <v-card>
-          <v-card-title class="text-h6">{{ tm('batchDeleteConfirm.title') }}</v-card-title>
+          <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{ tm('batchDeleteConfirm.title') }}</v-card-title>
           <v-card-text>
             {{ tm('batchDeleteConfirm.message', { count: selectedItems.length }) }}
             <div class="mt-3" style="max-height: 200px; overflow-y: auto">
@@ -657,7 +657,7 @@
       <!-- 快速编辑备注名对话框 -->
       <v-dialog v-model="quickEditNameDialog" max-width="400">
         <v-card>
-          <v-card-title class="py-3 px-4">{{ tm('quickEditName.title') }}</v-card-title>
+          <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{ tm('quickEditName.title') }}</v-card-title>
           <v-card-text class="pa-4">
             <v-text-field v-model="quickEditNameValue" :label="tm('ruleEditor.serviceConfig.customName')" variant="outlined" hide-details clearable autofocus @keyup.enter="saveQuickEditName" />
           </v-card-text>

--- a/dashboard/src/views/WelcomePage.vue
+++ b/dashboard/src/views/WelcomePage.vue
@@ -170,7 +170,7 @@
     <ProviderConfigDialog v-model="showProviderDialog" />
     <v-dialog v-model="showComputerAccessHelpDialog" max-width="640">
       <v-card>
-        <v-card-title class="text-h3 font-weight-bold pa-4">
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6">
           {{ tm('onboard.step3HelpTitle') }}
         </v-card-title>
         <v-card-text>

--- a/dashboard/src/views/alkaid/KnowledgeBase.vue
+++ b/dashboard/src/views/alkaid/KnowledgeBase.vue
@@ -76,7 +76,7 @@
         <!-- 创建知识库对话框 -->
         <v-dialog v-model="showCreateDialog" max-width="500px">
             <v-card>
-                <v-card-title class="text-h4">{{ tm('createDialog.title') }}</v-card-title>
+                <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{ tm('createDialog.title') }}</v-card-title>
                 <v-card-text>
 
                     <div style="width: 100%; display: flex; align-items: center; justify-content: center;">
@@ -111,7 +111,7 @@
                     <v-spacer></v-spacer>
                     <v-btn color="error" variant="text" @click="showCreateDialog = false">{{ tm('createDialog.cancel')
                         }}</v-btn>
-                    <v-btn color="primary" variant="text" @click="submitCreateForm">{{ tm('createDialog.create')
+                    <v-btn color="primary" variant="tonal" @click="submitCreateForm">{{ tm('createDialog.create')
                         }}</v-btn>
                 </v-card-actions>
             </v-card>
@@ -120,7 +120,7 @@
         <!-- 表情选择器对话框 -->
         <v-dialog v-model="showEmojiPicker" max-width="400px">
             <v-card>
-                <v-card-title class="text-h6">{{ tm('emojiPicker.title') }}</v-card-title>
+                <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{ tm('emojiPicker.title') }}</v-card-title>
                 <v-card-text>
                     <div class="emoji-picker">
                         <div v-for="(category, catIndex) in emojiCategories" :key="catIndex" class="mb-4">
@@ -145,11 +145,11 @@
         <!-- 知识库内容管理对话框 -->
         <v-dialog v-model="showContentDialog" max-width="1000px">
             <v-card>
-                <v-card-title class="d-flex align-center">
+                <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
                     <div class="me-2 emoji-sm">{{ currentKB.emoji || '🙂' }}</div>
                     <span>{{ currentKB.collection_name }} - {{ tm('contentDialog.title') }}</span>
                     <v-spacer></v-spacer>
-                    <v-btn variant="plain" icon @click="showContentDialog = false">
+                    <v-btn variant="text" icon @click="showContentDialog = false">
                         <v-icon>mdi-close</v-icon>
                     </v-btn>
                 </v-card-title>
@@ -249,7 +249,7 @@
                                         </div>
 
                                         <div class="text-center mt-4">
-                                            <v-btn color="primary" variant="elevated" :loading="uploading"
+                                            <v-btn color="primary" variant="tonal" :loading="uploading"
                                                 :disabled="!selectedFile" @click="uploadFile">
                                                 {{ tm('upload.upload') }}
                                             </v-btn>
@@ -340,7 +340,7 @@
                                     </v-card>
 
                                     <div class="text-center">
-                                        <v-btn color="primary" variant="elevated" :loading="importing"
+                                        <v-btn color="primary" variant="tonal" :loading="importing"
                                             :disabled="!importUrl" @click="startImportFromUrl">
                                             {{ tm('importFromUrl.startImport') }}
                                         </v-btn>
@@ -408,7 +408,7 @@
         <!-- 删除知识库确认对话框 -->
         <v-dialog v-model="showDeleteDialog" max-width="400px">
             <v-card>
-                <v-card-title class="text-h5">{{ tm('deleteDialog.title') }}</v-card-title>
+                <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{ tm('deleteDialog.title') }}</v-card-title>
                 <v-card-text>
                     <p>{{ tm('deleteDialog.confirmText', { name: deleteTarget.collection_name }) }}</p>
                     <p class="text-red">{{ tm('deleteDialog.warning') }}</p>
@@ -418,7 +418,7 @@
                     <v-btn color="grey-darken-1" variant="text" @click="showDeleteDialog = false">{{
                         tm('deleteDialog.cancel')
                         }}</v-btn>
-                    <v-btn color="error" variant="text" @click="deleteKnowledgeBase" :loading="deleting">{{
+                    <v-btn color="error" variant="tonal" @click="deleteKnowledgeBase" :loading="deleting">{{
                         tm('deleteDialog.delete') }}</v-btn>
                 </v-card-actions>
             </v-card>

--- a/dashboard/src/views/alkaid/LongTermMemory.vue
+++ b/dashboard/src/views/alkaid/LongTermMemory.vue
@@ -158,11 +158,11 @@
 
       <v-dialog v-model="showFactDialog" max-width="550" scrollable>
         <v-card class="fact-detail-card">
-          <v-card-title class="d-flex align-center bg-primary text-white px-4 py-3">
-            <v-icon class="mr-2" color="white">mdi-memory</v-icon>
+          <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
+            <v-icon class="mr-2" color="primary">mdi-memory</v-icon>
             {{ tm('factDialog.title') }}
             <v-spacer></v-spacer>
-            <v-btn icon variant="text" color="white" @click="showFactDialog = false">
+            <v-btn icon variant="text" @click="showFactDialog = false">
               <v-icon>mdi-close</v-icon>
             </v-btn>
           </v-card-title>

--- a/dashboard/src/views/authentication/auth/LoginPage.vue
+++ b/dashboard/src/views/authentication/auth/LoginPage.vue
@@ -250,7 +250,7 @@ onMounted(async () => {
     </v-card>
     <v-dialog v-model="versionDialogVisible" max-width="460">
       <v-card class="version-dialog-card">
-        <v-card-title class="version-dialog-title">
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6 version-dialog-title">
           <v-icon size="20" color="warning">mdi-alert-circle-outline</v-icon>
           <span>{{ t('versions.dialogTitle') }}</span>
         </v-card-title>
@@ -338,9 +338,6 @@ onMounted(async () => {
   align-items: center;
   display: flex;
   gap: 8px;
-  font-size: 17px;
-  line-height: 1.35;
-  padding-bottom: 8px;
 }
 
 .version-dialog-content {

--- a/dashboard/src/views/extension/InstalledPluginsTab.vue
+++ b/dashboard/src/views/extension/InstalledPluginsTab.vue
@@ -371,7 +371,7 @@ const togglePinnedExtension = (extension) => {
 
     <v-dialog v-model="sourceBindingDialog.show" max-width="680">
       <v-card>
-        <v-card-title class="d-flex align-center">
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
           {{
             sourceBindingDialog.pendingUpdate
               ? tm("dialogs.sourceBinding.selectTitle")
@@ -478,7 +478,7 @@ const togglePinnedExtension = (extension) => {
           </v-btn>
           <v-btn
             color="primary"
-            variant="flat"
+            variant="tonal"
             :loading="sourceBindingDialog.saving"
             :disabled="
               sourceBindingDialog.loading ||

--- a/dashboard/src/views/knowledge-base/DocumentDetail.vue
+++ b/dashboard/src/views/knowledge-base/DocumentDetail.vue
@@ -179,7 +179,7 @@
     <!-- 查看分块对话框 -->
     <v-dialog v-model="showViewDialog" max-width="800px" scrollable>
       <v-card>
-        <v-card-title class="pa-4">
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
           <span>{{ t('view.title') }}</span>
           <v-spacer />
           <v-btn icon="mdi-close" variant="text" @click="showViewDialog = false" />

--- a/dashboard/src/views/knowledge-base/KBList.vue
+++ b/dashboard/src/views/knowledge-base/KBList.vue
@@ -133,8 +133,8 @@
     <!-- 创建/编辑对话框 -->
     <v-dialog v-model="showCreateDialog" max-width="600px" persistent>
       <v-card>
-        <v-card-title class="d-flex align-center">
-          <span class="text-h5">{{ editingKB ? t('edit.title') : t('create.title') }}</span>
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
+          <span>{{ editingKB ? t('edit.title') : t('create.title') }}</span>
           <v-spacer />
           <v-btn icon="mdi-close" variant="text" @click="closeCreateDialog" />
         </v-card-title>
@@ -195,7 +195,7 @@
           <v-btn variant="text" @click="closeCreateDialog">
             {{ t('create.cancel') }}
           </v-btn>
-          <v-btn color="primary" variant="elevated" @click="submitForm" :loading="saving">
+          <v-btn color="primary" variant="tonal" @click="submitForm" :loading="saving">
             {{ editingKB ? t('edit.submit') : t('create.submit') }}
           </v-btn>
         </v-card-actions>
@@ -205,7 +205,7 @@
     <!-- Emoji 选择器对话框 -->
     <v-dialog v-model="showEmojiPicker" max-width="500px">
       <v-card>
-        <v-card-title class="pa-4">{{ t('emoji.title') }}</v-card-title>
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{ t('emoji.title') }}</v-card-title>
         <v-divider />
         <v-card-text class="pa-4">
           <div v-for="category in emojiCategories" :key="category.key" class="mb-4">
@@ -230,7 +230,7 @@
     <!-- 删除确认对话框 -->
     <v-dialog v-model="showDeleteDialog" max-width="450px" persistent>
       <v-card>
-        <v-card-title class="pa-4 text-h6">{{ t('delete.title') }}</v-card-title>
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{ t('delete.title') }}</v-card-title>
         <v-divider />
         <v-card-text class="pa-6">
           <p>{{ t('delete.confirmText', { name: deleteTarget?.kb_name || '' }) }}</p>
@@ -244,7 +244,7 @@
           <v-btn variant="text" @click="cancelDelete">
             {{ t('delete.cancel') }}
           </v-btn>
-          <v-btn color="error" variant="elevated" @click="deleteKB" :loading="deleting">
+          <v-btn color="error" variant="tonal" @click="deleteKB" :loading="deleting">
             {{ t('delete.confirm') }}
           </v-btn>
         </v-card-actions>

--- a/dashboard/src/views/knowledge-base/components/DocumentsTab.vue
+++ b/dashboard/src/views/knowledge-base/components/DocumentsTab.vue
@@ -61,8 +61,8 @@
     <!-- 上传对话框 -->
     <v-dialog v-model="showUploadDialog" max-width="650px" persistent @after-enter="initUploadSettings">
       <v-card>
-        <v-card-title class="pa-4 d-flex align-center">
-          <span class="text-h5">{{ t('upload.title') }}</span>
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex align-center">
+          <span>{{ t('upload.title') }}</span>
           <v-spacer />
           <v-btn icon="mdi-close" variant="text" @click="closeUploadDialog" />
         </v-card-title>
@@ -123,7 +123,7 @@
                     <span>
                       {{ tavilyConfigStatus === 'error' ? '检查网页搜索配置失败' : '使用此功能需要配置 Tavily Key' }}
                     </span>
-                    <v-btn size="small" variant="flat" @click="showTavilyDialog = true">
+                    <v-btn size="small" variant="tonal" @click="showTavilyDialog = true">
                       配置
                     </v-btn>
                   </div>
@@ -198,7 +198,7 @@
           <v-btn variant="text" @click="closeUploadDialog" :disabled="uploading">
             {{ t('upload.cancel') }}
           </v-btn>
-          <v-btn color="primary" variant="elevated" @click="startUpload" :loading="uploading"
+          <v-btn color="primary" variant="tonal" @click="startUpload" :loading="uploading"
             :disabled="isUploadDisabled">
             {{ t('upload.submit') }}
           </v-btn>
@@ -209,7 +209,7 @@
     <!-- 删除确认对话框 -->
     <v-dialog v-model="showDeleteDialog" max-width="450px">
       <v-card>
-        <v-card-title class="pa-4 text-h6">{{ t('documents.delete') }}</v-card-title>
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{ t('documents.delete') }}</v-card-title>
         <v-card-text class="pa-6">
           <p>{{ t('documents.deleteConfirm', { name: deleteTarget?.doc_name || '' }) }}</p>
           <v-alert type="error" variant="tonal" density="compact" class="mt-4">
@@ -219,7 +219,7 @@
         <v-card-actions class="pa-4">
           <v-spacer />
           <v-btn variant="text" @click="showDeleteDialog = false">取消</v-btn>
-          <v-btn color="error" variant="elevated" @click="deleteDocument" :loading="deleting">
+          <v-btn color="error" variant="tonal" @click="deleteDocument" :loading="deleting">
             删除
           </v-btn>
         </v-card-actions>

--- a/dashboard/src/views/knowledge-base/components/SettingsTab.vue
+++ b/dashboard/src/views/knowledge-base/components/SettingsTab.vue
@@ -125,7 +125,7 @@
     <!-- Embedding Provider修改确认对话框 -->
     <v-dialog v-model="embeddingChangeDialog" max-width="500px" persistent>
       <v-card>
-        <v-card-title class="bg-warning text-white">
+        <v-card-title class="text-h3 pa-4 pb-0 pl-6">
           <v-icon class="mr-2">mdi-alert</v-icon>
           确认修改嵌入模型
         </v-card-title>
@@ -148,7 +148,7 @@
           <v-btn variant="text" @click="cancelEmbeddingChange">
             取消
           </v-btn>
-          <v-btn color="warning" variant="elevated" @click="confirmEmbeddingChange">
+          <v-btn color="warning" variant="tonal" @click="confirmEmbeddingChange">
             确认修改
           </v-btn>
         </v-card-actions>

--- a/dashboard/src/views/knowledge-base/components/TavilyKeyDialog.vue
+++ b/dashboard/src/views/knowledge-base/components/TavilyKeyDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <v-dialog v-model="dialog" max-width="500px" persistent>
     <v-card>
-      <v-card-title class="text-h5">
+      <v-card-title class="text-h3 pa-4 pb-0 pl-6">
         配置 Tavily API Key
       </v-card-title>
       <v-card-text>
@@ -24,7 +24,7 @@
         <v-btn variant="text" @click="closeDialog" :disabled="saving">
           取消
         </v-btn>
-        <v-btn color="primary" variant="elevated" @click="saveKey" :loading="saving">
+        <v-btn color="primary" variant="tonal" @click="saveKey" :loading="saving">
           保存
         </v-btn>
       </v-card-actions>

--- a/dashboard/src/views/persona/FolderTree.vue
+++ b/dashboard/src/views/persona/FolderTree.vue
@@ -29,7 +29,7 @@
         <!-- 重命名对话框 -->
         <v-dialog v-model="renameDialog.show" max-width="400px" persistent>
             <v-card>
-                <v-card-title>{{ tm('folder.renameDialog.title') }}</v-card-title>
+                <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{ tm('folder.renameDialog.title') }}</v-card-title>
                 <v-card-text>
                     <v-text-field v-model="renameDialog.name" :label="tm('folder.form.name')"
                         :rules="[v => !!v || tm('folder.validation.nameRequired')]" variant="outlined"
@@ -40,7 +40,7 @@
                     <v-btn variant="text" @click="renameDialog.show = false">
                         {{ tm('buttons.cancel') }}
                     </v-btn>
-                    <v-btn color="primary" variant="flat" @click="submitRename" :loading="renameDialog.loading"
+                    <v-btn color="primary" variant="tonal" @click="submitRename" :loading="renameDialog.loading"
                         :disabled="!renameDialog.name">
                         {{ tm('buttons.save') }}
                     </v-btn>
@@ -51,7 +51,7 @@
         <!-- 删除确认对话框 -->
         <v-dialog v-model="deleteDialog.show" max-width="450px">
             <v-card>
-                <v-card-title class="text-error">
+                <v-card-title class="text-h3 pa-4 pb-0 pl-6">
                     <v-icon class="mr-2" color="error">mdi-alert</v-icon>
                     {{ tm('folder.deleteDialog.title') }}
                 </v-card-title>
@@ -67,7 +67,7 @@
                     <v-btn variant="text" @click="deleteDialog.show = false">
                         {{ tm('buttons.cancel') }}
                     </v-btn>
-                    <v-btn color="error" variant="flat" @click="submitDelete" :loading="deleteDialog.loading">
+                    <v-btn color="error" variant="tonal" @click="submitDelete" :loading="deleteDialog.loading">
                         {{ tm('buttons.delete') }}
                     </v-btn>
                 </v-card-actions>

--- a/dashboard/src/views/persona/MoveToFolderDialog.vue
+++ b/dashboard/src/views/persona/MoveToFolderDialog.vue
@@ -1,7 +1,7 @@
 <template>
     <v-dialog v-model="showDialog" max-width="500px" persistent>
         <v-card>
-            <v-card-title>
+            <v-card-title class="text-h3 pa-4 pb-0 pl-6">
                 <v-icon class="mr-2">mdi-folder-move</v-icon>
                 {{ tm('moveDialog.title') }}
             </v-card-title>
@@ -41,7 +41,7 @@
                 <v-btn variant="text" @click="closeDialog">
                     {{ tm('buttons.cancel') }}
                 </v-btn>
-                <v-btn color="primary" variant="flat" @click="submitMove" :loading="loading">
+                <v-btn color="primary" variant="tonal" @click="submitMove" :loading="loading">
                     {{ tm('buttons.move') }}
                 </v-btn>
             </v-card-actions>

--- a/dashboard/src/views/persona/PersonaManager.vue
+++ b/dashboard/src/views/persona/PersonaManager.vue
@@ -115,8 +115,8 @@
         <!-- 查看 Persona 详情对话框 -->
         <v-dialog v-model="showViewDialog" max-width="700px">
             <v-card v-if="viewingPersona">
-                <v-card-title class="d-flex justify-space-between align-center">
-                    <span class="text-h5">{{ viewingPersona.persona_id }}</span>
+                <v-card-title class="text-h3 pa-4 pb-0 pl-6 d-flex justify-space-between align-center">
+                    <span>{{ viewingPersona.persona_id }}</span>
                     <div class="d-flex align-center ga-1">
                         <v-btn
                             color="primary"
@@ -207,7 +207,7 @@
         <!-- 重命名文件夹对话框 -->
         <v-dialog v-model="showRenameFolderDialog" max-width="400px">
             <v-card>
-                <v-card-title>{{ tm('folder.renameDialog.title') }}</v-card-title>
+                <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{ tm('folder.renameDialog.title') }}</v-card-title>
                 <v-card-text>
                     <v-text-field v-model="renameFolderData.name" :label="tm('folder.form.name')"
                         :rules="[v => !!v || tm('folder.validation.nameRequired')]" variant="outlined"
@@ -218,7 +218,7 @@
                     <v-btn variant="text" @click="showRenameFolderDialog = false">
                         {{ tm('buttons.cancel') }}
                     </v-btn>
-                    <v-btn color="primary" variant="flat" @click="submitRenameFolder" :loading="renameLoading"
+                    <v-btn color="primary" variant="tonal" @click="submitRenameFolder" :loading="renameLoading"
                         :disabled="!renameFolderData.name">
                         {{ tm('buttons.save') }}
                     </v-btn>
@@ -233,7 +233,7 @@
         <!-- 删除文件夹确认对话框 -->
         <v-dialog v-model="showDeleteFolderDialog" max-width="450px">
             <v-card>
-                <v-card-title class="text-error">
+                <v-card-title class="text-h3 pa-4 pb-0 pl-6">
                     <v-icon class="mr-2" color="error">mdi-alert</v-icon>
                     {{ tm('folder.deleteDialog.title') }}
                 </v-card-title>
@@ -249,7 +249,7 @@
                     <v-btn variant="text" @click="showDeleteFolderDialog = false">
                         {{ tm('buttons.cancel') }}
                     </v-btn>
-                    <v-btn color="error" variant="flat" @click="submitDeleteFolder" :loading="deleteLoading">
+                    <v-btn color="error" variant="tonal" @click="submitDeleteFolder" :loading="deleteLoading">
                         {{ tm('buttons.delete') }}
                     </v-btn>
                 </v-card-actions>


### PR DESCRIPTION
## Summary\n- document the WebUI dialog title and button styling rule in AGENTS.md\n- standardize dashboard dialog title classes around \n- switch dialog buttons to  or  variants\n\n## Checks\n- pnpm typecheck\n- ruff check .\n- dialog title/button scan

## Summary by Sourcery

Standardize WebUI dashboard dialog styling for titles and buttons and document the styling conventions.

Enhancements:
- Align dialog title typography and padding across dashboard views and shared components using a common `text-h3` title style.
- Normalize dialog button appearance by preferring `variant="text"` for secondary actions and `variant="tonal"` for primary/confirm actions throughout the dashboard.

Documentation:
- Add a guideline to AGENTS.md describing the standard dialog title classes and button variants for WebUI dialogs.