### PR TITLE
fix: enable only synced ModelScope MCP servers

### DIFF
--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -1059,9 +1059,12 @@ class FunctionToolManager:
                         )
                         local_mcp_config = self.load_mcp_config()
 
-                        synced_count = 0
+                        mcp_servers = local_mcp_config.setdefault("mcpServers", {})
+                        synced_servers: list[tuple[str, dict]] = []
                         for server in mcp_server_list:
-                            server_name = server["name"]
+                            server_name = server.get("name")
+                            if not server_name:
+                                continue
                             operational_urls = server.get("operational_urls", [])
                             if not operational_urls:
                                 continue
@@ -1070,28 +1073,28 @@ class FunctionToolManager:
                             if not server_url:
                                 continue
                             # 添加到配置中(同名会覆盖)
-                            local_mcp_config["mcpServers"][server_name] = {
+                            server_config = {
                                 "url": server_url,
                                 "transport": "sse",
                                 "active": True,
                                 "provider": "modelscope",
                             }
-                            synced_count += 1
+                            mcp_servers[server_name] = server_config
+                            synced_servers.append((server_name, server_config))
 
-                        if synced_count > 0:
+                        if synced_servers:
                             self.save_mcp_config(local_mcp_config)
                             tasks = []
-                            for server in mcp_server_list:
-                                name = server["name"]
+                            for name, config in synced_servers:
                                 tasks.append(
                                     self.enable_mcp_server(
                                         name=name,
-                                        config=local_mcp_config["mcpServers"][name],
+                                        config=config,
                                     ),
                                 )
                             await asyncio.gather(*tasks)
                             logger.info(
-                                f"从 ModelScope 同步了 {synced_count} 个 MCP 服务器",
+                                f"从 ModelScope 同步了 {len(synced_servers)} 个 MCP 服务器",
                             )
                         else:
                             logger.warning("没有找到可用的 ModelScope MCP 服务器")

--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -1057,7 +1057,7 @@ class FunctionToolManager:
                             "mcp_server_list",
                             [],
                         )
-                        local_mcp_config = self.load_mcp_config()
+                        local_mcp_config = copy.deepcopy(self.load_mcp_config())
 
                         mcp_servers = local_mcp_config.setdefault("mcpServers", {})
                         synced_servers: list[tuple[str, dict]] = []

--- a/tests/unit/test_func_tool_manager.py
+++ b/tests/unit/test_func_tool_manager.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from astrbot.core import sp
+from astrbot.core.provider import func_tool_manager as ftm
 from astrbot.core.provider.func_tool_manager import FunctionToolManager
 from astrbot.core.tools.computer_tools.shell import ExecuteShellTool
 from astrbot.core.tools.message_tools import SendMessageToUserTool
@@ -345,3 +346,78 @@ def test_firecrawl_tools_are_registered_as_builtin_tools():
     assert extract_tool.name == "firecrawl_extract_web_page"
     assert manager.is_builtin_tool("web_search_firecrawl") is True
     assert manager.is_builtin_tool("firecrawl_extract_web_page") is True
+
+
+@pytest.mark.asyncio
+async def test_modelscope_sync_enables_only_synced_servers(monkeypatch):
+    class FakeResponse:
+        status = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def json(self):
+            return {
+                "data": {
+                    "mcp_server_list": [
+                        {
+                            "name": "valid",
+                            "operational_urls": [{"url": "https://example.com/mcp"}],
+                        },
+                        {"name": "missing-url", "operational_urls": []},
+                        {"name": "empty-url", "operational_urls": [{}]},
+                        {"operational_urls": [{"url": "https://example.com/no-name"}]},
+                    ]
+                }
+            }
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, *_args, **_kwargs):
+            return FakeResponse()
+
+    saved_configs = []
+    enabled_servers = []
+    manager = FunctionToolManager()
+
+    async def fake_enable_mcp_server(name, config):
+        enabled_servers.append((name, config))
+
+    monkeypatch.setattr(ftm.aiohttp, "ClientSession", lambda: FakeSession())
+    monkeypatch.setattr(manager, "load_mcp_config", lambda: {"mcpServers": {}})
+    monkeypatch.setattr(manager, "save_mcp_config", saved_configs.append)
+    monkeypatch.setattr(manager, "enable_mcp_server", fake_enable_mcp_server)
+
+    await manager.sync_modelscope_mcp_servers("token")
+
+    assert saved_configs == [
+        {
+            "mcpServers": {
+                "valid": {
+                    "url": "https://example.com/mcp",
+                    "transport": "sse",
+                    "active": True,
+                    "provider": "modelscope",
+                }
+            }
+        }
+    ]
+    assert enabled_servers == [
+        (
+            "valid",
+            {
+                "url": "https://example.com/mcp",
+                "transport": "sse",
+                "active": True,
+                "provider": "modelscope",
+            },
+        )
+    ]

--- a/tests/unit/test_func_tool_manager.py
+++ b/tests/unit/test_func_tool_manager.py
@@ -386,18 +386,20 @@ async def test_modelscope_sync_enables_only_synced_servers(monkeypatch):
 
     saved_configs = []
     enabled_servers = []
+    default_config = {"mcpServers": {}}
     manager = FunctionToolManager()
 
     async def fake_enable_mcp_server(name, config):
         enabled_servers.append((name, config))
 
     monkeypatch.setattr(ftm.aiohttp, "ClientSession", lambda: FakeSession())
