### PR TITLE
fix: improve conversation list performance and prevent stale updates

### DIFF
--- a/astrbot/core/conversation_mgr.py
+++ b/astrbot/core/conversation_mgr.py
@@ -79,7 +79,7 @@ class ConversationManager:
             platform_id=conv_v2.platform_id,
             user_id=conv_v2.user_id,
             cid=conv_v2.conversation_id,
-            history=json.dumps(conv_v2.content or []) if include_history else "",
+            history=json.dumps(conv_v2.content or []) if include_history else "[]",
             title=conv_v2.title,
             persona_id=conv_v2.persona_id,
             created_at=created_at,

--- a/astrbot/core/conversation_mgr.py
+++ b/astrbot/core/conversation_mgr.py
@@ -57,8 +57,20 @@ class ConversationManager:
                     f"会话删除回调执行失败 (session: {unified_msg_origin}): {e}",
                 )
 
-    def _convert_conv_from_v2_to_v1(self, conv_v2: ConversationV2) -> Conversation:
-        """将 ConversationV2 对象转换为 Conversation 对象"""
+    def _convert_conv_from_v2_to_v1(
+        self,
+        conv_v2: ConversationV2,
+        include_history: bool = True,
+    ) -> Conversation:
+        """Convert a ConversationV2 object into the legacy Conversation object.
+
+        Args:
+            conv_v2: Database conversation object.
+            include_history: Whether to access and serialize the full history.
+
+        Returns:
+            Legacy-compatible conversation object.
+        """
         created_ts = to_utc_timestamp(conv_v2.created_at)
         updated_ts = to_utc_timestamp(conv_v2.updated_at)
         created_at = int(created_ts) if created_ts is not None else 0
@@ -67,7 +79,7 @@ class ConversationManager:
             platform_id=conv_v2.platform_id,
             user_id=conv_v2.user_id,
             cid=conv_v2.conversation_id,
-            history=json.dumps(conv_v2.content or []),
+            history=json.dumps(conv_v2.content or []) if include_history else "",
             title=conv_v2.title,
             persona_id=conv_v2.persona_id,
             created_at=created_at,
@@ -229,6 +241,7 @@ class ConversationManager:
         page_size: int = 20,
         platform_ids: list[str] | None = None,
         search_query: str = "",
+        include_history: bool = True,
         **kwargs,
     ) -> tuple[list[Conversation], int]:
         """获取过滤后的对话列表.
@@ -238,20 +251,27 @@ class ConversationManager:
             page_size (int): 每页大小, 默认为 20
             platform_ids (list[str]): 平台 ID 列表, 可选
             search_query (str): 搜索查询字符串, 可选
+            include_history (bool): Whether to load the full conversation history.
         Returns:
             conversations (list[Conversation]): 对话对象列表
 
         """
-        convs, cnt = await self.db.get_filtered_conversations(
-            page=page,
-            page_size=page_size,
-            platform_ids=platform_ids,
-            search_query=search_query,
+        query_kwargs = {
+            "page": page,
+            "page_size": page_size,
+            "platform_ids": platform_ids,
+            "search_query": search_query,
             **kwargs,
-        )
+        }
+        if not include_history:
+            query_kwargs["include_content"] = False
+        convs, cnt = await self.db.get_filtered_conversations(**query_kwargs)
         convs_res = []
         for conv in convs:
-            conv_res = self._convert_conv_from_v2_to_v1(conv)
+            conv_res = self._convert_conv_from_v2_to_v1(
+                conv,
+                include_history=include_history,
+            )
             convs_res.append(conv_res)
         return convs_res, cnt
 

--- a/astrbot/core/conversation_mgr.py
+++ b/astrbot/core/conversation_mgr.py
@@ -261,10 +261,9 @@ class ConversationManager:
             "page_size": page_size,
             "platform_ids": platform_ids,
             "search_query": search_query,
+            "include_history": include_history,
             **kwargs,
         }
-        if not include_history:
-            query_kwargs["include_content"] = False
         convs, cnt = await self.db.get_filtered_conversations(**query_kwargs)
         convs_res = []
         for conv in convs:

--- a/astrbot/core/db/__init__.py
+++ b/astrbot/core/db/__init__.py
@@ -157,9 +157,19 @@ class BaseDatabase(abc.ABC):
         page_size: int = 20,
         platform_ids: list[str] | None = None,
         search_query: str = "",
+        include_content: bool = True,
         **kwargs,
     ) -> tuple[list[ConversationV2], int]:
-        """Get conversations filtered by platform IDs and search query."""
+        """Filter conversations by platform IDs and search text.
+
+        Args:
+            page: Page number.
+            page_size: Number of items per page.
+            platform_ids: Platform IDs to include, if any.
+            search_query: Search text, if any.
+            include_content: Whether to load the full history for returned rows.
+            **kwargs: Additional filters supported by the database backend.
+        """
         ...
 
     @abc.abstractmethod

--- a/astrbot/core/db/__init__.py
+++ b/astrbot/core/db/__init__.py
@@ -157,7 +157,7 @@ class BaseDatabase(abc.ABC):
         page_size: int = 20,
         platform_ids: list[str] | None = None,
         search_query: str = "",
-        include_content: bool = True,
+        include_history: bool = True,
         **kwargs,
     ) -> tuple[list[ConversationV2], int]:
         """Filter conversations by platform IDs and search text.
@@ -167,7 +167,7 @@ class BaseDatabase(abc.ABC):
             page_size: Number of items per page.
             platform_ids: Platform IDs to include, if any.
             search_query: Search text, if any.
-            include_content: Whether to load the full history for returned rows.
+            include_history: Whether to load the full history for returned rows.
             **kwargs: Additional filters supported by the database backend.
         """
         ...

--- a/astrbot/core/db/po.py
+++ b/astrbot/core/db/po.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TypedDict
 
+from sqlalchemy import Index, desc
 from sqlmodel import JSON, Field, SQLModel, Text, UniqueConstraint
 
 
@@ -89,6 +90,17 @@ class ConversationV2(TimestampMixin, SQLModel, table=True):
     """
 
     __table_args__ = (
+        Index(
+            "ix_conversations_created_at_inner_id",
+            desc("created_at"),
+            desc("inner_conversation_id"),
+        ),
+        Index(
+            "ix_conversations_platform_created_at_inner_id",
+            "platform_id",
+            desc("created_at"),
+            desc("inner_conversation_id"),
+        ),
         UniqueConstraint(
             "conversation_id",
             name="uix_conversation_id",

--- a/astrbot/core/db/sqlite.py
+++ b/astrbot/core/db/sqlite.py
@@ -1,11 +1,14 @@
 import asyncio
+import json
 import threading
 import typing as T
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import CursorResult, Row
+from sqlalchemy import CursorResult, Row, not_
+from sqlalchemy.dialects.sqlite import dialect as sqlite_dialect
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import defer
 from sqlmodel import col, delete, desc, func, or_, select, text, update
 
 from astrbot.core.db import BaseDatabase
@@ -65,7 +68,32 @@ class SQLiteDatabase(BaseDatabase):
             await self._ensure_persona_custom_error_message_column(conn)
             await self._ensure_platform_message_history_checkpoint_column(conn)
             await self._ensure_chatui_project_workspace_columns(conn)
+            await self._ensure_conversation_indexes(conn)
             await conn.commit()
+
+    async def _ensure_conversation_indexes(self, conn) -> None:
+        """Create indexes used by the dashboard conversation list."""
+        await conn.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS "
+                "ix_conversations_created_at_inner_id "
+                "ON conversations (created_at DESC, inner_conversation_id DESC)"
+            )
+        )
+        await conn.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS "
+                "ix_conversations_platform_created_at_inner_id "
+                "ON conversations (platform_id, created_at DESC, inner_conversation_id DESC)"
+            )
+        )
+        await conn.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS "
+                "ix_conversations_platform_user_id "
+                "ON conversations (platform_id, user_id)"
+            )
+        )
 
     async def _ensure_persona_folder_columns(self, conn) -> None:
         """确保 personas 表有 folder_id 和 sort_order 列。
