### PR TITLE
fix: exempt WebChat from friend wake prefix

### DIFF
--- a/astrbot/core/pipeline/waking_check/stage.py
+++ b/astrbot/core/pipeline/waking_check/stage.py
@@ -138,7 +138,10 @@ class WakingCheckStage(Stage):
                     event.is_at_or_wake_command = True
                     break
             # 检查是否是私聊
-            if event.is_private_chat() and not self.friend_message_needs_wake_prefix:
+            if event.is_private_chat() and (
+                not self.friend_message_needs_wake_prefix
+                or event.get_platform_name() == "webchat"
+            ):
                 is_wake = True
                 event.is_wake = True
                 event.is_at_or_wake_command = True


### PR DESCRIPTION
Fixes #9211

## Summary

- exempt built-in WebChat private messages from `friend_message_needs_wake_prefix`
- preserve the configured wake-prefix requirement for external private-chat platforms

## Root cause

WebChat messages use `MessageType.FRIEND_MESSAGE`, so the waking stage treated them like private messages from external platform adapters. When `friend_message_needs_wake_prefix` was enabled, a WebChat message without `/` was stopped before the normal response pipeline.

## Impact

The exemption is limited to the built-in `webchat` platform type. QQ and other external private-chat platforms continue to follow the existing setting.

## Validation

- focused behavior check covering WebChat exemption, external private-chat enforcement, and the disabled-setting path
- `uv run ruff format .` — 480 files left unchanged
- `uv run ruff check .` — all checks passed
- `uv run pytest` — 1780 passed

## Summary by Sourcery

Bug Fixes:
- Ensure WebChat private messages are treated as wake events even when friend_message_needs_wake_prefix is enabled.