### PR TITLE
fix: constrain custom workspace paths

### DIFF
--- a/astrbot/core/workspace.py
+++ b/astrbot/core/workspace.py
@@ -95,24 +95,24 @@ def workspace_path_to_root(path: str) -> Path:
 
     Args:
         path: Stored workspace path. Relative values are rooted under AstrBot
-            workspaces. Absolute values are allowed and resolved as provided.
+            workspaces. Absolute values must resolve to a workspaces subdirectory.
 
     Returns:
         Absolute resolved path.
 
     Raises:
-        ValueError: If a relative path escapes or targets the AstrBot workspaces
-            root.
+        ValueError: If the path escapes or targets the AstrBot workspaces root.
     """
     workspaces_root = Path(get_astrbot_workspaces_path()).resolve(strict=False)
     candidate = Path(path).expanduser()
-    if candidate.is_absolute():
-        return candidate.resolve(strict=False)
-
-    resolved = (workspaces_root / candidate).resolve(strict=False)
+    resolved = (
+        candidate.resolve(strict=False)
+        if candidate.is_absolute()
+        else (workspaces_root / candidate).resolve(strict=False)
+    )
     if resolved == workspaces_root or not resolved.is_relative_to(workspaces_root):
         raise ValueError(
-            "Relative workspace path must stay within a subdirectory of AstrBot workspaces"
+            "Custom workspace path must stay within a subdirectory of AstrBot workspaces"
         )
     return resolved
 

--- a/tests/unit/test_chatui_project_service.py
+++ b/tests/unit/test_chatui_project_service.py
@@ -6,8 +6,10 @@ from astrbot.dashboard.services.chatui_project_service import (
 )
 
 
-def test_custom_workspace_accepts_existing_directory(tmp_path, monkeypatch):
-    """Custom workspace paths should accept existing usable directories."""
+def test_custom_workspace_accepts_absolute_existing_workspace_subdirectory(
+    tmp_path, monkeypatch
+):
+    """Custom workspace paths should accept workspace subdirectories."""
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     monkeypatch.setattr(
@@ -60,9 +62,7 @@ def test_custom_workspace_rejects_file_path(tmp_path, monkeypatch):
         )
 
 
-def test_custom_workspace_relative_path_uses_astrbot_workspaces(
-    tmp_path, monkeypatch
-):
+def test_custom_workspace_relative_path_uses_astrbot_workspaces(tmp_path, monkeypatch):
     """Relative custom workspace paths should resolve under AstrBot workspaces."""
     relative_workspace = tmp_path / "relative-workspace"
     relative_workspace.mkdir()
@@ -118,10 +118,10 @@ def test_custom_workspace_rejects_workspaces_root(tmp_path, monkeypatch):
         )
 
 
-def test_custom_workspace_accepts_absolute_path_outside_workspaces(
+def test_custom_workspace_rejects_absolute_path_outside_workspaces(
     tmp_path, monkeypatch
 ):
-    """Absolute custom workspace paths may point outside AstrBot workspaces."""
+    """Absolute custom workspace paths must stay under AstrBot workspaces."""
     outside_workspace = tmp_path / "outside"
     workspaces_root = tmp_path / "workspaces"
     outside_workspace.mkdir()
@@ -131,12 +131,10 @@ def test_custom_workspace_accepts_absolute_path_outside_workspaces(
         lambda: str(workspaces_root),
     )
 
-    workspace_type, workspace_path = ChatUIProjectService._normalize_workspace_config(
-        {
-            "workspace_type": "custom",
-            "workspace_path": str(outside_workspace),
-        }
-    )
-
-    assert workspace_type == "custom"
-    assert workspace_path == str(outside_workspace)
+    with pytest.raises(ChatUIProjectServiceError, match="must stay within"):
+        ChatUIProjectService._normalize_workspace_config(
+            {
+                "workspace_type": "custom",
+                "workspace_path": str(outside_workspace),
+            }
+        )


### PR DESCRIPTION
### Motivation
- Close a security gap where ChatUI `custom` workspace paths could be absolute and point outside AstrBot's workspaces, allowing chat-scoped users to expand non-admin file-tool allowlists.
- Ensure both relative and absolute custom workspace values are constrained to subdirectories of the configured AstrBot workspaces root.

### Description
- Change `workspace_path_to_root()` in `astrbot/core/workspace.py` to always resolve the candidate path (absolute or relative) and then require the resolved path to be a subdirectory of the AstrBot workspaces root.
- Update the validation error message to reflect that any path (absolute or relative) must stay within a workspaces subdirectory.
- Adjust `tests/unit/test_chatui_project_service.py` to accept absolute paths that are workspace subdirectories and to reject absolute paths that resolve outside the workspaces root.

### Testing
- Ran formatting with `uv run --no-sync ruff format .` which completed successfully.
- Ran linting with `uv run --no-sync ruff check .` which completed successfully.
- Attempted to run unit tests with `uv run --no-sync pytest tests/unit/test_chatui_project_service.py` but test execution was blocked by a missing test dependency (`pytest_asyncio`) and an external PyPI fetch/connectivity failure, so full pytest validation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47e3d129a08320936ccd47d8c389e3)

## Summary by Sourcery

Constrain custom ChatUI workspaces so that both relative and absolute paths must resolve within the AstrBot workspaces root.

Bug Fixes:
- Prevent custom workspace configurations from using absolute paths that resolve outside the AstrBot workspaces root, closing a security gap around file-tool allowlists.

Enhancements:
- Unify workspace path resolution logic so all custom paths are resolved and validated against the AstrBot workspaces root.
- Clarify workspace validation error messaging to reflect the constraint on all custom paths, not just relative ones.

Tests:
- Update ChatUI project service tests to cover acceptance of absolute workspace subdirectories and rejection of absolute paths outside the workspaces root.