### PR TITLE
fix: surface provider errors in streaming WebChat

### DIFF
--- a/astrbot/core/astr_agent_run_util.py
+++ b/astrbot/core/astr_agent_run_util.py
@@ -264,9 +264,13 @@ async def run_agent(
                     )
                     yield resp.data["chain"]
                     astr_event.clear_result()
-                elif resp.type == "streaming_delta":
+                elif resp.type in ("streaming_delta", "err"):
                     chain = resp.data["chain"]
-                    if chain.type == "reasoning" and not show_reasoning:
+                    if (
+                        resp.type == "streaming_delta"
+                        and chain.type == "reasoning"
+                        and not show_reasoning
+                    ):
                         # display the reasoning content only when configured
                         continue
                     yield resp.data["chain"]  # MessageChain

--- a/tests/test_astr_agent_run_util.py
+++ b/tests/test_astr_agent_run_util.py
@@ -1,0 +1,95 @@
+from types import SimpleNamespace
+
+import pytest
+
+from astrbot.core.agent.response import AgentResponse, AgentResponseData
+from astrbot.core.astr_agent_run_util import run_agent
+from astrbot.core.message.message_event_result import MessageChain
+
+
+class _StreamingRunner:
+    """Provide the minimal streaming runner interface required by run_agent."""
+
+    def __init__(self, *responses: AgentResponse) -> None:
+        extras = {}
+        event = SimpleNamespace(
+            is_stopped=lambda: False,
+            get_extra=lambda key, default=None: extras.get(key, default),
+            get_platform_name=lambda: "test",
+        )
+        self.run_context = SimpleNamespace(
+            context=SimpleNamespace(event=event),
+            messages=[],
+        )
+        self.streaming = True
+        self.req = None
+        self._responses = responses
+        self._done = False
+
+    async def step(self):
+        """Yield configured responses and then mark the runner as done."""
+        for response in self._responses:
+            yield response
+        self._done = True
+
+    def done(self) -> bool:
+        """Return whether all configured responses have been yielded."""
+        return self._done
+
+    def request_stop(self) -> None:
+        """Mark the runner as done when run_agent requests a stop."""
+        self._done = True
+
+
+@pytest.mark.asyncio
+async def test_run_agent_yields_streaming_error_chain():
+    error_chain = MessageChain().message("LLM response failed")
+    runner = _StreamingRunner(
+        AgentResponse(
+            type="err",
+            data=AgentResponseData(chain=error_chain),
+        )
+    )
+
+    yielded = [chain async for chain in run_agent(runner)]
+
+    assert yielded == [error_chain]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_preserves_streaming_delta():
+    delta_chain = MessageChain().message("streamed answer")
+    runner = _StreamingRunner(
+        AgentResponse(
+            type="streaming_delta",
+            data=AgentResponseData(chain=delta_chain),
+        )
+    )
+
+    yielded = [chain async for chain in run_agent(runner)]
+
+    assert yielded == [delta_chain]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("show_reasoning", "expected_count"),
+    [(False, 0), (True, 1)],
+)
+async def test_run_agent_preserves_reasoning_visibility_filter(
+    show_reasoning: bool,
+    expected_count: int,
+):
+    reasoning_chain = MessageChain(type="reasoning").message("internal reasoning")
+    runner = _StreamingRunner(
+        AgentResponse(
+            type="streaming_delta",
+            data=AgentResponseData(chain=reasoning_chain),
+        )
+    )
+
+    yielded = [
+        chain async for chain in run_agent(runner, show_reasoning=show_reasoning)
+    ]
+
+    assert yielded == [reasoning_chain] * expected_count


### PR DESCRIPTION
Fixes #7915

### Modifications / 改动点

- Forward AgentResponse error chains from the native streaming bridge.
- Preserve existing reasoning visibility filtering for normal streaming deltas.
- Add focused tests for visible errors, normal deltas, and reasoning visibility.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

- pytest -q tests/test_astr_agent_run_util.py: 4 passed
- relevant ToolLoop fallback tests: passed
- ruff format --check .: passed
- ruff check .: passed

Note: #9154 touches the same runner bridge and may require a rebase if it merges first.

---

### Checklist / 检查清单

- [x] This change is covered by the linked issue.
- [x] My changes have been well-tested, and verification results are provided above.
- [x] No new dependencies are introduced.
- [x] My changes do not introduce malicious code.

## Summary by Sourcery

Surface provider error chains in streaming WebChat while preserving existing reasoning visibility behavior and adding focused coverage for the runner’s streaming paths.

Bug Fixes:
- Ensure error AgentResponse chains from the streaming runner are yielded to callers instead of being filtered out.
- Maintain existing reasoning visibility filtering for streaming deltas so internal reasoning is only surfaced when configured.

Tests:
- Add asynchronous tests covering streaming error chains, normal streaming deltas, and reasoning visibility handling in run_agent.