@@ -301,39 +329,62 @@ class SQLiteDatabase(BaseDatabase):
         page_size=20,
         platform_ids=None,
         search_query="",
+        include_content=True,
         **kwargs,
     ):
         async with self.get_db() as session:
             session: AsyncSession
             # Build the base query with filters
             base_query = select(ConversationV2)
+            conditions = []
 
             if platform_ids:
-                base_query = base_query.where(
-                    col(ConversationV2.platform_id).in_(platform_ids),
-                )
+                conditions.append(col(ConversationV2.platform_id).in_(platform_ids))
             if search_query:
-                search_query = search_query.encode("unicode_escape").decode("utf-8")
-                base_query = base_query.where(
+                escaped_search_query = json.dumps(
+                    search_query,
+                    ensure_ascii=True,
+                )[1:-1]
+                conditions.append(
                     or_(
                         col(ConversationV2.title).ilike(f"%{search_query}%"),
-                        col(ConversationV2.content).ilike(f"%{search_query}%"),
                         col(ConversationV2.user_id).ilike(f"%{search_query}%"),
                         col(ConversationV2.conversation_id).ilike(f"%{search_query}%"),
-                    ),
-                )
-            if "message_types" in kwargs and len(kwargs["message_types"]) > 0:
-                for msg_type in kwargs["message_types"]:
-                    base_query = base_query.where(
-                        col(ConversationV2.user_id).ilike(f"%:{msg_type}:%"),
+                        col(ConversationV2.content).ilike(f"%{search_query}%"),
+                        col(ConversationV2.content).ilike(f"%{escaped_search_query}%"),
                     )
-            if "platforms" in kwargs and len(kwargs["platforms"]) > 0:
-                base_query = base_query.where(
-                    col(ConversationV2.platform_id).in_(kwargs["platforms"]),
+                )
+            message_types = kwargs.get("message_types") or []
+            if message_types:
+                conditions.append(
+                    or_(
+                        *(
+                            col(ConversationV2.user_id).like(f"%:{msg_type}:%")
+                            for msg_type in message_types
+                        )
+                    )
+                )
+            platforms = kwargs.get("platforms") or []
+            if platforms:
+                conditions.append(col(ConversationV2.platform_id).in_(platforms))
+            exclude_ids = kwargs.get("exclude_ids") or []
+            for exclude_id in exclude_ids:
+                conditions.append(
+                    not_(col(ConversationV2.user_id).like(f"{exclude_id}%"))
+                )
+            exclude_platforms = kwargs.get("exclude_platforms") or []
+            if exclude_platforms:
+                conditions.append(
+                    not_(col(ConversationV2.platform_id).in_(exclude_platforms))
                 )
 
+            if conditions:
+                base_query = base_query.where(*conditions)
+
             # Get total count matching the filters
-            count_query = select(func.count()).select_from(base_query.subquery())
+            count_query = select(func.count(ConversationV2.inner_conversation_id))
+            if conditions:
+                count_query = count_query.where(*conditions)
             total_count = await session.execute(count_query)
             total = total_count.scalar_one()
 
@@ -341,10 +392,41 @@ class SQLiteDatabase(BaseDatabase):
             offset = (page - 1) * page_size
             result_query = (
                 base_query.order_by(desc(ConversationV2.created_at))
+                .order_by(desc(ConversationV2.inner_conversation_id))
                 .offset(offset)
                 .limit(page_size)
             )
-            result = await session.execute(result_query)
+            if not include_content:
+                result_query = result_query.options(defer(ConversationV2.content))
+            if len(platforms) > 1 or len(platform_ids or []) > 1:
+                # SQLite may choose the narrow platform index for IN queries and
+                # then materialize a temporary sort. Force the global ordering
+                # index for multi-platform pages while keeping ORM row mapping.
+                compiled = result_query.compile(
+                    dialect=sqlite_dialect(paramstyle="named"),
+                    compile_kwargs={"render_postcompile": True},
+                )
+                indexed_sql = compiled.string.replace(
+                    "FROM conversations",
+                    "FROM conversations INDEXED BY "
+                    "ix_conversations_created_at_inner_id",
+                    1,
+                )
+                conversation_columns = [
+                    column
+                    for column in ConversationV2.__table__.columns
+                    if include_content or column.name != "content"
+                ]
+                result_query = select(ConversationV2).from_statement(
+                    text(indexed_sql).columns(*conversation_columns),
+                )
+                if not include_content:
+                    result_query = result_query.options(
+                        defer(ConversationV2.content),
+                    )
+                result = await session.execute(result_query, compiled.params)
+            else:
+                result = await session.execute(result_query)
             conversations = result.scalars().all()
 
             return conversations, total

--- a/astrbot/core/db/sqlite.py
+++ b/astrbot/core/db/sqlite.py
@@ -72,7 +72,11 @@ class SQLiteDatabase(BaseDatabase):
             await conn.commit()
 
     async def _ensure_conversation_indexes(self, conn) -> None:
-        """Create indexes used by the dashboard conversation list."""
+        """Create indexes used by the dashboard conversation list.
+
+        Args:
+            conn: Active SQLAlchemy connection used during SQLite initialization.
+        """
         await conn.execute(
             text(
                 "CREATE INDEX IF NOT EXISTS "
@@ -85,13 +89,6 @@ class SQLiteDatabase(BaseDatabase):
                 "CREATE INDEX IF NOT EXISTS "
                 "ix_conversations_platform_created_at_inner_id "
                 "ON conversations (platform_id, created_at DESC, inner_conversation_id DESC)"
-            )
-        )
-        await conn.execute(
-            text(
-                "CREATE INDEX IF NOT EXISTS "
-                "ix_conversations_platform_user_id "
-                "ON conversations (platform_id, user_id)"
             )
         )
 

--- a/astrbot/core/db/sqlite.py
+++ b/astrbot/core/db/sqlite.py
@@ -326,7 +326,7 @@ class SQLiteDatabase(BaseDatabase):
         page_size=20,
         platform_ids=None,
         search_query="",
-        include_content=True,
+        include_history=True,
         **kwargs,
     ):
         async with self.get_db() as session:
@@ -393,7 +393,7 @@ class SQLiteDatabase(BaseDatabase):
                 .offset(offset)
                 .limit(page_size)
             )
-            if not include_content:
+            if not include_history:
                 result_query = result_query.options(defer(ConversationV2.content))
             if len(platforms) > 1 or len(platform_ids or []) > 1:
                 # SQLite may choose the narrow platform index for IN queries and
@@ -412,12 +412,12 @@ class SQLiteDatabase(BaseDatabase):
                 conversation_columns = [
                     column
                     for column in ConversationV2.__table__.columns
-                    if include_content or column.name != "content"
+                    if include_history or column.name != "content"
                 ]
                 result_query = select(ConversationV2).from_statement(
                     text(indexed_sql).columns(*conversation_columns),
                 )
-                if not include_content:
+                if not include_history:
                     result_query = result_query.options(
                         defer(ConversationV2.content),
                     )

