### PR TITLE
fix: segmented reply not applied to send_message_to_user messages

### DIFF
--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -1,6 +1,4 @@
 import asyncio
-import math
-import random
 from collections.abc import AsyncGenerator
 
 import astrbot.core.message.components as Comp
@@ -10,6 +8,11 @@ from astrbot.core.message.message_event_result import MessageChain, ResultConten
 from astrbot.core.platform.astr_message_event import AstrMessageEvent
 from astrbot.core.star.star_handler import EventType
 from astrbot.core.utils.path_util import path_Mapping
+from astrbot.core.utils.segmented_reply import (
+    SEGMENTED_REPLY_UNSUPPORTED_PLATFORMS,
+    calc_segment_interval,
+    parse_interval_range,
+)
 
 from ..context import PipelineContext, call_event_hook
 from ..stage import Stage, register_stage
@@ -80,31 +83,17 @@ class RespondStage(Stage):
             interval_str: str = ctx.astrbot_config["platform_settings"][
                 "segmented_reply"
             ]["interval"]
-            interval_str_ls = interval_str.replace(" ", "").split(",")
-            try:
-                self.interval = [float(t) for t in interval_str_ls]
-            except BaseException as e:
-                logger.error(f"解析分段回复的间隔时间失败。{e}")
+            self.interval = list(parse_interval_range(interval_str))
             logger.info(f"分段回复间隔时间：{self.interval}")
-
-    async def _word_cnt(self, text: str) -> int:
-        """分段回复 统计字数"""
-        if all(ord(c) < 128 for c in text):
-            word_count = len(text.split())
-        else:
-            word_count = len([c for c in text if c.isalnum()])
-        return word_count
 
     async def _calc_comp_interval(self, comp: BaseMessageComponent) -> float:
         """分段回复 计算间隔时间"""
