### PR TITLE
fix: adapt MiMo STT to V2.5 models and reject non-WAV audio payloads

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1593,7 +1593,7 @@ CONFIG_METADATA_2 = {
                         "enable": False,
                         "api_key": "",
                         "api_base": "https://api.xiaomimimo.com/v1",
-                        "model": "mimo-v2-omni",
+                        "model": "mimo-v2.5-asr",
                         "timeout": "20",
                         "proxy": "",
                     },

--- a/astrbot/core/provider/sources/mimo_api_common.py
+++ b/astrbot/core/provider/sources/mimo_api_common.py
@@ -81,6 +81,14 @@ async def prepare_audio_input(audio_source: str) -> tuple[str, list[Path]]:
     return audio_data.to_data_url(), []
 
 
+def _decode_base64_header(base64_data: str) -> bytes:
+    chunk = "".join(base64_data[:64].split())
+    padding = len(chunk) % 4
+    if padding:
+        chunk += "=" * (4 - padding)
+    return base64.b64decode(chunk)
+
+
 def _validate_wav_payload(base64_data: str, audio_source: str) -> None:
     """Reject audio payloads whose bytes are not RIFF/WAVE.
 
@@ -96,7 +104,7 @@ def _validate_wav_payload(base64_data: str, audio_source: str) -> None:
         MiMoAPIError: Raised when the payload is not valid WAV data.
     """
     try:
-        header = base64.b64decode(base64_data[:64])
+        header = _decode_base64_header(base64_data)
     except Exception:
         header = b""
     if len(header) >= 12 and header[:4] == b"RIFF" and header[8:12] == b"WAVE":

--- a/astrbot/core/provider/sources/mimo_api_common.py
+++ b/astrbot/core/provider/sources/mimo_api_common.py
@@ -1,3 +1,4 @@
+import base64
 from pathlib import Path
 
 import httpx
@@ -10,7 +11,16 @@ DEFAULT_MIMO_API_BASE = "https://api.xiaomimimo.com/v1"
 DEFAULT_MIMO_TTS_MODEL = "mimo-v2-tts"
 DEFAULT_MIMO_TTS_VOICE = "mimo_default"
 DEFAULT_MIMO_TTS_SEED_TEXT = "Hello, MiMo, have you had lunch?"
-DEFAULT_MIMO_STT_MODEL = "mimo-v2-omni"
+# The MiMo-V2 series went offline on 2026-06-30; mimo-v2.5-asr is the
+# dedicated speech recognition model per the official model lineup.
+DEFAULT_MIMO_STT_MODEL = "mimo-v2.5-asr"
+DEFAULT_MIMO_STT_SYSTEM_PROMPT = (
+    "You are a speech transcription assistant. "
+    "Transcribe the spoken content from the audio exactly and return only the transcription text."
+)
+DEFAULT_MIMO_STT_USER_PROMPT = (
+    "Please transcribe the content of the audio and return only the transcription text."
+)
 
 
 class MiMoAPIError(Exception):
@@ -67,7 +77,40 @@ async def prepare_audio_input(audio_source: str) -> tuple[str, list[Path]]:
     )
     if audio_data is None:
         raise ValueError(f"Invalid audio data: {describe_media_ref(audio_source)}")
+    _validate_wav_payload(audio_data.base64_data, audio_source)
     return audio_data.to_data_url(), []
+
+
+def _validate_wav_payload(base64_data: str, audio_source: str) -> None:
+    """Reject audio payloads whose bytes are not RIFF/WAVE.
+
+    MiMo only accepts wav/mp3 audio. When a platform voice file (e.g. Tencent
+    SILK from QQ) slips through the WAV conversion chain unchanged, the API
+    replies with an opaque HTTP 400, so fail locally with the real reason.
+
+    Args:
+        base64_data: Base64-encoded audio payload about to be sent.
+        audio_source: Original media reference, used in error messages.
+
+    Raises:
+        MiMoAPIError: Raised when the payload is not valid WAV data.
+    """
+    try:
+        header = base64.b64decode(base64_data[:64])
+    except Exception:
+        header = b""
+    if len(header) >= 12 and header[:4] == b"RIFF" and header[8:12] == b"WAVE":
+        return
+    if header.startswith((b"#!SILK_V3", b"\x02#!SILK_V3")):
+        raise MiMoAPIError(
+            "Audio for MiMo STT is still Tencent SILK data after WAV conversion; "
+            "check that the silk-python package is installed and working: "
+            f"{describe_media_ref(audio_source)}"
+        )
+    raise MiMoAPIError(
+        "Audio for MiMo STT could not be converted to WAV "
+        f"(unrecognized audio bytes): {describe_media_ref(audio_source)}"
+    )
 
 
 def cleanup_files(paths: list[Path]) -> None:

