### PR TITLE
fix(kb): replace fragile error string matching with pre-check for duplicate kb_name

### DIFF
--- a/astrbot/core/knowledge_base/kb_mgr.py
+++ b/astrbot/core/knowledge_base/kb_mgr.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from sqlalchemy.exc import IntegrityError  # type: ignore
+
 from astrbot.core import logger
 from astrbot.core.provider.manager import ProviderManager
 from astrbot.core.utils.astrbot_path import get_astrbot_knowledge_base_path
@@ -131,8 +133,11 @@ class KnowledgeBaseManager:
                 await session.commit()
                 self.kb_insts[kb.kb_id] = kb_helper
                 return kb_helper
-        except Exception as e:
-            logger.error(f"创建知识库失败: {e}")
+        except IntegrityError as e:
+            logger.exception("创建知识库失败：唯一约束冲突")
+            raise ValueError(f"知识库名称 '{kb_name}' 已存在") from e
+        except Exception:
+            logger.exception("创建知识库失败")
             raise
 
     async def get_kb(self, kb_id: str) -> KBHelper | None:

--- a/astrbot/core/knowledge_base/kb_mgr.py
+++ b/astrbot/core/knowledge_base/kb_mgr.py
@@ -98,6 +98,11 @@ class KnowledgeBaseManager:
         """创建新的知识库实例"""
         if embedding_provider_id is None:
             raise ValueError("创建知识库时必须提供embedding_provider_id")
+        # 预先检查名称是否已存在，避免依赖异常字符串匹配
+        existing = await self.kb_db.get_kb_by_name(kb_name)
+        if existing:
+            raise ValueError(f"知识库名称 '{kb_name}' 已存在")
+
         kb = KnowledgeBase(
             kb_name=kb_name,
             description=description,
@@ -127,8 +132,7 @@ class KnowledgeBaseManager:
                 self.kb_insts[kb.kb_id] = kb_helper
                 return kb_helper
         except Exception as e:
-            if "kb_name" in str(e):
-                raise ValueError(f"知识库名称 '{kb_name}' 已存在")
+            logger.error(f"创建知识库失败: {e}")
             raise
 
     async def get_kb(self, kb_id: str) -> KBHelper | None:


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

创建知识库时，原有的重复名称检测依赖于捕获所有异常后检查 `"kb_name" in str(e)`，这种字符串匹配方式脆弱且不可靠。

### Modifications / 改动点

- `astrbot/core/knowledge_base/kb_mgr.py`: 在创建知识库前预先查询名称是否已存在，如果存在直接抛出明确的 `ValueError` 异常。避免依赖异常字符串匹配合法性检查

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```
tests/ -k "kb" 19 passed
```

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Improve robustness of knowledge base creation error handling by explicitly checking for duplicate names before creation and logging unexpected failures.

Bug Fixes:
- Prevent fragile duplicate knowledge base name detection that relied on matching substrings in exception messages.

Enhancements:
- Add a pre-query for existing knowledge base names and raise a clear ValueError when a duplicate is found.
- Log knowledge base creation failures instead of reinterpreting all exceptions as duplicate name errors.