### PR TITLE
chore: translate core logs to English

### DIFF
--- a/astrbot/core/event_bus.py
+++ b/astrbot/core/event_bus.py
@@ -60,7 +60,7 @@ class EventBus:
             return
         exc = task.exception()
         if exc is not None:
-            logger.error("pipeline 任务执行异常", exc_info=exc)
+            logger.error("Pipeline task failed.", exc_info=exc)
 
     def _print_event(self, event: AstrMessageEvent, conf_name: str) -> None:
         """用于记录事件信息

--- a/astrbot/core/file_token_service.py
+++ b/astrbot/core/file_token_service.py
@@ -55,7 +55,7 @@ class FileTokenService:
 
             if not os.path.exists(local_path):
                 raise FileNotFoundError(
-                    f"文件不存在: {local_path} (原始输入: {file_path})",
+                    f"File does not exist: {local_path} (original input: {file_path})",
                 )
 
             file_token = str(uuid.uuid4())
@@ -84,9 +84,9 @@ class FileTokenService:
             await self._cleanup_expired_tokens()
 
             if file_token not in self.staged_files:
-                raise KeyError(f"无效或过期的文件 token: {file_token}")
+                raise KeyError(f"Invalid or expired file token: {file_token}")
 
             file_path, _ = self.staged_files.pop(file_token)
             if not os.path.exists(file_path):
-                raise FileNotFoundError(f"文件不存在: {file_path}")
+                raise FileNotFoundError(f"File does not exist: {file_path}")
             return file_path

--- a/astrbot/core/initial_loader.py
+++ b/astrbot/core/initial_loader.py
@@ -30,7 +30,7 @@ class InitialLoader:
             await core_lifecycle.initialize()
         except Exception as e:
             logger.critical(traceback.format_exc())
-            logger.critical(f"😭 初始化 AstrBot 失败：{e} !!!")
+            logger.critical(f"😭 Failed to initialize AstrBot: {e} !!!")
             return
 
         core_task = core_lifecycle.start()
@@ -53,5 +53,5 @@ class InitialLoader:
         try:
             await task  # 整个AstrBot在这里运行
         except asyncio.CancelledError:
-            logger.info("🌈 正在关闭 AstrBot...")
+            logger.info("🌈 Shutting down AstrBot...")
             await core_lifecycle.stop()

--- a/astrbot/core/pipeline/content_safety_check/stage.py
+++ b/astrbot/core/pipeline/content_safety_check/stage.py
@@ -32,10 +32,11 @@ class ContentSafetyCheckStage(Stage):
             if event.is_at_or_wake_command:
                 event.set_result(
                     MessageEventResult().message(
-                        "你的消息或者大模型的响应中包含不适当的内容，已被屏蔽。",
+                        "Your message or the model response contains inappropriate "
+                        "content and has been blocked.",
                     ),
                 )
                 yield
             event.stop_event()
-            logger.info(f"内容安全检查不通过，原因：{info}")
+            logger.info(f"Content safety check failed: {info}")
             return

--- a/astrbot/core/pipeline/content_safety_check/strategies/baidu_aip.py
+++ b/astrbot/core/pipeline/content_safety_check/strategies/baidu_aip.py
@@ -23,10 +23,10 @@ class BaiduAipStrategy(ContentSafetyStrategy):
         if "data" not in res:
             return False, ""
         count = len(res["data"])
-        parts = [f"百度审核服务发现 {count} 处违规：\n"]
+        parts = [f"Baidu content moderation found {count} violations:\n"]
         for i in res["data"]:
             # 百度 AIP 返回结构是动态 dict；类型检查时 i 可能被推断为序列，转成 dict 后用 get 取字段
-            parts.append(f"{cast(dict[str, Any], i).get('msg', '')}；\n")
-        parts.append("\n判断结果：" + res["conclusion"])
+            parts.append(f"{cast(dict[str, Any], i).get('msg', '')};\n")
+        parts.append("\nEvaluation: " + res["conclusion"])
         info = "".join(parts)
         return False, info

--- a/astrbot/core/pipeline/content_safety_check/strategies/keywords.py
+++ b/astrbot/core/pipeline/content_safety_check/strategies/keywords.py
@@ -20,5 +20,7 @@ class KeywordsStrategy(ContentSafetyStrategy):
     def check(self, content: str) -> tuple[bool, str]:
         for keyword in self.keywords:
             if re.search(keyword, content):
-                return False, "内容安全检查不通过，匹配到敏感词。"
+                return False, (
+                    "Content safety check failed because a blocked keyword was matched."
+                )
         return True, ""

--- a/astrbot/core/pipeline/content_safety_check/strategies/strategy.py
+++ b/astrbot/core/pipeline/content_safety_check/strategies/strategy.py
@@ -16,7 +16,9 @@ class StrategySelector:
             try:
                 from .baidu_aip import BaiduAipStrategy
             except ImportError:
-                logger.warning("使用百度内容审核应该先 pip install baidu-aip")
+                logger.warning(
+                    "Install baidu-aip before using Baidu content moderation."
+                )
                 return
             self.enabled_strategies.append(
                 BaiduAipStrategy(

--- a/astrbot/core/pipeline/context_utils.py
+++ b/astrbot/core/pipeline/context_utils.py
@@ -36,7 +36,10 @@ async def call_handler(
     try:
         ready_to_call = handler(event, *args, **kwargs)
     except TypeError:
-        logger.error("处理函数参数不匹配，请检查 handler 的定义。", exc_info=True)
+        logger.error(
+            "Plugin Handler arguments do not match its definition.",
+            exc_info=True,
+        )
 
     if not ready_to_call:
         return
@@ -101,7 +104,8 @@ async def call_event_hook(
 
         if event.is_stopped():
             logger.info(
-                f"{star_map[handler.handler_module_path].name} - {handler.handler_name} 终止了事件传播。",
+                f"{star_map[handler.handler_module_path].name} - "
+                f"{handler.handler_name} stopped event propagation.",
             )
             return True
 

--- a/astrbot/core/pipeline/preprocess_stage/stage.py
+++ b/astrbot/core/pipeline/preprocess_stage/stage.py
@@ -70,7 +70,9 @@ class PreProcessStage(Stage):
             try:
                 await event.react(random.choice(emojis))
             except Exception as e:
-                logger.warning(f"{platform} 预回应表情发送失败: {e}")
+                logger.warning(
+                    f"Failed to send a pre-response reaction on {platform}: {e}"
+                )
 
         # 路径映射
         if mappings := self.platform_settings.get("path_mapping", []):
@@ -91,7 +93,7 @@ class PreProcessStage(Stage):
                         )
                         if url.startswith(from_):
                             component.url = url.replace(from_, to_, 1)
-                            logger.debug(f"路径映射: {url} -> {component.url}")
+                            logger.debug(f"Path mapping: {url} -> {component.url}")
                     message_chain[idx] = component
 
         # Normalize provider-facing media early so downstream code sees local files.
@@ -170,17 +172,18 @@ class PreProcessStage(Stage):
             stt_provider = ctx.get_using_stt_provider(event.unified_msg_origin)
             if not stt_provider:
                 logger.warning(
-                    f"会话 {event.unified_msg_origin} 未配置语音转文本模型。",
+                    f"Session {event.unified_msg_origin} has no speech-to-text "
+                    "provider configured.",
                 )
                 return
 
             async def _stt_record(record_comp: Record, is_reply: bool = False):
                 """对单个 Record 组件执行语音转文本，成功返回 Plain，失败返回 None。"""
-                prefix = "引用消息" if is_reply else ""
+                prefix = "referenced " if is_reply else ""
                 try:
                     path = await record_comp.convert_to_file_path()
                 except Exception as e:
-                    logger.warning(f"获取{prefix}语音路径失败: {e}")
+                    logger.warning(f"Failed to resolve the {prefix}voice path: {e}")
                     return None
 
                 retry = 5
@@ -188,19 +191,21 @@ class PreProcessStage(Stage):
                     try:
                         result = await stt_provider.get_text(audio_url=path)
                         if result:
-                            suffix = "(引用消息)" if is_reply else ""
-                            logger.info(f"语音转文本{suffix}结果: " + result)
+                            suffix = " (referenced message)" if is_reply else ""
+                            logger.info(f"Speech-to-text{suffix} result: " + result)
                             return Plain(result)
                         break
                     except FileNotFoundError:
                         # napcat workaround: file may not be ready immediately
-                        logger.debug(f"文件尚未就绪 ({path})，重试 {i + 1}/{retry}")
+                        logger.debug(
+                            f"File is not ready ({path}); retrying {i + 1}/{retry}."
+                        )
                         await asyncio.sleep(0.5)
                         continue
                     except BaseException as e:
                         logger.error(traceback.format_exc())
-                        suffix = "(引用消息)" if is_reply else ""
-                        logger.error(f"语音转文本{suffix}失败: {e}")
+                        suffix = " (referenced message)" if is_reply else ""
+                        logger.error(f"Speech-to-text{suffix} failed: {e}")
                         break
                 return None
 

--- a/astrbot/core/pipeline/process_stage/method/agent_request.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_request.py
@@ -20,7 +20,9 @@ class AgentRequestSubStage(Stage):
         for bwp in self.bot_wake_prefixs:
             if self.prov_wake_prefix.startswith(bwp):
                 logger.info(
-                    f"识别 LLM 聊天额外唤醒前缀 {self.prov_wake_prefix} 以机器人唤醒前缀 {bwp} 开头，已自动去除。",
+                    f"The additional LLM wake prefix {self.prov_wake_prefix} starts "
+                    f"with the bot wake prefix {bwp}; the duplicate prefix was "
+                    "removed automatically.",
                 )
                 self.prov_wake_prefix = self.prov_wake_prefix[len(bwp) :]
 

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -293,7 +293,9 @@ class InternalAgentSubStage(Stage):
                     # 检测 Live Mode
                     if action_type == "live":
                         # Live Mode: 使用 run_live_agent
-                        logger.info("[Internal Agent] 检测到 Live Mode，启用 TTS 处理")
+                        logger.info(
+                            "[Internal Agent] Live Mode detected; enabling TTS processing."
+                        )
 
                         # 获取 TTS Provider
                         tts_provider = (
@@ -304,7 +306,8 @@ class InternalAgentSubStage(Stage):
 
                         if not tts_provider:
                             logger.warning(
-                                "[Live Mode] TTS Provider 未配置，将使用普通流式模式"
+                                "[Live Mode] No TTS provider is configured; using "
+                                "standard streaming mode."
                             )
 
                         # 使用 run_live_agent，总是使用流式响应
@@ -476,7 +479,7 @@ class InternalAgentSubStage(Stage):
             and not req.tool_calls_result
             and not user_aborted
         ):
-            logger.debug("LLM 响应为空，不保存记录。")
+            logger.debug("The LLM response is empty; not saving a record.")
             return
 
         messages_to_save: list[Message] = []

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/third_party.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/third_party.py
@@ -301,11 +301,15 @@ class ThirdPartyAgentSubStage(Stage):
             {},
         )
         if not self.prov_id:
-            logger.error("没有填写 Agent Runner 提供商 ID，请前往配置页面配置。")
+            logger.error(
+                "No Agent Runner provider ID is configured. Configure one on the "
+                "settings page."
+            )
             return
         if not self.prov_cfg:
             logger.error(
-                f"Agent Runner 提供商 {self.prov_id} 配置不存在，请前往配置页面修改配置。"
+                f"Configuration for Agent Runner provider {self.prov_id} does not "
+                "exist. Update it on the settings page."
             )
             return
 

--- a/astrbot/core/pipeline/rate_limit_check/stage.py
+++ b/astrbot/core/pipeline/rate_limit_check/stage.py
@@ -74,13 +74,17 @@ class RateLimitStage(Stage):
                 match self.rl_strategy:
                     case RateLimitStrategy.STALL.value:
                         logger.info(
-                            f"会话 {session_id} 被限流。根据限流策略，此会话处理将被暂停 {stall_duration:.2f} 秒。",
+                            f"Session {session_id} was rate-limited. Processing will "
+                            f"pause for {stall_duration:.2f} seconds according to the "
+                            "rate-limit policy.",
                         )
                         await asyncio.sleep(stall_duration)
                         now = datetime.now()
                     case RateLimitStrategy.DISCARD.value:
                         logger.info(
-                            f"会话 {session_id} 被限流。根据限流策略，此请求已被丢弃，直到限额于 {stall_duration:.2f} 秒后重置。",
+                            f"Session {session_id} was rate-limited. This request was "
+                            "discarded according to the rate-limit policy; the limit "
+                            f"resets in {stall_duration:.2f} seconds.",
                         )
                         return event.stop_event()
 

--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -84,8 +84,8 @@ class RespondStage(Stage):
             try:
                 self.interval = [float(t) for t in interval_str_ls]
             except BaseException as e:
-                logger.error(f"解析分段回复的间隔时间失败。{e}")
-            logger.info(f"分段回复间隔时间：{self.interval}")
+                logger.error(f"Failed to parse the segmented-reply interval: {e}")
+            logger.info(f"Segmented-reply interval: {self.interval}")
 
     async def _word_cnt(self, text: str) -> int:
         """分段回复 统计字数"""
@@ -209,7 +209,7 @@ class RespondStage(Stage):
 
         if result.result_content_type == ResultContentType.STREAMING_RESULT:
             if result.async_stream is None:
-                logger.warning("async_stream 为空，跳过发送。")
+                logger.warning("async_stream is empty; skipping delivery.")
                 return
             # 流式结果直接交付平台适配器处理
             realtime_segmenting = (
@@ -219,7 +219,7 @@ class RespondStage(Stage):
                 )
                 == "realtime_segmenting"
             )
-            logger.info(f"应用流式输出({event.get_platform_id()})")
+            logger.info(f"Applying streaming output ({event.get_platform_id()}).")
             await event.send_streaming(result.async_stream, realtime_segmenting)
             return
         if len(result.chain) > 0:
@@ -234,10 +234,10 @@ class RespondStage(Stage):
             # 检查消息链是否为空
             try:
                 if await self._is_empty_message_chain(result.chain):
-                    logger.info("消息为空，跳过发送阶段")
+                    logger.info("The message is empty; skipping the respond stage.")
                     return
             except Exception as e:
-                logger.warning(f"空内容检查异常: {e}")
+                logger.warning(f"Empty-content validation failed: {e}")
 
             # 将 Plain 为空的消息段移除
             result.chain = [
@@ -261,7 +261,9 @@ class RespondStage(Stage):
                 if not result.chain or len(result.chain) == 0:
                     # may fix #2670
                     logger.warning(
-                        f"实际消息链为空, 跳过发送阶段。header_chain: {header_comps}, actual_chain: {result.chain}",
+                        "The effective message chain is empty; skipping the respond "
+                        f"stage. header_chain: {header_comps}, "
+                        f"actual_chain: {result.chain}",
                     )
                     return
                 for comp in result.chain:
@@ -275,7 +277,8 @@ class RespondStage(Stage):
                             header_comps.clear()
                     except Exception as e:
                         logger.error(
-                            f"发送消息链失败: chain = {MessageChain([comp])}, error = {e}",
+                            "Failed to send the message chain: "
+                            f"chain = {MessageChain([comp])}, error = {e}",
                             exc_info=True,
                         )
             else:
@@ -285,7 +288,8 @@ class RespondStage(Stage):
                 ):
                     # may fix #2670
                     logger.warning(
-                        f"消息链全为 Reply 和 At 消息段, 跳过发送阶段。chain: {result.chain}",
+                        "The message chain contains only Reply and At segments; "
+                        f"skipping the respond stage. chain: {result.chain}",
                     )
                     return
                 sep_comps = self._extract_comp(
@@ -299,7 +303,8 @@ class RespondStage(Stage):
                         await event.send(chain)
                     except Exception as e:
                         logger.error(
-                            f"发送消息链失败: chain = {chain}, error = {e}",
+                            f"Failed to send the message chain: chain = {chain}, "
+                            f"error = {e}",
                             exc_info=True,
                         )
                 chain = result.derive(result.chain)
@@ -308,7 +313,8 @@ class RespondStage(Stage):
                         await event.send(chain)
                     except Exception as e:
                         logger.error(
-                            f"发送消息链失败: chain = {chain}, error = {e}",
+                            f"Failed to send the message chain: chain = {chain}, "
+                            f"error = {e}",
                             exc_info=True,
                         )
 

--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -167,20 +167,24 @@ class ResultDecorateStage(Stage):
                 )
                 if is_stream:
                     logger.warning(
-                        "启用流式输出时，依赖发送消息前事件钩子的插件可能无法正常工作",
+                        "Plugins that depend on the pre-send event hook may not work "
+                        "correctly when streaming output is enabled.",
                     )
                 await handler.handler(event)
 
                 if (result := event.get_result()) is None or not result.chain:
                     logger.debug(
-                        f"hook(on_decorating_result) -> {star_map[handler.handler_module_path].name} - {handler.handler_name} 将消息结果清空。",
+                        "hook(on_decorating_result) -> "
+                        f"{star_map[handler.handler_module_path].name} - "
+                        f"{handler.handler_name} cleared the message result.",
                     )
             except BaseException:
                 logger.error(traceback.format_exc())
 
             if event.is_stopped():
                 logger.info(
-                    f"{star_map[handler.handler_module_path].name} - {handler.handler_name} 终止了事件传播。",
+                    f"{star_map[handler.handler_module_path].name} - "
+                    f"{handler.handler_name} stopped event propagation.",
                 )
                 return
 
@@ -230,7 +234,9 @@ class ResultDecorateStage(Stage):
                                     )
                                 except re.error:
                                     logger.error(
-                                        f"分段回复正则表达式错误，使用默认分段方式: {traceback.format_exc()}",
+                                        "Invalid segmented-reply regular expression; "
+                                        "using the default segmentation method: "
+                                        f"{traceback.format_exc()}",
                                     )
                                     split_response = re.findall(
                                         r".*?[。？！~…]+|.+$",
@@ -247,7 +253,9 @@ class ResultDecorateStage(Stage):
                                         seg = re.sub(self.content_cleanup_rule, "", seg)
                                     except re.error:
                                         logger.error(
-                                            f"分段回复过滤表达式失败，无法成功过滤：{traceback.format_exc()}"
+                                            "The segmented-reply filter expression "
+                                            "failed, so the text could not be filtered: "
+                                            f"{traceback.format_exc()}"
                                         )
                                         self.content_cleanup_rule = None
                                 seg = seg.strip()
@@ -272,7 +280,8 @@ class ResultDecorateStage(Stage):
             )
             if should_tts and not tts_provider:
                 logger.warning(
-                    f"会话 {event.unified_msg_origin} 未配置文本转语音模型。",
+                    f"Session {event.unified_msg_origin} has no text-to-speech "
+                    "provider configured.",
                 )
 
             if (
@@ -304,12 +313,13 @@ class ResultDecorateStage(Stage):
                 for comp in result.chain:
                     if isinstance(comp, Plain) and len(comp.text) > 1:
                         try:
-                            logger.info(f"TTS 请求: {comp.text}")
+                            logger.info(f"TTS request: {comp.text}")
                             audio_path = await tts_provider.get_audio(comp.text)
-                            logger.info(f"TTS 结果: {audio_path}")
+                            logger.info(f"TTS result: {audio_path}")
                             if not audio_path:
                                 logger.error(
-                                    f"由于 TTS 音频文件未找到，消息段转语音失败: {comp.text}",
+                                    "Failed to convert the message segment to speech "
+                                    f"because no TTS audio file was found: {comp.text}",
                                 )
                                 new_chain.append(comp)
                                 continue
@@ -332,7 +342,7 @@ class ResultDecorateStage(Stage):
                                     audio_path,
                                 )
                                 url = f"{callback_api_base}/api/file/{token}"
-                                logger.debug(f"已注册：{url}")
+                                logger.debug(f"Registered: {url}")
 
                             new_chain.append(
                                 Record(
@@ -345,7 +355,7 @@ class ResultDecorateStage(Stage):
                                 new_chain.append(comp)
                         except Exception:
                             logger.error(traceback.format_exc())
-                            logger.error("TTS 失败，使用文本发送。")
+                            logger.error("TTS failed; sending text instead.")
                             new_chain.append(comp)
                     else:
                         new_chain.append(comp)
@@ -372,11 +382,14 @@ class ResultDecorateStage(Stage):
                             template_name=self.t2i_active_template,
                         )
                     except BaseException:
-                        logger.error("文本转图片失败，使用文本发送。")
+                        logger.error(
+                            "Text-to-image rendering failed; sending text instead."
+                        )
                         return
                     if time.time() - render_start > 3:
                         logger.warning(
-                            "文本转图片耗时超过了 3 秒，如果觉得很慢可以在 WebUI 中关闭文本转图片模式。",
+                            "Text-to-image rendering took more than 3 seconds. Disable "
+                            "text-to-image mode in the WebUI if it is too slow.",
                         )
                     if url:
                         if url.startswith("http"):
@@ -387,7 +400,7 @@ class ResultDecorateStage(Stage):
                         ):
                             token = await file_token_service.register_file(url)
                             url = f"{self.ctx.astrbot_config['callback_api_base']}/api/file/{token}"
-                            logger.debug(f"已注册：{url}")
+                            logger.debug(f"Registered: {url}")
                             result.chain = [Image.fromURL(url)]
                         else:
                             result.chain = [Image.fromFileSystem(url)]

--- a/astrbot/core/pipeline/scheduler.py
+++ b/astrbot/core/pipeline/scheduler.py
@@ -53,7 +53,7 @@ class PipelineScheduler:
                     # 此处是前置处理完成后的暂停点(yield), 下面开始执行后续阶段
                     if event.is_stopped():
                         logger.debug(
-                            f"阶段 {stage.__class__.__name__} 已终止事件传播。",
+                            f"Stage {stage.__class__.__name__} stopped event propagation.",
                         )
                         break
 
@@ -63,7 +63,7 @@ class PipelineScheduler:
                     # 此处是后续所有阶段处理完毕后返回的点, 执行后置处理
                     if event.is_stopped():
                         logger.debug(
-                            f"阶段 {stage.__class__.__name__} 已终止事件传播。",
+                            f"Stage {stage.__class__.__name__} stopped event propagation.",
                         )
                         break
             else:
@@ -72,7 +72,9 @@ class PipelineScheduler:
                 await coroutine
 
                 if event.is_stopped():
-                    logger.debug(f"阶段 {stage.__class__.__name__} 已终止事件传播。")
+                    logger.debug(
+                        f"Stage {stage.__class__.__name__} stopped event propagation."
+                    )
                     break
 
     async def execute(self, event: AstrMessageEvent) -> None:

--- a/astrbot/core/pipeline/session_status_check/stage.py
+++ b/astrbot/core/pipeline/session_status_check/stage.py
@@ -22,7 +22,10 @@ class SessionStatusCheckStage(Stage):
     ) -> None | AsyncGenerator[None, None]:
         # 检查会话是否整体启用
         if not await SessionServiceManager.is_session_enabled(event.unified_msg_origin):
-            logger.debug(f"会话 {event.unified_msg_origin} 已被关闭，已终止事件传播。")
+            logger.debug(
+                f"Session {event.unified_msg_origin} is disabled; event propagation "
+                "was stopped."
+            )
 
             # workaround for #2309
             conv_id = await self.conv_mgr.get_curr_conversation_id(

--- a/astrbot/core/pipeline/waking_check/stage.py
+++ b/astrbot/core/pipeline/waking_check/stage.py
@@ -208,7 +208,8 @@ class WakingCheckStage(Stage):
                             ),
                         )
                     logger.info(
-                        f"触发 {star_map[handler.handler_module_path].name} 时, 用户(ID={event.get_sender_id()}) 权限不足。",
+                        f"User ID {event.get_sender_id()} lacks permission to trigger "
+                        f"{star_map[handler.handler_module_path].name}.",
                     )
                     event.stop_event()
                     return

--- a/astrbot/core/pipeline/whitelist_check/stage.py
+++ b/astrbot/core/pipeline/whitelist_check/stage.py
@@ -63,6 +63,8 @@ class WhitelistCheckStage(Stage):
         ):
             if self.wl_log:
                 logger.info(
-                    f"会话 ID {event.unified_msg_origin} 不在会话白名单中，已终止事件传播。请在配置文件中添加该会话 ID 到白名单。",
+                    f"Session ID {event.unified_msg_origin} is not in the session "
+                    "allowlist, so event propagation was stopped. Add this session "
+                    "ID to the allowlist in the configuration file.",
                 )
             event.stop_event()

--- a/astrbot/core/platform/manager.py
+++ b/astrbot/core/platform/manager.py
@@ -22,7 +22,7 @@ class PlatformTasks:
 class PlatformManager:
     def __init__(self, config: AstrBotConfig, event_queue: Queue) -> None:
         self.platform_insts: list[Platform] = []
-        """加载的 Platform 的实例"""
+        """Loaded Platform instances."""
 
         self._inst_map: dict[str, dict] = {}
         self._platform_tasks: dict[str, PlatformTasks] = {}
@@ -30,9 +30,11 @@ class PlatformManager:
         self.astrbot_config = config
         self.platforms_config = config["platform"]
         self.settings = config["platform_settings"]
-        """NOTE: 这里是 default 的配置文件，以保证最大的兼容性；
-        这个配置中的 unique_session 需要特殊处理，
-        约定整个项目中对 unique_session 的引用都从 default 的配置中获取"""
+        """The default configuration is used here for maximum compatibility.
+
+        The unique_session setting requires special handling. All references to
+        unique_session in the project must use the default configuration.
+        """
         self.event_queue = event_queue
 
     def _is_valid_platform_id(self, platform_id: str | None) -> bool:
@@ -76,7 +78,7 @@ class PlatformManager:
                     raise
                 except Exception as e:
                     logger.error(
-                        "终止平台适配器失败: client_id=%s, error=%s",
+                        "Failed to terminate platform adapter: client_id=%s, error=%s",
                         client_id,
                         e,
                     )
@@ -92,7 +94,7 @@ class PlatformManager:
                     self.astrbot_config.save_config()
                 await self.load_platform(platform)
             except Exception as e:
-                logger.error(f"初始化 {platform} 平台适配器失败: {e}")
+                logger.error(f"Failed to initialize platform adapter {platform}: {e}")
 
         # 网页聊天
         webchat_inst = WebChatAdapter({}, self.settings, self.event_queue)
@@ -110,7 +112,8 @@ class PlatformManager:
                 sanitized_id, changed = self._sanitize_platform_id(platform_id)
                 if sanitized_id and changed:
                     logger.warning(
-                        "平台 ID %r 包含非法字符 ':' 或 '!'，已替换为 %r。",
+                        "Platform ID %r contains invalid ':' or '!' characters and "
+                        "was changed to %r.",
                         platform_id,
                         sanitized_id,
                     )
@@ -118,7 +121,8 @@ class PlatformManager:
                     self.astrbot_config.save_config()
                 else:
                     logger.error(
-                        f"平台 ID {platform_id!r} 不能为空，跳过加载该平台适配器。",
+                        f"Platform ID {platform_id!r} cannot be empty; skipping "
+                        "the platform adapter.",
                     )
                     return
 
@@ -196,10 +200,14 @@ class PlatformManager:
                     )
         except (ImportError, ModuleNotFoundError) as e:
             logger.error(
-                f"加载平台适配器 {platform_config['type']} 失败，原因：{e}。请检查依赖库是否安装。提示：可以在 管理面板->平台日志->安装Pip库 中安装依赖库。",
+                f"Failed to load platform adapter {platform_config['type']}: {e}. "
+                "Check whether its dependencies are installed. You can install "
+                "them from Dashboard -> Logs -> Install Pip Package.",
             )
         except Exception as e:
-            logger.error(f"加载平台适配器 {platform_config['type']} 失败，原因：{e}。")
+            logger.error(
+                f"Failed to load platform adapter {platform_config['type']}: {e}."
+            )
 
         if platform_config["type"] not in platform_cls_map:
             logger.error(
@@ -244,7 +252,7 @@ class PlatformManager:
         except Exception as e:
             error_msg = str(e)
             tb_str = traceback.format_exc()
-            logger.error(f"------- 任务 {task.get_name()} 发生错误: {e}")
+            logger.error(f"------- Task {task.get_name()} failed: {e}")
             for line in tb_str.split("\n"):
                 logger.error(f"|    {line}")
             logger.error("-------")
@@ -266,7 +274,7 @@ class PlatformManager:
 
     async def terminate_platform(self, platform_id: str) -> None:
         if platform_id in self._inst_map:
-            logger.info(f"正在尝试终止 {platform_id} 平台适配器 ...")
+            logger.info(f"Attempting to terminate platform adapter {platform_id} ...")
 
             # client_id = self._inst_map.pop(platform_id, None)
             info = self._inst_map.pop(platform_id)
@@ -281,7 +289,9 @@ class PlatformManager:
                     ),
                 )
             except Exception:
-                logger.warning(f"可能未完全移除 {platform_id} 平台适配器")
+                logger.warning(
+                    f"Platform adapter {platform_id} may not have been fully removed."
+                )
 
             await self._terminate_inst_and_tasks(inst)
 
@@ -328,7 +338,7 @@ class PlatformManager:
                     error_count += 1
             except Exception as e:
                 # 如果获取统计信息失败，记录基本信息
-                logger.warning(f"获取平台统计信息失败: {e}")
+                logger.warning(f"Failed to get platform statistics: {e}")
                 stats_list.append(
                     {
                         "id": getattr(inst, "config", {}).get("id", "unknown"),

--- a/astrbot/core/provider/manager.py
+++ b/astrbot/core/provider/manager.py
@@ -50,28 +50,28 @@ class ProviderManager:
         self.default_persona_name = persona_mgr.default_persona
 
         self.provider_insts: list[Provider] = []
-        """加载的 Provider 的实例"""
+        """Loaded Provider instances."""
         self.stt_provider_insts: list[STTProvider] = []
-        """加载的 Speech To Text Provider 的实例"""
+        """Loaded speech-to-text Provider instances."""
         self.tts_provider_insts: list[TTSProvider] = []
-        """加载的 Text To Speech Provider 的实例"""
+        """Loaded text-to-speech Provider instances."""
         self.embedding_provider_insts: list[EmbeddingProvider] = []
-        """加载的 Embedding Provider 的实例"""
+        """Loaded Embedding Provider instances."""
         self.rerank_provider_insts: list[RerankProvider] = []
-        """加载的 Rerank Provider 的实例"""
+        """Loaded Rerank Provider instances."""
         self.inst_map: dict[
             str,
             Providers,
         ] = {}
-        """Provider 实例映射. key: provider_id, value: Provider 实例"""
+        """Provider instance map. Key: provider_id; value: Provider instance."""
         self.llm_tools = llm_tools
 
         self.curr_provider_inst: Provider | None = None
-        """默认的 Provider 实例。已弃用，请使用 get_using_provider() 方法获取当前使用的 Provider 实例。"""
+        """Default Provider instance. Deprecated; use get_using_provider()."""
         self.curr_stt_provider_inst: STTProvider | None = None
-        """默认的 Speech To Text Provider 实例。已弃用，请使用 get_using_provider() 方法获取当前使用的 Provider 实例。"""
+        """Default speech-to-text Provider. Deprecated; use get_using_provider()."""
         self.curr_tts_provider_inst: TTSProvider | None = None
-        """默认的 Text To Speech Provider 实例。已弃用，请使用 get_using_provider() 方法获取当前使用的 Provider 实例。"""
+        """Default text-to-speech Provider. Deprecated; use get_using_provider()."""
         self.db_helper = db_helper
         self._provider_change_callback: (
             Callable[[str, ProviderType, str | None], None] | None
@@ -107,7 +107,7 @@ class ProviderManager:
                 self._provider_change_callback(provider_id, provider_type, umo)
             except Exception as e:
                 logger.warning(
-                    "调用 provider 变更回调失败: provider_id=%s, type=%s, err=%s",
+                    "Provider change callback failed: provider_id=%s, type=%s, err=%s",
                     provider_id,
                     provider_type,
                     safe_error("", e),
@@ -119,7 +119,7 @@ class ProviderManager:
                 hook(provider_id, provider_type, umo)
             except Exception as e:
                 logger.warning(
-                    "调用 provider 变更钩子失败: provider_id=%s, type=%s, err=%s",
+                    "Provider change hook failed: provider_id=%s, type=%s, err=%s",
                     provider_id,
                     provider_type,
                     safe_error("", e),
@@ -157,7 +157,9 @@ class ProviderManager:
 
         """
         if provider_id not in self.inst_map:
