### PR TITLE
修复多轮/引用识图串图：历史不再持久化原图，失败图片 URL 丢弃，请求图本地优先

### DIFF
--- a/astrbot/core/agent/message.py
+++ b/astrbot/core/agent/message.py
@@ -302,7 +302,6 @@ def get_checkpoint_id(message: Message | dict) -> str | None:
     return None
 
 
-
 _IMAGE_HISTORY_PLACEHOLDER = "[Image]"
 
 
@@ -415,22 +414,14 @@ def dump_messages_with_checkpoints(messages: list[Message]) -> list[dict]:
     for message in messages:
         message_data = message.model_dump()
         if isinstance(message.content, list):
-            persisted_parts: list[Any] = []
-            previous_was_image_placeholder = False
-            for part in message.content:
-                if getattr(part, "_no_save", False):
-                    continue
-                if _is_image_content_part(part):
-                    if previous_was_image_placeholder:
-                        continue
-                    persisted_parts.append(TextPart(text=_IMAGE_HISTORY_PLACEHOLDER))
-                    previous_was_image_placeholder = True
-                    continue
-                previous_was_image_placeholder = False
-                persisted_parts.append(part)
+            # Drop ephemeral parts first, then reuse shared image-stripping rules.
+            filtered_parts = [
+                part for part in message.content if not getattr(part, "_no_save", False)
+            ]
+            stripped_parts = strip_images_from_content_parts(filtered_parts)
             message_data["content"] = [
                 part.model_dump() if isinstance(part, ContentPart) else part
-                for part in persisted_parts
+                for part in stripped_parts
             ]
         dumped.append(message_data)
         if message._checkpoint_after is not None:

--- a/astrbot/core/agent/message.py
+++ b/astrbot/core/agent/message.py
@@ -302,6 +302,72 @@ def get_checkpoint_id(message: Message | dict) -> str | None:
     return None
 
 
+
+_IMAGE_HISTORY_PLACEHOLDER = "[Image]"
+
+
+def _is_image_content_part(part: Any) -> bool:
+    if isinstance(part, ImageURLPart):
+        return True
+    if isinstance(part, dict) and part.get("type") == "image_url":
+        return True
+    return getattr(part, "type", None) == "image_url"
+
+
+def _image_placeholder_part_dict() -> dict[str, Any]:
+    return {"type": "text", "text": _IMAGE_HISTORY_PLACEHOLDER}
+
+
+def strip_images_from_content_parts(content: Any) -> Any:
+    """Replace image parts with a short text placeholder.
+
+    Used when persisting or reloading conversation history so previous-turn
+    image pixels / remote URLs do not keep leaking into later requests.
+    """
+    if not isinstance(content, list):
+        return content
+
+    stripped: list[Any] = []
+    previous_was_image_placeholder = False
+    for part in content:
+        if _is_image_content_part(part):
+            if previous_was_image_placeholder:
+                continue
+            if isinstance(part, ContentPart):
+                stripped.append(TextPart(text=_IMAGE_HISTORY_PLACEHOLDER))
+            else:
+                stripped.append(_image_placeholder_part_dict())
+            previous_was_image_placeholder = True
+            continue
+
+        previous_was_image_placeholder = False
+        stripped.append(part)
+    return stripped
+
+
+def strip_images_from_history_message_dict(message: dict[str, Any]) -> dict[str, Any]:
+    """Return a shallow-copied history message dict without image payloads."""
+    if not isinstance(message, dict):
+        return message
+    if is_checkpoint_message(message):
+        return message
+
+    content = message.get("content")
+    if not isinstance(content, list):
+        return message
+
+    new_message = dict(message)
+    new_message["content"] = strip_images_from_content_parts(content)
+    return new_message
+
+
+def strip_images_from_history_messages(history: list[dict] | None) -> list[dict]:
+    """Strip image payloads from a full persisted history list."""
+    if not history:
+        return []
+    return [strip_images_from_history_message_dict(item) for item in history]
+
+
 def strip_checkpoint_messages(history: list[dict]) -> list[dict]:
     """Remove internal checkpoint messages from provider-facing history."""
     return [message for message in history if not is_checkpoint_message(message)]
