### PR TITLE
fix(qqofficial): resilient websocket reconnect and send retry

### DIFF
--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -494,6 +494,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
             logger.info("[QQOfficial] 回复消息失败: %s, 尝试使用主动发送接口。", err)
             if payload.get("msg_id"):
                 fallback_payload = payload.copy()
+                fallback_payload.pop("msg_id", None)
                 try:
                     ret = await send_func(fallback_payload)
                     logger.info("[QQOfficial] 使用主动发送接口发送成功。")

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
@@ -121,6 +121,7 @@ class ManagedBotWebSocket(BotWebSocket):
             logger.info("[QQOfficial] Gateway requested reconnect.")
             self._client.schedule_reconnect_delay("server requested reconnect")
             self._connection.add(self._session)
+            self._can_reconnect = False
             await ws.close()
             return True
         if event_op == self.WS_INVALID_SESSION:
@@ -133,6 +134,7 @@ class ManagedBotWebSocket(BotWebSocket):
                 self._session["last_seq"] = 0
             self._client.schedule_reconnect_delay("invalid session", custom_delay=3)
             self._connection.add(self._session)
+            self._can_reconnect = False
             await ws.close()
             return True
         return await super()._is_system_event(message_event, ws)

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import random
@@ -12,8 +13,9 @@ from typing import Any, cast
 import botpy
 import botpy.message
 from botpy import Client
-from botpy.connection import ConnectionState
+from botpy.connection import ConnectionSession, ConnectionState
 from botpy.gateway import BotWebSocket
+from botpy.robot import Robot, Token
 
 from astrbot import logger
 from astrbot.api.event import MessageChain
@@ -35,6 +37,16 @@ from .qqofficial_message_event import QQOfficialMessageEvent
 # remove logger handler
 for handler in logging.root.handlers[:]:
     logging.root.removeHandler(handler)
+
+_RECONNECT_DELAYS_SECONDS = (1, 2, 5, 10, 30, 60)
+_RATE_LIMIT_RECONNECT_DELAY_SECONDS = 60
+_MAX_QUICK_DISCONNECTS = 3
+_QUICK_DISCONNECT_THRESHOLD_SECONDS = 5
+_SESSION_INVALID_CLOSE_CODES = {4006, 4007, 4009}
+
+
+class QQOfficialGatewayUnavailableError(RuntimeError):
+    """Raised when qq-botpy returns unusable gateway metadata."""
 
 
 class PatchedGroupMessage(botpy.message.GroupMessage):
@@ -74,12 +86,99 @@ class ManagedBotWebSocket(BotWebSocket):
     def __init__(self, session, connection: Any, client: botClient):
         super().__init__(session, connection)
         self._client = client
