### PR TITLE
fix: handle max_tokens for NVIDIA MiniMax M3

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -404,10 +404,26 @@ class ProviderOpenAIOfficial(Provider):
             return value.strip().lower() in {"1", "true", "yes", "on"}
         return bool(value)
 
-    def _apply_provider_specific_extra_body_overrides(
-        self, extra_body: dict[str, Any]
+    def _apply_provider_specific_request_overrides(
+        self,
+        payloads: dict[str, Any],
+        extra_body: dict[str, Any],
     ) -> None:
-        if self.provider_config.get("provider") != "ollama":
+        provider = self.provider_config.get("provider")
+        model = str(payloads.get("model", "")).lower()
+
+        # NVIDIA's hosted MiniMax M3 endpoint can return empty choices when
+        # max_tokens is omitted (#9206). Scope the compatibility default to
+        # that model; other NVIDIA models have different token limits.
+        if (
+            provider == "nvidia"
+            and model == "minimaxai/minimax-m3"
+            and "max_tokens" not in payloads
+            and "max_tokens" not in extra_body
+        ):
+            payloads["max_tokens"] = 8192
+
+        if provider != "ollama":
             return
         if not self._ollama_disable_thinking_enabled():
             return
@@ -543,7 +559,7 @@ class ProviderOpenAIOfficial(Provider):
         custom_extra_body = self.provider_config.get("custom_extra_body", {})
         if isinstance(custom_extra_body, dict):
             extra_body.update(custom_extra_body)
-        self._apply_provider_specific_extra_body_overrides(extra_body)
+        self._apply_provider_specific_request_overrides(payloads, extra_body)
 
         model = payloads.get("model", "").lower()
 
@@ -603,7 +619,7 @@ class ProviderOpenAIOfficial(Provider):
                 to_del.append(key)
         for key in to_del:
             del payloads[key]
-        self._apply_provider_specific_extra_body_overrides(extra_body)
+        self._apply_provider_specific_request_overrides(payloads, extra_body)
 
         self._sanitize_assistant_messages(payloads)
 

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -1272,7 +1272,7 @@ async def test_prepare_chat_payload_keeps_original_context_image_when_materializ
 
 
 @pytest.mark.asyncio
-async def test_apply_provider_specific_extra_body_overrides_disables_ollama_thinking():
+async def test_apply_provider_specific_request_overrides_disables_ollama_thinking():
     provider = _make_provider(
         {
             "provider": "ollama",
@@ -1287,12 +1287,75 @@ async def test_apply_provider_specific_extra_body_overrides_disables_ollama_thin
             "temperature": 0.2,
         }
 
-        provider._apply_provider_specific_extra_body_overrides(extra_body)
+        provider._apply_provider_specific_request_overrides({}, extra_body)
 
         assert extra_body["reasoning_effort"] == "none"
         assert "reasoning" not in extra_body
         assert "think" not in extra_body
         assert extra_body["temperature"] == 0.2
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_provider_specific_request_overrides_sets_minimax_m3_max_tokens():
+    provider = _make_provider({"provider": "nvidia"})
+    try:
+        payloads = {"model": "minimaxai/minimax-m3"}
+        extra_body = {"temperature": 0.2}
+
+        provider._apply_provider_specific_request_overrides(payloads, extra_body)
+
+        assert payloads["max_tokens"] == 8192
+        assert extra_body == {"temperature": 0.2}
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_minimax_m3_max_tokens_preserves_custom_extra_body_value():
+    provider = _make_provider({"provider": "nvidia"})
+    try:
+        payloads = {"model": "minimaxai/minimax-m3"}
+        extra_body = {"max_tokens": 4096}
+
+        provider._apply_provider_specific_request_overrides(payloads, extra_body)
+
+        assert "max_tokens" not in payloads
+        assert extra_body["max_tokens"] == 4096
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_minimax_m3_max_tokens_preserves_standard_payload_value():
+    provider = _make_provider({"provider": "nvidia"})
+    try:
+        payloads = {
+            "model": "minimaxai/minimax-m3",
+            "max_tokens": 2048,
+        }
+        extra_body = {}
+
+        provider._apply_provider_specific_request_overrides(payloads, extra_body)
+
+        assert payloads["max_tokens"] == 2048
+        assert extra_body == {}
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_nvidia_request_does_not_set_max_tokens_for_other_models():
+    provider = _make_provider({"provider": "nvidia"})
+    try:
+        payloads = {"model": "nvidia/usdcode"}
+        extra_body = {}
+
+        provider._apply_provider_specific_request_overrides(payloads, extra_body)
+
+        assert "max_tokens" not in payloads
+        assert "max_tokens" not in extra_body
     finally:
         await provider.terminate()
 


### PR DESCRIPTION
Fixes #9206.

NVIDIA documents `8192` as the default `max_tokens` value for MiniMax M3, but the hosted endpoint behavior reported in #9206 returns an empty `choices` list when the field is omitted. This PR adds a narrow compatibility workaround for that model without changing request limits for other NVIDIA models.

Reference: https://docs.api.nvidia.com/nim/reference/minimaxai-minimax-m3-infer

### Modifications / 改动点

- Apply `max_tokens=8192` only when the provider is NVIDIA and the actual request model is `minimaxai/minimax-m3`.
- Add the default to the standard request payload rather than `extra_body`.
- Preserve values explicitly supplied through either the standard payload or `custom_extra_body`.
- Keep all other NVIDIA models unchanged because their documented token limits differ.
- Add regression tests for the default, both override paths, and an unrelated NVIDIA model.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

- `python -m pytest tests/test_openai_source.py -q`: **62 passed**
- `ruff format --check .`: **480 files already formatted**
- `ruff check .`: **All checks passed**
- `git diff --check`: **passed**
- A full-suite attempt reached an unrelated dashboard plugin test that requires outbound access to `api.soulter.top`; that request is blocked in the local sandbox. GitHub Actions remains the source of truth for the complete suite after workflow approval.

---

### Checklist / 检查清单

- [x] 😊 This is a bug fix tracked in #9206; no new feature is introduced.
- [x] 👀 My changes have been well-tested, and verification results are provided above.
- [x] 🤓 No new dependencies are introduced.
- [x] 😮 My changes do not introduce malicious code.

## Summary by Sourcery

Apply provider-specific request overrides to set a default max_tokens for NVIDIA MiniMax M3 while keeping other models unchanged and preserving any explicit values.

Bug Fixes:
- Ensure NVIDIA MiniMax M3 requests include a default max_tokens value to avoid empty choices when the field is omitted.

Enhancements:
- Generalize provider-specific overrides from extra_body-only to operate on both the standard payload and extra_body for request customization.

Tests:
- Add regression tests covering the MiniMax M3 default max_tokens behavior, explicit overrides via extra_body and standard payload, and confirming no defaults are applied to other NVIDIA models.
- Update existing Ollama-specific test to use the new provider-specific request overrides API.