--- a/astrbot/core/provider/sources/mimo_stt_api_source.py
+++ b/astrbot/core/provider/sources/mimo_stt_api_source.py
@@ -4,6 +4,8 @@ from ..register import register_provider_adapter
 from .mimo_api_common import (
     DEFAULT_MIMO_API_BASE,
     DEFAULT_MIMO_STT_MODEL,
+    DEFAULT_MIMO_STT_SYSTEM_PROMPT,
+    DEFAULT_MIMO_STT_USER_PROMPT,
     MiMoAPIError,
     build_api_url,
     build_headers,
@@ -33,23 +35,49 @@ class ProviderMiMoSTTAPI(STTProvider):
         self.set_model(provider_config.get("model", DEFAULT_MIMO_STT_MODEL))
         self.client = create_http_client(self.timeout, self.proxy)
 
+    def _is_asr_model(self) -> bool:
+        return "asr" in (self.model_name or "").lower()
+
+    def _build_messages(self, audio_data_url: str) -> list[dict]:
+        audio_content = {
+            "type": "input_audio",
+            "input_audio": {
+                "data": audio_data_url,
+            },
+        }
+        if self._is_asr_model():
+            # Dedicated ASR models (speech-recognition docs) take bare audio.
+            return [
+                {
+                    "role": "user",
+                    "content": [audio_content],
+                },
+            ]
+        # Multimodal models such as mimo-v2.5 (audio-understanding docs)
+        # require a text instruction alongside the audio, otherwise the API
+        # rejects the request.
+        return [
+            {
+                "role": "system",
+                "content": DEFAULT_MIMO_STT_SYSTEM_PROMPT,
+            },
+            {
+                "role": "user",
+                "content": [
+                    audio_content,
+                    {
+                        "type": "text",
+                        "text": DEFAULT_MIMO_STT_USER_PROMPT,
+                    },
+                ],
+            },
+        ]
+
     async def get_text(self, audio_url: str) -> str:
         audio_data_url, cleanup_paths = await prepare_audio_input(audio_url)
         payload = {
             "model": self.model_name,
-            "messages": [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "input_audio",
-                            "input_audio": {
-                                "data": audio_data_url,
-                            },
-                        },
-                    ],
-                },
-            ],
+            "messages": self._build_messages(audio_data_url),
             "max_completion_tokens": 1024,
         }
 

--- a/tests/test_mimo_api_sources.py
+++ b/tests/test_mimo_api_sources.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 from types import SimpleNamespace
 
 import pytest