-    monkeypatch.setattr(manager, "load_mcp_config", lambda: {"mcpServers": {}})
+    monkeypatch.setattr(manager, "load_mcp_config", lambda: default_config)
     monkeypatch.setattr(manager, "save_mcp_config", saved_configs.append)
     monkeypatch.setattr(manager, "enable_mcp_server", fake_enable_mcp_server)
 
     await manager.sync_modelscope_mcp_servers("token")
 
+    assert default_config == {"mcpServers": {}}
     assert saved_configs == [
         {
             "mcpServers": {


### PR DESCRIPTION
This PR fixes ModelScope MCP sync aborting when the provider response contains unavailable or malformed server entries.

### Modifications / 改动点

`sync_modelscope_mcp_servers()` has two separate steps after receiving the ModelScope provider response:

1. build and save the local MCP config from provider entries that have enough data to run locally
2. enable the MCP servers that were just synchronized

Before this PR, those two steps used different source lists. The config-building step effectively filtered the provider response, because entries without `operational_urls` or without a usable `url` were skipped and never written to `local_mcp_config["mcpServers"]`. The later enable step then iterated over the original `mcp_server_list` again and looked each name up in the filtered local config.

That mismatch allowed one unusable provider entry to abort the whole sync even when other valid servers had already been written:

```text
POST /api/v1/mcp/providers/modelscope/sync
  -> ToolsService.sync_provider(...)
    -> FunctionToolManager.sync_modelscope_mcp_servers(...)
      -> receive mixed ModelScope response: valid server + unavailable server
      -> write only the valid server into local_mcp_config["mcpServers"]
      -> save the filtered local MCP config
      -> iterate the original provider response during enablement
      -> look up local_mcp_config["mcpServers"]["missing-url"]
      -> KeyError before the valid synchronized server can be enabled reliably
```

### Changes

This change makes the saved-config list and the enabled-server list the same list. While building the local config, the sync code now skips entries without a server name, skips entries without `operational_urls`, skips entries whose first operational URL has no usable `url`, and records each successfully written `(name, config)` pair in `synced_servers`.

The enable step then iterates over `synced_servers` directly, so only configs that were actually saved can be enabled. There is also a small state-isolation fix in the same path: `load_mcp_config()` is deep-copied before mutation, which prevents a fallback module-level `DEFAULT_MCP_CONFIG` object from being modified in memory when the local config file is missing or unreadable.

The successful ModelScope sync behavior stays unchanged: valid MCP servers are still saved with `transport: "sse"`, `active: true`, and `provider: "modelscope"`. The change only aligns enablement with the same filtering rules already used when writing the local config.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Evidence

Focused reproduction covered by `test_modelscope_sync_enables_only_synced_servers`:

```text
Fake ModelScope response:
- valid: operational_urls: [{"url": "https://example.com/mcp"}]
- missing-url: operational_urls: []
- empty-url: operational_urls: [{}]
- no-name: operational_urls: [{"url": "https://example.com/no-name"}]

Before:
- only valid was written into local_mcp_config["mcpServers"]
- the enable step could still iterate over missing-url / empty-url / no-name
- skipped entries could raise KeyError and abort sync

After:
- only successfully synchronized server configs are recorded
- only valid is enabled
- skipped entries no longer abort the sync
```

The focused test also covers the mutable-default case by making `load_mcp_config()` return a shared default config object and asserting it remains unchanged after sync.

Local focused pytest evidence:

![Focused pytest evidence for PR 9084](https://img.vectorpeak.cn/obsidian/2026/05-06/20260630151451567.png?imageSlim)

Validation run locally after addressing review comments:

```text
uv run pytest tests/unit/test_func_tool_manager.py -q
18 passed

uv run ruff check astrbot/core/provider/func_tool_manager.py tests/unit/test_func_tool_manager.py
passed

uv run ruff format --check astrbot/core/provider/func_tool_manager.py tests/unit/test_func_tool_manager.py
passed

git diff --check
passed
```

GitHub CI is green for unit tests, format check, CodeQL, dashboard build, and smoke tests across Linux, macOS, and Windows.

### Affected call chain / impact

The affected path is the Dashboard ModelScope MCP provider sync flow:

```text
Dashboard MCP provider sync action
  -> POST /api/v1/mcp/providers/modelscope/sync
  -> astrbot/dashboard/api/tools.py::sync_modelscope_mcp_servers(...)
  -> _sync_modelscope_mcp_servers(...)
  -> ToolsService.sync_provider({"name": "modelscope", ...})
  -> FunctionToolManager.sync_modelscope_mcp_servers(access_token)
  -> fetch ModelScope mcp_server_list
  -> filter usable entries into local_mcp_config["mcpServers"]
  -> save_mcp_config(local_mcp_config)
  -> enable only the saved entries from synced_servers
```

A mixed ModelScope response can therefore no longer make an unavailable skipped server block valid synchronized servers. The change is limited to the ModelScope provider sync path. It does not change manual local MCP config loading, non-ModelScope providers, the saved config shape for valid ModelScope servers, or the SSE transport selection used for those valid entries.

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / No new feature is added; this is a bug fix.

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / Focused pytest, Ruff check, Ruff format check, `git diff --check`, and GitHub CI were verified.

- [x] 🧐 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / No new dependencies are introduced.

- [x] 😇 My changes do not introduce malicious code.