### PR TITLE
fix: return HTTP errors for failed skill downloads

### DIFF
--- a/astrbot/dashboard/api/skills.py
+++ b/astrbot/dashboard/api/skills.py
@@ -95,8 +95,7 @@ async def _download_skill(service: SkillsService, name: str):
         return _archive_response(service.prepare_skill_archive(name))
     except SkillsServiceError as exc:
         message = str(exc)
-        status_code = 404 if "not found" in message.lower() else 400
-        raise HTTPException(status_code=status_code, detail=message) from exc
+        raise HTTPException(status_code=exc.status_code, detail=message) from exc
     except Exception as exc:
         logger.error(str(exc), exc_info=True)
         raise HTTPException(

--- a/astrbot/dashboard/api/skills.py
+++ b/astrbot/dashboard/api/skills.py
@@ -95,11 +95,14 @@ async def _download_skill(service: SkillsService, name: str):
         return _archive_response(service.prepare_skill_archive(name))
     except SkillsServiceError as exc:
         message = str(exc)
-        status_code = 404 if message == "Local skill not found" else 400
+        status_code = 404 if "not found" in message.lower() else 400
         raise HTTPException(status_code=status_code, detail=message) from exc
     except Exception as exc:
         logger.error(str(exc), exc_info=True)
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to prepare skill archive",
+        ) from exc
 
 
 @router.get("/skills")

--- a/astrbot/dashboard/api/skills.py
+++ b/astrbot/dashboard/api/skills.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import FileResponse
 
 from astrbot.core import logger
@@ -94,10 +94,12 @@ async def _download_skill(service: SkillsService, name: str):
     try:
         return _archive_response(service.prepare_skill_archive(name))
     except SkillsServiceError as exc:
-        return error(str(exc))
+        message = str(exc)
+        status_code = 404 if message == "Local skill not found" else 400
+        raise HTTPException(status_code=status_code, detail=message) from exc
     except Exception as exc:
         logger.error(str(exc), exc_info=True)
-        return error(str(exc))
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
 @router.get("/skills")

--- a/astrbot/dashboard/services/skills_service.py
+++ b/astrbot/dashboard/services/skills_service.py
@@ -39,7 +39,9 @@ _EDITABLE_SKILL_FILENAMES = {"Dockerfile", "Makefile"}
 
 
 class SkillsServiceError(Exception):
