### PR TITLE
fix: 修复上下文持久化与 Dashboard 状态问题

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -194,7 +194,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             parts.append(TextPart(text=llm_resp.completion_text))
         if len(parts) == 0:
             logger.warning("LLM returned empty assistant message with no tool calls.")
-        self.run_context.messages.append(Message(role="assistant", content=parts))
+        self._append_run_messages([Message(role="assistant", content=parts)])
 
         try:
             await self.agent_hooks.on_agent_done(self.run_context, llm_resp)
@@ -313,6 +313,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
         ):
             m = await self._assemble_request_context_for_provider(request)
             messages.append(Message.model_validate(m))
+        self._persistent_messages = list(messages)
         if request.system_prompt:
             messages.insert(
                 0,
@@ -322,6 +323,23 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
 
         self.stats = AgentStats()
         self.stats.start_time = time.time()
+
+    def _append_run_messages(self, messages: list[Message]) -> None:
+        """Append new agent messages to request and persistent histories.
+
+        Args:
+            messages: New messages produced during the current agent run.
+        """
+        self.run_context.messages.extend(messages)
+        self._persistent_messages.extend(messages)
+
+    def get_persistent_messages(self) -> list[Message]:
+        """Return the complete conversation history for persistence.
+
+        Returns:
+            A copy of the untrimmed messages accumulated during this agent run.
+        """
+        return list(self._persistent_messages)
 
     def _read_tool_hint(self) -> str:
         if self.read_tool is not None:
@@ -926,9 +944,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 tool_calls_result=tool_call_result_blocks,
             )
             # record the assistant message with tool calls
-            self.run_context.messages.extend(
-                tool_calls_result.to_openai_messages_model()
-            )
+            self._append_run_messages(tool_calls_result.to_openai_messages_model())
 
             # If there are cached images and the model supports image input,
             # append a user message with images so LLM can see them
@@ -960,8 +976,8 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                                 )
                             )
                     if image_parts:
