### PR TITLE
fix: apply provider fallback to skills-like re-queries

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -260,6 +260,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
         )
 
         self.provider = provider
+        self._primary_provider = provider
         self.fallback_providers: list[Provider] = []
         seen_provider_ids: set[str] = {str(provider.provider_config.get("id", ""))}
         for fallback_provider in fallback_providers or []:
@@ -482,7 +483,14 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
         self,
     ) -> T.AsyncGenerator[LLMResponse, None]:
         """Wrap _iter_llm_responses with provider fallback handling."""
-        candidates = [self.provider, *self.fallback_providers]
+        candidates = [
+            self.provider,
+            *(
+                provider
+                for provider in self.fallback_providers
+                if provider is not self.provider
+            ),
+        ]
         total_candidates = len(candidates)
         last_exception: Exception | None = None
         last_err_response: LLMResponse | None = None
@@ -514,7 +522,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                     with attempt:
                         try:
                             async for resp in self._iter_llm_responses(
-                                include_model=idx == 0
+                                include_model=candidate is self._primary_provider
                             ):
                                 if resp.is_chunk:
                                     has_stream_output = True
@@ -576,6 +584,101 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             )
             return
         yield LLMResponse(
+            role="err",
+            completion_text="All available chat models are unavailable.",
+        )
+
+    async def _text_chat_with_fallback(
+        self,
+        *,
+        contexts: list[Message] | list[dict[str, T.Any]],
+        func_tool: ToolSet | None,
+    ) -> LLMResponse:
+        """Call a non-streaming tool re-query with provider fallback handling.
+
+        Args:
+            contexts: Conversation contexts for the tool re-query.
+            func_tool: Param-only tool schemas selected by the first-stage response.
+
+        Returns:
+            The first successful response, or the last provider error response.
+
+        Raises:
+            Exception: The final provider exception when every candidate raises.
+        """
+        candidates = [
+            self.provider,
+            *(
+                provider
+                for provider in self.fallback_providers
+                if provider is not self.provider
+            ),
+        ]
+        total_candidates = len(candidates)
+        last_exception: Exception | None = None
+        last_err_response: LLMResponse | None = None
+
+        for idx, candidate in enumerate(candidates):
+            candidate_id = candidate.provider_config.get("id", "<unknown>")
+            is_last_candidate = idx == total_candidates - 1
+            if idx > 0:
+                logger.warning(
+                    "Switched from %s to fallback chat provider: %s",
+                    self.provider.provider_config.get("id", "<unknown>"),
+                    candidate_id,
+                )
+            self.provider = candidate
+            candidate_func_tool = func_tool
+            modalities = candidate.provider_config.get("modalities", None)
+            if (
+                isinstance(modalities, list)
+                and modalities
+                and "tool_use" not in modalities
+            ):
+                logger.debug(
+                    "Provider %s does not support tool_use, clearing tools for request.",
+                    candidate_id,
+                )
+                candidate_func_tool = None
+            payload: dict[str, T.Any] = {
+                "contexts": self._sanitize_contexts_for_provider(contexts),
+                "func_tool": candidate_func_tool,
+                "session_id": self.req.session_id,
+                "extra_user_content_parts": self.req.extra_user_content_parts,
+                "abort_signal": self._abort_signal,
+                "request_max_retries": self.request_max_retries,
+            }
+            if candidate is self._primary_provider:
+                payload["model"] = self.req.model
+
+            try:
+                response = await candidate.text_chat(**payload)
+            except Exception as exc:  # noqa: BLE001
+                last_exception = exc
+                logger.warning(
+                    "Chat Model %s request error: %s",
+                    candidate_id,
+                    exc,
+                    exc_info=True,
+                )
+                continue
+
+            if response.role == "err" and not is_last_candidate:
+                last_err_response = response
+                logger.warning(
+                    "Chat Model %s returns error response, trying fallback to next provider.",
+                    candidate_id,
+                )
+                continue
+
+            self._sanitize_malformed_tool_calls(response)
+            return response
+
+        if last_err_response:
+            return last_err_response
+        if last_exception:
+            raise last_exception
+        return LLMResponse(
             role="err",
             completion_text="All available chat models are unavailable.",
         )