@@ -11,7 +12,9 @@ from astrbot.core.provider.sources.mimo_api_common import (
 from astrbot.core.provider.sources.mimo_stt_api_source import ProviderMiMoSTTAPI
 from astrbot.core.provider.sources.mimo_tts_api_source import ProviderMiMoTTSAPI
 
-MIMO_STT_TEST_AUDIO_DATA_URL = "data:audio/wav;base64,ZmFrZQ=="
+MIMO_STT_TEST_WAV_HEADER = b"RIFF\x24\x08\x00\x00WAVEfmt "
+MIMO_STT_TEST_AUDIO_BASE64 = base64.b64encode(MIMO_STT_TEST_WAV_HEADER).decode()
+MIMO_STT_TEST_AUDIO_DATA_URL = f"data:audio/wav;base64,{MIMO_STT_TEST_AUDIO_BASE64}"
 
 
 def _make_tts_provider(overrides: dict | None = None) -> ProviderMiMoTTSAPI:
@@ -33,7 +36,7 @@ def _make_stt_provider(overrides: dict | None = None) -> ProviderMiMoSTTAPI:
     provider_config = {
         "id": "test-mimo-stt",
         "type": "mimo_stt_api",
-        "model": "mimo-v2-omni",
+        "model": "mimo-v2.5-asr",
         "api_key": "test-key",
     }
     if overrides:
@@ -196,7 +199,8 @@ async def test_mimo_tts_get_audio_handles_empty_choices():
 
 
 @pytest.mark.asyncio
-async def test_mimo_stt_payload_includes_audio_only(monkeypatch):
+async def test_mimo_stt_asr_model_payload_includes_audio_only(monkeypatch):
+    """专用 ASR 模型按官方语音识别文档只传 input_audio，不带任何提示词。"""
     provider = _make_stt_provider(
         {
             "mimo-stt-system-prompt": "system prompt",
@@ -248,10 +252,91 @@ async def test_mimo_stt_payload_includes_audio_only(monkeypatch):
     ]
 
 
+def test_mimo_stt_default_model_is_v25_asr():
+    """mimo-v2-omni 已于 2026-06-30 下线，默认模型应为 mimo-v2.5-asr。"""
+    provider = ProviderMiMoSTTAPI(
+        provider_config={
+            "id": "test-mimo-stt",
+            "type": "mimo_stt_api",
+            "api_key": "test-key",
+        },
+        provider_settings={},
+    )
+    try:
+        assert provider.model_name == "mimo-v2.5-asr"
+    finally:
+        asyncio.run(provider.terminate())
+
+
+@pytest.mark.asyncio
+async def test_mimo_stt_multimodal_model_payload_includes_transcription_prompts(
+    monkeypatch,
+):
+    """非 ASR 模型（如 mimo-v2.5）按官方音频理解文档要求携带 system 与 text 指令。"""
+    provider = _make_stt_provider({"model": "mimo-v2.5"})
+
+    captured: dict = {}
+
+    async def fake_prepare_audio_input(_audio_source: str):
+        return MIMO_STT_TEST_AUDIO_DATA_URL, []
+
+    class _Response:
+        status_code = 200
+        text = '{"choices":[{"message":{"content":"transcribed text"}}]}'
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"choices": [{"message": {"content": "transcribed text"}}]}
+
+    async def fake_post(_url, headers=None, json=None):
+        captured["json"] = json
+        return _Response()
+
+    monkeypatch.setattr(
+        "astrbot.core.provider.sources.mimo_stt_api_source.prepare_audio_input",
+        fake_prepare_audio_input,
+    )
+    provider.client = SimpleNamespace(post=fake_post)
+
+    result = await provider.get_text("/tmp/test.wav")
+
+    assert result == "transcribed text"
+    assert captured["json"]["messages"] == [
+        {
+            "role": "system",
+            "content": (
+                "You are a speech transcription assistant. "
+                "Transcribe the spoken content from the audio exactly "
+                "and return only the transcription text."
+            ),
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_audio",
+                    "input_audio": {
+                        "data": MIMO_STT_TEST_AUDIO_DATA_URL,
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": (
+                        "Please transcribe the content of the audio "
+                        "and return only the transcription text."
+                    ),
+                },
+            ],
+        },
+    ]
+
+
 @pytest.mark.asyncio
 async def test_mimo_stt_prepare_audio_input_returns_data_url(monkeypatch):
     class _ResolvedAudio:
-        base64_data = "ZmFrZQ=="
+        base64_data = MIMO_STT_TEST_AUDIO_BASE64
         mime_type = "audio/wav"
         format = "wav"
 
@@ -282,6 +367,35 @@ async def test_mimo_stt_prepare_audio_input_returns_data_url(monkeypatch):
 
     assert audio_data == MIMO_STT_TEST_AUDIO_DATA_URL
     assert cleanup_paths == []
+
+
+@pytest.mark.asyncio
+async def test_mimo_stt_prepare_audio_input_rejects_non_wav_payload(monkeypatch):
+    """上游 SILK→WAV 转换静默失败时应本地报错，而不是把坏字节发给 API（#9113）。"""
+    silk_base64 = base64.b64encode(b"\x02#!SILK_V3" + b"\x00" * 16).decode()
+
+    class _ResolvedAudio:
+        base64_data = silk_base64
+        mime_type = "audio/wav"
+        format = "wav"
+
+        def to_data_url(self):
+            return f"data:audio/wav;base64,{silk_base64}"
+
+    class _Resolver:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        async def to_base64_data(self, **_kwargs):
+            return _ResolvedAudio()
+
+    monkeypatch.setattr(
+        "astrbot.core.provider.sources.mimo_api_common.MediaResolver",
+        _Resolver,
+    )
+
+    with pytest.raises(MiMoAPIError, match="SILK"):
+        await prepare_audio_input("/tmp/test.wav")
 
 
 @pytest.mark.asyncio

