### PR TITLE
fix: serialize webchat history timestamps as UTC-aware ISO strings

### DIFF
--- a/astrbot/dashboard/services/chat_service.py
+++ b/astrbot/dashboard/services/chat_service.py
@@ -345,6 +345,23 @@ def serialize_thread(thread) -> dict:
     }
 
 
+def serialize_history_entry(history) -> dict:
+    """Serialize a PlatformMessageHistory record with UTC-aware timestamps.
+
+    Args:
+        history: A PlatformMessageHistory instance. Must not be None.
+
+    Returns:
+        Dict with all model fields plus created_at/updated_at serialized as
+        UTC-aware ISO strings (e.g. ``2026-07-06T04:00:00+00:00``).
+    """
+    return {
+        **history.model_dump(),
+        "created_at": to_utc_isoformat(history.created_at),
+        "updated_at": to_utc_isoformat(history.updated_at),
+    }
+
+
 def find_checkpoint_index(history: list[dict], checkpoint_id: str) -> int | None:
     for index, message in enumerate(history):
         if get_checkpoint_id(message) == checkpoint_id:
@@ -1217,7 +1234,7 @@ class ChatService:
         )
 
         response_data = {
-            "history": [history.model_dump() for history in history_ls],
+            "history": [serialize_history_entry(history) for history in history_ls],
             "threads": [serialize_thread(thread) for thread in threads],
             "is_running": self.running_convs.get(session_id, False),
         }
@@ -1333,7 +1350,7 @@ class ChatService:
         )
         return {
             "thread": serialize_thread(thread),
-            "history": [history.model_dump() for history in history_ls],
+            "history": [serialize_history_entry(history) for history in history_ls],
             "is_running": self.running_convs.get(thread_id, False),
         }
 
@@ -1487,7 +1504,7 @@ class ChatService:
         await self.db.update_platform_session(session_id=session_id)
         updated = await self.db.get_platform_message_history_by_id(message_id)
         return {
-            "message": updated.model_dump() if updated else None,
+            "message": serialize_history_entry(updated) if updated else None,
             "needs_regenerate": True,
             "truncated_after_message": True,
         }


### PR DESCRIPTION
ChatService.get_session used bare model_dump() to serialize history records, causing created_at/updated_at to be emitted as naive ISO strings without a timezone suffix. The frontend new Date() parses such strings as local time per ES2015+, so UTC values were displayed as-is instead of converted.

Switch to to_utc_isoformat for timestamp serialization, matching the SSE real-time path and session list path. The frontend now consistently receives ISO strings with the +00:00 suffix across all code paths.

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

Fixes: #9157 

修复：astrbot/dashboard/services/chat_service.py 中将 history.model_dump() 改为在 dump 结果上用 to_utc_isoformat 覆盖 created_at/updated_at，与 SSE 实时消息路径（chat_service.py:815）和会话列表路径（chat_service.py:1184）保持一致，确保前端始终收到带 +00:00 后缀的 ISO 字符串。

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
本次改动较小，测试文件没有加入git控制，运行结果如下：
platform win32 -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0 -- C:\Users\leaf\code\AstrBot\.venv\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\leaf\code\AstrBot
configfile: pyproject.toml
plugins: anyio-4.14.1, asyncio-1.4.0, cov-7.1.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 3 items

tests/unit/test_chat_service_session_history.py::test_get_session_history_timestamps_carry_utc_suffix PASSED [ 33%]
tests/unit/test_chat_service_session_history.py::test_get_session_history_handles_naive_datetime_as_utc PASSED [ 66%]
tests/unit/test_chat_service_session_history.py::test_get_session_history_timestamps_match_sse_format PASSED [100%]

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure chat session and thread APIs return platform message history with consistently UTC-aware timestamp serialization.

Bug Fixes:
- Fix incorrect frontend rendering of message history timestamps caused by naive ISO datetime strings being interpreted as local time.

Enhancements:
- Introduce a dedicated serializer for PlatformMessageHistory entries to unify timestamp formatting across history, thread, and message update responses.

Tests:
- Add unit tests verifying session history timestamps include a UTC suffix, correctly handle naive datetimes as UTC, and match the SSE timestamp format.