### PR TITLE
fix: 修复 `astrbot_file_read_tool` 在读取目录时返回误导性 "Permission denied" 错误的 bug。

### DIFF
--- a/astrbot/core/tools/computer_tools/fs.py
+++ b/astrbot/core/tools/computer_tools/fs.py
@@ -304,6 +304,11 @@ class FileReadTool(FunctionTool):
             )
             if not normalized_path:
                 raise ValueError("`path` must be a non-empty string.")
+            if local_env and os.path.isdir(normalized_path):
+                return (
+                    f"Error: '{normalized_path}' is a directory, not a file. "
+                    "Use a file path instead, or use 'astrbot_execute_shell' to list directory contents."
+                )
             offset, limit = self._validate_read_window(offset, limit)
             sb = await get_booter(
                 context.context.context,

--- a/tests/test_computer_fs_tools.py
+++ b/tests/test_computer_fs_tools.py
@@ -620,3 +620,23 @@ async def test_grep_tool_applies_result_limit(
     assert "match-2" in result
     assert "match-3" not in result
     assert "[Truncated to first 2 result groups.]" in result
+
+
+@pytest.mark.asyncio
+async def test_file_read_tool_rejects_directory_with_clear_message(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    """FileReadTool should return a helpful message when given a directory path."""
+    workspace = _setup_local_fs_tools(monkeypatch, tmp_path)
+    subdir = workspace / "my-directory"
+    subdir.mkdir()
+
+    result = await fs_tools.FileReadTool().call(
+        _make_context(),
+        path="my-directory",
+    )
+
+    assert "is a directory, not a file" in result
+    assert "my-directory" in result
+    assert "'astrbot_execute_shell'" in result


### PR DESCRIPTION
## Problem / 问题
Fixes #9087 
当 LLM 调用 `astrbot_file_read_tool` 并传入目录路径时，工具返回 `Error: [Errno 13] Permission denied`，暗示是权限不足。实际原因是传入了目录而非文件——底层 `_probe_local_file()` 对目录执行 `open("rb")`，Windows 返回 `Errno 13`，被上层 `except PermissionError` 捕获后错误展示。

### Root Cause / 根因

调用链：

```
FileReadTool.call()                          # fs.py
  → read_file_tool_result()                  # file_read_utils.py
    → _probe_local_file(path)                # file_read_utils.py
      → Path(path).open("rb")                # 目录 → OSError(Errno 13)
        → except PermissionError             # 被当作权限错误
          → return f"Error: {exc}"           # 误导 LLM
```

在 `FileReadTool.call()` 中没有在文件 I/O 之前检查路径是否为目录。

## Modifications / 改动点

改动两个文件：

### 1. `astrbot/core/tools/computer_tools/fs.py`

在 `FileReadTool.call()` 中，路径规范化完成后、`read_file_tool_result` 调用之前，增加 `os.path.isdir()` 检查：

```diff
             if not normalized_path:
                 raise ValueError("`path` must be a non-empty string.")
+            if local_env and os.path.isdir(normalized_path):
+                return (
+                    f"Error: `{normalized_path}` is a directory, not a file. "
+                    "Use a file path instead, or use `astrbot_execute_shell` to list directory contents."
+                )
             offset, limit = self._validate_read_window(offset, limit)
```

- 检查时机：在 `_normalize_rw_path` 权限校验完成后、`get_booter` 之前，不浪费后续 I/O 资源
- 对 local 和 sandbox 两种模式均有效（sandbox 模式下 `normalized_path` 为原始 path，`os.path.isdir()` 在 host 上大概率返回 `False`，不会误拦截）
- `os` 已在文件顶部导入，无需新增 import

### 2. `tests/test_computer_fs_tools.py`

新增测试用例 `test_file_read_tool_rejects_directory_with_clear_message`：

```python
@pytest.mark.asyncio
async def test_file_read_tool_rejects_directory_with_clear_message(
    monkeypatch: pytest.MonkeyPatch,
    tmp_path,
):
    """FileReadTool should return a helpful message when given a directory path."""
    workspace = _setup_local_fs_tools(monkeypatch, tmp_path)
    subdir = workspace / "my-directory"
    subdir.mkdir()

    result = await fs_tools.FileReadTool().call(
        _make_context(),
        path="my-directory",
    )

    assert "is a directory, not a file" in result
    assert "my-directory" in result
```

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

## Verification Steps / 验证步骤

1. 运行新增测试：
   ```
   pytest tests/test_computer_fs_tools.py::test_file_read_tool_rejects_directory_with_clear_message -xvs
   ```
2. 运行全部 file_read 相关测试确认无回归：
   ```
   pytest tests/test_computer_fs_tools.py -k "file_read" -xvs
   ```
3. 实际调用验证（修改前后对比）：
   - **修改前**：`astrbot_file_read_tool(path="D:\some\directory")` → `Error: [Errno 13] Permission denied`
   - **修改后**：同一调用 → `Error: \`D:\some\directory\` is a directory, not a file. Use a file path instead, or use \`astrbot_execute_shell\` to list directory contents.`

## Screenshots or Test Results / 测试结果

```
============================= test session starts =============================
tests/test_computer_fs_tools.py::test_file_read_tool_rejects_directory_with_clear_message PASSED
tests/test_computer_fs_tools.py::test_file_read_tool_rejects_large_full_text_read_before_local_stream_read PASSED
tests/test_computer_fs_tools.py::test_file_read_tool_returns_image_call_tool_result_for_images PASSED
tests/test_computer_fs_tools.py::test_file_read_tool_treats_svg_as_text PASSED
tests/test_computer_fs_tools.py::test_file_read_tool_reads_pdf_via_parser PASSED
tests/test_computer_fs_tools.py::test_file_read_tool_reads_docx_via_parser_and_magic PASSED
tests/test_computer_fs_tools.py::test_file_read_tool_reads_epub_via_parser_and_magic PASSED
tests/test_computer_fs_tools.py::test_file_read_tool_stores_long_converted_document_in_workspace PASSED
====================== 8 passed in 2.52s ======================
```

全部 8 个相关测试通过。

注意：`test_file_read_tool_allows_partial_read_for_large_text_file` 在 Windows 下因 `\r\n` vs `\n` 换行符差异而失败，这是非本次改动引入的已有问题。

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Handle directory paths passed to the file read tool more gracefully and add coverage for this behavior.

Bug Fixes:
- Prevent astrbot_file_read_tool from misreporting 'Permission denied' when given a directory path by returning a clear directory-specific error message instead.

Tests:
- Add an async test ensuring FileReadTool returns a helpful message when invoked with a directory path.