### PR TITLE
fix: remove unexpected force argument from get_json in astrbot\core\platform\sources\line\line_adapter.py"

### DIFF
--- a/astrbot/core/platform/sources/line/line_adapter.py
+++ b/astrbot/core/platform/sources/line/line_adapter.py
@@ -133,7 +133,7 @@ class LinePlatformAdapter(Platform):
             return "invalid signature", 400
 
         try:
-            payload = await request.get_json(force=True, silent=False)
+            payload = await request.get_json(silent=False)
         except Exception as e:
             logger.warning("[LINE] invalid webhook body: %s", e)
             return "bad request", 400


### PR DESCRIPTION
Fixes an issue where the LINE adapter crashes when receiving webhooks in `v4.26.5`. 

The error message:
`[line.line_adapter:138]: [LINE] invalid webhook body: DashboardRequest.get_json() got an unexpected keyword argument 'force'`

Since `DashboardRequest.get_json()` does not accept the `force` keyword argument, this PR removes it to ensure compatibility with the current API signature.

### Modifications / 改動點

- Modified `src/astrbot/core/adapter/line/line_adapter.py` around line 136

- Removed the `force=True` argument from `request.get_json()` call to match the `DashboardRequest` API signature.

- [x] This is NOT a breaking change. / 這不是一個破壞性變更。

### Screenshots or Test Results / 運行截圖或測試結果

I have run the test suite locally on a Windows environment. There are 2 failures reported in `test_computer_skill_sync.py` due to Windows path separator issues (`\` vs `/`), which is an existing platform-specific bug and entirely unrelated to this LINE adapter fix.

Other than that, the core functionality works as expected.

<img width="1113" height="627" alt="Screenshot 2026_7_8 下午 11_27_35" src="https://github.com/user-attachments/assets/f7cc4832-8729-4725-8ce4-8490ac4cbd86" />

<img width="1113" height="627" alt="Windows PowerShell 2026_7_8 下午 11_59_56" src="https://github.com/user-attachments/assets/6a10ae67-5ff7-4553-a324-9a8dcaffa2e7" />

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. / 如果 PR 中有新加入的功能，已經透過 Issue / 郵件等方式和作者討論過。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**. / 我的更改經過了良好的測試，**並已在上方提供了“驗證步驟”和“運行截圖”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`. / 我確保沒有引入新依賴庫，或者引入了新依賴庫的同時將其添加到 `requirements.txt` 和 `pyproject.toml` 文件相應位置。

- [x] 😮 My changes do not introduce malicious code. / 我的更改沒有引入惡意程式碼。

## Summary by Sourcery

Bug Fixes:
- Prevent LINE adapter crashes on incoming webhooks by removing the unsupported force argument from the JSON payload parsing call.