### PR TITLE
fix: apply forward threshold to send_message_to_user

### DIFF
--- a/astrbot/core/tools/message_tools.py
+++ b/astrbot/core/tools/message_tools.py
@@ -332,10 +332,43 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
                 return f"error: invalid session: {session}"
 
         message_chain = MessageChain(chain=components)
+        forwarded_plain_text: str | None = None
+
+        # Tool messages bypass ResultDecorateStage, so apply its QQ threshold here.
+        target_platform = context.context.context.get_platform_inst(
+            target_session.platform_id
+        )
+        if (
+            target_platform
+            and target_platform.meta().name == "aiocqhttp"
+            and context.context.event.get_platform_name() == "aiocqhttp"
+            and context.context.event.get_platform_id() == target_session.platform_id
+        ):
+            cfg = context.context.context.get_config(umo=str(target_session))
+            threshold = cfg.get("platform_settings", {}).get("forward_threshold", 1500)
+            word_cnt = 0
+            for comp in message_chain.chain:
+                if isinstance(comp, Comp.Plain):
+                    word_cnt += len(comp.text)
+            if word_cnt > threshold:
+                if str(target_session) == current_session:
+                    forwarded_plain_text = message_chain.get_plain_text().strip()
+                message_chain.chain = [
+                    Comp.Node(
+                        uin=context.context.event.get_self_id(),
+                        name="AstrBot",
+                        content=[*message_chain.chain],
+                    )
+                ]
+
         await context.context.context.send_message(target_session, message_chain)
         if str(target_session) == current_session:
             context.context.event._has_send_oper = True
