### PR TITLE
fix(kb): improve retrieval resilience on per-KB failure and rerank selection

### DIFF
--- a/astrbot/core/knowledge_base/retrieval/manager.py
+++ b/astrbot/core/knowledge_base/retrieval/manager.py
@@ -171,8 +171,8 @@ class RetrievalManager:
 
         # 5. Rerank
         first_rerank = None
-        for kb_id in kb_ids:
-            vec_db = kb_options[kb_id].get("vec_db")
+        for kb_opt in kb_options.values():
+            vec_db = kb_opt.get("vec_db")
             rerank_provider = (
                 getattr(vec_db, "rerank_provider", None) if vec_db else None
             )
@@ -228,7 +228,10 @@ class RetrievalManager:
 
                 all_results.extend(vec_results)
             except Exception as e:
-                logger.error(f"知识库 {kb_id} 稠密检索失败: {e}", exc_info=True)
+                logger.error(
+                    f"知识库 {kb_id} 稠密检索失败: {type(e).__name__}: {e}",
+                    exc_info=True,
+                )
                 # skip the faulty KB and continue
 
         # 按相似度排序并返回 top_k

--- a/astrbot/core/knowledge_base/retrieval/manager.py
+++ b/astrbot/core/knowledge_base/retrieval/manager.py
@@ -172,20 +172,11 @@ class RetrievalManager:
         # 5. Rerank
         first_rerank = None
         for kb_id in kb_ids:
-            vec_db = kb_options[kb_id]["vec_db"]
+            vec_db = kb_options[kb_id].get("vec_db")
             rerank_provider = (
                 getattr(vec_db, "rerank_provider", None) if vec_db else None
             )
-            if rerank_provider is None:
-                continue
-
-            rerank_pi = kb_options[kb_id]["rerank_provider_id"]
-            if (
-                vec_db
-                and rerank_provider
-                and rerank_pi
-                and rerank_pi == rerank_provider.meta().id
-            ):
+            if rerank_provider is not None:
                 first_rerank = rerank_provider
                 break
         if first_rerank and retrieval_results:
@@ -238,9 +229,7 @@ class RetrievalManager:
                 all_results.extend(vec_results)
             except Exception as e:
                 logger.error(f"知识库 {kb_id} 稠密检索失败: {e}", exc_info=True)
-                if len(kb_ids) == 1:
-                    raise RuntimeError(f"知识库 {kb_id} 稠密检索失败: {e}") from e
-                # multi-KB: skip the faulty KB and continue
+                # skip the faulty KB and continue
 
         # 按相似度排序并返回 top_k
         all_results.sort(key=lambda x: x.similarity, reverse=True)


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

- `astrbot/core/knowledge_base/retrieval/manager.py`:
  - 单知识库稠密检索失败时不再抛出 `RuntimeError`，改为记录日志并跳过错的知识库，与其他知识库的行为保持一致，避免单点故障导致整体检索崩溃
  - 简化 rerank provider 选择逻辑：移除多余的 `rerank_pi == rerank_provider.meta().id` 检查（provider 本身就是从该 ID 加载的），以及不必要的嵌套条件

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```
tests/ -k "kb" 19 passed
```

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Improve knowledge base retrieval resilience and simplify rerank provider selection.

Bug Fixes:
- Prevent single knowledge base dense retrieval failures from raising runtime errors by logging and skipping faulty knowledge bases instead.

Enhancements:
- Simplify rerank provider detection by selecting the first available provider directly and making vec_db access more robust when retrieving rerank providers.