### PR TITLE
修复了DISCORD适配器注册命令正则过于严格的问题

### DIFF
--- a/astrbot/core/platform/sources/discord/discord_platform_adapter.py
+++ b/astrbot/core/platform/sources/discord/discord_platform_adapter.py
@@ -565,7 +565,7 @@ class DiscordPlatformAdapter(Platform):
             return None
 
         # Discord 斜杠指令名称规范
-        if not re.match(r"^[-_'\w]{1,32}$", cmd_name, re.UNICODE):
+        if cmd_name != cmd_name.lower() or not re.match(r"^[-_'\\w]{1,32}$", cmd_name):
             logger.debug(f"[Discord] Skipping invalid slash command format: {cmd_name}")
             return None
 

--- a/astrbot/core/platform/sources/discord/discord_platform_adapter.py
+++ b/astrbot/core/platform/sources/discord/discord_platform_adapter.py
@@ -565,7 +565,7 @@ class DiscordPlatformAdapter(Platform):
             return None
 
         # Discord 斜杠指令名称规范
-        if not re.match(r"^[a-z0-9_-]{1,32}$", cmd_name):
+        if not re.match(r"^[-_'\w]{1,32}$", cmd_name, re.UNICODE):
             logger.debug(f"[Discord] Skipping invalid slash command format: {cmd_name}")
             return None
 


### PR DESCRIPTION
针对：[Bug]Discord适配器中，注册命令匹配正则 [a-z0-9_-] 应当改成 [\w-] #9101
修复了discord斜杠的中文命令无法注册的问题
我就改了一行代码

# 改前
if not re.match(r"^[a-z0-9_-]{1,32}$", cmd_name):

# 改后
if not re.match(r"^[-_'\w]{1,32}$", cmd_name, re.UNICODE):

再无任何破坏性改动和其他改动

## Summary by Sourcery

Bug Fixes:
- Allow Discord slash commands with non-ASCII characters (e.g., Chinese) to be registered by broadening the command name validation regex.