-            sent_plain_text = message_chain.get_plain_text().strip()
+            sent_plain_text = (
+                forwarded_plain_text
+                if forwarded_plain_text is not None
+                else message_chain.get_plain_text().strip()
+            )
             if sent_plain_text:
                 sent_plain_texts = context.context.event.get_extra(
                     "_send_message_to_user_current_session_plain_texts",

--- a/tests/unit/test_message_tools.py
+++ b/tests/unit/test_message_tools.py
@@ -207,6 +207,7 @@ async def test_send_message_keeps_aiocqhttp_text_at_forward_threshold():
     ctx.context.context.get_config = lambda umo: {
         "platform_settings": {"forward_threshold": 5}
     }
+    ctx.context.event.get_platform_name = lambda: "aiocqhttp"
 
     result = await tool.call(
         ctx,

--- a/tests/unit/test_message_tools.py
+++ b/tests/unit/test_message_tools.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+import astrbot.core.message.components as Comp
 from astrbot.core.message.message_event_result import MessageEventResult
 from astrbot.core.pipeline.respond.stage import RespondStage
 from astrbot.core.tools.message_tools import SendMessageToUserTool
@@ -17,6 +18,7 @@ def _make_context(
     runtime="local",
 ):
     """Build a minimal ContextWrapper for SendMessageToUserTool."""
+    platform_id = current_session.split(":", 1)[0]
     cfg = {
         "provider_settings": {
             "computer_use_require_admin": require_admin,
@@ -28,15 +30,22 @@ def _make_context(
         unified_msg_origin=current_session,
         role=role,
         _has_send_oper=False,
+        get_platform_id=lambda: platform_id,
+        get_platform_name=lambda: platform_id,
+        get_self_id=lambda: "bot-1",
         get_sender_id=lambda: "user-1",
     )
     event.set_extra = lambda key, value: extras.__setitem__(key, value)
     event.get_extra = lambda key, default=None: extras.get(key, default)
+    platform = SimpleNamespace(
+        meta=lambda: SimpleNamespace(id=platform_id, name=platform_id)
+    )
     return SimpleNamespace(
         context=SimpleNamespace(
             event=event,
             context=SimpleNamespace(
                 get_config=lambda umo: cfg,
+                get_platform_inst=lambda _platform_id: platform,
                 send_message=AsyncMock(),
             ),
         )
@@ -151,6 +160,87 @@ async def test_send_message_defaults_to_current_session():
     assert ctx.context.event.get_extra(
         "_send_message_to_user_current_session_plain_texts",
     ) == ["hello"]
+
+
+@pytest.mark.asyncio
+async def test_send_message_applies_aiocqhttp_forward_threshold():
+    """Long aiocqhttp tool messages are wrapped as merged-forward nodes."""
+    tool = SendMessageToUserTool()
+    ctx = _make_context(current_session="napcat:GroupMessage:123456")
+    ctx.context.context.get_platform_inst = lambda _platform_id: SimpleNamespace(
+        meta=lambda: SimpleNamespace(name="aiocqhttp")
+    )
+    ctx.context.context.get_config = lambda umo: {
+        "platform_settings": {"forward_threshold": 5}
+    }
+    ctx.context.event.get_platform_name = lambda: "aiocqhttp"
+
+    result = await tool.call(
+        ctx,
+        messages=[
+            {"type": "plain", "text": "abc"},
+            {"type": "plain", "text": "def"},
+        ],
+    )
+
+    assert "Message sent to session" in result
+    sent_chain = ctx.context.context.send_message.await_args.args[1]
+    assert len(sent_chain.chain) == 1
+    node = sent_chain.chain[0]
+    assert isinstance(node, Comp.Node)
+    assert node.uin == "bot-1"
+    assert [comp.text for comp in node.content] == ["abc", "def"]
+    assert ctx.context.event._has_send_oper is True
+    assert ctx.context.event.get_extra(
+        "_send_message_to_user_current_session_plain_texts"
+    ) == ["abc def"]
+
+
+@pytest.mark.asyncio
+async def test_send_message_keeps_aiocqhttp_text_at_forward_threshold():
+    """Text equal to the threshold keeps the existing plain-message behavior."""
+    tool = SendMessageToUserTool()
+    ctx = _make_context(current_session="napcat:GroupMessage:123456")
+    ctx.context.context.get_platform_inst = lambda _platform_id: SimpleNamespace(
+        meta=lambda: SimpleNamespace(name="aiocqhttp")
+    )
+    ctx.context.context.get_config = lambda umo: {
+        "platform_settings": {"forward_threshold": 5}
+    }
+
+    result = await tool.call(
+        ctx,
+        messages=[{"type": "plain", "text": "hello"}],
+    )
+
+    assert "Message sent to session" in result
+    sent_chain = ctx.context.context.send_message.await_args.args[1]
+    assert len(sent_chain.chain) == 1
+    assert isinstance(sent_chain.chain[0], Comp.Plain)
+
+
+@pytest.mark.asyncio
+async def test_send_message_keeps_cross_platform_aiocqhttp_text():
+    """Do not create an invalid merged-forward node without the target bot ID."""
+    tool = SendMessageToUserTool()
+    ctx = _make_context(current_session="cron:FriendMessage:user-1")
+    ctx.context.context.get_platform_inst = lambda _platform_id: SimpleNamespace(
+        meta=lambda: SimpleNamespace(name="aiocqhttp")
+    )
+    ctx.context.context.get_config = lambda umo: {
+        "platform_settings": {"forward_threshold": 5}
+    }
+
+    result = await tool.call(
+        ctx,
+        session="napcat:GroupMessage:123456",
+        messages=[{"type": "plain", "text": "long message"}],
+    )
+
+    assert "Message sent to session" in result
+    sent_chain = ctx.context.context.send_message.await_args.args[1]
+    assert len(sent_chain.chain) == 1
+    assert isinstance(sent_chain.chain[0], Comp.Plain)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #8678.

### Modifications / 改动点

- Apply the existing `platform_settings.forward_threshold` rule to `send_message_to_user` output.
- Limit conversion to messages sent from an `aiocqhttp` event through the same adapter instance, where a valid bot UIN is available.
- Preserve plain-message behavior for cron, cross-platform, cross-instance, and non-`aiocqhttp` sends.
- Keep current-session duplicate reply suppression unchanged by recording plain text before wrapping the message in a forward node.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Verification:

- `uv run pytest tests/unit/test_message_tools.py tests/unit/test_func_tool_manager.py tests/unit/test_astr_agent_tool_exec.py -q` — 50 passed.
- `uv run ruff format --check .` — 480 files already formatted.
- `uv run ruff check .` — passed.
- `git diff --check origin/master` — passed.

Regression coverage includes the strict `>` boundary, same-instance forwarding, current-session deduplication, and the cron/cross-platform fallback to plain messages.

---

### Checklist / 检查清单

- [x] This is a bug fix and does not add a new feature.
- [x] The change is covered by targeted regression tests.
- [x] No new dependency is introduced.
- [x] This change does not introduce malicious code.

## Summary by Sourcery

Apply QQ forward-threshold handling to SendMessageToUserTool while preserving existing plain-message behavior and current-session deduplication.

Bug Fixes:
- Ensure long aiocqhttp tool messages are wrapped into merged-forward nodes according to platform forward_threshold settings.
- Prevent creation of invalid merged-forward nodes for cross-platform or cross-instance sends, falling back to plain messages instead.
- Maintain correct duplicate-reply suppression by recording the original plain text before wrapping messages in forward nodes.

Tests:
- Add unit tests covering aiocqhttp forward-threshold application, boundary behavior at the threshold, and cross-platform behavior for SendMessageToUserTool.