### PR TITLE
fix(core): return clear error when file read tool receives a directory path

### DIFF
--- a/astrbot/core/computer/file_read_utils.py
+++ b/astrbot/core/computer/file_read_utils.py
@@ -78,13 +78,26 @@ class ParsedDocument:
     text: str
 
 
+def _directory_read_error(path: str) -> str:
+    return (
+        f"Error: `{path}` is a directory, not a file. "
+        "Use a file path instead, or use `astrbot_execute_shell` "
+        "to list directory contents."
+    )
+
+
 def _build_probe_script(path: str) -> str:
+    directory_error = _directory_read_error(path)
     return f"""
 import base64
 import json
 from pathlib import Path
 
 path = Path({path!r})
+if path.is_dir():
+    raise ValueError({directory_error!r})
+if not path.is_file():
+    raise ValueError("Error: File does not exist: `{path}`")
 with path.open("rb") as file_obj:
     sample = file_obj.read({_FILE_SNIFF_BYTES})
 print(
@@ -652,13 +665,24 @@ async def read_file_tool_result(
     workspace_dir: str | None = None,
 ) -> ToolExecResult:
     if local_mode:
+        file_path = Path(path)
+        if file_path.is_dir():
+            return _directory_read_error(path)
+        if not file_path.is_file():
+            return f"Error: File does not exist: `{path}`"
         probe_payload = await _probe_local_file(path)
     else:
-        probe_payload = await _exec_python_json(
-            booter,
-            _build_probe_script(path),
-            action="file probe",
-        )
+        try:
+            probe_payload = await _exec_python_json(
+                booter,
+                _build_probe_script(path),
+                action="file probe",
+            )
+        except RuntimeError as exc:
+            probe_error = str(exc).removeprefix("file probe failed: ").strip()
+            if probe_error.startswith("Error:"):
+                return probe_error
+            raise
     sample_b64 = str(probe_payload.get("sample_b64", "") or "")
     sample = base64.b64decode(sample_b64) if sample_b64 else b""
     size_bytes = int(probe_payload.get("size_bytes", 0) or 0)

--- a/tests/test_computer_fs_tools.py
+++ b/tests/test_computer_fs_tools.py
@@ -408,6 +408,26 @@ def test_detect_text_encoding_allows_utf8_probe_cut_mid_character():
 
 
 @pytest.mark.asyncio
+async def test_file_read_tool_rejects_directory_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    workspace = _setup_local_fs_tools(monkeypatch, tmp_path)
+    directory = workspace / "api"
+    directory.mkdir()
+
+    result = await fs_tools.FileReadTool().call(
+        _make_context(),
+        path="api",
+    )
+
+    assert "is a directory, not a file" in result
+    assert "astrbot_execute_shell" in result
+    assert "Permission denied" not in result
+    assert "Is a directory" not in result
+
+
+@pytest.mark.asyncio
 async def test_file_read_tool_rejects_large_full_text_read_before_local_stream_read(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,


### PR DESCRIPTION
## Summary
...

## Summary by Sourcery

Clarify error handling when the file read tool is given invalid paths, especially directories, and cover the behavior with tests.

Bug Fixes:
- Return a clear, user-friendly error when the file read tool is invoked with a directory path instead of a file.
- Normalize error propagation from the remote probe script so structured file read errors are surfaced instead of generic runtime failures.

Tests:
- Add an async test to verify the file read tool rejects directory paths with the new, descriptive error message and without leaking low-level OS error text.