### PR TITLE
fix: support Spark Lite OpenAI-compatible requests

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -434,7 +434,19 @@ class ProviderOpenAIOfficial(Provider):
                 extra_body.pop(field, None)
 
             messages = payloads.get("messages")
-            if isinstance(messages, list):
+            first_user = (
+                next(
+                    (
+                        message
+                        for message in messages
+                        if isinstance(message, dict) and message.get("role") == "user"
+                    ),
+                    None,
+                )
+                if isinstance(messages, list)
+                else None
+            )
+            if first_user is None or isinstance(first_user.get("content"), str):
                 system_parts: list[str] = []
                 compatible_messages: list[Any] = []
                 for message in messages:
@@ -454,11 +466,7 @@ class ProviderOpenAIOfficial(Provider):
                 if system_parts:
                     system_prompt = "\n\n".join(system_parts)
                     for index, message in enumerate(compatible_messages):
-                        if (
-                            isinstance(message, dict)
-                            and message.get("role") == "user"
-                            and isinstance(message.get("content"), str)
-                        ):
+                        if isinstance(message, dict) and message.get("role") == "user":
                             user_message = dict(message)
                             user_content = user_message.get("content", "")
                             user_message["content"] = (

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -409,8 +409,72 @@ class ProviderOpenAIOfficial(Provider):
         payloads: dict[str, Any],
         extra_body: dict[str, Any],
     ) -> None:
+        """Apply request compatibility adjustments for known providers.
+
+        Args:
+            payloads: Standard OpenAI request fields sent to the SDK.
+            extra_body: Provider-specific fields sent through ``extra_body``.
+        """
         provider = self.provider_config.get("provider")
         model = str(payloads.get("model", "")).lower()
+
+        # Spark Lite rejects system messages and function-calling fields. Keep
+        # this compatibility path limited to iFlytek's official endpoint and
+        # exact Lite model so Spark Max/Ultra and compatible proxies are intact.
+        if self.client.base_url.host == "spark-api-open.xf-yun.com" and model == "lite":
+            for field in (
+                "tools",
+                "tool_choice",
+                "parallel_tool_calls",
+                "functions",
+                "function_call",
+                "tool_calls_switch",
+            ):
+                payloads.pop(field, None)
+                extra_body.pop(field, None)
+
+            messages = payloads.get("messages")
+            if isinstance(messages, list):
+                system_parts: list[str] = []
+                compatible_messages: list[Any] = []
+                for message in messages:
+                    if not isinstance(message, dict):
+                        compatible_messages.append(message)
+                        continue
+
+                    role = message.get("role")
+                    if role == "system":
+                        content = message.get("content")
+                        if isinstance(content, str):
+                            if content:
+                                system_parts.append(content)
+                            continue
+                    compatible_messages.append(message)
+
+                if system_parts:
+                    system_prompt = "\n\n".join(system_parts)
+                    for index, message in enumerate(compatible_messages):
+                        if (
+                            isinstance(message, dict)
+                            and message.get("role") == "user"
+                            and isinstance(message.get("content"), str)
+                        ):
+                            user_message = dict(message)
+                            user_content = user_message.get("content", "")
+                            user_message["content"] = (
+                                f"{system_prompt}\n\n{user_content}"
+                                if user_content
+                                else system_prompt
+                            )
+                            compatible_messages[index] = user_message
+                            break
+                    else:
+                        compatible_messages.insert(
+                            0,
+                            {"role": "user", "content": system_prompt},
+                        )
+
+                payloads["messages"] = compatible_messages
 
         # NVIDIA's hosted MiniMax M3 endpoint can return empty choices when
         # max_tokens is omitted (#9206). Scope the compatibility default to

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -11,6 +11,7 @@ from PIL import Image as PILImage
 
 import astrbot.core.provider.sources.openai_source as openai_source_module
 import astrbot.core.provider.sources.request_retry as request_retry
+from astrbot.core.agent.tool import FunctionTool, ToolSet
 from astrbot.core.exceptions import EmptyModelOutputError
 from astrbot.core.provider.entities import LLMResponse
 from astrbot.core.provider.sources.groq_source import ProviderGroq
