### PR TITLE
fix: validate dashboard account username updates

### DIFF
--- a/astrbot/dashboard/services/auth_service.py
+++ b/astrbot/dashboard/services/auth_service.py
@@ -369,6 +369,12 @@ class AuthService:
         if not new_pwd and not new_username:
             return self.error("新用户名和新密码不能同时为空")
 
+        username_to_save = None
+        if new_username is not None and new_username != "":
+            if not isinstance(new_username, str) or len(new_username.strip()) < 3:
+                return self.error("用户名长度至少3位")
+            username_to_save = new_username.strip()
+
         if new_pwd:
             if not isinstance(new_pwd, str):
                 return self.error("新密码无效")
@@ -384,8 +390,8 @@ class AuthService:
             await set_password_change_required(self.db, self.config, False)
             if is_totp_enabled(self.config):
                 await revoke_user_trusted_devices(self.db)
-        if new_username:
-            self.config["dashboard"]["username"] = new_username
+        if username_to_save:
+            self.config["dashboard"]["username"] = username_to_save
 
         self.config.save_config()
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1361,6 +1361,105 @@ async def test_generated_password_requires_password_change_until_changed(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("endpoint", "method"),
+    [
+        ("/api/auth/account/edit", "post"),
+        ("/api/v1/auth/account", "patch"),
+    ],
+)
+@pytest.mark.parametrize("new_username", ["ab", "   "])
+async def test_account_edit_rejects_invalid_username(
+    app: FastAPIAppAdapter,
+    core_lifecycle_td: AstrBotCoreLifecycle,
+    endpoint: str,
+    method: str,
+    new_username: str,
+):
+    original_dashboard_config = copy.deepcopy(
+        core_lifecycle_td.astrbot_config["dashboard"]
+    )
+    test_client = app.test_client()
+    current_username = core_lifecycle_td.astrbot_config["dashboard"]["username"]
+    current_password = _resolve_dashboard_password(core_lifecycle_td)
+
+    try:
+        login_response = await test_client.post(
+            "/api/auth/login",
+            json={"username": current_username, "password": current_password},
+        )
+        login_data = await login_response.get_json()
+        assert login_data["status"] == "ok"
+        headers = {"Authorization": f"Bearer {login_data['data']['token']}"}
+
+        payload = {
+            "password": current_password,
+            "new_password": "",
+            "confirm_password": "",
+            "new_username": new_username,
+        }
+        request = getattr(test_client, method)
+        response = await request(endpoint, headers=headers, json=payload)
+        data = await response.get_json()
+
+        assert data["status"] == "error"
+        assert data["message"] == "用户名长度至少3位"
+        assert (
+            core_lifecycle_td.astrbot_config["dashboard"]["username"]
+            == (original_dashboard_config["username"])
+        )
+    finally:
+        await _restore_dashboard_password_state(
+            core_lifecycle_td,
+            original_dashboard_config,
+        )
+
+
+@pytest.mark.asyncio
+async def test_account_edit_trims_valid_username(
+    app: FastAPIAppAdapter,
+    core_lifecycle_td: AstrBotCoreLifecycle,
+):
+    original_dashboard_config = copy.deepcopy(
+        core_lifecycle_td.astrbot_config["dashboard"]
+    )
+    test_client = app.test_client()
+    current_username = core_lifecycle_td.astrbot_config["dashboard"]["username"]
+    current_password = _resolve_dashboard_password(core_lifecycle_td)
+
+    try:
+        login_response = await test_client.post(
+            "/api/auth/login",
+            json={"username": current_username, "password": current_password},
+        )
+        login_data = await login_response.get_json()
+        assert login_data["status"] == "ok"
+        headers = {"Authorization": f"Bearer {login_data['data']['token']}"}
+
+        response = await test_client.post(
+            "/api/auth/account/edit",
+            headers=headers,
+            json={
+                "password": current_password,
+                "new_password": "",
+                "confirm_password": "",
+                "new_username": "  astrbot-admin  ",
+            },
+        )
+        data = await response.get_json()
+
+        assert data["status"] == "ok"
+        assert core_lifecycle_td.astrbot_config["dashboard"]["username"] == (
+            "astrbot-admin"
+        )
+    finally:
+        await _restore_dashboard_password_state(
+            core_lifecycle_td,
+            original_dashboard_config,
+        )
+
+
+@pytest.mark.asyncio
 async def test_local_setup_can_skip_default_password_auth(
     app: FastAPIAppAdapter,
     core_lifecycle_td: AstrBotCoreLifecycle,


### PR DESCRIPTION
﻿This PR fixes dashboard account updates so short or whitespace-only usernames are rejected instead of being saved to configuration.

### Modifications / 改动点

#### What Problem This Solves

Dashboard account setup already treats the username as a trimmed validation boundary: the stored username must be a string whose `strip()` length is at least 3 characters.

Account edit previously used a weaker rule. `AuthService.edit_account()` only checked whether `new_username` was truthy before saving it, so an authenticated account-update request could persist values that setup would reject, such as:

```text
ab
"   "
```

This created inconsistent dashboard account behavior: the initial setup flow enforced a minimum usable username length, while later account edits could save blank-after-trim or too-short usernames into configuration.

#### Changes

This PR moves the same username boundary into the shared account-edit service path:

- Validate `new_username` in `AuthService.edit_account()` before any config write.
- Reject non-string usernames and usernames whose trimmed length is less than 3.
- Persist `new_username.strip()` when a valid username is provided.
- Keep password-change behavior, TOTP trusted-device revocation, and existing account-update flow unchanged.

#### Evidence

The regression tests cover the invalid username cases through both dashboard account-update entry points:

```text
POST  /api/auth/account/edit
PATCH /api/v1/auth/account
```

Covered payloads:

```text
new_username: "ab"   -> rejected with 用户名长度至少3位
new_username: "   "  -> rejected with 用户名长度至少3位
```

The tests also cover the normalization behavior for a valid username with surrounding whitespace:

```text
new_username: "  astrbot-admin  " -> saved as astrbot-admin
```

#### Possible call chain / impact

Both account-update routes flow into the same service boundary:

```text
/api/auth/account/edit
/api/v1/auth/account
  -> account update handler
    -> AuthService.edit_account(...)
      -> validate new_username
      -> save trimmed username to dashboard config
```

This PR only changes dashboard username validation and normalization during account edits. It does not change login authentication, password update validation, TOTP settings, trusted-device revocation, token handling, or the initial dashboard setup behavior.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Before this change, dashboard setup rejected usernames whose trimmed length is less than 3, but account edit only checked whether `new_username` was truthy before saving it. That allowed an authenticated account-edit request to persist values such as `"ab"` or `"   "` into the dashboard config.

Validation payloads covered:

```text
new_username: "ab"                 -> rejected with 用户名长度至少3位
new_username: "   "                -> rejected with 用户名长度至少3位
new_username: "  astrbot-admin  "  -> saved as astrbot-admin
```

The account update routes both call the shared account update service, so the validation boundary now applies before either route can write a new username.

Focused validation run locally:

```text
D:\ZXY\Dev\Miniforge3\envs\prw-astrbot-py312\python.exe -m pytest tests/test_dashboard.py -k "account_edit_rejects_invalid_username or account_edit_trims_valid_username" -q
```

Result:

```text
5 passed, 72 deselected, 1 warning in 5.05s
```

Formatting, lint, and diff checks:

```text
D:\ZXY\Dev\Miniforge3\envs\prw-astrbot-py312\python.exe -m ruff format --check astrbot/dashboard/services/auth_service.py tests/test_dashboard.py
2 files already formatted

D:\ZXY\Dev\Miniforge3\envs\prw-astrbot-py312\python.exe -m ruff check astrbot/dashboard/services/auth_service.py tests/test_dashboard.py
All checks passed!

git diff --check
```

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Enforce consistent validation for dashboard account username updates and ensure trimmed usernames are persisted correctly.

Bug Fixes:
- Reject dashboard account username updates whose trimmed length is less than the configured minimum instead of saving them to configuration.
- Persist dashboard usernames in trimmed form when updates include surrounding whitespace.

Tests:
- Add regression tests covering invalid username updates for both dashboard account edit API endpoints and verifying the username remains unchanged.
- Add tests ensuring valid usernames with surrounding spaces are accepted and stored in trimmed form.
