### PR TITLE
fix: unbind disabled plugin handlers before reload

### DIFF
--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -964,7 +964,7 @@ class PluginManager:
             else:
                 return False, error
 
-    async def reload(self, specified_plugin_name=None):
+    async def reload(self, specified_plugin_name=None, *, force_unbind=False):
         """重新加载插件
 
         Args:
@@ -1013,7 +1013,7 @@ class PluginManager:
                         logger.warning(
                             f"插件 {smd.name} 未被正常终止: {e!s}, 可能会导致该插件运行不正常。",
                         )
-                    if smd.name and smd.activated:
+                    if smd.name and (smd.activated or force_unbind):
                         await self._unbind_plugin(smd.name, specified_module_path)
 
             result = await self.load(specified_module_path)
@@ -1933,7 +1933,7 @@ class PluginManager:
         for func_tool in self._iter_plugin_llm_tools(plugin.module_path):
             func_tool.active = func_tool.name not in inactivated_llm_tools
 
-        success, error = await self.reload(plugin_name)
+        success, error = await self.reload(plugin_name, force_unbind=True)
         if not success:
             raise Exception(error or f"插件 {plugin_name} 启用失败。")
         current_plugin = self.context.get_registered_star(plugin_name)

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -2147,7 +2147,7 @@ async def test_turn_on_plugin_rebinds_handlers_after_deactivated_reload(
     async def mock_global_put(*_):
         pass
 
-    async def mock_load(specified_module_path=None):
+    async def mock_load(specified_module_path=None, **kwargs):
         assert specified_module_path == module_path
 
         related_handlers = (

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import json
 import os
 from pathlib import Path
@@ -9,6 +10,7 @@ import pytest
 import yaml
 
 from astrbot.core.star import star_manager as star_manager_module
+from astrbot.core.star.star_handler import EventType, StarHandlerMetadata
 from astrbot.core.star.star_manager import PluginDependencyInstallError, PluginManager
 from astrbot.core.utils.pip_installer import PipInstallError
 from astrbot.core.utils.requirements_utils import MissingRequirementsPlan
@@ -627,7 +629,7 @@ async def test_turn_plugin_toggles_llm_tools_from_plugin_child_module(
     async def mock_terminate(star_metadata):
         assert star_metadata is plugin
 
-    async def mock_reload(plugin_name):
+    async def mock_reload(plugin_name, **_):
         assert plugin_name == plugin.root_dir_name
         return True, None
 
@@ -721,7 +723,7 @@ async def test_turn_plugin_preserves_user_disabled_llm_tools(
     async def mock_terminate(star_metadata):
         assert star_metadata is plugin
 
-    async def mock_reload(plugin_name):
+    async def mock_reload(plugin_name, **_):
         assert plugin_name == plugin.root_dir_name
         return True, None
 
@@ -2110,6 +2112,81 @@ async def test_reload_deactivated_plugin_preserves_tools(
 
 
 @pytest.mark.asyncio
+async def test_turn_on_plugin_rebinds_handlers_after_deactivated_reload(
+    plugin_manager_pm: PluginManager, monkeypatch
+):
+    _clear_star_runtime_state()
+    plugin_name = "demo_plugin"
+    module_path = f"data.plugins.{plugin_name}.main"
+    plugin = star_manager_module.StarMetadata(
+        name=plugin_name,
+        root_dir_name=plugin_name,
+        module_path=module_path,
+        activated=False,
+    )
+    cast(Any, plugin_manager_pm.context).stars.append(plugin)
+    star_manager_module.star_map[module_path] = plugin
+    star_manager_module.star_registry.append(plugin)
+
+    async def raw_handler(plugin_instance, event):
+        return plugin_instance, event
+
+    handler = StarHandlerMetadata(
+        event_type=EventType.OnLLMRequestEvent,
+        handler_full_name=f"{module_path}.handler",
+        handler_name="handler",
+        handler_module_path=module_path,
+        handler=functools.partial(raw_handler, None),
+        event_filters=[],
+    )
+    star_manager_module.star_handlers_registry.append(handler)
+
+    async def mock_global_get(key, default=None):
+        return [module_path] if key == "inactivated_plugins" else default
+
+    async def mock_global_put(*_):
+        pass
+
+    async def mock_load(specified_module_path=None):
+        assert specified_module_path == module_path
+
+        related_handlers = (
+            star_manager_module.star_handlers_registry.get_handlers_by_module_name(
+                module_path
+            )
+        )
+        if not related_handlers:
+            handler.handler = raw_handler
+            star_manager_module.star_handlers_registry.append(handler)
+            related_handlers = [handler]
+
+        for registered_handler in related_handlers:
+            registered_handler.handler = functools.partial(
+                registered_handler.handler, object()
+            )
+        return True, None
+
+    monkeypatch.setattr(star_manager_module.sp, "global_get", mock_global_get)
+    monkeypatch.setattr(star_manager_module.sp, "global_put", mock_global_put)
+    monkeypatch.setattr(plugin_manager_pm, "load", mock_load)
+
+    try:
+        await plugin_manager_pm.turn_on_plugin(plugin_name)
+        handlers = (
+            star_manager_module.star_handlers_registry.get_handlers_by_module_name(
+                module_path
+            )
+        )
+        assert len(handlers) == 1
+        result = await handlers[0].handler("event")
+        assert result[0] is not None
+        assert result[1] == "event"
+    finally:
+        cast(Any, plugin_manager_pm.context).stars.remove(plugin)
+        _clear_star_runtime_state()
+
+
+@pytest.mark.asyncio
 async def test_reload_activated_plugin_still_unbinds(
     plugin_manager_pm: PluginManager, monkeypatch
 ):
@@ -2238,7 +2315,7 @@ async def test_turn_on_plugin_after_deactivated_reload_reactivates_tools(
     async def mock_terminate(smd):
         pass
 
-    async def mock_reload(plugin_name_arg):
+    async def mock_reload(plugin_name_arg, **_):
         assert plugin_name_arg == plugin_name
         return True, None
 


### PR DESCRIPTION
Fixes #9280

### Modifications / Changes

- Force `turn_on_plugin()` to unbind handlers before reloading a previously disabled plugin.
- Keep the normal reload behavior unchanged; the forced unbind is limited to the enable path.
- Add a regression test covering a deactivated plugin whose handler would otherwise be wrapped twice.
- This is complementary to #9096: #9096 preserves tools for disabled plugins during reload, while this change removes stale handlers when that plugin is enabled again.

- [x] This is NOT a breaking change.

---

### Screenshots or Test Results / Verification

Reproduction path covered by the regression test:

1. Register a plugin handler while the plugin is deactivated.
2. Enable the plugin through `turn_on_plugin()`.
3. Verify the old handler is unbound before the plugin is loaded again.
4. Invoke the handler and verify that the instance and event arguments are passed exactly once.

Automated verification:

- `uv run pytest -q` — `1797 passed, 6 warnings`
- `uv run ruff check astrbot/core/star/star_manager.py tests/test_plugin_manager.py` — all checks passed
- `uv run ruff format --check astrbot/core/star/star_manager.py tests/test_plugin_manager.py` — both files already formatted
- `git diff --check` — passed

Manual WebUI verification on AstrBot v4.26.6:

- Installed `astrbot_plugin_livingmemory`, disabled it, restarted AstrBot, and enabled it again.
- Sent a real ChatUI request through the configured model provider.
- The UI returned `OK`; no handler argument-count `TypeError` appeared.
- An unrelated embedding-provider initialization timeout was observed because no embedding provider was configured.

### Checklist

- [ ] If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
- [x] My changes have been well-tested, and verification steps are provided above.
- [x] I have ensured that no new dependencies are introduced.
- [x] My changes do not introduce malicious code.

## Summary by Sourcery

Ensure plugin enablement reloads deactivated plugins with stale handlers correctly by unbinding handlers when turning a plugin back on.

Bug Fixes:
- Prevent previously disabled plugins from keeping stale handlers that would be wrapped or invoked multiple times after re-enabling.

Tests:
- Add a regression test verifying that enabling a previously deactivated plugin rebinds its handlers so requests are handled exactly once.