### PR TITLE
fix(webui): sync plugin activation status on enable

### DIFF
--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -1295,8 +1295,7 @@ class PluginManager:
                     star_registry.append(metadata)
 
                 # 禁用/启用插件
-                if metadata.module_path in inactivated_plugins:
-                    metadata.activated = False
+                metadata.activated = metadata.module_path not in inactivated_plugins
 
                 # Plugin logo path
                 if os.path.exists(logo_path):

--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -1933,7 +1933,9 @@ class PluginManager:
         for func_tool in self._iter_plugin_llm_tools(plugin.module_path):
             func_tool.active = func_tool.name not in inactivated_llm_tools
 
-        await self.reload(plugin_name)
+        success, error = await self.reload(plugin_name)
+        if not success:
+            raise Exception(error or f"插件 {plugin_name} 启用失败。")
         current_plugin = self.context.get_registered_star(plugin_name)
         if current_plugin:
             current_plugin.activated = True

--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -1934,6 +1934,9 @@ class PluginManager:
             func_tool.active = func_tool.name not in inactivated_llm_tools
 
         await self.reload(plugin_name)
+        current_plugin = self.context.get_registered_star(plugin_name)
+        if current_plugin:
+            current_plugin.activated = True
 
     async def install_plugin_from_file(
         self, zip_file_path: str, ignore_version_check: bool = False

--- a/dashboard/src/views/extension/useExtensionPage.js
+++ b/dashboard/src/views/extension/useExtensionPage.js
@@ -1043,9 +1043,12 @@ export const useExtensionPage = () => {
   };
 
   const pluginOn = async (extension) => {
+    const previousActivated = extension.activated;
+    extension.activated = true;
     try {
       const res = await pluginApi.setEnabled(extension.name, true);
       if (res.data.status === "error") {
+        extension.activated = previousActivated;
         toast(res.data.message, "error");
         return;
       }
@@ -1054,20 +1057,25 @@ export const useExtensionPage = () => {
 
       await checkAndPromptConflicts();
     } catch (err) {
+      extension.activated = previousActivated;
       toast(err, "error");
     }
   };
 
   const pluginOff = async (extension) => {
+    const previousActivated = extension.activated;
+    extension.activated = false;
     try {
       const res = await pluginApi.setEnabled(extension.name, false);
       if (res.data.status === "error") {
+        extension.activated = previousActivated;
         toast(res.data.message, "error");
         return;
       }
       toast(res.data.message, "success");
-      getExtensions();
+      await getExtensions();
     } catch (err) {
+      extension.activated = previousActivated;
       toast(err, "error");
     }
   };

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -2240,9 +2240,6 @@ async def test_turn_on_plugin_after_deactivated_reload_reactivates_tools(
 
     async def mock_reload(plugin_name_arg):
         assert plugin_name_arg == plugin_name
-        # Simulate what load() does: re-register with activated=True
-        # since it's no longer in inactivated_plugins
-        plugin.activated = True
         return True, None
 
     monkeypatch.setattr(star_manager_module.sp, "global_get", mock_global_get)

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 from pathlib import Path
+from types import ModuleType
 from typing import Any, cast
 
 import pytest
@@ -1979,6 +1980,89 @@ async def test_uninstall_failed_plugin_without_plugin_id_in_record(
 
 
 # --- reload + deactivated plugin regression tests ---
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("inactivated_plugins", "expected_activated"),
+    [
+        ([], True),
+        (["data.plugins.demo_plugin.main"], False),
+    ],
+)
+async def test_load_syncs_existing_metadata_activation_from_preferences(
+    plugin_manager_pm: PluginManager,
+    monkeypatch,
+    inactivated_plugins: list[str],
+    expected_activated: bool,
+):
+    """Existing plugin metadata activation follows persisted preferences."""
+    _clear_star_runtime_state()
+    plugin_name = "demo_plugin"
+    module_path = f"data.plugins.{plugin_name}.main"
+    metadata = star_manager_module.StarMetadata(
+        name=plugin_name,
+        author="AstrBot Team",
+        desc="Demo plugin",
+        version="1.0.0",
+        root_dir_name=plugin_name,
+        module_path=module_path,
+        activated=False,
+    )
+    star_manager_module.star_map[module_path] = metadata
+    star_manager_module.star_registry.append(metadata)
+    preferences = {
+        "inactivated_plugins": inactivated_plugins,
+        "inactivated_llm_tools": [],
+        "alter_cmd": {},
+    }
+
+    async def mock_global_get(key, default=None):
+        return preferences.get(key, default)
+
+    async def mock_import_plugin_with_dependency_recovery(
+        path,
+        module_str,
+        root_dir_name,
+        requirements_path,
+        *,
+        reserved=False,
+    ):
+        del module_str, root_dir_name, requirements_path, reserved
+        assert path == module_path
+        return ModuleType(module_path)
+
+    async def mock_sync_command_configs():
+        return None
+
+    monkeypatch.setattr(star_manager_module.sp, "global_get", mock_global_get)
+    monkeypatch.setattr(
+        plugin_manager_pm,
+        "_get_plugin_modules",
+        lambda: [{"pname": plugin_name, "module": "main"}],
+    )
+    monkeypatch.setattr(
+        plugin_manager_pm,
+        "_import_plugin_with_dependency_recovery",
+        mock_import_plugin_with_dependency_recovery,
+    )
+    monkeypatch.setattr(plugin_manager_pm, "_load_plugin_metadata", lambda **_: None)
+    monkeypatch.setattr(
+        star_manager_module,
+        "sync_command_configs",
+        mock_sync_command_configs,
+    )
+
+    try:
+        success, error = await plugin_manager_pm.load(
+            specified_module_path=module_path,
+        )
+
+        assert success is True
+        assert error is None
+        assert metadata.activated is expected_activated
+    finally:
+        _clear_star_runtime_state()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
Closes #9149

This PR fixes a WebUI plugin status sync issue where enabling a disabled plugin shows “enabled successfully”, but the dashboard switch remains gray and still appears disabled.

The issue was caused by stale plugin metadata in `PluginManager.reload()` / `PluginManager.load()`. After #9048 separated plugin activation state from LLM tool activation state, `turn_on_plugin()` relied on `reload()` to refresh `activated`. After #9096 skipped unbinding inactive plugin metadata during reload, the old `StarMetadata(activated=False)` could be reused, so the plugin was loaded but the list API still returned `activated: false`.
### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
- Updated `astrbot/core/star/star_manager.py`
  - Sync reused plugin metadata activation state from `inactivated_plugins`.
  - Ensure enabling a plugin updates the runtime `activated` state after reload.
  - Keep plugin/tool activation state separation unchanged.

- Updated `dashboard/src/views/extension/useExtensionPage.js`
  - Optimistically update the WebUI switch state when enabling/disabling plugins.
  - Roll back the switch state if the backend operation fails.
  - Await plugin list refresh after disabling.

- Updated `tests/test_plugin_manager.py`
  - Added regression coverage for syncing existing metadata activation state from preferences.
  - Adjusted plugin enable reload test so it no longer hides missing activation sync through test-only mocks.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
Verification commands:

```bash
uv run pytest tests/test_plugin_manager.py -k "load_syncs_existing_metadata_activation_from_preferences or turn_on_plugin_after_deactivated_reload_reactivates_tools or turn_plugin_toggles_llm_tools_from_plugin_child_module or turn_plugin_preserves_user_disabled_llm_tools"
ruff format .
ruff check .
```
Result:
```bash
5 passed, 53 deselected, 1 warning
ruff format . passed
ruff check . passed
```
Manual verification:
1. Start backend with uv run main.py.
2. Start dashboard with pnpm dev.
3. Open the WebUI plugin page.
4. Disable a plugin.
5. Enable the same plugin again.
6. Expected result: the enable request succeeds, the switch becomes green/enabled, and the plugin can be disabled again.

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

<img width="1162" height="850" alt="3fb172b6-046c-4e56-9133-1bb63ddc7b46" src="https://github.com/user-attachments/assets/50c7a265-1c95-432d-842b-ef039acb4ca1" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Fix WebUI plugin activation status desync by aligning backend plugin metadata and frontend switch state with persisted preferences.

Bug Fixes:
- Ensure plugin metadata activation is correctly derived from persisted inactivated plugin preferences during load.
- Guarantee that enabling a plugin updates its runtime activation state after reload so APIs reflect the change.
- Prevent the dashboard plugin switch from remaining visually disabled after successful enable/disable operations by synchronizing the UI state with backend results.

Enhancements:
- Improve plugin activation handling to keep plugin and LLM tool activation states consistent without breaking their separation.

Tests:
- Add regression tests covering metadata activation sync from stored preferences and plugin reload behavior to avoid future desync issues.