### PR TITLE
fix: reject invalid backup uploads

### DIFF
--- a/astrbot/dashboard/services/backup_service.py
+++ b/astrbot/dashboard/services/backup_service.py
@@ -221,11 +221,16 @@ class BackupService:
             with zipfile.ZipFile(zip_path, "r") as zf:
                 if "manifest.json" in zf.namelist():
                     manifest_data = zf.read("manifest.json")
-                    return json.loads(manifest_data.decode("utf-8"))
+                    manifest = json.loads(manifest_data.decode("utf-8"))
+                    return manifest if isinstance(manifest, dict) else None
                 return None
         except Exception as exc:
             logger.debug(f"读取备份 manifest 失败: {exc}")
         return None
+
+    def validate_uploaded_backup(self, zip_path: str) -> None:
+        if self.get_backup_manifest(zip_path) is None:
+            raise BackupServiceError("无效的备份文件：缺少或无法读取 manifest.json")
 
     def list_backups(self, *, page: int, page_size: int) -> dict:
         self.ensure_cleanup_task_started()
@@ -315,7 +320,13 @@ class BackupService:
 
         Path(self.backup_dir).mkdir(parents=True, exist_ok=True)
         zip_path = os.path.join(self.backup_dir, unique_filename)
-        await self._save_upload(file, zip_path)
+        try:
+            await self._save_upload(file, zip_path)
+            self.validate_uploaded_backup(zip_path)
+        except Exception:
+            if os.path.exists(zip_path):
+                os.remove(zip_path)
+            raise
 
         logger.info(
             f"上传的备份文件已保存: {unique_filename} (原始名称: {file.filename})"
@@ -463,6 +474,7 @@ class BackupService:
                             outfile.write(data_block)
 
             file_size = os.path.getsize(output_path)
+            self.validate_uploaded_backup(output_path)
             self.mark_backup_as_uploaded(output_path)
             logger.info(f"分片上传完成: {filename}, size={file_size}, chunks={total}")
             await self.cleanup_upload_session(upload_id)

--- a/astrbot/dashboard/services/backup_service.py
+++ b/astrbot/dashboard/services/backup_service.py
@@ -222,7 +222,13 @@ class BackupService:
                 if "manifest.json" in zf.namelist():
                     manifest_data = zf.read("manifest.json")
                     manifest = json.loads(manifest_data.decode("utf-8"))
-                    return manifest if isinstance(manifest, dict) else None
+                    if not isinstance(manifest, dict):
+                        logger.debug(
+                            "备份 manifest 格式无效: expected dict, got %s",
+                            type(manifest).__name__,
+                        )
+                        return None
+                    return manifest
                 return None
         except Exception as exc:
             logger.debug(f"读取备份 manifest 失败: {exc}")
@@ -324,8 +330,11 @@ class BackupService:
             await self._save_upload(file, zip_path)
             self.validate_uploaded_backup(zip_path)
         except Exception:
-            if os.path.exists(zip_path):
-                os.remove(zip_path)
+            try:
+                if os.path.exists(zip_path):
+                    os.remove(zip_path)
+            except Exception as exc:
+                logger.warning(f"清理失败的备份文件失败: {exc}")
             raise
 
         logger.info(
@@ -474,7 +483,11 @@ class BackupService:
                             outfile.write(data_block)
 
             file_size = os.path.getsize(output_path)
-            self.validate_uploaded_backup(output_path)
+            try:
+                self.validate_uploaded_backup(output_path)
+            except Exception:
+                await self.cleanup_upload_session(upload_id)
+                raise
             self.mark_backup_as_uploaded(output_path)
             logger.info(f"分片上传完成: {filename}, size={file_size}, chunks={total}")
             await self.cleanup_upload_session(upload_id)
@@ -485,8 +498,11 @@ class BackupService:
                 "size": file_size,
             }
         except Exception:
-            if os.path.exists(output_path):
-                os.remove(output_path)
+            try:
+                if os.path.exists(output_path):
+                    os.remove(output_path)
+            except Exception as exc:
+                logger.warning(f"清理失败的备份文件失败: {exc}")
             raise
 
     async def upload_abort(self, data: object) -> tuple[dict | None, str | None]:

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -3,8 +3,10 @@
 import json
 import os
 import re
+import time
 import zipfile
 from datetime import datetime
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -29,6 +31,8 @@ from astrbot.core.db.po import (
 )
 from astrbot.core.utils.version_comparator import VersionComparator
 from astrbot.dashboard.services.backup_service import (
+    BackupService,
+    BackupServiceError,
     generate_unique_filename,
     secure_filename,
 )
@@ -749,6 +753,79 @@ class TestSecureFilename:
         assert result.startswith("my_backup_file_")
         assert result.endswith(".zip")
         assert re.search(r"my_backup_file_\d{8}_\d{6}\.zip", result)
+
+
+class TestBackupUploadValidation:
+    """备份上传校验测试"""
+
+    @pytest.mark.asyncio
+    async def test_upload_backup_rejects_invalid_zip(
+        self, mock_main_db, tmp_path, monkeypatch
+    ):
+        """测试直接上传无效 ZIP 会失败且不留下文件"""
+        backup_dir = tmp_path / "backups"
+        data_dir = tmp_path / "data"
+        backup_dir.mkdir()
+        data_dir.mkdir()
+        monkeypatch.setattr(
+            "astrbot.dashboard.services.backup_service.get_astrbot_backups_path",
+            lambda: str(backup_dir),
+        )
+        monkeypatch.setattr(
+            "astrbot.dashboard.services.backup_service.get_astrbot_data_path",
+            lambda: str(data_dir),
+        )
+        core_lifecycle = MagicMock()
+        core_lifecycle.astrbot_config = {}
+        service = BackupService(mock_main_db, core_lifecycle)
+        upload = MagicMock()
+        upload.filename = "bad.zip"
+        upload.save = AsyncMock(
+            side_effect=lambda target: Path(target).write_bytes(b"not a zip")
+        )
+
+        with pytest.raises(BackupServiceError, match="无效的备份文件"):
+            await service.upload_backup(upload)
+
+        assert list(backup_dir.glob("*.zip")) == []
+
+    @pytest.mark.asyncio
+    async def test_upload_complete_rejects_invalid_zip(
+        self, mock_main_db, tmp_path, monkeypatch
+    ):
+        """测试分片上传无效 ZIP 会失败且清理合并文件"""
+        backup_dir = tmp_path / "backups"
+        data_dir = tmp_path / "data"
+        chunk_dir = backup_dir / ".chunks" / "upload-1"
+        chunk_dir.mkdir(parents=True)
+        data_dir.mkdir()
+        monkeypatch.setattr(
+            "astrbot.dashboard.services.backup_service.get_astrbot_backups_path",
+            lambda: str(backup_dir),
+        )
+        monkeypatch.setattr(
+            "astrbot.dashboard.services.backup_service.get_astrbot_data_path",
+            lambda: str(data_dir),
+        )
+        core_lifecycle = MagicMock()
+        core_lifecycle.astrbot_config = {}
+        service = BackupService(mock_main_db, core_lifecycle)
+        (chunk_dir / "0.part").write_bytes(b"not a zip")
+        service.upload_sessions["upload-1"] = {
+            "filename": "bad.zip",
+            "original_filename": "bad.zip",
+            "total_size": len(b"not a zip"),
+            "total_chunks": 1,
+            "received_chunks": {0},
+            "created_at": time.time(),
+            "last_activity": time.time(),
+            "chunk_dir": str(chunk_dir),
+        }
+
+        with pytest.raises(BackupServiceError, match="无效的备份文件"):
+            await service.upload_complete({"upload_id": "upload-1"})
+
+        assert not (backup_dir / "bad.zip").exists()
 
 
 class TestVersionComparison:

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -826,6 +826,8 @@ class TestBackupUploadValidation:
             await service.upload_complete({"upload_id": "upload-1"})
 
         assert not (backup_dir / "bad.zip").exists()
+        assert "upload-1" not in service.upload_sessions
+        assert not chunk_dir.exists()
 
 
 class TestVersionComparison:


### PR DESCRIPTION
﻿Uploaded backup files were previously accepted based mainly on the `.zip` filename suffix. That allowed invalid archives to enter the backups directory even when they were not usable AstrBot backups.

### Modifications / 改动点

#### What Problem This Solves

Before this change, the backup upload path mainly gated uploaded files by filename shape: a file ending in `.zip` could be saved into the backups directory before AstrBot checked whether it was a usable AstrBot backup archive.

In practice, the old acceptance boundary was closer to this shape: the filename suffix was checked, then the upload was persisted.

```python
if not file.filename or not file.filename.endswith(".zip"):
    raise BackupServiceError("请上传 ZIP 格式的备份文件")

await self._save_upload(file, zip_path)
```

That is different from a valid backup. The ZIP file is only the container; the minimum AstrBot backup contract is that the archive must contain a readable `manifest.json` whose JSON value is an object. When an arbitrary invalid ZIP, or a ZIP without a usable manifest, was accepted by the upload path, later backup consumers could not treat it like a real backup.

The existing backup listing path already depends on that manifest contract:

```python
manifest = self.get_backup_manifest(file_path)
if not manifest:
    continue
```

So an invalid upload could appear to succeed because the filename ended with `.zip`, but the saved file could then be skipped by `list_backups()`, unusable for restore/import paths that rely on the same manifest contract, and left behind as an orphaned archive in the backups directory.

This PR moves that failure to the upload boundary. Direct uploads and completed chunked uploads are now validated after the ZIP is saved or merged, but before the upload is accepted:

```python
await self._save_upload(file, zip_path)
self.validate_uploaded_backup(zip_path)
```

The validation reuses the existing manifest read path and accepts only a readable JSON object:

```python
with zipfile.ZipFile(zip_path, "r") as zf:
    if "manifest.json" in zf.namelist():
        manifest = json.loads(zf.read("manifest.json").decode("utf-8"))
        return manifest if isinstance(manifest, dict) else None
```

Archives without a readable JSON-object `manifest.json` now fail fast with `BackupServiceError` instead of being accepted first and failing later in backup consumers.
#### Changes

- Add `BackupService.validate_uploaded_backup()` to reject uploaded backup archives when `manifest.json` is missing, unreadable, or not a JSON object.
- Tighten `get_backup_manifest()` so it only returns a readable dictionary manifest and logs non-object manifest payloads at debug level.
- Validate direct uploads after saving the file and remove the saved ZIP if validation fails.
- Keep cleanup secondary to the primary failure: if deleting a failed direct-upload ZIP raises, log the cleanup failure without masking the original validation error.
- Validate chunked uploads after merging all chunks and before marking the archive as uploaded.
- On invalid chunked uploads, clean up the upload session, temporary chunk directory, and merged ZIP output before re-raising the validation failure.
- Add regression coverage in `tests/test_backup.py` for invalid direct upload cleanup and invalid merged archive cleanup after chunked upload completion, including the chunk session/chunk directory cleanup assertions.

#### Evidence

- `backup_service.py` now validates uploaded backups through the readable dict manifest path before accepting them.
- Direct upload failure deletes the newly saved ZIP before re-raising the validation error, while cleanup errors are logged without hiding the original failure.
- Chunked upload failure validates the merged ZIP before `mark_backup_as_uploaded()`, removes the upload session and chunk directory on validation failure, and still removes the merged ZIP output through the existing failure cleanup path.
- `tests/test_backup.py` covers both invalid direct ZIP uploads and invalid chunked ZIP uploads, including cleanup assertions for the saved/merged archive and the chunked upload session state.
- This uses the existing `zipfile` / `json` manifest-read path and does not add new dependencies. It verifies the minimum readable-dict `manifest.json` contract; it does not attempt to fully validate restore completeness or every backup payload file.

#### Possible call chain / impact

```text
Direct upload endpoint
  -> BackupService.upload_backup(...)
  -> _save_upload(...)
  -> validate_uploaded_backup(...)
  -> get_backup_manifest(...)
  -> reject unreadable / missing / non-object manifest
  -> remove newly saved ZIP without masking the primary error
```

```text
Chunked upload completion endpoint
  -> BackupService.upload_complete(...)
  -> merge received chunks into backup ZIP
  -> validate_uploaded_backup(...)
  -> reject unreadable / missing / non-object manifest
  -> cleanup upload session and temporary chunk directory
  -> remove merged ZIP output
```

New invalid uploads now fail fast with `BackupServiceError` instead of being accepted as unusable backup archives. Existing legacy invalid backup files are still handled by the existing `list_backups()` skip behavior; this PR changes the upload boundary, not historical cleanup or full backup restore validation.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Before this change, a file named `bad.zip` containing invalid ZIP bytes could be saved by the upload path. The archive would later be skipped by `list_backups()` because its manifest could not be read, so the upload could appear successful while leaving an unusable backup file behind.

After this change, both direct uploads and chunked uploads fail fast with `BackupServiceError` when the saved or merged archive does not contain a readable `manifest.json` object. The invalid saved or merged file is removed before returning the error, and invalid chunked uploads also clear their upload session and temporary chunk directory.

```bash
uv run ruff format --check astrbot/dashboard/services/backup_service.py tests/test_backup.py
# 2 files already formatted

uv run ruff check astrbot/dashboard/services/backup_service.py tests/test_backup.py
# All checks passed!

uv run pytest tests/test_backup.py -k "BackupUploadValidation or pre_check_invalid_zip or pre_check_missing_manifest" -q
# 4 passed, 60 deselected, 1 warning in 3.08s
```

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。
  Not applicable: this is a bug fix, not a new feature.

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Validate uploaded backup archives and ensure invalid ZIP files are rejected and cleaned up for both direct and chunked uploads.

Bug Fixes:
- Reject backup uploads whose archives lack a readable manifest.json object instead of silently accepting unusable backups.
- Ensure invalid direct backup uploads are cleaned up by deleting the partially saved ZIP file on failure.
- Ensure invalid chunked backup uploads are validated after merge and cleaned up by removing the merged ZIP file on failure.

Tests:
- Add async tests covering rejection and cleanup behavior for invalid direct backup uploads.
- Add async tests covering rejection and cleanup behavior for invalid chunked backup uploads.
