### PR TITLE
Fix NVIDIA requests missing max_tokens

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -407,7 +407,15 @@ class ProviderOpenAIOfficial(Provider):
     def _apply_provider_specific_extra_body_overrides(
         self, extra_body: dict[str, Any]
     ) -> None:
-        if self.provider_config.get("provider") != "ollama":
+        provider = self.provider_config.get("provider")
+
+        # Some NVIDIA NIM models (for example MiniMax M3) return an empty
+        # choices list when max_tokens is omitted. Keep an explicit user value
+        # when configured, otherwise provide the default exposed by the WebUI.
+        if provider == "nvidia":
+            extra_body.setdefault("max_tokens", 8192)
+
+        if provider != "ollama":
             return
         if not self._ollama_disable_thinking_enabled():
             return

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -1298,6 +1298,33 @@ async def test_apply_provider_specific_extra_body_overrides_disables_ollama_thin
 
 
 @pytest.mark.asyncio
+async def test_apply_provider_specific_extra_body_overrides_sets_nvidia_max_tokens():
+    provider = _make_provider({"provider": "nvidia"})
+    try:
+        extra_body = {"temperature": 0.2}
+
+        provider._apply_provider_specific_extra_body_overrides(extra_body)
+
+        assert extra_body["max_tokens"] == 8192
+        assert extra_body["temperature"] == 0.2
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_nvidia_max_tokens_override_preserves_custom_value():
+    provider = _make_provider({"provider": "nvidia"})
+    try:
+        extra_body = {"max_tokens": 4096}
+
+        provider._apply_provider_specific_extra_body_overrides(extra_body)
+
+        assert extra_body["max_tokens"] == 4096
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
 async def test_query_injects_reasoning_effort_none_for_ollama(monkeypatch):
     provider = _make_provider(
         {


### PR DESCRIPTION
## Summary

- provide NVIDIA OpenAI-compatible providers with a default `max_tokens=8192`
- preserve a user-supplied `max_tokens` value
- add regression coverage for both the default and override behavior

## Root cause

Some NVIDIA NIM models, including MiniMax M3, return an empty `choices` list when `max_tokens` is omitted. AstrBot's prepared payload only contained `messages` and `model`, so both provider connectivity checks and regular requests could fail unless users manually added the field through `custom_extra_body`.

The fix is limited to providers whose configured provider ID is `nvidia`, avoiding behavior changes for other OpenAI-compatible services.

## User impact

NVIDIA users no longer need to manually configure `max_tokens` for affected models. Existing custom values still take precedence.

## Validation

- `uv run --group dev pytest tests/test_openai_source.py -q` — 60 passed
- `.venv/bin/ruff check astrbot/core/provider/sources/openai_source.py tests/test_openai_source.py`
- `git diff --check`

Fixes #9206

## Summary by Sourcery

Ensure NVIDIA OpenAI-compatible providers send a sensible default max_tokens value while preserving user overrides, and add regression tests for this behavior.

Bug Fixes:
- Prevent NVIDIA NIM requests from failing due to missing max_tokens by applying a provider-specific default.

Enhancements:
- Introduce provider-specific extra body handling for NVIDIA to align request payloads with model expectations.

Tests:
- Add async tests verifying that NVIDIA providers receive a default max_tokens value and that custom max_tokens settings are preserved.