### PR TITLE
chore: bump version to 4.26.4

### DIFF
--- a/astrbot/__init__.py
+++ b/astrbot/__init__.py
@@ -1,4 +1,4 @@
 import logging
 
-__version__ = "4.26.3"
+__version__ = "4.26.4"
 logger = logging.getLogger("astrbot")

--- a/changelogs/v4.26.4.md
+++ b/changelogs/v4.26.4.md
@@ -1,0 +1,13 @@
+## What's Changed
+
+- fix: astrbot_file_read_tool returns clear error for directory path instead of misleading Permission denied (#9088) (41f896030)
+- fix: reduce markdown streaming lag (#9097) (372b9f5bf)
+- fix: resample and downmix WAV files for Tencent Silk encoding (#9100) (4cf210e50)
+- fix: guard desktop-managed core restart (#9098) (b673cb375)
+- fix: updated reboot logic (#9073) (3b41a870f)
+- 修复了DISCORD适配器注册命令正则过于严格的问题 (#9102) (029e9c84a)
+- fix: reject non-200 download responses (#9085) (70a52ea6d)
+- fix: wecom adapter returning json instead of plain text (#9107) (ea19be1d0)
+- fix: preserve webhook callback responses (1e3b12acc)
+- fix: skip _unbind_plugin for inactivated plugins in reload() (#9096) (152fb3be8)
+- fix: apply fallback chat models to background wakeups (#9094) (413340fca)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AstrBot"
-version = "4.26.3"
+version = "4.26.4"
 description = "Easy-to-use multi-platform LLM chatbot and development framework"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }


### PR DESCRIPTION
## Summary\n- bump project version to 4.26.4\n- add changelog for v4.26.4\n\n## Validation\n- uv run python scripts/prepare_release.py 4.26.4\n- uv run ruff format --check .\n- uv run ruff check .

## Summary by Sourcery

Prepare the 4.26.4 release by updating project metadata and adding the corresponding changelog.

Build:
- Bump project/package version metadata from 4.26.3 to 4.26.4.

Documentation:
- Add changelog entry for release v4.26.4 summarizing recent bug fixes and improvements.