### PR TITLE
fix: limit proactive cron LLM retries

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -169,6 +169,7 @@ DEFAULT_CONFIG = {
         },
         "proactive_capability": {
             "add_cron_tools": True,
+            "request_max_retries": 1,
         },
         "computer_use_runtime": "none",
         "computer_use_require_admin": True,
@@ -2895,6 +2896,9 @@ CONFIG_METADATA_2 = {
                             "add_cron_tools": {
                                 "type": "bool",
                             },
+                            "request_max_retries": {
+                                "type": "int",
+                            },
                         },
                     },
                 },
@@ -3560,6 +3564,11 @@ CONFIG_METADATA_3 = {
                 "hint": "https://docs.astrbot.app/use/proactive-agent.html",
                 "type": "object",
                 "items": {
+                    "provider_settings.proactive_capability.request_max_retries": {
+                        "description": "LLM request retries",
+                        "type": "int",
+                        "hint": "Maximum retry attempts for proactive scheduled Agent LLM requests. Lower values prevent future tasks from waiting several minutes before trying fallback providers or failing fast.",
+                    },
                     "provider_settings.proactive_capability.add_cron_tools": {
                         "description": "启用",
                         "type": "bool",

--- a/astrbot/core/cron/manager.py
+++ b/astrbot/core/cron/manager.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
 _CRONTAB_WEEKDAY_NAMES = ("sun", "mon", "tue", "wed", "thu", "fri", "sat")
 _CRONTAB_WEEKDAY_PATTERN = re.compile(r"^(?:(\*)|(\d+)(?:-(\d+))?)(?:/(\d+))?$")
+_DEFAULT_PROACTIVE_REQUEST_MAX_RETRIES = 1
 
 
 def _normalize_crontab_day_of_week(day_of_week: str) -> str:
@@ -417,12 +418,22 @@ class CronJobManager:
             cron_event.role = "admin"
 
         provider_settings = cfg.get("provider_settings", {}) or {}
+        proactive_settings = provider_settings.get("proactive_capability", {})
+        if not isinstance(proactive_settings, dict):
+            proactive_settings = {}
+        proactive_request_max_retries = proactive_settings.get("request_max_retries")
+        if proactive_request_max_retries is None:
+            proactive_request_max_retries = _DEFAULT_PROACTIVE_REQUEST_MAX_RETRIES
+        cron_provider_settings = {
+            **provider_settings,
+            "request_max_retries": proactive_request_max_retries,
+        }
         tool_call_timeout = provider_settings.get("tool_call_timeout", 120)
         config = MainAgentBuildConfig(
             tool_call_timeout=tool_call_timeout,
             llm_safety_mode=False,
             streaming_response=False,
-            provider_settings=provider_settings,
+            provider_settings=cron_provider_settings,
         )
         req = ProviderRequest()
         conv = await _get_session_conv(event=cron_event, plugin_context=self.ctx)

--- a/tests/unit/test_cron_manager.py
+++ b/tests/unit/test_cron_manager.py
@@ -596,8 +596,128 @@ class TestRunActiveAgentJob:
 
         config = captured["config"]
         assert config.tool_call_timeout == 77
-        assert config.provider_settings is provider_settings
+        assert config.provider_settings is not provider_settings
         assert config.provider_settings["fallback_chat_models"] == ["fallback-provider"]
+        assert config.provider_settings["request_max_retries"] == 1
+        assert "request_max_retries" not in provider_settings
+
+    @pytest.mark.asyncio
+    async def test_woke_main_agent_allows_proactive_retry_override(
+        self, cron_manager
+    ):
+        """Test active cron agent can override request retries for proactive runs."""
+        provider_settings = {
+            "tool_call_timeout": 77,
+            "request_max_retries": 5,
+            "proactive_capability": {"request_max_retries": 2},
+        }
+        ctx = MagicMock()
+        ctx.get_config.return_value = {
+            "admins_id": [],
+            "provider_settings": provider_settings,
+        }
+        cron_manager.ctx = ctx
+
+        conv = MagicMock()
+        conv.history = "[]"
+
+        class FakeRunner:
+            def step_until_done(self, max_step):
+                async def gen():
+                    if False:
+                        yield None
+
+                return gen()
+
+            def get_final_llm_resp(self):
+                return None
+
+        captured = {}
+
+        async def fake_build_main_agent(*, event, plugin_context, config, req):
+            captured["config"] = config
+            return MagicMock(agent_runner=FakeRunner())
+
+        with (
+            patch(
+                "astrbot.core.astr_main_agent._get_session_conv",
+                AsyncMock(return_value=conv),
+            ),
+            patch(
+                "astrbot.core.astr_main_agent.build_main_agent",
+                side_effect=fake_build_main_agent,
+            ),
+            patch(
+                "astrbot.core.cron.manager.persist_agent_history",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            await cron_manager._woke_main_agent(
+                message="run scheduled task",
+                session_str="test:FriendMessage:user123",
+                extras={"cron_job": {"id": "job-1"}, "cron_payload": {}},
+            )
+
+        assert captured["config"].provider_settings["request_max_retries"] == 2
+        assert provider_settings["request_max_retries"] == 5
+
+    @pytest.mark.asyncio
+    async def test_woke_main_agent_uses_default_when_proactive_retry_is_none(
+        self, cron_manager
+    ):
+        """Test None proactive retry config falls back to the cron default."""
+        provider_settings = {
+            "request_max_retries": 5,
+            "proactive_capability": {"request_max_retries": None},
+        }
+        ctx = MagicMock()
+        ctx.get_config.return_value = {
+            "admins_id": [],
+            "provider_settings": provider_settings,
+        }
+        cron_manager.ctx = ctx
+
+        conv = MagicMock()
+        conv.history = "[]"
+
+        class FakeRunner:
+            def step_until_done(self, max_step):
+                async def gen():
+                    if False:
+                        yield None
+
+                return gen()
+
+            def get_final_llm_resp(self):
+                return None
+
+        captured = {}
+
+        async def fake_build_main_agent(*, event, plugin_context, config, req):
+            captured["config"] = config
+            return MagicMock(agent_runner=FakeRunner())
+
+        with (
+            patch(
+                "astrbot.core.astr_main_agent._get_session_conv",
+                AsyncMock(return_value=conv),
+            ),
+            patch(
+                "astrbot.core.astr_main_agent.build_main_agent",
+                side_effect=fake_build_main_agent,
+            ),
+            patch(
+                "astrbot.core.cron.manager.persist_agent_history",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            await cron_manager._woke_main_agent(
+                message="run scheduled task",
+                session_str="test:FriendMessage:user123",
+                extras={"cron_job": {"id": "job-1"}, "cron_payload": {}},
+            )
+
+        assert captured["config"].provider_settings["request_max_retries"] == 1
 
 
 class TestGetNextRunTime:


### PR DESCRIPTION
## Summary
- limit proactive scheduled Agent LLM request retries to avoid multi-minute waits before fallback/failure
- add a proactive capability config override for scheduled-task retry attempts
- cover default and override behavior in cron manager tests

## Why
Issue #9140 shows scheduled future tasks trigger on time and execute the first tool call, but then wait around 10-11 minutes before the next LLM/tool step. That delay matches the default provider retry chain (`120s` timeout times multiple attempts) in proactive cron execution.

## Test
- `pytest tests/unit/test_cron_manager.py -q`

Closes #9140

## Summary by Sourcery

Limit proactive scheduled agent LLM request retries for cron runs and add configuration support for overriding retry behavior.

New Features:
- Introduce a proactive capability configuration option to override request_max_retries for scheduled cron tasks.

Bug Fixes:
- Ensure proactive cron executions use a bounded number of LLM request retries to prevent multi-minute delays before fallback or failure.

Enhancements:
- Adjust cron manager to derive a separate provider_settings copy for proactive runs with a default of one retry.
- Extend cron manager tests to cover default proactive retry behavior and configuration overrides for scheduled tasks.

Tests:
- Add unit tests verifying cron manager applies default and overridden proactive request_max_retries without mutating the original provider_settings.