### PR TITLE
fix: remove qq official reply id on proactive fallback

### DIFF
--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -502,6 +502,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
             logger.info("[QQOfficial] 回复消息失败: %s, 尝试使用主动发送接口。", err)
             if payload.get("msg_id"):
                 fallback_payload = payload.copy()
+                fallback_payload.pop("msg_id", None)
                 try:
                     ret = await send_func(fallback_payload)
                     logger.info("[QQOfficial] 使用主动发送接口发送成功。")


### PR DESCRIPTION
## Summary
- remove `msg_id` from QQ Official fallback payloads before retrying with proactive sending
- prevent oversized passive replies from failing again because the fallback request still carries the reply message id

## Tests
- `ruff format .`
- `ruff check .`
- `uv run pytest tests/test_qqofficial_group_message_create.py tests/test_qqofficial_webhook_signature.py tests/test_qqofficial_login_registration.py tests/test_platform_audio_media_resolver.py`

## Summary by Sourcery

Bug Fixes:
- Ensure QQ Official markdown fallback requests do not include msg_id so oversized passive replies can succeed via proactive sending.