-                        self.run_context.messages.append(
-                            Message(role="user", content=image_parts)
+                        self._append_run_messages(
+                            [Message(role="user", content=image_parts)]
                         )
                         logger.debug(
                             f"Appended {len(cached_images)} cached image(s) to context for LLM review"
@@ -988,11 +1004,13 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             if self.req:
                 self.req.func_tool = None
             # 注入提示词
-            self.run_context.messages.append(
-                Message(
-                    role="user",
-                    content=self.MAX_STEPS_REACHED_PROMPT,
-                )
+            self._append_run_messages(
+                [
+                    Message(
+                        role="user",
+                        content=self.MAX_STEPS_REACHED_PROMPT,
+                    )
+                ]
             )
             # 再执行最后一步
             async for resp in self.step():
@@ -1411,7 +1429,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
         if llm_resp.completion_text:
             parts.append(TextPart(text=llm_resp.completion_text))
         if parts:
-            self.run_context.messages.append(Message(role="assistant", content=parts))
+            self._append_run_messages([Message(role="assistant", content=parts)])
 
         try:
             await self.agent_hooks.on_agent_done(self.run_context, llm_resp)

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -329,7 +329,7 @@ class InternalAgentSubStage(Stage):
                                 event,
                                 req,
                                 agent_runner.get_final_llm_resp(),
-                                agent_runner.run_context.messages,
+                                agent_runner.get_persistent_messages(),
                                 agent_runner.stats,
                                 user_aborted=agent_runner.was_aborted(),
                             )
@@ -404,7 +404,7 @@ class InternalAgentSubStage(Stage):
                             event,
                             req,
                             final_resp,
-                            agent_runner.run_context.messages,
+                            agent_runner.get_persistent_messages(),
                             agent_runner.stats,
                             user_aborted=agent_runner.was_aborted(),
                         )

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -172,19 +172,38 @@ class Provider(AbstractProvider):
         raise NotImplementedError()
 
     async def pop_record(self, context: list) -> None:
-        """弹出 context 第一条非系统提示词对话记录"""
-        poped = 0
-        indexs_to_pop = []
-        for idx, record in enumerate(context):
-            if record["role"] == "system":
-                continue
-            indexs_to_pop.append(idx)
-            poped += 1
-            if poped == 2:
-                break
+        """Remove the oldest complete conversation turn from a request context.
 
-        for idx in reversed(indexs_to_pop):
-            context.pop(idx)
+        Args:
+            context: OpenAI-compatible message dictionaries to trim in place.
+        """
+        first_message_index = next(
+            (
+                index
+                for index, record in enumerate(context)
+                if record.get("role") != "system"
+            ),
+            None,
+        )
+        if first_message_index is None:
+            return
+
+        next_user_index = next(
+            (
+                index
+                for index in range(first_message_index + 1, len(context))
+                if context[index].get("role") == "user"
+            ),
+            len(context),
+        )
+        context[:] = [
+            record
+            for index, record in enumerate(context)
+            if not (
+                first_message_index <= index < next_user_index
+                and record.get("role") != "system"
+            )
+        ]
 
     def _ensure_message_to_dicts(
         self,

--- a/astrbot/dashboard/api/app.py
+++ b/astrbot/dashboard/api/app.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 
-from astrbot.core import LogBroker
+from astrbot.core import LogBroker, logger
 from astrbot.core.core_lifecycle import AstrBotCoreLifecycle
 from astrbot.core.db import BaseDatabase
 from astrbot.dashboard.responses import ApiError, error
@@ -161,6 +161,25 @@ def create_dashboard_asgi_app(
     async def http_error_handler(_request: Request, exc: HTTPException):
         detail = exc.detail if isinstance(exc.detail, str) else "Request failed"
         return JSONResponse(error(detail), status_code=exc.status_code)
+
+    @app.exception_handler(Exception)
+    async def unhandled_error_handler(request: Request, exc: Exception):
+        """Log unexpected API failures and return a safe JSON response.
+
+        Args:
+            request: Dashboard request that raised the exception.
+            exc: Unhandled exception raised while serving the request.
+
+        Returns:
+            A generic JSON error response without internal exception details.
+        """
+        logger.exception(
+            "Unhandled dashboard API exception for %s %s: %s",
+            request.method,
+            request.url.path,
+            exc,
+        )
+        return JSONResponse(error("Internal server error"), status_code=500)
 
     # Legacy dashboard routes keep old /api/* callers working without entering OpenAPI.
     app.include_router(legacy_api_keys_router)

--- a/astrbot/dashboard/services/skills_service.py
+++ b/astrbot/dashboard/services/skills_service.py
@@ -443,7 +443,7 @@ class SkillsService:
         export_dir = Path(get_astrbot_temp_path()) / "skill_exports"
         export_dir.mkdir(parents=True, exist_ok=True)
         zip_base = export_dir / skill_name
-        zip_path = zip_base.with_suffix(".zip")
+        zip_path = Path(f"{zip_base}.zip")
         if zip_path.exists():
             zip_path.unlink()
 

--- a/dashboard/src/composables/useProviderSources.ts
+++ b/dashboard/src/composables/useProviderSources.ts
@@ -67,6 +67,7 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
   const modelSearch = ref('')
 
   let suppressSourceWatch = false
+  let persistedProviderSourceIds = new Set<string>()
 
   const providerTypes = computed(() => [
     { value: 'chat_completion', label: tm('providers.tabs.chatCompletion'), icon: 'mdi-message-text' },
@@ -454,8 +455,14 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
     )
     if (!confirmed) return
 
+    const sourceId = String(source.id || '')
+    const isPersisted = persistedProviderSourceIds.has(sourceId)
+
     try {
-      await providerApi.deleteSource(source.id)
+      if (isPersisted) {
+        await providerApi.deleteSource(sourceId)
+        persistedProviderSourceIds.delete(sourceId)
+      }
 
       providers.value = providers.value.filter((p) => p.provider_source_id !== source.id)
       providerSources.value = providerSources.value.filter((s) => s.id !== source.id)
@@ -464,13 +471,18 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
         selectedProviderSource.value = null
         selectedProviderSourceOriginalId.value = null
         editableProviderSource.value = null
+        availableModels.value = []
+        modelMetadata.value = {}
+        isSourceModified.value = false
       }
 
       showMessage(tm('providerSources.deleteSuccess'))
     } catch (error: any) {
       showMessage(error.message || tm('providerSources.deleteError'), 'error')
     } finally {
-      await loadConfig()
+      if (isPersisted) {
+        await loadConfig()
+      }
     }
   }
 
@@ -691,6 +703,9 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
           providerTemplates.value = configSchema.value.provider.config_template
         }
         providerSources.value = response.data.data.provider_sources || []
+        persistedProviderSourceIds = new Set(
+          providerSources.value.map((source: any) => String(source.id || ''))
+        )
         modelMetadata.value = (response.data.data.model_metadata || {}) as Record<string, any>
         providers.value = response.data.data.providers || []
       }

--- a/dashboard/src/utils/providerMetadata.ts
+++ b/dashboard/src/utils/providerMetadata.ts
@@ -23,7 +23,7 @@ export function contextLimit(
   provider: ProviderMetadataSource | null | undefined,
   metadata?: ProviderModelMetadata | null
 ): number {
-  const context = Number(metadata?.limit?.context || provider?.max_context_tokens || 0)
+  const context = Number(provider?.max_context_tokens || metadata?.limit?.context || 0)
   return Number.isFinite(context) && context > 0 ? context : 0
 }
 

