### PR TITLE
fix: return correct WebChat image MIME types

### DIFF
--- a/astrbot/dashboard/services/chat_service.py
+++ b/astrbot/dashboard/services/chat_service.py
@@ -36,6 +36,13 @@ from astrbot.core.utils.media_utils import (
 
 SSE_HEARTBEAT = ": heartbeat\n\n"
 CHAT_RUN_SUBSCRIBER_QUEUE_SIZE = 256
+WEBCHAT_IMAGE_MIME_TYPES = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+}
 
 
 def sanitize_upload_filename(filename: str | None) -> str:
@@ -504,13 +511,6 @@ class ChatService:
         self.webchat_img_dir = os.path.join(get_astrbot_data_path(), "webchat", "imgs")
         os.makedirs(self.attachments_dir, exist_ok=True)
 
-        self.supported_img_mime_types = {
-            ".jpg": "image/jpeg",
-            ".jpeg": "image/jpeg",
-            ".png": "image/png",
-            ".gif": "image/gif",
-            ".webp": "image/webp",
-        }
         self.conv_mgr = core_lifecycle.conversation_manager
         self.platform_history_mgr = core_lifecycle.platform_message_history_manager
         self.umop_config_router = core_lifecycle.umop_config_router
@@ -563,8 +563,8 @@ class ChatService:
         filename_ext = file_path.suffix.lower()
         if filename_ext == ".wav":
             return str(file_path), "audio/wav"
