### PR TITLE
fix(agent): preserve tool metadata after skills-like requery

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -871,6 +871,9 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                     llm_resp.tools_call_name = requery_resp.tools_call_name
                     llm_resp.tools_call_args = requery_resp.tools_call_args
                     llm_resp.tools_call_ids = requery_resp.tools_call_ids
+                    llm_resp.tools_call_extra_content = (
+                        requery_resp.tools_call_extra_content
+                    )
 
             tool_call_result_blocks = []
             cached_images = []  # Collect cached images for LLM visibility

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -1331,6 +1331,10 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                     abort_signal=self._abort_signal,
                     request_max_retries=self.request_max_retries,
                 )
+                if requery_resp and requery_resp.usage:
+                    self.stats.token_usage += requery_resp.usage
+                    if self.req.conversation:
+                        self.req.conversation.token_usage += requery_resp.usage.total
                 if requery_resp:
                     llm_resp = requery_resp
                     self._sanitize_malformed_tool_calls(llm_resp)
@@ -1359,6 +1363,10 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                         abort_signal=self._abort_signal,
                         request_max_retries=self.request_max_retries,
                     )
+                    if repair_resp and repair_resp.usage:
+                        self.stats.token_usage += repair_resp.usage
+                        if self.req.conversation:
+                            self.req.conversation.token_usage += repair_resp.usage.total
                     if repair_resp:
                         llm_resp = repair_resp
                         self._sanitize_malformed_tool_calls(llm_resp)

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -1284,8 +1284,8 @@ async def test_follow_up_ticket_not_consumed_when_no_next_tool_call(
 
 
 @pytest.mark.asyncio
-async def test_skills_like_requery_passes_extra_user_content_parts():
-    """skills-like 模式 re-query 时应传递 extra_user_content_parts（如 image_caption）"""
+async def test_skills_like_requery_preserves_request_and_tool_metadata():
+    """skills-like re-query preserves request parts and provider tool metadata."""
     from astrbot.core.agent.message import TextPart
 
     captured_kwargs = {}
@@ -1301,6 +1301,11 @@ async def test_skills_like_requery_passes_extra_user_content_parts():
                     tools_call_name=["test_tool"],
                     tools_call_args=[{"query": "test"}],
                     tools_call_ids=["call_1"],
+                    tools_call_extra_content={
+                        "call_1": {
+                            "google": {"thought_signature": "selection-signature"}
+                        }
+                    },
                     usage=TokenUsage(input_other=10, output=5),
                 )
             if self.call_count == 2:
@@ -1312,6 +1317,9 @@ async def test_skills_like_requery_passes_extra_user_content_parts():
                     tools_call_name=["test_tool"],
                     tools_call_args=[{"query": "actual"}],
                     tools_call_ids=["call_2"],
+                    tools_call_extra_content={
+                        "call_2": {"google": {"thought_signature": "requery-signature"}}
+                    },
                     usage=TokenUsage(input_other=10, output=5),
                 )
             # 后续调用：正常回复
@@ -1362,6 +1370,16 @@ async def test_skills_like_requery_passes_extra_user_content_parts():
     parts = captured_kwargs["extra_user_content_parts"]
     assert len(parts) == 1
     assert parts[0].text == "<image_caption>一张猫的照片</image_caption>"
+
+    assistant_tool_message = next(
+        message
+        for message in run_context.messages
+        if message.role == "assistant" and message.tool_calls
+    )
+    assert assistant_tool_message.tool_calls[0].id == "call_2"
+    assert assistant_tool_message.tool_calls[0].extra_content == {
+        "google": {"thought_signature": "requery-signature"}
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -1284,8 +1284,8 @@ async def test_follow_up_ticket_not_consumed_when_no_next_tool_call(
 
 
 @pytest.mark.asyncio
-async def test_skills_like_requery_preserves_request_and_tool_metadata():
-    """skills-like re-query preserves request parts and provider tool metadata."""
+async def test_skills_like_requery_preserves_request_tool_metadata_and_usage():
+    """skills-like re-query preserves metadata and counts its token usage."""
     from astrbot.core.agent.message import TextPart
 
     captured_kwargs = {}
@@ -1306,7 +1306,7 @@ async def test_skills_like_requery_preserves_request_and_tool_metadata():
                             "google": {"thought_signature": "selection-signature"}
                         }
                     },
