### PR TITLE
fix: preserve embedding batch result order

### DIFF
--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -363,7 +363,7 @@ class EmbeddingProvider(AbstractProvider):
 
         """
         semaphore = asyncio.Semaphore(tasks_limit)
-        all_embeddings: list[list[float]] = []
+        batch_results: dict[int, list[list[float]]] = {}
         failed_batches: list[tuple[int, list[str]]] = []
         completed_count = 0
         total_count = len(texts)
@@ -374,7 +374,7 @@ class EmbeddingProvider(AbstractProvider):
                 for attempt in range(max_retries):
                     try:
                         batch_embeddings = await self.get_embeddings(batch_texts)
-                        all_embeddings.extend(batch_embeddings)
+                        batch_results[batch_idx] = batch_embeddings
                         completed_count += len(batch_texts)
                         if progress_callback:
                             await progress_callback(completed_count, total_count)
@@ -406,6 +406,9 @@ class EmbeddingProvider(AbstractProvider):
             )
             raise Exception(error_msg)
 
+        all_embeddings: list[list[float]] = []
+        for batch_idx in range(len(tasks)):
+            all_embeddings.extend(batch_results[batch_idx])
         return all_embeddings
 
 

--- a/tests/unit/test_faiss_vec_db.py
+++ b/tests/unit/test_faiss_vec_db.py
@@ -1,9 +1,27 @@
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
 
 from astrbot.core.db.vec_db.faiss_impl.vec_db import FaissVecDB
 from astrbot.core.exceptions import KnowledgeBaseUploadError
+from astrbot.core.provider.provider import EmbeddingProvider
+
+
+class DelayedEmbeddingProvider(EmbeddingProvider):
+    def __init__(self) -> None:
+        super().__init__({}, {})
+
+    async def get_embedding(self, text: str) -> list[float]:
+        return [float(text.removeprefix("chunk-"))]
+
+    async def get_embeddings(self, text: list[str]) -> list[list[float]]:
+        if text[0] == "chunk-0":
+            await asyncio.sleep(0.02)
+        return [[float(item.removeprefix("chunk-"))] for item in text]
+
+    def get_dim(self) -> int:
+        return 1
 
 
 @pytest.mark.asyncio
@@ -44,3 +62,16 @@ async def test_insert_batch_raises_friendly_error_for_embedding_count_mismatch()
     assert "期望 2，实际 1" in str(exc_info.value)
     vec_db.document_storage.insert_documents_batch.assert_not_awaited()
     vec_db.embedding_storage.insert_batch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_embeddings_batch_preserves_input_order_when_batches_finish_out_of_order():
+    provider = DelayedEmbeddingProvider()
+
+    embeddings = await provider.get_embeddings_batch(
+        ["chunk-0", "chunk-1", "chunk-2", "chunk-3"],
+        batch_size=2,
+        tasks_limit=2,
+    )
+
+    assert embeddings == [[0.0], [1.0], [2.0], [3.0]]


### PR DESCRIPTION
Fixes embedding batch result ordering when concurrent batches complete out of order.

### Modifications / 改动点

- Preserve the original batch order in `EmbeddingProvider.get_embeddings_batch` by storing batch results by index before flattening.
- Add a regression test covering delayed first-batch completion to ensure embeddings still match the original input order.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```bash
uv run pytest tests/unit/test_faiss_vec_db.py
```

Result:

```text
3 passed, 1 warning
```

```bash
uv run ruff format .
uv run ruff check .
```

Result:

```text
480 files left unchanged
All checks passed!
```

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure embedding batch results preserve the original input order even when concurrent batches complete out of order.

Bug Fixes:
- Fix embedding batch aggregation in `get_embeddings_batch` to maintain input ordering when batches finish asynchronously.

Tests:
- Add a regression test using a delayed embedding provider to verify batch embeddings remain aligned with the input sequence.