### PR TITLE
fix: guard desktop-managed core restart

### DIFF
--- a/astrbot/core/desktop_runtime.py
+++ b/astrbot/core/desktop_runtime.py
@@ -1,0 +1,10 @@
+import os
+
+DESKTOP_MANAGED_RESTART_MESSAGE = (
+    "AstrBot Desktop manages this backend process. Please restart or update from "
+    "the desktop app instead of the core WebUI."
+)
+
+
+def is_desktop_managed_backend() -> bool:
+    return os.environ.get("ASTRBOT_DESKTOP_MANAGED") == "1"

--- a/astrbot/core/updator.py
+++ b/astrbot/core/updator.py
@@ -8,6 +8,10 @@ import psutil
 
 from astrbot.core import logger
 from astrbot.core.config.default import VERSION
+from astrbot.core.desktop_runtime import (
+    DESKTOP_MANAGED_RESTART_MESSAGE,
+    is_desktop_managed_backend,
+)
 from astrbot.core.utils.astrbot_path import get_astrbot_path
 from astrbot.core.utils.io import ensure_dir
 
@@ -142,6 +146,10 @@ class AstrBotUpdator(RepoZipUpdator):
         在指定的延迟后，终止所有子进程并重新启动程序
         这里只能使用 os.exec* 来重启程序
         """
+        if is_desktop_managed_backend():
+            logger.error(DESKTOP_MANAGED_RESTART_MESSAGE)
+            raise RuntimeError(DESKTOP_MANAGED_RESTART_MESSAGE)
+
         time.sleep(delay)
         self.terminate_child_processes()
         executable = sys.executable

--- a/astrbot/dashboard/api/updates.py
+++ b/astrbot/dashboard/api/updates.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import JSONResponse
 
 from astrbot.core import logger
+from astrbot.core.desktop_runtime import DESKTOP_MANAGED_RESTART_MESSAGE
 from astrbot.dashboard.async_utils import run_maybe_async
 from astrbot.dashboard.schemas import PipInstallRequest, UpdateRequest
 from astrbot.dashboard.services.update_service import (
@@ -58,6 +59,15 @@ def _service_response(result: UpdateServiceResult) -> JSONResponse:
 
 def _service_error(exc: UpdateServiceError) -> JSONResponse:
     logger.error(f"Dashboard update operation failed: {exc}", exc_info=True)
+    if exc.code == "desktop_managed":
+        return JSONResponse(
+            {
+                "status": "error",
+                "message": DESKTOP_MANAGED_RESTART_MESSAGE,
+                "data": None,
+            },
+            status_code=200,
+        )
     return JSONResponse(
         {"status": "error", "message": "An internal error has occurred.", "data": None},
         status_code=200,

--- a/astrbot/dashboard/services/stat_service.py
+++ b/astrbot/dashboard/services/stat_service.py
@@ -21,6 +21,10 @@ from astrbot.core.config.astrbot_config import AstrBotConfig
 from astrbot.core.core_lifecycle import AstrBotCoreLifecycle
 from astrbot.core.db import BaseDatabase
 from astrbot.core.db.po import ProviderStat
+from astrbot.core.desktop_runtime import (
+    DESKTOP_MANAGED_RESTART_MESSAGE,
+    is_desktop_managed_backend,
+)
 from astrbot.core.utils.astrbot_path import get_astrbot_path
 from astrbot.core.utils.auth_password import (
     is_default_dashboard_password,
@@ -57,6 +61,9 @@ class StatService:
             raise StatServiceError(
                 "You are not permitted to do this operation in demo mode"
             )
+        if is_desktop_managed_backend():
+            raise StatServiceError(DESKTOP_MANAGED_RESTART_MESSAGE)
+
         await self.core_lifecycle.restart()
 
     @staticmethod

--- a/astrbot/dashboard/services/update_service.py
+++ b/astrbot/dashboard/services/update_service.py
@@ -15,6 +15,10 @@ from astrbot.core import logger
 from astrbot.core import pip_installer as _pip_installer
 from astrbot.core.config.default import VERSION
 from astrbot.core.core_lifecycle import AstrBotCoreLifecycle
+from astrbot.core.desktop_runtime import (
+    DESKTOP_MANAGED_RESTART_MESSAGE,
+    is_desktop_managed_backend,
+)
 from astrbot.core.updator import AstrBotUpdator
 from astrbot.core.utils.astrbot_path import (
     get_astrbot_data_path,
@@ -67,7 +71,9 @@ class UpdateServiceResult:
 
 
 class UpdateServiceError(Exception):
-    pass
+    def __init__(self, message: str, *, code: str | None = None) -> None:
+        super().__init__(message)
+        self.code = code
 
 
 class UpdateService:
@@ -143,6 +149,12 @@ class UpdateService:
             raise UpdateServiceError(exc.__str__()) from exc
 
     async def update_project(self, data: object) -> UpdateServiceResult:
+        if is_desktop_managed_backend():
+            raise UpdateServiceError(
+                DESKTOP_MANAGED_RESTART_MESSAGE,
+                code="desktop_managed",
+            )
+
         payload = data if isinstance(data, dict) else {}
         version = payload.get("version", "")
         reboot = payload.get("reboot", True)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -20,6 +20,7 @@ from werkzeug.datastructures import FileStorage
 from astrbot.core import LogBroker
 from astrbot.core.core_lifecycle import AstrBotCoreLifecycle
 from astrbot.core.db.sqlite import SQLiteDatabase
+from astrbot.core.desktop_runtime import DESKTOP_MANAGED_RESTART_MESSAGE
 from astrbot.core.star.star import StarMetadata, star_registry
 from astrbot.core.star.star_handler import star_handlers_registry
 from astrbot.core.utils.auth_password import (
@@ -2663,6 +2664,35 @@ async def test_check_update(
 
 
 @pytest.mark.asyncio
+async def test_restart_core_rejects_desktop_managed_backend(
+    app: FastAPIAppAdapter,
+    authenticated_header: dict,
+    core_lifecycle_td: AstrBotCoreLifecycle,
+    monkeypatch,
+):
+    test_client = app.test_client()
+    restart_called = False
+
+    async def mock_restart():
+        nonlocal restart_called
+        restart_called = True
+
+    monkeypatch.setenv("ASTRBOT_DESKTOP_MANAGED", "1")
+    monkeypatch.setattr(core_lifecycle_td, "restart", mock_restart)
+
+    response = await test_client.post(
+        "/api/stat/restart-core",
+        headers=authenticated_header,
+    )
+
+    assert response.status_code == 400
+    data = await response.get_json()
+    assert data["status"] == "error"
+    assert data["message"] == DESKTOP_MANAGED_RESTART_MESSAGE
+    assert restart_called is False
+
+
+@pytest.mark.asyncio
 async def test_do_update(
     app: FastAPIAppAdapter,
     authenticated_header: dict,
@@ -2824,6 +2854,44 @@ async def test_do_update_does_not_apply_files_when_core_download_fails(
     )
     assert progress_data["data"]["status"] == "error"
     assert calls == ["download-dashboard", "download-core"]
+
+
+@pytest.mark.asyncio
+async def test_do_update_rejects_desktop_managed_backend(
+    app: FastAPIAppAdapter,
+    authenticated_header: dict,
+    core_lifecycle_td: AstrBotCoreLifecycle,
+    monkeypatch,
+):
+    test_client = app.test_client()
+    calls = []
+
+    async def mock_download_core(*args, **kwargs):
+        del args, kwargs
+        calls.append("download-core")
+
+    async def mock_restart():
+        calls.append("restart")
+
+    monkeypatch.setenv("ASTRBOT_DESKTOP_MANAGED", "1")
+    monkeypatch.setattr(
+        core_lifecycle_td.astrbot_updator,
+        "download_update_package",
+        mock_download_core,
+    )
+    monkeypatch.setattr(core_lifecycle_td, "restart", mock_restart)
+
+    response = await test_client.post(
+        "/api/update/do",
+        headers=authenticated_header,
+        json={"version": "v3.4.0", "progress_id": "desktop-progress"},
+    )
+
+    assert response.status_code == 200
+    data = await response.get_json()
+    assert data["status"] == "error"
+    assert data["message"] == DESKTOP_MANAGED_RESTART_MESSAGE
+    assert calls == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Background

AstrBot Desktop can serve the bundled WebUI to an external browser. In that path, the page does not have the Tauri desktop bridge, so the original WebUI fallback can call core restart/update APIs directly:

- `POST /api/stat/restart-core`
- `POST /api/update/do`

When the backend process is managed by the desktop shell, those APIs must not self-reboot or self-update the core process. Otherwise, a browser-triggered restart/update can spawn a backend process outside Tauri's process management. This is especially risky on Windows with reboot behavior changes such as #9073, where a reboot can start a new console process.

## Summary

- Add `astrbot.core.desktop_runtime` with a shared `ASTRBOT_DESKTOP_MANAGED=1` guard.
- Reject system/core restart when the backend is desktop-managed.
- Reject core update when the backend is desktop-managed, before creating an update task or downloading files.
- Add a `_reboot()` fallback guard and log the desktop-managed rejection before raising.
- Preserve the dashboard service/API refactor by placing the guards in `StatService` and `UpdateService`.
- Add dashboard tests covering blocked restart/update paths and existing update task behavior.

## Behavior

When `ASTRBOT_DESKTOP_MANAGED=1` is set:

- Core restart via WebUI/API returns an error response.
- Core update via WebUI/API returns the desktop-managed error before downloading dashboard/core assets.
- Direct calls into `AstrBotUpdator._reboot()` raise a runtime error instead of replacing/spawning the process.

Normal non-desktop AstrBot behavior is unchanged.

## Related Desktop PR

The paired desktop shell PR sets `ASTRBOT_DESKTOP_MANAGED=1` for packaged desktop-managed backend processes:

- https://github.com/AstrBotDevs/AstrBot-desktop/pull/146

## Tests

```bash
uv run ruff check astrbot/core/desktop_runtime.py astrbot/core/updator.py astrbot/dashboard/api/updates.py astrbot/dashboard/services/stat_service.py astrbot/dashboard/services/update_service.py tests/test_dashboard.py
uv run pytest tests/test_dashboard.py -k "desktop_managed_backend or test_do_update"
```

CI status at last check: all reported checks passed, no failing checks.

## Summary by Sourcery

Guard core restart and update logic when the backend is managed by the desktop shell, preventing WebUI-triggered reboots and updates from escaping desktop process management.

New Features:
- Introduce a desktop runtime helper that detects desktop-managed backend processes via the ASTRBOT_DESKTOP_MANAGED environment flag.

Bug Fixes:
- Block system/core restart and core update operations initiated from the dashboard when the backend is desktop-managed, avoiding unmanaged process spawns.

Enhancements:
- Propagate a desktop-managed error message through stat and update services and their API layer, including a typed error code for update failures.
- Add a runtime guard to the updater reboot path that logs and refuses to restart when running under a desktop-managed backend.

Tests:
- Add dashboard tests verifying that restart-core and update APIs reject operations for desktop-managed backends without invoking lifecycle or download actions.