### PR TITLE
fix: exit MCP anyio contexts in the lifecycle task on disable

### DIFF
--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -723,8 +723,10 @@ class FunctionToolManager:
                 logger.debug(f"MCP client {name} task was cancelled")
                 raise
             finally:
-                # Cleanup in the same task that entered the anyio contexts
-                await asyncio.shield(self._terminate_mcp_client(name))
+                # Cleanup in the same task that entered the anyio contexts.
+                # No asyncio.shield() here: it would run the cleanup in a new
+                # task, and anyio cancel scopes cannot exit across tasks (#9068).
+                await self._terminate_mcp_client(name)
 
         lifecycle_task = asyncio.create_task(
             connect_and_lifecycle(), name=f"mcp-client:{name}"

--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -723,10 +723,19 @@ class FunctionToolManager:
                 logger.debug(f"MCP client {name} task was cancelled")
                 raise
             finally:
-                # Cleanup in the same task that entered the anyio contexts.
-                # No asyncio.shield() here: it would run the cleanup in a new
-                # task, and anyio cancel scopes cannot exit across tasks (#9068).
-                await self._terminate_mcp_client(name)
+                # Cleanup in the same task that entered the anyio contexts:
+                # asyncio.shield() would schedule the coroutine as a separate
+                # Task, and anyio cancel scopes cannot exit across tasks (#9068).
+                # Absorb late cancellations so a forced shutdown cannot abort
+                # the cleanup halfway.
+                task = asyncio.current_task()
+                while True:
+                    try:
+                        await self._terminate_mcp_client(name)
+                        break
+                    except asyncio.CancelledError:
+                        if task is not None:
+                            task.uncancel()
 
         lifecycle_task = asyncio.create_task(
             connect_and_lifecycle(), name=f"mcp-client:{name}"

--- a/astrbot/core/provider/func_tool_manager.py
+++ b/astrbot/core/provider/func_tool_manager.py
@@ -734,7 +734,9 @@ class FunctionToolManager:
                         await self._terminate_mcp_client(name)
                         break
                     except asyncio.CancelledError:
-                        if task is not None:
+                        # Task.uncancel() is 3.11+; on 3.10 absorbing the
+                        # cancellation is sufficient.
+                        if task is not None and hasattr(task, "uncancel"):
                             task.uncancel()
 
         lifecycle_task = asyncio.create_task(

--- a/tests/unit/test_func_tool_manager.py
+++ b/tests/unit/test_func_tool_manager.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 
 import pytest
@@ -346,6 +347,37 @@ def test_firecrawl_tools_are_registered_as_builtin_tools():
     assert extract_tool.name == "firecrawl_extract_web_page"
     assert manager.is_builtin_tool("web_search_firecrawl") is True
     assert manager.is_builtin_tool("firecrawl_extract_web_page") is True
+
+
+@pytest.mark.asyncio
+async def test_mcp_shutdown_cleanup_runs_in_lifecycle_task(monkeypatch):
+    """Disabling an MCP server must clean up in the task that connected.
+
+    anyio cancel scopes entered in connect_to_server() can only be exited
+    from the same task, otherwise the scope state is corrupted and its
+    cancellation loop spins at 100% CPU (#9068).
+    """
+    manager = FunctionToolManager()
+    seen = {}
+
+    async def fake_connect(self, config, name):
+        seen["connect_task"] = asyncio.current_task()
+
+    async def fake_list_tools(self):
+        self.tools = []
+
+    async def fake_cleanup(self):
+        seen["cleanup_task"] = asyncio.current_task()
+
+    monkeypatch.setattr(ftm.MCPClient, "connect_to_server", fake_connect)
+    monkeypatch.setattr(ftm.MCPClient, "list_tools_and_save", fake_list_tools)
+    monkeypatch.setattr(ftm.MCPClient, "cleanup", fake_cleanup)
+
+    await manager.enable_mcp_server("dummy", {"command": "python"}, timeout=5)
+    await manager.disable_mcp_server("dummy", timeout=5)
+
+    assert seen["cleanup_task"] is seen["connect_task"]
+    assert "dummy" not in manager.mcp_client_dict
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_func_tool_manager.py
+++ b/tests/unit/test_func_tool_manager.py
@@ -381,6 +381,34 @@ async def test_mcp_shutdown_cleanup_runs_in_lifecycle_task(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_mcp_shutdown_cleanup_survives_late_cancellation(monkeypatch):
+    """A cancellation arriving mid-cleanup must not abort the cleanup."""
+    manager = FunctionToolManager()
+    cleanup_calls = []
+
+    async def fake_connect(self, config, name):
+        pass
+
+    async def fake_list_tools(self):
+        self.tools = []
+
+    async def fake_cleanup(self):
+        cleanup_calls.append(asyncio.current_task())
+        if len(cleanup_calls) == 1:
+            raise asyncio.CancelledError()
+
+    monkeypatch.setattr(ftm.MCPClient, "connect_to_server", fake_connect)
+    monkeypatch.setattr(ftm.MCPClient, "list_tools_and_save", fake_list_tools)
+    monkeypatch.setattr(ftm.MCPClient, "cleanup", fake_cleanup)
+
+    await manager.enable_mcp_server("dummy", {"command": "python"}, timeout=5)
+    await manager.disable_mcp_server("dummy", timeout=5)
+
+    assert len(cleanup_calls) == 2
+    assert "dummy" not in manager.mcp_client_dict
+
+
+@pytest.mark.asyncio
 async def test_modelscope_sync_enables_only_synced_servers(monkeypatch):
     class FakeResponse:
         status = 200


### PR DESCRIPTION
#9068 is still reproducible on current master: disabling an MCP server exits the anyio cancel scopes from a task other than the one that entered them, which corrupts their state — the failure mode behind the reported 100% CPU spin.

#9070 introduced the per-server lifecycle task precisely so that cleanup happens in the task that entered the anyio contexts, but running the cleanup through `asyncio.shield()` defeats that: `shield()` wraps the coroutine in a *new* task, so `exit_stack.aclose()` still runs outside the owning task and fails with `Attempted to exit cancel scope in a different task than it was entered in` (visible at debug level) on every plain enable → disable, no cancellation involved.

### Modifications / 改动点

- `astrbot/core/provider/func_tool_manager.py`: await `_terminate_mcp_client()` directly in the lifecycle task's `finally` instead of wrapping it in `asyncio.shield()`. The graceful disable path has no cancellation in flight, and on forced shutdown the lifecycle task still runs its `finally` in-task, so the shield only served to break task affinity.
- `tests/unit/test_func_tool_manager.py`: regression test asserting that shutdown cleanup runs in the same task that connected (fails on master, passes with this fix).

Related: a reconnect from a tool call can still create an exit stack owned by a different task (#8056, addressed by the larger rework in #8307). This PR deliberately keeps to the disable path and does not touch `mcp_client.py`, so it does not conflict with #8307.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Enable → disable of a real stdio MCP server (FastMCP echo server), instrumented to record which task runs the cleanup:

On master (20008f1):

```text
cleanup in connect task: False
cancel scope errors: ['Error closing current exit stack: Attempted to exit cancel scope in a different task than it was entered in']
```

With this fix:

```text
cleanup in connect task: True
cancel scope errors: none
CPU after disable: cpu=0.00s over wall=3.00s (idle)
```

`uv run pytest tests/unit`: 666 passed; the 6 failures on this Windows machine (test_computer, test_message_tools, test_astr_main_agent) are identical on clean master. `ruff format --check` and `ruff check` pass on the changed files.

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure MCP server disable cleanup runs in the same lifecycle task that established the connection to avoid anyio cancel scope corruption and CPU spin.

Bug Fixes:
- Fix MCP server disable path so exit stack and cleanup execute in the owning lifecycle task instead of a separate shielded task, preventing cross-task cancel scope errors and high CPU usage.

Tests:
- Add regression test verifying MCP shutdown cleanup runs in the same task that performed the connection and that the MCP client is removed after disable.