@@ -1293,6 +1294,191 @@ async def test_apply_provider_specific_request_overrides_disables_ollama_thinkin
         assert "reasoning" not in extra_body
         assert "think" not in extra_body
         assert extra_body["temperature"] == 0.2
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("api_base", "model"),
+    [
+        ("https://spark-api-open.xf-yun.com/v1", "generalv3.5"),
+        ("https://spark-api-open.xf-yun.com/v1", "4.0Ultra"),
+        ("https://example.com/v1", "lite"),
+    ],
+)
+async def test_spark_lite_request_overrides_are_strictly_scoped(api_base, model):
+    """Leave Spark Max/Ultra and non-iFlytek Lite payloads unchanged."""
+    provider = _make_provider({"api_base": api_base, "model": model})
+    try:
+        payloads = {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": "persona"},
+                {"role": "user", "content": "hello"},
+                {"role": "tool", "tool_call_id": "call-1", "content": "result"},
+            ],
+            "tools": [{"type": "function"}],
+            "tool_choice": "auto",
+        }
+        extra_body = {"function_call": "auto"}
+
+        provider._apply_provider_specific_request_overrides(payloads, extra_body)
+
+        assert payloads == {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": "persona"},
+                {"role": "user", "content": "hello"},
+                {"role": "tool", "tool_call_id": "call-1", "content": "result"},
+            ],
+            "tools": [{"type": "function"}],
+            "tool_choice": "auto",
+        }
+        assert extra_body == {"function_call": "auto"}
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_spark_lite_does_not_drop_unsupported_history_content():
+    """Keep unsupported history content so fallback can handle the error."""
+    provider = _make_provider(
+        {
+            "api_base": "https://spark-api-open.xf-yun.com/v1",
+            "model": "lite",
+        }
+    )
+    try:
+        structured_content = [{"type": "text", "text": "persona"}]
+        messages = [
+            {"role": "system", "content": structured_content},
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "call-1", "type": "function"}],
+            },
+            {"role": "tool", "tool_call_id": "call-1", "content": "result"},
+        ]
+        payloads = {
+            "model": "lite",
+            "messages": messages,
+        }
+
+        provider._apply_provider_specific_request_overrides(payloads, {})
+
+        assert payloads["messages"] == messages
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streaming", [False, True])
+async def test_spark_lite_query_removes_unsupported_request_fields(
+    monkeypatch,
+    streaming,
+):
+    """Send Spark Lite only supported roles and fields in both query paths."""
+    provider = _make_provider(
+        {
+            "api_base": "https://spark-api-open.xf-yun.com/v1",
+            "model": "lite",
+            "custom_extra_body": {
+                "temperature": 0.2,
+                "tool_calls_switch": True,
+            },
+        }
+    )
+    try:
+        captured_kwargs = {}
+
+        async def fake_stream():
+            yield ChatCompletionChunk.model_validate(
+                {
+                    "id": "chatcmpl-spark-lite",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": "lite",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"role": "assistant", "content": "ok"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                }
+            )
+
+        async def fake_create(**kwargs):
+            captured_kwargs.update(kwargs)
+            if streaming:
+                return fake_stream()
+            return ChatCompletion.model_validate(
+                {
+                    "id": "chatcmpl-spark-lite",
+                    "object": "chat.completion",
+                    "created": 0,
+                    "model": "lite",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "ok"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                }
+            )
+
+        monkeypatch.setattr(provider.client.chat.completions, "create", fake_create)
+
+        tools = ToolSet(
+            tools=[
+                FunctionTool(
+                    name="search",
+                    description="Search for information.",
+                    parameters={"type": "object", "properties": {}},
+                )
+            ]
+        )
+        payloads = {
+            "model": "lite",
+            "messages": [
+                {"role": "system", "content": "Follow the persona."},
+                {"role": "user", "content": "Hello."},
+                {"role": "assistant", "content": "Previous answer."},
+                {"role": "user", "content": "Continue."},
+            ],
+            "functions": [{"name": "legacy"}],
+            "function_call": "auto",
+            "parallel_tool_calls": True,
+        }
+
+        if streaming:
+            async for _ in provider._query_stream(payloads=payloads, tools=tools):
+                pass
+        else:
+            await provider._query(payloads=payloads, tools=tools)
+
+        assert captured_kwargs["messages"] == [
+            {"role": "user", "content": "Follow the persona.\n\nHello."},
+            {"role": "assistant", "content": "Previous answer."},
+            {"role": "user", "content": "Continue."},
+        ]
+        for field in (
+            "tools",
+            "tool_choice",
+            "parallel_tool_calls",
+            "functions",
+            "function_call",
+        ):
+            assert field not in captured_kwargs
+        assert captured_kwargs["extra_body"] == {"temperature": 0.2}
     finally:
         await provider.terminate()
 

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -1374,6 +1374,84 @@ async def test_spark_lite_does_not_drop_unsupported_history_content():
 
 
 @pytest.mark.asyncio
+async def test_spark_lite_keeps_structured_first_user_content_unchanged():
+    """Keep structured first-user content unchanged for fallback handling."""
+    provider = _make_provider(
+        {
+            "api_base": "https://spark-api-open.xf-yun.com/v1",
+            "model": "lite",
+        }
+    )
+    try:
+        messages = [
+            {"role": "system", "content": "persona"},
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "hello"}],
+            },
+        ]
+        payloads = {"model": "lite", "messages": messages}
+
+        provider._apply_provider_specific_request_overrides(payloads, {})
+
+        assert payloads["messages"] == messages
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_spark_lite_converts_string_system_without_user():
+    """Preserve the existing system-only compatibility conversion."""
+    provider = _make_provider(
+        {
+            "api_base": "https://spark-api-open.xf-yun.com/v1",
+            "model": "lite",
+        }
+    )
+    try:
+        payloads = {
+            "model": "lite",
+            "messages": [{"role": "system", "content": "persona"}],
+        }
+
+        provider._apply_provider_specific_request_overrides(payloads, {})
+
+        assert payloads["messages"] == [
+            {"role": "user", "content": "persona"}
+        ]
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_spark_lite_does_not_move_system_prompt_past_structured_user():
+    """Do not move a system prompt into a later string user message."""
+    provider = _make_provider(
+        {
+            "api_base": "https://spark-api-open.xf-yun.com/v1",
+            "model": "lite",
+        }
+    )
+    try:
+        messages = [
+            {"role": "system", "content": "persona"},
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "hello"}],
+            },
+            {"role": "assistant", "content": "answer"},
+            {"role": "user", "content": "continue"},
+        ]
+        payloads = {"model": "lite", "messages": messages}
+
+        provider._apply_provider_specific_request_overrides(payloads, {})
+
+        assert payloads["messages"] == messages
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("streaming", [False, True])
 async def test_spark_lite_query_removes_unsupported_request_fields(
     monkeypatch,


### PR DESCRIPTION
Fixes #8234.

### Modifications / 改动点

- Add a compatibility adjustment scoped to the official `spark-api-open.xf-yun.com` endpoint and the exact `lite` model.
- Remove top-level Function Calling fields that Spark Lite does not support.
- Merge ordinary string `system` prompts into the first text `user` message so the configured persona is retained.
- Leave Spark Max/Ultra, third-party OpenAI-compatible endpoints, structured system content, and existing tool/function history unchanged.
- Apply the same request adjustment to streaming and non-streaming calls.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Verification:

- `uv run pytest tests/test_openai_source.py -q` — 68 passed.
- `uv run ruff format --check .` — 480 files already formatted.
- `uv run ruff check .` — passed.
- `git diff --check origin/master` — passed.

Regression coverage confirms the exact endpoint/model boundary, both query modes, preservation of non-target provider payloads, and fail-safe retention of unsupported structured/tool history for provider fallback.

The compatibility rules follow iFlytek's Spark HTTP API documentation. A live API-key smoke test is still recommended during review.

---

### Checklist / 检查清单

- [x] This is a bug fix and does not add a new feature.
- [x] The change is covered by targeted regression tests.
- [x] No new dependency is introduced.
- [x] This change does not introduce malicious code.

## Summary by Sourcery

Adjust OpenAI-compatible request handling for Spark Lite to match iFlytek’s official API constraints while preserving behavior for other models and providers.

Bug Fixes:
- Ensure Spark Lite requests to the official iFlytek endpoint strip unsupported function-calling and tooling fields before sending.
- Merge plain string system prompts into the first text user message for Spark Lite so persona configuration is retained without breaking compatibility.
- Maintain unsupported structured system and tool history content in Spark Lite payloads so downstream fallback can handle resulting errors.
- Apply Spark Lite compatibility adjustments consistently to both streaming and non-streaming query paths.

Tests:
- Add regression tests verifying Spark Lite overrides are scoped to the official endpoint and exact lite model only.
- Add tests covering preservation of unsupported structured history content and first-user structured messages for Spark Lite.
- Add tests confirming system-only and mixed system/user prompts are converted correctly for Spark Lite.
- Add tests ensuring Spark Lite query paths remove unsupported request fields and send only supported roles/fields for both streaming and non-streaming calls.