### PR TITLE
fix: reject non-200 download responses

### DIFF
--- a/astrbot/core/utils/io.py
+++ b/astrbot/core/utils/io.py
@@ -178,6 +178,101 @@ async def _emit_download_progress(progress_callback, payload: dict) -> None:
         await result
 
 
+class DownloadFileHTTPError(RuntimeError):
+    """Raised when a file download returns an unsuccessful HTTP status."""
+
+
+def _raise_for_download_status(resp, url: str) -> None:
+    if resp.status == 200:
+        return
+    logger.error(
+        "Failed to download file from %s. HTTP status code: %s",
+        _safe_url_for_log(url),
+        resp.status,
+    )
+    raise DownloadFileHTTPError(
+        "Failed to download file from "
+        f"{_safe_url_for_log(url)}. HTTP status code: {resp.status}"
+    )
+
+
+async def _download_response_to_file(
+    resp,
+    file_obj,
+    url: str,
+    show_progress: bool,
+    progress_callback,
+    show_downloading_label: bool = True,
+) -> None:
+    """Write a successful download response to a local file.
+
+    Args:
+        resp: aiohttp response object to read from.
+        file_obj: Open writable binary file object.
+        url: Source URL used for progress events and sanitized errors.
+        show_progress: Whether to print progress to stdout.
+        progress_callback: Optional callback for progress payloads.
+        show_downloading_label: Whether to use the standard download heading.
+
+    """
+
+    total_size = int(resp.headers.get("content-length", 0))
+    downloaded_size = 0
+    start_time = time.time()
+    if show_progress:
+        if show_downloading_label:
+            print(
+                f"Downloading: {_safe_url_for_log(url)} | "
+                f"Size: {total_size / 1024:.2f} KB"
+            )
+        else:
+            print(f"Size: {total_size / 1024:.2f} KB | URL: {_safe_url_for_log(url)}")
+    await _emit_download_progress(
+        progress_callback,
+        {
+            "url": url,
+            "downloaded": 0,
+            "total": total_size,
+            "percent": 0,
+            "speed": 0,
+        },
+    )
+    while True:
+        chunk = await resp.content.read(8192)
+        if not chunk:
+            break
+        file_obj.write(chunk)
+        downloaded_size += len(chunk)
+        elapsed_time = time.time() - start_time if time.time() - start_time > 0 else 1
+        speed = downloaded_size / 1024 / elapsed_time  # KB/s
+        percent = downloaded_size / total_size if total_size > 0 else 0
+        await _emit_download_progress(
+            progress_callback,
+            {
+                "url": url,
+                "downloaded": downloaded_size,
+                "total": total_size,
+                "percent": percent,
+                "speed": speed,
+            },
+        )
+        if show_progress:
+            print(
+                f"\rProgress: {percent:.2%} Speed: {speed:.2f} KB/s",
+                end="",
+            )
+    await _emit_download_progress(
+        progress_callback,
+        {
+            "url": url,
+            "downloaded": downloaded_size,
+            "total": total_size,
+            "percent": 1,
+            "speed": 0,
+        },
+    )
+
+
 async def download_file(
     url: str,
     path: str,
@@ -209,73 +304,15 @@ async def download_file(
             connector=connector,
         ) as session:
             async with session.get(url, timeout=1800) as resp:
-                if resp.status != 200:
-                    logger.error(
-                        "Failed to download file from %s. HTTP status code: %s",
-                        _safe_url_for_log(url),
-                        resp.status,
-                    )
-                    raise RuntimeError(
-                        "Failed to download file from "
-                        f"{_safe_url_for_log(url)}. HTTP status code: {resp.status}"
-                    )
-                total_size = int(resp.headers.get("content-length", 0))
-                downloaded_size = 0
-                start_time = time.time()
-                if show_progress:
-                    print(
-                        f"Downloading: {_safe_url_for_log(url)} | "
-                        f"Size: {total_size / 1024:.2f} KB"
-                    )
-                await _emit_download_progress(
-                    progress_callback,
-                    {
-                        "url": url,
-                        "downloaded": 0,
-                        "total": total_size,
-                        "percent": 0,
-                        "speed": 0,
-                    },
-                )
+                _raise_for_download_status(resp, url)
                 with open(path, "wb") as f:
-                    while True:
-                        chunk = await resp.content.read(8192)
-                        if not chunk:
-                            break
-                        f.write(chunk)
-                        downloaded_size += len(chunk)
-                        elapsed_time = (
-                            time.time() - start_time
-                            if time.time() - start_time > 0
-                            else 1
-                        )
-                        speed = downloaded_size / 1024 / elapsed_time  # KB/s
-                        percent = downloaded_size / total_size if total_size > 0 else 0
-                        await _emit_download_progress(
-                            progress_callback,
-                            {
-                                "url": url,
-                                "downloaded": downloaded_size,
-                                "total": total_size,
-                                "percent": percent,
-                                "speed": speed,
-                            },
-                        )
-                        if show_progress:
-                            print(
-                                f"\rProgress: {percent:.2%} Speed: {speed:.2f} KB/s",
-                                end="",
-                            )
-                await _emit_download_progress(
-                    progress_callback,
-                    {
-                        "url": url,
-                        "downloaded": downloaded_size,
-                        "total": total_size,
-                        "percent": 1,
-                        "speed": 0,
-                    },
-                )
+                    await _download_response_to_file(
+                        resp,
+                        f,
+                        url,
+                        show_progress,
+                        progress_callback,
+                    )
     except (aiohttp.ClientConnectorSSLError, aiohttp.ClientConnectorCertificateError):
         if not allow_insecure_ssl_fallback:
             raise
@@ -295,73 +332,16 @@ async def download_file(
         ssl_context.verify_mode = ssl.CERT_NONE
         async with aiohttp.ClientSession() as session:
             async with session.get(url, ssl=ssl_context, timeout=120) as resp:
-                if resp.status != 200:
-                    logger.error(
-                        "Failed to download file from %s. HTTP status code: %s",
-                        _safe_url_for_log(url),
-                        resp.status,
-                    )
-                    raise RuntimeError(
-                        "Failed to download file from "
-                        f"{_safe_url_for_log(url)}. HTTP status code: {resp.status}"
-                    )
-                total_size = int(resp.headers.get("content-length", 0))
-                downloaded_size = 0
-                start_time = time.time()
-                if show_progress:
-                    print(
-                        f"Size: {total_size / 1024:.2f} KB | "
-                        f"URL: {_safe_url_for_log(url)}"
-                    )
-                await _emit_download_progress(
-                    progress_callback,
-                    {
-                        "url": url,
-                        "downloaded": 0,
-                        "total": total_size,
-                        "percent": 0,
-                        "speed": 0,
-                    },
-                )
+                _raise_for_download_status(resp, url)
                 with open(path, "wb") as f:
-                    while True:
-                        chunk = await resp.content.read(8192)
-                        if not chunk:
-                            break
-                        f.write(chunk)
-                        downloaded_size += len(chunk)
-                        elapsed_time = (
-                            time.time() - start_time
-                            if time.time() - start_time > 0
-                            else 1
-                        )
-                        speed = downloaded_size / 1024 / elapsed_time  # KB/s
-                        percent = downloaded_size / total_size if total_size > 0 else 0
-                        await _emit_download_progress(
-                            progress_callback,
-                            {
-                                "url": url,
-                                "downloaded": downloaded_size,
-                                "total": total_size,
-                                "percent": percent,
-                                "speed": speed,
-                            },
-                        )
-                        if show_progress:
-                            print(
-                                f"\rProgress: {percent:.2%} Speed: {speed:.2f} KB/s",
-                                end="",
-                            )
-                await _emit_download_progress(
-                    progress_callback,
-                    {
-                        "url": url,
-                        "downloaded": downloaded_size,
-                        "total": total_size,
-                        "percent": 1,
-                        "speed": 0,
-                    },
-                )
+                    await _download_response_to_file(
+                        resp,
+                        f,
+                        url,
+                        show_progress,
+                        progress_callback,
+                        show_downloading_label=False,
+                    )
     if show_progress:
         print()
 

--- a/astrbot/core/utils/io.py
+++ b/astrbot/core/utils/io.py
@@ -215,6 +215,10 @@ async def download_file(
                         _safe_url_for_log(url),
                         resp.status,
                     )
+                    raise RuntimeError(
+                        "Failed to download file from "
+                        f"{_safe_url_for_log(url)}. HTTP status code: {resp.status}"
+                    )
                 total_size = int(resp.headers.get("content-length", 0))
                 downloaded_size = 0
                 start_time = time.time()
@@ -291,6 +295,16 @@ async def download_file(
         ssl_context.verify_mode = ssl.CERT_NONE
         async with aiohttp.ClientSession() as session:
             async with session.get(url, ssl=ssl_context, timeout=120) as resp:
+                if resp.status != 200:
+                    logger.error(
+                        "Failed to download file from %s. HTTP status code: %s",
+                        _safe_url_for_log(url),
+                        resp.status,
+                    )
+                    raise RuntimeError(
+                        "Failed to download file from "
+                        f"{_safe_url_for_log(url)}. HTTP status code: {resp.status}"
+                    )
                 total_size = int(resp.headers.get("content-length", 0))
                 downloaded_size = 0
                 start_time = time.time()

--- a/tests/unit/test_io_download_file.py
+++ b/tests/unit/test_io_download_file.py
@@ -1,0 +1,76 @@
+import pytest
+
+from astrbot.core.utils import io
+
+
+class _FakeContent:
+    def __init__(self, chunks: list[bytes]):
+        self._chunks = chunks
+
+    async def read(self, _size: int) -> bytes:
+        if self._chunks:
+            return self._chunks.pop(0)
+        return b""
+
+
+class _FakeResponse:
+    def __init__(self, *, status: int, chunks: list[bytes]):
+        self.status = status
+        self.headers = {"content-length": str(sum(len(chunk) for chunk in chunks))}
+        self.content = _FakeContent(chunks)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, response: _FakeResponse):
+        self._response = response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def get(self, *_args, **_kwargs):
+        return self._response
+
+
+def _patch_download_session(monkeypatch, response: _FakeResponse):
+    monkeypatch.setattr(io.aiohttp, "TCPConnector", lambda **_kwargs: object())
+    monkeypatch.setattr(
+        io.aiohttp,
+        "ClientSession",
+        lambda **_kwargs: _FakeSession(response),
+    )
+
+
+@pytest.mark.asyncio
+async def test_download_file_rejects_non_200_response(monkeypatch, tmp_path):
+    target_path = tmp_path / "missing.bin"
+    _patch_download_session(
+        monkeypatch,
+        _FakeResponse(status=404, chunks=[b"not found"]),
+    )
+
+    with pytest.raises(RuntimeError, match="HTTP status code: 404"):
+        await io.download_file("https://example.test/missing", str(target_path))
+
+    assert not target_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_download_file_writes_successful_response(monkeypatch, tmp_path):
+    target_path = tmp_path / "ok.bin"
+    _patch_download_session(
+        monkeypatch,
+        _FakeResponse(status=200, chunks=[b"hello", b" world"]),
+    )
+
+    await io.download_file("https://example.test/ok.bin", str(target_path))
+
+    assert target_path.read_bytes() == b"hello world"

--- a/tests/unit/test_io_download_file.py
+++ b/tests/unit/test_io_download_file.py
@@ -27,7 +27,7 @@ class _FakeResponse:
 
 
 class _FakeSession:
-    def __init__(self, response: _FakeResponse):
+    def __init__(self, response: _FakeResponse | Exception):
         self._response = response
 
     async def __aenter__(self):
@@ -37,15 +37,21 @@ class _FakeSession:
         return False
 
     def get(self, *_args, **_kwargs):
+        if isinstance(self._response, Exception):
+            raise self._response
         return self._response
 
 
 def _patch_download_session(monkeypatch, response: _FakeResponse):
+    _patch_download_sessions(monkeypatch, [response])
+
+
+def _patch_download_sessions(monkeypatch, responses: list[_FakeResponse | Exception]):
     monkeypatch.setattr(io.aiohttp, "TCPConnector", lambda **_kwargs: object())
     monkeypatch.setattr(
         io.aiohttp,
         "ClientSession",
-        lambda **_kwargs: _FakeSession(response),
+        lambda **_kwargs: _FakeSession(responses.pop(0)),
     )
 
 
@@ -57,7 +63,32 @@ async def test_download_file_rejects_non_200_response(monkeypatch, tmp_path):
         _FakeResponse(status=404, chunks=[b"not found"]),
     )
 
-    with pytest.raises(RuntimeError, match="HTTP status code: 404"):
+    with pytest.raises(io.DownloadFileHTTPError, match="HTTP status code: 404"):
+        await io.download_file("https://example.test/missing", str(target_path))
+
+    assert not target_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_download_file_rejects_non_200_response_after_ssl_fallback(
+    monkeypatch,
+    tmp_path,
+):
+    class FakeSSLError(Exception):
+        pass
+
+    target_path = tmp_path / "missing.bin"
+    _patch_download_sessions(
+        monkeypatch,
+        [
+            FakeSSLError(),
+            _FakeResponse(status=404, chunks=[b"not found"]),
+        ],
+    )
+    monkeypatch.setattr(io.aiohttp, "ClientConnectorSSLError", FakeSSLError)
+    monkeypatch.setattr(io.aiohttp, "ClientConnectorCertificateError", FakeSSLError)
+
+    with pytest.raises(io.DownloadFileHTTPError, match="HTTP status code: 404"):
         await io.download_file("https://example.test/missing", str(target_path))
 
     assert not target_path.exists()


### PR DESCRIPTION
This PR fixes `download_file()` treating unsuccessful HTTP responses as successful local downloads.

### Modifications / 改动点

`download_file()` is a shared helper for downloading a remote response into a caller-provided local path. Before this PR, the helper noticed non-`200` HTTP responses but did not stop the write path. The old control flow was effectively:

```text
aiohttp session.get(url)
  -> receive HTTP response
  -> if status != 200: log an error
  -> still open(path, "wb")
  -> stream resp.content into the target file
  -> return normally to the caller
```

That means a `404`, `403`, `500`, or other error response could be persisted as a successful downloaded file. The caller would then continue with a local path that exists, but whose bytes are actually an error page/body rather than the requested file.

### Changes

This change moves the status check in front of the file write in both download branches:

- normal TLS download path: `session.get(url, timeout=1800)` now calls `_raise_for_download_status(resp, url)` before `open(path, "wb")`
- insecure SSL fallback path: `session.get(url, ssl=ssl_context, timeout=120)` uses the same status check before opening the target file
- successful `200` responses continue through the shared `_download_response_to_file()` writer, preserving chunked writes, progress output, and progress callbacks
- non-`200` responses raise `DownloadFileHTTPError`, a `RuntimeError` subclass, so existing `RuntimeError` handling remains compatible while callers can still distinguish HTTP download failures if needed

Successful downloads keep the existing behavior. The changed behavior is only that failed HTTP responses are rejected before they can create or overwrite the destination file.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Evidence

Focused reproduction covered by `test_download_file_rejects_non_200_response`:

```text
Fake HTTP response:
- status: 404
- body: not found
- destination: missing.bin

Before:
- an error was logged
- missing.bin could still be created
- missing.bin contained: not found
- the caller saw a normal return path

After:
- the non-200 response raises a download failure
- the failed response body is not written as a successful downloaded file
```

Successful download behavior is covered by `test_download_file_writes_successful_response`. The SSL fallback rejection path is covered by `test_download_file_rejects_non_200_response_after_ssl_fallback`.

Validation run locally after addressing review comments:

```text
uv run pytest tests/unit/test_io_download_file.py -q
3 passed in 0.67s

uv run pytest tests/unit/test_file_message_component.py -q
1 passed in 0.73s

uv run ruff check astrbot/core/utils/io.py tests/unit/test_io_download_file.py
All checks passed!

uv run ruff format --check astrbot/core/utils/io.py tests/unit/test_io_download_file.py
2 files already formatted

git diff --check
passed
```

Local focused pytest evidence:

![Focused pytest evidence for PR 9085](https://img.vectorpeak.cn/obsidian/2026/05-06/20260630152850025.png?imageSlim)

Additional related check attempted before the review updates:

```text
uv run pytest tests/unit/test_file_message_component.py tests/test_media_utils.py -q
```

This command failed in an existing Windows file URI assertion unrelated to this change:

```text
tests/test_media_utils.py::test_file_uri_to_path_supports_localhost_and_encoded_paths
expected: C:\Users\...\voice note.wav
actual  : \\localhostC:\Users\...\voice note.wav
```

### Affected call chain / impact

`download_file()` sits below several user-facing and maintenance flows. Representative callers include:

```text
File message component with remote URL
  -> astrbot/core/message/components.py::File._download_file(...)
  -> download_file(self.url, temp_file_path)
  -> _raise_for_download_status(resp, url)
  -> _download_response_to_file(...) only for HTTP 200

Remote media resolution
  -> astrbot/core/utils/media_utils.py::resolve_media_source(...)
  -> download_file(media_ref, target_path)
  -> media parsing / MIME detection uses the downloaded bytes

Platform attachment downloads
  -> DingTalk / Telegram adapter receives a platform file URL
  -> download_file(download_url or file.file_path, temp_path)
  -> downstream message handling reads the local file

Core/plugin update downloads
  -> updater selects a release or plugin archive URL
  -> _download_file(...)
  -> download_file(url, archive_path)
  -> unzip / validation uses the downloaded archive
```

Before this fix, any of those paths could receive a real local file path after an HTTP error response and fail later while parsing, registering, converting, or unzipping the error body. After this fix, the failure stays at the download boundary: non-`200` responses raise before the destination file is opened, while successful `200` responses keep the same write and progress behavior.

Boundary note: this PR intentionally keeps the behavior change inside `download_file()`. It only makes that shared helper reject non-`200` HTTP responses before opening or writing the destination file, including the SSL fallback path. It does not change callers, caller retry/error handling, media/file message flows, updater logic, or other download/media helpers; those paths are mentioned only to explain the impact of fixing the shared download boundary.

`download_image_by_url()` is a sibling download helper in `astrbot/core/utils/io.py`, but it is not changed here. Any equivalent status-handling change for that image-specific helper should be evaluated separately with its own `GET`/`POST` behavior and callers.

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / No new feature is added; this is a bug fix.

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / Focused pytest, related file message component test, Ruff check, Ruff format check, and `git diff --check` were run locally after addressing review comments. One broader related media test command was also attempted and the unrelated failure is documented above.

- [x] 🧐 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / No new dependencies are introduced.

- [x] 😇 My changes do not introduce malicious code.

## Summary by Sourcery

Ensure HTTP downloads fail fast on non-200 responses instead of writing error bodies to disk.

New Features:
- Introduce a dedicated DownloadFileHTTPError exception type for HTTP download failures.

Bug Fixes:
- Prevent download_file() from writing non-200 HTTP responses (e.g., 404, 500) to the target file and instead raise an error before file creation, including in the insecure SSL fallback path.

Enhancements:
- Extract shared HTTP status validation and response-to-file streaming into helper functions to unify download behavior and progress reporting across code paths.

Tests:
- Add unit tests covering rejection of non-200 responses in both normal and SSL-fallback download flows, and successful writing of 200 responses to disk.