### PR TITLE
fix: use ephemeral cache control mode in anthropic provider to increase cache hit rate

### DIFF
--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -35,6 +35,8 @@ from .request_retry import retry_provider_request, retry_provider_request_contex
     "Anthropic Claude API 提供商适配器",
 )
 class ProviderAnthropic(Provider):
+    _PROMPT_CACHE_CONTROL = {"type": "ephemeral"}
+
     @staticmethod
     def _ensure_usable_response(
         llm_response: LLMResponse,
@@ -479,6 +481,16 @@ class ProviderAnthropic(Provider):
         logger.warning(f"未知的 tool_choice 值: {tool_choice}，已回退为 'auto'")
         return {"type": "auto"}
 
+    @classmethod
+    def _apply_explicit_prompt_cache_breakpoints(cls, payloads: dict) -> None:
+        system_blocks = payloads.get("system")
+        if not isinstance(system_blocks, list) or not system_blocks:
+            return
+
+        last_block = system_blocks[-1]
+        if isinstance(last_block, dict) and "cache_control" not in last_block:
+            last_block["cache_control"] = dict(cls._PROMPT_CACHE_CONTROL)
+
     async def _query(
         self,
         payloads: dict,
@@ -497,6 +509,7 @@ class ProviderAnthropic(Provider):
 
         if "max_tokens" not in payloads:
             payloads["max_tokens"] = 65536
+        self._apply_explicit_prompt_cache_breakpoints(payloads)
         self._apply_thinking_config(payloads)
         self._sanitize_assistant_messages(payloads)
 
@@ -598,6 +611,7 @@ class ProviderAnthropic(Provider):
 
         if "max_tokens" not in payloads:
             payloads["max_tokens"] = 65536
+        self._apply_explicit_prompt_cache_breakpoints(payloads)
         self._apply_thinking_config(payloads)
         self._sanitize_assistant_messages(payloads)
 


### PR DESCRIPTION
Related to #9196

### Changes / 改动

- add explicit `cache_control` to the last `system` block in the Anthropic provider request payload

### Verification / 验证

- `python3 -m py_compile astrbot/core/provider/sources/anthropic_source.py`
- tested with the running `astrbot` Docker container after syncing the updated file
- confirmed the container loaded the updated code