### PR TITLE
fix: prevent the WebChat token ring from over-reporting context usage

### DIFF
--- a/astrbot/core/agent/response.py
+++ b/astrbot/core/agent/response.py
@@ -18,6 +18,8 @@ class AgentResponse:
 @dataclass
 class AgentStats:
     token_usage: TokenUsage = field(default_factory=TokenUsage)
+    current_context_tokens: int = 0
+    """Input tokens sent in the most recent LLM request."""
     start_time: float = 0.0
     end_time: float = 0.0
     time_to_first_token: float = 0.0
@@ -29,6 +31,7 @@ class AgentStats:
     def to_dict(self) -> dict:
         return {
             "token_usage": self.token_usage.__dict__,
+            "current_context_tokens": self.current_context_tokens,
             "start_time": self.start_time,
             "end_time": self.end_time,
             "time_to_first_token": self.time_to_first_token,

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -770,9 +770,14 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 continue
             llm_resp_result = llm_response
 
-            if not llm_response.is_chunk and llm_response.usage:
-                # only count the token usage of the final response for computation purpose
+            # Chunk responses have already continued above. A missing usage report
+            # means the latest context occupancy is unknown.
+            self.stats.current_context_tokens = 0
+            if llm_response.usage:
+                # Keep cumulative usage for billing and expose the latest request
+                # input separately for context-window occupancy displays.
                 self.stats.token_usage += llm_response.usage
+                self.stats.current_context_tokens = llm_response.usage.input
                 if self.req.conversation:
                     self.req.conversation.token_usage = llm_response.usage.total
             break  # got final response

--- a/dashboard/src/components/chat/Chat.vue
+++ b/dashboard/src/components/chat/Chat.vue
@@ -867,11 +867,16 @@ const currentTokenMetadata = computed(() => {
   const model = currentTokenProvider.value?.model;
   return model ? tokenModelMetadata.value[model] || null : null;
 });
-const latestTokenUsageTotal = computed(() => {
+const latestContextTokens = computed(() => {
   for (let index = activeMessages.value.length - 1; index >= 0; index -= 1) {
     const message = activeMessages.value[index];
     if (isUserMessage(message)) continue;
-    const usage = message.content?.agentStats?.token_usage;
+    const stats = message.content?.agentStats;
+    if (!stats) continue;
+    if (stats.current_context_tokens != null) {
+      return readTokenCount(stats.current_context_tokens);
+    }
+    const usage = stats.token_usage;
     if (!usage) continue;
     return (
       readTokenCount(usage.input_other) +
@@ -882,7 +887,7 @@ const latestTokenUsageTotal = computed(() => {
   return 0;
 });
 const tokenUsageIndicator = computed(() => {
-  const used = latestTokenUsageTotal.value;
+  const used = latestContextTokens.value;
   const limit = contextLimit(currentTokenProvider.value, currentTokenMetadata.value);
   if (used <= 0 || limit <= 0) return null;
 

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -142,6 +142,41 @@ class MockMixedContentToolExecutor:
         return generator()
 
 
+class VaryingUsageProvider(MockProvider):
+    """Return distinct token usage values for each tool-loop request."""
+
+    async def text_chat(self, **kwargs) -> LLMResponse:
+        self.call_count += 1
+        usage = TokenUsage(
+            input_other=self.call_count * 100,
+            input_cached=self.call_count * 10,
+            output=self.call_count,
+        )
+        if self.call_count == 1:
+            return LLMResponse(
+                role="assistant",
+                tools_call_name=["test_tool"],
+                tools_call_args=[{"query": "test"}],
+                tools_call_ids=["call_varying_usage"],
+                usage=usage,
+            )
+        return LLMResponse(
+            role="assistant",
+            completion_text="final",
+            usage=usage,
+        )
+
+
+class MissingFinalUsageProvider(VaryingUsageProvider):
+    """Omit usage from the final response after reporting an earlier request."""
+
+    async def text_chat(self, **kwargs) -> LLMResponse:
+        response = await super().text_chat(**kwargs)
+        if self.call_count == 2:
+            response.usage = None
+        return response
+
+
 class MockFailingProvider(MockProvider):
     async def text_chat(self, **kwargs) -> LLMResponse:
         self.call_count += 1
@@ -585,6 +620,63 @@ async def test_normal_completion_without_max_step(
 
     # 验证工具仍然可用（没有被禁用）
     assert runner.req.func_tool is not None, "正常完成时工具不应该被禁用"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streaming", [False, True])
+async def test_stats_separate_latest_context_from_cumulative_usage(
+    runner, provider_request, mock_tool_executor, mock_hooks, streaming
+):
+    """Context occupancy uses the latest input while usage remains cumulative."""
+    provider = VaryingUsageProvider()
+    await runner.reset(
+        provider=provider,
+        request=provider_request,
+        run_context=ContextWrapper(context=None),
+        tool_executor=mock_tool_executor,
+        agent_hooks=mock_hooks,
+        streaming=streaming,
+    )
+
+    async for _ in runner.step_until_done(3):
+        pass
+
+    assert provider.call_count == 2
+    assert runner.stats.token_usage == TokenUsage(
+        input_other=300,
+        input_cached=30,
+        output=3,
+    )
+    assert runner.stats.current_context_tokens == 220
+    assert runner.stats.to_dict()["current_context_tokens"] == 220
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streaming", [False, True])
+async def test_stats_clear_current_context_when_latest_usage_is_missing(
+    runner, provider_request, mock_tool_executor, mock_hooks, streaming
+):
+    """Do not expose stale context occupancy when the latest usage is unknown."""
+    provider = MissingFinalUsageProvider()
+    await runner.reset(
+        provider=provider,
+        request=provider_request,
+        run_context=ContextWrapper(context=None),
+        tool_executor=mock_tool_executor,
+        agent_hooks=mock_hooks,
+        streaming=streaming,
+    )
+
+    async for _ in runner.step_until_done(3):
+        pass
+
+    assert runner.stats.token_usage == TokenUsage(
+        input_other=100,
+        input_cached=10,
+        output=1,
+    )
+    assert runner.stats.current_context_tokens == 0
+    assert runner.stats.to_dict()["current_context_tokens"] == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

Fixes #9248。

WebChat 输入框旁的 Token 用量圆环此前直接使用 `AgentStats.token_usage` 计算上下文占用率。然而，`token_usage` 会累计一次 Agent 运行中所有 LLM 请求的输入和输出 Token。在包含多轮工具调用的场景下，同一段历史上下文会被重复计入，导致圆环显示 200%、1000% 等明显高于实际上下文占用率的数值。

本次修改将“累计 Token 用量”和“当前上下文占用”拆分为两个独立指标：

- `token_usage` 继续保留累计语义，供统计、计费和 Agent 运行信息展示使用；
- 新增 `current_context_tokens`，记录最近一次完整 LLM 请求的输入 Token，即 `input_other + input_cached`；
- Token 圆环改用 `current_context_tokens` 计算占用率，不再把多轮请求的累计用量误认为当前上下文大小。

输出 Token 没有计入 `current_context_tokens`，因为圆环需要反映的是最近一次请求发送给模型的输入上下文，而不是这次请求产生的输出或整个 Agent 运行的累计消耗。

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- 修改 `astrbot/core/agent/response.py`：
  - 在 `AgentStats` 中新增 `current_context_tokens` 字段；
  - 在 `AgentStats.to_dict()` 中序列化该字段，使其能够随 `agent_stats` 事件发送并保存到 WebChat 历史消息中。

- 修改 `astrbot/core/agent/runners/tool_loop_agent_runner.py`：
  - 保留 `token_usage` 原有的累计逻辑，不影响 Provider 统计和计费用量；
  - 每次收到完整 LLM 响应后，将 `current_context_tokens` 更新为该次响应的输入 Token；
  - 如果最新完整响应没有提供 usage，则将 `current_context_tokens` 重置为 `0`，避免继续显示上一轮请求的陈旧上下文数据；
  - 保持原有 `conversation.token_usage` 更新逻辑不变。

- 修改 `dashboard/src/components/chat/Chat.vue`：
  - Token 圆环优先使用 `agentStats.current_context_tokens`；
  - 对于修改前保存的历史消息，如果不存在该字段，则继续使用原有 `token_usage` 计算逻辑，保证旧数据兼容；
  - 当最新上下文用量未知或为 `0` 时，不显示圆环，避免展示不可靠的数据。

- 修改 `tests/test_tool_loop_agent_runner.py`：
  - 增加具有不同 Token 用量的两轮工具调用回归测试；
  - 验证累计 `token_usage` 仍等于各轮用量之和；
  - 验证 `current_context_tokens` 只等于最后一次请求的输入 Token，并排除输出 Token；
  - 同时覆盖流式和非流式执行；
  - 覆盖最新响应缺少 usage 时清除陈旧上下文占用值的情况；
  - 验证 `current_context_tokens` 能正确序列化。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

#### 验证步骤

1. 运行后端格式和静态检查：

```bash
uv run ruff format --check astrbot/core/agent/response.py astrbot/core/agent/runners/tool_loop_agent_runner.py tests/test_tool_loop_agent_runner.py
uv run ruff check astrbot/core/agent/response.py astrbot/core/agent/runners/tool_loop_agent_runner.py tests/test_tool_loop_agent_runner.py
```

结果：检查通过。

2. 运行 Tool Loop Agent 和 Provider 统计相关测试：

```bash
uv run pytest tests/test_tool_loop_agent_runner.py tests/unit/test_provider_stats.py -q
```

结果：

```text
...................................                                      [100%]
35 passed, 1 warning in 2.98s
```

其中 warning 为项目已有的 Python `audioop` 弃用提示，与本次修改无关。

3. 运行前端 TypeScript 类型检查：

```bash
cd dashboard
pnpm typecheck
```

结果：`vue-tsc --noEmit` 执行通过。

4. 额外运行了更大范围的 Agent 相关后端测试：

```text
136 passed, 2 failed
```

两个失败均来自 Windows 下视频附件测试对 `file:///path/...` 路径分隔符的既有预期差异：测试期望 `/path/to/video.mp4`，实际在 Windows 上被规范化为 `\path\to\video.mp4`。失败用例与本次 Token 统计修改无关。

#### 回归测试覆盖的核心场景

模拟一次包含两次 LLM 请求的工具调用流程：

```text
请求 1：input_other=100, input_cached=10, output=1
请求 2：input_other=200, input_cached=20, output=2
```

修复后的预期和测试结果：

```text
累计 token_usage：
input_other=300, input_cached=30, output=3

当前上下文 current_context_tokens：
200 + 20 = 220
```

这证明累计统计仍被完整保留，而 Token 圆环可以使用最后一次请求的 `220` 个输入 Token，不再错误使用累计值 `333`。

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Separate WebChat context-window occupancy from cumulative token usage and ensure the token ring reflects only the latest request’s input tokens.

New Features:
- Expose current_context_tokens in AgentStats to represent input tokens of the most recent LLM request.
- Update the WebChat token ring to use current_context_tokens for context occupancy while falling back to legacy token_usage for older messages.

Bug Fixes:
- Prevent the WebChat token ring from over-reporting context usage by no longer using cumulative token_usage as the current context size.
- Clear current_context_tokens when the latest LLM response omits usage data to avoid displaying stale context occupancy.

Enhancements:
- Keep cumulative token_usage accounting unchanged for billing and statistics while adding a separate metric for display purposes.
- Extend tool-loop agent runner stats serialization so current_context_tokens is available to the frontend.

Tests:
- Add provider and agent runner regression tests covering multi-step tool loops, cumulative usage, latest-context tracking, missing usage handling, and serialization of current_context_tokens.