--- a/astrbot/dashboard/api/conversations.py
+++ b/astrbot/dashboard/api/conversations.py
@@ -95,6 +95,7 @@ async def _list_conversations(
     search: str,
     exclude_ids: str,
     exclude_platforms: str,
+    include_history: bool,
 ):
     return await _run(
         lambda: service.list_conversations(
@@ -105,6 +106,7 @@ async def _list_conversations(
             search_query=search,
             exclude_ids=exclude_ids,
             exclude_platforms=exclude_platforms,
+            include_history=include_history,
         )
     )
 
@@ -118,6 +120,7 @@ async def list_conversations(
     search: str = Query(default=""),
     exclude_ids: str = Query(default=""),
     exclude_platforms: str = Query(default=""),
+    include_history: bool = Query(default=True),
     _auth: AuthContext = Depends(require_data_scope),
     service: ConversationService = Depends(get_service),
 ):
@@ -130,6 +133,7 @@ async def list_conversations(
         search=search,
         exclude_ids=exclude_ids,
         exclude_platforms=exclude_platforms,
+        include_history=include_history,
     )
 
 
@@ -224,6 +228,7 @@ async def list_dashboard_conversations(
     search: str = Query(default=""),
     exclude_ids: str = Query(default=""),
     exclude_platforms: str = Query(default=""),
+    include_history: bool = Query(default=True),
     _username: str = Depends(require_dashboard_user),
     service: ConversationService = Depends(get_service),
 ):
@@ -236,6 +241,7 @@ async def list_dashboard_conversations(
         search=search,
         exclude_ids=exclude_ids,
         exclude_platforms=exclude_platforms,
+        include_history=include_history,
     )
 
 

--- a/astrbot/dashboard/services/conversation_service.py
+++ b/astrbot/dashboard/services/conversation_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import traceback
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from datetime import datetime
 from io import BytesIO
 
@@ -43,12 +43,16 @@ class ConversationService:
         exclude_ids: str,
         exclude_platforms: str,
     ) -> dict:
-        platform_list = platforms.split(",") if platforms else []
-        message_type_list = message_types.split(",") if message_types else []
-        exclude_id_list = exclude_ids.split(",") if exclude_ids else []
-        exclude_platform_list = (
-            exclude_platforms.split(",") if exclude_platforms else []
-        )
+        platform_list = [item.strip() for item in platforms.split(",") if item.strip()]
+        message_type_list = [
+            item.strip() for item in message_types.split(",") if item.strip()
+        ]
+        exclude_id_list = [
+            item.strip() for item in exclude_ids.split(",") if item.strip()
+        ]
+        exclude_platform_list = [
+            item.strip() for item in exclude_platforms.split(",") if item.strip()
+        ]
 
         page = max(page, 1)
         if page_size < 1:
@@ -64,6 +68,7 @@ class ConversationService:
                 search_query=search_query,
                 exclude_ids=exclude_id_list,
                 exclude_platforms=exclude_platform_list,
+                include_history=False,
             )
         except Exception as exc:
             logger.error(f"数据库查询出错: {exc!s}\n{traceback.format_exc()}")
@@ -77,7 +82,7 @@ class ConversationService:
 
         return {
             "conversations": [
-                self._serialize_conversation(conversation, alias_map)
+                self._serialize_conversation_summary(conversation, alias_map)
                 for conversation in conversations
             ],
             "pagination": {
@@ -270,9 +275,16 @@ class ConversationService:
             "failed_items": failed_items,
         }
 
-    def _serialize_conversation(self, conversation, alias_map: dict) -> dict:
+    def _serialize_conversation_summary(self, conversation, alias_map: dict) -> dict:
         return {
-            **asdict(conversation),
+            "platform_id": conversation.platform_id,
+            "user_id": conversation.user_id,
+            "cid": conversation.cid,
+            "title": conversation.title,
+            "persona_id": conversation.persona_id,
+            "token_usage": conversation.token_usage,
+            "created_at": conversation.created_at,
+            "updated_at": conversation.updated_at,
             "umo_info": self._build_umo_info(conversation.user_id, alias_map),
         }
 

--- a/astrbot/dashboard/services/conversation_service.py
+++ b/astrbot/dashboard/services/conversation_service.py
@@ -42,6 +42,7 @@ class ConversationService:
         search_query: str,
         exclude_ids: str,
         exclude_platforms: str,
+        include_history: bool = True,
     ) -> dict:
         platform_list = [item.strip() for item in platforms.split(",") if item.strip()]
         message_type_list = [
@@ -68,7 +69,7 @@ class ConversationService:
                 search_query=search_query,
                 exclude_ids=exclude_id_list,
                 exclude_platforms=exclude_platform_list,
-                include_history=False,
+                include_history=include_history,
             )
         except Exception as exc:
             logger.error(f"数据库查询出错: {exc!s}\n{traceback.format_exc()}")
