### PR TITLE
feat: stream agent stats after each LLM call

### DIFF
--- a/astrbot/core/agent/response.py
+++ b/astrbot/core/agent/response.py
@@ -30,7 +30,7 @@ class AgentStats:
 
     def to_dict(self) -> dict:
         return {
-            "token_usage": self.token_usage.__dict__,
+            "token_usage": self.token_usage.__dict__.copy(),
             "current_context_tokens": self.current_context_tokens,
             "start_time": self.start_time,
             "end_time": self.end_time,

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -780,6 +780,15 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 self.stats.current_context_tokens = llm_response.usage.input
                 if self.req.conversation:
                     self.req.conversation.token_usage = llm_response.usage.total
+            yield AgentResponse(
+                type="agent_stats",
+                data=AgentResponseData(
+                    chain=MessageChain(
+                        type="agent_stats",
+                        chain=[Json(data=self.stats.to_dict())],
+                    )
+                ),
+            )
             break  # got final response
 
         if not llm_resp_result:

--- a/astrbot/core/astr_agent_run_util.py
+++ b/astrbot/core/astr_agent_run_util.py
@@ -183,6 +183,11 @@ async def run_agent(
                 if _should_stop_agent(astr_event):
                     continue
 
+                if resp.type == "agent_stats":
+                    if astr_event.get_platform_name() == "webchat":
+                        await astr_event.send(resp.data["chain"])
+                    continue
+
                 if resp.type == "tool_call_result":
                     msg_chain = resp.data["chain"]
 
@@ -290,15 +295,6 @@ async def run_agent(
                 except asyncio.CancelledError:
                     pass
             if agent_runner.done():
-                # send agent stats to webchat
-                if astr_event.get_platform_name() == "webchat":
-                    await astr_event.send(
-                        MessageChain(
-                            type="agent_stats",
-                            chain=[Json(data=agent_runner.stats.to_dict())],
-                        )
-                    )
-
                 break
 
         except Exception as e:

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -653,6 +653,57 @@ async def test_stats_separate_latest_context_from_cumulative_usage(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("streaming", [False, True])
+async def test_stats_emit_update_after_each_completed_llm_request(
+    runner, provider_request, mock_tool_executor, mock_hooks, streaming
+):
+    """Emit one stats update for every completed LLM request."""
+    provider = VaryingUsageProvider()
+    await runner.reset(
+        provider=provider,
+        request=provider_request,
+        run_context=ContextWrapper(context=None),
+        tool_executor=mock_tool_executor,
+        agent_hooks=mock_hooks,
+        streaming=streaming,
+    )
+
+    responses = [response async for response in runner.step_until_done(3)]
+    stats_responses = [
+        response for response in responses if response.type == "agent_stats"
+    ]
+
+    assert provider.call_count == 2
+    assert len(stats_responses) == 2
+    assert [response.data["chain"].type for response in stats_responses] == [
+        "agent_stats",
+        "agent_stats",
+    ]
+    stats_snapshots = [
+        response.data["chain"].chain[0].data for response in stats_responses
+    ]
+    assert [snapshot["current_context_tokens"] for snapshot in stats_snapshots] == [
+        110,
+        220,
+    ]
+    assert stats_snapshots[0]["token_usage"]["input_other"] == 100
+    assert stats_snapshots[0]["token_usage"]["input_cached"] == 10
+    assert stats_snapshots[1]["token_usage"]["input_other"] == 300
+    assert stats_snapshots[1]["token_usage"]["input_cached"] == 30
+
+    # Emitted events keep their own snapshots even if live stats mutate later.
+    runner.stats.token_usage.input_other = 999
+    assert stats_snapshots[0]["token_usage"]["input_other"] == 100
+    assert stats_snapshots[1]["token_usage"]["input_other"] == 300
+
+    assert responses.index(stats_responses[0]) < next(
+        index
+        for index, response in enumerate(responses)
+        if response.type == "tool_call"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streaming", [False, True])
 async def test_stats_clear_current_context_when_latest_usage_is_missing(
     runner, provider_request, mock_tool_executor, mock_hooks, streaming
 ):
@@ -1236,6 +1287,8 @@ async def test_stop_interrupts_pending_subagent_handoff(mock_hooks):
 
     step_iter = runner.step()
     first_resp = await step_iter.__anext__()
+    if first_resp.type == "agent_stats":
+        first_resp = await step_iter.__anext__()
     assert first_resp.type == "tool_call"
     assert provider.abort_signal is not None
     assert provider.abort_signal.is_set() is False
@@ -1286,6 +1339,8 @@ async def test_stop_interrupts_pending_regular_tool(mock_hooks):
 
     step_iter = runner.step()
     first_resp = await step_iter.__anext__()
+    if first_resp.type == "agent_stats":
+        first_resp = await step_iter.__anext__()
     assert first_resp.type == "tool_call"
     assert provider.abort_signal is not None
     assert provider.abort_signal.is_set() is False


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

Resolves #9250。


WebChat 的 `agent_stats` 此前只在 Agent 完全结束时发送一次。对于包含多轮工具调用的任务，用户需要等待整个 Agent 执行完成后才能看到 Token 圆环更新，无法在执行过程中了解上下文增长情况。

本次修改让 Tool Loop Agent 在每次完整 LLM 响应返回并更新统计后立即产生一次 `agent_stats` 控制事件。WebChat 会立刻把最新统计发送给前端，因此多轮工具调用期间 Token 圆环可以逐轮更新。

最终 LLM 调用也通过同一机制发送统计，原有的结束时额外推送已移除，避免最终统计重复发送。

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- 修改 `astrbot/core/agent/runners/tool_loop_agent_runner.py`：
  - 每次收到完整 LLM 响应并更新 `AgentStats` 后，产生一次 `agent_stats` 控制响应；
  - 统计事件在工具执行前产生，使前端能够及时看到本轮请求的上下文占用；
  - 流式响应 chunk 不会产生统计事件，只有完整响应会产生一次更新；
  - usage 缺失时仍会发送更新，使前端及时清除上一轮陈旧的上下文占用。

- 修改 `astrbot/core/astr_agent_run_util.py`：
  - 拦截 runner 产生的 `agent_stats` 控制响应；
  - 仅在 WebChat 平台发送 `MessageChain(type="agent_stats")`，其他平台保持原有行为；
  - 控制响应处理后立即 `continue`，不会进入普通消息链处理流程；
  - 移除 Agent 结束时的旧统计推送，避免最终调用重复发送。

- 修改 `tests/test_tool_loop_agent_runner.py`：
  - 增加流式和非流式回归测试；
  - 验证两次完整 LLM 调用恰好产生两次统计更新；
  - 验证首次统计更新早于后续工具调用事件；
  - 调整停止执行相关测试，使其显式跳过新增的统计控制事件后继续验证工具中断行为。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

#### 验证步骤

1. 运行后端格式和静态检查：

```bash
uv run ruff format --check astrbot/core/agent/runners/tool_loop_agent_runner.py astrbot/core/astr_agent_run_util.py tests/test_tool_loop_agent_runner.py
uv run ruff check astrbot/core/agent/runners/tool_loop_agent_runner.py astrbot/core/astr_agent_run_util.py tests/test_tool_loop_agent_runner.py
```

结果：检查通过。

2. 运行 Tool Loop Agent 和 Provider 统计相关测试：

```bash
uv run pytest tests/test_tool_loop_agent_runner.py tests/unit/test_provider_stats.py -q
```

结果：

```text
......................................                                   [100%]
38 passed, 1 warning in 12.35s
```

warning 为项目已有的 Python `audioop` 弃用提示，与本次修改无关。

3. 核心回归场景：

```text
LLM 调用 1 完成 → agent_stats 更新 → tool_call / 工具执行
LLM 调用 2 完成 → agent_stats 更新 → Agent 完成
```

测试验证两次完整调用恰好产生两次 `agent_stats`，最终调用不会被重复发送。

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Stream agent stats after each completed LLM request so WebChat can update token usage incrementally during multi-step tool executions.

New Features:
- Emit an agent_stats control response after each completed LLM call in the tool loop agent runner to expose up-to-date token statistics mid-run.

Enhancements:
- Route agent_stats control responses through the generic agent run utility and only forward them to WebChat, removing the separate final stats push to avoid duplicate updates.

Tests:
- Add regression coverage to ensure exactly one agent_stats update per completed LLM call in both streaming and non-streaming modes and adjust stop-interruption tests to account for the new stats events.