### PR TITLE
feat: add categorization to platform logs and a UI toggle to hide user chat entries from the console view

### DIFF
--- a/astrbot/core/event_bus.py
+++ b/astrbot/core/event_bus.py
@@ -73,9 +73,11 @@ class EventBus:
         if event.get_sender_name():
             logger.info(
                 f"[{conf_name}] [{event.get_platform_id()}({event.get_platform_name()})] {event.get_sender_name()}/{event.get_sender_id()}: {event.get_message_outline()}",
+                extra={"category": "user_chat"},
             )
         # 没有发送者名称: [平台名] 发送者ID: 消息概要
         else:
             logger.info(
                 f"[{conf_name}] [{event.get_platform_id()}({event.get_platform_name()})] {event.get_sender_id()}: {event.get_message_outline()}",
+                extra={"category": "user_chat"},
             )

--- a/astrbot/core/log.py
+++ b/astrbot/core/log.py
@@ -32,7 +32,7 @@ class _RecordEnricherFilter(logging.Filter):
         record.source_file = _build_source_file(record.pathname)
         record.source_line = record.lineno
         record.is_trace = record.name == "astrbot.trace"
-        record.category = getattr(record, "category", "system")
+        record.category = getattr(record, "category", None) or "system"
         return True
 
 

--- a/astrbot/core/log.py
+++ b/astrbot/core/log.py
@@ -32,6 +32,7 @@ class _RecordEnricherFilter(logging.Filter):
         record.source_file = _build_source_file(record.pathname)
         record.source_line = record.lineno
         record.is_trace = record.name == "astrbot.trace"
+        record.category = getattr(record, "category", "system")
         return True
 
 
@@ -88,6 +89,7 @@ def _patch_record(record: "Record") -> None:
     extra.setdefault("source_file", _build_source_file(record["file"].path))
     extra.setdefault("source_line", record["line"])
     extra.setdefault("is_trace", False)
+    extra.setdefault("category", "system")
 
 
 _loguru = _raw_loguru_logger.patch(_patch_record)
@@ -161,6 +163,7 @@ class LogQueueHandler(logging.Handler):
                 "level": record.levelname,
                 "time": time.time(),
                 "data": log_entry,
+                "category": getattr(record, "category", "system"),
             },
         )
 

--- a/astrbot/core/log.py
+++ b/astrbot/core/log.py
@@ -163,7 +163,7 @@ class LogQueueHandler(logging.Handler):
                 "level": record.levelname,
                 "time": time.time(),
                 "data": log_entry,
-                "category": getattr(record, "category", "system"),
+                "category": getattr(record, "category", None) or "system",
             },
         )
 

--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -205,6 +205,7 @@ class RespondStage(Stage):
 
         logger.info(
             f"Prepare to send - {event.get_sender_name()}/{event.get_sender_id()}: {event._outline_chain(result.chain)}",
+            extra={"category": "user_chat"},
         )
 
         if result.result_content_type == ResultContentType.STREAMING_RESULT:

--- a/dashboard/src/components/shared/ConsoleDisplayer.vue
+++ b/dashboard/src/components/shared/ConsoleDisplayer.vue
@@ -76,6 +76,10 @@ export default {
     showLevelBtns: {
       type: Boolean,
       default: true
+    },
+    hideUserChat: {
+      type: Boolean,
+      default: false
     }
   },
   watch: {
@@ -84,6 +88,9 @@ export default {
         this.refreshDisplay();
       },
       deep: true
+    },
+    hideUserChat() {
+      this.refreshDisplay();
     }
   },
   async mounted() {
@@ -203,8 +210,8 @@ export default {
         if (!exists) {
             this.localLogCache.push(log);
             hasUpdate = true;
-            
-            if (this.isLevelSelected(log.level)) {
+
+            if (this.isLevelSelected(log.level) && !this.isHiddenByCategory(log)) {
               this.printLog(log.data);
             }
         }
@@ -245,6 +252,10 @@ export default {
       return false;
     },
 
+    isHiddenByCategory(log) {
+      return this.hideUserChat && log && log.category === 'user_chat';
+    },
+
     refreshDisplay() {
       const termElement = document.getElementById('term');
       if (termElement) {
@@ -252,7 +263,7 @@ export default {
         
         if (this.localLogCache && this.localLogCache.length > 0) {
           this.localLogCache.forEach(logItem => {
-            if (this.isLevelSelected(logItem.level)) {
+            if (this.isLevelSelected(logItem.level) && !this.isHiddenByCategory(logItem)) {
               this.printLog(logItem.data);
             }
           });

--- a/dashboard/src/i18n/locales/en-US/features/console.json
+++ b/dashboard/src/i18n/locales/en-US/features/console.json
@@ -4,6 +4,10 @@
     "enabled": "Auto-scroll enabled",
     "disabled": "Auto-scroll disabled"
   },
+  "hideUserChat": {
+    "enabled": "User chat hidden",
+    "disabled": "Hide user chat"
+  },
   "pipInstall": {
     "button": "Install pip Package",
     "dialogTitle": "Install Pip Package",

--- a/dashboard/src/i18n/locales/zh-CN/features/console.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/console.json
@@ -4,6 +4,10 @@
     "enabled": "自动滚动已开启",
     "disabled": "自动滚动已关闭"
   },
+  "hideUserChat": {
+    "enabled": "已排除用户对话",
+    "disabled": "排除用户对话"
+  },
   "pipInstall": {
     "button": "安装 pip 库",
     "dialogTitle": "安装 Pip 库",

--- a/dashboard/src/views/ConsolePage.vue
+++ b/dashboard/src/views/ConsolePage.vue
@@ -18,6 +18,15 @@ const { tm } = useModuleI18n('features/console');
       </div>
       <div class="d-flex align-center">
         <v-switch
+          v-model="hideUserChatEnabled"
+          :label="hideUserChatEnabled ? tm('hideUserChat.enabled') : tm('hideUserChat.disabled')"
+          hide-details
+          density="compact"
+          inset
+          color="primary"
+          style="margin-right: 16px;"
+        ></v-switch>
+        <v-switch
           v-model="autoScrollEnabled"
           :label="autoScrollEnabled ? tm('autoScroll.enabled') : tm('autoScroll.disabled')"
           hide-details
@@ -49,7 +58,7 @@ const { tm } = useModuleI18n('features/console');
         </v-dialog>
       </div>
     </div>
-    <ConsoleDisplayer ref="consoleDisplayer" class="console-display" />
+    <ConsoleDisplayer ref="consoleDisplayer" class="console-display" :hide-user-chat="hideUserChatEnabled" />
   </div>
 </template>
 <script>
@@ -61,6 +70,7 @@ export default {
   data() {
     return {
       autoScrollEnabled: localStorage.getItem('console_auto_scroll') !== 'false',
+      hideUserChatEnabled: localStorage.getItem('console_hide_user_chat') === 'true',
       pipDialog: false,
       pipInstallPayload: {
         package: '',
@@ -80,6 +90,9 @@ export default {
       if (this.$refs.consoleDisplayer) {
         this.$refs.consoleDisplayer.autoScroll = val;
       }
+    },
+    hideUserChatEnabled(val) {
+      localStorage.setItem('console_hide_user_chat', val);
     }
   },
   methods: {


### PR DESCRIPTION
### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

**平台日志新增「排除用户对话」开关，方便排查插件/调用类 bug**

为 WebUI 「平台日志」页面新增一个开关，开启后过滤掉冲屏的用户收发消息日志，只保留插件调用、Provider 调用、pipeline 调度、异常堆栈等系统侧日志，便于快速定位 bug。

**功能简介：**

- 在「平台日志」页面右上角自动滚动开关旁并排新增「排除用户对话」`v-switch`
- 状态持久化到 `localStorage`（`console_hide_user_chat`），刷新后恢复
- 与已有日志级别 chip（DEBUG / INFO / WARN / ERRO / CRIT）可叠加使用
- 后端给每条日志打 `category` 标签，默认 `system`；用户收发消息日志标 `user_chat`
- 历史日志缓存中无 `category` 字段的老条目按 `system` 处理，不会被误隐藏，向后兼容
- 与 SSE 断线重连、日志级别筛选组合时行为正确

**改动文件：**

1. `astrbot/core/log.py`
   - `_RecordEnricherFilter.filter()` 为 `LogRecord` 注入默认 `record.category = "system"`
   - `_patch_record()` 在 loguru extra 中设默认 `category` 为 `system`，保持对称
   - `LogQueueHandler.emit()` 在发布到 `LogBroker` 的字典中新增 `category` 字段

2. `astrbot/core/event_bus.py`
   - `_print_event()` 两处 `logger.info(...)` 增加 `extra={"category": "user_chat"}`，标记收到用户消息的日志

3. `astrbot/core/pipeline/respond/stage.py`
   - 发送回复处的 `logger.info(f"Prepare to send - ...")` 增加 `extra={"category": "user_chat"}`，标记回复用户消息的日志
   - 同文件其它日志（调度/异常）不动，天然归入 `system`

4. `dashboard/src/components/shared/ConsoleDisplayer.vue`
   - 新增 prop `hideUserChat: Boolean`（默认 `false`）
   - 新增方法 `isHiddenByCategory(log)`：当 `hideUserChat && log.category === 'user_chat'` 时返回 true
   - `processNewLogs()` 与 `refreshDisplay()` 中在已有级别筛选基础上复合 `&& !this.isHiddenByCategory(log)`
   - 新增对 `hideUserChat` prop 的 watcher，变化时调用 `refreshDisplay()`

5. `dashboard/src/views/ConsolePage.vue`
   - `data()` 新增 `hideUserChatEnabled`，从 `localStorage('console_hide_user_chat')` 初始化
   - header 右侧 auto-scroll 开关前并排新增一个「排除用户对话」`v-switch`
   - `watch.hideUserChatEnabled` 写 localStorage
   - `<ConsoleDisplayer>` 新增 `:hide-user-chat="hideUserChatEnabled"` 单向 prop 绑定

6. `dashboard/src/i18n/locales/{zh-CN,en-US,ru-RU}/features/console.json`
   - 新增 `hideUserChat.enabled` / `hideUserChat.disabled` 文案

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行"验证步骤"的证据，证明此改动有效。-->

**验证步骤：**

1. 重启后端与前端 dev server，进入 WebUI「平台日志」页面
2. 确认右上角自动滚动开关旁出现「排除用户对话」开关，状态为关闭
3. 触发若干用户消息，确认默认（开关关闭）时所有日志（含 `[平台] xxx/xxx: ...` 收消息行、`Prepare to send - ...` 回复行、插件 handler / Provider / stage 调度日志）均显示
4. 打开「排除用户对话」开关，确认：
   - `[平台] xxx/xxx: ...` 收消息行被隐藏
   - `Prepare to send - xxx/xxx: ...` 回复行被隐藏
   - 插件 handler / Provider / pipeline stage 的 INFO 日志仍显示
5. 同时组合「排除用户对话」开关与日志级别 chip（如只勾选 ERROR），确认两类过滤叠加正确
6. 刷新页面：开关状态从 localStorage 恢复，历史日志缓存中无 `category` 字段的老条目不被误隐藏

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！请在提交前核查以下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Add categorization to platform logs and a UI toggle to hide user chat entries from the console view.

New Features:
- Introduce a "Exclude user conversation" switch on the platform log web UI to filter out user chat logs while retaining system-side logs.

Enhancements:
- Tag backend log records with a category field (system vs user_chat) and propagate it through the log queue for more flexible frontend filtering.
- Persist the "Exclude user conversation" switch state in localStorage and integrate it with existing log level filtering and auto-scroll behavior.
- Extend console i18n resources with labels for the new "Exclude user conversation" switch in supported locales.