-    pass
+    def __init__(self, message: str, *, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.status_code = status_code
 
 
 @dataclass
@@ -436,7 +438,7 @@ class SkillsService:
         skill_dir = Path(skill_mgr.skills_root) / skill_name
         skill_md = skill_dir / "SKILL.md"
         if not skill_dir.is_dir() or not skill_md.exists():
-            raise SkillsServiceError("Local skill not found")
+            raise SkillsServiceError("Local skill not found", status_code=404)
 
         export_dir = Path(get_astrbot_temp_path()) / "skill_exports"
         export_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_fastapi_v1_dashboard.py
+++ b/tests/test_fastapi_v1_dashboard.py
@@ -3235,7 +3235,7 @@ async def test_v1_skill_archive_errors_return_http_status(
     skill_service = asgi_app.state.services.skills
 
     def fake_prepare_skill_archive_404(_name: str):
-        raise SkillsServiceError("Local skill not found")
+        raise SkillsServiceError("Local skill not found", status_code=404)
 
     monkeypatch.setattr(
         skill_service,

--- a/tests/test_fastapi_v1_dashboard.py
+++ b/tests/test_fastapi_v1_dashboard.py
@@ -28,7 +28,7 @@ from astrbot.dashboard.services.plugin_service import (
     PLUGIN_UPDATE_SOURCE_REQUIRED_MESSAGE,
     PluginServiceError,
 )
-from astrbot.dashboard.services.skills_service import SkillArchive
+from astrbot.dashboard.services.skills_service import SkillArchive, SkillsServiceError
 
 JWT_SECRET = "fastapi-v1-test-secret-with-32-bytes"
 
@@ -1215,8 +1215,7 @@ async def test_v1_knowledge_base_create_validation_uses_api_error_shape(
     assert missing_provider_response.status_code == 200
     assert missing_provider_response.json()["status"] == "error"
     assert (
-        missing_provider_response.json()["message"]
-        == "缺少参数 embedding_provider_id"
+        missing_provider_response.json()["message"] == "缺少参数 embedding_provider_id"
     )
 
 
@@ -3225,6 +3224,42 @@ async def test_v1_safe_skill_routes_accept_slash_names(
     }
     assert delete_response.status_code == 200
     assert delete_response.json()["data"]["payload"] == {"name": skill_name}
+
+
+@pytest.mark.asyncio
+async def test_v1_skill_archive_errors_return_http_status(
+    asgi_app: FastAPI,
+    asgi_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    skill_service = asgi_app.state.services.skills
+
+    def fake_prepare_skill_archive(_name: str):
+        raise SkillsServiceError("Local skill not found")
+
+    monkeypatch.setattr(
+        skill_service,
+        "prepare_skill_archive",
+        fake_prepare_skill_archive,
+    )
+
+    by_name_response = await asgi_client.get(
+        "/api/v1/skills/archive",
+        params={"skill_name": "missing_skill"},
+        headers=_jwt_headers(),
+    )
+    path_response = await asgi_client.get(
+        "/api/v1/skills/missing_skill/archive",
+        headers=_jwt_headers(),
+    )
+
+    assert by_name_response.status_code == 404
+    assert by_name_response.headers["content-type"].startswith("application/json")
+    assert by_name_response.json()["status"] == "error"
+    assert by_name_response.json()["message"] == "Local skill not found"
+    assert path_response.status_code == 404
+    assert path_response.headers["content-type"].startswith("application/json")
+    assert path_response.json()["message"] == "Local skill not found"
 
 
 @pytest.mark.asyncio

--- a/tests/test_fastapi_v1_dashboard.py
+++ b/tests/test_fastapi_v1_dashboard.py
@@ -3234,13 +3234,13 @@ async def test_v1_skill_archive_errors_return_http_status(
 ):
     skill_service = asgi_app.state.services.skills
 
-    def fake_prepare_skill_archive(_name: str):
+    def fake_prepare_skill_archive_404(_name: str):
         raise SkillsServiceError("Local skill not found")
 
     monkeypatch.setattr(
         skill_service,
         "prepare_skill_archive",
-        fake_prepare_skill_archive,
+        fake_prepare_skill_archive_404,
     )
 
     by_name_response = await asgi_client.get(
@@ -3260,6 +3260,47 @@ async def test_v1_skill_archive_errors_return_http_status(
     assert path_response.status_code == 404
     assert path_response.headers["content-type"].startswith("application/json")
     assert path_response.json()["message"] == "Local skill not found"
+
+    def fake_prepare_skill_archive_400(_name: str):
+        raise SkillsServiceError("Invalid skill name")
+
+    monkeypatch.setattr(
+        skill_service,
+        "prepare_skill_archive",
+        fake_prepare_skill_archive_400,
+    )
+
+    bad_request_response = await asgi_client.get(
+        "/api/v1/skills/archive",
+        params={"skill_name": "invalid_skill"},
+        headers=_jwt_headers(),
+    )
+
+    assert bad_request_response.status_code == 400
+    assert bad_request_response.headers["content-type"].startswith("application/json")
+    assert bad_request_response.json()["status"] == "error"
+    assert bad_request_response.json()["message"] == "Invalid skill name"
+
+    def fake_prepare_skill_archive_500(_name: str):
+        raise RuntimeError("Unexpected database error")
+
+    monkeypatch.setattr(
+        skill_service,
+        "prepare_skill_archive",
+        fake_prepare_skill_archive_500,
+    )
+
+    server_error_response = await asgi_client.get(
+        "/api/v1/skills/archive",
+        params={"skill_name": "error_skill"},
+        headers=_jwt_headers(),
+    )
+
+    assert server_error_response.status_code == 500
+    assert server_error_response.headers["content-type"].startswith("application/json")
+    assert server_error_response.json()["status"] == "error"
+    assert server_error_response.json()["message"] == "Failed to prepare skill archive"
+    assert "Unexpected database error" not in server_error_response.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
﻿Fixes #9212

Skill archive download failures now return HTTP error statuses instead of HTTP 200 JSON bodies, so blob/ZIP callers do not save backend error envelopes as fake `.zip` files.

## What Problem This Solves

The skill archive download endpoints succeed with `FileResponse(..., media_type="application/zip")`, but `_download_skill()` previously caught `SkillsServiceError` and returned `error(str(exc))` directly.

Because `error()` is a normal JSON envelope, FastAPI serialized failed downloads as HTTP 200 JSON. The dashboard download flow calls `skillApi.download()` with `responseType: 'blob'`, then wraps the response as `application/zip` before saving it as `<skill>.zip`. That means failed archive preparation could be persisted by the browser as a ZIP-looking file containing an error payload.

## Modifications

- Updated `astrbot/dashboard/api/skills.py` so failed skill archive downloads raise `HTTPException` instead of returning a 200 JSON envelope.
- Added an optional `SkillsServiceError.status_code` attribute so the service layer can mark missing local skill archives as 404 without parsing exception text; other `SkillsServiceError` cases default to 400.
- Preserved full unexpected-exception logging while returning a generic HTTP 500 message to clients for unexpected archive preparation failures.
- Added focused FastAPI v1 regression coverage for 404, 400, and 500 archive failure paths; 404 is covered through both query-name and path-name archive endpoints.
- Left successful ZIP downloads, skill upload/list/edit/delete behavior, frontend API code, OpenAPI generation, and normal JSON skill APIs unchanged.

- [x] This is NOT a breaking change. This is a focused bug fix.

## Evidence

Before this change, a failed archive preparation path looked like this:

```text
Dashboard Skills download button
  -> skillApi.download(skill.name)
  -> GET /api/v1/skills/archive?skill_name=...
  -> _download_skill()
  -> service.prepare_skill_archive(name)
  -> SkillsServiceError("Local skill not found")
  -> return error(str(exc))
  -> HTTP 200 JSON body
  -> frontend treats response as Blob/application/zip
```

After this change, the same failure path returns a non-2xx JSON error response, so blob/ZIP callers do not treat the failed download as a successful archive. The regression test also covers the 400 branch for default service errors and the 500 branch for unexpected exceptions, including the guarantee that the raw internal exception message is not returned to the client.

## Possible call chain / impact

```text
Dashboard skill archive download
  -> dashboard/src/api/v1.ts skillApi.download(..., responseType: 'blob')
  -> GET /api/v1/skills/archive or /api/v1/skills/{skill_name}/archive
  -> astrbot/dashboard/api/skills.py _download_skill()
  -> SkillsService.prepare_skill_archive(name)
  -> SkillsServiceError / unexpected exception
  -> HTTP 400/404/500 JSON error instead of HTTP 200 JSON error
```

This only changes failed skill archive download responses. Successful archive downloads still return `application/zip`, and ordinary skill JSON APIs keep the existing dashboard response envelope behavior.

## Screenshots or Test Results

```text
uv run pytest tests/test_fastapi_v1_dashboard.py -k "skill_archive_errors_return_http_status or safe_skill_routes_accept_slash_names" -q
..                                                                       [100%]
2 passed, 70 deselected, 1 warning in 3.83s
```

```text
uv run pytest tests/test_fastapi_v1_dashboard.py -q
........................................................................ [100%]
72 passed, 1 warning in 19.54s
```

```text
uv run ruff check astrbot/dashboard/api/skills.py astrbot/dashboard/services/skills_service.py tests/test_fastapi_v1_dashboard.py
All checks passed!
```

```text
uv run ruff format astrbot/dashboard/api/skills.py astrbot/dashboard/services/skills_service.py tests/test_fastapi_v1_dashboard.py
2 files reformatted, 1 file left unchanged
```

---

## Checklist

- [x] No new feature is added; this is a focused bug fix linked to #9212.
- [x] The change has been tested, and verification output is provided above.
- [x] No new dependencies are introduced.
- [x] This change does not introduce malicious code.

## Summary by Sourcery

Return appropriate HTTP error statuses for failed skill archive downloads instead of successful ZIP responses.

Bug Fixes:
- Ensure skill archive download failures return HTTP 404/400/500 JSON errors rather than HTTP 200 responses that appear as valid ZIP downloads.
- Align skill archive error handling across both query-based and path-based endpoints to prevent saving backend error envelopes as ZIP files.

Tests:
- Add regression test verifying skill archive endpoints return correct HTTP status codes and JSON error payloads when archive preparation fails.


