### PR TITLE
fix: exclude repository hosts from plugin search

### DIFF
--- a/dashboard/src/utils/pluginSearch.mjs
+++ b/dashboard/src/utils/pluginSearch.mjs
@@ -78,6 +78,14 @@ export const getPluginSearchFields = (plugin) => {
     ? plugin.support_platforms.join(" ")
     : "";
   const tags = Array.isArray(plugin?.tags) ? plugin.tags.join(" ") : "";
+  const repositoryPath = normalizeStr(plugin?.repo)
+    .replace(
+      /^(?:(?:[a-z][a-z\d+.-]*:)?\/\/[^/]+|(?:www\.)?github\.com)\/?/i,
+      "",
+    )
+    .replace(/[?#].*$/, "")
+    .replace(/\/+$/, "")
+    .replace(/\.git$/i, "");
 
   return [
     plugin?.name,
@@ -86,7 +94,7 @@ export const getPluginSearchFields = (plugin) => {
     plugin?.short_desc,
     plugin?.desc,
     plugin?.author,
-    plugin?.repo,
+    repositoryPath,
     plugin?.version,
     plugin?.astrbot_version,
     supportPlatforms,

--- a/dashboard/src/views/extension/useExtensionPage.js
+++ b/dashboard/src/views/extension/useExtensionPage.js
@@ -11,7 +11,7 @@ import {
   normalizeStr,
   toInitials,
   toPinyinText,
-} from "@/utils/pluginSearch";
+} from "@/utils/pluginSearch.mjs";
 import { computed, onMounted, onUnmounted, reactive, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 

--- a/dashboard/tests/pluginSearch.test.mjs
+++ b/dashboard/tests/pluginSearch.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildSearchQuery,
+  getPluginSearchFields,
+  matchesPluginSearch,
+} from "../src/utils/pluginSearch.mjs";
+
+const plugin = {
+  name: "weather-tools",
+  display_name: "Weather Tools",
+  desc: "Weather forecasts",
+  author: "Example Author",
+  repo: "https://github.com/example-owner/astrbot-plugin-weather.git/",
+};
+
+test("plugin search excludes repository URL infrastructure", () => {
+  for (const term of ["github", "http", "https", "//"]) {
+    assert.equal(matchesPluginSearch(plugin, buildSearchQuery(term)), false);
+  }
+});
+
+test("plugin search keeps the repository owner and name searchable", () => {
+  const repositoryUrls = [
+    "https://github.com/example-owner/astrbot-plugin-weather.git/",
+    "//github.com/example-owner/astrbot-plugin-weather?source=market",
+    "github.com/example-owner/astrbot-plugin-weather#readme",
+    "https://gitlab.com/example-owner/astrbot-plugin-weather",
+  ];
+
+  for (const repo of repositoryUrls) {
+    const candidate = { ...plugin, repo };
+    assert.equal(
+      matchesPluginSearch(
+        candidate,
+        buildSearchQuery("example-owner/astrbot-plugin-weather"),
+      ),
+      true,
+    );
+    assert.ok(
+      getPluginSearchFields(candidate).includes(
+        "example-owner/astrbot-plugin-weather",
+      ),
+    );
+  }
+});
+
+test("plugin search still matches github when it belongs to plugin metadata", () => {
+  const githubPlugin = {
+    ...plugin,
+    name: "github-trending",
+    repo: "example-owner/github-trending",
+  };
+
+  assert.equal(
+    matchesPluginSearch(githubPlugin, buildSearchQuery("github")),
+    true,
+  );
+});


### PR DESCRIPTION
Fixes #9225.

Plugin marketplace search currently indexes the complete repository URL. Common URL infrastructure terms such as `github`, `http`, `https`, and `//` therefore match almost every plugin instead of narrowing the results.

### Modifications / 改动点

- Search the meaningful repository owner/path while excluding the URL scheme, host, query, fragment, trailing slash, and `.git` suffix.
- Preserve searches by repository owner/name and all existing plugin metadata fields.
- Use an `.mjs` module so the search behavior can be tested directly across supported Node.js versions.
- Add regression coverage for generic URL terms, repository paths, protocol-relative and bare-host URLs, query/fragment suffixes, and non-GitHub hosts.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```text
node --test tests/*.test.mjs
39 passed

pnpm run typecheck
Passed

pnpm run build
Passed

git diff --check
Passed
```

---

### Checklist / 检查清单

- [x] 😊 The bug and expected behavior were discussed in #9225.
- [x] 👀 The change is covered by regression tests and the verification results are included above.
- [x] 🤓 No new dependencies are introduced.
- [x] 😮 This change does not introduce malicious code.

## Summary by Sourcery

Refine plugin marketplace search to ignore repository URL boilerplate while preserving meaningful repository identifiers and add regression tests for the new behavior.

Bug Fixes:
- Prevent generic repository URL terms like github, http, https, and // from causing nearly all plugins to match search queries.

Enhancements:
- Index only the normalized repository owner/path instead of full repository URLs in plugin search metadata.
- Migrate plugin search utilities to an ES module to enable direct testing across supported Node.js versions.

Tests:
- Add node:test-based coverage to verify plugin search behavior for URL infrastructure terms, repository paths, query/fragment suffixes, and non-GitHub hosts.