### PR TITLE
fix: update MiniMax TTS default model

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1766,7 +1766,7 @@ CONFIG_METADATA_2 = {
                         "api_key": "",
                         "api_base": "https://api.minimax.chat/v1/t2a_v2",
                         "minimax-group-id": "",
-                        "model": "speech-02-turbo",
+                        "model": "speech-2.8-hd",
                         "minimax-langboost": "auto",
                         "minimax-voice-speed": 1.0,
                         "minimax-voice-vol": 1.0,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,7 +6,7 @@ import os
 import pytest
 
 from astrbot.core.config.astrbot_config import AstrBotConfig, RateLimitStrategy
-from astrbot.core.config.default import CONFIG_METADATA_2, DEFAULT_VALUE_MAP
+from astrbot.core.config.default import DEFAULT_VALUE_MAP
 from astrbot.core.config.i18n_utils import ConfigMetadataI18n
 from astrbot.core.utils.auth_password import (
     DEFAULT_DASHBOARD_PASSWORD,
@@ -41,15 +41,6 @@ def minimal_default_config():
             "default_provider_id": "",
         },
     }
-
-
-def test_minimax_tts_default_model_is_speech_28_hd():
-    """MiniMax TTS should default to the current HD speech model."""
-    provider_sources = CONFIG_METADATA_2["provider_group"]["metadata"]["provider"][
-        "config_template"
-    ]
-
-    assert provider_sources["MiniMax TTS(API)"]["model"] == "speech-2.8-hd"
 
 
 class TestRateLimitStrategy:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,7 +6,7 @@ import os
 import pytest
 
 from astrbot.core.config.astrbot_config import AstrBotConfig, RateLimitStrategy
-from astrbot.core.config.default import DEFAULT_VALUE_MAP
+from astrbot.core.config.default import CONFIG_METADATA_2, DEFAULT_VALUE_MAP
 from astrbot.core.config.i18n_utils import ConfigMetadataI18n
 from astrbot.core.utils.auth_password import (
     DEFAULT_DASHBOARD_PASSWORD,
@@ -41,6 +41,15 @@ def minimal_default_config():
             "default_provider_id": "",
         },
     }
+
+
+def test_minimax_tts_default_model_is_speech_28_hd():
+    """MiniMax TTS should default to the current HD speech model."""
+    provider_sources = CONFIG_METADATA_2["provider_group"]["metadata"]["provider"][
+        "config_template"
+    ]
+
+    assert provider_sources["MiniMax TTS(API)"]["model"] == "speech-2.8-hd"
 
 
 class TestRateLimitStrategy:


### PR DESCRIPTION
Reason: MiniMax TTS is integrated but still defaults to speech-02-turbo instead of the target speech-2.8-hd model.

## Summary
- Update the built-in MiniMax TTS provider template to default to `speech-2.8-hd`.

## Validation
- `uv run --group dev pytest tests/unit/test_config.py` (`41 passed`)
- `uv run --group dev ruff format --check astrbot/core/config/default.py tests/unit/test_config.py`
- `uv run --group dev ruff check astrbot/core/config/default.py tests/unit/test_config.py`
- `git diff --check`