-            raise ValueError(f"提供商 {provider_id} 不存在，无法设置。")
+            raise ValueError(
+                f"Provider {provider_id} does not exist and cannot be set."
+            )
         if umo:
             await sp.session_put(
                 umo,
@@ -269,7 +271,8 @@ class ProviderManager:
 
         if not provider and provider_id:
             logger.warning(
-                f"没有找到 ID 为 {provider_id} 的提供商，这可能是由于您修改了提供商（模型）ID 导致的。"
+                f"Provider {provider_id} was not found. Its provider or model ID "
+                "may have been changed."
             )
 
         return provider
@@ -566,7 +569,9 @@ class ProviderManager:
                     if env_val is None:
                         provider_id = provider_config.get("id")
                         logger.warning(
-                            f"Provider {provider_id} 配置项 key[{idx}] 使用环境变量 {env_key} 但未设置。",
+                            f"Provider {provider_id} configuration key[{idx}] "
+                            f"references environment variable {env_key}, but it is "
+                            "not set.",
                         )
                         resolved_keys.append("")
                     else:
@@ -602,13 +607,15 @@ class ProviderManager:
             self.dynamic_import_provider(provider_config["type"])
         except (ImportError, ModuleNotFoundError) as e:
             logger.critical(
-                f"加载 {provider_config['type']}({provider_config['id']}) 提供商适配器失败：{e}。可能是因为有未安装的依赖。",
+                f"Failed to load provider adapter {provider_config['type']}"
+                f"({provider_config['id']}): {e}. A dependency may be missing.",
                 exc_info=True,
             )
             return
         except Exception as e:
             logger.critical(
-                f"加载 {provider_config['type']}({provider_config['id']}) 提供商适配器失败：{e}。未知原因",
+                f"Failed to load provider adapter {provider_config['type']}"
+                f"({provider_config['id']}): {e}. Unknown cause.",
                 exc_info=True,
             )
             return
@@ -625,7 +632,7 @@ class ProviderManager:
             # 按任务实例化提供商
             cls_type = provider_metadata.cls_type
             if not cls_type:
-                logger.error(f"无法找到 {provider_metadata.type} 的类")
+                logger.error(f"Could not find a class for {provider_metadata.type}")
                 return
 
             provider_metadata.id = provider_config["id"]
@@ -725,16 +732,18 @@ class ProviderManager:
                     # 未知供应商抛出异常，确保inst初始化
                     # Should be unreachable
                     raise Exception(
-                        f"未知的提供商类型：{provider_metadata.provider_type}"
+                        f"Unknown provider type: {provider_metadata.provider_type}"
                     )
 
             self.inst_map[provider_config["id"]] = inst
         except Exception as e:
             logger.error(
-                f"实例化 {provider_config['type']}({provider_config['id']}) 提供商适配器失败：{e}",
+                f"Failed to instantiate provider adapter {provider_config['type']}"
+                f"({provider_config['id']}): {e}",
             )
             raise Exception(
-                f"实例化 {provider_config['type']}({provider_config['id']}) 提供商适配器失败：{e}",
+                f"Failed to instantiate provider adapter {provider_config['type']}"
+                f"({provider_config['id']}): {e}",
             )
 
     async def reload(self, provider_config: dict) -> None:
@@ -757,7 +766,8 @@ class ProviderManager:
             elif self.curr_provider_inst is None and len(self.provider_insts) > 0:
                 self.curr_provider_inst = self.provider_insts[0]
                 logger.info(
-                    f"自动选择 {self.curr_provider_inst.meta().id} 作为当前提供商适配器。",
+                    f"Automatically selected {self.curr_provider_inst.meta().id} "
+                    "as the current provider adapter.",
                 )
 
             if len(self.stt_provider_insts) == 0:
@@ -767,7 +777,8 @@ class ProviderManager:
             ):
                 self.curr_stt_provider_inst = self.stt_provider_insts[0]
                 logger.info(
-                    f"自动选择 {self.curr_stt_provider_inst.meta().id} 作为当前语音转文本提供商适配器。",
+                    f"Automatically selected {self.curr_stt_provider_inst.meta().id} "
+                    "as the current speech-to-text provider adapter.",
                 )
 
             if len(self.tts_provider_insts) == 0:
@@ -777,7 +788,8 @@ class ProviderManager:
             ):
                 self.curr_tts_provider_inst = self.tts_provider_insts[0]
                 logger.info(
-                    f"自动选择 {self.curr_tts_provider_inst.meta().id} 作为当前文本转语音提供商适配器。",
+                    f"Automatically selected {self.curr_tts_provider_inst.meta().id} "
+                    "as the current text-to-speech provider adapter.",
                 )
 
     def get_insts(self):
@@ -786,7 +798,9 @@ class ProviderManager:
     async def terminate_provider(self, provider_id: str) -> None:
         if provider_id in self.inst_map:
             logger.info(
-                f"终止 {provider_id} 提供商适配器({len(self.provider_insts)}, {len(self.stt_provider_insts)}, {len(self.tts_provider_insts)}) ...",
+                f"Terminating provider adapter {provider_id} "
+                f"({len(self.provider_insts)}, {len(self.stt_provider_insts)}, "
+                f"{len(self.tts_provider_insts)}) ...",
             )
 
             if self.inst_map[provider_id] in self.provider_insts:
@@ -813,7 +827,9 @@ class ProviderManager:
                 await self.inst_map[provider_id].terminate()  # type: ignore
 
             logger.info(
-                f"{provider_id} 提供商适配器已终止({len(self.provider_insts)}, {len(self.stt_provider_insts)}, {len(self.tts_provider_insts)})",
+                f"Provider adapter {provider_id} terminated "
+                f"({len(self.provider_insts)}, {len(self.stt_provider_insts)}, "
+                f"{len(self.tts_provider_insts)})",
             )
             del self.inst_map[provider_id]
 
