### PR TITLE
fix: 保护 @昵称(ID) 格式在命令参数解析时不被空格拆坏

### DIFF
--- a/astrbot/core/star/filter/command.py
+++ b/astrbot/core/star/filter/command.py
@@ -11,6 +11,10 @@ from ..star_handler import StarHandlerMetadata
 from . import HandlerFilter
 from .custom_filter import CustomFilter
 
+# Preserve @nickname(ID) as one argument even when the nickname contains spaces.
+# IDs are platform-specific and may be strings (for example Slack/Lark IDs).
+COMMAND_ARGUMENT_PATTERN = re.compile(r"@[^@]*\([^()\s]+\)(?=\s|$)|[^\s]+")
+
 
 class GreedyStr(str):
     """标记指令完成其他参数接收后的所有剩余文本。"""
@@ -205,10 +209,8 @@ class CommandFilter(HandlerFilter):
         if not ok:
             return False
 
-        # 分割为列表，同时保护 @昵称(ID) 格式不被空格拆坏
-        # 例如 "@Heaven Whisper(488267082) 64" 应拆为 ["@Heaven Whisper(488267082)", "64"]
-        # 而非 ["@Heaven", "Whisper(488267082)", "64"]
-        ls = re.findall(r"@[^@]+?\(\d+\)|[^\s]+", message_str)
+        # Split into arguments while preserving @nickname(ID) mentions as one token.
+        ls = COMMAND_ARGUMENT_PATTERN.findall(message_str)
         # 去除空字符串
         ls = [param for param in ls if param]
         params = {}

--- a/astrbot/core/star/filter/command.py
+++ b/astrbot/core/star/filter/command.py
@@ -205,8 +205,10 @@ class CommandFilter(HandlerFilter):
         if not ok:
             return False
 
-        # 分割为列表
-        ls = message_str.split(" ")
+        # 分割为列表，同时保护 @昵称(ID) 格式不被空格拆坏
+        # 例如 "@Heaven Whisper(488267082) 64" 应拆为 ["@Heaven Whisper(488267082)", "64"]
+        # 而非 ["@Heaven", "Whisper(488267082)", "64"]
+        ls = re.findall(r"@[^@]+?\(\d+\)|[^\s]+", message_str)
         # 去除空字符串
         ls = [param for param in ls if param]
         params = {}

--- a/tests/unit/test_command_filter.py
+++ b/tests/unit/test_command_filter.py
@@ -1,0 +1,59 @@
+import pytest
+
+from astrbot.core.star.filter.command import CommandFilter
+
+
+class FakeCommandEvent:
+    def __init__(self, message_str: str):
+        self.message_str = message_str
+        self.is_at_or_wake_command = True
+        self.extras = {}
+
+    def get_message_str(self) -> str:
+        return self.message_str
+
+    def set_extra(self, key: str, value) -> None:
+        self.extras[key] = value
+
+
+@pytest.mark.parametrize(
+    ("command_name", "message_str", "handler_params", "expected_params"),
+    [
+        (
+            "修改好感度",
+            "修改好感度 @Heaven Whisper(488267082) 64",
+            {"target": str, "value": int},
+            {"target": "@Heaven Whisper(488267082)", "value": 64},
+        ),
+        (
+            "修改好感度",
+            "修改好感度 @Jane Doe(U01ABC-DEF) 64",
+            {"target": str, "value": int},
+            {"target": "@Jane Doe(U01ABC-DEF)", "value": 64},
+        ),
+        (
+            "修改好感度",
+            "修改好感度 488267082 64",
+            {"target": str, "value": int},
+            {"target": "488267082", "value": 64},
+        ),
+        (
+            "修改关系",
+            "修改关系 @Alice One(U1) @Bob Two(U2)",
+            {"source": str, "target": str},
+            {"source": "@Alice One(U1)", "target": "@Bob Two(U2)"},
+        ),
+    ],
+)
+def test_command_filter_keeps_at_mentions_with_spaces_as_single_params(
+    command_name,
+    message_str,
+    handler_params,
+    expected_params,
+):
+    command_filter = CommandFilter(command_name)
+    command_filter.handler_params = handler_params
+    event = FakeCommandEvent(message_str)
+
+    assert command_filter.filter(event, cfg=None)
+    assert event.extras["parsed_params"] == expected_params


### PR DESCRIPTION
## 问题说明 / Motivation

当 `@mention` 的昵称包含空格时（例如 `@Heaven Whisper(488267082)`），原先的 `message_str.split(" ")` 会将其拆成多个参数，导致后续参数转换失败（例如 `value` 收到 `Whisper(488267082)` 而无法转换为 `int`）。

## Modifications / 改动点

- 使用预编译正则将 `@昵称(ID)` 保留为单个命令参数，不受昵称中空格影响。
- ID 不再限定为纯数字，兼容 Slack/Lark 等平台使用的字符串 ID；ID 仍要求为非空白、非括号内容，避免吞掉后续普通参数。
- 添加 `CommandFilter` 回归测试，覆盖：
  - 含空格昵称 + 数字 ID
  - 含空格昵称 + 字符串 ID
  - 普通非 mention 参数
  - 连续两个 mention

影响范围仅为 `CommandFilter.filter()` 的参数分割逻辑；无新依赖、无破坏性变更。

### Test Results / 验证结果

```text
ruff check astrbot/core/star/filter/command.py tests/unit/test_command_filter.py
All checks passed!

pytest tests/unit/test_command_filter.py tests/unit/test_astr_message_event.py -q
82 passed, 1 warning
```

> 该 warning 来自既有 `audioop` 弃用提示，与本次改动无关。

### Checklist / 检查清单

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
- [x] My changes have been well-tested, and verification results are provided above. / 我的更改经过测试，并已在上方提供验证结果。
- [x] No new dependencies are introduced. / 未引入新依赖。
- [x] My changes do not introduce malicious code. / 未引入恶意代码。