--- a/tests/test_mimo_api_sources.py
+++ b/tests/test_mimo_api_sources.py
@@ -6,6 +6,7 @@ import pytest
 
 from astrbot.core.provider.sources.mimo_api_common import (
     MiMoAPIError,
+    _validate_wav_payload,
     build_headers,
     prepare_audio_input,
 )
@@ -396,6 +397,12 @@ async def test_mimo_stt_prepare_audio_input_rejects_non_wav_payload(monkeypatch)
 
     with pytest.raises(MiMoAPIError, match="SILK"):
         await prepare_audio_input("/tmp/test.wav")
+
+
+def test_mimo_stt_wav_validation_accepts_unpadded_base64_header():
+    wav_base64 = base64.b64encode(MIMO_STT_TEST_WAV_HEADER).decode().rstrip("=")
+
+    _validate_wav_payload(wav_base64, "/tmp/test.wav")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #9113

The MiMo STT provider is currently broken for every default configuration, in three stacking ways:

1. **Dead default model.** The default `mimo-v2-omni` (and the whole MiMo-V2 series) went offline on 2026-06-30 per the [official deprecation notice](https://mimo.mi.com/docs/updates/deprecate), so requests with the default config always fail.
2. **Bare audio is rejected by multimodal models.** For the multimodal `mimo-v2.5`, the [audio understanding docs](https://mimo.mi.com/docs/zh-CN/quick-start/usage-guide/multimodal-understanding/audio-understanding) require a text instruction alongside `input_audio`; sending audio alone gets HTTP 400.
3. **Non-WAV bytes are silently shipped to the API.** When a platform voice file (e.g. Tencent SILK from QQ/NapCat) slips through the WAV conversion chain unchanged, the raw bytes are base64-encoded as `audio/wav` and sent anyway — producing exactly the opaque `400 ... invalid audio format, only mp3/flac/m4a/wav/ogg are supported` error shown in the issue logs, with no hint about the real local cause.

### Modifications / 改动点

**`astrbot/core/provider/sources/mimo_api_common.py`**
- `DEFAULT_MIMO_STT_MODEL`: `mimo-v2-omni` → `mimo-v2.5-asr`, the dedicated speech recognition model in the [current model lineup](https://mimo.mi.com/docs/quick-start/summary/model). Chosen over `mimo-v2.5` because the [official ASR docs](https://mimo.mi.com/docs/zh-CN/quick-start/usage-guide/audio/Speech-Recognition) use exactly the bare `input_audio` payload this provider already sends, and ASR is billed per audio hour rather than per token.
- Restored `DEFAULT_MIMO_STT_SYSTEM_PROMPT` / `DEFAULT_MIMO_STT_USER_PROMPT` (the same strings removed in #8938), now used **only** for non-ASR multimodal models — see below. No config surface is re-added.
- `prepare_audio_input()` now validates that the resolved payload really is RIFF/WAVE before calling the API. If not, it raises `MiMoAPIError` locally with the actual reason, including a dedicated message when the bytes are still un-converted Tencent SILK data (pointing at silk-python).

**`astrbot/core/provider/sources/mimo_stt_api_source.py`**
- Payload construction is now split by model family:
  - dedicated `*asr*` models keep the bare `input_audio` payload, matching the ASR docs and preserving the prompt-removal decision from #8938;
  - non-ASR multimodal models (e.g. `mimo-v2.5`) get the system prompt + text instruction required by the audio understanding docs.

**`astrbot/core/config/default.py`**
- STT provider template default model → `mimo-v2.5-asr`.

**`tests/test_mimo_api_sources.py`**
- Three new regression tests: default model value, multimodal payload shape, and non-WAV payload rejection. STT test fixtures now use genuine RIFF/WAVE header bytes instead of arbitrary base64.

Notes:
- `DEFAULT_MIMO_TTS_MODEL = "mimo-v2-tts"` is hit by the same V2 shutdown, but this issue and PR are scoped to STT; TTS can be handled in a follow-up.
- The deeper conversion-chain issue (a `.wav`-suffixed file with non-WAV content passes `convert_audio_format()` untouched via its extension short-circuit) lives in shared `media_utils` code used by all platforms; this PR deliberately guards at the MiMo provider boundary instead of changing shared conversion semantics.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

(Users who explicitly configured a model keep it — only the default value changes, and the old default is already dead upstream.)

### Screenshots or Test Results / 运行截图或测试结果

**Verification steps:**

1. `python -m pytest tests/test_mimo_api_sources.py -q` — the 3 new tests fail on `master` (old default model, no prompts for `mimo-v2.5`, SILK bytes not rejected) and pass with this fix:

```
master:   3 failed, 15 passed
this PR: 18 passed, 1 warning in 2.95s
```

2. Related audio/media suites stay green:

```
$ python -m pytest tests/test_media_utils.py tests/test_platform_audio_media_resolver.py tests/test_agent_runner_media_resolver.py -q
56 passed, 3 warnings in 6.59s
```

3. `make pr-test-neo` (uv sync, repo-wide ruff format/check, Neo tests, startup smoke test):

```
==> Running Ruff format check
478 files already formatted
==> Running Ruff lint check
All checks passed!
==> Running pytest
12 passed, 1 warning in 4.47s
==> Starting smoke test on http://localhost:6185
==> Smoke test passed
==> PR checks completed successfully
```

4. End-to-end behavior demo through the **real** `MediaResolver` conversion chain (no mocks):

<details>
<summary>Demo script output (default model, both payload shapes, mis-labeled .wav rejected, genuine .wav passes)</summary>

```
=== 1) Default STT model (was: mimo-v2-omni, offline since 2026-06-30) ===
default model: mimo-v2.5-asr

=== 2) Payload for dedicated ASR model (bare audio per ASR docs) ===
[
  {
    "role": "user",
    "content": [
      {
        "type": "input_audio",
        "input_audio": {
          "data": "data:audio/wav;base64,UklGRiQAAABXQVZF"
        }
      }
    ]
  }
]

=== 3) Payload for multimodal mimo-v2.5 (system + text per audio-understanding docs) ===
[
  {
    "role": "system",
    "content": "You are a speech transcription assistant. Transcribe the spoken content from the audio exactly and return only the transcription text."
  },
  {
    "role": "user",
    "content": [
      {
        "type": "input_audio",
        "input_audio": {
          "data": "data:audio/wav;base64,UklGRiQAAABXQVZF"
        }
      },
      {
        "type": "text",
        "text": "Please transcribe the content of the audio and return only the transcription text."
      }
    ]
  }
]

=== 4) Mis-labeled .wav (unrecognized bytes) now fails fast locally ===
MiMoAPIError: Audio for MiMo STT could not be converted to WAV (unrecognized audio bytes): local media path name='tmpiy6u1x1s.wav' len=20

=== 5) Genuine WAV still passes the real conversion chain ===
OK, data url head: data:audio/wav;base64,UklGRqQMAABXQVZFZm10IBAAAAABAAEAgD4AAA
```

</details>

Step 4 reproduces the silent failure path from the issue logs (a `.wav`-named file whose content never got converted): previously those bytes were sent to the API and came back as the confusing HTTP 400; now the provider fails locally with the real reason before any network call.

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Update MiMo STT defaults and request shaping to work with current v2.5 models while validating audio payloads before sending them to the API.

Bug Fixes:
- Switch the default MiMo STT model to the v2.5 ASR model so default configurations use a live, dedicated speech recognition model.
- Adjust multimodal MiMo STT requests so non-ASR models receive both audio and required transcription prompts, preventing API rejections.
- Validate outgoing STT audio as RIFF/WAVE and raise local errors, including a specific message for unconverted Tencent SILK data, instead of silently sending invalid bytes to MiMo.

Enhancements:
- Introduce shared STT system and user prompts for use with non-ASR multimodal MiMo models.

Tests:
- Add regression tests for the new default STT model, multimodal payload structure, and rejection of non-WAV audio payloads, updating fixtures to use real WAV headers.