@@ -327,7 +393,8 @@ def _get_checkpoint_data(message: Message | dict) -> CheckpointData | None:
 def bind_checkpoint_messages(history: list[dict]) -> list[Message]:
     """Load persisted history and bind checkpoint segments to prior messages."""
     messages: list[Message] = []
-    for item in history:
+    for raw_item in history:
+        item = strip_images_from_history_message_dict(raw_item)
         if is_checkpoint_message(item):
             checkpoint = _get_checkpoint_data(item)
             if checkpoint is not None and messages:
@@ -348,10 +415,22 @@ def dump_messages_with_checkpoints(messages: list[Message]) -> list[dict]:
     for message in messages:
         message_data = message.model_dump()
         if isinstance(message.content, list):
+            persisted_parts: list[Any] = []
+            previous_was_image_placeholder = False
+            for part in message.content:
+                if getattr(part, "_no_save", False):
+                    continue
+                if _is_image_content_part(part):
+                    if previous_was_image_placeholder:
+                        continue
+                    persisted_parts.append(TextPart(text=_IMAGE_HISTORY_PLACEHOLDER))
+                    previous_was_image_placeholder = True
+                    continue
+                previous_was_image_placeholder = False
+                persisted_parts.append(part)
             message_data["content"] = [
-                part.model_dump()
-                for part in message.content
-                if not getattr(part, "_no_save", False)
+                part.model_dump() if isinstance(part, ContentPart) else part
+                for part in persisted_parts
             ]
         dumped.append(message_data)
         if message._checkpoint_after is not None:

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from astrbot.core import logger
 from astrbot.core.agent.handoff import HandoffTool
 from astrbot.core.agent.mcp_client import MCPTool
-from astrbot.core.agent.message import TextPart
+from astrbot.core.agent.message import TextPart, strip_images_from_history_messages
 from astrbot.core.agent.tool import ToolSet
 from astrbot.core.astr_agent_context import AgentContextWrapper, AstrAgentContext
 from astrbot.core.astr_agent_hooks import MAIN_AGENT_HOOKS
@@ -115,7 +115,6 @@ from astrbot.core.utils.quoted_message_parser import (
     extract_quoted_message_text,
 )
 from astrbot.core.utils.string_utils import normalize_and_dedupe_strings
