### PR TITLE
fix: prevent tool-call preface text leaks

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -794,27 +794,28 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             await self._complete_with_assistant_response(llm_resp)
 
         # 返回 LLM 结果
-        if llm_resp.reasoning_content:
-            yield AgentResponse(
-                type="llm_result",
-                data=AgentResponseData(
-                    chain=MessageChain(type="reasoning").message(
-                        llm_resp.reasoning_content,
+        if not llm_resp.tools_call_name:
+            if llm_resp.reasoning_content:
+                yield AgentResponse(
+                    type="llm_result",
+                    data=AgentResponseData(
+                        chain=MessageChain(type="reasoning").message(
+                            llm_resp.reasoning_content,
+                        ),
                     ),
-                ),
-            )
-        if llm_resp.result_chain:
-            yield AgentResponse(
-                type="llm_result",
-                data=AgentResponseData(chain=llm_resp.result_chain),
-            )
-        elif llm_resp.completion_text:
-            yield AgentResponse(
-                type="llm_result",
-                data=AgentResponseData(
-                    chain=MessageChain().message(llm_resp.completion_text),
-                ),
-            )
+                )
+            if llm_resp.result_chain:
+                yield AgentResponse(
+                    type="llm_result",
+                    data=AgentResponseData(chain=llm_resp.result_chain),
+                )
+            elif llm_resp.completion_text:
+                yield AgentResponse(
+                    type="llm_result",
+                    data=AgentResponseData(
+                        chain=MessageChain().message(llm_resp.completion_text),
+                    ),
+                )
 
         # 如果有工具调用，还需处理工具调用
         if llm_resp.tools_call_name:

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -769,14 +769,17 @@ class ProviderOpenAIOfficial(Provider):
 
         if isinstance(raw_content, str):
             content = raw_content.strip() if strip else raw_content
+            repr_like_prefix = "[{text="
+            repr_like_suffix = ", type=text}]"
+            repr_like_max_len = 8192
             check_content = raw_content.strip()
             while (
-                check_content.startswith("[{text=")
-                and check_content.endswith(", type=text}]")
-                and len(check_content) < 8192
+                check_content.startswith(repr_like_prefix)
+                and check_content.endswith(repr_like_suffix)
+                and len(check_content) < repr_like_max_len
             ):
                 check_content = check_content[
-                    len("[{text=") : -len(", type=text}]")
+                    len(repr_like_prefix) : -len(repr_like_suffix)
                 ].strip()
             if check_content != raw_content.strip():
                 return check_content.strip() if strip else check_content

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -769,6 +769,17 @@ class ProviderOpenAIOfficial(Provider):
 
         if isinstance(raw_content, str):
             content = raw_content.strip() if strip else raw_content
+            check_content = raw_content.strip()
+            while (
+                check_content.startswith("[{text=")
+                and check_content.endswith(", type=text}]")
+                and len(check_content) < 8192
+            ):
+                check_content = check_content[
+                    len("[{text=") : -len(", type=text}]")
+                ].strip()
+            if check_content != raw_content.strip():
+                return check_content.strip() if strip else check_content
             # Check if the string is a JSON-encoded list (e.g., "[{'type': 'text', ...}]")
             # This can happen when streaming concatenates content that was originally list format
             # Only check if it looks like a complete JSON array (requires strip for check)

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -68,10 +68,24 @@ def test_normalize_content_handles_text_part_repr_string():
     )
 
 
+def test_normalize_content_handles_text_part_repr_string_without_strip():
+    raw = "  [{text=I will use the file reading tool., type=text}]  "
+
+    assert ProviderOpenAIOfficial._normalize_content(raw, strip=False) == (
+        "I will use the file reading tool."
+    )
+
+
 def test_normalize_content_drops_empty_nested_text_part_repr_string():
     raw = "[{text=[{text=[{text=, type=text}], type=text}], type=text}]"
 
     assert ProviderOpenAIOfficial._normalize_content(raw) == ""
+
+
+def test_normalize_content_handles_non_empty_nested_text_part_repr_string():
+    raw = "[{text=[{text=[{text=hello, type=text}], type=text}], type=text}]"
+
+    assert ProviderOpenAIOfficial._normalize_content(raw) == "hello"
 
 
 def test_create_http_client_uses_openai_httpx_module(monkeypatch):

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -60,6 +60,20 @@ def _make_groq_provider(overrides: dict | None = None) -> ProviderGroq:
     )
 
 
