### PR TITLE
fix: support code block copy over insecure HTTP

### DIFF
--- a/dashboard/src/components/shared/ThemeAwareMarkdownCodeBlock.vue
+++ b/dashboard/src/components/shared/ThemeAwareMarkdownCodeBlock.vue
@@ -2,7 +2,12 @@
   <MarkdownCodeBlockNode
     :key="themeRenderKey"
     v-bind="forwardedBindings"
-    @copy="copyToClipboard"
+    @copy="
+      (payload) =>
+        typeof payload === 'string' &&
+        shouldUseClipboardFallback &&
+        copyToClipboard(payload)
+    "
   >
     <template
       v-for="(_, slotName) in $slots"
@@ -27,6 +32,12 @@ const props = defineProps<{
   node: Record<string, unknown>;
   isDark?: boolean;
 }>();
+
+const shouldUseClipboardFallback =
+  typeof window !== "undefined" &&
+  (!window.isSecureContext ||
+    typeof navigator === "undefined" ||
+    !navigator.clipboard?.writeText);
 
 const injectedIsDark = inject<Ref<boolean> | boolean>("isDark");
 const effectiveIsDark = computed(

--- a/dashboard/src/components/shared/ThemeAwareMarkdownCodeBlock.vue
+++ b/dashboard/src/components/shared/ThemeAwareMarkdownCodeBlock.vue
@@ -2,12 +2,7 @@
   <MarkdownCodeBlockNode
     :key="themeRenderKey"
     v-bind="forwardedBindings"
-    @copy="
-      (payload) =>
-        typeof payload === 'string' &&
-        shouldUseClipboardFallback &&
-        copyToClipboard(payload)
-    "
+    @copy="handleCopy"
   >
     <template
       v-for="(_, slotName) in $slots"
@@ -19,25 +14,39 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject, type Ref } from "vue";
+import { computed, inject, type Ref, useAttrs } from "vue";
 import { MarkdownCodeBlockNode } from "markstream-vue";
-import { useAttrs } from "vue";
 import { copyToClipboard } from "@/utils/clipboard";
 
 defineOptions({
   inheritAttrs: false,
 });
 
+type MarkdownCodeBlockEmits = {
+  copy: [payload: string];
+};
+
 const props = defineProps<{
   node: Record<string, unknown>;
   isDark?: boolean;
 }>();
+
+const emit = defineEmits<MarkdownCodeBlockEmits>();
 
 const shouldUseClipboardFallback =
   typeof window !== "undefined" &&
   (!window.isSecureContext ||
     typeof navigator === "undefined" ||
     !navigator.clipboard?.writeText);
+
+function handleCopy(payload: MarkdownCodeBlockEmits["copy"][0]) {
+  if (typeof payload !== "string") return;
+
+  if (shouldUseClipboardFallback) {
+    void copyToClipboard(payload);
+  }
+  emit("copy", payload);
+}
 
 const injectedIsDark = inject<Ref<boolean> | boolean>("isDark");
 const effectiveIsDark = computed(

--- a/dashboard/src/components/shared/ThemeAwareMarkdownCodeBlock.vue
+++ b/dashboard/src/components/shared/ThemeAwareMarkdownCodeBlock.vue
@@ -2,6 +2,7 @@
   <MarkdownCodeBlockNode
     :key="themeRenderKey"
     v-bind="forwardedBindings"
+    @copy="copyToClipboard"
   >
     <template
       v-for="(_, slotName) in $slots"
@@ -16,6 +17,7 @@
 import { computed, inject, type Ref } from "vue";
 import { MarkdownCodeBlockNode } from "markstream-vue";
 import { useAttrs } from "vue";
+import { copyToClipboard } from "@/utils/clipboard";
 
 defineOptions({
   inheritAttrs: false,


### PR DESCRIPTION
## Summary

- Route Markdown code block copy events through AstrBot's shared clipboard utility.
- Restore code copying when the WebUI is served from an insecure HTTP LAN origin.

## Problem

The `markstream-vue` code block component uses `navigator.clipboard` directly. Browsers do not expose that API on insecure HTTP IP origins, so the component reported success without copying any text. AstrBot already provides an `execCommand` fallback, but code block copy actions did not use it.

## Testing

- `corepack pnpm@10.28.2 build`
- `uv run ruff format .`
- `uv run ruff check .`
- Verified the code block copy event forwards the complete code payload to the shared clipboard utility on an insecure HTTP origin.

## Summary by Sourcery

Bug Fixes:
- Route markdown code block copy events through the shared clipboard utility to restore copy support on insecure HTTP origins.