### PR TITLE
feat: honor partial Telegram reply quotes

### DIFF
--- a/astrbot/core/platform/sources/telegram/tg_adapter.py
+++ b/astrbot/core/platform/sources/telegram/tg_adapter.py
@@ -506,15 +506,22 @@ class TelegramPlatformAdapter(Platform):
             reply_abm = await self.convert_message(reply_update, context, False)
 
             if reply_abm:
+                quote_text = update.message.quote.text if update.message.quote else None
+                reply_chain = reply_abm.message
+                reply_message_str = reply_abm.message_str
+                if quote_text:
+                    reply_chain = [Comp.Plain(quote_text)]
+                    reply_message_str = quote_text
+
                 message.message.append(
                     Comp.Reply(
                         id=reply_abm.message_id,
-                        chain=reply_abm.message,
+                        chain=reply_chain,
                         sender_id=reply_abm.sender.user_id,
                         sender_nickname=reply_abm.sender.nickname,
                         time=reply_abm.timestamp,
-                        message_str=reply_abm.message_str,
-                        text=reply_abm.message_str,
+                        message_str=reply_message_str,
+                        text=reply_message_str,
                         qq=reply_abm.sender.user_id,
                     ),
                 )

--- a/tests/fixtures/helpers.py
+++ b/tests/fixtures/helpers.py
@@ -100,6 +100,7 @@ def create_mock_update(
     voice: MagicMock | None = None,
     sticker: MagicMock | None = None,
     reply_to_message: MagicMock | None = None,
+    quote: MagicMock | None = None,
     caption: str | None = None,
     entities: list | None = None,
     caption_entities: list | None = None,
@@ -122,6 +123,7 @@ def create_mock_update(
         voice: 语音对象
         sticker: 贴纸对象
         reply_to_message: 回复的消息
+        quote: 回复消息中的部分引用
         caption: 说明文字
         entities: 实体列表
         caption_entities: 说明实体列表
@@ -158,6 +160,7 @@ def create_mock_update(
     message.voice = voice
     message.sticker = sticker
     message.reply_to_message = reply_to_message
+    message.quote = quote
     message.caption = caption
     message.entities = entities
     message.caption_entities = caption_entities

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -83,6 +83,79 @@ def _build_context() -> MagicMock:
 
 
 @pytest.mark.asyncio
+async def test_telegram_partial_quote_uses_exact_quote_text():
+    TelegramPlatformAdapter = _load_telegram_adapter()
+    adapter = TelegramPlatformAdapter(
+        make_platform_config("telegram"),
+        {},
+        asyncio.Queue(),
+    )
+    original_text = "😀 prefix target suffix"
+    quoted_text = "target"
+    reply_update = create_mock_update(
+        message_text=original_text,
+        message_id=42,
+        user_id=1001,
+        username="original_sender",
+    )
+    quote = MagicMock(text=quoted_text, position=10)
+    update = create_mock_update(
+        message_text="What does this mean?",
+        reply_to_message=reply_update.message,
+        quote=quote,
+    )
+
+    result = await adapter.convert_message(update, _build_context())
+
+    assert result is not None
+    reply = result.message[0]
+    assert isinstance(reply, Comp.Reply)
+    assert reply.id == "42"
+    assert reply.message_str == quoted_text
+    assert reply.text == quoted_text
+    assert reply.chain is not None
+    assert len(reply.chain) == 1
+    assert isinstance(reply.chain[0], Comp.Plain)
+    assert reply.chain[0].text == quoted_text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("quote_text", [None, ""])
+async def test_telegram_reply_without_quote_text_uses_full_message(quote_text):
+    TelegramPlatformAdapter = _load_telegram_adapter()
+    adapter = TelegramPlatformAdapter(
+        make_platform_config("telegram"),
+        {},
+        asyncio.Queue(),
+    )
+    original_text = "Use the complete replied message"
+    reply_update = create_mock_update(
+        message_text=original_text,
+        message_id=43,
+        user_id=1002,
+        username="original_sender",
+    )
+    quote = MagicMock(text=quote_text) if quote_text is not None else None
+    update = create_mock_update(
+        message_text="Follow-up question",
+        reply_to_message=reply_update.message,
+        quote=quote,
+    )
+
+    result = await adapter.convert_message(update, _build_context())
+
+    assert result is not None
+    reply = result.message[0]
+    assert isinstance(reply, Comp.Reply)
+    assert reply.message_str == original_text
+    assert reply.text == original_text
+    assert reply.chain is not None
+    assert len(reply.chain) == 1
+    assert isinstance(reply.chain[0], Comp.Plain)
+    assert reply.chain[0].text == original_text
+
+
+@pytest.mark.asyncio
 async def test_telegram_document_caption_populates_message_text_and_plain():
     TelegramPlatformAdapter = _load_telegram_adapter()
     adapter = TelegramPlatformAdapter(


### PR DESCRIPTION
Fixes #7938

### Modifications / 改动点

- Use Telegram TextQuote.text as the exact quoted reply content.
- Keep the full replied message as the fallback when no non-empty partial quote exists.
- Add regression coverage with emoji and a non-zero UTF-16 quote position.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

- uv run pytest -q tests/test_telegram_adapter.py: 12 passed
- ruff format --check .: passed
- ruff check .: passed

---

### Checklist / 检查清单

- [x] The feature was discussed with a maintainer in the linked issue.
- [x] My changes have been well-tested, and verification results are provided above.
- [x] No new dependencies are introduced.
- [x] My changes do not introduce malicious code.

## Summary by Sourcery

Honor Telegram partial reply quotes when constructing reply components while preserving existing behavior as a fallback.

New Features:
- Support using Telegram reply quote text as the replied message content when present.

Enhancements:
- Fallback to the full replied message when no non-empty quote text is available in Telegram replies.

Tests:
- Add Telegram adapter tests covering partial quote handling, empty or missing quote text, and emoji with non-zero UTF-16 quote positions.