-        if self.interval_method == "log":
-            if isinstance(comp, Comp.Plain):
-                wc = await self._word_cnt(comp.text)
-                i = math.log(wc + 1, self.log_base)
-                return random.uniform(i, i + 0.5)
-            return random.uniform(1, 1.75)
-        # random
-        return random.uniform(self.interval[0], self.interval[1])
+        return calc_segment_interval(
+            comp.text if isinstance(comp, Comp.Plain) else None,
+            self.interval_method,
+            (self.interval[0], self.interval[1]),
+            self.log_base,
+        )
 
     async def _is_empty_message_chain(self, chain: list[BaseMessageComponent]) -> bool:
         """检查消息链是否为空
@@ -137,11 +126,7 @@ class RespondStage(Stage):
         if self.only_llm_result and not result.is_model_result():
             return False
 
-        if event.get_platform_name() in [
-            "qq_official_webhook",
-            "weixin_official_account",
-            "dingtalk",
-        ]:
+        if event.get_platform_name() in SEGMENTED_REPLY_UNSUPPORTED_PLATFORMS:
             return False
 
         return True

--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -1,5 +1,4 @@
 import random
-import re
 import time
 import traceback
 from collections.abc import AsyncGenerator
@@ -13,6 +12,13 @@ from astrbot.core.platform.message_type import MessageType
 from astrbot.core.star.session_llm_manager import SessionServiceManager
 from astrbot.core.star.star import star_map
 from astrbot.core.star.star_handler import EventType, star_handlers_registry
+from astrbot.core.utils.segmented_reply import (
+    SEGMENTED_REPLY_UNSUPPORTED_PLATFORMS,
+    cleanup_segments,
+    compile_split_words_pattern,
+    split_text_by_regex,
+    split_text_by_words,
+)
 
 from ..context import PipelineContext
 from ..stage import Stage, register_stage, registered_stages
@@ -74,15 +80,7 @@ class ResultDecorateStage(Stage):
         self.split_words = ctx.astrbot_config["platform_settings"][
             "segmented_reply"
         ].get("split_words", ["。", "？", "！", "~", "…"])
-        if self.split_words:
-            escaped_words = sorted(
-                [re.escape(word) for word in self.split_words], key=len, reverse=True
-            )
-            self.split_words_pattern = re.compile(
-                f"(.*?({'|'.join(escaped_words)})|.+$)", re.DOTALL
-            )
-        else:
-            self.split_words_pattern = None
+        self.split_words_pattern = compile_split_words_pattern(self.split_words)
         self.content_cleanup_rule = ctx.astrbot_config["platform_settings"][
             "segmented_reply"
         ]["content_cleanup_rule"]
@@ -100,28 +98,6 @@ class ResultDecorateStage(Stage):
 
         provider_cfg = ctx.astrbot_config.get("provider_settings", {})
         self.show_reasoning = provider_cfg.get("display_reasoning_text", False)
-
-    def _split_text_by_words(self, text: str) -> list[str]:
-        """使用分段词列表分段文本"""
-        if not self.split_words_pattern:
-            return [text]
-
-        segments = self.split_words_pattern.findall(text)
-        result = []
-        for seg in segments:
-            if isinstance(seg, tuple):
-                content = seg[0]
-                if not isinstance(content, str):
-                    continue
-                for word in self.split_words:
-                    if content.endswith(word):
-                        content = content[: -len(word)]
-                        break
-                if content.strip():
-                    result.append(content)
-            elif seg and seg.strip():
-                result.append(seg)
-        return result if result else [text]
 
     async def process(
         self,
@@ -202,11 +178,11 @@ class ResultDecorateStage(Stage):
                         break
 
             # 分段回复
-            if self.enable_segmented_reply and event.get_platform_name() not in [
-                "qq_official_webhook",
-                "weixin_official_account",
-                "dingtalk",
-            ]:
+            if (
+                self.enable_segmented_reply
+                and event.get_platform_name()
+                not in SEGMENTED_REPLY_UNSUPPORTED_PLATFORMS
+            ):
                 if (
                     self.only_llm_result and result.is_model_result()
                 ) or not self.only_llm_result:
@@ -220,33 +196,25 @@ class ResultDecorateStage(Stage):
 
                             # 根据 split_mode 选择分段方式
                             if self.split_mode == "words":
-                                split_response = self._split_text_by_words(comp.text)
+                                split_response = split_text_by_words(
+                                    comp.text,
+                                    self.split_words,
+                                    self.split_words_pattern,
+                                )
                             else:  # regex 模式
-                                try:
-                                    split_response = re.findall(
-                                        self.regex,
-                                        comp.text,
-                                        re.DOTALL | re.MULTILINE,
-                                    )
-                                except re.error:
-                                    logger.error(
-                                        f"分段回复正则表达式错误，使用默认分段方式: {traceback.format_exc()}",
-                                    )
-                                    split_response = re.findall(
-                                        r".*?[。？！~…]+|.+$",
-                                        comp.text,
-                                        re.DOTALL | re.MULTILINE,
-                                    )
+                                split_response = split_text_by_regex(
+                                    comp.text,
+                                    self.regex,
+                                )
 
                             if not split_response:
                                 new_chain.append(comp)
                                 continue
-                            for seg in split_response:
-                                if self.content_cleanup_rule:
-                                    seg = re.sub(self.content_cleanup_rule, "", seg)
-                                seg = seg.strip()
-                                if seg:
-                                    new_chain.append(Plain(seg))
+                            for seg in cleanup_segments(
+                                split_response,
+                                self.content_cleanup_rule,
+                            ):
+                                new_chain.append(Plain(seg))
                         else:
                             # 非 Plain 类型的消息段不分段
                             new_chain.append(comp)

--- a/astrbot/core/tools/message_tools.py
+++ b/astrbot/core/tools/message_tools.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import shlex
@@ -25,6 +26,17 @@ from astrbot.core.tools.registry import builtin_tool
 from astrbot.core.utils.astrbot_path import (
     get_astrbot_system_tmp_path,
     get_astrbot_temp_path,
+)
+from astrbot.core.utils.segmented_reply import (
+    DEFAULT_SPLIT_REGEX,
+    DEFAULT_SPLIT_WORDS,
+    SEGMENTED_REPLY_UNSUPPORTED_PLATFORMS,
+    calc_segment_interval,
+    cleanup_segments,
+    compile_split_words_pattern,
+    parse_interval_range,
+    split_text_by_regex,
+    split_text_by_words,
 )
 
 
@@ -187,6 +199,146 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
 
         raise FileNotFoundError(f"{component_type} path does not exist: {path}")
 
+    def _get_segmented_reply_conf(
+        self,
+        context: ContextWrapper[AstrAgentContext],
+        target_session: MessageSession,
+    ) -> dict | None:
+        """获取目标会话生效的分段回复配置；不需要分段时返回 None。
+
+        send_message_to_user 直接调用 send_message 发送，绕过了
+        ResultDecorateStage/RespondStage，因此需要在这里应用与 pipeline
+        一致的分段回复行为。See #8325.
+        """
+        try:
+            cfg = context.context.context.get_config(umo=str(target_session))
+        except Exception:
+            return None
+        if not isinstance(cfg, dict):
+            return None
+        seg_conf = cfg.get("platform_settings", {}).get("segmented_reply", {})
+        # 工具消息由 LLM 主动发出，属于 LLM 结果，无需检查 only_llm_result。
+        if not seg_conf.get("enable", False):
+            return None
+        platform_id = target_session.platform_id
+        if platform_id in SEGMENTED_REPLY_UNSUPPORTED_PLATFORMS:
+            return None
+        platform_manager = getattr(
+            context.context.context,
+            "platform_manager",
+            None,
+        )
+        if platform_manager is not None:
+            try:
+                for inst in platform_manager.platform_insts:
+                    meta = inst.meta()
+                    if (
+                        meta.id == platform_id
+                        and meta.name in SEGMENTED_REPLY_UNSUPPORTED_PLATFORMS
+                    ):
+                        return None
+            except Exception:
+                pass
+        return seg_conf
+
+    def _build_segmented_chains(
+        self,
+        components: list[Comp.BaseMessageComponent],
+        seg_conf: dict,
+    ) -> list[list[Comp.BaseMessageComponent]] | None:
+        """按分段回复配置将消息组件拆分为多条消息链；返回 None 表示原样发送。
+
+        与 pipeline 行为对齐：Plain 文本按配置分段，At/Reply 附加在第一条
+        消息上（Record 需要单独发送，不附加）。
+        """
+        try:
+            words_count_threshold = int(seg_conf.get("words_count_threshold", 150))
+        except (TypeError, ValueError):
+            words_count_threshold = 150
+        split_mode = seg_conf.get("split_mode", "regex")
+        regex = seg_conf.get("regex", DEFAULT_SPLIT_REGEX)
+        split_words = seg_conf.get("split_words", DEFAULT_SPLIT_WORDS)
+        content_cleanup_rule = seg_conf.get("content_cleanup_rule", "")
+        split_words_pattern = (
+            compile_split_words_pattern(split_words) if split_mode == "words" else None
+        )
+
+        header_comps = [
+            comp for comp in components if isinstance(comp, (Comp.At, Comp.Reply))
+        ]
+        body_comps = [
+            comp for comp in components if not isinstance(comp, (Comp.At, Comp.Reply))
+        ]
+        if not body_comps:
+            return None
+
+        units: list[Comp.BaseMessageComponent] = []
+        for comp in body_comps:
+            if (
+                not isinstance(comp, Comp.Plain)
+                or len(comp.text) > words_count_threshold
+            ):
+                # 与 ResultDecorateStage 一致：非 Plain 或超过阈值的长文本不分段
+                units.append(comp)
+                continue
+            if split_mode == "words":
+                split_response = split_text_by_words(
+                    comp.text,
+                    split_words,
+                    split_words_pattern,
+                )
+            else:
+                split_response = split_text_by_regex(comp.text, regex)
+            if not split_response:
+                units.append(comp)
+                continue
+            segments = cleanup_segments(split_response, content_cleanup_rule)
+            if segments:
+                units.extend(Comp.Plain(text=seg) for seg in segments)
+            else:
+                units.append(comp)
+
+        chains: list[list[Comp.BaseMessageComponent]] = []
+        pending_header = list(header_comps)
+        for unit in units:
+            if isinstance(unit, Comp.Record):
+                # Record 需要单独发送，与 RespondStage 一致
+                chains.append([unit])
+            else:
+                chains.append([*pending_header, unit])
+                pending_header = []
+        if pending_header:
+            # 全部是 Record 时，单独发送 At/Reply，避免丢失 LLM 显式要求的提及
+            chains.insert(0, pending_header)
+        return chains
+
+    async def _send_segmented_chains(
+        self,
+        context: ContextWrapper[AstrAgentContext],
+        target_session: MessageSession,
+        chains: list[list[Comp.BaseMessageComponent]],
+        seg_conf: dict,
+    ) -> None:
+        interval_method = seg_conf.get("interval_method", "random")
+        interval_range = parse_interval_range(str(seg_conf.get("interval", "1.5,3.5")))
+        try:
+            log_base = float(seg_conf.get("log_base", 2.6))
+        except (TypeError, ValueError):
+            log_base = 2.6
+        for chain in chains:
+            main_comp = chain[-1]
+            interval = calc_segment_interval(
+                main_comp.text if isinstance(main_comp, Comp.Plain) else None,
+                interval_method,
+                interval_range,
+                log_base,
+            )
+            await asyncio.sleep(interval)
+            await context.context.context.send_message(
+                target_session,
+                MessageChain(chain=chain),
+            )
+
     async def call(
         self, context: ContextWrapper[AstrAgentContext], **kwargs
     ) -> ToolExecResult:
@@ -318,7 +470,19 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
                 return f"error: invalid session: {session}"
 
         message_chain = MessageChain(chain=components)
-        await context.context.context.send_message(target_session, message_chain)
+        seg_conf = self._get_segmented_reply_conf(context, target_session)
+        seg_chains = (
+            self._build_segmented_chains(components, seg_conf) if seg_conf else None
+        )
+        if seg_chains:
+            await self._send_segmented_chains(
+                context,
+                target_session,
+                seg_chains,
+                seg_conf,
+            )
+        else:
+            await context.context.context.send_message(target_session, message_chain)
         if str(target_session) == current_session:
             context.context.event._has_send_oper = True
             sent_plain_text = message_chain.get_plain_text().strip()

--- a/astrbot/core/utils/segmented_reply.py
+++ b/astrbot/core/utils/segmented_reply.py
@@ -1,0 +1,124 @@
+"""分段回复（segmented reply）共享工具。
+
+ResultDecorateStage 与 send_message_to_user 等绕过 pipeline 直接发送消息的
+路径共用这里的分段逻辑，保证两条路径的分段行为一致。
+See https://github.com/AstrBotDevs/AstrBot/issues/8325
+"""
+
+import math
+import random
+import re
+import traceback
+
+from astrbot.core import logger
+
+# 这些平台不支持主动分段发送（只能被动回复），与 pipeline 各阶段保持一致。
+SEGMENTED_REPLY_UNSUPPORTED_PLATFORMS = (
+    "qq_official_webhook",
+    "weixin_official_account",
+    "dingtalk",
+)
+
+DEFAULT_SPLIT_REGEX = r".*?[。？！~…]+|.+$"
+DEFAULT_SPLIT_WORDS = ["。", "？", "！", "~", "…"]
+DEFAULT_INTERVAL_RANGE = (1.5, 3.5)
+
+
+def compile_split_words_pattern(split_words: list[str]) -> re.Pattern | None:
+    """编译分段词列表对应的正则。split_words 为空时返回 None。"""
+    if not split_words:
+        return None
+    escaped_words = sorted(
+        [re.escape(word) for word in split_words], key=len, reverse=True
+    )
+    return re.compile(f"(.*?({'|'.join(escaped_words)})|.+$)", re.DOTALL)
+
+
+def split_text_by_words(
+    text: str,
+    split_words: list[str],
+    split_words_pattern: re.Pattern | None,
+) -> list[str]:
+    """使用分段词列表分段文本"""
+    if not split_words_pattern:
+        return [text]
+
+    segments = split_words_pattern.findall(text)
+    result = []
+    for seg in segments:
+        if isinstance(seg, tuple):
+            content = seg[0]
+            if not isinstance(content, str):
+                continue
+            for word in split_words:
+                if content.endswith(word):
+                    content = content[: -len(word)]
+                    break
+            if content.strip():
+                result.append(content)
+        elif seg and seg.strip():
+            result.append(seg)
+    return result if result else [text]
+
+
+def split_text_by_regex(text: str, regex: str) -> list[str]:
+    """使用正则表达式分段文本，正则非法时回退到默认分段正则。"""
+    try:
+        return re.findall(regex, text, re.DOTALL | re.MULTILINE)
+    except re.error:
+        logger.error(
+            f"分段回复正则表达式错误，使用默认分段方式: {traceback.format_exc()}",
+        )
+        return re.findall(DEFAULT_SPLIT_REGEX, text, re.DOTALL | re.MULTILINE)
+
+
+def cleanup_segments(segments: list[str], content_cleanup_rule: str) -> list[str]:
+    """对分段结果应用内容过滤正则并去除空白段。"""
+    result = []
+    for seg in segments:
+        if content_cleanup_rule:
+            seg = re.sub(content_cleanup_rule, "", seg)
+        seg = seg.strip()
+        if seg:
+            result.append(seg)
+    return result
+
+
+def parse_interval_range(interval: str) -> tuple[float, float]:
+    """解析 "最小值,最大值" 形式的间隔配置，非法时回退默认值。"""
+    try:
+        parts = [float(t) for t in interval.replace(" ", "").split(",") if t]
+        if len(parts) >= 2:
+            return parts[0], parts[1]
+        if len(parts) == 1:
+            return parts[0], parts[0]
+        raise ValueError(f"invalid interval: {interval!r}")
+    except (TypeError, ValueError, AttributeError) as e:
+        logger.error(f"解析分段回复的间隔时间失败。{e}")
+        return DEFAULT_INTERVAL_RANGE
+
+
+def count_words(text: str) -> int:
+    """分段回复 统计字数"""
+    if all(ord(c) < 128 for c in text):
+        word_count = len(text.split())
+    else:
+        word_count = len([c for c in text if c.isalnum()])
+    return word_count
+
+
+def calc_segment_interval(
+    text: str | None,
+    interval_method: str,
+    interval_range: tuple[float, float],
+    log_base: float,
+) -> float:
+    """计算一段消息发送前的间隔时间。text 为 None 表示非纯文本消息段。"""
+    if interval_method == "log":
+        if text is not None:
+            wc = count_words(text)
+            i = math.log(wc + 1, log_base)
+            return random.uniform(i, i + 0.5)
+        return random.uniform(1, 1.75)
+    # random
+    return random.uniform(interval_range[0], interval_range[1])

--- a/astrbot/core/utils/segmented_reply.py
+++ b/astrbot/core/utils/segmented_reply.py
@@ -24,8 +24,33 @@ DEFAULT_SPLIT_WORDS = ["。", "？", "！", "~", "…"]
 DEFAULT_INTERVAL_RANGE = (1.5, 3.5)
 
 
+def _normalize_split_words(split_words: list[str]) -> list[str]:
+    if not isinstance(split_words, (list, tuple)):
+        return []
+    result = []
+    for word in split_words:
+        if word is None:
+            continue
+        word = str(word)
+        if word:
+            result.append(word)
+    return result
+
+
+def _normalize_regex_segments(segments) -> list[str]:
+    result = []
+    for seg in segments:
+        if isinstance(seg, tuple):
+            seg = "".join(part for part in seg if isinstance(part, str))
+        elif not isinstance(seg, str):
+            seg = str(seg)
+        result.append(seg)
+    return result
+
+
 def compile_split_words_pattern(split_words: list[str]) -> re.Pattern | None:
     """编译分段词列表对应的正则。split_words 为空时返回 None。"""
+    split_words = _normalize_split_words(split_words)
     if not split_words:
         return None
     escaped_words = sorted(
@@ -43,6 +68,7 @@ def split_text_by_words(
     if not split_words_pattern:
         return [text]
 
+    split_words = _normalize_split_words(split_words)
     segments = split_words_pattern.findall(text)
     result = []
     for seg in segments:
@@ -63,13 +89,20 @@ def split_text_by_words(
 
 def split_text_by_regex(text: str, regex: str) -> list[str]:
     """使用正则表达式分段文本，正则非法时回退到默认分段正则。"""
+    if not isinstance(regex, str):
+        logger.error(f"分段回复正则表达式类型错误，使用默认分段方式: {type(regex)}")
+        regex = DEFAULT_SPLIT_REGEX
     try:
-        return re.findall(regex, text, re.DOTALL | re.MULTILINE)
-    except re.error:
+        return _normalize_regex_segments(
+            re.findall(regex, text, re.DOTALL | re.MULTILINE),
+        )
+    except Exception:
         logger.error(
             f"分段回复正则表达式错误，使用默认分段方式: {traceback.format_exc()}",
         )
-        return re.findall(DEFAULT_SPLIT_REGEX, text, re.DOTALL | re.MULTILINE)
+        return _normalize_regex_segments(
+            re.findall(DEFAULT_SPLIT_REGEX, text, re.DOTALL | re.MULTILINE),
+        )
 
 
 def cleanup_segments(segments: list[str], content_cleanup_rule: str) -> list[str]:
@@ -117,8 +150,19 @@ def calc_segment_interval(
     if interval_method == "log":
         if text is not None:
             wc = count_words(text)
-            i = math.log(wc + 1, log_base)
-            return random.uniform(i, i + 0.5)
-        return random.uniform(1, 1.75)
+            safe_log_base = (
+                log_base
+                if isinstance(log_base, (int, float)) and log_base > 1.0
+                else 2.6
+            )
+            try:
+                i = math.log(wc + 1, safe_log_base)
+                interval = random.uniform(i, i + 0.5)
+            except Exception:
+                interval = random.uniform(1, 1.75)
+            return max(0.0, interval)
+        return max(0.0, random.uniform(1, 1.75))
     # random
-    return random.uniform(interval_range[0], interval_range[1])
+    low = max(0.0, float(interval_range[0]))
+    high = max(0.0, float(interval_range[1]))
+    return max(0.0, random.uniform(low, high))

--- a/tests/unit/test_message_tools.py
+++ b/tests/unit/test_message_tools.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+import astrbot.core.message.components as Comp
 from astrbot.core.message.message_event_result import MessageEventResult
 from astrbot.core.pipeline.respond.stage import RespondStage
 from astrbot.core.tools.message_tools import SendMessageToUserTool
@@ -15,13 +16,15 @@ def _make_context(
     role="admin",
     require_admin=True,
     runtime="local",
+    platform_settings=None,
 ):
     """Build a minimal ContextWrapper for SendMessageToUserTool."""
     cfg = {
         "provider_settings": {
             "computer_use_require_admin": require_admin,
             "computer_use_runtime": runtime,
-        }
+        },
+        "platform_settings": platform_settings or {},
     }
     extras = {}
     event = SimpleNamespace(
@@ -450,3 +453,146 @@ async def test_send_message_downloads_trailing_slash_sandbox_file_with_basename(
     sent_chain = ctx.context.context.send_message.await_args.args[1]
     sent_file = sent_chain.chain[0]
     assert sent_file.name == "export"
+
+
+def _seg_cfg(**overrides):
+    """Segmented-reply config with fast (zero) intervals for tests."""
+    seg = {
+        "enable": True,
+        "only_llm_result": True,
+        "interval_method": "random",
+        "interval": "0,0",
+        "log_base": 2.6,
+        "words_count_threshold": 150,
+        "split_mode": "words",
+        "split_words": ["|"],
+        "regex": ".*?[。？！~…]+|.+$",
+        "content_cleanup_rule": "",
+    }
+    seg.update(overrides)
+    return seg
+
+
+@pytest.mark.asyncio
+async def test_send_message_segments_mention_reply_like_pipeline():
+    """Issue #8325: tool-sent messages respect the segmented reply config.
+
+    A mention component must ride on the first segment, and the plain text
+    must be split the same way ResultDecorateStage splits pipeline replies.
+    """
+    tool = SendMessageToUserTool()
+    ctx = _make_context(
+        current_session="aiocqhttp:GroupMessage:684468174",
+        platform_settings={"segmented_reply": _seg_cfg()},
+    )
+    result = await tool.call(
+        ctx,
+        messages=[
+            {"type": "mention_user", "mention_user_id": "2842682873"},
+            {"type": "plain", "text": "啊这|找到bug了（"},
+        ],
+    )
+    assert "Message sent to session" in result
+    send = ctx.context.context.send_message
+    assert send.await_count == 2
+    first_chain = send.await_args_list[0].args[1].chain
+    second_chain = send.await_args_list[1].args[1].chain
+    assert isinstance(first_chain[0], Comp.At)
+    assert str(first_chain[0].qq) == "2842682873"
+    assert isinstance(first_chain[1], Comp.Plain)
+    assert first_chain[1].text == "啊这"
+    assert len(second_chain) == 1
+    assert isinstance(second_chain[0], Comp.Plain)
+    assert second_chain[0].text == "找到bug了（"
+    # Dedupe bookkeeping still records the original full text.
+    assert ctx.context.event.get_extra(
+        "_send_message_to_user_current_session_plain_texts",
+    ) == ["啊这|找到bug了（"]
+
+
+@pytest.mark.asyncio
+async def test_send_message_not_segmented_when_disabled():
+    """Segmented reply disabled keeps the single-send behavior."""
+    tool = SendMessageToUserTool()
+    ctx = _make_context(
+        platform_settings={"segmented_reply": _seg_cfg(enable=False)},
+    )
+    result = await tool.call(
+        ctx,
+        messages=[
+            {"type": "mention_user", "mention_user_id": "u1"},
+            {"type": "plain", "text": "啊这|找到bug了（"},
+        ],
+    )
+    assert "Message sent to session" in result
+    send = ctx.context.context.send_message
+    assert send.await_count == 1
+    chain = send.await_args.args[1].chain
+    assert [type(comp) for comp in chain] == [Comp.At, Comp.Plain]
+    assert chain[1].text == "啊这|找到bug了（"
+
+
+@pytest.mark.asyncio
+async def test_send_message_segmented_respects_words_count_threshold():
+    """Text longer than the threshold is sent unsplit, like the pipeline."""
+    tool = SendMessageToUserTool()
+    ctx = _make_context(
+        platform_settings={
+            "segmented_reply": _seg_cfg(words_count_threshold=5),
+        },
+    )
+    text = "这条消息比阈值长|不应被分段"
+    result = await tool.call(ctx, messages=[{"type": "plain", "text": text}])
+    assert "Message sent to session" in result
+    send = ctx.context.context.send_message
+    assert send.await_count == 1
+    assert send.await_args.args[1].chain[0].text == text
+
+
+@pytest.mark.asyncio
+async def test_send_message_segmented_regex_mode_with_cleanup_rule():
+    """Regex split mode and content cleanup rule match pipeline behavior."""
+    tool = SendMessageToUserTool()
+    ctx = _make_context(
+        platform_settings={
+            "segmented_reply": _seg_cfg(
+                split_mode="regex",
+                content_cleanup_rule="[。]",
+            ),
+        },
+    )
+    result = await tool.call(
+        ctx,
+        messages=[{"type": "plain", "text": "你好。再见。"}],
+    )
+    assert "Message sent to session" in result
+    send = ctx.context.context.send_message
+    assert send.await_count == 2
+    assert send.await_args_list[0].args[1].chain[0].text == "你好"
+    assert send.await_args_list[1].args[1].chain[0].text == "再见"
+
+
+@pytest.mark.asyncio
+async def test_send_message_not_segmented_on_unsupported_platform():
+    """Platforms that cannot send proactive segments keep the single send."""
+    tool = SendMessageToUserTool()
+    ctx = _make_context(
+        current_session="qq_official_webhook:GroupMessage:g1",
+        platform_settings={"segmented_reply": _seg_cfg()},
+    )
+    ctx.context.context.platform_manager = SimpleNamespace(
+        platform_insts=[
+            SimpleNamespace(
+                meta=lambda: SimpleNamespace(
+                    id="qq_official_webhook",
+                    name="qq_official_webhook",
+                ),
+            ),
+        ],
+    )
+    result = await tool.call(
+        ctx,
+        messages=[{"type": "plain", "text": "你好。再见。"}],
+    )
+    assert "Message sent to session" in result
+    assert ctx.context.context.send_message.await_count == 1

--- a/tests/unit/test_segmented_reply.py
+++ b/tests/unit/test_segmented_reply.py
@@ -1,0 +1,46 @@
+import pytest
+
+from astrbot.core.utils.segmented_reply import (
+    calc_segment_interval,
+    cleanup_segments,
+    compile_split_words_pattern,
+    split_text_by_regex,
+    split_text_by_words,
+)
+
+
+def test_regex_split_normalizes_capture_group_matches_before_cleanup():
+    segments = split_text_by_regex("alpha.beta.", r"(\w+)(\.)")
+
+    assert segments == ["alpha.", "beta."]
+    assert cleanup_segments(segments, r"\.") == ["alpha", "beta"]
+
+
+def test_regex_split_falls_back_when_regex_is_not_a_string():
+    assert split_text_by_regex("plain text", None) == ["plain text"]
+
+
+def test_split_words_ignores_invalid_container_types():
+    assert compile_split_words_pattern("|") is None
+
+
+def test_split_words_converts_non_string_words_for_matching():
+    split_words = [7, "", None]
+    pattern = compile_split_words_pattern(split_words)
+
+    assert split_text_by_words("alpha7beta", split_words, pattern) == ["alpha", "beta"]
+
+
+def test_log_interval_uses_safe_non_negative_fallback_for_invalid_base():
+    assert calc_segment_interval("alpha beta", "log", (0, 0), 1.0) >= 0
+
+
+@pytest.mark.parametrize(
+    "interval_range",
+    [
+        (-3.0, -1.0),
+        (-2.0, 2.0),
+    ],
+)
+def test_random_interval_is_never_negative(interval_range):
+    assert calc_segment_interval("alpha", "random", interval_range, 2.6) >= 0


### PR DESCRIPTION
Fixes #8325.

When the LLM mentions a group member, it must go through the `send_message_to_user` tool (a `mention_user` component cannot be produced by the plain-text reply path). The tool delivers messages via `context.send_message()` → `platform.send_by_session()` directly, which bypasses both `ResultDecorateStage` (text splitting / content cleanup) and `RespondStage` (interval sending). As a result, any message containing a mention is sent as one whole message and the user's segmented reply (分段回复) settings are silently ignored, while normal replies are segmented correctly — exactly the inconsistency reported in #8325.

### Modifications / 改动点

- **`astrbot/core/utils/segmented_reply.py` (new)**: shared segmented-reply helpers (split-words pattern compilation, words/regex splitting, content cleanup, interval parsing/calculation), extracted verbatim from the two pipeline stages so both paths behave identically.
- **`astrbot/core/pipeline/result_decorate/stage.py`** and **`astrbot/core/pipeline/respond/stage.py`**: refactored to use the shared helpers (behavior-preserving; the hardcoded unsupported-platform lists are also unified into one constant).
- **`astrbot/core/tools/message_tools.py`**: `SendMessageToUserTool` now applies the target session's segmented reply config before sending:
  - `Plain` text is split with the same `split_mode` / `regex` / `split_words` / `content_cleanup_rule` / `words_count_threshold` semantics as the pipeline;
  - `At` / `Reply` components ride on the first segment (matching `RespondStage`), `Record` is still sent separately;
  - segments are sent with the configured interval (`random` / `log`), matching pipeline pacing;
  - platforms that cannot send proactive segments (`qq_official_webhook`, `weixin_official_account`, `dingtalk`) keep the single-send behavior;
  - the dedupe bookkeeping (`_send_message_to_user_current_session_plain_texts`) still records the original full text, so the existing duplicate-reply suppression in `RespondStage` is unaffected.
  - `only_llm_result` is intentionally not checked here: tool messages are always LLM-initiated, so they qualify as LLM results.
- **`tests/unit/test_message_tools.py`**: 5 new regression tests covering the issue scenario (mention + custom split word), disabled config, words-count threshold, regex mode + cleanup rule, and unsupported platforms.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

New regression test reproducing the exact scenario from #8325 (mention + custom split word `|`) fails on master and passes with this fix:

```
$ python -m pytest tests/unit/test_message_tools.py -q
20 passed, 1 warning in 2.86s

$ python -m pytest tests/ -q
1692 passed, 4 warnings in 93.96s (0:01:33)

$ ruff format --check . && ruff check .
479 files already formatted
All checks passed!
```

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Apply segmented reply behavior to tool-sent messages and centralize segmented-reply logic for consistent behavior across pipelines and direct sends.

Bug Fixes:
- Ensure send_message_to_user messages respect segmented reply configuration, including splitting and pacing, consistent with normal pipeline replies.

Enhancements:
- Extract segmented reply utilities into a shared module and reuse them in ResultDecorateStage, RespondStage, and message tools for unified behavior across platforms.

Tests:
- Add regression tests covering segmented replies for mention + custom split word, disabled config, word-count threshold, regex mode with cleanup rules, and unsupported platforms.