@@ -843,6 +946,22 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
         if llm_resp.tools_call_name:
             if self.tool_schema_mode == "skills_like":
                 requery_resp, _ = await self._resolve_tool_exec(llm_resp)
+                if requery_resp.role == "err":
+                    self.final_llm_resp = requery_resp
+                    self.stats.end_time = time.time()
+                    self._transition_state(AgentState.ERROR)
+                    self._resolve_unconsumed_follow_ups()
+                    custom_error_message = self._get_persona_custom_error_message()
+                    error_text = custom_error_message or (
+                        f"LLM 响应错误: {requery_resp.completion_text or '未知错误'}"
+                    )
+                    yield AgentResponse(
+                        type="err",
+                        data=AgentResponseData(
+                            chain=MessageChain().message(error_text),
+                        ),
+                    )
+                    return
                 if not requery_resp.tools_call_name:
                     llm_resp = requery_resp
                     logger.warning(
@@ -1323,19 +1442,16 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             )
             if param_subset.tools and tool_names:
                 contexts = self._build_tool_requery_context(tool_names)
-                requery_resp = await self.provider.text_chat(
-                    contexts=self._sanitize_contexts_for_provider(contexts),
+                requery_resp = await self._text_chat_with_fallback(
+                    contexts=contexts,
                     func_tool=param_subset,
-                    model=self.req.model,
-                    session_id=self.req.session_id,
-                    extra_user_content_parts=self.req.extra_user_content_parts,
-                    # tool_choice="required",
-                    abort_signal=self._abort_signal,
-                    request_max_retries=self.request_max_retries,
                 )
                 if requery_resp:
                     llm_resp = requery_resp
                     self._sanitize_malformed_tool_calls(llm_resp)
+
+                if llm_resp.role == "err":
+                    return llm_resp, subset
 
                 # If the re-query still returns no tool calls, and also does not have a meaningful assistant reply,
                 # we consider it as a failure of the LLM to follow the tool-use instruction,
@@ -1351,15 +1467,9 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                         tool_names,
                         extra_instruction=self.SKILLS_LIKE_REQUERY_REPAIR_INSTRUCTION,
                     )
-                    repair_resp = await self.provider.text_chat(
-                        contexts=self._sanitize_contexts_for_provider(repair_contexts),
+                    repair_resp = await self._text_chat_with_fallback(
+                        contexts=repair_contexts,
                         func_tool=param_subset,
-                        model=self.req.model,
-                        session_id=self.req.session_id,
-                        extra_user_content_parts=self.req.extra_user_content_parts,
-                        # tool_choice="required",
-                        abort_signal=self._abort_signal,
-                        request_max_retries=self.request_max_retries,
                     )
                     if repair_resp:
                         llm_resp = repair_resp

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -192,6 +192,80 @@ class MockErrProvider(MockProvider):
         )
 
 
+class ScriptedProvider(MockProvider):
+    """Return a fixed response or exception sequence while capturing requests.
+
+    Args:
+        provider_id: Provider ID exposed through the test configuration.
+        responses: Ordered responses or exceptions for successive calls.
+        modalities: Optional modalities advertised by the provider.
+    """
+
+    def __init__(
+        self,
+        provider_id: str,
+        responses: list[LLMResponse | Exception],
+        *,
+        modalities: list[str] | None = None,
+    ) -> None:
+        super().__init__()
+        self.provider_config["id"] = provider_id
+        if modalities is not None:
+            self.provider_config["modalities"] = modalities
+        self.responses = responses
+        self.requests = []
+
+    async def text_chat(self, **kwargs) -> LLMResponse:
+        self.requests.append(kwargs)
+        response = self.responses[self.call_count]
+        self.call_count += 1
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+def _tool_call_response(
+    *,
+    completion_text: str = "选择工具",
+    query: str | None = None,
+    call_id: str = "call_select",
+) -> LLMResponse:
+    """Build a successful tool-call response for fallback scenarios.
+
+    Args:
+        completion_text: Assistant text accompanying the tool call.
+        query: Optional query argument included in the tool call.
+        call_id: Tool-call ID for the response.
+
+    Returns:
+        A successful response that selects the test tool.
+    """
+    return LLMResponse(
+        role="assistant",
+        completion_text=completion_text,
+        tools_call_name=["test_tool"],
+        tools_call_args=[{} if query is None else {"query": query}],
+        tools_call_ids=[call_id],
+        usage=TokenUsage(input_other=10, output=5),
+    )
+
+
+def _assistant_response(completion_text: str) -> LLMResponse:
+    """Build a successful assistant response.
+
+    Args:
+        completion_text: Final assistant response text.
+
+    Returns:
+        A successful response without tool calls.
+    """
+    return LLMResponse(
+        role="assistant",
+        completion_text=completion_text,
+        usage=TokenUsage(input_other=10, output=5),
+    )
+
+
 class CapturingProvider(MockProvider):
     def __init__(self, modalities: list[str]):
         super().__init__()