-from astrbot.core.agent.message import strip_images_from_history_messages
 from astrbot.core.workspace import (
     normalize_umo_for_workspace,
     resolve_workspace_root_for_umo,
@@ -1352,9 +1351,9 @@ def _select_image_chat_provider(
     return provider
 
 
-
 def _is_remote_image_ref(image_ref: str) -> bool:
-    return image_ref.startswith("http://") or image_ref.startswith("https://")
+    lowered = image_ref.lower()
+    return lowered.startswith("http://") or lowered.startswith("https://")
 
 
 def _finalize_request_image_urls(
@@ -1376,9 +1375,10 @@ def _finalize_request_image_urls(
     embedded_refs: list[str] = []
     remote_refs: list[str] = []
     for ref in urls:
+        lowered = ref.lower()
         if _is_remote_image_ref(ref):
             remote_refs.append(ref)
-        elif ref.startswith("data:") or ref.startswith("base64://"):
+        elif lowered.startswith("data:") or lowered.startswith("base64://"):
             embedded_refs.append(ref)
         else:
             local_refs.append(ref)
@@ -1419,7 +1419,9 @@ async def build_main_agent(
                 "provider_request 必须是 ProviderRequest 类型。"
             )
             if req.conversation:
-                req.contexts = strip_images_from_history_messages(json.loads(req.conversation.history))
+                req.contexts = strip_images_from_history_messages(
+                    json.loads(req.conversation.history)
+                )
         else:
             req = ProviderRequest()
             req.prompt = ""
@@ -1552,7 +1554,9 @@ async def build_main_agent(
 
             conversation = await _get_session_conv(event, plugin_context)
             req.conversation = conversation
-            req.contexts = strip_images_from_history_messages(json.loads(conversation.history))
+            req.contexts = strip_images_from_history_messages(
+                json.loads(conversation.history)
+            )
             event.set_extra("provider_request", req)
 
     if isinstance(req.contexts, str):
@@ -1568,9 +1572,11 @@ async def build_main_agent(
                 )
             )
         )
+    raw_max_quoted_fallback_images = getattr(config, "max_quoted_fallback_images", 4)
+    max_quoted_fallback_images = max(int(raw_max_quoted_fallback_images or 4), 4)
     req.image_urls = _finalize_request_image_urls(
-        normalize_and_dedupe_strings(req.image_urls),
-        max_total=max(int(getattr(config, "max_quoted_fallback_images", 4) or 4), 4),
+        req.image_urls,
+        max_total=max_quoted_fallback_images,
     )
     req.audio_urls = normalize_and_dedupe_strings(req.audio_urls)
 

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -115,6 +115,7 @@ from astrbot.core.utils.quoted_message_parser import (
     extract_quoted_message_text,
 )
 from astrbot.core.utils.string_utils import normalize_and_dedupe_strings
+from astrbot.core.agent.message import strip_images_from_history_messages
 from astrbot.core.workspace import (
     normalize_umo_for_workspace,
     resolve_workspace_root_for_umo,
@@ -1351,6 +1352,43 @@ def _select_image_chat_provider(
     return provider
 
 
+
+def _is_remote_image_ref(image_ref: str) -> bool:
+    return image_ref.startswith("http://") or image_ref.startswith("https://")
+
+
+def _finalize_request_image_urls(
+    image_urls: list[str] | None,
+    *,
+    max_total: int = 4,
+) -> list[str]:
+    """Dedupe and prioritize local image refs over remote URLs.
+
+    Remote CDN links (especially QQ multimedia URLs) expire easily. Keeping them
+    beside already-downloaded local paths causes models to "see" missing/wrong
+    images in later turns.
+    """
+    urls = normalize_and_dedupe_strings(image_urls or [])
+    if not urls:
+        return []
+
+    local_refs: list[str] = []
+    embedded_refs: list[str] = []
+    remote_refs: list[str] = []
+    for ref in urls:
+        if _is_remote_image_ref(ref):
+            remote_refs.append(ref)
+        elif ref.startswith("data:") or ref.startswith("base64://"):
+            embedded_refs.append(ref)
+        else:
+            local_refs.append(ref)
+
+    ordered = local_refs + embedded_refs + remote_refs
+    if max_total > 0:
+        ordered = ordered[:max_total]
+    return ordered
+
+
 async def build_main_agent(
     *,
     event: AstrMessageEvent,
@@ -1381,7 +1419,7 @@ async def build_main_agent(
                 "provider_request 必须是 ProviderRequest 类型。"
             )
             if req.conversation:
-                req.contexts = json.loads(req.conversation.history)
+                req.contexts = strip_images_from_history_messages(json.loads(req.conversation.history))
         else:
             req = ProviderRequest()
             req.prompt = ""
@@ -1514,7 +1552,7 @@ async def build_main_agent(
 
             conversation = await _get_session_conv(event, plugin_context)
             req.conversation = conversation
-            req.contexts = json.loads(conversation.history)
+            req.contexts = strip_images_from_history_messages(json.loads(conversation.history))
             event.set_extra("provider_request", req)
 
     if isinstance(req.contexts, str):
@@ -1530,7 +1568,10 @@ async def build_main_agent(
                 )
             )
         )
-    req.image_urls = normalize_and_dedupe_strings(req.image_urls)
+    req.image_urls = _finalize_request_image_urls(
+        normalize_and_dedupe_strings(req.image_urls),
+        max_total=max(int(getattr(config, "max_quoted_fallback_images", 4) or 4), 4),
+    )
     req.audio_urls = normalize_and_dedupe_strings(req.audio_urls)
 
     if config.file_extract_enabled:

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -273,7 +273,10 @@ class ProviderOpenAIOfficial(Provider):
         if part.get("type") == "image_url":
             url, image_detail = self._extract_image_part_info(part)
             if not url:
-                return part
+                return {
+                    "type": "text",
+                    "text": "[Image unavailable]",
+                }
 
             try:
                 resolved_part = await self._resolve_image_part(
@@ -281,13 +284,26 @@ class ProviderOpenAIOfficial(Provider):
                 )
             except Exception as exc:
                 logger.warning(
-                    "图片 %s 预处理失败，将保留原始内容。错误: %s",
+                    "Image preprocess failed; dropping image content. url=%s err=%s",
                     url,
                     exc,
                 )
-                return part
+                return {
+                    "type": "text",
+                    "text": "[Image unavailable]",
+                }
 
-            return resolved_part or part
+            if resolved_part:
+                return resolved_part
+
+            logger.warning(
+                "Image preprocess returned empty; dropping image content. url=%s",
+                url,
+            )
+            return {
+                "type": "text",
+                "text": "[Image unavailable]",
+            }
 
         if part.get("type") == "audio_url":
             audio_ref = self._extract_audio_part_info(part)

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -43,6 +43,8 @@ from astrbot.core.utils.string_utils import normalize_and_dedupe_strings
 from ..register import register_provider_adapter
 from .request_retry import retry_provider_request
 
+IMAGE_UNAVAILABLE_PLACEHOLDER = "[Image unavailable]"
+
 
 @register_provider_adapter(
     "openai_chat_completion",
@@ -275,7 +277,7 @@ class ProviderOpenAIOfficial(Provider):
             if not url:
                 return {
                     "type": "text",
-                    "text": "[Image unavailable]",
+                    "text": IMAGE_UNAVAILABLE_PLACEHOLDER,
                 }
 
             try:
@@ -290,7 +292,7 @@ class ProviderOpenAIOfficial(Provider):
                 )
                 return {
                     "type": "text",
-                    "text": "[Image unavailable]",
+                    "text": IMAGE_UNAVAILABLE_PLACEHOLDER,
                 }
 
             if resolved_part:
@@ -302,7 +304,7 @@ class ProviderOpenAIOfficial(Provider):
             )
             return {
                 "type": "text",
-                "text": "[Image unavailable]",
+                "text": IMAGE_UNAVAILABLE_PLACEHOLDER,
             }
 
         if part.get("type") == "audio_url":

--- a/tests/test_image_history_strip.py
+++ b/tests/test_image_history_strip.py
@@ -1,0 +1,57 @@
+from astrbot.core.agent.message import (
+    ImageURLPart,
+    Message,
+    TextPart,
+    bind_checkpoint_messages,
+    dump_messages_with_checkpoints,
+    strip_images_from_history_messages,
+)
+from astrbot.core.astr_main_agent import _finalize_request_image_urls
+
+
+def test_dump_messages_strips_image_parts():
+    msg = Message(
+        role="user",
+        content=[
+            TextPart(text="see this"),
+            ImageURLPart(image_url=ImageURLPart.ImageURL(url="data:image/png;base64,AAAA")),
+            ImageURLPart(image_url=ImageURLPart.ImageURL(url="https://example.com/x.jpg")),
+        ],
+    )
+    dumped = dump_messages_with_checkpoints([msg])
+    content = dumped[0]["content"]
+    assert all(part.get("type") != "image_url" for part in content)
+    assert sum(1 for part in content if part.get("text") == "[Image]") == 1
+
+
+def test_bind_checkpoint_messages_strips_polluted_history():
+    hist = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "old"},
+                {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,BBB"}},
+                {"type": "image_url", "image_url": {"url": "https://example.com/a.jpg"}},
+            ],
+        }
+    ]
+    bound = bind_checkpoint_messages(hist)
+    types = [getattr(part, "type", None) for part in bound[0].content]
+    assert "image_url" not in types
+    stripped = strip_images_from_history_messages(hist)
+    assert all(part.get("type") != "image_url" for part in stripped[0]["content"])
+
+
+def test_finalize_request_image_urls_prefers_local_and_limits():
+    out = _finalize_request_image_urls(
+        [
+            "https://example.com/a",
+            r"C:\\tmp\\a.jpg",
+            "https://example.com/a",
+            r"C:\\tmp\\b.jpg",
+            "https://example.com/c.jpg",
+        ],
+        max_total=2,
+    )
+    assert len(out) == 2
+    assert all(not u.startswith("http") for u in out)

--- a/tests/test_image_history_strip.py
+++ b/tests/test_image_history_strip.py
@@ -14,8 +14,12 @@ def test_dump_messages_strips_image_parts():
         role="user",
         content=[
             TextPart(text="see this"),
-            ImageURLPart(image_url=ImageURLPart.ImageURL(url="data:image/png;base64,AAAA")),
-            ImageURLPart(image_url=ImageURLPart.ImageURL(url="https://example.com/x.jpg")),
+            ImageURLPart(
+                image_url=ImageURLPart.ImageURL(url="data:image/png;base64,AAAA")
+            ),
+            ImageURLPart(
+                image_url=ImageURLPart.ImageURL(url="https://example.com/x.jpg")
+            ),
         ],
     )
     dumped = dump_messages_with_checkpoints([msg])
