### PR TITLE
fix: make ChatUI model selection theme-aware

### DIFF
--- a/dashboard/src/components/chat/ProviderModelMenu.vue
+++ b/dashboard/src/components/chat/ProviderModelMenu.vue
@@ -442,7 +442,7 @@ defineExpose({
 }
 
 .provider-menu-item.v-list-item--active {
-  background: #f2f2f2;
+  background: rgba(var(--v-theme-primary), 0.08);
   color: rgb(var(--v-theme-on-surface));
 }
 
@@ -515,10 +515,6 @@ defineExpose({
   color: rgba(var(--v-theme-on-surface), 0.5);
   font-size: 12px;
   text-align: center;
-}
-
-:global(.v-theme--dark) .provider-menu-item.v-list-item--active {
-  background: rgba(255, 255, 255, 0.1);
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary

- replace the hard-coded selected-model background with a Vuetify theme color
- remove the ineffective generic dark-theme override
- keep the change scoped to the ChatUI provider model menu

## Root cause

The selected model item used the fixed light color `#f2f2f2`. The fallback dark-mode selector targeted `.v-theme--dark`, while AstrBot uses named Vuetify themes such as `v-theme--PurpleThemeDark`, so the light background remained visible with white text in dark mode.

## Impact

The compiled selector remains scoped to `ProviderModelMenu.vue` and only changes the active item background. Provider data, API calls, selection behavior, hover styles, and other list components are unchanged.

## Validation

- `cd dashboard && pnpm build`
- `uv run ruff format .`
- `uv run ruff check .`
- verified the selected item in the running ChatUI under both light and dark themes
- confirmed computed backgrounds resolve from each theme's `--v-theme-primary` value

Fixes #9193

## Summary by Sourcery

Make the ChatUI provider model selection background use Vuetify theme colors for better light/dark theme support.

Enhancements:
- Use the Vuetify primary theme color for the active provider model menu item background instead of a hard-coded light color.
- Remove the obsolete dark-theme-specific background override for active provider model menu items to rely on theme-derived styling.