### PR TITLE
fix: prioritize configured context limit

### DIFF
--- a/dashboard/src/utils/providerMetadata.ts
+++ b/dashboard/src/utils/providerMetadata.ts
@@ -23,7 +23,7 @@ export function contextLimit(
   provider: ProviderMetadataSource | null | undefined,
   metadata?: ProviderModelMetadata | null
 ): number {
-  const context = Number(metadata?.limit?.context || provider?.max_context_tokens || 0)
+  const context = Number(provider?.max_context_tokens) || Number(metadata?.limit?.context) || 0
   return Number.isFinite(context) && context > 0 ? context : 0
 }
 


### PR DESCRIPTION
Fixes #9254

修复 Dashboard 中上下文窗口大小的取值优先级错误。

此前 `contextLimit()` 会优先采用外部模型元数据中的 `limit.context`，导致用户手动配置的 `max_context_tokens` 被 `models.dev` 等元数据覆盖。例如用户将中转站模型限制为 400K，上下文圆环在获取模型列表后仍可能显示模型原生规格 1M，与提供商配置面板不一致。

本次修改后，取值优先级调整为：

1. 用户配置的 `provider.max_context_tokens`
2. 外部元数据的 `metadata.limit.context`
3. 默认值 `0`

当用户未配置上下文限制（值为 `0` 或空）时，仍会正常回退到外部模型元数据。

### Modifications / 改动点

- 调整 `dashboard/src/utils/providerMetadata.ts` 中 `contextLimit()` 的取值顺序。
- 保证用户显式配置的上下文窗口不会被外部模型元数据覆盖。
- 保留未配置时回退到模型元数据的现有行为。
- 未引入新依赖，也未修改后端接口。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

#### 验证步骤

1. 配置 OpenAI-compatible 提供商，并将 `max_context_tokens` 设置为 `400000`。
2. 为对应模型加载包含更大上下文窗口（例如 `1048576`）的外部元数据。
3. 进入对话页面，检查 Token 圆环显示的上下文上限。
4. 确认显示值保持为用户配置的 `400K`，不会被元数据覆盖为 `1M`。
5. 将 `max_context_tokens` 设置为 `0` 或留空，确认界面仍回退显示元数据中的上下文窗口。

#### 自动验证

```text
pnpm typecheck
结果：通过

pnpm build
结果：通过（Vite production build completed successfully）

git diff --check
结果：通过
```

独立代码审阅未发现阻塞问题，确认改动正确解决 #9254，且未引入新的兼容性问题。

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。