--- a/tests/agent/test_tool_loop_runner_history.py
+++ b/tests/agent/test_tool_loop_runner_history.py
@@ -1,0 +1,47 @@
+import pytest
+
+from astrbot.core.agent.hooks import BaseAgentRunHooks
+from astrbot.core.agent.run_context import ContextWrapper
+from astrbot.core.agent.runners.tool_loop_agent_runner import ToolLoopAgentRunner
+from astrbot.core.agent.tool_executor import BaseFunctionToolExecutor
+from astrbot.core.provider.entities import ProviderRequest
+from astrbot.core.provider.sources.openai_source import ProviderOpenAIOfficial
+
+
+@pytest.mark.asyncio
+async def test_persistent_history_is_not_replaced_by_trimmed_request_context():
+    provider = ProviderOpenAIOfficial(
+        provider_config={
+            "id": "test-openai",
+            "type": "openai_chat_completion",
+            "model": "gpt-4o-mini",
+            "key": ["test-key"],
+        },
+        provider_settings={},
+    )
+    request = ProviderRequest(
+        prompt="current request",
+        contexts=[
+            {"role": "user", "content": "old request"},
+            {"role": "assistant", "content": "old response"},
+        ],
+    )
+    try:
+        runner = ToolLoopAgentRunner()
+        await runner.reset(
+            provider=provider,
+            request=request,
+            run_context=ContextWrapper(context=None),
+            tool_executor=BaseFunctionToolExecutor(),
+            agent_hooks=BaseAgentRunHooks(),
+        )
+
+        runner.run_context.messages = runner.run_context.messages[-1:]
+
+        assert [message.role for message in runner.get_persistent_messages()] == [
+            "user",
+            "assistant",
+            "user",
+        ]
+    finally:
+        await provider.terminate()

--- a/tests/test_fastapi_v1_dashboard.py
+++ b/tests/test_fastapi_v1_dashboard.py
@@ -992,6 +992,35 @@ def _jwt_headers() -> dict[str, str]:
 
 
 @pytest.mark.asyncio