-        if filename_ext in self.supported_img_mime_types:
-            return str(file_path), self.supported_img_mime_types[filename_ext]
+        if filename_ext in WEBCHAT_IMAGE_MIME_TYPES:
+            return str(file_path), WEBCHAT_IMAGE_MIME_TYPES[filename_ext]
         return str(file_path), None
 
     async def resolve_webchat_file_from_dashboard_query(

--- a/astrbot/dashboard/services/chat_service.py
+++ b/astrbot/dashboard/services/chat_service.py
@@ -504,7 +504,13 @@ class ChatService:
         self.webchat_img_dir = os.path.join(get_astrbot_data_path(), "webchat", "imgs")
         os.makedirs(self.attachments_dir, exist_ok=True)
 
-        self.supported_imgs = ["jpg", "jpeg", "png", "gif", "webp"]
+        self.supported_img_mime_types = {
+            ".jpg": "image/jpeg",
+            ".jpeg": "image/jpeg",
+            ".png": "image/png",
+            ".gif": "image/gif",
+            ".webp": "image/webp",
+        }
         self.conv_mgr = core_lifecycle.conversation_manager
         self.platform_history_mgr = core_lifecycle.platform_message_history_manager
         self.umop_config_router = core_lifecycle.umop_config_router
@@ -557,8 +563,8 @@ class ChatService:
         filename_ext = file_path.suffix.lower()
         if filename_ext == ".wav":
             return str(file_path), "audio/wav"
-        if filename_ext[1:] in self.supported_imgs:
-            return str(file_path), "image/jpeg"
+        if filename_ext in self.supported_img_mime_types:
+            return str(file_path), self.supported_img_mime_types[filename_ext]
         return str(file_path), None
 
     async def resolve_webchat_file_from_dashboard_query(

--- a/tests/unit/test_webchat_upload_image_format.py
+++ b/tests/unit/test_webchat_upload_image_format.py
@@ -4,7 +4,10 @@ from types import SimpleNamespace
 import pytest
 from PIL import Image as PILImage
 
-from astrbot.dashboard.services.chat_service import ChatService
+from astrbot.dashboard.services.chat_service import (
+    WEBCHAT_IMAGE_MIME_TYPES,
+    ChatService,
+)
 
 
 @pytest.mark.asyncio
@@ -48,13 +51,7 @@ async def test_webchat_upload_uses_detected_image_type(tmp_path):
 
 @pytest.mark.parametrize(
     ("filename", "expected_mime_type"),
-    [
-        ("photo.jpg", "image/jpeg"),
-        ("photo.jpeg", "image/jpeg"),
-        ("photo.png", "image/png"),
-        ("photo.gif", "image/gif"),
-        ("photo.webp", "image/webp"),
-    ],
+    [(f"photo{ext}", mime_type) for ext, mime_type in WEBCHAT_IMAGE_MIME_TYPES.items()],
 )
 @pytest.mark.asyncio
 async def test_resolve_webchat_file_uses_image_extension_mime_type(

--- a/tests/unit/test_webchat_upload_image_format.py
+++ b/tests/unit/test_webchat_upload_image_format.py
@@ -44,3 +44,41 @@ async def test_webchat_upload_uses_detected_image_type(tmp_path):
     assert fake_db.inserted["type"] == "image"
     assert (tmp_path / result["filename"]).exists()
     assert not (tmp_path / "pasted.png").exists()
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected_mime_type"),
+    [
+        ("photo.jpg", "image/jpeg"),
+        ("photo.jpeg", "image/jpeg"),
+        ("photo.png", "image/png"),
+        ("photo.gif", "image/gif"),
+        ("photo.webp", "image/webp"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_resolve_webchat_file_uses_image_extension_mime_type(
+    tmp_path,
+    monkeypatch,
+    filename,
+    expected_mime_type,
+):
+    monkeypatch.setattr(
+        "astrbot.dashboard.services.chat_service.get_astrbot_data_path",
+        lambda: str(tmp_path),
+    )
+    service = ChatService(
+        SimpleNamespace(),
+        SimpleNamespace(
+            conversation_manager=None,
+            platform_message_history_manager=None,
+            umop_config_router=None,
+        ),
+    )
+    file_path = tmp_path / "attachments" / filename
+    file_path.write_bytes(b"image-bytes")
+
+    resolved_path, mime_type = await service.resolve_webchat_file(filename)
+
+    assert resolved_path == str(file_path.resolve(strict=False))
+    assert mime_type == expected_mime_type


### PR DESCRIPTION
﻿Fixes WebChat file responses so PNG, GIF, and WebP files are served with their real image MIME types instead of always using `image/jpeg`.

### Modifications / 改动点

#### What Problem This Solves

`ChatService.resolve_webchat_file()` treated every supported WebChat image extension as JPEG:

```py
if filename_ext[1:] in self.supported_imgs:
    return str(file_path), "image/jpeg"
```

That meant files such as `photo.png`, `photo.gif`, and `photo.webp` could be resolved successfully but then passed to `FileResponse(media_type="image/jpeg")`. The file bytes and filename stayed unchanged, but the HTTP `Content-Type` no longer matched the actual image format.

#### Changes

- Centralized the WebChat image extension-to-MIME mapping as `WEBCHAT_IMAGE_MIME_TYPES`, then reused that same mapping for runtime lookup and test parametrization.
- Kept the existing `.wav` handling, basename normalization, attachments directory lookup, WebChat fallback image directory lookup, and path boundary checks unchanged.
- Added a focused regression test that initializes `ChatService` and verifies each supported image extension resolves to the expected MIME type.

#### Possible call chain / impact

```text
GET /api/v1/files/content?filename=photo.png
  -> ChatService.resolve_webchat_file(filename)
    -> filename_ext = ".png"
    -> return (file_path, "image/png")
  -> FileResponse(file_path, media_type="image/png")

GET /api/chat/get_file?filename=photo.webp
  -> ChatService.resolve_webchat_file_from_dashboard_query(filename)
    -> ChatService.resolve_webchat_file(filename)
    -> return (file_path, "image/webp")
  -> FileResponse(file_path, media_type="image/webp")
```

This only changes the MIME header selected for WebChat image file responses. It does not change upload behavior, authentication, filename sanitization, path traversal protection, attachment database records, audio handling, or unknown-file fallback behavior.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

#### Evidence

Before this change, a minimal local reproduction showed a `.png` file being resolved as JPEG:

```text
('C:\\Users\\MiaoXing\\AppData\\Local\\Temp\\tmp8cdx8o_v\\demo.png', 'image/jpeg')
```

After this change, the regression test covers all supported WebChat image extensions:

```py
[
    ("photo.jpg", "image/jpeg"),
    ("photo.jpeg", "image/jpeg"),
    ("photo.png", "image/png"),
    ("photo.gif", "image/gif"),
    ("photo.webp", "image/webp"),
]
```

#### Validation

```text
uv run pytest tests/unit/test_webchat_upload_image_format.py -q
......                                                                   [100%]
6 passed, 1 warning in 3.53s
```

```text
uv run ruff check astrbot/dashboard/services/chat_service.py tests/unit/test_webchat_upload_image_format.py
All checks passed!
```

```text
uv run ruff format --check astrbot/dashboard/services/chat_service.py tests/unit/test_webchat_upload_image_format.py
2 files already formatted
```

```text
git diff --check
# no whitespace errors
```

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👖 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤸 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确认没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😷 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Correct WebChat file resolution to return accurate MIME types for supported image formats and cover the behavior with tests.

Bug Fixes:
- Serve WebChat image attachments with MIME types that match their actual file extensions instead of always using image/jpeg.

Tests:
- Add a regression test ensuring each supported WebChat image extension resolves to its correct MIME type.
