### PR TITLE
chore: bump version to 4.26.6

### DIFF
--- a/astrbot/__init__.py
+++ b/astrbot/__init__.py
@@ -1,4 +1,4 @@
 import logging
 
-__version__ = "4.26.5"
+__version__ = "4.26.6"
 logger = logging.getLogger("astrbot")

--- a/changelogs/v4.26.6.md
+++ b/changelogs/v4.26.6.md
@@ -1,0 +1,27 @@
+## [4.26.6] - 2026-07-14
+
+### Added
+
+- Added persona import and export in the WebUI. Exported personas intentionally exclude tools and Skills configuration. (#4532)
+
+### Changed
+
+- Enabled ephemeral cache control for Anthropic providers to improve cache hit rates. (#9197)
+- Refined README documentation and corrected the Satori and Mattermost tutorial links. (#9205)
+- Updated grouped GitHub Actions dependencies. (#9170)
+
+### Fixed
+
+- Validated dashboard account username updates. (#9175)
+- Removed an unsupported `force` argument from LINE response parsing. (#9187)
+- Handled invalid response cleanup regular expressions without interrupting message delivery. (#9183)
+- Fixed the mobile chat input freeze and multiline attachment button alignment. (#9202)
+- Made ChatUI model selection theme-aware. (#9200)
+- Corrected the i18n callback path to Settings General. (#9201)
+- Returned appropriate HTTP errors when skill downloads fail. (#9213)
+- Exempted WebChat from the friend wake prefix. (#9215)
+- Handled `max_tokens` correctly for NVIDIA MiniMax M3. (#9209)
+- Reported current context usage accurately in the token indicator. (#9255)
+- Resumed active ChatUI streams after a page refresh. (#9259)
+
+[4.26.6]: https://github.com/AstrBotDevs/AstrBot/compare/v4.26.5...v4.26.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AstrBot"
-version = "4.26.5"
+version = "4.26.6"
 description = "Easy-to-use multi-platform LLM chatbot and development framework"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }


### PR DESCRIPTION
## What changed

- Bump the project and package versions from `4.26.5` to `4.26.6`.
- Add the curated `v4.26.6` changelog covering the latest changes on `master`.

## Release scope

This release branch is based on `master` at `a298c7bf4`. It does not include the global Agent skills changes from #9272.

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `pnpm build`

## After merge

Create and push tag `v4.26.6` from the updated `master` branch.

## Summary by Sourcery

Bump project version to 4.26.6 and add the curated changelog for this release.

Build:
- Update package metadata and internal version constant to 4.26.6.

Documentation:
- Add the v4.26.6 changelog documenting recent features, changes, and fixes.