### PR TITLE
fix: updated reboot logic

### DIFF
--- a/astrbot/core/updator.py
+++ b/astrbot/core/updator.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 import time
 import zipfile
@@ -135,6 +136,11 @@ class AstrBotUpdator(RepoZipUpdator):
             quoted_args = [f'"{arg}"' if " " in arg else arg for arg in argv[1:]]
             os.execl(executable, quoted_executable, *quoted_args)
             return
+        elif os.name == "nt":
+            subprocess.Popen(
+                [executable] + argv[1:], creationflags=subprocess.CREATE_NEW_CONSOLE
+            )
+            os._exit(0)
         os.execv(executable, argv)
 
     def _reboot(self, delay: int = 3) -> None:

--- a/tests/test_updator_socks.py
+++ b/tests/test_updator_socks.py
@@ -10,6 +10,7 @@ import certifi
 import httpx
 import pytest
 
+from astrbot.core import updator as core_updator
 from astrbot.core.star.updator import PluginUpdator
 from astrbot.core.updator import AstrBotUpdator
 from astrbot.core.utils import io as io_utils
@@ -78,6 +79,60 @@ class _FakeStatusErrorResponse:
             request=request,
             response=response,
         )
+
+
+def test_astrbot_updator_exec_reboot_spawns_new_console_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    popen_calls = []
+    exit_codes = []
+    execv_calls = []
+
+    def fake_popen(args, creationflags=0):
+        popen_calls.append((args, creationflags))
+        return SimpleNamespace(pid=1234)
+
+    def fake_exit(code):
+        exit_codes.append(code)
+        raise SystemExit(code)
+
+    def fake_execv(*args):
+        execv_calls.append(args)
+
+    monkeypatch.setattr(core_updator.os, "name", "nt")
+    monkeypatch.setattr(core_updator.sys, "frozen", False, raising=False)
+    monkeypatch.setattr(
+        core_updator.subprocess, "CREATE_NEW_CONSOLE", 0x00000010, raising=False
+    )
+    monkeypatch.setattr(core_updator.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(core_updator.os, "_exit", fake_exit)
+    monkeypatch.setattr(core_updator.os, "execv", fake_execv)
+
+    with pytest.raises(SystemExit) as exc_info:
+        AstrBotUpdator._exec_reboot(
+            r"C:\Python312\python.exe",
+            [
+                r"C:\Python312\python.exe",
+                "main.py",
+                "--webui-dir",
+                r"C:\AstrBot WebUI\dist",
+            ],
+        )
+
+    assert exc_info.value.code == 0
+    assert popen_calls == [
+        (
+            [
+                r"C:\Python312\python.exe",
+                "main.py",
+                "--webui-dir",
+                r"C:\AstrBot WebUI\dist",
+            ],
+            core_updator.subprocess.CREATE_NEW_CONSOLE,
+        )
+    ]
+    assert exit_codes == [0]
+    assert execv_calls == []
 
 
 @dataclass


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Issue / 问题
Running the program directly on Windows OS without using the CLI results in new process not being configured correctly in the original terminal. As a result, the user has to close the original terminal or manually find the new PID. 

在Windows OS上不使用CLI直接运行程序会导致原先终端无法终止新进程，导致用户必须关闭原终端或寻找新的PID

See [Issue 9064](https://github.com/AstrBotDevs/AstrBot/issues/9064) for more details

详情请见 [Issue 9064](https://github.com/AstrBotDevs/AstrBot/issues/9064)

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

Added new logic in updator to handle reboot when compiling directly on a Windows machine. By using subprocesses, the reboot process for compiling directly now opens a new window that maps correctly to the new process.

在updator中增加了在Windows OS上reboot的新逻辑，现在程序使用subprocess来实现在重启时打开新的终端来控制新进程

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

<img width="1676" height="568" alt="image" src="https://github.com/user-attachments/assets/f99e0b49-7590-434e-ada6-e721ce301d4c" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Update reboot logic to correctly spawn a new console for AstrBot when running directly on Windows, and add tests to verify the new behavior.

Bug Fixes:
- Ensure reboot on Windows spawns a new console process so the new instance is properly attached and the original terminal can exit cleanly.

Tests:
- Add unit test to verify that Windows reboot logic starts a new console process, exits the original process, and does not fall back to the POSIX exec path.