### PR TITLE
fix: make plugin handler binding idempotent

### DIFF
--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -1244,7 +1244,8 @@ class PluginManager:
                     for func_tool in llm_tools.func_list:
                         for ft in self._iter_concrete_llm_tools(func_tool):
                             if ft.handler and (
-                                ft.handler.__module__ == metadata.module_path
+                                getattr(ft.handler, "__module__", None)
+                                == metadata.module_path
                                 or (
                                     isinstance(ft.handler, functools.partial)
                                     and ft.handler_module_path == metadata.module_path

--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -1207,6 +1207,7 @@ class PluginManager:
                             setattr(metadata.star_cls, "author", p_author)
                             setattr(metadata.star_cls, "plugin_id", plugin_id)
                     else:
+                        metadata.star_cls = None
                         logger.info("Plugin %s is disabled.", metadata.name)
 
                     metadata.module = module
@@ -1217,31 +1218,53 @@ class PluginManager:
                         f"插件 {metadata.name} 的模块路径为空。"
                     )
 
-                    # 绑定 handler
+                    plugin_disabled = metadata.module_path in inactivated_plugins
+
+                    # Restore decorator-registered callables before binding the current
+                    # instance so repeated loads cannot stack stale plugin instances.
                     related_handlers = (
                         star_handlers_registry.get_handlers_by_module_name(
                             metadata.module_path,
                         )
                     )
                     for handler in related_handlers:
-                        handler.handler = functools.partial(
-                            handler.handler,
-                            metadata.star_cls,  # type: ignore
+                        raw_handler = (
+                            handler.handler.func
+                            if isinstance(handler.handler, functools.partial)
+                            else handler.handler
                         )
-                    plugin_disabled = metadata.module_path in inactivated_plugins
+                        handler.handler = raw_handler
+                        if not plugin_disabled and metadata.star_cls is not None:
+                            handler.handler = functools.partial(
+                                raw_handler,
+                                metadata.star_cls,
+                            )
 
-                    # 绑定 llm_tool handler
+                    # Apply the same idempotent binding lifecycle to LLM tools.
                     for func_tool in llm_tools.func_list:
                         for ft in self._iter_concrete_llm_tools(func_tool):
-                            if (
-                                ft.handler
-                                and ft.handler.__module__ == metadata.module_path
-                            ):
-                                ft.handler_module_path = metadata.module_path
-                                ft.handler = functools.partial(
-                                    ft.handler,
-                                    metadata.star_cls,  # type: ignore
+                            if ft.handler and (
+                                ft.handler.__module__ == metadata.module_path
+                                or (
+                                    isinstance(ft.handler, functools.partial)
+                                    and ft.handler_module_path == metadata.module_path
                                 )
+                            ):
+                                raw_handler = (
+                                    ft.handler.func
+                                    if isinstance(ft.handler, functools.partial)
+                                    else ft.handler
+                                )
+                                ft.handler_module_path = metadata.module_path
+                                ft.handler = raw_handler
+                                if (
+                                    not plugin_disabled
+                                    and metadata.star_cls is not None
+                                ):
+                                    ft.handler = functools.partial(
+                                        raw_handler,
+                                        metadata.star_cls,
+                                    )
                             if self._is_plugin_llm_tool(ft, metadata.module_path):
                                 ft.active = (
                                     not plugin_disabled

--- a/dashboard/src/components/chat/ChatMessageList.vue
+++ b/dashboard/src/components/chat/ChatMessageList.vue
@@ -1141,11 +1141,14 @@ function formatDuration(seconds: number) {
 
 .image-part {
   display: block;
+  width: fit-content;
+  max-width: 100%;
   border: 0;
   padding: 0;
   margin-top: 8px;
   background: transparent;
   cursor: zoom-in;
+  text-align: left;
 }
 
 .image-part img {

--- a/dashboard/src/components/chat/MessageList.vue
+++ b/dashboard/src/components/chat/MessageList.vue
@@ -714,11 +714,14 @@ function formatDuration(seconds: number) {
 
 .image-part {
   display: block;
+  width: fit-content;
+  max-width: 100%;
   border: 0;
   padding: 0;
   margin-top: 8px;
   background: transparent;
   cursor: zoom-in;
+  text-align: left;
 }
 
 .image-part img {

--- a/dashboard/src/components/chat/StandaloneChat.vue
+++ b/dashboard/src/components/chat/StandaloneChat.vue
@@ -584,11 +584,14 @@ function closeImage() {
 
 .image-part {
   display: block;
+  width: fit-content;
+  max-width: 100%;
   border: 0;
   padding: 0;
   margin-top: 8px;
   background: transparent;
   cursor: zoom-in;
+  text-align: left;
 }
 
 .image-part img {

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -10,8 +10,8 @@ import pytest
 import yaml
 
 from astrbot.core.star import star_manager as star_manager_module
-from astrbot.core.star.star_manager import PluginDependencyInstallError, PluginManager
 from astrbot.core.star.star_handler import EventType, StarHandlerMetadata
+from astrbot.core.star.star_manager import PluginDependencyInstallError, PluginManager
 from astrbot.core.utils.pip_installer import PipInstallError
 from astrbot.core.utils.requirements_utils import MissingRequirementsPlan
 

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import json
 import os
 from pathlib import Path
@@ -10,6 +11,7 @@ import yaml
 
 from astrbot.core.star import star_manager as star_manager_module
 from astrbot.core.star.star_manager import PluginDependencyInstallError, PluginManager
+from astrbot.core.star.star_handler import EventType, StarHandlerMetadata
 from astrbot.core.utils.pip_installer import PipInstallError
 from astrbot.core.utils.requirements_utils import MissingRequirementsPlan
 
@@ -2283,4 +2285,158 @@ async def test_turn_on_plugin_after_deactivated_reload_reactivates_tools(
     finally:
         llm_tools.func_list = original_func_list
         cast(Any, plugin_manager_pm.context).stars.remove(plugin)
+        _clear_star_runtime_state()
+
+
+@pytest.mark.asyncio
+async def test_repeated_deactivated_loads_bind_handlers_once_when_activated(
+    plugin_manager_pm: PluginManager, monkeypatch
+):
+    """Repeated disabled loads keep raw callables and activation binds once."""
+    _clear_star_runtime_state()
+    plugin_name = "demo_plugin"
+    module_path = f"data.plugins.{plugin_name}.main"
+
+    class DemoPlugin:
+        def __init__(self, context):
+            self.context = context
+            self.initialize_count = 0
+
+        async def initialize(self):
+            self.initialize_count += 1
+
+    stale_plugin = DemoPlugin(plugin_manager_pm.context)
+
+    metadata = star_manager_module.StarMetadata(
+        name=plugin_name,
+        author="AstrBot Team",
+        desc="Demo plugin",
+        version="1.0.0",
+        root_dir_name=plugin_name,
+        module_path=module_path,
+        star_cls_type=cast(Any, DemoPlugin),
+        star_cls=cast(Any, stale_plugin),
+        activated=False,
+    )
+    cast(Any, plugin_manager_pm.context).stars.append(metadata)
+    star_manager_module.star_map[module_path] = metadata
+    star_manager_module.star_registry.append(metadata)
+
+    async def raw_event_handler(plugin, event):
+        return plugin, event
+
+    async def raw_tool_handler(plugin, query):
+        return plugin, query
+
+    raw_event_handler.__module__ = module_path
+    raw_tool_handler.__module__ = module_path
+    event_handler = StarHandlerMetadata(
+        event_type=EventType.AdapterMessageEvent,
+        handler_full_name=f"{module_path}_raw_event_handler",
+        handler_name="raw_event_handler",
+        handler_module_path=module_path,
+        handler=functools.partial(raw_event_handler, stale_plugin),
+        event_filters=[],
+    )
+    star_manager_module.star_handlers_registry.append(event_handler)
+
+    plugin_tool = star_manager_module.FunctionTool(
+        name="plugin_search",
+        description="plugin search",
+        parameters={"type": "object", "properties": {}},
+        handler=functools.partial(raw_tool_handler, stale_plugin),
+        handler_module_path=module_path,
+    )
+    llm_tools = cast(Any, star_manager_module.llm_tools)
+    original_func_list = llm_tools.func_list
+    llm_tools.func_list = [plugin_tool]
+    preferences = {
+        "inactivated_plugins": [module_path],
+        "inactivated_llm_tools": [],
+        "alter_cmd": {},
+    }
+
+    async def mock_global_get(key, default=None):
+        return preferences.get(key, default)
+
+    async def mock_global_put(key, value):
+        preferences[key] = value
+
+    async def mock_import_plugin_with_dependency_recovery(
+        path,
+        module_str,
+        root_dir_name,
+        requirements_path,
+        *,
+        reserved=False,
+    ):
+        del module_str, root_dir_name, requirements_path, reserved
+        assert path == module_path
+        return ModuleType(module_path)
+
+    async def mock_sync_command_configs():
+        return None
+
+    monkeypatch.setattr(star_manager_module.sp, "global_get", mock_global_get)
+    monkeypatch.setattr(star_manager_module.sp, "global_put", mock_global_put)
+    monkeypatch.setattr(
+        plugin_manager_pm,
+        "_get_plugin_modules",
+        lambda: [{"pname": plugin_name, "module": "main"}],
+    )
+    monkeypatch.setattr(
+        plugin_manager_pm,
+        "_import_plugin_with_dependency_recovery",
+        mock_import_plugin_with_dependency_recovery,
+    )
+    monkeypatch.setattr(plugin_manager_pm, "_load_plugin_metadata", lambda **_: None)
+    monkeypatch.setattr(
+        star_manager_module,
+        "sync_command_configs",
+        mock_sync_command_configs,
+    )
+
+    try:
+        for _ in range(2):
+            success, error = await plugin_manager_pm.load(
+                specified_module_path=module_path,
+            )
+            assert success is True
+            assert error is None
+            assert event_handler.handler is raw_event_handler
+            assert plugin_tool.handler is raw_tool_handler
+            assert plugin_tool.active is False
+            assert metadata.star_cls is None
+            assert stale_plugin.initialize_count == 0
+
+        await plugin_manager_pm.turn_on_plugin(plugin_name)
+
+        assert isinstance(event_handler.handler, functools.partial)
+        assert event_handler.handler.func is raw_event_handler
+        assert event_handler.handler.args == (metadata.star_cls,)
+        assert isinstance(plugin_tool.handler, functools.partial)
+        assert plugin_tool.handler.func is raw_tool_handler
+        assert plugin_tool.handler.args == (metadata.star_cls,)
+        assert plugin_tool.active is True
+        assert metadata.star_cls.initialize_count == 1
+        assert await event_handler.handler("event") == (metadata.star_cls, "event")
+        assert await plugin_tool.handler("query") == (metadata.star_cls, "query")
+
+        success, error = await plugin_manager_pm.load(
+            specified_module_path=module_path,
+        )
+        assert success is True
+        assert error is None
+        assert isinstance(event_handler.handler, functools.partial)
+        assert event_handler.handler.func is raw_event_handler
+        assert event_handler.handler.args == (metadata.star_cls,)
+        assert isinstance(plugin_tool.handler, functools.partial)
+        assert plugin_tool.handler.func is raw_tool_handler
+        assert plugin_tool.handler.args == (metadata.star_cls,)
+        assert metadata.star_cls.initialize_count == 1
+        assert await event_handler.handler("event") == (metadata.star_cls, "event")
+        assert await plugin_tool.handler("query") == (metadata.star_cls, "query")
+    finally:
+        llm_tools.func_list = original_func_list
+        cast(Any, plugin_manager_pm.context).stars.remove(metadata)
         _clear_star_runtime_state()


### PR DESCRIPTION
## Summary

- restore decorator-registered event and LLM tool callables before runtime instance binding
- keep disabled plugins unbound and clear stale `star_cls` instances
- bind active handlers and tools exactly once to the current plugin instance
- add a lifecycle regression test covering stale bindings, repeated disabled loads, activation, and repeated active loads

## Root cause

Since #9096, reloading an inactive plugin intentionally skips `_unbind_plugin()` so its tool registrations remain available. The existing `load()` path, however, reused the already-bound handler metadata and wrapped it in another `functools.partial`. Disabled loads could also bind `None`. When the plugin was enabled later, another plugin instance was prepended, so a method such as `Main.get_moe(self, message)` received an extra positional argument and raised the error reported in #9280.

#9284 fixes the observed enable path by forcing an unbind before reload. That removes the stale state for that entry point, but it does not make `load()` idempotent and does not repair the same lifecycle for LLM tool handlers. This change enforces the invariant at the binding point while preserving the inactive-plugin tool registrations introduced by #9096.

Fixes #9280.
Closes #9284

## Validation

- `uv run ruff format .`
- `uv run ruff check .`
- `uv run pytest -q tests` (`1826 passed`)

## Summary by Sourcery

Ensure plugin handler and LLM tool binding is idempotent across plugin load and activation cycles.

Bug Fixes:
- Prevent multiple or stale plugin instance bindings for event handlers and LLM tools when plugins are repeatedly loaded or toggled between disabled and enabled states.

Tests:
- Add an async regression test verifying repeated disabled loads, activation, and subsequent loads only bind handlers once and preserve correct plugin behavior.