@@ -82,7 +83,11 @@ class ConversationService:
 
         return {
             "conversations": [
-                self._serialize_conversation_summary(conversation, alias_map)
+                self._serialize_conversation(
+                    conversation,
+                    alias_map,
+                    include_history=include_history,
+                )
                 for conversation in conversations
             ],
             "pagination": {
@@ -275,8 +280,24 @@ class ConversationService:
             "failed_items": failed_items,
         }
 
-    def _serialize_conversation_summary(self, conversation, alias_map: dict) -> dict:
-        return {
+    def _serialize_conversation(
+        self,
+        conversation,
+        alias_map: dict,
+        *,
+        include_history: bool,
+    ) -> dict:
+        """Serialize a conversation for a list response.
+
+        Args:
+            conversation: Conversation object returned by the manager.
+            alias_map: UMO aliases keyed by unified message origin.
+            include_history: Whether to include the serialized message history.
+
+        Returns:
+            Conversation data suitable for a dashboard API response.
+        """
+        result = {
             "platform_id": conversation.platform_id,
             "user_id": conversation.user_id,
             "cid": conversation.cid,
@@ -287,6 +308,9 @@ class ConversationService:
             "updated_at": conversation.updated_at,
             "umo_info": self._build_umo_info(conversation.user_id, alias_map),
         }
+        if include_history:
+            result["history"] = conversation.history
+        return result
 
     @staticmethod
     def _build_umo_info(umo: str | None, alias_map: dict) -> dict:

--- a/dashboard/src/api/generated/openapi-v1/types.gen.ts
+++ b/dashboard/src/api/generated/openapi-v1/types.gen.ts
@@ -3035,6 +3035,10 @@ export type ListConversationsData = {
          */
         exclude_platforms?: string;
         /**
+         * Include full message history in each conversation.
+         */
+        include_history?: boolean;
+        /**
          * Comma-separated message types.
          */
         message_types?: string;

--- a/dashboard/src/views/ConversationPage.vue
+++ b/dashboard/src/views/ConversationPage.vue
@@ -71,7 +71,7 @@
                         class="elevation-0" :items-per-page="pagination.page_size"
                         :items-per-page-options="pageSizeOptions" show-select return-object
                         @update:options="handleTableOptions">
-                        <template v-slot:top v-if="listLoadState === 'error'">
+                        <template v-slot:top v-if="listLoadState === 'error' && conversations.length">
                             <v-alert type="error" variant="tonal" density="compact" class="ma-3" closable>
                                 {{ tm('messages.fetchError') }}
                                 <template v-slot:append>

--- a/dashboard/src/views/ConversationPage.vue
+++ b/dashboard/src/views/ConversationPage.vue
@@ -37,7 +37,7 @@
                         </v-col>
                     </v-row>
                     <v-btn color="primary" prepend-icon="mdi-refresh" variant="tonal" @click="fetchConversations"
-                        :loading="loading" size="small" class="mr-2">
+                        :loading="listLoading" size="small" class="mr-2">
                         {{ tm('history.refresh') }}
                     </v-btn>
                     <v-btn 
@@ -46,7 +46,7 @@
                         prepend-icon="mdi-download"
                         variant="tonal" 
                         @click="exportConversations" 
-                        :disabled="loading"
+                        :disabled="actionLoading"
                         size="small"
                         class="mr-2">
                         {{ tm('batch.exportSelected', { count: selectedItems.length }) }}
@@ -57,7 +57,7 @@
                         prepend-icon="mdi-delete"
                         variant="tonal" 
                         @click="confirmBatchDelete" 
-                        :disabled="loading"
+                        :disabled="actionLoading"
                         size="small">
                         {{ tm('batch.deleteSelected', { count: selectedItems.length }) }}
                     </v-btn>
@@ -67,10 +67,20 @@
 
                 <v-card-text class="pa-0">
                     <v-data-table v-model="selectedItems" :headers="tableHeaders" :items="conversations"
-                        :loading="loading" style="font-size: 12px;" density="comfortable" hide-default-footer
+                        :loading="listLoading" style="font-size: 12px;" density="comfortable" hide-default-footer
                         class="elevation-0" :items-per-page="pagination.page_size"
                         :items-per-page-options="pageSizeOptions" show-select return-object
-                        :disabled="loading" @update:options="handleTableOptions">
+                        @update:options="handleTableOptions">
+                        <template v-slot:top v-if="listLoadState === 'error'">
+                            <v-alert type="error" variant="tonal" density="compact" class="ma-3" closable>
+                                {{ tm('messages.fetchError') }}
+                                <template v-slot:append>
+                                    <v-btn size="small" variant="text" @click="fetchConversations">
+                                        {{ tm('history.refresh') }}
+                                    </v-btn>
+                                </template>
+                            </v-alert>
+                        </template>
                         <template v-slot:header.umo_source>
                             <div class="umo-header-cell">
                                 <span>{{ tm('table.headers.umo') }}</span>
@@ -104,7 +114,7 @@
                                         :ripple="false"
                                         class="conversation-inline-edit"
                                         @click.stop="editConversation(item)"
-                                        :disabled="loading"
+                                        :disabled="actionLoading"
                                     >
                                         <v-icon size="14">mdi-pencil</v-icon>
                                     </v-btn>
@@ -160,11 +170,11 @@
                         <template v-slot:item.actions="{ item }">
                             <div class="actions-wrapper">
                                 <v-btn icon variant="plain" size="x-small" class="action-button"
-                                    @click="viewConversation(item)" :disabled="loading">
+                                    @click="viewConversation(item)" :disabled="actionLoading">
                                     <v-icon>mdi-eye</v-icon>
                                 </v-btn>
                                 <v-btn icon color="error" variant="plain" size="x-small" class="action-button"
-                                    @click="confirmDeleteConversation(item)" :disabled="loading">
+                                    @click="confirmDeleteConversation(item)" :disabled="actionLoading">
                                     <v-icon>mdi-delete</v-icon>
                                 </v-btn>
                             </div>
@@ -172,8 +182,20 @@
 
                         <template v-slot:no-data>
                             <div class="d-flex flex-column align-center py-6">
-                                <v-icon size="64" color="grey lighten-1">mdi-chat-remove</v-icon>
-                                <span class="text-subtitle-1 text-disabled mt-3">{{ tm('status.noData') }}</span>
+                                <template v-if="listLoadState === 'loading'">
+                                    <v-progress-circular indeterminate color="primary" />
+                                </template>
+                                <template v-else-if="listLoadState === 'empty'">
+                                    <v-icon size="64" color="grey lighten-1">mdi-chat-remove</v-icon>
+                                    <span class="text-subtitle-1 text-disabled mt-3">{{ tm('status.noData') }}</span>
+                                </template>
+                                <template v-else-if="listLoadState === 'error'">
+                                    <v-icon size="64" color="error">mdi-alert-circle-outline</v-icon>
+                                    <span class="text-subtitle-1 text-disabled mt-3">{{ tm('messages.fetchError') }}</span>
+                                    <v-btn class="mt-3" size="small" variant="tonal" @click="fetchConversations">
+                                        {{ tm('history.refresh') }}
+                                    </v-btn>
+                                </template>
                             </div>
                         </template>
                     </v-data-table>
@@ -186,7 +208,7 @@
                                 <span class="text-caption mr-2">{{ tm('pagination.itemsPerPage') }}:</span>
                                 <v-select v-model="pagination.page_size" :items="pageSizeOptions" variant="outlined"
                                     density="compact" hide-details style="max-width: 100px;"
-                                    :disabled="loading" @update:model-value="onPageSizeChange"></v-select>
+                                    @update:model-value="onPageSizeChange"></v-select>
                             </div>
                             <div class="text-caption ml-4">
                                 {{ tm('pagination.showingItems', {
@@ -196,7 +218,7 @@
                                 }) }}
                             </div>
                         </div>
-                        <v-pagination v-model="pagination.page" :length="pagination.total_pages" :disabled="loading"
+                        <v-pagination v-model="pagination.page" :length="pagination.total_pages"
                             @update:model-value="fetchConversations" rounded="circle" :total-visible="7"></v-pagination>
                     </div>
                 </v-card-text>
@@ -270,7 +292,7 @@
 
                 <v-card-actions class="pa-4">
                     <v-spacer></v-spacer>
-                    <v-btn variant="text" @click="closeHistoryDialog">
+                    <v-btn variant="text" @click="closeHistoryDialog" :disabled="actionLoading">
                         {{ tm('dialogs.view.close') }}
                     </v-btn>
                 </v-card-actions>
@@ -297,10 +319,10 @@
 
                 <v-card-actions class="pa-4">
                     <v-spacer></v-spacer>
-                    <v-btn variant="text" @click="dialogEdit = false" :disabled="loading">
+                    <v-btn variant="text" @click="dialogEdit = false" :disabled="actionLoading">
                         {{ tm('dialogs.edit.cancel') }}
                     </v-btn>
-                    <v-btn color="primary" variant="tonal" @click="saveConversation" :loading="loading">
+                    <v-btn color="primary" variant="tonal" @click="saveConversation" :loading="actionLoading">
                         {{ tm('dialogs.edit.save') }}
                     </v-btn>
                 </v-card-actions>
@@ -324,10 +346,10 @@
 
                 <v-card-actions class="pa-4">
                     <v-spacer></v-spacer>
-                    <v-btn variant="text" @click="dialogDelete = false" :disabled="loading">
+                    <v-btn variant="text" @click="dialogDelete = false" :disabled="actionLoading">
                         {{ tm('dialogs.delete.cancel') }}
                     </v-btn>
-                    <v-btn color="error" variant="tonal" @click="deleteConversation" :loading="loading">
+                    <v-btn color="error" variant="tonal" @click="deleteConversation" :loading="actionLoading">
                         {{ tm('dialogs.delete.confirm') }}
                     </v-btn>
                 </v-card-actions>
@@ -349,7 +371,7 @@
                     <div v-if="selectedItems.length > 0" class="mb-3">
                         <v-chip v-for="(item, index) in selectedItems.slice(0, 5)" :key="`${item.user_id}-${item.cid}`"
                             size="small" class="mr-1 mb-1" closable @click:close="removeFromSelection(item)"
-                            :disabled="loading">
+                            :disabled="actionLoading">
                             {{ item.title || tm('status.noTitle') }}
                         </v-chip>
                         <v-chip v-if="selectedItems.length > 5" size="small" class="mr-1 mb-1">
@@ -366,10 +388,10 @@
 
                 <v-card-actions class="pa-4">
                     <v-spacer></v-spacer>
-                    <v-btn variant="text" @click="dialogBatchDelete = false" :disabled="loading">
+                    <v-btn variant="text" @click="dialogBatchDelete = false" :disabled="actionLoading">
                         {{ tm('dialogs.batchDelete.cancel') }}
                     </v-btn>
-                    <v-btn color="error" variant="tonal" @click="batchDeleteConversations" :loading="loading">
+                    <v-btn color="error" variant="tonal" @click="batchDeleteConversations" :loading="actionLoading">
                         {{ tm('dialogs.batchDelete.confirm') }}
                     </v-btn>
                 </v-card-actions>
@@ -386,6 +408,7 @@
 <script>
 import { isCancel } from 'axios';
 import { debounce } from 'lodash';
+import { markRaw } from 'vue';
 import { VueMonacoEditor } from '@guolao/vue-monaco-editor';
 import { conversationApi } from '@/api/v1';
 import { useCommonStore } from '@/stores/common';
@@ -465,7 +488,11 @@ export default {
             valid: true,
 
             // 状态控制
-            loading: false,
+            listLoading: false,
+            listLoadState: 'idle',
+            listAbortController: null,
+            listRequestId: 0,
+            actionLoading: false,
             showMessage: false,
             message: '',
             messageType: 'success',
@@ -484,12 +511,15 @@ export default {
     watch: {
         // 监听筛选条件变化，使用防抖处理
         platformFilter() {
+            this.invalidateConversationListRequest();
             this.debouncedApplyFilters();
         },
         messageTypeFilter() {
+            this.invalidateConversationListRequest();
             this.debouncedApplyFilters();
         },
         search() {
+            this.invalidateConversationListRequest();
             this.debouncedApplyFilters();
         }
     },
@@ -500,6 +530,12 @@ export default {
             this.pagination.page = 1;
             this.fetchConversations();
         }, 300);
+    },
+
+    beforeUnmount() {
+        this.debouncedApplyFilters?.cancel();
+        this.listRequestId += 1;
+        this.listAbortController?.abort();
     },
 
     computed: {
@@ -639,6 +675,14 @@ export default {
             }
         },
 
+        invalidateConversationListRequest() {
+            this.listRequestId += 1;
+            this.listAbortController?.abort();
+            this.listAbortController = null;
+            this.listLoading = true;
+            this.listLoadState = 'loading';
+        },
+
         // 从会话ID解析平台和消息类型信息
         parseSessionId(userId) {
             if (!userId) return { platform: 'default', messageType: 'default', sessionId: '' };
@@ -725,102 +769,102 @@ export default {
         },
 
         // 获取对话列表
-        fetchConversations: (() => {
-            let controller = new AbortController();
+        async fetchConversations() {
+            this.debouncedApplyFilters?.cancel();
+            this.listAbortController?.abort();
+            const controller = new AbortController();
+            const requestId = ++this.listRequestId;
+            const filtersSnapshot = {
+                platforms: this.platformFilter.map(item =>
+                    typeof item === 'object' ? item.value : item
+                ),
+                messageTypes: [...this.messageTypeFilter],
+                search: this.search
+            };
+            this.listAbortController = markRaw(controller);
+            this.listLoading = true;
+            this.listLoadState = 'loading';
 
-            return async function () {
-                // 新请求前停止之前的请求
-                controller?.abort()
-                controller = new AbortController();
+            try {
+                const params = {
+                    page: this.pagination.page,
+                    page_size: this.pagination.page_size
+                };
 
-                this.loading = true;
-                try {
-                    // 准备请求参数，包含分页和筛选条件
-                    const params = {
-                        page: this.pagination.page,
-                        page_size: this.pagination.page_size
+                if (filtersSnapshot.platforms.length > 0) {
+                    params.platforms = filtersSnapshot.platforms.join(',');
+                }
+
+                if (filtersSnapshot.messageTypes.length > 0) {
+                    params.message_types = filtersSnapshot.messageTypes.join(',');
+                }
+
+                const search = filtersSnapshot.search.trim();
+                if (search) {
+                    params.search = search;
+                }
+
+                params.exclude_ids = 'astrbot';
+                params.exclude_platforms = 'webchat';
+
+                const response = await conversationApi.list(params, {
+                    signal: controller.signal,
+                });
+
+                if (requestId !== this.listRequestId) return;
+                if (response.data.status !== "ok") {
+                    throw new Error(response.data.message || this.tm('messages.fetchError'));
+                }
+
+                const data = response.data.data;
+                if (!data || !Array.isArray(data.conversations)) {
+                    throw new Error(this.tm('messages.fetchError'));
+                }
+
+                this.conversations = data.conversations.map(conv => {
+                    const umoInfo = this.getConversationUmoInfo(conv);
+                    conv.sessionInfo = {
+                        platform: umoInfo.platform,
+                        messageType: umoInfo.message_type,
+                        sessionId: umoInfo.session_id
                     };
+                    return conv;
+                });
 
-                    // 添加筛选条件 - 处理combobox的混合数据格式
-                    if (this.platformFilter.length > 0) {
-                        const platforms = this.platformFilter.map(item =>
-                            typeof item === 'object' ? item.value : item
-                        );
-                        params.platforms = platforms.join(',');
+                if (data.pagination) {
+                    this.pagination = {
+                        page: data.pagination.page || 1,
+                        page_size: data.pagination.page_size || 20,
+                        total: data.pagination.total || 0,
+                        total_pages: data.pagination.total_pages || 1
+                    };
+                }
+                this.lastAppliedFilters = filtersSnapshot;
+                this.listLoadState = this.conversations.length ? 'success' : 'empty';
+            } catch (error) {
+                if (
+                    requestId !== this.listRequestId ||
+                    isCancel(error) ||
+                    controller.signal.aborted
+                ) return;
+
+                console.error('获取对话列表出错:', error);
+                this.listLoadState = 'error';
+                this.showErrorMessage(error.response?.data?.message || error.message || this.tm('messages.fetchError'));
+            } finally {
+                if (requestId === this.listRequestId) {
+                    this.listLoading = false;
+                    if (this.listAbortController === controller) {
+                        this.listAbortController = null;
                     }
-
-                    if (this.messageTypeFilter.length > 0) {
-                        params.message_types = this.messageTypeFilter.join(',');
-                    }
-
-                    if (this.search) {
-                        params.search = this.search.trim();
-                    }
-
-                    // 添加排除条件
-                    params.exclude_ids = 'astrbot';
-                    params.exclude_platforms = 'webchat';
-
-                    const response = await conversationApi.list(params, {
-                        signal: controller.signal,
-                    });
-
-                    this.lastAppliedFilters = { ...this.currentFilters }; // 记录已应用的筛选条件
-
-                    if (response.data.status === "ok") {
-                        const data = response.data.data;
-
-                        if (!data || !data.conversations) {
-                            console.error('API 返回数据格式不符合预期:', data);
-                            this.showErrorMessage(this.tm('messages.fetchError'));
-                            return;
-                        }
-
-                        // 处理会话数据，解析sessionId
-                        this.conversations = (data.conversations || []).map(conv => {
-                            // 为每个会话添加会话信息
-                            const umoInfo = this.getConversationUmoInfo(conv);
-                            conv.sessionInfo = {
-                                platform: umoInfo.platform,
-                                messageType: umoInfo.message_type,
-                                sessionId: umoInfo.session_id
-                            };
-                            return conv;
-                        });
-
-                        // 更新分页信息
-                        if (data.pagination) {
-                            this.pagination = {
-                                page: data.pagination.page || 1,
-                                page_size: data.pagination.page_size || 20,
-                                total: data.pagination.total || 0,
-                                total_pages: data.pagination.total_pages || 1
-                            };
-                        } else {
-                            console.warn('API 响应中没有分页信息');
-                        }
-                    } else {
-                        this.showErrorMessage(response.data.message || this.tm('messages.fetchError'));
-                    }
-                } catch (error) {
-                    if (isCancel(error)) return;
-                    
-                    console.error('获取对话列表出错:', error);
-                    if (error.response) {
-                        console.error('错误响应数据:', error.response.data);
-                        console.error('错误状态码:', error.response.status);
-                    }
-                    this.showErrorMessage(error.response?.data?.message || error.message || this.tm('messages.fetchError'));
-                } finally {
-                    this.loading = false;
                 }
             }
-        })(),
+        },
 
         // 查看对话详情
         async viewConversation(item) {
             this.selectedConversation = item;
-            this.loading = true;
+            this.actionLoading = true;
             this.isEditingHistory = false;
 
             try {
@@ -855,7 +899,7 @@ export default {
                 console.error('获取对话详情出错:', error);
                 this.showErrorMessage(error.response?.data?.message || error.message || this.tm('messages.historyError'));
             } finally {
-                this.loading = false;
+                this.actionLoading = false;
             }
         },
 
@@ -920,7 +964,7 @@ export default {
         async saveConversation() {
             if (!this.$refs.form.validate()) return;
 
-            this.loading = true;
+            this.actionLoading = true;
             try {
                 const response = await conversationApi.update(
                     this.editedItem.user_id,
@@ -950,7 +994,7 @@ export default {
             } catch (error) {
                 this.showErrorMessage(error.response?.data?.message || error.message || this.tm('messages.saveError'));
             } finally {
-                this.loading = false;
+                this.actionLoading = false;
             }
         },
 
@@ -962,7 +1006,7 @@ export default {
 
         // 删除对话
         async deleteConversation() {
-            this.loading = true;
+            this.actionLoading = true;
             try {
                 const response = await conversationApi.delete(
                     this.selectedConversation.user_id,
@@ -979,13 +1023,14 @@ export default {
 
                     this.dialogDelete = false;
                     this.showSuccessMessage(this.tm('messages.deleteSuccess'));
+                    this.fetchConversations();
                 } else {
                     this.showErrorMessage(response.data.message || this.tm('messages.deleteError'));
                 }
             } catch (error) {
                 this.showErrorMessage(error.response?.data?.message || error.message || this.tm('messages.deleteError'));
             } finally {
-                this.loading = false;
+                this.actionLoading = false;
                 this.selectedItems = this.selectedItems.filter(item =>
                     !(item.user_id === this.selectedConversation.user_id && item.cid === this.selectedConversation.cid)
                 );
@@ -1025,7 +1070,7 @@ export default {
                 return;
             }
 
-            this.loading = true;
+            this.actionLoading = true;
             try {
                 // 准备批量删除的数据
                 const conversations = this.selectedItems.map(item => ({
@@ -1067,7 +1112,7 @@ export default {
                 console.error('批量删除对话出错:', error);
                 this.showErrorMessage(error.response?.data?.message || error.message || this.tm('messages.batchDeleteError'));
             } finally {
-                this.loading = false;
+                this.actionLoading = false;
             }
         },
 
@@ -1078,7 +1123,7 @@ export default {
                 return;
             }
 
-            this.loading = true;
+            this.actionLoading = true;
             try {
                 // 准备导出的数据
                 const conversations = this.selectedItems.map(item => ({
@@ -1112,7 +1157,7 @@ export default {
                 console.error(this.tm('messages.exportError'), error);
                 this.showErrorMessage(error.response?.data?.message || error.message || this.tm('messages.exportError'));
             } finally {
-                this.loading = false;
+                this.actionLoading = false;
             }
         },
 

--- a/dashboard/src/views/ConversationPage.vue
+++ b/dashboard/src/views/ConversationPage.vue
@@ -806,6 +806,7 @@ export default {
 
                 params.exclude_ids = 'astrbot';
                 params.exclude_platforms = 'webchat';
+                params.include_history = false;
 
                 const response = await conversationApi.list(params, {
                     signal: controller.signal,

--- a/openspec/openapi-v1.yaml
+++ b/openspec/openapi-v1.yaml
@@ -4021,6 +4021,12 @@ paths:
           schema:
             type: string
           description: Comma-separated platforms to exclude.
+        - name: include_history
+          in: query
+          schema:
+            type: boolean
+            default: true
+          description: Include full message history in each conversation.
       responses:
         "200":
           $ref: "#/components/responses/Ok"

--- a/tests/test_conversation_list.py
+++ b/tests/test_conversation_list.py
@@ -1,0 +1,183 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy import event, text
+from sqlalchemy import inspect as sqlalchemy_inspect
+
+from astrbot.core.db.po import ConversationV2
+from astrbot.core.db.sqlite import SQLiteDatabase
+
+
+@pytest.mark.asyncio
+async def test_filtered_conversations_summary_skips_content_and_applies_filters(
+    tmp_path: Path,
+):
+    db = SQLiteDatabase(str(tmp_path / "conversations.db"))
+    await db.initialize()
+
+    conversations = [
+        ConversationV2(
+            conversation_id="group",
+            platform_id="qq",
+            user_id="qq:GroupMessage:1",
+            content=[{"role": "user", "content": "x" * 10_000}],
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        ),
+        ConversationV2(
+            conversation_id="friend",
+            platform_id="qq",
+            user_id="qq:FriendMessage:2",
+            title="中文标题",
+            content=[{"role": "assistant", "content": "中文正文 😀"}],
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        ),
+        ConversationV2(
+            conversation_id="other",
+            platform_id="telegram",
+            user_id="telegram:FriendMessage:3",
+            content=[{"role": "assistant", "content": "ordinary"}],
+            created_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        ),
+        ConversationV2(
+            conversation_id="webchat",
+            platform_id="webchat",
+            user_id="webchat:FriendMessage:4",
+            content=[{"role": "assistant", "content": "excluded"}],
+            created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        ),
+        ConversationV2(
+            conversation_id="astrbot",
+            platform_id="qq",
+            user_id="astrbot:FriendMessage:5",
+            content=[{"role": "assistant", "content": "excluded"}],
+            created_at=datetime(2023, 1, 1, tzinfo=timezone.utc),
+        ),
+    ]
+    async with db.get_db() as session:
+        async with session.begin():
+            session.add_all(conversations)
+
+    summary, total = await db.get_filtered_conversations(
+        page=1,
+        page_size=10,
+        include_content=False,
+        message_types=["GroupMessage", "FriendMessage"],
+        exclude_ids=["astrbot"],
+        exclude_platforms=["webchat"],
+    )
+
+    assert total == 3
+    assert [item.conversation_id for item in summary] == [
+        "friend",
+        "group",
+        "other",
+    ]
+    assert all("content" in sqlalchemy_inspect(item).unloaded for item in summary)
+
+    title_matches, _ = await db.get_filtered_conversations(
+        search_query="中文标题",
+        include_content=False,
+    )
+    content_matches, _ = await db.get_filtered_conversations(
+        search_query="中文正文",
+        include_content=False,
+    )
+    assert [item.conversation_id for item in title_matches] == ["friend"]
+    assert [item.conversation_id for item in content_matches] == ["friend"]
+
+    full, full_total = await db.get_filtered_conversations(page_size=10)
+    assert full_total == 5
+    assert all("content" not in sqlalchemy_inspect(item).unloaded for item in full)
+
+
+@pytest.mark.asyncio
+async def test_conversation_indexes_are_idempotent_and_support_ordered_list(
+    tmp_path: Path,
+):
+    db = SQLiteDatabase(str(tmp_path / "conversations.db"))
+    await db.initialize()
+    await db.initialize()
+
+    async with db.get_db() as session:
+        index_rows = (
+            await session.execute(text("PRAGMA index_list(conversations)"))
+        ).all()
+        index_names = {row[1] for row in index_rows}
+        plan = (
+            await session.execute(
+                text(
+                    "EXPLAIN QUERY PLAN "
+                    "SELECT conversation_id FROM conversations "
+                    "ORDER BY created_at DESC, inner_conversation_id DESC LIMIT 20"
+                )
+            )
+        ).all()
+
+    assert {
+        "ix_conversations_created_at_inner_id",
+        "ix_conversations_platform_created_at_inner_id",
+        "ix_conversations_platform_user_id",
+    }.issubset(index_names)
+    assert not any("TEMP B-TREE" in str(row) for row in plan)
+
+
+@pytest.mark.asyncio
+async def test_multi_platform_summary_uses_global_order_index(
+    tmp_path: Path,
+):
+    db = SQLiteDatabase(str(tmp_path / "multi-platform.db"))
+    await db.initialize()
+
+    async with db.get_db() as session:
+        async with session.begin():
+            session.add_all(
+                [
+                    ConversationV2(
+                        conversation_id=f"conversation-{index}",
+                        platform_id="qq" if index % 2 else "telegram",
+                        user_id=f"platform:FriendMessage:{index}",
+                        content=[{"role": "user", "content": "x" * 1000}],
+                        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                    )
+                    for index in range(20)
+                ],
+            )
+
+    statements = []
+
+    def capture_statement(_conn, _cursor, statement, _parameters, _context, _many):
+        statements.append(statement)
+
+    event.listen(db.engine.sync_engine, "before_cursor_execute", capture_statement)
+    try:
+        conversations, total = await db.get_filtered_conversations(
+            page=1,
+            page_size=5,
+            platforms=["qq", "telegram"],
+            include_content=False,
+        )
+    finally:
+        event.remove(
+            db.engine.sync_engine,
+            "before_cursor_execute",
+            capture_statement,
+        )
+
+    assert total == 20
+    assert [conversation.conversation_id for conversation in conversations] == [
+        "conversation-19",
+        "conversation-18",
+        "conversation-17",
+        "conversation-16",
+        "conversation-15",
+    ]
+    assert all("content" in sqlalchemy_inspect(item).unloaded for item in conversations)
+
+    ordered_queries = [statement for statement in statements if "ORDER BY" in statement]
+    assert len(ordered_queries) == 1
+    assert (
+        "FROM conversations INDEXED BY ix_conversations_created_at_inner_id"
+        in ordered_queries[0]
+    )
+    assert "content" not in ordered_queries[0].split("FROM", 1)[0]

--- a/tests/test_conversation_list.py
+++ b/tests/test_conversation_list.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -5,6 +6,7 @@ import pytest
 from sqlalchemy import event, text
 from sqlalchemy import inspect as sqlalchemy_inspect
 
+from astrbot.core.conversation_mgr import ConversationManager
 from astrbot.core.db.po import ConversationV2
 from astrbot.core.db.sqlite import SQLiteDatabase
 
@@ -74,6 +76,20 @@ async def test_filtered_conversations_summary_skips_content_and_applies_filters(
         "other",
     ]
     assert all("content" in sqlalchemy_inspect(item).unloaded for item in summary)
+
+    manager_summary, manager_total = await ConversationManager(
+        db,
+    ).get_filtered_conversations(
+        page=1,
+        page_size=10,
+        include_history=False,
+        message_types=["GroupMessage", "FriendMessage"],
+        exclude_ids=["astrbot"],
+        exclude_platforms=["webchat"],
+    )
+    assert manager_total == total
+    assert all(item.history == "[]" for item in manager_summary)
+    assert all(json.loads(item.history) == [] for item in manager_summary)
 
     title_matches, _ = await db.get_filtered_conversations(
         search_query="中文标题",

--- a/tests/test_conversation_list.py
+++ b/tests/test_conversation_list.py
@@ -63,7 +63,7 @@ async def test_filtered_conversations_summary_skips_content_and_applies_filters(
     summary, total = await db.get_filtered_conversations(
         page=1,
         page_size=10,
-        include_content=False,
+        include_history=False,
         message_types=["GroupMessage", "FriendMessage"],
         exclude_ids=["astrbot"],
         exclude_platforms=["webchat"],
@@ -93,11 +93,11 @@ async def test_filtered_conversations_summary_skips_content_and_applies_filters(
 
     title_matches, _ = await db.get_filtered_conversations(
         search_query="中文标题",
-        include_content=False,
+        include_history=False,
     )
     content_matches, _ = await db.get_filtered_conversations(
         search_query="中文正文",
-        include_content=False,
+        include_history=False,
     )
     assert [item.conversation_id for item in title_matches] == ["friend"]
     assert [item.conversation_id for item in content_matches] == ["friend"]
@@ -175,7 +175,7 @@ async def test_multi_platform_summary_uses_global_order_index(
             page=1,
             page_size=5,
             platforms=["qq", "telegram"],
-            include_content=False,
+            include_history=False,
         )
     finally:
         event.remove(

--- a/tests/test_conversation_list.py
+++ b/tests/test_conversation_list.py
@@ -130,11 +130,15 @@ async def test_conversation_indexes_are_idempotent_and_support_ordered_list(
             )
         ).all()
 
-    assert {
+    expected_indexes = {
         "ix_conversations_created_at_inner_id",
         "ix_conversations_platform_created_at_inner_id",
-        "ix_conversations_platform_user_id",
-    }.issubset(index_names)
+    }
+    assert expected_indexes.issubset(index_names)
+    assert expected_indexes.issubset(
+        {index.name for index in ConversationV2.__table__.indexes}
+    )
+    assert "ix_conversations_platform_user_id" not in index_names
     assert not any("TEMP B-TREE" in str(row) for row in plan)
 
 

--- a/tests/test_fastapi_v1_dashboard.py
+++ b/tests/test_fastapi_v1_dashboard.py
@@ -289,6 +289,7 @@ class FakeConversation:
     title: str = "Demo conversation"
     persona_id: str | None = "persona/foo"
     history: str = "[]"
+    token_usage: int = 0
     created_at: str = "2026-01-01T00:00:00"
     updated_at: str = "2026-01-01T00:00:00"
 
@@ -296,6 +297,7 @@ class FakeConversation:
 class FakeConversationManager:
     def __init__(self) -> None:
         user_id = "webchat:FriendMessage:webchat!user!session-1"
+        self.last_filter_args: dict[str, list[str]] = {}
         self.conversations: dict[tuple[str, str], FakeConversation] = {
             (user_id, "conversation/with/slash"): FakeConversation(
                 cid="conversation/with/slash",
@@ -313,7 +315,14 @@ class FakeConversationManager:
         search_query: str,
         exclude_ids: list[str],
         exclude_platforms: list[str],
+        include_history: bool = True,
     ):
+        self.last_filter_args = {
+            "platforms": platforms,
+            "message_types": message_types,
+            "exclude_ids": exclude_ids,
+            "exclude_platforms": exclude_platforms,
+        }
         conversations = list(self.conversations.values())
         if platforms:
             conversations = [
@@ -1231,6 +1240,64 @@ async def test_v1_conversation_path_id_allows_slash(asgi_client: httpx.AsyncClie
     payload = response.json()
     assert payload["status"] == "ok"
     assert payload["data"]["cid"] == "conversation/with/slash"
+
+
+@pytest.mark.asyncio
+async def test_v1_conversation_list_returns_summary_without_history(
+    asgi_client: httpx.AsyncClient,
+):
+    response = await asgi_client.get(
+        "/api/v1/conversations",
+        headers=_jwt_headers(),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    conversation = payload["data"]["conversations"][0]
+    assert conversation["cid"] == "conversation/with/slash"
+    assert "history" not in conversation
+
+
+@pytest.mark.asyncio
+async def test_legacy_conversation_list_returns_summary_without_history(
+    asgi_client: httpx.AsyncClient,
+):
+    response = await asgi_client.get(
+        "/api/conversation/list",
+        headers=_jwt_headers(),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert "history" not in payload["data"]["conversations"][0]
+
+
+@pytest.mark.asyncio
+async def test_conversation_list_normalizes_comma_separated_filters(
+    asgi_client: httpx.AsyncClient,
+    fake_core_lifecycle,
+):
+    response = await asgi_client.get(
+        "/api/v1/conversations",
+        params={
+            "platforms": ", webchat-main ,",
+            "message_types": ", FriendMessage ,",
+            "exclude_ids": "astrbot, ,",
+            "exclude_platforms": ", webchat ,",
+        },
+        headers=_jwt_headers(),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+    assert fake_core_lifecycle.conversation_manager.last_filter_args == {
+        "platforms": ["webchat-main"],
+        "message_types": ["FriendMessage"],
+        "exclude_ids": ["astrbot"],
+        "exclude_platforms": ["webchat"],
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_fastapi_v1_dashboard.py
+++ b/tests/test_fastapi_v1_dashboard.py
@@ -298,6 +298,7 @@ class FakeConversationManager:
     def __init__(self) -> None:
         user_id = "webchat:FriendMessage:webchat!user!session-1"
         self.last_filter_args: dict[str, list[str]] = {}
+        self.last_include_history = True
         self.conversations: dict[tuple[str, str], FakeConversation] = {
             (user_id, "conversation/with/slash"): FakeConversation(
                 cid="conversation/with/slash",
@@ -317,6 +318,7 @@ class FakeConversationManager:
         exclude_platforms: list[str],
         include_history: bool = True,
     ):
+        self.last_include_history = include_history
         self.last_filter_args = {
             "platforms": platforms,
             "message_types": message_types,
@@ -1243,8 +1245,9 @@ async def test_v1_conversation_path_id_allows_slash(asgi_client: httpx.AsyncClie
 
 
 @pytest.mark.asyncio
-async def test_v1_conversation_list_returns_summary_without_history(
+async def test_v1_conversation_list_preserves_history_by_default(
     asgi_client: httpx.AsyncClient,
+    fake_core_lifecycle,
 ):
     response = await asgi_client.get(
         "/api/v1/conversations",
@@ -1256,7 +1259,43 @@ async def test_v1_conversation_list_returns_summary_without_history(
     assert payload["status"] == "ok"
     conversation = payload["data"]["conversations"][0]
     assert conversation["cid"] == "conversation/with/slash"
+    assert conversation["history"] == "[]"
+    assert fake_core_lifecycle.conversation_manager.last_include_history is True
+
+
+@pytest.mark.asyncio
+async def test_v1_conversation_list_returns_summary_without_history(
+    asgi_client: httpx.AsyncClient,
+    fake_core_lifecycle,
+):
+    response = await asgi_client.get(
+        "/api/v1/conversations",
+        params={"include_history": "false"},
+        headers=_jwt_headers(),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    conversation = payload["data"]["conversations"][0]
+    assert conversation["cid"] == "conversation/with/slash"
     assert "history" not in conversation
+    assert fake_core_lifecycle.conversation_manager.last_include_history is False
+
+
+@pytest.mark.asyncio
+async def test_legacy_conversation_list_preserves_history_by_default(
+    asgi_client: httpx.AsyncClient,
+):
+    response = await asgi_client.get(
+        "/api/conversation/list",
+        headers=_jwt_headers(),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["data"]["conversations"][0]["history"] == "[]"
 
 
 @pytest.mark.asyncio
@@ -1265,6 +1304,7 @@ async def test_legacy_conversation_list_returns_summary_without_history(
 ):
     response = await asgi_client.get(
         "/api/conversation/list",
+        params={"include_history": "false"},
         headers=_jwt_headers(),
     )
 


### PR DESCRIPTION
AstrBot 的对话数据页面在记录较多、单条历史较长或通过公网访问时，普通列表加载、分页、每页数量切换以及群聊/私聊筛选都会读取并返回完整聊天历史。列表响应会随历史正文持续增大，造成不必要的数据库读取、JSON 序列化和网络传输开销。

此外，页面在连续筛选或慢网络环境下存在请求竞态：较早发出的请求可能晚于新请求返回，并覆盖最新列表或加载状态；筛选防抖也可能覆盖紧接着进行的分页操作。删除成功时，如果删除前的列表请求稍后返回，已删除记录还可能短暂重新出现在页面中。

### 改动点

#### 后端列表性能

- 为数据库过滤查询增加默认开启的 `include_content`，并为对话管理器增加默认开启的 `include_history`，保持插件及内部调用默认获取完整 `Conversation` 的兼容行为。
- Dashboard 对话列表固定使用摘要查询，通过 SQLAlchemy `defer(content)` 避免普通列表读取完整历史正文。
- 两个对话列表接口仅显式返回列表所需字段和 `umo_info`，不再在列表响应中包含 `history`；对话详情、历史编辑和导出仍读取完整历史。
- 计数与数据查询复用同一组过滤条件，直接对主键计数，避免从包含完整列的子查询统计。
- 修复群聊/私聊多选、平台筛选、`exclude_ids` 前缀排除及 `exclude_platforms` 平台排除逻辑，并清理逗号参数中的空项和多余空格。
- 使用 `created_at DESC, inner_conversation_id DESC` 作为稳定排序，避免相同创建时间下分页重复或遗漏。
- 保留标题、UMO、对话 ID 和完整正文搜索；正文同时支持原始关键词及 JSON 转义后的中文、英文和 emoji 内容。
- 幂等创建普通列表、平台列表和平台用户过滤所需的三个 SQLite 索引；多平台分页避免使用临时排序表。

#### 前端请求一致性

- 将列表请求控制移入 `ConversationPage` 组件实例，使用递增请求编号保证只有最新请求能够更新列表、分页、错误信息和 loading 状态。
- 保留 `AbortController` 以减少无用传输，同时确保取消失败时仍由请求编号阻止旧响应覆盖新结果。
- 筛选变化时立即使旧请求失效，并保留 300ms 防抖；分页、每页数量和手动刷新会取消尚未执行的筛选防抖，避免页面被重新拉回第一页。
- 首次加载显示 loading，刷新时保留旧列表；仅在最新请求成功且结果为空时显示“暂无记录”，失败时显示列表级错误和重试入口。
- 将列表 loading 与详情、编辑、删除和导出操作状态分离，避免不同操作互相关闭 loading。
- 单条删除成功后重新获取服务器最新列表，防止删除前的迟到响应把已删除记录重新显示。
- 组件卸载时取消防抖、终止请求并使请求编号失效，避免离开页面后的迟到更新。

- [x] 这不是破坏性变更。现有 HTTP 路径和查询参数保持不变，插件默认行为以及详情、编辑、导出流程保持兼容。

### 运行截图或测试结果

专项 SQLite 和 API 验证中，将历史正文扩大到约 200 万字符后，摘要列表响应仍保持为 5327 字节，响应大小不再随正文增长。

后端完整测试：

```text
bash scripts/run_pytests_ci.sh ./tests
1764 passed, 6 warnings
```

代码格式与静态检查：

```text
uv run ruff format --check .
480 files already formatted

uv run ruff check .
All checks passed!
```

Dashboard 验证：

```text
./node_modules/.bin/vue-tsc --noEmit
通过

node --test tests/*.test.mjs
36 passed

./node_modules/.bin/vite build
构建通过
```

真实浏览器专项验证已覆盖：

- A/B/C 连续请求、旧成功响应迟到和旧错误迟到。
- `AbortController.abort()` 失效时仍只应用最新请求。
- 首次加载、20/100 条切换、手动刷新、失败重试及空列表失败状态。
- 筛选后立即分页不会被待执行的防抖任务拉回第一页。
- 删除期间存在旧列表请求时，已删除记录不会重新出现。
- 组件卸载后，迟到响应不会更新页面。

---

### 检查清单

- [x] 本 PR 为性能与竞态修复，不包含需要前置讨论的新功能。
- [x] 更改已经过完整测试，并在上方提供了验证步骤和结果。
- [x] 未引入新的依赖库。
- [x] 更改不包含恶意代码。

## Summary by Sourcery

Optimize dashboard conversation listing to avoid loading full histories, improve database filtering and ordering, and harden frontend list requests against stale or competing updates.

New Features:
- Expose a token usage field in conversation list summaries for dashboard consumption.

Bug Fixes:
- Prevent stale or aborted frontend list requests from overwriting newer results, including during filtering, pagination, and deletion flows.
- Ensure deletion operations refresh the conversation list so removed items do not briefly reappear when older responses arrive.
- Normalize and correctly apply comma-separated platform, message type, and exclusion filters in conversation list APIs.
- Fix group/private message and platform filtering, ID and platform exclusion, and pagination stability in conversation queries.

Enhancements:
- Split frontend loading state into separate list and action indicators, with dedicated empty, loading, and error UI for the conversation table.
- Change backend conversation list APIs to return summary data without full history content while keeping detail and export endpoints unchanged.
- Improve text search over conversations to support titles, IDs, and both raw and JSON-escaped content including Chinese and emoji.
- Add idempotent SQLite indexes and query adjustments to support efficient, globally ordered conversation listing across single and multiple platforms.

Tests:
- Add unit and integration tests covering conversation list summaries, filter normalization, SQLite index behavior, and multi-platform ordering, along with existing dashboard API tests.