### PR TITLE
fix: resample and downmix WAV files for Tencent Silk encoding

### DIFF
--- a/astrbot/core/utils/tencent_record_helper.py
+++ b/astrbot/core/utils/tencent_record_helper.py
@@ -74,14 +74,18 @@ async def wav_to_tencent_silk(wav_path: str, output_path: str) -> float:
     with wave.open(wav_path, "rb") as wav:
         rate = wav.getframerate()
         channels = wav.getnchannels()
+        sampwidth = wav.getsampwidth()
         pcm_data = wav.readframes(wav.getnframes())
 
-    # downmix to mono and resample to 24 kHz -- no external dependency.
+    # Downmix to mono, resample to 24 kHz if needed, and convert to 16-bit PCM
+    # (pysilk only accepts 16-bit linear PCM)
     if channels == 2:
-        pcm_data = audioop.tomono(pcm_data, 2, 0.5, 0.5)
+        pcm_data = audioop.tomono(pcm_data, sampwidth, 0.5, 0.5)
     if rate not in _PYSILK_SUPPORTED_RATES:
-        pcm_data, _ = audioop.ratecv(pcm_data, 2, 1, rate, 24000, None)
+        pcm_data, _ = audioop.ratecv(pcm_data, sampwidth, 1, rate, 24000, None)
         rate = 24000
+    if sampwidth != 2:
+        pcm_data = audioop.lin2lin(pcm_data, sampwidth, 2)
 
     input_io = BytesIO(pcm_data)
     output_io = BytesIO()

--- a/astrbot/core/utils/tencent_record_helper.py
+++ b/astrbot/core/utils/tencent_record_helper.py
@@ -1,12 +1,16 @@
 """Tencent Silk audio conversion helpers."""
 
 import asyncio
+import audioop
 import os
 import subprocess
 import wave
 from io import BytesIO
 
 from astrbot.core import logger
+
+# The SILK SDK only supports these rates
+_PYSILK_SUPPORTED_RATES = frozenset({8000, 12000, 16000, 24000, 32000, 48000})
 
 
 async def tencent_silk_to_wav(silk_path: str, output_path: str) -> str:
@@ -69,8 +73,15 @@ async def wav_to_tencent_silk(wav_path: str, output_path: str) -> float:
 
     with wave.open(wav_path, "rb") as wav:
         rate = wav.getframerate()
-        frames = wav.getnframes()
-        pcm_data = wav.readframes(frames)
+        channels = wav.getnchannels()
+        pcm_data = wav.readframes(wav.getnframes())
+
+    # downmix to mono and resample to 24 kHz -- no external dependency.
+    if channels == 2:
+        pcm_data = audioop.tomono(pcm_data, 2, 0.5, 0.5)
+    if rate not in _PYSILK_SUPPORTED_RATES:
+        pcm_data, _ = audioop.ratecv(pcm_data, 2, 1, rate, 24000, None)
+        rate = 24000
 
     input_io = BytesIO(pcm_data)
     output_io = BytesIO()
@@ -78,7 +89,7 @@ async def wav_to_tencent_silk(wav_path: str, output_path: str) -> float:
     pysilk.encode(input_io, output_io, rate, rate, tencent=True)
     with open(output_path, "wb") as f:
         f.write(output_io.getvalue())
-    return frames / rate if rate else 0
+    return len(pcm_data) / (2 * rate) if rate else 0
 
 
 async def convert_to_pcm_wav(input_path: str, output_path: str) -> str:

--- a/tests/test_media_utils.py
+++ b/tests/test_media_utils.py
@@ -2,6 +2,7 @@ import base64
 import math
 import os
 import struct
+import sys
 import wave
 from io import BytesIO
 from pathlib import Path