-                    usage=TokenUsage(input_other=10, output=5),
+                    usage=TokenUsage(input_other=10, input_cached=2, output=5),
                 )
             if self.call_count == 2:
                 # 第二次调用：re-query with param schema
@@ -1320,7 +1320,7 @@ async def test_skills_like_requery_preserves_request_and_tool_metadata():
                     tools_call_extra_content={
                         "call_2": {"google": {"thought_signature": "requery-signature"}}
                     },
-                    usage=TokenUsage(input_other=10, output=5),
+                    usage=TokenUsage(input_other=20, input_cached=3, output=7),
                 )
             # 后续调用：正常回复
             return LLMResponse(
@@ -1339,11 +1339,13 @@ async def test_skills_like_requery_preserves_request_and_tool_metadata():
     tool_set = ToolSet(tools=[tool])
 
     caption_part = TextPart(text="<image_caption>一张猫的照片</image_caption>")
+    conversation = SimpleNamespace(cid="test-conversation", token_usage=0)
     req = ProviderRequest(
         prompt="看看这张图",
         func_tool=tool_set,
         contexts=[],
         extra_user_content_parts=[caption_part],
+        conversation=cast(Any, conversation),
     )
 
     event = MockEvent(umo="test_umo", sender_id="test_sender")
@@ -1380,6 +1382,135 @@ async def test_skills_like_requery_preserves_request_and_tool_metadata():
     assert assistant_tool_message.tool_calls[0].extra_content == {
         "google": {"thought_signature": "requery-signature"}
     }
+    assert runner.stats.token_usage == TokenUsage(
+        input_other=30,
+        input_cached=5,
+        output=12,
+    )
+    assert conversation.token_usage == 47
+
+
+@pytest.mark.asyncio
+async def test_skills_like_requery_repair_counts_both_extra_requests():
+    """skills-like repair counts both provider requests after tool selection."""
+
+    class RepairProvider(MockProvider):
+        async def text_chat(self, **kwargs) -> LLMResponse:
+            self.call_count += 1
+            if self.call_count == 1:
+                return LLMResponse(
+                    role="assistant",
+                    tools_call_name=["test_tool"],
+                    tools_call_args=[{"query": "test"}],
+                    tools_call_ids=["call_1"],
+                    usage=TokenUsage(input_other=2, input_cached=3, output=5),
+                )
+            if self.call_count == 2:
+                return LLMResponse(
+                    role="assistant",
+                    completion_text="",
+                    usage=TokenUsage(input_other=7, input_cached=11, output=13),
+                )
+            if self.call_count == 3:
+                return LLMResponse(
+                    role="assistant",
+                    tools_call_name=["test_tool"],
+                    tools_call_args=[{"query": "repaired"}],
+                    tools_call_ids=["call_3"],
+                    usage=TokenUsage(input_other=17, input_cached=19, output=23),
+                )
+            raise AssertionError("Unexpected provider request")
+
+    provider = RepairProvider()
+    tool = FunctionTool(
+        name="test_tool",
+        description="test",
+        parameters={"type": "object", "properties": {"query": {"type": "string"}}},
+        handler=AsyncMock(),
+    )
+    conversation = SimpleNamespace(cid="test-conversation", token_usage=0)
+    request = ProviderRequest(
+        prompt="run tool",
+        func_tool=ToolSet(tools=[tool]),
+        contexts=[],
+        conversation=cast(Any, conversation),
+    )
+    run_context = ContextWrapper(
+        context=MockAgentContext(MockEvent("test_umo", "test_sender"))
+    )
+    runner = ToolLoopAgentRunner()
+
+    await runner.reset(
+        provider=provider,
+        request=request,
+        run_context=run_context,
+        tool_executor=cast(Any, MockToolExecutor()),
+        agent_hooks=MockHooks(),
+        tool_schema_mode="skills_like",
+    )
+
+    async for _ in runner.step():
+        pass
+
+    assert provider.call_count == 3
+    assert runner.stats.token_usage == TokenUsage(
+        input_other=26,
+        input_cached=33,
+        output=41,
+    )
+    assert conversation.token_usage == 100
+
+
+@pytest.mark.asyncio
+async def test_skills_like_without_requery_does_not_double_count_usage():
+    """A tool selection without a matching schema is counted only once."""
+
+    class UnknownToolProvider(MockProvider):
+        async def text_chat(self, **kwargs) -> LLMResponse:
+            self.call_count += 1
+            return LLMResponse(
+                role="assistant",
+                tools_call_name=["missing_tool"],
+                tools_call_args=[{}],
+                tools_call_ids=["call_missing"],
+                usage=TokenUsage(input_other=29, input_cached=31, output=37),
+            )
+
+    provider = UnknownToolProvider()
+    tool = FunctionTool(
+        name="test_tool",
+        description="test",
+        parameters={"type": "object", "properties": {}},
+        handler=AsyncMock(),
+    )
+    conversation = SimpleNamespace(cid="test-conversation", token_usage=0)
+    request = ProviderRequest(
+        prompt="run tool",
+        func_tool=ToolSet(tools=[tool]),
+        contexts=[],
+        conversation=cast(Any, conversation),
+    )
+    runner = ToolLoopAgentRunner()
+
+    await runner.reset(
+        provider=provider,
+        request=request,
+        run_context=ContextWrapper(context=None),
+        tool_executor=cast(Any, MockToolExecutor()),
+        agent_hooks=MockHooks(),
+        tool_schema_mode="skills_like",
+    )
+
+    async for _ in runner.step():
+        pass
+
+    assert provider.call_count == 1
+    assert runner.stats.token_usage == TokenUsage(
+        input_other=29,
+        input_cached=31,
+        output=37,
+    )
+    assert conversation.token_usage == 97
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #9217.

Gemini returns a thought signature with the function call produced by a
`skills_like` parameter re-query. The runner replaced the selected tool call's
name, arguments, and ID with the re-query result, but kept the original
provider metadata map. When the call ID changed, the re-query signature was
therefore absent from the assistant history, and Gemini rejected the next turn.

This change follows Google's
[thought-signature guidance](https://ai.google.dev/gemini-api/docs/generate-content/thinking#thought-signatures),
which requires model-generated function-call signatures to be returned
unchanged in subsequent turns.

### Modifications / 改动点

- Keep `tools_call_extra_content` synchronized with the name, arguments, and ID
  returned by a `skills_like` re-query.
- Preserve the real provider metadata associated with the final function call
  instead of retaining metadata from the initial tool-selection response.
- Add regression coverage using distinct initial and re-query call IDs and
  signatures, verifying that the recorded assistant history contains the
  re-query signature.
- Leave non-`skills_like` execution, Gemini serialization, shared message
  models, configuration, and dependencies unchanged.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```text
python -m pytest -q \
  tests/test_tool_loop_agent_runner.py \
  tests/test_gemini_source.py

34 passed
```

```text
ruff format --check .
480 files already formatted
```

```text
ruff check .
All checks passed!
```

```text
git diff --check
Passed
```

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure skills-like tool re-queries correctly preserve provider metadata and token usage accounting for Gemini tool calls.

Bug Fixes:
- Preserve tools_call_extra_content when replacing a skills-like tool selection with a re-query response so the final function-call signature is recorded in assistant history.

Enhancements:
- Track and aggregate token usage from skills-like requery and repair provider calls into runner stats and per-conversation usage without double-counting non-requery tool selections.

Tests:
- Add regression tests covering skills-like requery metadata preservation, usage accumulation across extra provider requests, and avoiding double-counting when no schema match occurs.