@@ -1454,6 +1528,252 @@ async def test_skills_like_requery_passes_extra_user_content_parts():
     parts = captured_kwargs["extra_user_content_parts"]
     assert len(parts) == 1
     assert parts[0].text == "<image_caption>一张猫的照片</image_caption>"
+
+
+async def _reset_skills_like_runner(
+    provider_request: ProviderRequest,
+    primary_provider: Provider,
+    fallback_provider: Provider,
+    tool_executor: Any,
+    agent_hooks: BaseAgentRunHooks,
+) -> ToolLoopAgentRunner:
+    """Reset a skills-like runner with one fallback provider.
+
+    Args:
+        provider_request: Request containing the test tool set.
+        primary_provider: Primary provider used for the first attempt.
+        fallback_provider: Provider used after a re-query failure.
+        tool_executor: Executor used by the test runner.
+        agent_hooks: Hooks used by the test runner.
+
+    Returns:
+        A reset runner ready for execution.
+    """
+    runner = ToolLoopAgentRunner()
+    await runner.reset(
+        provider=primary_provider,
+        request=provider_request,
+        run_context=ContextWrapper(context=None),
+        tool_executor=tool_executor,
+        agent_hooks=agent_hooks,
+        streaming=False,
+        tool_schema_mode="skills_like",
+        fallback_providers=[fallback_provider],
+    )
+    return runner
+
+
+@pytest.mark.parametrize("failure_kind", ["exception", "error_response"])
+@pytest.mark.asyncio
+async def test_skills_like_requery_uses_fallback_provider(
+    failure_kind,
+    provider_request,
+    mock_tool_executor,
+    mock_hooks,
+):
+    requery_failure: LLMResponse | Exception
+    if failure_kind == "exception":
+        requery_failure = RuntimeError("429 Too Many Requests")
+    else:
+        requery_failure = LLMResponse(
+            role="err",
+            completion_text="429 Too Many Requests",
+        )
+    primary_provider = ScriptedProvider(
+        "primary",
+        [_tool_call_response(), requery_failure],
+    )
+    fallback_provider = ScriptedProvider(
+        "fallback",
+        [
+            _tool_call_response(
+                completion_text="调用工具",
+                query="fallback",
+                call_id="call_fallback",
+            ),
+            _assistant_response("回退模型完成回答"),
+        ],
+    )
+    provider_request.model = "primary-only-model"
+    caption_part = TextPart(text="<image_caption>fallback context</image_caption>")
+    provider_request.extra_user_content_parts = [caption_part]
+    runner = await _reset_skills_like_runner(
+        provider_request,
+        primary_provider,
+        fallback_provider,
+        mock_tool_executor,
+        mock_hooks,
+    )
+
+    async for _ in runner.step_until_done(5):
+        pass
+
+    final_resp = runner.get_final_llm_resp()
+    assert final_resp is not None
+    assert final_resp.role == "assistant"
+    assert final_resp.completion_text == "回退模型完成回答"
+    assert primary_provider.call_count == 2
+    assert fallback_provider.call_count == 2
+    assert runner.provider is fallback_provider
+    assert [request["model"] for request in primary_provider.requests] == [
+        "primary-only-model",
+        "primary-only-model",
+    ]
+    assert all("model" not in request for request in fallback_provider.requests)
+    assert fallback_provider.requests[0]["extra_user_content_parts"] == [caption_part]
+    requery_tool_set = fallback_provider.requests[0]["func_tool"]
+    assert isinstance(requery_tool_set, ToolSet)
+    requery_tool = requery_tool_set.get_tool("test_tool")
+    assert requery_tool is not None
+    assert "query" in requery_tool.parameters["properties"]
+
+
+@pytest.mark.asyncio
+async def test_skills_like_repair_requery_uses_fallback_provider(
+    provider_request,
+    mock_tool_executor,
+    mock_hooks,
+):
+    primary_provider = ScriptedProvider(
+        "primary",
+        [
+            _tool_call_response(),
+            LLMResponse(role="assistant", completion_text=""),
+            RuntimeError("429 Too Many Requests"),
+        ],
+    )
+    fallback_provider = ScriptedProvider(
+        "fallback",
+        [
+            _tool_call_response(
+                completion_text="调用工具",
+                query="repaired",
+                call_id="call_repaired",
+            ),
+            _assistant_response("修复重查后完成回答"),
+        ],
+    )
+    provider_request.model = "primary-only-model"
+    runner = await _reset_skills_like_runner(
+        provider_request,
+        primary_provider,
+        fallback_provider,
+        mock_tool_executor,
+        mock_hooks,
+    )
+
+    async for _ in runner.step_until_done(5):
+        pass
+
+    final_resp = runner.get_final_llm_resp()
+    assert final_resp is not None
+    assert final_resp.role == "assistant"
+    assert final_resp.completion_text == "修复重查后完成回答"
+    assert primary_provider.call_count == 3
+    assert fallback_provider.call_count == 2
+    repair_contexts = fallback_provider.requests[0]["contexts"]
+    assert (
+        ToolLoopAgentRunner.SKILLS_LIKE_REQUERY_REPAIR_INSTRUCTION
+        in (repair_contexts[0]["content"])
+    )
+    assert all("model" not in request for request in fallback_provider.requests)
+
+
+@pytest.mark.asyncio
+async def test_skills_like_requery_error_response_finishes_runner_without_repair(
+    provider_request,
+    mock_tool_executor,
+    mock_hooks,
+):
+    fallback_error = LLMResponse(role="err", completion_text="")
+    primary_provider = ScriptedProvider(
+        "primary",
+        [_tool_call_response(), LLMResponse(role="err", completion_text="")],
+    )
+    fallback_provider = ScriptedProvider("fallback", [fallback_error])
+    runner = await _reset_skills_like_runner(
+        provider_request,
+        primary_provider,
+        fallback_provider,
+        mock_tool_executor,
+        mock_hooks,
+    )
+    follow_up_ticket = runner.follow_up(message_text="pending follow-up")
+
+    responses = [response async for response in runner.step()]
+
+    assert responses[-1].type == "err"
+    assert runner.done() is True
+    assert runner.get_final_llm_resp() is fallback_error
+    assert primary_provider.call_count == 2
+    assert fallback_provider.call_count == 1
+    assert follow_up_ticket is not None
+    assert follow_up_ticket.resolved.is_set() is True
+    assert follow_up_ticket.consumed is False
+
+
+@pytest.mark.asyncio
+async def test_skills_like_requery_reraises_final_provider_exception(
+    provider_request,
+    mock_tool_executor,
+    mock_hooks,
+):
+    class FinalProviderError(RuntimeError):
+        pass
+
+    final_exception = FinalProviderError("fallback failed")
+    primary_provider = ScriptedProvider(
+        "primary",
+        [_tool_call_response(), ValueError("primary failed")],
+    )
+    fallback_provider = ScriptedProvider("fallback", [final_exception])
+    runner = await _reset_skills_like_runner(
+        provider_request,
+        primary_provider,
+        fallback_provider,
+        mock_tool_executor,
+        mock_hooks,
+    )
+
+    with pytest.raises(FinalProviderError) as exc_info:
+        async for _ in runner.step():
+            pass
+
+    assert exc_info.value is final_exception
+    assert primary_provider.call_count == 2
+    assert fallback_provider.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_skills_like_requery_clears_tools_for_unsupported_fallback(
+    provider_request,
+    mock_tool_executor,
+    mock_hooks,
+):
+    primary_provider = ScriptedProvider(
+        "primary",
+        [_tool_call_response(), RuntimeError("primary failed")],
+    )
+    fallback_provider = ScriptedProvider(
+        "fallback",
+        [_assistant_response("工具不可用，直接说明")],
+        modalities=["text"],
+    )
+    runner = await _reset_skills_like_runner(
+        provider_request,
+        primary_provider,
+        fallback_provider,
+        mock_tool_executor,
+        mock_hooks,
+    )
+
+    async for _ in runner.step():
+        pass
+
+    final_resp = runner.get_final_llm_resp()
+    assert final_resp is not None
+    assert final_resp.completion_text == "工具不可用，直接说明"
+    assert fallback_provider.requests[0]["func_tool"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -1685,7 +1685,10 @@ async def test_skills_like_requery_error_response_finishes_runner_without_repair
     mock_tool_executor,
     mock_hooks,
 ):
