### PR TITLE
feat: support Fish Audio TTS model selection

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1725,6 +1725,7 @@ CONFIG_METADATA_2 = {
                         "enable": False,
                         "api_key": "",
                         "api_base": "https://api.fish.audio/v1",
+                        "model": "s1",
                         "fishaudio-tts-character": "可莉",
                         "fishaudio-tts-reference-id": "",
                         "timeout": "20",

--- a/astrbot/core/provider/sources/fishaudio_tts_api_source.py
+++ b/astrbot/core/provider/sources/fishaudio_tts_api_source.py
@@ -67,7 +67,7 @@ class ProviderFishAudioTTSAPI(TTSProvider):
         self.headers = {
             "Authorization": f"Bearer {self.chosen_api_key}",
         }
-        self.set_model(provider_config.get("model", ""))
+        self.set_model(provider_config.get("model") or "s1")
 
     async def _get_reference_id_by_character(self, character: str) -> str | None:
         """获取角色的reference_id
@@ -153,7 +153,7 @@ class ProviderFishAudioTTSAPI(TTSProvider):
         ).stream(
             "POST",
             "/tts",
-            headers=self.headers,
+            headers={**self.headers, "model": self.model_name},
             content=ormsgpack.packb(request, option=ormsgpack.OPT_SERIALIZE_PYDANTIC),
         ) as response:
             if response.status_code == 200 and response.headers.get(

--- a/astrbot/core/provider/sources/fishaudio_tts_api_source.py
+++ b/astrbot/core/provider/sources/fishaudio_tts_api_source.py
@@ -144,7 +144,6 @@ class ProviderFishAudioTTSAPI(TTSProvider):
     async def get_audio(self, text: str) -> str:
         temp_dir = get_astrbot_temp_path()
         path = os.path.join(temp_dir, f"fishaudio_tts_api_{uuid.uuid4()}.wav")
-        self.headers["content-type"] = "application/msgpack"
         request = await self._generate_request(text)
         async with AsyncClient(
             base_url=self.api_base,
@@ -153,7 +152,11 @@ class ProviderFishAudioTTSAPI(TTSProvider):
         ).stream(
             "POST",
             "/tts",
-            headers={**self.headers, "model": self.model_name},
+            headers={
+                **self.headers,
+                "content-type": "application/msgpack",
+                "model": self.model_name,
+            },
             content=ormsgpack.packb(request, option=ormsgpack.OPT_SERIALIZE_PYDANTIC),
         ) as response:
             if response.status_code == 200 and response.headers.get(

--- a/tests/test_fishaudio_tts_api_source.py
+++ b/tests/test_fishaudio_tts_api_source.py
@@ -81,4 +81,5 @@ async def test_fishaudio_tts_sends_configured_model_header(
         "content-type": "application/msgpack",
         "model": expected_model,
     }
+    assert provider.headers == {"Authorization": "Bearer test-key"}
     assert Path(audio_path).read_bytes() == b"test-audio"

--- a/tests/test_fishaudio_tts_api_source.py
+++ b/tests/test_fishaudio_tts_api_source.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+import pytest
+
+import astrbot.core.provider.sources.fishaudio_tts_api_source as fishaudio_source
+from astrbot.core.config.default import CONFIG_METADATA_2
+
+
+def test_fishaudio_tts_template_exposes_stable_model_default():
+    templates = CONFIG_METADATA_2["provider_group"]["metadata"]["provider"][
+        "config_template"
+    ]
+
+    assert templates["FishAudio TTS(API)"]["model"] == "s1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("configured_model", "expected_model"),
+    [
+        ("s2.1-pro-free", "s2.1-pro-free"),
+        (None, "s1"),
+        ("", "s1"),
+    ],
+)
+async def test_fishaudio_tts_sends_configured_model_header(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    configured_model: str | None,
+    expected_model: str,
+):
+    captured: dict[str, object] = {}
+
+    class _FakeResponse:
+        status_code = 200
+        headers = {"content-type": "audio/wav"}
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def aiter_bytes(self):
+            yield b"test-audio"
+
+    class _FakeAsyncClient:
+        def __init__(self, **kwargs):
+            captured["client_kwargs"] = kwargs
+
+        def stream(self, method, url, **kwargs):
+            captured["method"] = method
+            captured["url"] = url
+            captured["headers"] = dict(kwargs["headers"])
+            return _FakeResponse()
+
+    monkeypatch.setattr(fishaudio_source, "AsyncClient", _FakeAsyncClient)
+    monkeypatch.setattr(fishaudio_source, "get_astrbot_temp_path", lambda: tmp_path)
+
+    provider_config = {
+        "id": "test-fishaudio-tts",
+        "type": "fishaudio_tts_api",
+        "api_key": "test-key",
+        "fishaudio-tts-reference-id": "a" * 32,
+    }
+    if configured_model is not None:
+        provider_config["model"] = configured_model
+
+    provider = fishaudio_source.ProviderFishAudioTTSAPI(
+        provider_config=provider_config,
+        provider_settings={},
+    )
+
+    audio_path = await provider.get_audio("hello")
+
+    assert provider.get_model() == expected_model
+    assert captured["method"] == "POST"
+    assert captured["url"] == "/tts"
+    assert captured["headers"] == {
+        "Authorization": "Bearer test-key",
+        "content-type": "application/msgpack",
+        "model": expected_model,
+    }
+    assert Path(audio_path).read_bytes() == b"test-audio"


### PR DESCRIPTION
Closes #9188.

Fish Audio selects its TTS engine through the `model` request header. AstrBot already tracked a provider model internally, but the Fish Audio configuration did not expose it and TTS requests did not send it.

### Modifications / 改动点

- Expose the Fish Audio TTS model in the provider configuration with a stable `s1` fallback for existing and blank configurations.
- Send the configured model in the `POST /tts` request header without affecting model discovery requests.
- Add regression coverage for custom, missing, and blank model configurations using a mocked streaming response.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```text
uv run pytest -q
1789 passed, 5 warnings

uv run ruff format --check .
480 files already formatted

uv run ruff check .
All checks passed!
```

---

### Checklist / 检查清单

- [x] 😊 The feature was discussed in #9188.
- [x] 👀 The change is covered by regression tests and the verification results are included above.
- [x] 🤓 No new dependencies are introduced.
- [x] 😮 This change does not introduce malicious code.

## Summary by Sourcery

Add configurable Fish Audio TTS model support and ensure it is sent with TTS requests while defaulting safely for existing configurations.

New Features:
- Expose the Fish Audio TTS model in provider configuration with a default stable model value.
- Include the selected Fish Audio TTS model in POST /tts request headers for audio generation.

Enhancements:
- Set a safe default Fish Audio TTS model in the global configuration template to support existing setups.

Tests:
- Add async tests verifying default, custom, and blank Fish Audio TTS model configurations and that the correct model header is sent in TTS requests.