### PR TITLE
fix: prevent accidental persona editor dismissal

### DIFF
--- a/dashboard/src/components/shared/PersonaForm.vue
+++ b/dashboard/src/components/shared/PersonaForm.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-dialog v-model="showDialog" :max-width="$vuetify.display.smAndDown ? undefined : '1200px'" scrollable>
+    <v-dialog v-model="showDialog" :max-width="$vuetify.display.smAndDown ? undefined : '1200px'" scrollable persistent>
         <v-card class="persona-form-card" :class="{ 'persona-form-card-mobile': $vuetify.display.smAndDown }">
             <v-card-title class="persona-form-title text-h3 pa-4 pb-0 pl-6">
                 {{ editingPersona ? tm('dialog.edit.title') : tm('dialog.create.title') }}


### PR DESCRIPTION
Fixes #8481

### Modifications / 改动点

- Make the persona editor dialog persistent so outside clicks do not discard unsaved edits.
- Use Vuetify persistent behavior; scrim and Escape dismissal are disabled while explicit cancel, save, and delete close paths remain unchanged.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

- corepack pnpm@10.28.2 --dir dashboard run build: passed (includes vue-tsc --noEmit and vite build)
- git diff --check: passed

---

### Checklist / 检查清单

- [x] The behavior was discussed in the linked issue.
- [x] My changes have been well-tested, and verification results are provided above.
- [x] No new dependencies are introduced.
- [x] My changes do not introduce malicious code.

## Summary by Sourcery

Bug Fixes:
- Prevent persona editor dialog from closing on outside clicks or Escape, preserving unsaved changes until an explicit action is taken.