### PR TITLE
Fix GLM OpenAI-compatible content format handling

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -992,6 +992,20 @@ class ProviderOpenAIOfficial(Provider):
     def _finally_convert_payload(self, payloads: dict) -> None:
         """Finally convert the payload. Such as think part conversion, tool inject."""
         model = payloads.get("model", "").lower()
+        # GLM's OpenAI-compatible API only accepts string content.
+        if "glm" in model:
+            for message in payloads.get("messages", []):
+                content = message.get("content")
+
+                if isinstance(content, list):
+                    texts = []
+
+                    for part in content:
+                        if isinstance(part, dict) and part.get("type") == "text":
+                            texts.append(part.get("text", ""))
+
+                    message["content"] = "\n".join(texts)
+
         is_gemini = "gemini" in model
         _deepseek_v4_markers = ("deepseek-v4-pro", "deepseek-v4-flash", "deepseek-v4")
         is_deepseek_v4_reasoning = (
@@ -1420,6 +1434,12 @@ class ProviderOpenAIOfficial(Provider):
             and content_blocks[0]["type"] == "text"
         ):
             return {"role": "user", "content": content_blocks[0]["text"]}
+
+        if "glm" in self.get_model().lower() and all(
+            part.get("type") == "text" for part in content_blocks
+        ):
+            text_content = "".join(part.get("text", "") for part in content_blocks)
+            return {"role": "user", "content": text_content}
 
         # 否则返回多模态格式
         return {"role": "user", "content": content_blocks}


### PR DESCRIPTION
## Description

This PR fixes compatibility with Zhipu GLM OpenAI-Compatible APIs.

Currently AstrBot sends:

```json
content: [
  {
    "type": "text",
    "text": "..."
  }
]
```

However GLM expects:

```json
content: "..."
```

which causes the API to return:

```text
messages.content.type 参数非法，取值范围 ['text']
```

## Changes

- Move GLM compatibility logic into `_finally_convert_payload()`.
- Apply conversion only when the model name contains `glm`.
- Convert text-only content arrays into plain strings.
- Restrict the string conversion in `assemble_context()` to GLM only.

## Tested

Tested with:

- `GLM-4.7-Flash`
- OpenAI-Compatible API

The API now works correctly without affecting Gemini, DeepSeek, or other providers.

This patch was generated with assistance from ChatGPT Codex and verified through actual testing.

## Summary by Sourcery

Improve compatibility with Zhipu GLM models in the OpenAI-compatible provider by normalizing chat message content formatting.

Enhancements:
- Normalize GLM chat messages by converting text-only content arrays into plain string content in the final payload conversion.
- Adjust user context assembly to emit plain string content specifically for GLM models when all parts are text-only.