+        self._heartbeat_interval_seconds: float | None = None
+        self._last_heartbeat_ack_at = 0.0
+
+    async def on_connected(self, ws) -> None:
+        self._client.mark_websocket_connected()
+        await super().on_connected(ws)
+
+    async def on_message(self, ws, message) -> None:
+        event = None
+        try:
+            payload = json.loads(message)
+            event = payload.get("t")
+        except Exception:
+            pass
+
+        await super().on_message(ws, message)
+
+        if event in {"READY", "RESUMED"}:
+            self._client.reset_reconnect_backoff()
+
+    async def _is_system_event(self, message_event, ws):
+        event_op = message_event["op"]
+        if event_op == self.WS_HELLO:
+            interval_ms = (message_event.get("d") or {}).get("heartbeat_interval")
+            if isinstance(interval_ms, int | float) and interval_ms > 0:
+                self._heartbeat_interval_seconds = interval_ms / 1000
+                logger.info(f"[QQOfficial] Gateway heartbeat interval: {interval_ms}ms")
+            return await super()._is_system_event(message_event, ws)
+        if event_op == self.WS_HEARTBEAT_ACK:
+            self._last_heartbeat_ack_at = time.monotonic()
+            return True
+        if event_op == self.WS_RECONNECT:
+            logger.info("[QQOfficial] Gateway requested reconnect.")
+            self._client.schedule_reconnect_delay("server requested reconnect")
+            self._connection.add(self._session)
+            await ws.close()
+            return True
+        if event_op == self.WS_INVALID_SESSION:
+            can_resume = bool(message_event.get("d"))
+            logger.warning(
+                f"[QQOfficial] Gateway reported invalid session, can_resume={can_resume}."
+            )
+            if not can_resume:
+                self._session["session_id"] = ""
+                self._session["last_seq"] = 0
+            self._client.schedule_reconnect_delay("invalid session", custom_delay=3)
+            self._connection.add(self._session)
+            await ws.close()
+            return True
+        return await super()._is_system_event(message_event, ws)
+
+    async def _send_heart(self, interval):
+        """Send gateway heartbeat using the interval announced by QQ."""
+
+        heartbeat_interval = self._heartbeat_interval_seconds or interval
+        logger.info(
+            f"[QQOfficial] Heartbeat loop started, interval={heartbeat_interval}s."
+        )
+        while True:
+            payload = {
+                "op": self.WS_HEARTBEAT,
+                "d": self._session["last_seq"],
+            }
+
+            if self._conn is None:
+                logger.debug("[QQOfficial] Websocket is closed, stop heartbeat.")
+                return
+            if self._conn.closed:
+                logger.debug("[QQOfficial] Websocket closed, stop heartbeat.")
+                return
+
+            await self.send_msg(json.dumps(payload))
+            await asyncio.sleep(heartbeat_interval)
 
     async def on_closed(self, close_status_code, close_msg):
         if self._client.is_shutting_down:
             logger.debug("[QQOfficial] Ignore websocket reconnect during shutdown.")
             return
+        rate_limited = close_status_code == 4008
+        if close_status_code in _SESSION_INVALID_CLOSE_CODES or (
+            isinstance(close_status_code, int) and 4900 <= close_status_code <= 4913
+        ):
+            self._can_reconnect = False
+        self._client.schedule_reconnect_delay(
+            f"websocket closed: {close_status_code} {close_msg}",
+            rate_limited=rate_limited,
+        )
         await super().on_closed(close_status_code, close_msg)
+
+    async def on_error(self, exception: BaseException):
+        if not self._client.is_shutting_down:
+            self._client.schedule_reconnect_delay(f"websocket error: {exception}")
+        await super().on_error(exception)
 
     async def close(self) -> None:
         self._can_reconnect = False
@@ -93,6 +192,10 @@ class botClient(Client):
         super().__init__(*args, **kwargs)
         self._shutting_down = False
         self._active_websockets: set[ManagedBotWebSocket] = set()
+        self._next_connect_at = 0.0
+        self._reconnect_attempts = 0
+        self._last_connect_at = 0.0
+        self._quick_disconnect_count = 0
 
     def set_platform(self, platform: QQOfficialPlatformAdapter) -> None:
         self.platform = platform
@@ -100,6 +203,97 @@ class botClient(Client):
     @property
     def is_shutting_down(self) -> bool:
         return self._shutting_down or self.is_closed()
