### PR TITLE
fix: avoid logging env dashboard password

### DIFF
--- a/astrbot/core/config/astrbot_config.py
+++ b/astrbot/core/config/astrbot_config.py
@@ -115,7 +115,9 @@ class AstrBotConfig(dict):
         object.__setattr__(
             self,
             "_generated_dashboard_password",
-            generated_password,
+            generated_password
+            if DASHBOARD_INITIAL_PASSWORD_ENV not in os.environ
+            else None,
         )
         object.__setattr__(
             self,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -234,7 +234,7 @@ class TestAstrBotConfigLoad:
     def test_empty_dashboard_password_uses_initial_password_env(
         self, temp_config_path, monkeypatch
     ):
-        """Test that the generated dashboard password can be provided by env."""
+        """Test that env-provided dashboard passwords are hashed but not exposed."""
         env_password = "CustomInitial123"
         monkeypatch.setenv("ASTRBOT_DASHBOARD_INITIAL_PASSWORD", env_password)
         default_config = {
@@ -249,7 +249,7 @@ class TestAstrBotConfigLoad:
             default_config=default_config,
         )
 
-        assert getattr(config, "_generated_dashboard_password", None) == env_password
+        assert getattr(config, "_generated_dashboard_password", None) is None
         assert verify_dashboard_password(
             config["dashboard"]["pbkdf2_password"],
             env_password,


### PR DESCRIPTION
### Motivation
- Prevent accidental leakage of operator-provided dashboard secrets when the app prints the startup WebUI banner. 
- The previous behavior stored `ASTRBOT_DASHBOARD_INITIAL_PASSWORD` in the transient `_generated_dashboard_password` attribute which was later included verbatim in logger output. 
- Keep existing functionality that hashes and enforces the initial password while removing the one-shot plaintext exposure to logs.

### Description
- Change `AstrBotConfig._reset_generated_dashboard_password` to avoid setting `self._generated_dashboard_password` when `ASTRBOT_DASHBOARD_INITIAL_PASSWORD` is present in the environment by writing `generated_password if DASHBOARD_INITIAL_PASSWORD_ENV not in os.environ else None` into the attribute. 
- Preserve hashing of the provided password into `conf['dashboard']['pbkdf2_password']` and legacy MD5 field so authentication behavior is unchanged. 
- Update the unit test `test_empty_dashboard_password_uses_initial_password_env` to assert that env-provided passwords are hashed into config but are not exposed via `config._generated_dashboard_password`.

### Testing
- Ran code style checks with `uv run --no-sync ruff format astrbot/core/config/astrbot_config.py tests/unit/test_config.py` and `uv run --no-sync ruff check astrbot/core/config/astrbot_config.py tests/unit/test_config.py`, which passed. 
- Attempted to run `uv run --no-sync pytest tests/unit/test_config.py -q`, but test execution was blocked due to missing test runtime dependency `pytest_asyncio` in the environment. 
- Static/diff validation verifies `astrbot/core/config/astrbot_config.py` and `tests/unit/test_config.py` were updated to implement and assert the new non-logging behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f507f37c48320ad1c793c13b7d9c4)

## Summary by Sourcery

Ensure environment-provided dashboard passwords are no longer stored in a runtime attribute that is later logged, while keeping authentication behavior unchanged.

Bug Fixes:
- Stop exposing the ASTRBOT_DASHBOARD_INITIAL_PASSWORD value via the generated dashboard password attribute that can end up in logs.

Tests:
- Update dashboard password configuration tests to confirm env-provided passwords are hashed into config but not exposed via the generated password attribute.