### PR TITLE
fix: resolve mobile chat input freeze and multiline attachment button alignment

### DIFF
--- a/dashboard/src/components/chat/ChatInput.vue
+++ b/dashboard/src/components/chat/ChatInput.vue
@@ -1633,10 +1633,10 @@ defineExpose({
   }
 
   .input-container.is-multiline .composer-row {
-    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-columns: auto minmax(0, 1fr) auto;
     grid-template-areas:
-      "field field"
-      "left right";
+      "field field field"
+      "left . right";
     min-height: auto;
     row-gap: 4px;
   }

--- a/dashboard/src/components/chat/ChatInput.vue
+++ b/dashboard/src/components/chat/ChatInput.vue
@@ -656,18 +656,19 @@ function autoResize() {
     return;
   }
   el.style.height = "auto";
-  el.style.minHeight = "0";
+  el.style.setProperty("min-height", "0", "important");
   const measuredHeight = el.scrollHeight;
-  el.style.minHeight = "";
+  el.style.removeProperty("min-height");
   const computed = getComputedStyle(el);
-  const lineHeight = parseFloat(computed.lineHeight);
+  let lineHeight = parseFloat(computed.lineHeight);
+  if (!Number.isFinite(lineHeight)) {
+    lineHeight = parseFloat(computed.fontSize) * 1.2;
+  }
   const paddingVertical =
     parseFloat(computed.paddingTop) + parseFloat(computed.paddingBottom);
-  const canMeasure =
-    Number.isFinite(lineHeight) && Number.isFinite(paddingVertical);
   const shouldUseMultiline =
     localPrompt.value.includes("\n") ||
-    (canMeasure ? measuredHeight > lineHeight + paddingVertical + 0.5 : true);
+    measuredHeight > lineHeight + paddingVertical + 0.5;
   if (inputIsMultiline.value !== shouldUseMultiline) {
     const cursor = el.selectionStart ?? localPrompt.value.length;
     inputIsMultiline.value = shouldUseMultiline;

--- a/dashboard/src/components/chat/ChatInput.vue
+++ b/dashboard/src/components/chat/ChatInput.vue
@@ -656,9 +656,18 @@ function autoResize() {
     return;
   }
   el.style.height = "auto";
+  el.style.minHeight = "0";
   const measuredHeight = el.scrollHeight;
+  el.style.minHeight = "";
+  const computed = getComputedStyle(el);
+  const lineHeight = parseFloat(computed.lineHeight);
+  const paddingVertical =
+    parseFloat(computed.paddingTop) + parseFloat(computed.paddingBottom);
+  const canMeasure =
+    Number.isFinite(lineHeight) && Number.isFinite(paddingVertical);
   const shouldUseMultiline =
-    localPrompt.value.includes("\n") || measuredHeight > minHeight + 8;
+    localPrompt.value.includes("\n") ||
+    (canMeasure ? measuredHeight > lineHeight + paddingVertical + 0.5 : true);
   if (inputIsMultiline.value !== shouldUseMultiline) {
     const cursor = el.selectionStart ?? localPrompt.value.length;
     inputIsMultiline.value = shouldUseMultiline;


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

Fixes: #9181 

文件：dashboard/src/components/chat/ChatInput.vue

1. 修复 autoResize() 无限振荡循环
将硬编码的 minHeight + 8 阈值替换为通过 getComputedStyle() 动态计算的单行内容高度（line-height + 上下 padding），能正确检测文本是否换行，不受视口相关 CSS 值的影响。
测量 scrollHeight 前临时设置 min-height: 0，避免 CSS min-height: 52px !important 抬高测量值。
当 getComputedStyle 返回非数值（如 line-height: normal）时，默认 shouldUseMultiline = true 作为安全回退，避免振荡。
2. 修复移动端多行附件按钮对齐
将移动端多行 grid 布局从两列 minmax(0, 1fr) auto（"left right"）改为三列 auto minmax(0, 1fr) auto（"left . right"），与桌面端一致，使 + 按钮靠左显示。
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<img width="497" height="695" alt="image" src="https://github.com/user-attachments/assets/4b09b47a-bbbd-4384-9dfa-77a4786ae160" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。
