### PR TITLE
fix: fix skills download archive filename mismatch with versioned skill n…

### DIFF
--- a/astrbot/dashboard/services/skills_service.py
+++ b/astrbot/dashboard/services/skills_service.py
@@ -443,7 +443,11 @@ class SkillsService:
         export_dir = Path(get_astrbot_temp_path()) / "skill_exports"
         export_dir.mkdir(parents=True, exist_ok=True)
         zip_base = export_dir / skill_name
-        zip_path = zip_base.with_suffix(".zip")
+        # with_suffix(".zip") replaces only the last suffix (e.g. ".0" in
+        # "skill-writing-1.0.0"), producing "skill-writing-1.0.zip" —
+        # which mismatches shutil.make_archive's "skill-writing-1.0.0.zip".
+        # Append ".zip" to the full name instead.
+        zip_path = zip_base.with_name(zip_base.name + ".zip")
         if zip_path.exists():
             zip_path.unlink()
 


### PR DESCRIPTION
Fixes #9268 
修复带版本号命名的 skill（如 `skill-writing-1.0.0`）下载失败的问题。

### 问题

`Path.with_suffix('.zip')` 只替换最后一个后缀。对于 `skill-writing-1.0.0`，`.0` 被视为后缀，替换后得到 `skill-writing-1.0.zip`。但 `shutil.make_archive` 将 `.zip` 追加到完整名称，创建 `skill-writing-1.0.0.zip`。两个文件名不匹配，`FileResponse` 找不到文件导致 `RuntimeError`。

### Modifications / 改动点

- `services/skills_service.py` 第 446 行：将 `zip_base.with_suffix(".zip")` 改为 `Path(str(zip_base) + ".zip")`，与 `shutil.make_archive` 的文件命名保持一致

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

验证步骤：

1. 在 Skills 页面，点击一个不带版本号命名的 skill（如 `my-skill`）的下载按钮 → 确认下载正常 ✅
2. 在 Skills 页面，点击一个带版本号命名的 skill（如 `skill-writing-1.0.0`）的下载按钮 → 确认下载正常 ✅（此前失败）
3. 重复步骤 1-2 多次，确保稳定 ✅

---


### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Resolve download failures for skills with versioned names by aligning the archive file path with the created zip filename.