### PR TITLE
fix: accept UTF-8 BOM in plugin schemas

### DIFF
--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -576,6 +576,22 @@ class PluginManager:
         return translations
 
     @staticmethod
+    def _load_plugin_config_schema(schema_path: str) -> dict:
+        """Load a plugin config schema, accepting an optional UTF-8 BOM."""
+        try:
+            with open(schema_path, encoding="utf-8-sig") as f:
+                return json.load(f)
+        except UnicodeDecodeError as exc:
+            raise ValueError(
+                f"插件配置 schema 必须使用 UTF-8 编码: {schema_path}"
+            ) from exc
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"插件配置 schema 不是有效的 JSON: {schema_path} "
+                f"(line {exc.lineno}, column {exc.colno})"
+            ) from exc
+
+    @staticmethod
     def _normalize_plugin_dir_name(plugin_name: str) -> str:
         return plugin_name.strip()
 
@@ -1111,14 +1127,13 @@ class PluginManager:
                 )
                 if os.path.exists(plugin_schema_path):
                     # 加载插件配置
-                    with open(plugin_schema_path, encoding="utf-8") as f:
-                        plugin_config = AstrBotConfig(
-                            config_path=os.path.join(
-                                self.plugin_config_path,
-                                f"{root_dir_name}_config.json",
-                            ),
-                            schema=json.loads(f.read()),
-                        )
+                    plugin_config = AstrBotConfig(
+                        config_path=os.path.join(
+                            self.plugin_config_path,
+                            f"{root_dir_name}_config.json",
+                        ),
+                        schema=self._load_plugin_config_schema(plugin_schema_path),
+                    )
                 logo_path = os.path.join(plugin_dir_path, self.logo_fname)
 
                 if path in star_map:

--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -559,7 +559,7 @@ class PluginManager:
                     continue
 
                 try:
-                    with file_path.open(encoding="utf-8") as f:
+                    with file_path.open(encoding="utf-8-sig") as f:
                         locale_data = json.load(f)
                     if isinstance(locale_data, dict):
                         translations[locale] = locale_data

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -20,6 +20,32 @@ TEST_PLUGIN_REPO = "https://github.com/AstrBotDevs/astrbot_plugin_helloworld"
 TEST_PLUGIN_DIR = "helloworld"
 
 
+def test_load_plugin_config_schema_accepts_utf8_bom(tmp_path: Path):
+    schema_path = tmp_path / "_conf_schema.json"
+    schema_path.write_bytes(b'\xef\xbb\xbf{"type": "object"}')
+
+    assert PluginManager._load_plugin_config_schema(str(schema_path)) == {
+        "type": "object"
+    }
+
+
+def test_load_plugin_config_schema_accepts_utf8_without_bom(tmp_path: Path):
+    schema_path = tmp_path / "_conf_schema.json"
+    schema_path.write_text('{"type": "object"}', encoding="utf-8")
+
+    assert PluginManager._load_plugin_config_schema(str(schema_path)) == {
+        "type": "object"
+    }
+
+
+def test_load_plugin_config_schema_reports_invalid_json(tmp_path: Path):
+    schema_path = tmp_path / "_conf_schema.json"
+    schema_path.write_text("{invalid", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="不是有效的 JSON"):
+        PluginManager._load_plugin_config_schema(str(schema_path))
+
+
 class MockStar:
     def __init__(self):
         self.root_dir_name = TEST_PLUGIN_DIR

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -85,9 +85,11 @@ def test_load_plugin_i18n_reads_locale_files(tmp_path: Path):
     plugin_path = tmp_path / "plugin"
     i18n_path = plugin_path / ".astrbot-plugin" / "i18n"
     i18n_path.mkdir(parents=True)
-    (i18n_path / "zh-CN.json").write_text(
-        json.dumps({"metadata": {"desc": "中文描述"}}, ensure_ascii=False),
-        encoding="utf-8",
+    (i18n_path / "zh-CN.json").write_bytes(
+        b"\xef\xbb\xbf"
+        + json.dumps({"metadata": {"desc": "中文描述"}}, ensure_ascii=False).encode(
+            "utf-8"
+        ),
     )
     (i18n_path / "en-US.json").write_text(
         json.dumps({"metadata": {"desc": "English description"}}),


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
fix #9222 
### Modifications / 改动点
- 修改 `astrbot/core/star/star_manager.py`：
  - 新增 `_load_plugin_config_schema()`，统一处理插件 `_conf_schema.json` 的读取与解析。
  - 使用 `utf-8-sig` 读取插件配置 schema，同时兼容 UTF-8 无 BOM 和 UTF-8 BOM。
  - 分别处理编码错误与 JSON 语法错误，并在 JSON 错误信息中提供行号和列号。
  - 使用 `utf-8-sig` 读取 `.astrbot-plugin/i18n/*.json`，避免带 BOM 的插件翻译文件加载失败。

- 修改 `tests/test_plugin_manager.py`：
  - 添加带 UTF-8 BOM 的插件配置 schema 测试。
  - 添加无 BOM 的普通 UTF-8 schema 测试。
  - 添加无效 JSON schema 的错误处理测试。
  - 扩展插件 i18n 测试，同时覆盖带 BOM 和无 BOM 的 locale JSON 文件。
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Handle plugin config schemas and i18n locale files encoded with UTF-8 BOM while improving error reporting.

Bug Fixes:
- Allow plugin config schema files with UTF-8 BOM to be parsed correctly.
- Ensure plugin i18n locale JSON files with UTF-8 BOM are loaded without errors.
- Report invalid plugin config schema JSON with clear errors including line and column information.

Enhancements:
- Introduce a dedicated helper to load plugin config schemas with consistent UTF-8 handling.
- Extend plugin manager tests to cover UTF-8 BOM and non-BOM schemas, invalid JSON handling, and BOM i18n files.