### PR TITLE
fix(webchat): 修复WebChat SSE断开后agent未停止及队列残留问题

### DIFF
--- a/astrbot/core/platform/sources/webchat/webchat_event.py
+++ b/astrbot/core/platform/sources/webchat/webchat_event.py
@@ -43,13 +43,9 @@ class WebChatMessageEvent(AstrMessageEvent):
         emit_complete: bool = False,
     ) -> str | None:
         request_id = str(message_id)
-        conversation_id = _extract_conversation_id(session_id)
-        web_chat_back_queue = webchat_queue_mgr.get_or_create_back_queue(
-            request_id,
-            conversation_id,
-        )
         if not message:
-            await web_chat_back_queue.put(
+            await webchat_queue_mgr.put_back_queue(
+                request_id,
                 {
                     "type": "end",
                     "data": "",
@@ -63,7 +59,8 @@ class WebChatMessageEvent(AstrMessageEvent):
         for comp in message.chain:
             if isinstance(comp, Plain):
                 data = comp.text
-                await web_chat_back_queue.put(
+                accepted = await webchat_queue_mgr.put_back_queue(
+                    request_id,
                     {
                         "type": "plain",
                         "data": data,
@@ -72,8 +69,11 @@ class WebChatMessageEvent(AstrMessageEvent):
                         "message_id": message_id,
                     },
                 )
+                if not accepted:
+                    return None
             elif isinstance(comp, Json):
-                await web_chat_back_queue.put(
+                accepted = await webchat_queue_mgr.put_back_queue(
+                    request_id,
                     {
                         "type": "plain",
                         "data": json.dumps(comp.data, ensure_ascii=False),
@@ -82,6 +82,8 @@ class WebChatMessageEvent(AstrMessageEvent):
                         "message_id": message_id,
                     },
                 )
+                if not accepted:
+                    return None
             elif isinstance(comp, Image):
                 # save image to local
                 image_base64 = await comp.convert_to_base64()
@@ -95,7 +97,8 @@ class WebChatMessageEvent(AstrMessageEvent):
                 path = os.path.join(attachments_dir, filename)
                 await asyncio.to_thread(Path(path).write_bytes, image_bytes)
                 data = f"[IMAGE]{filename}"
-                await web_chat_back_queue.put(
+                accepted = await webchat_queue_mgr.put_back_queue(
+                    request_id,
                     {
                         "type": "image",
                         "data": data,
@@ -103,6 +106,8 @@ class WebChatMessageEvent(AstrMessageEvent):
                         "message_id": message_id,
                     },
                 )
+                if not accepted:
+                    return None
             elif isinstance(comp, Record):
                 # save record to local
                 filename = f"{str(uuid.uuid4())}.wav"
@@ -111,7 +116,8 @@ class WebChatMessageEvent(AstrMessageEvent):
                 record_bytes = base64.b64decode(record_base64)
                 await asyncio.to_thread(Path(path).write_bytes, record_bytes)
                 data = f"[RECORD]{filename}"
-                await web_chat_back_queue.put(
+                accepted = await webchat_queue_mgr.put_back_queue(
+                    request_id,
                     {
                         "type": "record",
                         "data": data,
@@ -119,6 +125,8 @@ class WebChatMessageEvent(AstrMessageEvent):
                         "message_id": message_id,
                     },
                 )
+                if not accepted:
+                    return None
             elif isinstance(comp, File):
                 # save file to local
                 file_path = await comp.get_file()
@@ -135,7 +143,8 @@ class WebChatMessageEvent(AstrMessageEvent):
                 dest_path = os.path.join(attachments_dir, filename)
                 shutil.copy2(file_path, dest_path)
                 data = f"[FILE]{filename}|{original_name}"
-                await web_chat_back_queue.put(
+                accepted = await webchat_queue_mgr.put_back_queue(
+                    request_id,
                     {
                         "type": "file",
                         "data": data,
@@ -143,11 +152,14 @@ class WebChatMessageEvent(AstrMessageEvent):
                         "message_id": message_id,
                     },
                 )
+                if not accepted:
+                    return None
             else:
                 logger.debug(f"webchat 忽略: {comp.type}")
 
         if emit_complete:
-            await web_chat_back_queue.put(
+            await webchat_queue_mgr.put_back_queue(
+                request_id,
                 {
                     "type": "complete",
                     "data": data,
@@ -169,11 +181,6 @@ class WebChatMessageEvent(AstrMessageEvent):
         reasoning_content = ""
         message_id = self.message_obj.message_id
         request_id = str(message_id)
-        conversation_id = _extract_conversation_id(self.session_id)
-        web_chat_back_queue = webchat_queue_mgr.get_or_create_back_queue(
-            request_id,
-            conversation_id,
-        )
         async for chain in generator:
             # 处理音频流（Live Mode）
             if chain.type == "audio_chunk":
@@ -196,7 +203,7 @@ class WebChatMessageEvent(AstrMessageEvent):
                 if text:
                     payload["text"] = text
 
-                await web_chat_back_queue.put(payload)
+                await webchat_queue_mgr.put_back_queue(request_id, payload)
                 continue
 
             # if chain.type == "break" and final_data:
@@ -224,7 +231,8 @@ class WebChatMessageEvent(AstrMessageEvent):
             else:
                 final_data += r
 
-        await web_chat_back_queue.put(
+        await webchat_queue_mgr.put_back_queue(
+            request_id,
             {
                 "type": "complete",  # complete means we return the final result
                 "data": final_data,

--- a/astrbot/core/platform/sources/webchat/webchat_event.py
+++ b/astrbot/core/platform/sources/webchat/webchat_event.py
@@ -203,7 +203,9 @@ class WebChatMessageEvent(AstrMessageEvent):
                 if text:
                     payload["text"] = text
 
-                await webchat_queue_mgr.put_back_queue(request_id, payload)
+                accepted = await webchat_queue_mgr.put_back_queue(request_id, payload)
+                if not accepted:
+                    return
                 continue
 
             # if chain.type == "break" and final_data:

--- a/astrbot/core/platform/sources/webchat/webchat_queue_mgr.py
+++ b/astrbot/core/platform/sources/webchat/webchat_queue_mgr.py
@@ -66,6 +66,8 @@ class WebChatQueueMgr:
         except asyncio.QueueFull:
             pass
 
+        # A full queue can block indefinitely after its SSE consumer disconnects.
+        # Race the pending write against queue closure so removal wakes the sender.
         put_task = asyncio.create_task(queue.put(data))
         close_task = asyncio.create_task(close_event.wait())
         try:
@@ -78,6 +80,7 @@ class WebChatQueueMgr:
             await put_task
             return True
         finally:
+            # Cancel and consume the losing task to avoid leaking pending tasks.
             for task in (put_task, close_task):
                 if not task.done():
                     task.cancel()

--- a/astrbot/core/platform/sources/webchat/webchat_queue_mgr.py
+++ b/astrbot/core/platform/sources/webchat/webchat_queue_mgr.py
@@ -10,6 +10,7 @@ class WebChatQueueMgr:
         """Conversation ID to asyncio.Queue mapping"""
         self.back_queues: dict[str, asyncio.Queue] = {}
         """Request ID to asyncio.Queue mapping for responses"""
+        self._back_queue_close_events: dict[str, asyncio.Event] = {}
         self._conversation_back_requests: dict[str, set[str]] = {}
         self._request_conversation: dict[str, str] = {}
         self._queue_close_events: dict[str, asyncio.Event] = {}
@@ -36,6 +37,7 @@ class WebChatQueueMgr:
             self.back_queues[request_id] = asyncio.Queue(
                 maxsize=self.back_queue_maxsize
             )
+            self._back_queue_close_events[request_id] = asyncio.Event()
         if conversation_id:
             self._request_conversation[request_id] = conversation_id
             if conversation_id not in self._conversation_back_requests:
@@ -43,8 +45,49 @@ class WebChatQueueMgr:
             self._conversation_back_requests[conversation_id].add(request_id)
         return self.back_queues[request_id]
 
+    async def put_back_queue(self, request_id: str, data: object) -> bool:
+        """Write a response payload while the request queue remains active.
+
+        Args:
+            request_id: Response request identifier.
+            data: Payload to enqueue.
+
+        Returns:
+            Whether the payload was accepted by an active response queue.
+        """
+        queue = self.back_queues.get(request_id)
+        close_event = self._back_queue_close_events.get(request_id)
+        if queue is None or close_event is None or close_event.is_set():
+            return False
+
+        try:
+            queue.put_nowait(data)
+            return True
+        except asyncio.QueueFull:
+            pass
+
+        put_task = asyncio.create_task(queue.put(data))
+        close_task = asyncio.create_task(close_event.wait())
+        try:
+            done, _ = await asyncio.wait(
+                {put_task, close_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if close_task in done:
+                return False
+            await put_task
+            return True
+        finally:
+            for task in (put_task, close_task):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(put_task, close_task, return_exceptions=True)
+
     def remove_back_queue(self, request_id: str):
         """Remove back queue for the given request ID"""
+        close_event = self._back_queue_close_events.pop(request_id, None)
+        if close_event is not None:
+            close_event.set()
         self.back_queues.pop(request_id, None)
         conversation_id = self._request_conversation.pop(request_id, None)
         if conversation_id:

--- a/astrbot/dashboard/services/chat_service.py
+++ b/astrbot/dashboard/services/chat_service.py
@@ -990,7 +990,7 @@ class ChatService:
                     )
                 webchat_queue_mgr.remove_back_queue(message_id)
                 try:
-                    await flush_pending_bot_message()
+                    await asyncio.shield(flush_pending_bot_message())
                 except Exception as e:
                     logger.exception(
                         f"Failed to persist pending webchat message: {e}",

--- a/astrbot/dashboard/services/chat_service.py
+++ b/astrbot/dashboard/services/chat_service.py
@@ -968,9 +968,27 @@ class ChatService:
                                     pass
                         if msg_type == "end":
                             break
+            except (asyncio.CancelledError, GeneratorExit):
+                client_disconnected = True
+                raise
             except BaseException as e:
                 logger.exception(f"WebChat stream unexpected error: {e}", exc_info=True)
             finally:
+                if client_disconnected:
+                    unified_msg_origin = build_thread_unified_msg_origin(
+                        username,
+                        webchat_conv_id,
+                    )
+                    stopped_count = active_event_registry.request_agent_stop_all(
+                        unified_msg_origin
+                    )
+                    logger.debug(
+                        "[WebChat] Requested agent stop after client disconnect, "
+                        "umo=%s, stopped_count=%s",
+                        unified_msg_origin,
+                        stopped_count,
+                    )
+                webchat_queue_mgr.remove_back_queue(message_id)
                 try:
                     await flush_pending_bot_message()
                 except Exception as e:
@@ -978,7 +996,6 @@ class ChatService:
                         f"Failed to persist pending webchat message: {e}",
                         exc_info=True,
                     )
-                webchat_queue_mgr.remove_back_queue(message_id)
 
         chat_queue = webchat_queue_mgr.get_or_create_queue(webchat_conv_id)
         await chat_queue.put(

--- a/tests/test_chat_route.py
+++ b/tests/test_chat_route.py
@@ -1,7 +1,10 @@
 import asyncio
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from astrbot.dashboard.services import chat_service
+from astrbot.dashboard.services.chat_service import ChatService
 from astrbot.dashboard.services.chat_service import poll_webchat_stream_result
 
 
@@ -54,3 +57,84 @@ async def test_poll_webchat_stream_result_returns_queue_payload():
 
     assert result == payload
     assert should_break is False
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_disconnect_requests_agent_stop(monkeypatch):
+    service = object.__new__(ChatService)
+    service.running_convs = {}
+    service.build_user_message_parts = AsyncMock(
+        return_value=[{"type": "plain", "text": "hello"}]
+    )
+    service.save_bot_message = AsyncMock()
+
+    stop_agent = Mock(return_value=1)
+    monkeypatch.setattr(
+        chat_service.active_event_registry,
+        "request_agent_stop_all",
+        stop_agent,
+    )
+    monkeypatch.setattr(
+        chat_service,
+        "poll_webchat_stream_result",
+        AsyncMock(return_value=(None, True)),
+    )
+
+    session_id = "disconnect-session"
+    stream = await service.build_chat_stream(
+        "alice",
+        {
+            "message": "hello",
+            "session_id": session_id,
+            "_skip_user_history": True,
+        },
+    )
+
+    try:
+        await anext(stream)
+        with pytest.raises(StopAsyncIteration):
+            await anext(stream)
+    finally:
+        await stream.aclose()
+        chat_service.webchat_queue_mgr.remove_queues(session_id)
+
+    stop_agent.assert_called_once_with(
+        chat_service.build_thread_unified_msg_origin("alice", session_id)
+    )
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_close_requests_agent_stop(monkeypatch):
+    service = object.__new__(ChatService)
+    service.running_convs = {}
+    service.build_user_message_parts = AsyncMock(
+        return_value=[{"type": "plain", "text": "hello"}]
+    )
+    service.save_bot_message = AsyncMock()
+
+    stop_agent = Mock(return_value=1)
+    monkeypatch.setattr(
+        chat_service.active_event_registry,
+        "request_agent_stop_all",
+        stop_agent,
+    )
+
+    session_id = "closed-session"
+    stream = await service.build_chat_stream(
+        "alice",
+        {
+            "message": "hello",
+            "session_id": session_id,
+            "_skip_user_history": True,
+        },
+    )
+
+    try:
+        await anext(stream)
+        await stream.aclose()
+    finally:
+        chat_service.webchat_queue_mgr.remove_queues(session_id)
+
+    stop_agent.assert_called_once_with(
+        chat_service.build_thread_unified_msg_origin("alice", session_id)
+    )

--- a/tests/test_chat_route.py
+++ b/tests/test_chat_route.py
@@ -1,11 +1,14 @@
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import pytest
 
 from astrbot.dashboard.services import chat_service
-from astrbot.dashboard.services.chat_service import ChatService
-from astrbot.dashboard.services.chat_service import poll_webchat_stream_result
+from astrbot.dashboard.services.chat_service import (
+    ChatService,
+    poll_webchat_stream_result,
+)
 
 
 class _QueueThatRaises:
@@ -22,6 +25,18 @@ class _QueueWithResult:
 
     async def get(self):
         return self._result
+
+
+@pytest.fixture
+def chat_service_instance(monkeypatch, tmp_path):
+    """Create ChatService through its public constructor for stream tests."""
+    monkeypatch.setattr(chat_service, "get_astrbot_data_path", lambda: str(tmp_path))
+    core_lifecycle = SimpleNamespace(
+        conversation_manager=Mock(),
+        platform_message_history_manager=Mock(),
+        umop_config_router=Mock(),
+    )
+    return ChatService(Mock(), core_lifecycle)
 
 
 @pytest.mark.asyncio
@@ -60,9 +75,11 @@ async def test_poll_webchat_stream_result_returns_queue_payload():
 
 
 @pytest.mark.asyncio
-async def test_chat_stream_disconnect_requests_agent_stop(monkeypatch):
-    service = object.__new__(ChatService)
-    service.running_convs = {}
+async def test_chat_stream_disconnect_requests_agent_stop(
+    monkeypatch,
+    chat_service_instance,
+):
+    service = chat_service_instance
     service.build_user_message_parts = AsyncMock(
         return_value=[{"type": "plain", "text": "hello"}]
     )
@@ -104,9 +121,11 @@ async def test_chat_stream_disconnect_requests_agent_stop(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_chat_stream_close_requests_agent_stop(monkeypatch):
-    service = object.__new__(ChatService)
-    service.running_convs = {}
+async def test_chat_stream_close_requests_agent_stop(
+    monkeypatch,
+    chat_service_instance,
+):
+    service = chat_service_instance
     service.build_user_message_parts = AsyncMock(
         return_value=[{"type": "plain", "text": "hello"}]
     )
@@ -138,3 +157,81 @@ async def test_chat_stream_close_requests_agent_stop(monkeypatch):
     stop_agent.assert_called_once_with(
         chat_service.build_thread_unified_msg_origin("alice", session_id)
     )
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_cancellation_does_not_cancel_pending_persistence(
+    monkeypatch,
+    chat_service_instance,
+):
+    service = chat_service_instance
+    service.build_user_message_parts = AsyncMock(
+        return_value=[{"type": "plain", "text": "hello"}]
+    )
+
+    save_started = asyncio.Event()
+    allow_save = asyncio.Event()
+    save_completed = asyncio.Event()
+    save_cancelled = asyncio.Event()
+
+    async def save_bot_message(*_args, **_kwargs):
+        save_started.set()
+        try:
+            await allow_save.wait()
+        except asyncio.CancelledError:
+            save_cancelled.set()
+            raise
+        save_completed.set()
+        return None
+
+    service.save_bot_message = save_bot_message
+    monkeypatch.setattr(
+        chat_service.active_event_registry,
+        "request_agent_stop_all",
+        Mock(return_value=1),
+    )
+
+    session_id = "cancelled-persistence-session"
+    stream = await service.build_chat_stream(
+        "alice",
+        {
+            "message": "hello",
+            "session_id": session_id,
+            "_skip_user_history": True,
+        },
+    )
+    request_id = chat_service.webchat_queue_mgr.list_back_request_ids(session_id)[0]
+    monkeypatch.setattr(
+        chat_service,
+        "poll_webchat_stream_result",
+        AsyncMock(
+            side_effect=[
+                (
+                    {
+                        "type": "plain",
+                        "data": "partial response",
+                        "streaming": True,
+                        "message_id": request_id,
+                    },
+                    False,
+                ),
+                (None, True),
+            ]
+        ),
+    )
+
+    try:
+        await anext(stream)
+        await anext(stream)
+        stream_task = asyncio.create_task(anext(stream))
+        await asyncio.wait_for(save_started.wait(), timeout=1)
+        stream_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await stream_task
+
+        allow_save.set()
+        await asyncio.wait_for(save_completed.wait(), timeout=1)
+        assert not save_cancelled.is_set()
+    finally:
+        allow_save.set()
+        chat_service.webchat_queue_mgr.remove_queues(session_id)

--- a/tests/test_platform_image_format_preservation.py
+++ b/tests/test_platform_image_format_preservation.py
@@ -62,11 +62,16 @@ async def test_webchat_image_attachment_uses_detected_extension(tmp_path, monkey
         "data:image/png;base64," + base64.b64encode(image_buffer.getvalue()).decode()
     )
     queue = asyncio.Queue()
+
+    async def put_back_queue(_request_id, payload):
+        await queue.put(payload)
+        return True
+
     monkeypatch.setattr(webchat_event, "attachments_dir", str(tmp_path))
     monkeypatch.setattr(
         webchat_event.webchat_queue_mgr,
-        "get_or_create_back_queue",
-        lambda *_args: queue,
+        "put_back_queue",
+        put_back_queue,
     )
 
     await webchat_event.WebChatMessageEvent._send(

--- a/tests/test_webchat_queue_lifecycle.py
+++ b/tests/test_webchat_queue_lifecycle.py
@@ -1,0 +1,49 @@
+import asyncio
+
+import pytest
+
+from astrbot.api.event import MessageChain
+from astrbot.core.platform.sources.webchat import webchat_event
+from astrbot.core.platform.sources.webchat.webchat_queue_mgr import WebChatQueueMgr
+
+
+@pytest.mark.asyncio
+async def test_removed_back_queue_unblocks_sender_and_is_not_recreated(monkeypatch):
+    queue_manager = WebChatQueueMgr(back_queue_maxsize=1)
+    monkeypatch.setattr(webchat_event, "webchat_queue_mgr", queue_manager)
+
+    request_id = "request-1"
+    conversation_id = "conversation-1"
+    session_id = f"webchat!user!{conversation_id}"
+    back_queue = queue_manager.get_or_create_back_queue(
+        request_id,
+        conversation_id,
+    )
+    await back_queue.put({"type": "plain", "data": "pending"})
+
+    blocked_sender = asyncio.create_task(
+        webchat_event.WebChatMessageEvent._send(
+            request_id,
+            MessageChain().message("first late chunk"),
+            session_id,
+            streaming=True,
+        )
+    )
+    await asyncio.sleep(0)
+    assert not blocked_sender.done()
+
+    queue_manager.remove_back_queue(request_id)
+    await asyncio.wait_for(blocked_sender, timeout=1)
+
+    await asyncio.wait_for(
+        webchat_event.WebChatMessageEvent._send(
+            request_id,
+            MessageChain().message("second late chunk"),
+            session_id,
+            streaming=True,
+        ),
+        timeout=1,
+    )
+
+    assert request_id not in queue_manager.back_queues
+    assert queue_manager.list_back_request_ids(conversation_id) == []

--- a/tests/test_webchat_queue_lifecycle.py
+++ b/tests/test_webchat_queue_lifecycle.py
@@ -1,8 +1,11 @@
 import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
 from astrbot.api.event import MessageChain
+from astrbot.api.message_components import Json, Plain
 from astrbot.core.platform.sources.webchat import webchat_event
 from astrbot.core.platform.sources.webchat.webchat_queue_mgr import WebChatQueueMgr
 
@@ -47,3 +50,36 @@ async def test_removed_back_queue_unblocks_sender_and_is_not_recreated(monkeypat
 
     assert request_id not in queue_manager.back_queues
     assert queue_manager.list_back_request_ids(conversation_id) == []
+
+
+@pytest.mark.asyncio
+async def test_audio_stream_stops_when_back_queue_is_closed(monkeypatch):
+    put_back_queue = AsyncMock(return_value=False)
+    monkeypatch.setattr(
+        webchat_event.webchat_queue_mgr,
+        "put_back_queue",
+        put_back_queue,
+    )
+    second_chunk_requested = False
+
+    async def generate_audio_chunks():
+        nonlocal second_chunk_requested
+        yield MessageChain(
+            chain=[Plain("audio-data"), Json(data={"text": "transcript"})],
+            type="audio_chunk",
+        )
+        second_chunk_requested = True
+        yield MessageChain(chain=[Plain("late-audio")], type="audio_chunk")
+
+    generator = generate_audio_chunks()
+    event = SimpleNamespace(
+        message_obj=SimpleNamespace(message_id="request-1"),
+        session_id="webchat!user!conversation-1",
+    )
+    try:
+        await webchat_event.WebChatMessageEvent.send_streaming(event, generator)
+    finally:
+        await generator.aclose()
+
+    put_back_queue.assert_awaited_once()
+    assert not second_chunk_requested

--- a/tests/unit/test_webchat_message_parts.py
+++ b/tests/unit/test_webchat_message_parts.py
@@ -16,6 +16,11 @@ from astrbot.core.platform.sources.webchat.message_parts_helper import (
 async def test_webchat_file_send_keeps_original_filename(tmp_path, monkeypatch):
     """WebChat file payloads should carry both stored and display filenames."""
     queue = asyncio.Queue()
+
+    async def put_back_queue(_request_id, payload):
+        await queue.put(payload)
+        return True
+
     attachments_dir = tmp_path / "attachments"
     attachments_dir.mkdir()
     source_file = tmp_path / "source.txt"
@@ -23,8 +28,8 @@ async def test_webchat_file_send_keeps_original_filename(tmp_path, monkeypatch):
     monkeypatch.setattr(webchat_event, "attachments_dir", str(attachments_dir))
     monkeypatch.setattr(
         webchat_event.webchat_queue_mgr,
-        "get_or_create_back_queue",
-        lambda *_args: queue,
+        "put_back_queue",
+        put_back_queue,
     )
 
     await webchat_event.WebChatMessageEvent._send(


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点
- 为 back_queue 引入关闭事件，put_back_queue 方法在写入前检查队列有效性，避免向已关闭队列入队
- WebChat 消息事件在推送响应时对 put_back_queue 返回值进行判断，队列关闭后提前终止消息链处理
- chat_service 捕获客户端断开异常，主动调用 active_event_registry 停止对应 agent，并在 finally 块中清理 back_queue
closes #9253, #9249 
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
<img width="1172" height="850" alt="image" src="https://github.com/user-attachments/assets/ffa43762-85dd-447c-897f-721afb0d599d" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Improve WebChat SSE stream robustness by adding back-queue lifecycle control, stopping agents and clearing queues when clients disconnect, and updating message sending to avoid writing into closed response queues.

Bug Fixes:
- Prevent WebChat message sending from enqueuing responses into closed back queues after SSE disconnects.
- Ensure WebChat agents are requested to stop when clients disconnect or close streams, and clean up associated back queues.

Enhancements:
- Introduce lifecycle management for WebChat back queues with close events to coordinate senders and cleanup.
- Update WebChat streaming and message sending to use a guarded back-queue write API that respects queue closure.

Tests:
- Add tests covering WebChat back-queue lifecycle, including blocked senders and queue removal behaviour.
- Add tests verifying that WebChat chat streams request agent stop on client disconnect and stream closure.
- Adapt existing WebChat attachment tests to the new back-queue write API.