### PR TITLE
fix(computer): clear error when file_read_tool is given a directory (#9087)

### DIFF
--- a/astrbot/core/computer/file_read_utils.py
+++ b/astrbot/core/computer/file_read_utils.py
@@ -652,6 +652,12 @@ async def read_file_tool_result(
     workspace_dir: str | None = None,
 ) -> ToolExecResult:
     if local_mode:
+        if Path(path).is_dir():
+            return (
+                f"Error: `{path}` is a directory, not a file. "
+                "Provide a file path instead, or use `astrbot_execute_shell` "
+                "to list directory contents."
+            )
         probe_payload = await _probe_local_file(path)
     else:
         probe_payload = await _exec_python_json(

--- a/tests/test_computer_fs_tools.py
+++ b/tests/test_computer_fs_tools.py
@@ -451,6 +451,25 @@ async def test_file_read_tool_allows_partial_read_for_large_text_file(
 
 
 @pytest.mark.asyncio
+async def test_file_read_tool_reports_directory_clearly(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+):
+    workspace = _setup_local_fs_tools(monkeypatch, tmp_path)
+    (workspace / "some_dir").mkdir()
+
+    result = await fs_tools.FileReadTool().call(
+        _make_context(),
+        path="some_dir",
+    )
+
+    assert isinstance(result, str)
+    assert "is a directory" in result
+    assert "astrbot_execute_shell" in result
+    assert "Permission denied" not in result
+
+
+@pytest.mark.asyncio
 async def test_file_read_tool_returns_image_call_tool_result_for_images(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,


### PR DESCRIPTION
## 问题 / Problem

`astrbot_file_read_tool` 在传入**目录路径**时会直接 `open()`，于是返回了误导性的系统错误（Windows 上为 `[Errno 13] Permission denied`，Linux 上为 `IsADirectoryError`），而不是告诉用户传入的是一个目录。详见 #9087。

When `astrbot_file_read_tool` is given a **directory** path, it opened the path directly, so the LLM/user saw a misleading OS error (`[Errno 13] Permission denied` on Windows, `IsADirectoryError` on Linux) instead of being told it's a directory.

## 修复 / Fix

在 `read_file_tool_result`（local 模式）探测文件前增加 `Path(path).is_dir()` 主动判断，返回清晰提示并引导改用 `astrbot_execute_shell` 列出目录内容。跨平台一致，不依赖具体的 errno。

Add a proactive `Path(path).is_dir()` guard in `read_file_tool_result` (local mode) before probing, returning a clear message and pointing to `astrbot_execute_shell` for directory listing. Cross-platform — it doesn't depend on the OS-specific errno.

返回信息 / Returned message:

> Error: `<path>` is a directory, not a file. Provide a file path instead, or use `astrbot_execute_shell` to list directory contents.

## 测试 / Test

新增 `test_file_read_tool_reports_directory_clearly`（`tests/test_computer_fs_tools.py`）：传入目录时返回包含 “is a directory”、引导使用 `astrbot_execute_shell` 且不再包含 “Permission denied” 的提示。

Adds `test_file_read_tool_reports_directory_clearly` covering the directory case.

---
*AI 协助、人工审阅 / AI-assisted, human-reviewed — I'm an AI engineer; I find, fix, and test with AI, then review and verify before opening it under my name.*

## Summary by Sourcery

Clarify behavior of the file read tool when invoked on directories in local mode to provide a user-friendly, cross-platform error message.

Bug Fixes:
- Prevent misleading OS errors by explicitly detecting directory paths in the local file read tool and returning a clear directory-specific error message.

Tests:
- Add a regression test ensuring the file read tool reports directories clearly, suggests using the shell tool, and no longer surfaces 'Permission denied' errors for this case.