### PR TITLE
fix: hide the command suggestion tooltip whenever the suggestion panel closes

### DIFF
--- a/dashboard/src/components/chat/CommandSuggestion.vue
+++ b/dashboard/src/components/chat/CommandSuggestion.vue
@@ -47,7 +47,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, reactive } from "vue";
+import { computed, reactive, watch } from "vue";
 import { useModuleI18n } from "@/i18n/composables";
 
 export interface SuggestionCommand {
@@ -87,6 +87,15 @@ const tooltip = reactive({
   x: 0,
   y: 0,
 });
+
+watch(
+  () => props.visible,
+  (visible) => {
+    if (!visible) {
+      tooltip.visible = false;
+    }
+  },
+);
 
 const tooltipStyle = computed(() => ({
   position: "fixed" as const,


### PR DESCRIPTION
## Summary

- hide the command suggestion tooltip whenever the suggestion panel closes
- cover keyboard selection, Escape, blur, and other programmatic close paths without coupling the parent to child internals

## Root cause

The suggestion panel remained mounted when its `visible` prop became false, while the tooltip was teleported to `document.body` and controlled by independent local state. Selecting a command with Enter closed the panel without firing `mouseleave`, so the tooltip stayed visible.

## Impact

Command tooltips no longer remain over the WebChat UI after selecting a command with Enter or closing the suggestion panel through another non-pointer path.

## Validation

- `pnpm typecheck`
- `pnpm exec prettier --check src/components/chat/CommandSuggestion.vue`
- `pnpm build`
- `uv run ruff format --check .`
- `uv run ruff check .`

Closes #9286

## Summary by Sourcery

Bug Fixes:
- Hide the command suggestion tooltip whenever the suggestion panel visibility is toggled off, preventing stray tooltips after non-pointer closes.