### PR TITLE
fix: prefer explicit dates in Tavily searches

### DIFF
--- a/astrbot/core/tools/web_search_tools.py
+++ b/astrbot/core/tools/web_search_tools.py
@@ -653,13 +653,17 @@ class TavilyWebSearchTool(FunctionTool[AstrAgentContext]):
         if topic == "news":
             payload["days"] = kwargs.get("days", 3)
 
-        time_range = kwargs.get("time_range", "")
-        if time_range in ["day", "week", "month", "year"]:
-            payload["time_range"] = time_range
-        if kwargs.get("start_date"):
-            payload["start_date"] = kwargs["start_date"]
-        if kwargs.get("end_date"):
-            payload["end_date"] = kwargs["end_date"]
+        start_date = str(kwargs.get("start_date") or "").strip()
+        end_date = str(kwargs.get("end_date") or "").strip()
+        if start_date or end_date:
+            if start_date:
+                payload["start_date"] = start_date
+            if end_date:
+                payload["end_date"] = end_date
+        else:
+            time_range = kwargs.get("time_range", "")
+            if time_range in ["day", "week", "month", "year"]:
+                payload["time_range"] = time_range
 
         results = await _tavily_search(provider_settings, payload)
         if not results:

--- a/tests/unit/test_web_search_tools.py
+++ b/tests/unit/test_web_search_tools.py
@@ -607,6 +607,71 @@ def _context_with_provider_settings(provider_settings):
     return SimpleNamespace(context=agent_context)
 
 
+# --- Tavily tool tests ---
+
+
+@pytest.mark.parametrize(
+    ("date_filters", "expected_filters"),
+    [
+        ({"time_range": "week"}, {"time_range": "week"}),
+        (
+            {"time_range": "week", "start_date": "2026-05-10"},
+            {"start_date": "2026-05-10"},
+        ),
+        (
+            {"time_range": "week", "end_date": "2026-05-11"},
+            {"end_date": "2026-05-11"},
+        ),
+        (
+            {
+                "time_range": "week",
+                "start_date": "2026-05-10",
+                "end_date": "2026-05-11",
+            },
+            {"start_date": "2026-05-10", "end_date": "2026-05-11"},
+        ),
+        (
+            {"time_range": "week", "start_date": "", "end_date": ""},
+            {"time_range": "week"},
+        ),
+        (
+            {"time_range": "week", "start_date": "   ", "end_date": "\t"},
+            {"time_range": "week"},
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_tavily_search_tool_normalizes_date_filters(
+    monkeypatch,
+    date_filters,
+    expected_filters,
+):
+    captured_payload = {}
+
+    async def fake_tavily_search(provider_settings, payload):
+        captured_payload.update(payload)
+        return [
+            tools.SearchResult(
+                title="AstrBot",
+                url="https://example.com",
+                snippet="Search result",
+            )
+        ]
+
+    monkeypatch.setattr(tools, "_tavily_search", fake_tavily_search)
+    tool = tools.TavilyWebSearchTool()
+    context = _context_with_provider_settings({"websearch_tavily_key": ["tavily-key"]})
+
+    await tool.call(context, query="AstrBot", **date_filters)
+
+    actual_filters = {
+        key: captured_payload[key]
+        for key in ("time_range", "start_date", "end_date")
+        if key in captured_payload
+    }
+    assert actual_filters == expected_filters
+
+
 # --- Exa tests ---
 
 


### PR DESCRIPTION
Fixes #8154

### Modifications / 改动点

- Prefer explicit start/end dates when a Tavily request also contains time_range.
- Preserve the existing time_range behavior when no explicit date is provided.
- Add regression coverage for both dates, either single date, and empty dates.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

- uv run pytest -q tests/unit/test_web_search_tools.py: 27 passed
- ruff format --check .: passed
- ruff check .: passed

---

### Checklist / 检查清单

- [x] This change is covered by the linked issue.
- [x] My changes have been well-tested, and verification results are provided above.
- [x] No new dependencies are introduced.
- [x] My changes do not introduce malicious code.

## Summary by Sourcery

Normalize Tavily web search date filters to prefer explicit start/end dates over time_range while preserving existing behavior when no valid dates are provided.

Bug Fixes:
- Ensure Tavily searches use provided start/end dates instead of time_range when explicit non-empty dates are given.
- Fall back to time_range when start/end date inputs are empty or whitespace-only, avoiding invalid date payloads.

Tests:
- Add parametrized async tests covering Tavily date filter normalization for time_range-only, explicit dates, single-date, and empty/whitespace date cases.