@@ -30,8 +34,14 @@ def test_bind_checkpoint_messages_strips_polluted_history():
             "role": "user",
             "content": [
                 {"type": "text", "text": "old"},
-                {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,BBB"}},
-                {"type": "image_url", "image_url": {"url": "https://example.com/a.jpg"}},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/jpeg;base64,BBB"},
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/a.jpg"},
+                },
             ],
         }
     ]
@@ -46,12 +56,12 @@ def test_finalize_request_image_urls_prefers_local_and_limits():
     out = _finalize_request_image_urls(
         [
             "https://example.com/a",
-            r"C:\\tmp\\a.jpg",
-            "https://example.com/a",
-            r"C:\\tmp\\b.jpg",
+            "C:/tmp/a.jpg",
+            "HTTPS://example.com/a",
+            "C:/tmp/b.jpg",
             "https://example.com/c.jpg",
+            "data:image/png;base64,AAAA",
         ],
         max_total=2,
     )
-    assert len(out) == 2
-    assert all(not u.startswith("http") for u in out)
+    assert out == ["C:/tmp/a.jpg", "C:/tmp/b.jpg"]

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -1217,7 +1217,7 @@ async def test_audio_preprocess_failure_does_not_log_media_ref(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_prepare_chat_payload_keeps_original_context_image_when_materialization_fails(
+async def test_prepare_chat_payload_drops_context_image_when_materialization_fails(
     monkeypatch,
 ):
     provider = _make_provider()
@@ -1261,10 +1261,8 @@ async def test_prepare_chat_payload_keeps_original_context_image_when_materializ
         assert payloads["messages"][0]["content"] == [
             {"type": "text", "text": "look"},
             {
-                "type": "image_url",
-                "image_url": {
-                    "url": "https://example.com/expired.png",
-                },
+                "type": "text",
+                "text": "[Image unavailable]",
             },
         ]
     finally:


### PR DESCRIPTION
## 问题

在多轮对话和引用消息识图场景中，模型容易“看错图”或“看到不存在的图”，常见表现包括：

1. **历史会话中的 `image_url`（含 `data:image...` base64）被反复回放到后续请求**，旧图与当前图混在一起。
2. **图片 URL 解析失败后仍保留原始链接**（尤其是 QQ `multimedia.nt.qq.com.cn` 等易过期 CDN），模型继续尝试“看”死链。
3. **同一请求中本地已下载路径与远程 URL 并存**，模型一次看到多张相关/无关图片，进一步放大串图概率。

## 改动

### 1. 历史落库 / 加载时剥离图片载荷
- 文件：`astrbot/core/agent/message.py`
- `dump_messages_with_checkpoints`：持久化时将 `image_url` 替换为文本占位 `[Image]`
- `bind_checkpoint_messages` / `strip_images_from_history_messages`：加载历史时同样剥离，兼容旧库中已污染的历史

### 2. OpenAI source：解析失败不再回退保留原 URL
- 文件：`astrbot/core/provider/sources/openai_source.py`
- `_transform_content_part` 在 URL 为空、预处理异常、或 resolve 结果为空时，统一改为文本 `[Image unavailable]`，避免死链继续进入模型请求

### 3. 请求图片本地优先 + 去重限量
- 文件：`astrbot/core/astr_main_agent.py`
- 新增 `_finalize_request_image_urls`：本地路径 / embedded base64 优先于远程 URL，并限制总数
- `build_main_agent` 加载 `conversation.history` 时走剥离逻辑

### 4. 测试
- 新增 `tests/test_image_history_strip.py`
  - dump 剥离 image
  - bind/加载污染历史剥离
  - finalize 本地优先与数量限制
- 同步更新 `tests/test_openai_source.py` 中“解析失败仍保留原图”的旧预期

## 行为变化说明（有意为之）

- **历史多轮不再自动携带旧图像素/URL**，只保留 `[Image]` 文本占位。
- **当前轮仍可正常识图**（当前消息的图片仍会进入 `image_urls` / 当前 content）。
- 这样可显著降低串图、误看失效链接，并减少上下文 token 浪费。

未改动默认 `max_quoted_fallback_images` 配置值，避免影响既有部署策略；本 PR 只做防串图的核心路径修复。

## 根据审查意见的后续更新（`b2407e0d`）

已根据 Sourcery / Gemini Code Assist 的 review，以及 CI 失败项做了第二轮收敛：

1. **去掉重复逻辑**：`dump_messages_with_checkpoints` 改为先过滤 `_no_save`，再复用 `strip_images_from_content_parts`，避免两套“连续 image 折叠为 `[Image]`”状态机分叉。
2. **去掉双重 normalize**：`_finalize_request_image_urls` 内部已 `normalize_and_dedupe_strings`，调用侧不再包一层。
3. **scheme 大小写不敏感**：`http(s)` / `data:` / `base64://` 判断统一 `.lower()`。
4. **占位符常量**：OpenAI source 抽成 `IMAGE_UNAVAILABLE_PLACEHOLDER`，避免魔法字符串散落。
5. **测试与格式**：
   - 修正 `test_image_history_strip.py` 路径写法，并覆盖本地优先断言
   - 将 `test_prepare_chat_payload_keeps_original_context_image_when_materialization_fails` 更新为 drop 行为预期
   - `ruff format` / import 整理，修复 `format-check` 与 `Run pytest suite`

关于“失败图片是否保留 alt/description 元数据”的建议：当前 AstrBot 图 part 主路径基本不携带稳定 alt 字段，为控制范围未额外拼接描述文本；若后续 content part 协议补齐 metadata，可再扩展占位文案。

## 测试计划

- [x] 本地运行 `tests/test_image_history_strip.py` 相关用例通过
- [x] CI `format-check` 通过
- [x] CI `Run pytest suite` 通过
- [ ] 新会话发送图片提问，当前轮识图正常
- [ ] 多轮后再提问不引用旧图内容时，模型不再描述历史图细节
- [ ] 引用一条带图消息提问，只围绕被引用图回答
- [ ] 人为制造失效图片 URL 时，请求中不再保留该 URL，日志可见 drop 提示

## 相关背景

桌面安装版实测：历史库清理 + 上述代码修复后，引用图可正确识别；仅清库不修代码，后续仍可能因落库/死链回退再次复发。