+
+    async def _bot_login(self, token: Token) -> None:
+        logger.info("[QQOfficial] 登录机器人账号中...")
+
+        user = await self.http.login(token)
+        self._ws_ap = await self.api.get_ws_url()
+        session_limit = (
+            self._ws_ap.get("session_start_limit")
+            if isinstance(self._ws_ap, dict)
+            else None
+        )
+        max_concurrency = (
+            session_limit.get("max_concurrency")
+            if isinstance(session_limit, dict)
+            else None
+        )
+        if not isinstance(max_concurrency, int):
+            raise QQOfficialGatewayUnavailableError(
+                "gateway metadata unavailable during qq_official startup"
+            )
+
+        self._connection = ConnectionSession(
+            max_async=max_concurrency,
+            connect=self.bot_connect,
+            dispatch=self.ws_dispatch,
+            loop=self.loop,
+            api=self.api,
+        )
+        self._connection.state.robot = Robot(user)
+
+    def mark_websocket_connected(self) -> None:
+        self._last_connect_at = time.monotonic()
+
+    def reset_reconnect_backoff(self) -> None:
+        if self._reconnect_attempts or self._quick_disconnect_count:
+            logger.info("[QQOfficial] Websocket session resumed, reset backoff.")
+        self._next_connect_at = 0.0
+        self._reconnect_attempts = 0
+        self._quick_disconnect_count = 0
+
+    def schedule_reconnect_delay(
+        self,
+        reason: str,
+        *,
+        custom_delay: float | None = None,
+        rate_limited: bool = False,
+    ) -> None:
+        """Schedule the next websocket connection attempt.
+
+        Args:
+            reason: Human-readable reason for logging.
+            custom_delay: Explicit reconnect delay in seconds.
+            rate_limited: Whether QQ reported gateway rate limiting.
+        """
+
+        if self.is_shutting_down:
+            return
+
+        delay = custom_delay
+        if delay is None and rate_limited:
+            delay = _RATE_LIMIT_RECONNECT_DELAY_SECONDS
+        if delay is None:
+            if self._last_connect_at:
+                duration = time.monotonic() - self._last_connect_at
+                if duration < _QUICK_DISCONNECT_THRESHOLD_SECONDS:
+                    self._quick_disconnect_count += 1
+                else:
+                    self._quick_disconnect_count = 0
+                if self._quick_disconnect_count >= _MAX_QUICK_DISCONNECTS:
+                    delay = _RATE_LIMIT_RECONNECT_DELAY_SECONDS
+                    self._quick_disconnect_count = 0
+                    logger.warning(
+                        "[QQOfficial] Too many quick disconnects; delaying reconnect."
+                    )
+            if delay is None:
+                idx = min(
+                    self._reconnect_attempts,
+                    len(_RECONNECT_DELAYS_SECONDS) - 1,
+                )
+                delay = _RECONNECT_DELAYS_SECONDS[idx]
+                self._reconnect_attempts += 1
+
+        self._next_connect_at = max(self._next_connect_at, time.monotonic() + delay)
+        logger.info(f"[QQOfficial] Reconnect scheduled in {delay}s, reason: {reason}")
+
+    async def wait_for_reconnect_delay(self) -> None:
+        delay = self._next_connect_at - time.monotonic()
+        if delay <= 0:
+            return
+        logger.info(f"[QQOfficial] Waiting {delay:.1f}s before reconnect.")
+        await asyncio.sleep(delay)
 
     # 收到群消息
     async def on_group_at_message_create(
@@ -165,6 +359,9 @@ class botClient(Client):
         self.platform.commit_event(self.platform.create_event(abm))
 
     async def bot_connect(self, session) -> None:
+        await self.wait_for_reconnect_delay()
+        if self.is_shutting_down:
+            return
         logger.info("[QQOfficial] Websocket session starting.")
 
         websocket = ManagedBotWebSocket(session, self._connection, self)
@@ -191,6 +388,8 @@ class botClient(Client):
 
 @register_platform_adapter("qq_official", "QQ 机器人官方 API 适配器")
 class QQOfficialPlatformAdapter(Platform):
+    STARTUP_RETRY_DELAYS_SECONDS = (5, 10, 30, 60)
+
     def __init__(
         self,
         platform_config: dict,
@@ -215,13 +414,9 @@ class QQOfficialPlatformAdapter(Platform):
                 public_guild_messages=True,
                 direct_message=guild_dm,
             )
-        self.client = botClient(
-            intents=self.intents,
-            bot_log=False,
-            timeout=20,
-        )
-
-        self.client.set_platform(self)
+        self._shutdown_event = asyncio.Event()
+        self._startup_retry_attempts = 0
+        self.client = self._create_client()
 
         _ensure_group_message_create_parser()
 
@@ -230,6 +425,67 @@ class QQOfficialPlatformAdapter(Platform):
         self._allow_group_proactive_send = True
 
         self.test_mode = os.environ.get("TEST_MODE", "off") == "on"
+
+    def _create_client(self) -> botClient:
+        client = botClient(
+            intents=self.intents,
+            bot_log=False,
+            timeout=20,
+        )
+        client.set_platform(self)
+        return client
+
+    @staticmethod
+    def _should_retry_startup_error(error: Exception) -> bool:
+        if isinstance(
+            error,
+            (
+                asyncio.TimeoutError,
+                ConnectionError,
+                OSError,
+                QQOfficialGatewayUnavailableError,
+            ),
+        ):
+            return True
+        if isinstance(error, botpy.errors.ServerError):
+            error_msg = str(error)
+            return any(
+                marker in error_msg
+                for marker in ("100017", "频率限制", "Too many requests")
+            )
+        return False
+
+    def _next_startup_retry_delay(self, error: Exception | None = None) -> int:
+        if isinstance(error, botpy.errors.ServerError):
+            error_msg = str(error)
+            if any(
+                marker in error_msg
+                for marker in ("100017", "频率限制", "Too many requests")
+            ):
+                return _RATE_LIMIT_RECONNECT_DELAY_SECONDS
+
+        idx = min(
+            self._startup_retry_attempts,
+            len(self.STARTUP_RETRY_DELAYS_SECONDS) - 1,
+        )
+        self._startup_retry_attempts += 1
+        return self.STARTUP_RETRY_DELAYS_SECONDS[idx]
+
+    async def _restart_client(self) -> None:
+        try:
+            await self.client.shutdown()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"[QQOfficial] Close client failed during recovery: {e}")
+        self.client = self._create_client()
+
+    async def _sleep_until_retry_or_shutdown(self, delay: float) -> bool:
+        try:
+            await asyncio.wait_for(self._shutdown_event.wait(), timeout=delay)
+            return False
+        except asyncio.TimeoutError:
+            return True
 
     async def send_by_session(
         self,
@@ -696,12 +952,41 @@ class QQOfficialPlatformAdapter(Platform):
             abm.self_id = "qq_official"
         return abm
 
-    def run(self):
-        return self.client.start(appid=self.appid, secret=self.secret)
+    async def run(self) -> None:
+        while not self._shutdown_event.is_set():
+            try:
+                await self.client.start(appid=self.appid, secret=self.secret)
+                self._startup_retry_attempts = 0
+                if self._shutdown_event.is_set():
+                    break
+                logger.warning(
+                    f"[QQOfficial] Client stopped unexpectedly, restarting in "
+                    f"{self.STARTUP_RETRY_DELAYS_SECONDS[0]}s."
+                )
+                await self._restart_client()
+                if not await self._sleep_until_retry_or_shutdown(
+                    self.STARTUP_RETRY_DELAYS_SECONDS[0]
+                ):
+                    break
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                if self._shutdown_event.is_set():
+                    break
+                if not self._should_retry_startup_error(e):
+                    raise
+                delay = self._next_startup_retry_delay(e)
+                logger.warning(
+                    f"[QQOfficial] Startup failed, retrying in {delay}s: {e}"
+                )
+                await self._restart_client()
+                if not await self._sleep_until_retry_or_shutdown(delay):
+                    break
 
     def get_client(self) -> botClient:
         return self.client
 
     async def terminate(self) -> None:
+        self._shutdown_event.set()
         await self.client.shutdown()
         logger.info("QQ 官方机器人接口 适配器已被关闭")

--- a/tests/test_qqofficial_group_message_create.py
+++ b/tests/test_qqofficial_group_message_create.py
@@ -183,7 +183,8 @@ async def test_managed_websocket_uses_qq_hello_heartbeat_interval(monkeypatch):
     assert sent_payloads == [{"op": 1, "d": 7}]
 
 
-def test_bot_client_schedules_rate_limit_reconnect_delay():
+@pytest.mark.asyncio
+async def test_bot_client_schedules_rate_limit_reconnect_delay():
     client = QQOfficialBotClient(
         intents=botpy.Intents(public_messages=True),
         bot_log=False,

--- a/tests/test_qqofficial_group_message_create.py
+++ b/tests/test_qqofficial_group_message_create.py
@@ -1,5 +1,7 @@
 import asyncio
+import json
 import re
+import time
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock
@@ -19,7 +21,12 @@ from astrbot.core.pipeline.respond.stage import RespondStage
 from astrbot.core.pipeline.result_decorate.stage import ResultDecorateStage
 from astrbot.core.platform.message_session import MessageSession
 from astrbot.core.platform.message_type import MessageType
+from astrbot.core.platform.sources.qqofficial.qqofficial_message_event import (
+    QQOfficialMessageEvent,
+)
 from astrbot.core.platform.sources.qqofficial.qqofficial_platform_adapter import (
+    ManagedBotWebSocket,
+    QQOfficialGatewayUnavailableError,
     QQOfficialPlatformAdapter,
     _ensure_group_message_create_parser,
 )
@@ -66,25 +73,160 @@ def _dispatch_group_message(payload: dict) -> tuple[str, botpy.message.GroupMess
     return dispatched[0]
 
 
+def _platform_config() -> dict:
+    return {
+        "id": "qq-official-test",
+        "appid": "123",
+        "secret": "secret",
+        "enable_group_c2c": True,
+        "enable_guild_direct_message": False,
+    }
+
+
 @pytest.mark.asyncio
 async def test_group_message_create_parser_is_registered_and_dispatches_group_message():
-    QQOfficialPlatformAdapter(
-        {
-            "id": "qq-official-test",
-            "appid": "123",
-            "secret": "secret",
-            "enable_group_c2c": True,
-            "enable_guild_direct_message": False,
-        },
-        {},
-        asyncio.Queue(),
-    )
+    QQOfficialPlatformAdapter(_platform_config(), {}, asyncio.Queue())
 
     event_name, message = _dispatch_group_message(_make_group_payload())
 
     assert event_name == "group_message_create"
     assert isinstance(message, botpy.message.GroupMessage)
     assert message.group_openid == "group-1"
+
+
+@pytest.mark.asyncio
+async def test_qqofficial_bot_login_raises_retryable_error_when_gateway_metadata_missing():
+    adapter = QQOfficialPlatformAdapter(_platform_config(), {}, asyncio.Queue())
+    adapter.client.http = SimpleNamespace(
+        login=AsyncMock(return_value=SimpleNamespace()),
+        close=AsyncMock(),
+    )
+    adapter.client.api = SimpleNamespace(get_ws_url=AsyncMock(return_value=None))
+
+    with pytest.raises(
+        QQOfficialGatewayUnavailableError,
+        match="gateway metadata unavailable",
+    ):
+        await adapter.client._bot_login(SimpleNamespace())
+
+    await adapter.terminate()
+
+
+@pytest.mark.asyncio
+async def test_managed_websocket_uses_qq_hello_heartbeat_interval(monkeypatch):
+    sent_payloads: list[dict] = []
+
+    class ConnectionStub:
+        parser = {}
+
+        def add(self, _session):
+            raise AssertionError("unexpected reconnect")
+
+    class ClientStub:
+        def mark_websocket_connected(self):
+            pass
+
+        def reset_reconnect_backoff(self):
+            pass
+
+        @property
+        def is_shutting_down(self):
+            return False
+
+    class WebSocketStub:
+        closed = False
+
+        async def send_str(self, data: str):
+            sent_payloads.append(json.loads(data))
+
+        async def close(self):
+            self.closed = True
+
+    class TokenStub:
+        async def check_token(self):
+            pass
+
+        def get_string(self):
+            return "QQBot token"
+
+    async def fake_send_msg(data: str):
+        sent_payloads.append(json.loads(data))
+
+    async def fake_sleep(delay: float):
+        assert delay == 41.25
+        raise asyncio.CancelledError
+
+    websocket = ManagedBotWebSocket(
+        {
+            "session_id": "",
+            "last_seq": 7,
+            "intent": 1,
+            "token": TokenStub(),
+            "shards": {"shard_id": 0, "shard_count": 1},
+        },
+        cast(Any, ConnectionStub()),
+        cast(Any, ClientStub()),
+    )
+    websocket._conn = cast(Any, WebSocketStub())
+    monkeypatch.setattr(websocket, "send_msg", fake_send_msg)
+
+    assert await websocket._is_system_event(
+        {"op": 10, "d": {"heartbeat_interval": 41250}},
+        websocket._conn,
+    )
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    sent_payloads.clear()
+
+    with pytest.raises(asyncio.CancelledError):
+        await websocket._send_heart(30)
+
+    assert sent_payloads == [{"op": 1, "d": 7}]
+
+
+def test_bot_client_schedules_rate_limit_reconnect_delay():
+    client = QQOfficialBotClient(
+        intents=botpy.Intents(public_messages=True),
+        bot_log=False,
+    )
+    now = time.monotonic()
+
+    client.schedule_reconnect_delay("rate limit", rate_limited=True)
+
+    delay = client._next_connect_at - now
+    assert 59 <= delay <= 61
+
+
+@pytest.mark.asyncio
+async def test_managed_websocket_requeues_on_gateway_reconnect_request():
+    queued_sessions: list[dict] = []
+
+    class ConnectionStub:
+        parser = {}
+
+        def add(self, session):
+            queued_sessions.append(session)
+
+    class ClientStub:
+        @property
+        def is_shutting_down(self):
+            return False
+
+        def schedule_reconnect_delay(self, reason: str, **_kwargs):
+            assert reason == "server requested reconnect"
+
+    class WebSocketStub:
+        async def close(self):
+            pass
+
+    session = {"session_id": "sid", "last_seq": 3}
+    websocket = ManagedBotWebSocket(
+        session,
+        cast(Any, ConnectionStub()),
+        cast(Any, ClientStub()),
+    )
+
+    assert await websocket._is_system_event({"op": 7}, cast(Any, WebSocketStub()))
+    assert queued_sessions == [session]
 
 
 @pytest.mark.asyncio
@@ -283,6 +425,35 @@ async def test_webhook_group_send_by_session_without_cached_msg_id_omits_msg_id(
     assert "msg_id" not in kwargs
     assert "msg_seq" in kwargs
     assert adapter._session_last_message_id["group-1"] == "sent-1"
+
+
+@pytest.mark.asyncio
+async def test_qqofficial_reply_fallback_removes_expired_msg_id_for_proactive_send():
+    event = object.__new__(QQOfficialMessageEvent)
+    sent_payloads: list[dict] = []
+
+    async def send_func(payload: dict):
+        sent_payloads.append(payload.copy())
+        if len(sent_payloads) == 1:
+            raise botpy.errors.ServerError("回复消息msg_id已过期")
+        return {"id": "sent-1"}
+
+    ret = await event._send_with_markdown_fallback(
+        send_func,
+        {
+            "content": "hello",
+            "msg_type": 0,
+            "msg_id": "expired-msg-id",
+            "msg_seq": 1,
+        },
+        "hello",
+    )
+
+    assert ret == {"id": "sent-1"}
+    assert sent_payloads[0]["msg_id"] == "expired-msg-id"
+    assert "msg_id" not in sent_payloads[1]
+    assert sent_payloads[1]["content"] == "hello"
+    assert sent_payloads[1]["msg_seq"] == 1
 
 
 def test_qqofficial_ws_is_not_excluded_from_segmented_reply():


### PR DESCRIPTION
QQ 官方机器人(qq_official)适配器在 WebSocket 连接稳定性与发送重试上存在若干缺陷,导致机器人长时间运行后容易出现掉线不恢复、被 QQ限流无法接收消息、以及回复消息时偶发发送失败的问题。
现状问题:
   1. botpy SDK 原生的心跳间隔为硬编码,未采用 QQ HELLO(op=10)实际下发的心跳周期,且缺少对op=7(服务器要求重连)、会话失效 close code(4006/4007/4009)的处理,断线后无法可靠恢复。
   2. 短时间内频繁断连/重连无退避,极易触发 QQ 网关限流,反而加剧掉线。
   3. 启动时若 gateway 元数据暂时不可用(如 `get_ws_url` 返回 None),直接崩溃,无重试。
   4. 被动回复时若引用的 `msg_id` 已过期,QQ 返回 `ServerError: 回复消息msg_id已过期`,消息发送中断且无兜底。
 Fixes #8977
### Modifications / 改动点
核心文件:`astrbot/core/platform/sources/qqofficial/` 

   **1. `qqofficial_platform_adapter.py`**
   - 新增 `ManagedBotWebSocket`:接管 botpy 的 WebSocket 生命周期
     - 采用 QQ HELLO(op=10)实际下发的 `heartbeat_interval` 发送心跳,而非硬编码
     - 处理 op=7(RECONNECT):将 session 重新排队触发受控重连
     - 心跳失败时标记不可重连并触发重连流程
   - 新增重连退避机制(`botClient`):
     - `schedule_reconnect_delay`:指数退避(1/2/5/10/30/60s)
     - **快速断连检测**:5 秒内断连 ≥3 次时,强制 60s 限速延迟,避免被 QQ 网关封禁
     - 会话失效 close code(4006/4007/4009):标记为不可恢复会话
     - 连接稳定后通过 `reset_reconnect_backoff` 重置退避计数
   - 新增启动韧性:
     - `QQOfficialGatewayUnavailableError`:gateway 元数据不可用时抛出
     - `_bot_login`:校验 gateway 元数据
     - `_should_retry_startup_error` / `_restart_client` / `_sleep_until_retry_or_shutdown`:启动失败按 5/10/30/60s 自动重试,全程尊重 shutdown 信号

   **2. `qqofficial_message_event.py`**
   - `_send_with_markdown_fallback`:捕获 `ServerError: 回复消息msg_id已过期`,移除过期 `msg_id` 后重试主动发送

   **3. `tests/test_qqofficial_group_message_create.py`**
   - gateway 元数据缺失时抛出可重试错误
   - HELLO 心跳间隔采用 QQ 下发值
   - rate-limit 触发 60s 重连延迟
   - op=7 重连时 session 正确重新排队
   - msg_id 过期时移除后重

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Improve QQ official platform adapter resilience by adding controlled websocket reconnect logic, startup retry handling, and safer message send fallback when replies fail.

New Features:
- Use gateway-provided heartbeat interval and handle reconnect/invalid-session opcodes in a managed websocket for QQ official bots.
- Introduce startup retry loop for the QQ official adapter with rate-limit aware delays and graceful shutdown integration.

Bug Fixes:
- Prevent crashes when QQ websocket gateway metadata is temporarily unavailable by treating it as a retryable startup error.
- Avoid repeated send failures when replying to expired messages by falling back to proactive send without msg_id.
- Reduce dropouts and unrecovered sessions by marking invalid or non-resumable websocket sessions and scheduling reconnects appropriately.
- Mitigate gateway rate limiting by applying exponential backoff and longer delays after rapid disconnects or explicit rate-limit signals.

Tests:
- Add unit tests covering gateway metadata absence, heartbeat interval usage from HELLO, rate-limit reconnect scheduling, server-requested reconnect handling, and reply fallback behavior when msg_id is expired.