### PR TITLE
fix: sync fallback chat models when a provider is deleted or renamed

### DIFF
--- a/astrbot/core/provider/manager.py
+++ b/astrbot/core/provider/manager.py
@@ -813,6 +813,24 @@ class ProviderManager:
             )
             del self.inst_map[provider_id]
 
+    @staticmethod
+    def _sync_fallback_chat_models(
+        config: dict, old_id: str, new_id: str | None = None
+    ) -> None:
+        """Remove or remap a provider id in fallback_chat_models after delete/rename."""
+        provider_settings = config.get("provider_settings")
+        if not isinstance(provider_settings, dict):
+            return
+        fallback_ids = provider_settings.get("fallback_chat_models")
+        if not isinstance(fallback_ids, list) or old_id not in fallback_ids:
+            return
+        updated_ids = []
+        for fallback_id in fallback_ids:
+            mapped_id = new_id if fallback_id == old_id else fallback_id
+            if mapped_id is not None and mapped_id not in updated_ids:
+                updated_ids.append(mapped_id)
+        provider_settings["fallback_chat_models"] = updated_ids
+
     async def delete_provider(
         self, provider_id: str | None = None, provider_source_id: str | None = None
     ) -> None:
@@ -832,6 +850,7 @@ class ProviderManager:
                 config["provider"] = [
                     prov for prov in config["provider"] if prov.get("id") != tpid
                 ]
+                self._sync_fallback_chat_models(config, tpid)
             config.save_config()
             logger.info(f"Provider {target_prov_ids} 已从配置中删除。")
 
@@ -855,6 +874,8 @@ class ProviderManager:
                     break
             else:
                 raise ValueError(f"Provider ID {origin_provider_id} not found")
+            if npid != origin_provider_id:
+                self._sync_fallback_chat_models(config, origin_provider_id, npid)
             config.save_config()
             # reload instance
             await self.reload(new_config)