-    fallback_error = LLMResponse(role="err", completion_text="")
+    fallback_error = LLMResponse(
+        role="err",
+        completion_text="429 Too Many Requests",
+    )
     primary_provider = ScriptedProvider(
         "primary",
         [_tool_call_response(), LLMResponse(role="err", completion_text="")],
@@ -1703,6 +1706,10 @@ async def test_skills_like_requery_error_response_finishes_runner_without_repair
     responses = [response async for response in runner.step()]
 
     assert responses[-1].type == "err"
+    assert (
+        responses[-1].data["chain"].get_plain_text()
+        == "LLM 响应错误: 429 Too Many Requests"
+    )
     assert runner.done() is True
     assert runner.get_final_llm_resp() is fallback_error
     assert primary_provider.call_count == 2


### PR DESCRIPTION
Fixes #8293

### Modifications / 改动点

- Apply the configured chat-provider fallback chain to skills-like tool re-queries and repair re-queries.
- Keep the selected fallback provider active for later Agent steps without passing the primary-only model override.
- Preserve provider modality filtering, error terminal state, and final exception behavior.
- Add regression coverage for exceptions, error responses, repair re-queries, model routing, content parts, parameter schemas, and text-only fallbacks.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

- pytest -q tests/test_tool_loop_agent_runner.py: 37 passed
- ruff format --check .: passed
- ruff check .: passed
- git diff --check: passed

Note: #9154 modifies the same runner and test file and may require a rebase if it merges first.

---

### Checklist / 检查清单

- [x] This change is covered by the linked issue.
- [x] My changes have been well-tested, and verification results are provided above.
- [x] No new dependencies are introduced.
- [x] My changes do not introduce malicious code.

## Summary by Sourcery

Apply provider fallback handling to skills-like tool re-queries and ensure consistent agent behavior when fallbacks are used.

Bug Fixes:
- Ensure skills-like tool re-queries and repair re-queries respect the configured provider fallback chain and reuse the selected fallback provider for subsequent steps.
- Fix error handling so that skills-like re-queries terminate the runner cleanly with an error state and response when the final provider returns an error or exception.
- Preserve primary-only model routing while avoiding passing a model override to fallback providers, and ensure tool-use is disabled when the fallback provider does not support tool modalities.

Enhancements:
- Introduce a scripted mock provider and helper response builders to simplify testing of multi-provider fallback scenarios.
- Add regression tests covering skills-like re-query fallback behavior, repair re-queries, error and exception paths, modality filtering, tool parameter schemas, and text-only fallbacks.

Tests:
- Expand tool loop agent runner tests to cover provider fallback behavior for skills-like re-queries, including primary/fallback call sequences, error termination, repair instructions, and unsupported tool modalities.