### PR TITLE
fix: normalize scheme-less HTTP proxy settings

### DIFF
--- a/astrbot/core/core_lifecycle.py
+++ b/astrbot/core/core_lifecycle.py
@@ -66,6 +66,9 @@ class AstrBotCoreLifecycle:
 
         # 设置代理
         proxy_config = self.astrbot_config.get("http_proxy", "")
+        proxy_config = proxy_config.strip() if proxy_config is not None else ""
+        if proxy_config and "://" not in proxy_config:
+            proxy_config = f"http://{proxy_config}"
         if proxy_config != "":
             os.environ["https_proxy"] = proxy_config
             os.environ["http_proxy"] = proxy_config

--- a/tests/unit/test_core_lifecycle.py
+++ b/tests/unit/test_core_lifecycle.py
@@ -77,6 +77,48 @@ class TestAstrBotCoreLifecycleInit:
             assert "localhost" in os.environ.get("no_proxy", "")
             assert "127.0.0.1" in os.environ.get("no_proxy", "")
 
+    @pytest.mark.parametrize(
+        ("configured_proxy", "expected_proxy"),
+        [
+            ("127.0.0.1:7890", "http://127.0.0.1:7890"),
+            ("  proxy.example.com:8080  ", "http://proxy.example.com:8080"),
+            (" http://proxy.example.com:8080 ", "http://proxy.example.com:8080"),
+            (" https://proxy.example.com:8080 ", "https://proxy.example.com:8080"),
+            ("socks5://proxy.example.com:1080", "socks5://proxy.example.com:1080"),
+            ("   ", None),
+            (None, None),
+        ],
+    )
+    def test_init_normalizes_proxy_scheme(
+        self,
+        configured_proxy,
+        expected_proxy,
+        mock_log_broker,
+        mock_db,
+        mock_astrbot_config,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Normalize configured proxies before exporting environment variables."""
+        mock_astrbot_config.get = MagicMock(
+            side_effect=lambda key, default="": {
+                "http_proxy": configured_proxy,
+                "no_proxy": [],
+            }.get(key, default)
+        )
+        monkeypatch.delenv("http_proxy", raising=False)
+        monkeypatch.delenv("https_proxy", raising=False)
+        monkeypatch.delenv("no_proxy", raising=False)
+
+        with patch("astrbot.core.core_lifecycle.astrbot_config", mock_astrbot_config):
+            AstrBotCoreLifecycle(mock_log_broker, mock_db)
+
+        if expected_proxy is None:
+            assert "http_proxy" not in os.environ
+            assert "https_proxy" not in os.environ
+        else:
+            assert os.environ.get("http_proxy") == expected_proxy
+            assert os.environ.get("https_proxy") == expected_proxy
+
     def test_init_clears_proxy(
         self,
         mock_log_broker,


### PR DESCRIPTION
Fixes #8292

### Modifications / 改动点

- Trim the global HTTP proxy setting before exporting it.
- Default scheme-less proxy addresses to http://.
- Preserve explicit HTTP, HTTPS, and SOCKS proxy schemes and the existing empty-value cleanup.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

- uv run pytest -q tests/unit/test_core_lifecycle.py: 33 passed
- ruff format --check .: passed
- ruff check .: passed

---

### Checklist / 检查清单

- [x] This change is covered by the linked issue.
- [x] My changes have been well-tested, and verification results are provided above.
- [x] No new dependencies are introduced.
- [x] My changes do not introduce malicious code.

## Summary by Sourcery

Normalize HTTP proxy configuration before exporting environment variables.

Bug Fixes:
- Ensure scheme-less HTTP proxy settings are treated as http:// proxies instead of invalid values.
- Trim whitespace-only or empty HTTP proxy values to avoid exporting meaningless environment variables.

Enhancements:
- Align http_proxy and https_proxy environment variables to use a normalized, scheme-consistent proxy value.

Tests:
- Add parameterized tests verifying proxy normalization, including scheme-less, trimmed, explicit scheme, and empty/None configurations.