+async def test_unhandled_dashboard_exception_returns_json_error(
+    asgi_app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def raise_unhandled_error():
+        raise RuntimeError("sensitive internal detail")
+
+    monkeypatch.setattr(
+        asgi_app.state.services.stats,
+        "get_start_time",
+        raise_unhandled_error,
+    )
+    transport = httpx.ASGITransport(app=asgi_app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as client:
+        response = await client.get("/api/v1/stats/start-time")
+
+    assert response.status_code == 500
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.json() == {
+        "status": "error",
+        "message": "Internal server error",
+    }
+    assert "sensitive internal detail" not in response.text
+
+
+@pytest.mark.asyncio
 async def test_public_versions_route_uses_static_folder(
     fake_core_lifecycle,
     fake_db: FakeDb,

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -1,6 +1,7 @@
 import base64
 import builtins
 from io import BytesIO
+from pathlib import Path
 from types import SimpleNamespace
 
 import httpx
@@ -58,6 +59,36 @@ def _make_groq_provider(overrides: dict | None = None) -> ProviderGroq:
         provider_config=provider_config,
         provider_settings={},
     )
+
+
+@pytest.mark.asyncio
+async def test_pop_record_removes_complete_oldest_tool_call_turn():
+    provider = ProviderOpenAIOfficial.__new__(ProviderOpenAIOfficial)
+    context = [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "first request"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call-1", "content": "result"},
+        {"role": "assistant", "content": "first response"},
+        {"role": "user", "content": "second request"},
+    ]
+
+    await provider.pop_record(context)
+
+    assert context == [
+        {"role": "system", "content": "system"},
+        {"role": "user", "content": "second request"},
+    ]
 
 
 def test_create_http_client_uses_openai_httpx_module(monkeypatch):
@@ -902,21 +933,21 @@ async def test_prepare_chat_payload_materializes_context_file_uri_image_urls(tmp
         await provider.terminate()
 
 
-def test_file_uri_to_path_preserves_windows_drive_letter():
-    assert file_uri_to_path("file:///C:/tmp/quoted-image.png") == (
-        "C:/tmp/quoted-image.png"
+def test_file_uri_to_path_normalizes_windows_drive_letter():
+    assert file_uri_to_path("file:///C:/tmp/quoted-image.png") == str(
+        Path("C:/tmp/quoted-image.png")
     )
 
 
-def test_file_uri_to_path_preserves_windows_netloc_drive_letter():
-    assert file_uri_to_path("file://C:/tmp/quoted-image.png") == (
-        "C:/tmp/quoted-image.png"
+def test_file_uri_to_path_normalizes_windows_netloc_drive_letter():
+    assert file_uri_to_path("file://C:/tmp/quoted-image.png") == str(
+        Path("C:/tmp/quoted-image.png")
     )
 
 
-def test_file_uri_to_path_preserves_remote_netloc_as_unc_path():
-    assert file_uri_to_path("file://server/share/quoted-image.png") == (
-        "//server/share/quoted-image.png"
+def test_file_uri_to_path_normalizes_remote_netloc_as_unc_path():
+    assert file_uri_to_path("file://server/share/quoted-image.png") == str(
+        Path("//server/share/quoted-image.png")
     )
 
 

--- a/tests/unit/test_skills_service.py
+++ b/tests/unit/test_skills_service.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import astrbot.dashboard.services.skills_service as skills_service_module
+from astrbot.dashboard.services.skills_service import SkillsService
+
+
+def test_prepare_skill_archive_preserves_versioned_skill_name(
+    monkeypatch, tmp_path: Path
+):
+    skills_root = tmp_path / "skills"
+    skill_dir = skills_root / "skill-writing-1.0.0"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Skill", encoding="utf-8")
+
+    class FakeSkillManager:
+        @staticmethod
+        def is_sandbox_only_skill(_name: str) -> bool:
+            return False
+
+        @staticmethod
+        def is_plugin_skill(_name: str) -> bool:
+            return False
+
+    FakeSkillManager.skills_root = skills_root
+
+    monkeypatch.setattr(skills_service_module, "SkillManager", FakeSkillManager)
+    monkeypatch.setattr(
+        skills_service_module,
+        "get_astrbot_temp_path",
+        lambda: str(tmp_path / "temp"),
+    )
+
+    archive = SkillsService(None).prepare_skill_archive("skill-writing-1.0.0")
+
+    assert archive.path.name == "skill-writing-1.0.0.zip"
+    assert archive.path.is_file()
+    assert archive.filename == "skill-writing-1.0.0.zip"


### PR DESCRIPTION
Closes #9278

## 变更说明

本 PR 优先处理一组共享可靠性问题：

- 将 Agent 的模型请求工作上下文与持久化历史分离，避免上下文裁剪后覆盖完整对话历史。
- OpenAI-compatible Provider 上下文超限时按完整会话轮次删除，避免破坏 `assistant(tool_calls)` 与 `tool` 消息配对。
- 修复带版本号或 `.` 的 Skill 名称生成 ZIP 时文件名被截断的问题。
- 为 Dashboard API 增加未处理异常的统一 JSON 响应；服务端保留完整堆栈，客户端不暴露内部异常详情。
- 删除未保存的 Provider 草稿时仅清理前端状态，不再错误调用后端。
- 调整上下文上限优先级：用户显式配置优先于外部模型元数据。
- 修正 Windows `file://` URI 测试，使断言符合本地文件系统路径语义。

## 关联问题

- #8972
- #7225
- #9268
- #9269
- #9262
- #9254

## 验证结果

- `uv run pytest tests/test_openai_source.py tests/agent/test_tool_loop_runner_history.py tests/unit/test_skills_service.py tests/test_fastapi_v1_dashboard.py -q`
  - 138 passed
- Dashboard Node tests
  - 36 passed
- `pnpm typecheck`
  - passed
- `uv run ruff format .`
  - passed
- `uv run ruff check .`
  - passed

## 完整测试说明

Windows 本地执行完整 pytest 时，在测试收集阶段触发原生 access violation，堆栈涉及 APScheduler 后台线程，尚未进入本 PR 修改的测试。上述定向测试均已通过，完整 Linux CI 结果以 GitHub Actions 为准。

## Summary by Sourcery

Separate agent request context trimming from persistent conversation history, improve OpenAI-compatible context trimming behavior, and harden dashboard and provider management reliability.

Bug Fixes:
- Ensure OpenAI-compatible context trimming removes the oldest complete conversation turn, preserving assistant tool_calls and tool message pairing.
- Prevent agent persistent conversation history from being overwritten by trimmed request contexts so full histories are stored correctly.
- Fix skill archive creation so versioned or dotted skill names produce ZIP filenames without truncation.
- Avoid backend delete calls when removing unsaved provider source drafts, and properly clear related frontend state only.
- Adjust provider context limit resolution so explicit user configuration takes precedence over external model metadata.
- Normalize Windows file:// URI handling to align with local path semantics in tests.
- Return a consistent JSON error payload for unhandled dashboard API exceptions while logging full server-side details.

Enhancements:
- Introduce persistent message tracking in the tool loop agent runner and use it when emitting final agent events for storage.
- Record whether provider sources originate from persisted IDs to drive delete behavior and configuration reloads more accurately.

Tests:
- Add tests covering OpenAI provider context trimming around tool call turns.
- Add tests ensuring persistent agent history is decoupled from trimmed request contexts.
- Add tests verifying skill archive filenames preserve versioned skill names.
- Add tests validating unhandled dashboard exceptions yield safe JSON responses.
- Update Windows file URI tests to assert normalized path behavior.