@@ -653,19 +654,39 @@ def test_path_mapping_accepts_standard_and_legacy_file_uri(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_tencent_silk_encoding_uses_pysilk_tencent_format(tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    "rate, channels",
+    [
+        (24000, 1),  # supported, no resample
+        (44100, 1),  # unsupported rate, triggers resample
+        (22050, 1),  # unsupported rate, triggers resample
+        (48000, 2),  # stereo at supported rate, triggers downmix
+        (44100, 2),  # stereo + unsupported rate, triggers both
+    ],
+    ids=["24k-mono", "44.1k-mono", "22.05k-mono", "48k-stereo", "44.1k-stereo"],
+)
+async def test_tencent_silk_encoding_uses_pysilk_tencent_format(
+    rate, channels, tmp_path, monkeypatch
+):
+    """Real pysilk end-to-end across sample rates that previously failed.
+
+    44100 Hz was the regression trigger: pysilk rejects it with
+    ENC_INPUT_INVALID_NO_OF_SAMPLES. The fix resamples to 24 kHz mono via
+    audioop.ratecv before encoding.
+    """
     monkeypatch.setattr(media_utils, "get_astrbot_temp_path", lambda: str(tmp_path))
     wav_path = tmp_path / "tone.wav"
     silk_path = tmp_path / "tone.silk"
-    rate = 24000
-    frames = int(rate * 0.2)
+    secs = 0.2
+    frames = int(rate * secs)
     with wave.open(str(wav_path), "wb") as wav:
-        wav.setnchannels(1)
+        wav.setnchannels(channels)
         wav.setsampwidth(2)
         wav.setframerate(rate)
         for i in range(frames):
             sample = int(0.2 * 32767 * math.sin(2 * math.pi * 440 * i / rate))
-            wav.writeframesraw(struct.pack("<h", sample))
+            for _ in range(channels):
+                wav.writeframesraw(struct.pack("<h", sample))
 
     duration = await wav_to_tencent_silk(str(wav_path), str(silk_path))
     silk_bytes = silk_path.read_bytes()
@@ -679,7 +700,82 @@ async def test_tencent_silk_encoding_uses_pysilk_tencent_format(tmp_path, monkey
         assert resolved.format == "tencent_silk"
         assert resolved.mime_type == "audio/silk"
 
-    assert duration == pytest.approx(0.2)
+    assert duration == pytest.approx(secs, abs=0.05)
     assert silk_bytes.startswith(b"\x02#!SILK_V3")
     assert resolved_silk_bytes.startswith(b"\x02#!SILK_V3")
     assert not resolved_silk_path.exists()
+
+
+def _make_wav(path, rate, channels=1, secs=0.2, freq=440):
+    """Write a short sine-tone WAV at the given rate/channels."""
+    nframes = int(rate * secs)
+    with wave.open(str(path), "wb") as wav:
+        wav.setnchannels(channels)
+        wav.setsampwidth(2)
+        wav.setframerate(rate)
+        for i in range(nframes):
+            sample = int(0.2 * 32767 * math.sin(2 * math.pi * freq * i / rate))
+            for _ in range(channels):
+                wav.writeframesraw(struct.pack("<h", sample))
+
+
+class _FakePysilk:
+    """Stand-in for the ``pysilk`` module that records encode() calls."""
+
+    def __init__(self):
+        self.calls = []
+
+    def encode(self, input_io, output_io, sample_rate, bit_rate, tencent=True):
+        self.calls.append({"sample_rate": sample_rate, "tencent": tencent})
+        output_io.write(b"\x02#!SILK_V3")
+
+
+@pytest.mark.asyncio
+async def test_wav_to_tencent_silk_resamples_unsupported_rate(tmp_path, monkeypatch):
+    """44100 Hz input must be resampled to 24 kHz before pysilk.encode."""
+    fake = _FakePysilk()
+    monkeypatch.setitem(sys.modules, "pysilk", fake)
+
+    wav_path = tmp_path / "tts_44100.wav"
+    _make_wav(wav_path, 44100)
+
+    silk_path = tmp_path / "out.silk"
+    await wav_to_tencent_silk(str(wav_path), str(silk_path))
+
+    assert len(fake.calls) == 1
+    assert fake.calls[0]["sample_rate"] == 24000
+    assert fake.calls[0]["tencent"] is True
+    assert silk_path.read_bytes().startswith(b"\x02#!SILK_V3")
+
+
+@pytest.mark.asyncio
+async def test_wav_to_tencent_silk_resamples_stereo(tmp_path, monkeypatch):
+    """Stereo input at a supported rate must still be downmixed to mono."""
+    fake = _FakePysilk()
+    monkeypatch.setitem(sys.modules, "pysilk", fake)
+
+    wav_path = tmp_path / "stereo_48k.wav"
+    _make_wav(wav_path, 48000, channels=2)
+
+    await wav_to_tencent_silk(str(wav_path), str(tmp_path / "out.silk"))
+
+    assert len(fake.calls) == 1
+    # 48000 Hz is supported, so only downmix happens -- rate stays unchanged.
+    assert fake.calls[0]["sample_rate"] == 48000
+
+
+@pytest.mark.asyncio
+async def test_wav_to_tencent_silk_skips_resample_for_supported_rate(
+    tmp_path, monkeypatch
+):
+    """24000 Hz mono must go straight to pysilk without resampling."""
+    fake = _FakePysilk()
+    monkeypatch.setitem(sys.modules, "pysilk", fake)
+
+    wav_path = tmp_path / "tone_24k.wav"
+    _make_wav(wav_path, 24000)
+
+    await wav_to_tencent_silk(str(wav_path), str(tmp_path / "out.silk"))
+
+    assert len(fake.calls) == 1
+    assert fake.calls[0]["sample_rate"] == 24000


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

Fixes: #9089

astrbot/core/utils/tencent_record_helper.py: In wav_to_tencent_silk, added resampling logic before pysilk.encode:

Stereo audio is downmixed to mono via audioop.tomono
Unsupported sample rates (e.g. 44100, 22050 Hz) are resampled to 24000 Hz via audioop.ratecv
Duration calculation updated to use the actual resampled PCM length
Zero external dependencies — audioop is in the Python standard library (3.12) and audioop-lts is already declared in pyproject.toml for Python 3.13+
tests/test_media_utils.py: Enhanced tests:

Parametrized the existing real pysilk end-to-end test to cover 5 scenarios: 24k-mono, 44.1k-mono, 22.05k-mono, 48k-stereo, 44.1k-stereo
Added 3 mock tests verifying resample triggers (unsupported rate), downmix triggers (stereo), and no-op passthrough (supported rate)

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

test environment: python3.12

tests/test_media_utils.py::test_tencent_silk_encoding_uses_pysilk_tencent_format[24k-mono] PASSED [ 12%]
tests/test_media_utils.py::test_tencent_silk_encoding_uses_pysilk_tencent_format[44.1k-mono] PASSED [ 25%]
tests/test_media_utils.py::test_tencent_silk_encoding_uses_pysilk_tencent_format[22.05k-mono] PASSED [ 37%]
tests/test_media_utils.py::test_tencent_silk_encoding_uses_pysilk_tencent_format[48k-stereo] PASSED [ 50%]
tests/test_media_utils.py::test_tencent_silk_encoding_uses_pysilk_tencent_format[44.1k-stereo] PASSED [ 62%]
tests/test_media_utils.py::test_wav_to_tencent_silk_resamples_unsupported_rate PASSED [ 75%]
tests/test_media_utils.py::test_wav_to_tencent_silk_resamples_stereo PASSED [ 87%]
tests/test_media_utils.py::test_wav_to_tencent_silk_skips_resample_for_supported_rate PASSED [100%]

================= 8 passed, 41 deselected, 1 warning in 11.89s =================

注：这个 warning 是 Python 3.13 将移除 audioop 的弃用警告

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Handle WAV preprocessing for Tencent Silk encoding to support more input formats and ensure correct duration reporting.

Bug Fixes:
- Downmix stereo WAV input to mono and resample unsupported sample rates before Tencent Silk encoding to avoid pysilk input errors.
- Adjust Tencent Silk duration calculation to use the processed PCM length so reported durations stay accurate across resampling.

Tests:
- Extend end-to-end Tencent Silk encoding tests to cover multiple sample rate and channel combinations that previously failed.
- Add mock-based tests to verify when resampling, downmixing, and passthrough paths are used in wav_to_tencent_silk.