@@ -837,7 +853,7 @@ class ProviderManager:
                     prov for prov in config["provider"] if prov.get("id") != tpid
                 ]
             config.save_config()
-            logger.info(f"Provider {target_prov_ids} 已从配置中删除。")
+            logger.info(f"Providers {target_prov_ids} were removed from configuration.")
 
     async def update_provider(self, origin_provider_id: str, new_config: dict) -> None:
         """Update provider config and reload the instance. Config will be saved after update."""

--- a/astrbot/core/star/command_management.py
+++ b/astrbot/core/star/command_management.py
@@ -263,7 +263,8 @@ def _collect_descriptors(include_sub_commands: bool) -> list[CommandDescriptor]:
             descriptors.append(desc)
         except Exception as e:
             logger.warning(
-                f"解析指令处理函数 {handler.handler_full_name} 失败，跳过该指令。原因: {e!s}"
+                f"Failed to parse command handler {handler.handler_full_name}; "
+                f"skipping the command: {e!s}"
             )
             continue
     return descriptors

--- a/astrbot/core/star/context.py
+++ b/astrbot/core/star/context.py
@@ -401,7 +401,8 @@ class Context:
         prov = self.provider_manager.inst_map.get(provider_id)
         if provider_id and not prov:
             logger.warning(
-                f"没有找到 ID 为 {provider_id} 的提供商，这可能是由于您修改了提供商（模型）ID 导致的。"
+                f"Provider {provider_id} was not found. Its provider or model ID "
+                "may have been changed."
             )
         return prov
 
@@ -561,7 +562,7 @@ class Context:
             )
 
             if tool.name in tool_name:
-                logger.warning("替换已存在的 LLM 工具: " + tool.name)
+                logger.warning("Replacing existing LLM tool: " + tool.name)
                 self.provider_manager.llm_tools.remove_func(tool.name)
             self.provider_manager.llm_tools.func_list.append(tool)
 

