### PR TITLE
fix: silence repeated SiliconFlow embedding dimensions warning

### DIFF
--- a/astrbot/core/provider/sources/openai_embedding_source.py
+++ b/astrbot/core/provider/sources/openai_embedding_source.py
@@ -69,7 +69,7 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
 
     def _embedding_kwargs(self) -> dict:
         """返回启动时构建并缓存的 embedding 请求参数"""
-        return self._cached_kwargs
+        return self._cached_kwargs.copy()
 
     def _build_embedding_kwargs(self) -> dict:
         """构建嵌入请求的可选参数。仅在 __init__ 时调用一次，SiliconFlow 检测与 WARN 日志只触发一次。"""

--- a/astrbot/core/provider/sources/openai_embedding_source.py
+++ b/astrbot/core/provider/sources/openai_embedding_source.py
@@ -44,6 +44,8 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
             http_client=http_client,
         )
         self.model = provider_config.get("embedding_model", "text-embedding-3-small")
+        # 一次性构建并缓存 embedding 请求参数，避免每次调用都执行 SiliconFlow 检测并刷 WARN 日志
+        self._cached_kwargs = self._build_embedding_kwargs()
 
     async def get_embedding(self, text: str) -> list[float]:
         """获取文本的嵌入"""
@@ -66,7 +68,11 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
         return [item.embedding for item in embeddings.data]
 
     def _embedding_kwargs(self) -> dict:
-        """构建嵌入请求的可选参数"""
+        """返回启动时构建并缓存的 embedding 请求参数"""
+        return self._cached_kwargs
+
+    def _build_embedding_kwargs(self) -> dict:
+        """构建嵌入请求的可选参数。仅在 __init__ 时调用一次，SiliconFlow 检测与 WARN 日志只触发一次。"""
         kwargs = {}
         if "embedding_dimensions" in self.provider_config:
             try:


### PR DESCRIPTION
### Modifications
Fixes #9228.

Implements option 2 from the issue ("initialization-time one-shot warning"):

- Moved SiliconFlow dimensions detection and warning log from `_embedding_kwargs()` (called per embedding request) to `__init__` via a new `_build_embedding_kwargs()` method. The resulting kwargs dict is cached in `self._cached_kwargs`; `_embedding_kwargs()` now just returns the cached dict.
- `get_dim()` is intentionally left unchanged, to preserve the dimension-mismatch guard in `knowledge_base_service.create_kb` and FAISS index sizing in `vec_db.py`.

### Why
PR #8508 fixed the SiliconFlow embedding 400 error by stripping the `dimensions` parameter for non-Qwen models, but the detection ran on every `_embedding_kwargs()` call. When `embedding_dimensions` is configured, this emitted a WARN log per embedding request (3+ per conversation due to memory recall + reflection), severely hurting log readability.

### Why option 2 (init-time one-shot) over the other two options in the issue
- Option 1 (first WARN, then DEBUG): still executes the detection logic on every call; only downgrades the log level. The per-call overhead remains.
- Option 3 (auto-clear config): mutating user config has side effects and may break other code paths that read `embedding_dimensions`. Higher complexity, lower payoff.
- Option 2 (chosen): detection runs exactly once at init; zero per-call overhead; warning still surfaces at startup so users know their `dimensions` config is being ignored.

### Behavior change
- Before: WARN logged on every `get_embedding` / `get_embeddings` call when SiliconFlow + non-Qwen + `embedding_dimensions` configured.
- After: WARN logged exactly once at provider initialization.
- API request parameters: unchanged (still stripped for SiliconFlow non-Qwen).
- Non-SiliconFlow paths: unchanged.

- [x] This is NOT a breaking change.

### Screenshots or Test Results
<img width="1646" height="800" alt="0b60b8614eaea88199839f3f602f33c9" src="https://github.com/user-attachments/assets/9983141a-7da9-4c42-bd43-d980e4cb2a96" />
<img width="2020" height="1111" alt="6ba50e2fe1450e67406388dbd2b9b1ec" src="https://github.com/user-attachments/assets/05d2a4f1-9d65-42ff-97a0-2e94bc579198" />

- `uv run ruff format --check .` ✅ (480 files already formatted)
- `uv run ruff check .` ✅ (All checks passed)
- `uv run pytest tests/test_openai_embedding_source.py tests/unit/test_faiss_vec_db.py` ✅ (4 passed)
- Smoke test: AstrBot started, WebUI returned HTTP 200 on localhost:6185

### Checklist
- [x] 😊 No new features added (bug fix only, discussed in #9228).
- [x] 👀 My changes have been well-tested, and "Verification Steps" and "Screenshots" have been provided above.
- [x] 🤓 No new dependencies introduced.
- [x] 😮 No malicious code.

## Summary by Sourcery

Bug Fixes:
- Ensure SiliconFlow embedding dimensions warnings are emitted only once at initialization instead of on every embedding request.

## Summary by Sourcery

Bug Fixes:
- Emit SiliconFlow embedding-dimension warnings only once at provider initialization instead of on every embedding request.