### PR TITLE
fix: apply text-to-image when TTS dual output keeps text in the chain

### DIFF
--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -351,13 +351,16 @@ class ResultDecorateStage(Stage):
             ) or result.use_t2i_:
                 parts = []
                 records = []
-                for comp in result.chain:
+                remain = []
+                for i, comp in enumerate(result.chain):
                     if isinstance(comp, Plain):
                         parts.append("\n\n" + comp.text)
                     elif isinstance(comp, Record):
                         # TTS 双输出时语音段与文本段交错，跳过语音段并在转图后保留
                         records.append(comp)
                     else:
+                        # 其余消息段不参与转图，转图后追加回结果链避免丢失
+                        remain = result.chain[i:]
                         break
                 plain_str = "".join(parts)
                 if plain_str and len(plain_str) > self.t2i_word_threshold:
@@ -378,7 +381,7 @@ class ResultDecorateStage(Stage):
                         )
                     if url:
                         if url.startswith("http"):
-                            result.chain = [*records, Image.fromURL(url)]
+                            result.chain = [*records, Image.fromURL(url), *remain]
                         elif (
                             self.ctx.astrbot_config["t2i_use_file_service"]
                             and self.ctx.astrbot_config["callback_api_base"]
@@ -386,9 +389,9 @@ class ResultDecorateStage(Stage):
                             token = await file_token_service.register_file(url)
                             url = f"{self.ctx.astrbot_config['callback_api_base']}/api/file/{token}"
                             logger.debug(f"已注册：{url}")
-                            result.chain = [*records, Image.fromURL(url)]
+                            result.chain = [*records, Image.fromURL(url), *remain]
                         else:
-                            result.chain = [*records, Image.fromFileSystem(url)]
+                            result.chain = [*records, Image.fromFileSystem(url), *remain]
 
             # 触发转发消息
             if event.get_platform_name() == "aiocqhttp":

--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -346,13 +346,17 @@ class ResultDecorateStage(Stage):
                 result.chain = new_chain
 
             # 文本转图片
-            elif (
+            if (
                 result.use_t2i_ is None and self.ctx.astrbot_config["t2i"]
             ) or result.use_t2i_:
                 parts = []
+                records = []
                 for comp in result.chain:
                     if isinstance(comp, Plain):
                         parts.append("\n\n" + comp.text)
+                    elif isinstance(comp, Record):
+                        # TTS 双输出时语音段与文本段交错，跳过语音段并在转图后保留
+                        records.append(comp)
                     else:
                         break
                 plain_str = "".join(parts)
@@ -374,7 +378,7 @@ class ResultDecorateStage(Stage):
                         )
                     if url:
                         if url.startswith("http"):
-                            result.chain = [Image.fromURL(url)]
+                            result.chain = [*records, Image.fromURL(url)]
                         elif (
                             self.ctx.astrbot_config["t2i_use_file_service"]
                             and self.ctx.astrbot_config["callback_api_base"]
@@ -382,9 +386,9 @@ class ResultDecorateStage(Stage):
                             token = await file_token_service.register_file(url)
                             url = f"{self.ctx.astrbot_config['callback_api_base']}/api/file/{token}"
                             logger.debug(f"已注册：{url}")
-                            result.chain = [Image.fromURL(url)]
+                            result.chain = [*records, Image.fromURL(url)]
                         else:
-                            result.chain = [Image.fromFileSystem(url)]
+                            result.chain = [*records, Image.fromFileSystem(url)]
 
             # 触发转发消息
             if event.get_platform_name() == "aiocqhttp":

--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -391,7 +391,11 @@ class ResultDecorateStage(Stage):
                             logger.debug(f"已注册：{url}")
                             result.chain = [*records, Image.fromURL(url), *remain]
                         else:
-                            result.chain = [*records, Image.fromFileSystem(url), *remain]
+                            result.chain = [
+                                *records,
+                                Image.fromFileSystem(url),
+                                *remain,
+                            ]
 
             # 触发转发消息
             if event.get_platform_name() == "aiocqhttp":

--- a/tests/unit/test_result_decorate_t2i.py
+++ b/tests/unit/test_result_decorate_t2i.py
@@ -1,0 +1,177 @@
+from types import SimpleNamespace
+
+import pytest
+
+import astrbot.core.pipeline.result_decorate.stage as stage_module
+from astrbot.core.message.components import Image, Plain, Record
+from astrbot.core.message.message_event_result import (
+    MessageEventResult,
+    ResultContentType,
+)
+from astrbot.core.pipeline.result_decorate.stage import ResultDecorateStage
+
+LONG_TEXT = "这是一段用于验证文本转图像阈值的长文本。" * 20
+SHORT_TEXT = "短文本"
+
+
+def _build_config(*, tts_enable: bool, dual_output: bool, t2i: bool) -> dict:
+    return {
+        "platform_settings": {
+            "reply_prefix": "",
+            "reply_with_mention": False,
+            "reply_with_quote": False,
+            "forward_threshold": 999999,
+            "segmented_reply": {
+                "enable": False,
+                "only_llm_result": True,
+                "words_count_threshold": 150,
+                "regex": r".*?[。？！~…]+|.+$",
+                "content_cleanup_rule": "",
+            },
+        },
+        "t2i": t2i,
+        "t2i_word_threshold": 50,
+        "t2i_strategy": "local",
+        "t2i_active_template": "base",
+        "t2i_use_file_service": False,
+        "callback_api_base": "",
+        "provider_tts_settings": {
+            "enable": tts_enable,
+            "dual_output": dual_output,
+            "use_file_service": False,
+            "trigger_probability": 1,
+        },
+        "content_safety": {"also_use_in_response": False},
+        "provider_settings": {"display_reasoning_text": False},
+    }
+
+
+class FakeTTSProvider:
+    async def get_audio(self, text: str) -> str:
+        del text
+        return "/tmp/fake_tts_audio.wav"
+
+
+class FakeEvent:
+    def __init__(self, result: MessageEventResult):
+        self._result = result
+        self.plugins_name = None
+        self.unified_msg_origin = "test:GroupMessage:1"
+        self.tracked_files: list[str] = []
+
+    def get_result(self) -> MessageEventResult:
+        return self._result
+
+    def get_extra(self, key: str):
+        del key
+        return None
+
+    def get_platform_name(self) -> str:
+        return "test"
+
+    def is_stopped(self) -> bool:
+        return False
+
+    def track_temporary_local_file(self, path: str) -> None:
+        self.tracked_files.append(path)
+
+
+async def _run_stage(
+    config: dict, result: MessageEventResult, monkeypatch
+) -> FakeEvent:
+    tts_provider = (
+        FakeTTSProvider() if config["provider_tts_settings"]["enable"] else None
+    )
+    ctx = SimpleNamespace(
+        astrbot_config=config,
+        plugin_manager=SimpleNamespace(
+            context=SimpleNamespace(
+                get_using_tts_provider=lambda umo: tts_provider,
+            ),
+        ),
+    )
+
+    async def _always_tts(event):
+        del event
+        return True
+
+    async def _fake_render(text, return_url=True, use_network=False, template_name=""):
+        del text, return_url, use_network, template_name
+        return "http://fake.local/t2i.png"
+
+    monkeypatch.setattr(
+        stage_module.SessionServiceManager,
+        "should_process_tts_request",
+        staticmethod(_always_tts),
+    )
+    monkeypatch.setattr(stage_module.html_renderer, "render_t2i", _fake_render)
+
+    stage = ResultDecorateStage()
+    await stage.initialize(ctx)
+    event = FakeEvent(result)
+    generator = stage.process(event)
+    if generator is not None:
+        async for _ in generator:
+            pass
+    return event
+
+
+@pytest.mark.asyncio
+async def test_t2i_still_applies_when_tts_dual_output(monkeypatch):
+    result = MessageEventResult(chain=[Plain(LONG_TEXT)]).set_result_content_type(
+        ResultContentType.LLM_RESULT
+    )
+    await _run_stage(
+        _build_config(tts_enable=True, dual_output=True, t2i=True),
+        result,
+        monkeypatch,
+    )
+
+    assert any(isinstance(comp, Record) for comp in result.chain)
+    assert isinstance(result.chain[-1], Image)
+    assert not any(isinstance(comp, Plain) for comp in result.chain)
+
+
+@pytest.mark.asyncio
+async def test_t2i_without_tts_keeps_original_behavior(monkeypatch):
+    result = MessageEventResult(chain=[Plain(LONG_TEXT)]).set_result_content_type(
+        ResultContentType.LLM_RESULT
+    )
+    await _run_stage(
+        _build_config(tts_enable=False, dual_output=False, t2i=True),
+        result,
+        monkeypatch,
+    )
+
+    assert len(result.chain) == 1
+    assert isinstance(result.chain[0], Image)
+
+
+@pytest.mark.asyncio
+async def test_dual_output_below_threshold_keeps_voice_and_text(monkeypatch):
+    result = MessageEventResult(chain=[Plain(SHORT_TEXT)]).set_result_content_type(
+        ResultContentType.LLM_RESULT
+    )
+    await _run_stage(
+        _build_config(tts_enable=True, dual_output=True, t2i=True),
+        result,
+        monkeypatch,
+    )
+
+    assert isinstance(result.chain[0], Record)
+    assert isinstance(result.chain[1], Plain)
+
+
+@pytest.mark.asyncio
+async def test_tts_without_dual_output_sends_voice_only(monkeypatch):
+    result = MessageEventResult(chain=[Plain(LONG_TEXT)]).set_result_content_type(
+        ResultContentType.LLM_RESULT
+    )
+    await _run_stage(
+        _build_config(tts_enable=True, dual_output=False, t2i=True),
+        result,
+        monkeypatch,
+    )
+
+    assert len(result.chain) == 1
+    assert isinstance(result.chain[0], Record)

--- a/tests/unit/test_result_decorate_t2i.py
+++ b/tests/unit/test_result_decorate_t2i.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 import pytest
 
 import astrbot.core.pipeline.result_decorate.stage as stage_module
-from astrbot.core.message.components import Image, Plain, Record
+from astrbot.core.message.components import At, Image, Plain, Record
 from astrbot.core.message.message_event_result import (
     MessageEventResult,
     ResultContentType,
@@ -160,6 +160,21 @@ async def test_dual_output_below_threshold_keeps_voice_and_text(monkeypatch):
 
     assert isinstance(result.chain[0], Record)
     assert isinstance(result.chain[1], Plain)
+
+
+@pytest.mark.asyncio
+async def test_t2i_keeps_components_after_text(monkeypatch):
+    result = MessageEventResult(
+        chain=[Plain(LONG_TEXT), At(qq="10001", name="someone")]
+    ).set_result_content_type(ResultContentType.LLM_RESULT)
+    await _run_stage(
+        _build_config(tts_enable=False, dual_output=False, t2i=True),
+        result,
+        monkeypatch,
+    )
+
+    assert isinstance(result.chain[0], Image)
+    assert isinstance(result.chain[1], At)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation / 动机

修复 #8261。

开启 TTS 且勾选"同时输出语音和文字内容"（dual_output）后，文本转图像完全失效，超过阈值的长文本不再转成图片。

原因有两处：

1. `result_decorate/stage.py` 里文本转图像分支是挂在 TTS 分支后面的 `elif`——只要 TTS 执行了，T2I 连判断的机会都没有；
2. 即使改成 `if`，T2I 收集文本的循环遇到非 `Plain` 组件就 `break`，而 dual_output 产生的消息链是 `[Record(语音), Plain(文字), ...]`，开头的 `Record` 会直接让收集结果为空。

### Modifications / 改动点

`astrbot/core/pipeline/result_decorate/stage.py`：

- T2I 分支由 `elif` 改为独立的 `if`，TTS 之后仍会评估；
- 收集文本时跳过 `Record` 段（记录下来），其余组件的 `break` 行为保持不变；
- 转图成功后把语音段保留在结果链里（`[Record..., Image]`），不再整链替换丢掉语音。

行为保持不变的部分：未开启 TTS 时链的处理与原来一致；TTS 不带 dual_output 时链里没有 `Plain`，T2I 依旧不触发；低于阈值时链保持 `[Record, Plain]` 原样。

`tests/unit/test_result_decorate_t2i.py`：新增 4 个用例覆盖上述四种组合（dual_output 长文本转图并保留语音、纯文本原行为、低于阈值不转、仅语音不转）。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```
$ python -m pytest tests/unit/test_result_decorate_t2i.py -v
tests/unit/test_result_decorate_t2i.py::test_t2i_still_applies_when_tts_dual_output PASSED
tests/unit/test_result_decorate_t2i.py::test_t2i_without_tts_keeps_original_behavior PASSED
tests/unit/test_result_decorate_t2i.py::test_dual_output_below_threshold_keeps_voice_and_text PASSED
tests/unit/test_result_decorate_t2i.py::test_tts_without_dual_output_sends_voice_only PASSED
4 passed
```

未修复时 `test_t2i_still_applies_when_tts_dual_output` 失败、其余三个通过（即其余三个用例锁定的是需要保持的现有行为）。`tests/unit` 全量与 master 基线对比无新增失败；`ruff check` / `ruff format --check` 通过。

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

## Summary by Sourcery

Ensure text-to-image conversion still runs when TTS dual output is enabled and preserves generated voice alongside the image.

New Features:
- Support combining TTS dual output with text-to-image so long texts are still converted to images while retaining the voice segment.

Bug Fixes:
- Fix text-to-image not triggering when TTS dual output keeps text in the message chain.

Enhancements:
- Preserve TTS voice records before text-to-image conversion so the final response includes both audio and image when applicable.

Tests:
- Add unit tests covering interactions between TTS (with and without dual output) and text-to-image conversion, including threshold behavior and chain composition.