--- a/tests/unit/test_provider_manager_fallback_sync.py
+++ b/tests/unit/test_provider_manager_fallback_sync.py
@@ -1,0 +1,130 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+import astrbot.core.star.context  # noqa: F401  # 先导入以规避 provider.manager 的循环导入
+from astrbot.core.provider.manager import ProviderManager
+
+
+class FakeConfig(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.save_count = 0
+
+    def save_config(self):
+        self.save_count += 1
+
+
+def _build_manager(config: FakeConfig) -> ProviderManager:
+    manager = ProviderManager.__new__(ProviderManager)
+    manager.resource_lock = asyncio.Lock()
+    manager.acm = SimpleNamespace(default_conf=config)
+    manager.providers_config = config["provider"]
+    return manager
+
+
+async def _noop_terminate(provider_id: str) -> None:
+    del provider_id
+
+
+@pytest.mark.asyncio
+async def test_delete_provider_removes_fallback_reference():
+    config = FakeConfig(
+        {
+            "provider": [{"id": "p1"}, {"id": "p2"}],
+            "provider_settings": {"fallback_chat_models": ["p1", "p2"]},
+        }
+    )
+    manager = _build_manager(config)
+    manager.terminate_provider = _noop_terminate
+
+    await manager.delete_provider(provider_id="p1")
+
+    assert config["provider"] == [{"id": "p2"}]
+    assert config["provider_settings"]["fallback_chat_models"] == ["p2"]
+    assert config.save_count == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_provider_source_removes_all_fallback_references():
+    config = FakeConfig(
+        {
+            "provider": [
+                {"id": "p1", "provider_source_id": "src"},
+                {"id": "p2", "provider_source_id": "src"},
+                {"id": "p3"},
+            ],
+            "provider_settings": {"fallback_chat_models": ["p1", "p2", "p3"]},
+        }
+    )
+    manager = _build_manager(config)
+    manager.terminate_provider = _noop_terminate
+
+    await manager.delete_provider(provider_source_id="src")
+
+    assert config["provider"] == [{"id": "p3"}]
+    assert config["provider_settings"]["fallback_chat_models"] == ["p3"]
+
+
+@pytest.mark.asyncio
+async def test_update_provider_renames_fallback_reference():
+    config = FakeConfig(
+        {
+            "provider": [{"id": "p1", "enable": True}],
+            "provider_settings": {"fallback_chat_models": ["p1", "p3"]},
+        }
+    )
+    manager = _build_manager(config)
+    reloaded = []
+
+    async def _record_reload(new_config: dict) -> None:
+        reloaded.append(new_config)
+
+    manager.reload = _record_reload
+
+    await manager.update_provider("p1", {"id": "p1-renamed", "enable": True})
+
+    assert config["provider_settings"]["fallback_chat_models"] == ["p1-renamed", "p3"]
+    assert reloaded and reloaded[0]["id"] == "p1-renamed"
+
+
+@pytest.mark.asyncio
+async def test_update_provider_rename_dedupes_stale_target():
+    # "p2" 是残留在回退列表里的失效 ID；把 p1 改名为 p2 后不应产生重复项
+    config = FakeConfig(
+        {
+            "provider": [{"id": "p1", "enable": True}],
+            "provider_settings": {"fallback_chat_models": ["p1", "p2"]},
+        }
+    )
+    manager = _build_manager(config)
+
+    async def _record_reload(new_config: dict) -> None:
+        del new_config
+
+    manager.reload = _record_reload
+
+    await manager.update_provider("p1", {"id": "p2", "enable": True})
+
+    assert config["provider_settings"]["fallback_chat_models"] == ["p2"]
+
+
+@pytest.mark.asyncio
+async def test_update_provider_same_id_keeps_fallback_list():
+    config = FakeConfig(
+        {
+            "provider": [{"id": "p1", "enable": True}],
+            "provider_settings": {"fallback_chat_models": ["p1"]},
+        }
+    )
+    manager = _build_manager(config)
+
+    async def _record_reload(new_config: dict) -> None:
+        del new_config
+
+    manager.reload = _record_reload
+
+    await manager.update_provider("p1", {"id": "p1", "enable": False})
+
+    assert config["provider_settings"]["fallback_chat_models"] == ["p1"]


### PR DESCRIPTION
### Motivation / 动机

修复 #8479。

删除或重命名对话模型后，`provider_settings.fallback_chat_models` 里的引用不会被同步：

- 删除 provider 后，失效的 ID 一直留在回退列表里，每次触发回退都会打出 `Fallback chat provider ... not found, skip.` 的警告；
- 通过 WebUI 修改 provider 的 ID 后，回退列表仍指向旧 ID，回退时同样找不到（issue 日志里的 `这可能是由于您修改了提供商（模型）ID 导致的` 正是这种情况）。

### Modifications / 改动点

- `astrbot/core/provider/manager.py`：新增 `_sync_fallback_chat_models()`；`delete_provider()` 删除 provider 时同步移除回退列表中的对应 ID，`update_provider()` 在 ID 变更时把回退列表中的旧 ID 迁移为新 ID（若新 ID 已在列表中则去重），随后才 `save_config()`。
- `tests/unit/test_provider_manager_fallback_sync.py`：新增 5 个用例，覆盖按 ID 删除、按 provider source 批量删除、改名迁移、改名撞残留 ID 去重、ID 不变不动列表。

运行时的 `_get_fallback_chat_providers()` 行为保持不变（仍会跳过找不到的 provider），本 PR 只是让配置不再残留失效引用。WebUI 下拉里已禁用模型仍可被选择的问题在前端 `ProviderSelector`，不在本 PR 范围内。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```
$ python -m pytest tests/unit/test_provider_manager_fallback_sync.py -v
tests/unit/test_provider_manager_fallback_sync.py::test_delete_provider_removes_fallback_reference PASSED
tests/unit/test_provider_manager_fallback_sync.py::test_delete_provider_source_removes_all_fallback_references PASSED
tests/unit/test_provider_manager_fallback_sync.py::test_update_provider_renames_fallback_reference PASSED
tests/unit/test_provider_manager_fallback_sync.py::test_update_provider_rename_dedupes_stale_target PASSED
tests/unit/test_provider_manager_fallback_sync.py::test_update_provider_same_id_keeps_fallback_list PASSED
5 passed
```

相关既有套件（`test_astr_main_agent.py`、`test_astr_agent_tool_exec.py`、`test_cron_manager.py`）与 master 基线对比无新增失败；`ruff check` / `ruff format --check` 通过。

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

## Summary by Sourcery

Synchronize fallback chat model IDs in provider settings when providers are deleted or renamed to avoid stale references.

Bug Fixes:
- Remove deleted providers from provider_settings.fallback_chat_models so fallback lists no longer contain invalid IDs.
- Remap fallback_chat_models entries when a provider ID is changed, deduplicating any existing target IDs to keep the list consistent.

Tests:
- Add unit tests covering fallback list updates on provider deletion by ID and source, provider renames, deduplication of renamed IDs, and no-op behavior when IDs remain unchanged.