### PR TITLE
fix(core): 解除 call_event_hook 中 functools.partial 包装

### DIFF
--- a/astrbot/core/pipeline/context_utils.py
+++ b/astrbot/core/pipeline/context_utils.py
@@ -99,7 +99,7 @@ async def call_event_hook(
             logger.debug(
                 f"hook({hook_type.name}) -> {star_map[handler.handler_module_path].name} - {handler.handler_name}",
             )
-            await _handler_fn(event, *args, **kwargs)
+            await handler.handler(event, *args, **kwargs)
         except BaseException:
             logger.error(traceback.format_exc())
 

--- a/astrbot/core/pipeline/context_utils.py
+++ b/astrbot/core/pipeline/context_utils.py
@@ -1,6 +1,7 @@
 import inspect
 import traceback
 import typing as T
+import functools
 
 from astrbot import logger
 from astrbot.core.message.message_event_result import CommandResult, MessageEventResult
@@ -91,11 +92,14 @@ async def call_event_hook(
     )
     for handler in handlers:
         try:
-            assert inspect.iscoroutinefunction(handler.handler)
+            _handler_fn = handler.handler
+            while isinstance(_handler_fn, functools.partial):
+                _handler_fn = _handler_fn.func
+            assert inspect.iscoroutinefunction(_handler_fn)
             logger.debug(
                 f"hook({hook_type.name}) -> {star_map[handler.handler_module_path].name} - {handler.handler_name}",
             )
-            await handler.handler(event, *args, **kwargs)
+            await _handler_fn(event, *args, **kwargs)
         except BaseException:
             logger.error(traceback.format_exc())
 


### PR DESCRIPTION
### 改动

修复了 `call_event_hook` 中调用插件事件处理器时，`handler.handler` 可能被 `star_manager` 绑定为 `functools.partial` 对象，导致参数传递异常的问题。

**修改文件：**
- `astrbot/core/utils/context_utils.py` — 在 `call_event_hook` 函数中，调用前通过 `while isinstance(_handler_fn, functools.partial)` 解开所有 partial 包装，再执行原始函数。

### 测试结果

已在 AstrBot v4.26.5 + OneBotV11 环境下测试通过：
1. 安装 `astrbot_plugin_ai_draw` 插件
2. 修复前：`on_llm_request` 中 `self` 为 None，调用 `self.provider` 报错
3. 修复后：插件正常运行，`/画图`、`/识图` 功能正常，`self` 正确绑定到插件实例
4. 控制台无红色错误日志

### 运行日志

> [2026-07-07 14:40:11.082] [Core][INFO][core.event_bus:74]: [11Qtest] [QQ_Costom(aiocqhttp)] Aryun: [引用消息(Sakura: 🎨 生成完成：)] [At:2705889261] 这是什么 ？
> [2026-07-07 14:40:15.489] [Core][INFO][astrbot_plugin_ai_draw.main:438]: AiDraw on_agent_begin: 已拦截 1 张图片
> [2026-07-07 14:40:32.150] [Core][INFO][pipeline.context_utils:118]: astrbot_plugin_ai_draw - on_agent_begin 终止了事件传播。
> [2026-07-07 14:40:34.550] [Core][INFO][runners.tool_loop_agent_runner:1385]: Agent execution was requested to stop by user.
> [2026-07-07 14:40:34.552] [Core][INFO][pipeline.context_utils:118]: astrbot_plugin_recall_cancel - on_llm_response 终止了事件传播。
> [2026-07-07 14:40:34.579] [Core][INFO][respond.stage:206]: Prepare to send - Aryun: 📷 图片识别结果：
> 这张图片展示了一颗**CPU处理器芯片**的特写镜头，整体采用专业的产品摄影风格拍摄。以下是详细内容：
> 主体对象
> 芯片本体：一颗方形的处理器，以对角线角度放置在深色背景上。
> 基板颜色：PCB基板呈深绿色，边缘略微泛黄，显示出典型的电路板质感。
<img width="639" height="1622" alt="25b019bf-fe64-4cf9-9e2d-cdf76459b741" src="https://github.com/user-attachments/assets/80ef4664-0a5d-4f0c-9a75-bf506427cfe6" />

### Checklist / 检查清单
- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Resolve incorrect parameter binding when plugin event handlers are wrapped in functools.partial before execution.
Closes #9176

## Summary by Sourcery

Bug Fixes:
- Ensure plugin event handlers wrapped in functools.partial are unwrapped before coroutine checks and invocation to prevent incorrect parameter binding.