--- a/astrbot/core/star/register/star_handler.py
+++ b/astrbot/core/star/register/star_handler.py
@@ -96,11 +96,14 @@ def register_command(
             command_name.parent_group.add_sub_command_filter(new_command)
         else:
             logger.warning(
-                f"注册指令{command_name} 的子指令时未提供 sub_command 参数。",
+                f"No sub_command argument was provided while registering a "
+                f"subcommand for {command_name}.",
             )
     # 裸指令
     elif command_name is None:
-        logger.warning("注册裸指令时未提供 command_name 参数。")
+        logger.warning(
+            "No command_name argument was provided while registering a bare command."
+        )
     else:
         new_command = CommandFilter(command_name, alias, None)
         add_to_event_filters = True
@@ -213,7 +216,10 @@ def register_command_group(
     if isinstance(command_group_name, RegisteringCommandable):
         # 子指令组
         if sub_command is None:
-            logger.warning(f"{command_group_name} 指令组的子指令组 sub_command 未指定")
+            logger.warning(
+                f"No sub_command was specified for a subgroup of command group "
+                f"{command_group_name}."
+            )
         else:
             new_group = CommandGroupFilter(
                 sub_command,
@@ -223,7 +229,7 @@ def register_command_group(
             command_group_name.parent_group.add_sub_command_filter(new_group)
     # 根指令组
     elif command_group_name is None:
-        logger.warning("根指令组的名称未指定")
+        logger.warning("No name was specified for the root command group.")
     else:
         new_group = CommandGroupFilter(command_group_name, alias)
 

--- a/astrbot/core/star/session_llm_manager.py
+++ b/astrbot/core/star/session_llm_manager.py
@@ -136,7 +136,8 @@ class SessionServiceManager:
         )
 
         logger.info(
-            f"会话 {session_id} 的TTS状态已更新为: {'启用' if enabled else '禁用'}",
+            f"TTS status for session {session_id} was updated to "
+            f"{'enabled' if enabled else 'disabled'}.",
         )
 
     @staticmethod

--- a/astrbot/core/star/session_plugin_manager.py
+++ b/astrbot/core/star/session_plugin_manager.py
@@ -93,7 +93,8 @@ class SessionPluginManager:
             # 检查插件是否在当前会话中启用
             if plugin.name in disabled_plugins:
                 logger.debug(
-                    f"插件 {plugin.name} 在会话 {session_id} 中被禁用，跳过处理器 {handler.handler_name}",
+                    f"Plugin {plugin.name} is disabled in session {session_id}; "
+                    f"skipping handler {handler.handler_name}.",
                 )
             else:
                 filtered_handlers.append(handler)

--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -58,7 +58,9 @@ try:
     from watchfiles import PythonFilter, awatch
 except ImportError:
     if os.getenv("ASTRBOT_RELOAD", "0") == "1":
-        logger.warning("未安装 watchfiles，无法实现插件的热重载。")
+        logger.warning(
+            "watchfiles is not installed, so plugin hot reloading is unavailable."
+        )
 
 
 class PluginVersionUnsupportedError(Exception):
@@ -75,7 +77,7 @@ class PluginDependencyInstallError(Exception):
         requirements_path: str,
         error: Exception,
     ) -> None:
-        message = f"插件 {plugin_label} 依赖安装失败: {error!s}"
+        message = f"Failed to install dependencies for plugin {plugin_label}: {error!s}"
         super().__init__(message)
         self.plugin_label = plugin_label
         self.requirements_path = requirements_path
@@ -125,7 +127,8 @@ def _temporary_filtered_requirements_file(
                 os.remove(filtered_requirements_path)
             except OSError as exc:
                 logger.warning(
-                    "删除临时插件依赖文件失败：%s（路径：%s）",
+                    "Failed to remove the temporary plugin requirements file: %s "
+                    "(path: %s)",
                     exc,
                     filtered_requirements_path,
                 )
@@ -140,20 +143,26 @@ async def _install_requirements_with_precheck(
 
     if install_plan is None:
         logger.info(
-            f"正在安装插件 {plugin_label} 的依赖库（缺失依赖预检查不可裁剪，回退到完整安装）: "
+            f"Installing dependencies for plugin {plugin_label}; the missing-"
+            "dependency precheck could not safely reduce the requirements, so "
+            "the complete requirements file will be installed: "
             f"{requirements_path}"
         )
         await pip_installer.install(requirements_path=requirements_path)
         return
 
     if not install_plan.missing_names:
-        logger.info(f"插件 {plugin_label} 的依赖已满足，跳过安装。")
+        logger.info(
+            f"Dependencies for plugin {plugin_label} are already satisfied; "
+            "skipping installation."
+        )
         return
 
     if not install_plan.install_lines:
         fallback_reason = install_plan.fallback_reason or "unknown reason"
         logger.info(
-            "检测到插件 %s 缺失依赖，但无法安全裁剪 requirements，回退到完整安装: %s (%s)",
+            "Plugin %s has missing dependencies, but its requirements could not "
+            "be safely reduced; installing the complete requirements file: %s (%s)",
             plugin_label,
             requirements_path,
             fallback_reason,
@@ -165,7 +174,8 @@ async def _install_requirements_with_precheck(
         return
 
     logger.info(
-        f"检测到插件 {plugin_label} 缺失依赖，正在按 requirements.txt 安装: "
+        f"Plugin {plugin_label} has missing dependencies; installing them from "
+        "requirements.txt: "
         f"{requirements_path} -> {sorted(install_plan.missing_names)}"
     )
 
@@ -224,12 +234,12 @@ class PluginManager:
         except asyncio.CancelledError:
             pass
         except Exception as e:
-            logger.error(f"插件热重载监视任务异常: {e!s}")
+            logger.error(f"Plugin hot-reload watcher failed: {e!s}")
             logger.error(traceback.format_exc())
 
     async def _handle_file_changes(self, changes) -> None:
         """处理文件变化"""
-        logger.info(f"检测到文件变化: {changes}")
+        logger.info(f"Detected file changes: {changes}")
         plugins_to_check = []
 
         for star in star_registry:
@@ -257,7 +267,9 @@ class PluginManager:
                     == os.path.commonpath([plugin_dir_path, file_path])
                     and plugin_name not in reloaded_plugins
                 ):
-                    logger.info(f"检测到插件 {plugin_name} 文件变化，正在重载...")
+                    logger.info(
+                        f"Detected file changes for plugin {plugin_name}; reloading."
+                    )
                     await self.reload(plugin_name)
                     reloaded_plugins.add(plugin_name)
                     break
@@ -286,7 +298,9 @@ class PluginManager:
                 elif os.path.exists(os.path.join(path, d, d + ".py")):
                     module_str = d
                 else:
-                    logger.info(f"插件 {d} 未找到 main.py 或者 {d}.py，跳过。")
+                    logger.info(
+                        f"Plugin {d} has neither main.py nor {d}.py; skipping it."
+                    )
                     continue
                 if os.path.exists(os.path.join(path, d, "main.py")) or os.path.exists(
                     os.path.join(path, d, d + ".py"),
@@ -348,7 +362,7 @@ class PluginManager:
         except asyncio.CancelledError:
             raise
         except DependencyConflictError as e:
-            logger.error(f"插件 {plugin_label} 依赖冲突: {e!s}")
+            logger.error(f"Dependency conflict in plugin {plugin_label}: {e!s}")
             raise
         except Exception as e:
             dependency_error = PluginDependencyInstallError(
@@ -394,19 +408,22 @@ class PluginManager:
     ) -> ModuleType | None:
         try:
             logger.info(
-                f"插件 {root_dir_name} 导入失败，尝试从已安装依赖恢复: {import_exc!s}"
+                f"Plugin {root_dir_name} failed to import; attempting recovery "
+                f"from installed dependencies: {import_exc!s}"
             )
             pip_installer.prefer_installed_dependencies(
                 requirements_path=requirements_path
             )
             module = __import__(path, fromlist=[module_str])
             logger.info(
-                f"插件 {root_dir_name} 已从 site-packages 恢复依赖，跳过重新安装。"
+                f"Plugin {root_dir_name} recovered its dependencies from "
+                "site-packages; skipping reinstallation."
             )
             return module
         except (ImportError, ModuleNotFoundError) as recover_exc:
             logger.info(
-                f"插件 {root_dir_name} 已安装依赖恢复失败，将重新安装依赖: {recover_exc!s}"
+                f"Plugin {root_dir_name} could not recover from installed "
+                f"dependencies; reinstalling them: {recover_exc!s}"
             )
             return None
 
@@ -431,7 +448,8 @@ class PluginManager:
                 )
             except Exception as preload_exc:
                 logger.info(
-                    f"插件 {root_dir_name} 预加载已安装依赖失败，将继续常规导入: {preload_exc!s}"
+                    f"Plugin {root_dir_name} could not preload installed "
+                    f"dependencies; continuing with a normal import: {preload_exc!s}"
                 )
 
         try:
@@ -455,7 +473,8 @@ class PluginManager:
             ):
                 assert recovery_state.install_plan is not None
                 logger.info(
-                    "插件 %s 预检查检测到版本不匹配，跳过已安装依赖恢复: %s",
+                    "The precheck for plugin %s found version mismatches; skipping "
+                    "recovery from installed dependencies: %s",
                     root_dir_name,
                     sorted(recovery_state.install_plan.version_mismatch_names),
                 )
@@ -555,7 +574,9 @@ class PluginManager:
                 if not file_path.is_file():
                     continue
                 if file_path.stat().st_size > 1024 * 1024:
-                    logger.warning("插件 i18n 文件超过 1MB，已跳过: %s", file_path)
+                    logger.warning(
+                        "Plugin i18n file exceeds 1 MB and was skipped: %s", file_path
+                    )
                     continue
 
                 try:
@@ -565,13 +586,16 @@ class PluginManager:
                         translations[locale] = locale_data
                     else:
                         logger.warning(
-                            "插件 i18n 文件内容不是 JSON object，已跳过: %s",
+                            "Plugin i18n file does not contain a JSON object and was "
+                            "skipped: %s",
                             file_path,
                         )
                 except Exception as exc:
-                    logger.warning("加载插件 i18n 文件失败 %s: %s", file_path, exc)
+                    logger.warning(
+                        "Failed to load plugin i18n file %s: %s", file_path, exc
+                    )
         except OSError as exc:
-            logger.warning("读取插件 i18n 目录失败 %s: %s", i18n_dir, exc)
+            logger.warning("Failed to read plugin i18n directory %s: %s", i18n_dir, exc)
 
         return translations
 
@@ -728,7 +752,7 @@ class PluginManager:
                 for key in list(sys.modules.keys()):
                     if key.startswith(pattern):
                         del sys.modules[key]
-                        logger.debug(f"删除模块 {key}")
+                        logger.debug(f"Removed module {key}")
 
         if root_dir_name:
             for module_name in self._get_plugin_related_modules(
@@ -737,9 +761,9 @@ class PluginManager:
             ):
                 try:
                     del sys.modules[module_name]
-                    logger.debug(f"删除模块 {module_name}")
+                    logger.debug(f"Removed module {module_name}")
                 except KeyError:
-                    logger.warning(f"模块 {module_name} 未载入")
+                    logger.warning(f"Module {module_name} is not loaded")
 
     def _cleanup_plugin_state(self, dir_name: str, is_reserved: bool = False) -> None:
         plugin_root_name = "astrbot.builtin_stars." if is_reserved else "data.plugins."
@@ -748,7 +772,7 @@ class PluginManager:
         # 清理 sys.modules
         for key in list(sys.modules.keys()):
             if self._is_plugin_module_path(key, module_prefix):
-                logger.info(f"清除了插件{dir_name}中的{key}模块")
+                logger.info(f"Removed module {key} from plugin {dir_name}")
                 del sys.modules[key]
 
         # Clean plugin metadata registered before a failed load completes.
@@ -759,30 +783,32 @@ class PluginManager:
                 star_map.pop(module_path, None)
                 if metadata in star_registry:
                     star_registry.remove(metadata)
-                logger.info(f"清理插件元数据: {module_path}")
+                logger.info(f"Removed plugin metadata: {module_path}")
 
         for metadata in list(star_registry):
             if self._is_plugin_module_path(metadata.module_path, module_prefix) or (
                 metadata.root_dir_name == dir_name and metadata.reserved == is_reserved
             ):
                 star_registry.remove(metadata)
-                logger.info(f"清理插件注册项: {metadata.name or dir_name}")
+                logger.info(
+                    f"Removed plugin registry entry: {metadata.name or dir_name}"
+                )
 
         # 清理 handlers
         for handler in list(star_handlers_registry):
             if self._is_plugin_module_path(handler.handler_module_path, module_prefix):
                 star_handlers_registry.remove(handler)
-                logger.info(f"清理处理器: {handler.handler_name}")
+                logger.info(f"Removed handler: {handler.handler_name}")
 
         # 清理工具
         for tool in list(llm_tools.func_list):
             handler_module_path = getattr(tool, "handler_module_path", None)
             if self._is_plugin_module_path(handler_module_path, module_prefix):
                 llm_tools.func_list.remove(tool)
-                logger.info(f"清理工具: {tool.name}")
+                logger.info(f"Removed tool: {tool.name}")
 
         for adapter_name in unregister_platform_adapters_by_module(module_prefix):
-            logger.info(f"清理平台适配器: {adapter_name}")
+            logger.info(f"Removed platform adapter: {adapter_name}")
 
     def _build_failed_plugin_record(
         self,
@@ -818,7 +844,8 @@ class PluginManager:
                 )
         except Exception as metadata_error:
             logger.debug(
-                f"读取失败插件 {root_dir_name} 元数据失败: {metadata_error!s}",
+                f"Failed to read metadata for failed plugin {root_dir_name}: "
+                f"{metadata_error!s}",
             )
 
         return record
@@ -1010,7 +1037,8 @@ class PluginManager:
                     except Exception as e:
                         logger.warning(traceback.format_exc())
                         logger.warning(
-                            f"插件 {smd.name} 未被正常终止: {e!s}, 可能会导致该插件运行不正常。",
+                            f"Plugin {smd.name} did not terminate cleanly: {e!s}. "
+                            "The plugin may not work correctly.",
                         )
                     if smd.name and smd.module_path:
                         await self._unbind_plugin(smd.name, smd.module_path)
@@ -1027,7 +1055,8 @@ class PluginManager:
                     except Exception as e:
                         logger.warning(traceback.format_exc())
                         logger.warning(
-                            f"插件 {smd.name} 未被正常终止: {e!s}, 可能会导致该插件运行不正常。",
+                            f"Plugin {smd.name} did not terminate cleanly: {e!s}. "
+                            "The plugin may not work correctly.",
                         )
                     if smd.name and smd.activated:
                         await self._unbind_plugin(smd.name, specified_module_path)
@@ -1105,7 +1134,7 @@ class PluginManager:
                 except Exception as e:
                     error_trace = traceback.format_exc()
                     logger.error(error_trace)
-                    logger.error(f"插件 {root_dir_name} 导入失败。原因：{e!s}")
+                    logger.error(f"Failed to import plugin {root_dir_name}: {e!s}")
                     has_load_error = True
                     self.failed_plugin_dict[root_dir_name] = (
                         self._build_failed_plugin_record(
@@ -1159,7 +1188,8 @@ class PluginManager:
                             metadata.i18n = metadata_yaml.i18n
                     except Exception as e:
                         logger.warning(
-                            f"插件 {root_dir_name} 元数据载入失败: {e!s}。使用默认元数据。",
+                            f"Failed to load metadata for plugin {root_dir_name}: "
+                            f"{e!s}. Using default metadata.",
                         )
 
                     if not ignore_version_check:
@@ -1275,7 +1305,8 @@ class PluginManager:
                 else:
                     # v3.4.0 以前的方式注册插件
                     logger.debug(
-                        f"插件 {path} 未通过装饰器注册。尝试通过旧版本方式载入。",
+                        f"Plugin {path} was not registered with the decorator; "
+                        "attempting the legacy loading method.",
                     )
                     classes = self._get_classes(module)
                     if not classes:
@@ -1376,7 +1407,8 @@ class PluginManager:
                             )
 
                         logger.debug(
-                            f"插入权限过滤器 {cmd_type} 到 {metadata.name} 的 {handler.handler_name} 方法。",
+                            f"Inserted permission filter {cmd_type} into "
+                            f"{metadata.name}.{handler.handler_name}.",
                         )
 
                 metadata.star_handler_full_names = full_names
@@ -1399,7 +1431,7 @@ class PluginManager:
                         logger.error(traceback.format_exc())
 
             except BaseException as e:
-                logger.error(f"----- 插件 {root_dir_name} 载入失败 -----")
+                logger.error(f"----- Failed to load plugin {root_dir_name} -----")
                 errors = traceback.format_exc()
                 for line in errors.split("\n"):
                     logger.error(f"| {line}")
@@ -1435,7 +1467,7 @@ class PluginManager:
         try:
             await sync_command_configs()
         except Exception as e:
-            logger.error(f"同步指令配置失败: {e!s}")
+            logger.error(f"Failed to synchronize command configuration: {e!s}")
             logger.error(traceback.format_exc())
 
         self._rebuild_failed_plugin_info()
@@ -1467,10 +1499,13 @@ class PluginManager:
         if os.path.exists(plugin_path):
             try:
                 remove_dir(plugin_path)
-                logger.warning(f"已清理安装失败的插件目录: {plugin_path}")
+                logger.warning(
+                    f"Removed directory for the failed plugin installation: {plugin_path}"
+                )
             except Exception as e:
                 logger.warning(
-                    f"清理安装失败插件目录失败: {plugin_path}，原因: {e!s}",
+                    "Failed to remove the directory for the failed plugin "
+                    f"installation {plugin_path}: {e!s}",
                 )
 
         plugin_config_path = os.path.join(
@@ -1480,10 +1515,14 @@ class PluginManager:
         if os.path.exists(plugin_config_path):
             try:
                 os.remove(plugin_config_path)
-                logger.warning(f"已清理安装失败插件配置: {plugin_config_path}")
+                logger.warning(
+                    "Removed configuration for the failed plugin installation: "
+                    f"{plugin_config_path}"
+                )
             except Exception as e:
                 logger.warning(
-                    f"清理安装失败插件配置失败: {plugin_config_path}，原因: {e!s}",
+                    "Failed to remove configuration for the failed plugin "
+                    f"installation {plugin_config_path}: {e!s}",
                 )
 
     async def _cleanup_plugin_optional_artifacts(
@@ -1503,9 +1542,14 @@ class PluginManager:
             if os.path.exists(config_file):
                 try:
                     os.remove(config_file)
-                    logger.info(f"已删除插件 {plugin_label} 的配置文件")
+                    logger.info(
+                        f"Deleted the configuration file for plugin {plugin_label}"
+                    )
                 except Exception as e:
-                    logger.warning(f"删除插件配置文件失败 ({plugin_label}): {e!s}")
+                    logger.warning(
+                        f"Failed to delete the plugin configuration file "
+                        f"({plugin_label}): {e!s}"
+                    )
 
         if delete_data:
             data_base_dir = os.path.dirname(self.plugin_store_path)
@@ -1519,19 +1563,25 @@ class PluginManager:
                     try:
                         remove_dir(plugin_data_dir)
                         logger.info(
-                            f"已删除插件 {plugin_label} 的持久化数据 ({data_dir_name})",
+                            f"Deleted persistent data for plugin {plugin_label} "
+                            f"({data_dir_name})",
                         )
                     except Exception as e:
                         logger.warning(
-                            f"删除插件持久化数据失败 ({data_dir_name}, {plugin_label}): {e!s}",
+                            "Failed to delete persistent plugin data "
+                            f"({data_dir_name}, {plugin_label}): {e!s}",
                         )
 
             if plugin_id:
                 try:
                     await self.context.get_db().clear_preferences("plugin", plugin_id)
-                    logger.info(f"已清除插件 {plugin_label}({plugin_id}) 的 KV 数据")
+                    logger.info(
+                        f"Cleared KV data for plugin {plugin_label} ({plugin_id})"
+                    )
                 except Exception as e:
-                    logger.warning(f"清除插件 KV 数据失败 ({plugin_label}): {e!s}")
+                    logger.warning(
+                        f"Failed to clear plugin KV data ({plugin_label}): {e!s}"
+                    )
 
     def _track_failed_install_dir(
         self,
@@ -1662,7 +1712,7 @@ class PluginManager:
                             readme_content = f.read()
                     except Exception as e:
                         logger.warning(
-                            f"读取插件 {dir_name} 的 README.md 文件失败: {e!s}",
+                            f"Failed to read README.md for plugin {dir_name}: {e!s}",
                         )
 
                 plugin_info = None
@@ -1682,7 +1732,8 @@ class PluginManager:
                 )
                 if dir_name and plugin_path:
                     logger.warning(
-                        f"安装插件 {dir_name} 失败，插件安装目录：{plugin_path}",
+                        f"Failed to install plugin {dir_name}; installation "
+                        f"directory: {plugin_path}",
                     )
                 raise
 
@@ -1718,7 +1769,8 @@ class PluginManager:
             except Exception as e:
                 logger.warning(traceback.format_exc())
                 logger.warning(
-                    f"插件 {plugin_name} 未被正常终止 {e!s}, 可能会导致资源泄露等问题。",
+                    f"Plugin {plugin_name} did not terminate cleanly: {e!s}. "
+                    "This may cause resource leaks.",
                 )
 
             # 从 star_registry 和 star_map 中删除
@@ -1779,7 +1831,9 @@ class PluginManager:
                     )
             else:
                 logger.debug(
-                    "插件目录不存在，视为已部分卸载状态，继续清理失败插件记录和可选产物: %s",
+                    "The plugin directory does not exist, indicating a partial "
+                    "uninstall. Continuing to clean the failed-plugin record and "
+                    "optional artifacts: %s",
                     plugin_path,
                 )
 
@@ -1823,7 +1877,8 @@ class PluginManager:
             plugin_module_path,
         ):
             logger.info(
-                f"移除了插件 {plugin_name} 的处理函数 {handler.handler_name} ({len(star_handlers_registry)})",
+                f"Removed handler {handler.handler_name} from plugin {plugin_name} "
+                f"({len(star_handlers_registry)})",
             )
             star_handlers_registry.remove(handler)
 
@@ -1856,7 +1911,7 @@ class PluginManager:
             )
             for adapter_name in unregistered_adapters:
                 logger.info(
-                    f"移除了插件 {plugin_name} 的平台适配器 {adapter_name}",
+                    f"Removed platform adapter {adapter_name} from plugin {plugin_name}",
                 )
 
         if plugin is None:
@@ -1915,11 +1970,14 @@ class PluginManager:
     @staticmethod
     async def _terminate_plugin(star_metadata: StarMetadata) -> None:
         """终止插件，调用插件的 terminate() 和 __del__() 方法"""
-        logger.info(f"正在终止插件 {star_metadata.name} ...")
+        logger.info(f"Terminating plugin {star_metadata.name} ...")
 
         if not star_metadata.activated:
             # 说明之前已经被禁用了
-            logger.debug(f"插件 {star_metadata.name} 未被激活，不需要终止，跳过。")
+            logger.debug(
+                f"Plugin {star_metadata.name} is inactive and does not need to be "
+                "terminated; skipping it."
+            )
             return
 
         if star_metadata.star_cls is None:
@@ -1937,7 +1995,7 @@ class PluginManager:
                     return
                 if (exc := fut.exception()) is not None:
                     logger.error(
-                        "插件 %s 在 __del__ 中抛出了异常：%r",
+                        "Plugin %s raised an exception in __del__: %r",
                         star_metadata.name,
                         exc,
                     )
@@ -2008,7 +2066,7 @@ class PluginManager:
             try:
                 os.remove(zip_file_path)
             except BaseException as e:
-                logger.warning(f"删除插件压缩包失败: {e!s}")
+                logger.warning(f"Failed to delete the plugin archive: {e!s}")
             await self._ensure_plugin_requirements(desti_dir, dir_name)
             # await self.reload()
             success, error_message = await self.load(
@@ -2041,7 +2099,9 @@ class PluginManager:
                     with open(readme_path, encoding="utf-8") as f:
                         readme_content = f.read()
                 except Exception as e:
-                    logger.warning(f"读取插件 {dir_name} 的 README.md 文件失败: {e!s}")
+                    logger.warning(
+                        f"Failed to read README.md for plugin {dir_name}: {e!s}"
+                    )
 
             plugin_info = None
             if plugin:
@@ -2068,7 +2128,8 @@ class PluginManager:
                     error=e,
                 )
             logger.warning(
-                f"安装插件 {dir_name} 失败，插件安装目录：{desti_dir}",
+                f"Failed to install plugin {dir_name}; installation directory: "
+                f"{desti_dir}",
             )
             raise
         finally:
@@ -2079,5 +2140,6 @@ class PluginManager:
                     remove_dir(temp_desti_dir)
                 except Exception as e:
                     logger.warning(
-                        f"清理临时插件解压目录失败: {temp_desti_dir}，原因: {e!s}",
+                        "Failed to remove the temporary plugin extraction directory "
+                        f"{temp_desti_dir}: {e!s}",
                     )

--- a/astrbot/core/updator.py
+++ b/astrbot/core/updator.py
@@ -61,16 +61,19 @@ class AstrBotUpdator(RepoZipUpdator):
         try:
             parent = psutil.Process(os.getpid())
             children = parent.children(recursive=True)
-            logger.info(f"正在终止 {len(children)} 个子进程。")
+            logger.info(f"Terminating {len(children)} child processes.")
             for child in children:
-                logger.info(f"正在终止子进程 {child.pid}")
+                logger.info(f"Terminating child process {child.pid}")
                 child.terminate()
                 try:
                     child.wait(timeout=3)
                 except psutil.NoSuchProcess:
                     continue
                 except psutil.TimeoutExpired:
-                    logger.info(f"子进程 {child.pid} 没有被正常终止, 正在强行杀死。")
+                    logger.info(
+                        f"Child process {child.pid} did not terminate cleanly; "
+                        "killing it."
+                    )
                     child.kill()
         except psutil.NoSuchProcess:
             pass
@@ -165,7 +168,9 @@ class AstrBotUpdator(RepoZipUpdator):
             reboot_argv = self._build_reboot_argv(executable)
             self._exec_reboot(executable, reboot_argv)
         except Exception as e:
-            logger.error(f"重启失败（{executable}, {e}），请尝试手动重启。")
+            logger.error(
+                f"Restart failed ({executable}, {e}). Try restarting manually."
+            )
             raise e
 
     async def check_update(
@@ -239,7 +244,7 @@ class AstrBotUpdator(RepoZipUpdator):
         if latest:
             latest_version = update_data[0]["tag_name"]
             if self.compare_version(VERSION, latest_version) >= 0:
-                raise Exception("当前已经是最新版本。")
+                raise Exception("AstrBot is already up to date.")
             target_version = latest_version
             file_url = update_data[0]["zipball_url"]
         elif str(version).startswith("v"):
@@ -249,12 +254,12 @@ class AstrBotUpdator(RepoZipUpdator):
                     target_version = data["tag_name"]
                     file_url = data["zipball_url"]
             if not file_url:
-                raise Exception(f"未找到版本号为 {version} 的更新文件。")
+                raise Exception(f"No update package was found for version {version}.")
         else:
             if len(str(version)) != 40:
-                raise Exception("commit hash 长度不正确，应为 40")
+                raise Exception("The commit hash must be 40 characters long.")
             file_url = f"https://github.com/AstrBotDevs/AstrBot/archive/{version}.zip"
-        logger.info(f"准备更新至指定版本的 AstrBot Core: {version}")
+        logger.info(f"Preparing to update AstrBot Core to version {version}")
 
         if proxy:
             proxy = proxy.removesuffix("/")
@@ -266,7 +271,8 @@ class AstrBotUpdator(RepoZipUpdator):
         if hosted_package_url:
             try:
                 logger.info(
-                    f"优先从托管存储下载 AstrBot Core 更新包: {hosted_package_url}"
+                    "Attempting to download the AstrBot Core update package from "
+                    f"hosted storage first: {hosted_package_url}"
                 )
                 await self._download_file(
                     hosted_package_url,
@@ -280,8 +286,8 @@ class AstrBotUpdator(RepoZipUpdator):
                 return zip_path
             except Exception as exc:
                 logger.warning(
-                    f"从托管存储下载 AstrBot Core 更新包失败: {exc}，"
-                    "将回退到当前更新源。"
+                    "Failed to download the AstrBot Core update package from hosted "
+                    f"storage: {exc}. Falling back to the current update source."
                 )
 
         await self._download_file(
@@ -304,5 +310,5 @@ class AstrBotUpdator(RepoZipUpdator):
             Exception: If the archive cannot be extracted or applied.
         """
 
-        logger.info("下载 AstrBot Core 更新文件完成，正在执行解压...")
+        logger.info("AstrBot Core update package downloaded; extracting the archive.")
         self.unzip_file(str(zip_path), self.MAIN_PATH)

--- a/astrbot/core/utils/io.py
+++ b/astrbot/core/utils/io.py
@@ -67,21 +67,24 @@ def ensure_dir(dir_path: str | Path) -> None:
     """确保目录存在。如果路径处存在非目录的文件或损坏的符号链接，则先将其删除。"""
     p = Path(dir_path)
     if (p.exists() or p.is_symlink()) and not p.is_dir():
-        logger.warning(f"路径 {p} 已存在但不是目录，正在清理以创建目录。")
+        logger.warning(
+            f"Path {p} exists but is not a directory; removing it before creating "
+            "the directory."
+        )
         try:
             if p.is_dir():
                 shutil.rmtree(p, onerror=on_error)
             else:
                 p.unlink()
         except Exception as e:
-            logger.error(f"清理冲突路径 {p} 失败: {e!s}")
-            raise RuntimeError(f"无法清理冲突路径 {p}：{e!s}") from e
+            logger.error(f"Failed to remove conflicting path {p}: {e!s}")
+            raise RuntimeError(f"Could not remove conflicting path {p}: {e!s}") from e
 
     try:
         p.mkdir(parents=True, exist_ok=True)
     except Exception as e:
-        logger.error(f"创建目录 {p} 失败: {e!s}")
-        raise RuntimeError(f"无法创建目录 {p}：{e!s}") from e
+        logger.error(f"Failed to create directory {p}: {e!s}")
+        raise RuntimeError(f"Could not create directory {p}: {e!s}") from e
 
 
 def port_checker(port: int, host: str = "localhost") -> bool:

--- a/astrbot/core/utils/network_utils.py
+++ b/astrbot/core/utils/network_utils.py
@@ -79,11 +79,13 @@ def log_connection_failure(
 
     if effective_proxy:
         logger.error(
-            f"[{provider_label}] 网络/代理连接失败 ({error_type})。"
-            f"代理地址: {effective_proxy}，错误: {error}"
+            f"[{provider_label}] Network or proxy connection failed ({error_type}). "
+            f"Proxy: {effective_proxy}; error: {error}"
         )
     else:
-        logger.error(f"[{provider_label}] 网络连接失败 ({error_type})。错误: {error}")
+        logger.error(
+            f"[{provider_label}] Network connection failed ({error_type}): {error}"
+        )
 
 
 def create_proxy_client(
@@ -117,7 +119,7 @@ def create_proxy_client(
     """
     resolved_verify = _SYSTEM_SSL_CTX if verify is None else verify
     if proxy:
-        logger.info(f"[{provider_label}] 使用代理: {proxy}")
+        logger.info(f"[{provider_label}] Using proxy: {proxy}")
         return httpx_module.AsyncClient(
             proxy=proxy, verify=resolved_verify, headers=headers
         )

--- a/astrbot/core/utils/pip_installer.py
+++ b/astrbot/core/utils/pip_installer.py
@@ -458,24 +458,26 @@ def _classify_pip_failure(output_lines: list[str]) -> DependencyConflictError | 
     detail = ""
     if context.constraint_lines and context.requested_lines:
         detail = (
-            " 冲突详情: "
+            " Conflict details: "
             f"{_normalize_conflict_detail_line(context.requested_lines[0])} vs "
-            f"{_normalize_conflict_detail_line(context.constraint_lines[0])}。"
+            f"{_normalize_conflict_detail_line(context.constraint_lines[0])}."
         )
     elif len(context.dependency_detail_lines) >= 2:
         detail = (
-            " 冲突详情: "
+            " Conflict details: "
             f"{_normalize_conflict_detail_line(context.dependency_detail_lines[0])} vs "
-            f"{_normalize_conflict_detail_line(context.dependency_detail_lines[1])}。"
+            f"{_normalize_conflict_detail_line(context.dependency_detail_lines[1])}."
         )
 
     if is_core_conflict:
         message = (
-            f"检测到核心依赖版本保护冲突。{detail}插件要求的依赖版本与 AstrBot 核心不兼容，"
-            "为了系统稳定，已阻止该降级行为。请联系插件作者或调整 requirements.txt。"
+            f"A core dependency version protection conflict was detected.{detail} "
+            "The dependency version required by the plugin is incompatible with "
+            "AstrBot Core. The downgrade was blocked to preserve system stability. "
+            "Contact the plugin author or adjust requirements.txt."
         )
     else:
-        message = f"检测到依赖冲突。{detail}"
+        message = f"A dependency conflict was detected.{detail}"
 
     return DependencyConflictError(
         message,
@@ -518,7 +520,10 @@ def _collect_candidate_modules(
             canonical_name = _canonicalize_distribution_name(distribution_name)
             by_name.setdefault(canonical_name, []).append(distribution)
     except Exception as exc:
-        logger.warning("读取 site-packages 元数据失败，使用回退模块名: %s", exc)
+        logger.warning(
+            "Failed to read site-packages metadata; using fallback module names: %s",
+            exc,
+        )
 
     expanded_requirement_names: set[str] = set()
     pending = deque(requirement_names)
@@ -581,8 +586,9 @@ def _ensure_preferred_modules(
 
     if unresolved_modules:
         conflict_message = (
-            "检测到插件依赖与当前运行时发生冲突，无法安全加载该插件。"
-            f"冲突模块: {', '.join(unresolved_modules)}"
+            "A conflict between plugin dependencies and the current runtime was "
+            "detected, so the plugin cannot be loaded safely. "
+            f"Conflicting modules: {', '.join(unresolved_modules)}"
         )
         raise RuntimeError(conflict_message)
 
@@ -995,7 +1001,10 @@ class PipInstaller:
             package_name, requirements_path, mirror
         )
         if not args:
-            logger.info("Pip 包管理器跳过安装：未提供有效的包名或 requirements 文件。")
+            logger.info(
+                "The pip package manager skipped installation because no valid "
+                "package name or requirements file was provided."
+            )
             return
 
         target_site_packages = None
@@ -1020,7 +1029,7 @@ class PipInstaller:
                 args.extend(["-c", constraints_file_path])
 
             logger.info(
-                "Pip 包管理器 argv: %s",
+                "Pip package manager argv: %s",
                 ["pip", *_redact_pip_args_for_logging(args)],
             )
             await self._run_pip_with_classification(args)
@@ -1077,4 +1086,7 @@ class PipInstaller:
     async def _run_pip_with_classification(self, args: list[str]) -> None:
         result_code = await self._run_pip_in_process(args)
         if result_code != 0:
-            raise PipInstallError(f"安装失败，错误码：{result_code}", code=result_code)
+            raise PipInstallError(
+                f"Installation failed with error code {result_code}",
+                code=result_code,
+            )

--- a/astrbot/core/zip_updator.py
+++ b/astrbot/core/zip_updator.py
@@ -31,7 +31,10 @@ class ReleaseInfo:
         self.body = body
 
     def __str__(self) -> str:
-        return f"\n{self.body}\n\n版本: {self.version} | 发布于: {self.published_at}"
+        return (
+            f"\n{self.body}\n\nVersion: {self.version} | "
+            f"Published at: {self.published_at}"
+        )
 
 
 class RepoZipUpdator:
@@ -71,7 +74,12 @@ class RepoZipUpdator:
                 response.raise_for_status()
                 repo_info = response.json()
         except Exception as exc:
-            logger.debug("获取 GitHub 默认分支失败 %s/%s: %s", author, repo, exc)
+            logger.debug(
+                "Failed to get the default GitHub branch for %s/%s: %s",
+                author,
+                repo,
+                exc,
+            )
             return None
 
         default_branch = str(repo_info.get("default_branch") or "").strip()
@@ -100,7 +108,11 @@ class RepoZipUpdator:
         if default_branch:
             return author, repo, default_branch
 
-        logger.info("未能获取 %s/%s 的默认分支，将尝试 main 分支", author, repo)
+        logger.info(
+            "Could not get the default branch for %s/%s; trying the main branch.",
+            author,
+            repo,
+        )
         return author, repo, "main"
 
     async def _download_file(
@@ -163,7 +175,7 @@ class RepoZipUpdator:
                         },
                     )
         except Exception as e:
-            logger.error(f"下载文件失败: {url} -> {target_path}, 错误: {e}")
+            logger.error(f"Failed to download file: {url} -> {target_path}: {e}")
             if self.rm_on_error and target_path.exists():
                 target_path.unlink()
             raise
@@ -199,12 +211,13 @@ class RepoZipUpdator:
             if e.response is not None:
                 response_body = self._truncate_response_body(e.response.text)
                 logger.error(
-                    f"请求 {url} 失败，状态码: {e.response.status_code}, 内容: {response_body}",
+                    f"Request to {url} failed with status "
+                    f"{e.response.status_code}; response: {response_body}",
                 )
-            raise Exception("解析版本信息失败") from e
+            raise Exception("Failed to parse release information.") from e
         except Exception as e:
-            logger.error(f"解析版本信息时发生异常: {e}")
-            raise Exception("解析版本信息失败") from e
+            logger.error(f"An error occurred while parsing release information: {e}")
+            raise Exception("Failed to parse release information.") from e
         return ret
 
     def github_api_release_parser(self, releases: list) -> list:
@@ -260,7 +273,7 @@ class RepoZipUpdator:
                 break
 
         if not sel_release_data or not tag_name:
-            logger.error("未找到合适的发布版本")
+            logger.error("No suitable release was found.")
             return None
 
         if self.compare_version(current_version, tag_name) >= 0:
@@ -276,8 +289,8 @@ class RepoZipUpdator:
     ) -> None:
         author, repo, branch = await self.resolve_github_source_branch(repo_url)
 
-        logger.info(f"正在下载更新 {repo} ...")
-        logger.info(f"正在从分支 {branch} 下载 {author}/{repo}")
+        logger.info(f"Downloading update for {repo} ...")
+        logger.info(f"Downloading {author}/{repo} from branch {branch}")
         release_url = (
             f"https://github.com/{author}/{repo}/archive/refs/heads/{branch}.zip"
         )
@@ -286,7 +299,8 @@ class RepoZipUpdator:
             proxy = proxy.rstrip("/")
             release_url = f"{proxy}/{release_url}"
             logger.info(
-                f"检查到设置了镜像站，将使用镜像站下载 {author}/{repo} 仓库源码: {release_url}",
+                f"A mirror is configured; downloading the {author}/{repo} source "
+                f"from the mirror: {release_url}",
             )
 
         await self._download_file(release_url, target_path + ".zip")
@@ -307,7 +321,7 @@ class RepoZipUpdator:
             repo = match.group(2)
             branch = match.group(4)
             return author, repo, branch
-        raise ValueError("无效的 GitHub URL")
+        raise ValueError("Invalid GitHub URL")
 
     def unzip_file(self, zip_path: str, target_dir: str) -> None:
         """解压缩文件, 并将压缩包内**第一个**文件夹内的文件移动到 target_dir"""
@@ -315,7 +329,7 @@ class RepoZipUpdator:
         with zipfile.ZipFile(zip_path, "r") as z:
             update_dir = self._resolve_archive_root_dir(z.namelist())
             z.extractall(target_dir)
-        logger.debug(f"解压文件完成: {zip_path}")
+        logger.debug(f"Finished extracting archive: {zip_path}")
 
         self._finalize_extracted_archive(zip_path, target_dir, update_dir)
 
@@ -370,7 +384,9 @@ class RepoZipUpdator:
             try:
                 os.remove(zip_path)
             except Exception:
-                logger.warning(f"删除更新文件失败，可以手动删除 {zip_path}")
+                logger.warning(
+                    f"Failed to delete the update file; delete it manually: {zip_path}"
+                )
             return
 
         update_root_path = _join_under_root(target_root_path, update_dir)
@@ -387,12 +403,15 @@ class RepoZipUpdator:
             shutil.move(update_item_path, target_root_path)
 
         try:
-            logger.debug(f"删除临时更新文件: {zip_path} 和 {update_root_path}")
+            logger.debug(
+                f"Deleting temporary update files: {zip_path} and {update_root_path}"
+            )
             shutil.rmtree(update_root_path, onerror=on_error)
             os.remove(zip_path)
         except Exception:
             logger.warning(
-                f"删除更新文件失败，可以手动删除 {zip_path} 和 {update_root_path}"
+                "Failed to delete the update files; delete them manually: "
+                f"{zip_path} and {update_root_path}"
             )
 
     def format_name(self, name: str) -> str:

--- a/astrbot/dashboard/services/plugin_service.py
+++ b/astrbot/dashboard/services/plugin_service.py
@@ -289,7 +289,7 @@ class PluginService:
             self._logo_cache[logo_path] = token
             return token
         except Exception as exc:
-            logger.warning(f"获取插件 Logo 失败: {exc}")
+            logger.warning(f"Failed to get the plugin logo: {exc}")
             return None
 
     def resolve_plugin_metadata_dir(self, plugin: StarMetadata) -> Path | None:
@@ -317,7 +317,9 @@ class PluginService:
                 timezone.utc,
             ).isoformat()
         except OSError as exc:
-            logger.warning(f"获取插件安装时间失败 {plugin.name}: {exc!s}")
+            logger.warning(
+                f"Failed to get the installation time for plugin {plugin.name}: {exc!s}"
+            )
             return None
 
     @staticmethod
@@ -577,7 +579,10 @@ class PluginService:
             plugin_name = str(plugin_info.get("name") or "").strip()
         plugin = self.find_plugin_by_name(plugin_name)
         if not plugin or not plugin.root_dir_name:
-            logger.warning("插件安装成功，但无法记录安装来源：缺少插件元数据。")
+            logger.warning(
+                "The plugin was installed, but its installation source could not "
+                "be recorded because plugin metadata is missing."
+            )
             return
 
         registry_name = await self.resolve_registry_name(payload.get("registry_url"))
@@ -806,7 +811,7 @@ class PluginService:
                 show_sandbox_path=False,
             )
         except Exception as exc:
-            logger.warning(f"获取插件 Skills 失败 {plugin.name}: {exc!s}")
+            logger.warning(f"Failed to get skills for plugin {plugin.name}: {exc!s}")
             return []
 
         components = []
@@ -974,7 +979,9 @@ class PluginService:
         if not force_refresh and await self.is_cache_valid(source):
             cached_data = self.load_plugin_cache(source.cache_file)
             if cached_data:
-                logger.debug("缓存MD5匹配，使用缓存的插件市场数据")
+                logger.debug(
+                    "The cached MD5 matches; using cached plugin marketplace data."
+                )
                 return cached_data, None
 
         remote_data = None
@@ -1000,11 +1007,14 @@ class PluginService:
                         if not remote_data or (
                             isinstance(remote_data, dict) and len(remote_data) == 0
                         ):
-                            logger.warning(f"远程插件市场数据为空: {url}")
+                            logger.warning(
+                                f"Remote plugin marketplace data is empty: {url}"
+                            )
                             continue
 
                         logger.info(
-                            f"成功获取远程插件市场数据，包含 {len(remote_data)} 个插件"
+                            "Fetched remote plugin marketplace data successfully; "
+                            f"received {len(remote_data)} plugins."
                         )
                         current_md5 = await self.fetch_remote_md5(source.md5_url)
                         self.save_plugin_cache(
@@ -1013,15 +1023,19 @@ class PluginService:
                             current_md5,
                         )
                         return remote_data, None
-                    logger.error(f"请求 {url} 失败，状态码：{response.status}")
+                    logger.error(
+                        f"Request to {url} failed with status {response.status}."
+                    )
             except Exception as exc:
-                logger.error(f"请求 {url} 失败，错误：{exc}")
+                logger.error(f"Request to {url} failed: {exc}")
 
         if not cached_data:
             cached_data = self.load_plugin_cache(source.cache_file)
 
         if cached_data:
-            logger.warning("远程插件市场数据获取失败，使用缓存数据")
+            logger.warning(
+                "Failed to fetch remote plugin marketplace data; using cached data."
+            )
             return cached_data, "使用缓存数据，可能不是最新版本"
 
         raise PluginServiceError("获取插件列表失败，且没有可用的缓存数据")
@@ -1115,7 +1129,7 @@ class PluginService:
             return is_valid
 
         except Exception as exc:
-            logger.warning(f"检查缓存有效性失败: {exc}")
+            logger.warning(f"Failed to validate the plugin marketplace cache: {exc}")
             return False
 
     @staticmethod
@@ -1572,7 +1586,7 @@ class PluginService:
             proxy = proxy.removesuffix("/")
 
         try:
-            logger.info(f"正在安装插件 {repo_url}")
+            logger.info(f"Installing plugin {repo_url}")
             plugin_info = await self.plugin_manager.install_plugin(
                 repo_url,
                 proxy or "",
@@ -1589,7 +1603,7 @@ class PluginService:
                 download_url=download_url,
             )
             await self.sync_skills_after_plugin_change()
-            logger.info(f"安装插件 {repo_url} 成功。")
+            logger.info(f"Installed plugin {repo_url} successfully.")
             return plugin_info or {}, "安装成功。"
         except PluginVersionUnsupportedError as exc:
             raise PluginServiceWarning(
@@ -1719,7 +1733,9 @@ class PluginService:
         except Exception as exc:
             if isinstance(exc, PluginServiceError):
                 raise
-            logger.warning("插件仓库校验失败 %s: %s", repo_url, exc)
+            logger.warning(
+                "Plugin repository validation failed for %s: %s", repo_url, exc
+            )
             raise PluginServiceError(
                 "插件校验失败",
                 public_message="插件校验失败，请查看服务端日志。",
@@ -1732,7 +1748,7 @@ class PluginService:
         ignore_version_check: bool,
     ) -> tuple[dict, str]:
         self._ensure_not_demo()
-        logger.info(f"正在安装用户上传的插件 {upload_file.filename}")
+        logger.info(f"Installing uploaded plugin {upload_file.filename}")
         filename = str(upload_file.filename or "plugin.zip").replace("\\", "/")
         file_path = os.path.join(
             get_astrbot_temp_path(),
@@ -1752,7 +1768,7 @@ class PluginService:
                 download_url="",
             )
             await self.sync_skills_after_plugin_change()
-            logger.info(f"安装插件 {upload_file.filename} 成功")
+            logger.info(f"Installed plugin {upload_file.filename} successfully.")
             return plugin_info or {}, "安装成功。"
         except PluginVersionUnsupportedError as exc:
             raise PluginServiceWarning(
@@ -1781,7 +1797,7 @@ class PluginService:
         plugin_name = payload["name"]
         delete_config = payload.get("delete_config", False)
         delete_data = payload.get("delete_data", False)
-        logger.info(f"正在卸载插件 {plugin_name}")
+        logger.info(f"Uninstalling plugin {plugin_name}")
         plugin = self.find_plugin_by_name(plugin_name)
         root_dir_name = plugin.root_dir_name if plugin else None
         await self.plugin_manager.uninstall_plugin(
@@ -1791,7 +1807,7 @@ class PluginService:
         )
         await self.remove_plugin_install_source(root_dir_name)
         await self.sync_skills_after_plugin_change()
-        logger.info(f"卸载插件 {plugin_name} 成功")
+        logger.info(f"Uninstalled plugin {plugin_name} successfully.")
         return None, "卸载成功"
 
     async def uninstall_failed_plugin(self, data: object) -> tuple[None, str]:
@@ -1803,14 +1819,14 @@ class PluginService:
         if not dir_name:
             raise PluginServiceError("缺少失败插件目录名")
 
-        logger.info(f"正在卸载失败插件 {dir_name}")
+        logger.info(f"Uninstalling failed plugin {dir_name}")
         await self.plugin_manager.uninstall_failed_plugin(
             dir_name,
             delete_config=delete_config,
             delete_data=delete_data,
         )
         await self.sync_skills_after_plugin_change()
-        logger.info(f"卸载失败插件 {dir_name} 成功")
+        logger.info(f"Uninstalled failed plugin {dir_name} successfully.")
         return None, "卸载成功"
 
     async def update_plugin(self, data: object) -> tuple[None, str]:
@@ -1820,14 +1836,14 @@ class PluginService:
         proxy: str | None = payload.get("proxy", None)
         update_info = await self.resolve_market_update_info(plugin_name)
         download_url = str(update_info.get("download_url") or "").strip()
-        logger.info(f"正在更新插件 {plugin_name}")
+        logger.info(f"Updating plugin {plugin_name}")
         await self.plugin_manager.update_plugin(
             plugin_name, proxy or "", download_url=download_url
         )
         await self.refresh_plugin_install_source_after_update(plugin_name, update_info)
         await self.plugin_manager.reload(plugin_name)
         await self.sync_skills_after_plugin_change()
-        logger.info(f"更新插件 {plugin_name} 成功。")
+        logger.info(f"Updated plugin {plugin_name} successfully.")
         return None, "更新成功。"
 
     async def update_all_plugins(self, data: object) -> tuple[dict, str]:
@@ -1845,7 +1861,7 @@ class PluginService:
         async def _update_one(name: str):
             async with sem:
                 try:
-                    logger.info(f"批量更新插件 {name}")
+                    logger.info(f"Updating plugin {name} as part of a batch update.")
                     update_info = await self.resolve_market_update_info(name)
                     download_url = str(update_info.get("download_url") or "").strip()
                     await self.plugin_manager.update_plugin(
@@ -1858,7 +1874,7 @@ class PluginService:
                     return {"name": name, "status": "ok", "message": "更新成功"}
                 except PluginServiceError as exc:
                     logger.error(
-                        f"/api/plugin/update-all: 更新插件 {name} 失败: {exc}",
+                        f"/api/plugin/update-all: Failed to update plugin {name}: {exc}",
                     )
                     return {
                         "name": name,
@@ -1867,7 +1883,7 @@ class PluginService:
                     }
                 except Exception:
                     logger.error(
-                        f"/api/plugin/update-all: 更新插件 {name} 失败",
+                        f"/api/plugin/update-all: Failed to update plugin {name}",
                         exc_info=True,
                     )
                     return {
@@ -1885,7 +1901,8 @@ class PluginService:
                 raise result
             if isinstance(result, BaseException):
                 logger.error(
-                    f"/api/plugin/update-all: 更新插件 {name} 任务失败: {result!r}"
+                    f"/api/plugin/update-all: Update task for plugin {name} failed: "
+                    f"{result!r}"
                 )
                 results.append(
                     {
@@ -1917,13 +1934,13 @@ class PluginService:
         if enabled:
             await self.plugin_manager.turn_on_plugin(plugin_name)
             message = "启用成功。"
-            log_action = "启用"
+            log_action = "Enabled"
         else:
             await self.plugin_manager.turn_off_plugin(plugin_name)
             message = "停用成功。"
-            log_action = "停用"
+            log_action = "Disabled"
         await self.sync_skills_after_plugin_change()
-        logger.info(f"{log_action}插件 {plugin_name} 。")
+        logger.info(f"{log_action} plugin {plugin_name}.")
         return None, message
 
     def resolve_plugin_dir(self, plugin_name: str) -> Path:
@@ -1955,14 +1972,14 @@ class PluginService:
 
     def get_plugin_readme(self, plugin_name: str | None) -> tuple[dict, str]:
         if not plugin_name:
-            logger.warning("插件名称为空")
+            logger.warning("The plugin name is empty.")
             raise PluginServiceError("插件名称不能为空")
 
         plugin_dir = self.resolve_plugin_dir(plugin_name)
         readme_path = plugin_dir / "README.md"
 
         if not readme_path.is_file():
-            logger.warning(f"插件 {plugin_name} 没有README文件")
+            logger.warning(f"Plugin {plugin_name} has no README file.")
             raise PluginServiceError(f"插件 {plugin_name} 没有README文件")
 
         try:
@@ -1970,7 +1987,7 @@ class PluginService:
                 "content": readme_path.read_text(encoding="utf-8")
             }, "成功获取README内容"
         except Exception as exc:
-            logger.warning(f"读取插件 {plugin_name} README 文件失败: {exc}")
+            logger.warning(f"Failed to read README for plugin {plugin_name}: {exc}")
             raise PluginServiceError(
                 "读取README文件失败",
                 public_message="读取README文件失败",
@@ -1983,9 +2000,9 @@ class PluginService:
         return self.get_plugin_readme(plugin_name)
 
     def get_plugin_changelog(self, plugin_name: str | None) -> tuple[dict, str]:
-        logger.debug(f"正在获取插件 {plugin_name} 的更新日志")
+        logger.debug(f"Getting the changelog for plugin {plugin_name}")
         if not plugin_name:
-            logger.warning("插件名称为空")
+            logger.warning("The plugin name is empty.")
             raise PluginServiceError("插件名称不能为空")
 
         plugin_dir = self.resolve_plugin_dir(plugin_name)
@@ -2000,13 +2017,15 @@ class PluginService:
                     "成功获取更新日志",
                 )
             except Exception as exc:
-                logger.warning(f"读取插件 {plugin_name} 更新日志失败: {exc}")
+                logger.warning(
+                    f"Failed to read the changelog for plugin {plugin_name}: {exc}"
+                )
                 raise PluginServiceError(
                     "读取更新日志失败",
                     public_message="读取更新日志失败",
                 ) from exc
 
-        logger.warning(f"插件 {plugin_name} 没有更新日志文件")
+        logger.warning(f"Plugin {plugin_name} has no changelog file.")
         return {"content": None}, "该插件没有更新日志文件"
 
     def get_plugin_changelog_from_dashboard_query(

--- a/main.py
+++ b/main.py
@@ -71,7 +71,7 @@ logo_tmpl = r"""
 
 def check_env() -> None:
     if not (sys.version_info.major == 3 and sys.version_info.minor >= 10):
-        logger.error("请使用 Python3.10+ 运行本项目。")
+        logger.error("Please run this project with Python 3.10 or later.")
         exit()
 
     astrbot_root = get_astrbot_root()
@@ -159,7 +159,7 @@ async def check_dashboard_files(webui_dir: str | None = None):
                 allow_insecure_ssl_fallback=False,
             )
         except Exception as e:
-            logger.critical(f"下载管理面板文件失败: {e}。")
+            logger.critical(f"Failed to download dashboard files: {e}.")
             if (data_dist_path / "index.html").is_file():
                 logger.warning(
                     "Falling back to existing data/dist WebUI %s even though core expects v%s. "
@@ -169,7 +169,7 @@ async def check_dashboard_files(webui_dir: str | None = None):
                 )
                 return str(data_dist_path)
             return None
-        logger.info("管理面板下载完成。")
+        logger.info("Dashboard download completed.")
         return str(data_dist_path)
 
     if is_dashboard_dist_compatible(bundled_dist, VERSION):
@@ -189,10 +189,10 @@ async def check_dashboard_files(webui_dir: str | None = None):
             allow_insecure_ssl_fallback=False,
         )
     except Exception as e:
-        logger.critical(f"下载管理面板文件失败: {e}。")
+        logger.critical(f"Failed to download dashboard files: {e}.")
         return None
 
-    logger.info("管理面板下载完成。")
+    logger.info("Dashboard download completed.")
     return str(data_dist_path)
 
 
@@ -202,8 +202,8 @@ async def main_async(webui_dir_arg: str | None) -> None:
     webui_dir = await check_dashboard_files(webui_dir_arg)
     if webui_dir is None:
         logger.warning(
-            "管理面板文件检查失败，WebUI 功能将不可用。"
-            "请检查网络连接或手动指定 --webui-dir 参数。"
+            "Dashboard file validation failed, so WebUI features will be unavailable. "
+            "Check the network connection or specify the --webui-dir argument manually."
         )
 
     db = db_helper

--- a/tests/test_pip_installer.py
+++ b/tests/test_pip_installer.py
@@ -699,7 +699,10 @@ async def test_install_raises_dedicated_pip_install_error_on_non_conflict_failur
 
     installer = PipInstaller("")
 
-    with pytest.raises(pip_installer_module.PipInstallError, match="错误码：2"):
+    with pytest.raises(
+        pip_installer_module.PipInstallError,
+        match="error code 2",
+    ):
         await installer.install(package_name="demo-package")
 
 
@@ -715,7 +718,10 @@ async def test_run_pip_with_classification_raises_install_error_on_non_conflict_
 
     installer = PipInstaller("")
 
-    with pytest.raises(pip_installer_module.PipInstallError, match="错误码：3"):
+    with pytest.raises(
+        pip_installer_module.PipInstallError,
+        match="error code 3",
+    ):
         await installer._run_pip_with_classification(["install", "demo-package"])
 
 
@@ -1827,7 +1833,9 @@ async def test_install_logs_redacted_pip_argv_when_credentials_present(monkeypat
         package_name="--index-url https://user:secret@example.com/simple demo-package"
     )
 
-    argv_logs = [line for line in logged_lines if line.startswith("Pip 包管理器 argv:")]
+    argv_logs = [
+        line for line in logged_lines if line.startswith("Pip package manager argv:")
+    ]
 
     assert len(argv_logs) == 1
     assert "secret" not in argv_logs[0]

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1085,7 +1085,7 @@ async def test_ensure_plugin_requirements_logs_requirements_file_install_for_mis
         TEST_PLUGIN_DIR,
     )
 
-    assert any("按 requirements.txt 安装" in line for line in logged_lines)
+    assert any("installing them from requirements.txt" in line for line in logged_lines)
 
 
 @pytest.mark.asyncio
@@ -1779,7 +1779,10 @@ async def test_ensure_plugin_requirements_does_not_mask_install_error_when_clean
             TEST_PLUGIN_DIR,
         )
 
-    assert any("删除临时插件依赖文件失败" in log for log in warning_logs)
+    assert any(
+        "Failed to remove the temporary plugin requirements file" in log
+        for log in warning_logs
+    )
 
 
 # --- Tests for plugin_id KV cleanup logic ---

--- a/tests/test_updator_socks.py
+++ b/tests/test_updator_socks.py
@@ -841,11 +841,11 @@ async def test_fetch_release_info_logs_status_code_and_truncated_body_on_http_er
         lambda message: log_messages.append(message),
     )
 
-    with pytest.raises(Exception, match="解析版本信息失败"):
+    with pytest.raises(Exception, match="Failed to parse release information"):
         await RepoZipUpdator().fetch_release_info(url)
 
-    assert any("状态码: 502" in message for message in log_messages)
-    assert any("内容: " in message for message in log_messages)
+    assert any("status 502" in message for message in log_messages)
+    assert any("response: " in message for message in log_messages)
     assert any("...[truncated]" in message for message in log_messages)
 
 


### PR DESCRIPTION
## Summary

- translate startup, pipeline, platform, provider, updater, and plugin-management logs to English
- translate related runtime error messages, content-safety feedback, and dependency-conflict diagnostics
- update affected tests to assert the English messages

## Why

Core operational logs mixed Chinese and English, which made diagnostics and support workflows inconsistent. This change standardizes the affected core and plugin-management paths on English without changing their control flow.

## Validation

- `uv run ruff format .`
- `uv run ruff check .`
- 334 focused tests covering startup, event bus, plugin management, dashboard, pip installer, updater, media, and file-token paths
- 115 focused tests covering platform/provider managers, lifecycle, knowledge-base resilience, and Dashboard provider paths
- AST scans confirmed no Chinese logger literals in scope and no Chinese runtime strings in the explicitly requested modules

## Summary by Sourcery

Standardize core logs, runtime errors, and content-safety messages on English while keeping behavior unchanged.

Enhancements:
- Translate plugin management, provider, platform, updater, pipeline, and startup log messages from Chinese to clear English phrasing.
- Align exception and diagnostic messages for dependency conflicts, file tokens, IO, and network failures with the new English logging language.
- Clarify docstrings and inline comments for provider and platform managers to reflect current behavior and configuration semantics.

Tests:
- Update plugin, updater, pip installer, and related tests to assert the new English log and error message text.