### PR TITLE
feat(provider): make outer OpenAI retry count configurable

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -104,6 +104,7 @@ DEFAULT_CONFIG = {
         "default_provider_id": "",
         "fallback_chat_models": [],
         "request_max_retries": 5,
+        "provider_error_retries": 1,
         "default_image_caption_provider_id": "",
         "image_caption_prompt": "Please describe the image using Chinese.",
         "provider_pool": ["*"],  # "*" 表示使用所有可用的提供者
@@ -2801,6 +2802,9 @@ CONFIG_METADATA_2 = {
                         "items": {"type": "string"},
                     },
                     "request_max_retries": {
+                        "type": "int",
+                    },
+                    "provider_error_retries": {
                         "type": "int",
                     },
                     "wake_prefix": {

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -409,7 +409,8 @@ class ProviderOpenAIOfficial(Provider):
         multiplying latency for proxy/aggregator providers that already perform
         their own upstream retry and fallback.
         """
-        raw = self.provider_settings.get("provider_error_retries", 1)
+        provider_settings = getattr(self, "provider_settings", {}) or {}
+        raw = provider_settings.get("provider_error_retries", 1)
         try:
             retries = int(raw)
         except (TypeError, ValueError):
@@ -1246,7 +1247,7 @@ class ProviderOpenAIOfficial(Provider):
                 if success:
                     break
 
-        if retry_cnt == max_retries - 1 or llm_response is None:
+        if llm_response is None:
             logger.error(f"API 调用失败，重试 {max_retries} 次仍然失败。")
             if last_exception is None:
                 raise Exception("未知错误")
@@ -1289,6 +1290,7 @@ class ProviderOpenAIOfficial(Provider):
 
         last_exception = None
         retry_cnt = 0
+        completed = False
         for retry_cnt in range(max_retries):
             try:
                 self.client.api_key = chosen_key
@@ -1298,6 +1300,7 @@ class ProviderOpenAIOfficial(Provider):
                     request_max_retries=request_max_retries,
                 ):
                     yield response
+                completed = True
                 break
             except Exception as e:
                 last_exception = e
@@ -1323,7 +1326,7 @@ class ProviderOpenAIOfficial(Provider):
                 if success:
                     break
 
-        if retry_cnt == max_retries - 1:
+        if not completed:
             logger.error(f"API 调用失败，重试 {max_retries} 次仍然失败。")
             if last_exception is None:
                 raise Exception("未知错误")

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -398,6 +398,24 @@ class ProviderOpenAIOfficial(Provider):
 
         self.reasoning_key = "reasoning_content"
 
+    def _provider_error_retries(self) -> int:
+        """Return retry attempts for provider-level recovery paths.
+
+        This outer retry loop handles payload mutation and key rotation (for
+        example context trimming, tool removal, image fallback, or switching to
+        another configured API key). Transport/status-code retries are handled
+        separately by ``request_max_retries`` in ``retry_provider_request``.
+        Keeping this value configurable prevents nested retry loops from
+        multiplying latency for proxy/aggregator providers that already perform
+        their own upstream retry and fallback.
+        """
+        raw = self.provider_settings.get("provider_error_retries", 1)
+        try:
+            retries = int(raw)
+        except (TypeError, ValueError):
+            retries = 1
+        return max(1, retries)
+
     def _ollama_disable_thinking_enabled(self) -> bool:
         value = self.provider_config.get("ollama_disable_thinking", False)
         if isinstance(value, str):
@@ -1188,7 +1206,7 @@ class ProviderOpenAIOfficial(Provider):
             payloads["tool_choice"] = tool_choice
 
         llm_response = None
-        max_retries = 10
+        max_retries = self._provider_error_retries()
         available_api_keys = self.api_keys.copy()
         chosen_key = random.choice(available_api_keys)
         image_fallback_used = False
@@ -1264,7 +1282,7 @@ class ProviderOpenAIOfficial(Provider):
         if func_tool and not func_tool.empty():
             payloads["tool_choice"] = tool_choice
 
-        max_retries = 10
+        max_retries = self._provider_error_retries()
         available_api_keys = self.api_keys.copy()
         chosen_key = random.choice(available_api_keys)
         image_fallback_used = False

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -123,6 +123,8 @@ def test_create_http_client_falls_back_to_global_httpx_module(monkeypatch):
 def test_provider_error_retries_defaults_and_coerces_values():
     provider = ProviderOpenAIOfficial.__new__(ProviderOpenAIOfficial)
 
+    assert provider._provider_error_retries() == 1
+
     provider.provider_settings = {}
     assert provider._provider_error_retries() == 1
 

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -120,6 +120,22 @@ def test_create_http_client_falls_back_to_global_httpx_module(monkeypatch):
     assert captured["httpx_module"] is openai_source_module.httpx
 
 
+def test_provider_error_retries_defaults_and_coerces_values():
+    provider = ProviderOpenAIOfficial.__new__(ProviderOpenAIOfficial)
+
+    provider.provider_settings = {}
+    assert provider._provider_error_retries() == 1
+
+    provider.provider_settings = {"provider_error_retries": "3"}
+    assert provider._provider_error_retries() == 3
+
+    provider.provider_settings = {"provider_error_retries": 0}
+    assert provider._provider_error_retries() == 1
+
+    provider.provider_settings = {"provider_error_retries": "invalid"}
+    assert provider._provider_error_retries() == 1
+
+
 @pytest.mark.asyncio
 async def test_get_models_retries_transient_request_error(monkeypatch):
     monkeypatch.setattr(request_retry, "REQUEST_RETRY_WAIT_MIN_S", 0)


### PR DESCRIPTION
## Summary

- Add `provider_settings.provider_error_retries` to configure the OpenAI-compatible provider's outer recovery retry loop.
- Default the outer provider-level retry loop to 1 attempt to avoid multiplying latency with `request_max_retries`.
- Keep transport/status retry behavior controlled by the existing `request_max_retries` setting.
- Add unit coverage for coercing the new retry setting.

## Motivation

OpenAI-compatible proxy/aggregator providers often perform their own upstream retry and fallback. AstrBot currently has an inner request retry loop plus a fixed outer provider-level retry loop of 10 attempts. When the upstream proxy is slow or unstable, those nested retries can significantly delay fallback to other providers.

This change makes the outer loop configurable while preserving the existing recovery paths for users who need more attempts.

## Testing

- `python -m py_compile astrbot/core/provider/sources/openai_source.py astrbot/core/config/default.py tests/test_openai_source.py`

`pytest` was not available in the local environment used for this change.

## Summary by Sourcery

Make the OpenAI-compatible provider’s outer recovery retry loop configurable via provider settings and align defaults.

New Features:
- Add a provider_settings.provider_error_retries option to control provider-level recovery retries for the OpenAI-compatible provider.

Enhancements:
- Default provider-level recovery retries to 1 attempt and wire this setting into text and streaming chat flows to avoid compounding latency with request_max_retries.
- Extend default configuration schema to include the new provider_error_retries setting.

Tests:
- Add unit tests to verify defaulting and coercion behavior for the new provider_error_retries setting.