### PR TITLE
fix: restrict future tasks to administrators

### DIFF
--- a/astrbot/core/tools/cron_tools.py
+++ b/astrbot/core/tools/cron_tools.py
@@ -98,6 +98,13 @@ class FutureTaskTool(FunctionTool[AstrAgentContext]):
     async def call(
         self, context: ContextWrapper[AstrAgentContext], **kwargs
     ) -> ToolExecResult:
+        event = context.context.event
+        if getattr(event, "role", None) != "admin":
+            return (
+                "error: Permission denied. Future task management is only allowed "
+                f"for admin users. User's ID is: {event.get_sender_id()}."
+            )
+
         cron_mgr = context.context.context.cron_manager
         if cron_mgr is None:
             return "error: cron manager is not available."

--- a/astrbot/core/tools/cron_tools.py
+++ b/astrbot/core/tools/cron_tools.py
@@ -99,7 +99,7 @@ class FutureTaskTool(FunctionTool[AstrAgentContext]):
         self, context: ContextWrapper[AstrAgentContext], **kwargs
     ) -> ToolExecResult:
         event = context.context.event
-        if getattr(event, "role", None) != "admin":
+        if not event.is_admin():
             return (
                 "error: Permission denied. Future task management is only allowed "
                 f"for admin users. User's ID is: {event.get_sender_id()}."

--- a/tests/unit/test_cron_tools.py
+++ b/tests/unit/test_cron_tools.py
@@ -8,11 +8,18 @@ import pytest
 from astrbot.core.tools.cron_tools import FutureTaskTool
 
 
-def _context(cron_mgr, *, umo: str = "test:group:shared", sender_id: str = "user-1"):
+def _context(
+    cron_mgr,
+    *,
+    umo: str = "test:group:shared",
+    sender_id: str = "user-1",
+    role: str = "admin",
+):
     return SimpleNamespace(
         context=SimpleNamespace(
             context=SimpleNamespace(cron_manager=cron_mgr),
             event=SimpleNamespace(
+                role=role,
                 unified_msg_origin=umo,
                 get_sender_id=lambda: sender_id,
             ),
@@ -80,6 +87,7 @@ async def test_future_task_edit_requires_job_id():
         context=SimpleNamespace(
             context=SimpleNamespace(cron_manager=cron_mgr),
             event=SimpleNamespace(
+                role="admin",
                 unified_msg_origin="test:private:session",
                 get_sender_id=lambda: "user-1",
             ),
@@ -123,6 +131,7 @@ async def test_future_task_edit_updates_existing_job():
         context=SimpleNamespace(
             context=SimpleNamespace(cron_manager=cron_mgr),
             event=SimpleNamespace(
+                role="admin",
                 unified_msg_origin="test:private:session",
                 get_sender_id=lambda: "user-1",
             ),
@@ -154,6 +163,26 @@ async def test_future_task_edit_updates_existing_job():
         },
     )
     assert result == "Updated future task job-1 (new name)."
+
+
+@pytest.mark.asyncio
+async def test_future_task_create_rejects_non_admin_users():
+    """Regular members must not create persistent, token-consuming tasks."""
+    tool = FutureTaskTool()
+    cron_mgr = SimpleNamespace(add_active_job=AsyncMock())
+
+    result = await tool.call(
+        _context(cron_mgr, sender_id="regular-user", role="member"),
+        action="create",
+        cron_expression="0 8 * * *",
+        note="Generate a daily report",
+    )
+
+    assert result == (
+        "error: Permission denied. Future task management is only allowed for "
+        "admin users. User's ID is: regular-user."
+    )
+    cron_mgr.add_active_job.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_cron_tools.py
+++ b/tests/unit/test_cron_tools.py
@@ -13,13 +13,14 @@ def _context(
     *,
     umo: str = "test:group:shared",
     sender_id: str = "user-1",
-    role: str = "admin",
+    role: str | None = "admin",
 ):
     return SimpleNamespace(
         context=SimpleNamespace(
             context=SimpleNamespace(cron_manager=cron_mgr),
             event=SimpleNamespace(
                 role=role,
+                is_admin=lambda: role == "admin",
                 unified_msg_origin=umo,
                 get_sender_id=lambda: sender_id,
             ),
@@ -83,18 +84,10 @@ async def test_future_task_edit_requires_job_id():
     """Edit mode should require job_id."""
     tool = FutureTaskTool()
     cron_mgr = SimpleNamespace()
-    context = SimpleNamespace(
-        context=SimpleNamespace(
-            context=SimpleNamespace(cron_manager=cron_mgr),
-            event=SimpleNamespace(
-                role="admin",
-                unified_msg_origin="test:private:session",
-                get_sender_id=lambda: "user-1",
-            ),
-        )
-    )
 
-    result = await tool.call(context, action="edit")
+    result = await tool.call(
+        _context(cron_mgr, umo="test:private:session"), action="edit"
+    )
 
     assert result == "error: job_id is required when action=edit."
 
@@ -127,19 +120,9 @@ async def test_future_task_edit_updates_existing_job():
         db=SimpleNamespace(get_cron_job=AsyncMock(return_value=existing_job)),
         update_job=AsyncMock(return_value=updated_job),
     )
-    context = SimpleNamespace(
-        context=SimpleNamespace(
-            context=SimpleNamespace(cron_manager=cron_mgr),
-            event=SimpleNamespace(
-                role="admin",
-                unified_msg_origin="test:private:session",
-                get_sender_id=lambda: "user-1",
-            ),
-        )
-    )
 
     result = await tool.call(
-        context,
+        _context(cron_mgr, umo="test:private:session"),
         action="edit",
         job_id="job-1",
         name="new name",
@@ -166,23 +149,81 @@ async def test_future_task_edit_updates_existing_job():
 
 
 @pytest.mark.asyncio
-async def test_future_task_create_rejects_non_admin_users():
-    """Regular members must not create persistent, token-consuming tasks."""
+async def test_future_task_uses_event_admin_contract():
+    """Authorization should use the event's public admin predicate."""
     tool = FutureTaskTool()
-    cron_mgr = SimpleNamespace(add_active_job=AsyncMock())
+    context = SimpleNamespace(
+        context=SimpleNamespace(
+            context=SimpleNamespace(cron_manager=SimpleNamespace()),
+            event=SimpleNamespace(
+                is_admin=lambda: True,
+                unified_msg_origin="test:private:session",
+                get_sender_id=lambda: "admin-user",
+            ),
+        )
+    )
+
+    result = await tool.call(context, action="edit")
+
+    assert result == "error: job_id is required when action=edit."
+
+
+@pytest.mark.asyncio
+async def test_future_task_admin_can_create_task():
+    """Administrators should retain the existing task creation behavior."""
+    tool = FutureTaskTool()
+    job = SimpleNamespace(
+        job_id="job-1",
+        name="daily-report",
+        next_run_time="2026-07-14T08:00:00+08:00",
+    )
+    cron_mgr = SimpleNamespace(add_active_job=AsyncMock(return_value=job))
 
     result = await tool.call(
-        _context(cron_mgr, sender_id="regular-user", role="member"),
+        _context(cron_mgr, sender_id="admin-user"),
         action="create",
+        name="daily-report",
         cron_expression="0 8 * * *",
         note="Generate a daily report",
+    )
+
+    cron_mgr.add_active_job.assert_awaited_once_with(
+        name="daily-report",
+        cron_expression="0 8 * * *",
+        payload={
+            "session": "test:group:shared",
+            "sender_id": "admin-user",
+            "note": "Generate a daily report",
+            "origin": "tool",
+        },
+        description="Generate a daily report",
+        run_once=False,
+        run_at=None,
+    )
+    assert result == (
+        "Scheduled future task job-1 (daily-report) expression '0 8 * * *' "
+        "(next 2026-07-14T08:00:00+08:00)."
+    )
+
+
+@pytest.mark.parametrize("action", ["create", "edit", "delete", "list"])
+@pytest.mark.parametrize("role", ["member", None])
+@pytest.mark.asyncio
+async def test_future_task_rejects_non_admin_users_for_every_action(
+    action: str, role: str | None
+):
+    """Every action should fail closed for members and missing roles."""
+    tool = FutureTaskTool()
+
+    result = await tool.call(
+        _context(SimpleNamespace(), sender_id="regular-user", role=role),
+        action=action,
     )
 
     assert result == (
         "error: Permission denied. Future task management is only allowed for "
         "admin users. User's ID is: regular-user."
     )
-    cron_mgr.add_active_job.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Related to #8517 and #8512. Complements the future-task ownership hardening in #8881, which closed #8859.

AstrBot's built-in `future_task` tool was not covered by the configurable permission wrapper for plugin and MCP tools, and unlike other stateful built-in tools, it had no execution-time administrator check. As a result, a regular group member could create persistent agent jobs that later invoke the configured LLM and consume provider tokens.

This can be abused to create many high-frequency recurring tasks. Each execution can trigger another LLM request, so allowing every group member to schedule tasks may cause sustained and potentially substantial token consumption and provider API costs until the jobs are discovered and removed.

### Modifications / 改动点

- Require an AstrBot administrator role for every `future_task` action through the event's standard `is_admin()` contract.
- Reject unauthorized calls before accessing the cron manager, database, or scheduler.
- Cover create, edit, delete, and list for regular members and missing roles to ensure authorization fails closed.
- Verify administrators retain task creation behavior and persist the correct session and sender identity.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

This is a backend-only authorization fix, so no UI screenshot is applicable.

- Regression test before the fix: **failed as expected** because the member call reached `add_active_job()` and returned a successful scheduling response.
- Admin-contract test before the follow-up: **failed as expected** because the implementation inspected a raw role string instead of `event.is_admin()`.
- `pytest tests/unit/test_cron_tools.py tests/unit/test_cron_manager.py -q`: **52 passed**
- `ruff format --check .`: **480 files already formatted**
- `ruff check .`: **All checks passed**
- `python -m py_compile astrbot/core/tools/cron_tools.py tests/unit/test_cron_tools.py`: **passed**
- `git diff --check`: **passed**

---

### Checklist / 检查清单

- [x] 😊 This is a narrowly scoped authorization bug fix related to #8517 and #8512; no new feature is introduced.
  / 这是与 #8517 和 #8512 相关的权限修复，不引入新功能。
- [x] 👀 My changes have been well-tested, and verification results are provided above.
  / 我的更改经过了充分测试，并已在上方提供验证结果。
- [x] 🤓 No new dependencies are introduced.
  / 本次更改没有引入新依赖。
- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。