+def test_normalize_content_handles_text_part_repr_string():
+    raw = "[{text=I will use the file reading tool., type=text}]"
+
+    assert ProviderOpenAIOfficial._normalize_content(raw) == (
+        "I will use the file reading tool."
+    )
+
+
+def test_normalize_content_drops_empty_nested_text_part_repr_string():
+    raw = "[{text=[{text=[{text=, type=text}], type=text}], type=text}]"
+
+    assert ProviderOpenAIOfficial._normalize_content(raw) == ""
+
+
 def test_create_http_client_uses_openai_httpx_module(monkeypatch):
     captured: dict[str, object] = {}
 

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -508,6 +508,36 @@ async def test_max_step_final_request_includes_limit_prompt(
 
 
 @pytest.mark.asyncio
+async def test_tool_call_assistant_preface_is_not_sent_as_llm_result(
+    runner, provider_request, mock_tool_executor, mock_hooks, mock_provider
+):
+    """Assistant preface text on a tool-call turn must stay internal."""
+    mock_provider.should_call_tools = True
+    mock_provider.max_calls_before_normal_response = 1
+
+    await runner.reset(
+        provider=mock_provider,
+        request=provider_request,
+        run_context=ContextWrapper(context=None),
+        tool_executor=mock_tool_executor,
+        agent_hooks=mock_hooks,
+        streaming=False,
+    )
+
+    responses = []
+    async for response in runner.step_until_done(3):
+        responses.append(response)
+
+    llm_texts = [
+        response.data["chain"].get_plain_text()
+        for response in responses
+        if response.type == "llm_result"
+    ]
+    assert "我需要使用工具来帮助您" not in llm_texts
+    assert llm_texts == ["这是我的最终回答"]
+
+
+@pytest.mark.asyncio
 async def test_tool_loop_next_request_includes_tool_result(
     runner, provider_request, mock_tool_executor, mock_hooks
 ):

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -528,11 +528,13 @@ async def test_tool_call_assistant_preface_is_not_sent_as_llm_result(
     async for response in runner.step_until_done(3):
         responses.append(response)
 
-    llm_texts = [
-        response.data["chain"].get_plain_text()
-        for response in responses
-        if response.type == "llm_result"
-    ]
+    response_types = [response.type for response in responses]
+    assert response_types[-1] == "llm_result"
+    assert "llm_result" not in response_types[:-1]
+
+    llm_results = [response for response in responses if response.type == "llm_result"]
+    llm_texts = [response.data["chain"].get_plain_text() for response in llm_results]
+    assert len(llm_results) == 1
     assert "我需要使用工具来帮助您" not in llm_texts
     assert llm_texts == ["这是我的最终回答"]
 


### PR DESCRIPTION
## Summary
- Suppress assistant preface text on turns that include tool calls so internal tool-use narration is not sent as a user-visible LLM result.
- Normalize OpenAI-compatible text-part repr strings like `[{text=..., type=text}]` to plain text, and drop empty nested repr shells.
- Add regression coverage for both the tool-loop leak and provider content normalization.

## Test plan
- [x] `uv run pytest tests/test_tool_loop_agent_runner.py -k "tool_call_assistant_preface_is_not_sent_as_llm_result"`
- [x] `uv run pytest tests/test_openai_source.py -k "normalize_content_handles_text_part_repr_string or normalize_content_drops_empty_nested_text_part_repr_string"`
- [x] `uv run ruff format astrbot/core/agent/runners/tool_loop_agent_runner.py astrbot/core/provider/sources/openai_source.py tests/test_tool_loop_agent_runner.py tests/test_openai_source.py --check`
- [x] `uv run ruff check astrbot/core/agent/runners/tool_loop_agent_runner.py astrbot/core/provider/sources/openai_source.py tests/test_tool_loop_agent_runner.py tests/test_openai_source.py`

Note: Running the full related files with `uv run pytest tests/test_tool_loop_agent_runner.py tests/test_openai_source.py` passed the tool-loop file but hit 3 pre-existing Windows path separator assertions in `test_openai_source.py` (`file_uri_to_path` expects `/` while Windows returns `\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent internal assistant preface text from being surfaced as user-visible LLM output during tool-call turns and improve normalization of OpenAI-compatible content representations.

Bug Fixes:
- Suppress LLM reasoning and completion text outputs on steps that invoke tools so assistant preface narration does not leak to users.
- Normalize OpenAI provider content strings that use text-part repr formatting into plain text and remove empty nested text shells.

Tests:
- Add regression tests ensuring tool-call assistant preface text is not returned as an LLM result.
- Add regression tests verifying _normalize_content handles text-part repr strings and drops empty nested text-part repr shells.