### PR TITLE
fix: delete unsaved provider sources locally

### DIFF
--- a/dashboard/src/composables/useProviderSources.ts
+++ b/dashboard/src/composables/useProviderSources.ts
@@ -67,6 +67,7 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
   const modelSearch = ref('')
 
   let suppressSourceWatch = false
+  const unsavedProviderSourceMarker = Symbol('unsavedProviderSource')
 
   const providerTypes = computed(() => [
     { value: 'chat_completion', label: tm('providers.tabs.chatCompletion'), icon: 'mdi-message-text' },
@@ -422,6 +423,27 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
     return candidate
   }
 
+  function removeProviderSourceFromLocalState(sourceId: string) {
+    providers.value = providers.value.filter(
+      (p) => p.provider_source_id == null || String(p.provider_source_id) !== sourceId
+    )
+    providerSources.value = providerSources.value.filter(
+      (s) => s.id == null || String(s.id) !== sourceId
+    )
+
+    if (
+      selectedProviderSource.value?.id != null &&
+      String(selectedProviderSource.value.id) === sourceId
+    ) {
+      selectedProviderSource.value = null
+      selectedProviderSourceOriginalId.value = null
+      editableProviderSource.value = null
+      availableModels.value = []
+      modelMetadata.value = {}
+      isSourceModified.value = false
+    }
+  }
+
   function addProviderSource(templateKey: string) {
     const template = providerTemplates.value[templateKey]
     if (!template) {
@@ -439,6 +461,7 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
       enable: true
     })
 
+    newSource[unsavedProviderSourceMarker] = true
     providerSources.value.push(newSource)
     selectedProviderSource.value = newSource
     selectedProviderSourceOriginalId.value = newId
@@ -454,18 +477,16 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
     )
     if (!confirmed) return
 
+    const sourceId = String(source.id)
+    if (source[unsavedProviderSourceMarker]) {
+      removeProviderSourceFromLocalState(sourceId)
+      showMessage(tm('providerSources.deleteSuccess'))
+      return
+    }
+
     try {
-      await providerApi.deleteSource(source.id)
-
-      providers.value = providers.value.filter((p) => p.provider_source_id !== source.id)
-      providerSources.value = providerSources.value.filter((s) => s.id !== source.id)
-
-      if (selectedProviderSource.value?.id === source.id) {
-        selectedProviderSource.value = null
-        selectedProviderSourceOriginalId.value = null
-        editableProviderSource.value = null
-      }
-
+      await providerApi.deleteSource(sourceId)
+      removeProviderSourceFromLocalState(sourceId)
       showMessage(tm('providerSources.deleteSuccess'))
     } catch (error: any) {
       showMessage(error.message || tm('providerSources.deleteError'), 'error')
@@ -478,7 +499,8 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
     if (!selectedProviderSource.value) return
 
     savingSource.value = true
-    const originalId = String(selectedProviderSourceOriginalId.value || selectedProviderSource.value.id || '')
+    const sourceBeingSaved = selectedProviderSource.value
+    const originalId = String(selectedProviderSourceOriginalId.value || sourceBeingSaved.id || '')
     try {
       const response = await providerApi.upsertSource(originalId, editableProviderSource.value)
 
@@ -507,6 +529,7 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
         suppressSourceWatch = false
       })
 
+      delete sourceBeingSaved[unsavedProviderSourceMarker]
       isSourceModified.value = false
       showMessage(response.data.message || tm('providerSources.saveSuccess'))
       return true


### PR DESCRIPTION
修复新建但尚未保存的 Provider Source 在删除时触发 400，并导致右侧配置面板残留的问题。

Fixes #9262

### Modifications / 改动点

- 为前端新建且尚未持久化的 Provider Source 添加内部 `Symbol` 标记；该标记不会进入 JSON 克隆或 API 请求载荷。
- 删除 Provider Source 时先识别其是否为未保存草稿：
  - 未保存草稿仅清理本地状态，不再请求后端删除接口，避免 `Request failed with code 400`。
  - 已持久化的 Provider Source 保持原有后端删除流程。
- 抽取统一的本地状态清理逻辑，同时清理 Provider Source、关联 Provider、当前选中项、编辑副本、模型列表及修改状态，避免右侧配置面板残留。
- Provider Source 保存成功后移除草稿标记；保存失败时保留标记，后续仍可正确取消新建。
- 不使用 `isSourceModified` 判断是否持久化，避免将“正在编辑的已保存源”误判为未保存草稿。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

验证步骤：

1. 新建 Provider Source，不修改且不保存，直接删除。
2. 确认删除后不再出现 HTTP 400 Toast。
3. 确认左侧列表中的草稿源消失，右侧配置面板同时关闭。
4. 编辑一个已保存的 Provider Source 后删除，确认仍正常调用后端并完成删除。
5. 新建 Provider Source 并保存后再删除，确认保存后的源按正常后端流程删除。

自动化验证：

```text
pnpm typecheck
✓ vue-tsc --noEmit passed

node --test tests\*.test.mjs
ℹ tests 36
ℹ pass 36
ℹ fail 0

pnpm build
✓ 3768 modules transformed
✓ built successfully
```

构建过程中仅出现仓库既有的 MDI 图标及运行时资源解析警告，无新增错误。

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Handle deletion and persistence of newly created, unsaved provider sources as local drafts to avoid backend errors and UI inconsistencies.

Bug Fixes:
- Prevent HTTP 400 errors when deleting provider sources that were created but never saved.
- Ensure the provider configuration panel and related state are fully cleared when an unsaved provider source is deleted.

Enhancements:
- Introduce an internal marker for unsaved provider source drafts and centralized local state cleanup when sources are deleted or saved.