### PR TITLE
fix: stop matching plugin repository URLs

### DIFF
--- a/dashboard/src/utils/pluginSearch.js
+++ b/dashboard/src/utils/pluginSearch.js
@@ -86,7 +86,6 @@ export const getPluginSearchFields = (plugin) => {
     plugin?.short_desc,
     plugin?.desc,
     plugin?.author,
-    plugin?.repo,
     plugin?.version,
     plugin?.astrbot_version,
     supportPlatforms,


### PR DESCRIPTION
Fixes #9225.

## What changed

Remove the `repo` URL from the plugin marketplace's general text-search fields.

## Why

Repository URLs commonly contain infrastructure terms such as `github`, `http`, `https`, and `//`. Matching the complete URL causes those queries to match nearly every plugin instead of narrowing the results.

Repository links remain available on plugin cards; they simply no longer influence general marketplace search results. Searches across plugin names, descriptions, authors, versions, platforms, and tags are unchanged.

## Validation

- `pnpm typecheck`
- Focused regression assertions for `github`, `http`, `https`, and `//`
- Positive assertions for plugin name and author matching
- `git diff --check`

## Summary by Sourcery

Bug Fixes:
- Prevent marketplace text searches for common infrastructure terms (e.g., github, http/https, //) from matching nearly all plugins by removing repository URLs from search indexing.