### PR TITLE
fix: reject non-200 image download responses

### DIFF
--- a/astrbot/core/utils/io.py
+++ b/astrbot/core/utils/io.py
@@ -113,6 +113,16 @@ def save_temp_img(img: Image.Image | bytes) -> str:
     return p
 
 
+async def _save_image_response(resp, url: str, path: str | None) -> str:
+    _raise_for_download_status(resp, url)
+    content = await resp.read()
+    if not path:
+        return save_temp_img(content)
+    with open(path, "wb") as f:
+        f.write(content)
+    return path
+
+
 async def download_image_by_url(
     url: str,
     post: bool = False,
@@ -131,18 +141,10 @@ async def download_image_by_url(
         ) as session:
             if post:
                 async with session.post(url, json=post_data) as resp:
-                    if not path:
-                        return save_temp_img(await resp.read())
-                    with open(path, "wb") as f:
-                        f.write(await resp.read())
-                    return path
+                    return await _save_image_response(resp, url, path)
             else:
                 async with session.get(url) as resp:
-                    if not path:
-                        return save_temp_img(await resp.read())
-                    with open(path, "wb") as f:
-                        f.write(await resp.read())
-                    return path
+                    return await _save_image_response(resp, url, path)
     except (aiohttp.ClientConnectorSSLError, aiohttp.ClientConnectorCertificateError):
         # 关闭SSL验证（仅在证书验证失败时作为fallback）
         logger.warning(
@@ -157,18 +159,10 @@ async def download_image_by_url(
         async with aiohttp.ClientSession() as session:
             if post:
                 async with session.post(url, json=post_data, ssl=ssl_context) as resp:
-                    if not path:
-                        return save_temp_img(await resp.read())
-                    with open(path, "wb") as f:
-                        f.write(await resp.read())
-                    return path
+                    return await _save_image_response(resp, url, path)
             else:
                 async with session.get(url, ssl=ssl_context) as resp:
-                    if not path:
-                        return save_temp_img(await resp.read())
-                    with open(path, "wb") as f:
-                        f.write(await resp.read())
-                    return path
+                    return await _save_image_response(resp, url, path)
     except Exception as e:
         raise e
 

--- a/astrbot/core/utils/io.py
+++ b/astrbot/core/utils/io.py
@@ -113,7 +113,11 @@ def save_temp_img(img: Image.Image | bytes) -> str:
     return p
 
 
-async def _save_image_response(resp, url: str, path: str | None) -> str:
+async def _save_image_response(
+    resp: aiohttp.ClientResponse,
+    url: str,
+    path: str | None,
+) -> str:
     _raise_for_download_status(resp, url)
     content = await resp.read()
     if not path:
@@ -163,8 +167,6 @@ async def download_image_by_url(
             else:
                 async with session.get(url, ssl=ssl_context) as resp:
                     return await _save_image_response(resp, url, path)
-    except Exception as e:
-        raise e
 
 
 async def _emit_download_progress(progress_callback, payload: dict) -> None:

--- a/tests/unit/test_io_download_file.py
+++ b/tests/unit/test_io_download_file.py
@@ -17,7 +17,11 @@ class _FakeResponse:
     def __init__(self, *, status: int, chunks: list[bytes]):
         self.status = status
         self.headers = {"content-length": str(sum(len(chunk) for chunk in chunks))}
+        self._body = b"".join(chunks)
         self.content = _FakeContent(chunks)
+
+    async def read(self) -> bytes:
+        return self._body
 
     async def __aenter__(self):
         return self
@@ -37,6 +41,11 @@ class _FakeSession:
         return False
 
     def get(self, *_args, **_kwargs):
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
+
+    def post(self, *_args, **_kwargs):
         if isinstance(self._response, Exception):
             raise self._response
         return self._response
@@ -105,3 +114,77 @@ async def test_download_file_writes_successful_response(monkeypatch, tmp_path):
     await io.download_file("https://example.test/ok.bin", str(target_path))
 
     assert target_path.read_bytes() == b"hello world"
+
+
+@pytest.mark.asyncio
+async def test_download_image_by_url_rejects_non_200_post_response(
+    monkeypatch,
+    tmp_path,
+):
+    target_path = tmp_path / "image.jpg"
+    _patch_download_session(
+        monkeypatch,
+        _FakeResponse(status=404, chunks=[b'{"error":"not found"}']),
+    )
+
+    with pytest.raises(io.DownloadFileHTTPError, match="HTTP status code: 404"):
+        await io.download_image_by_url(
+            "https://example.test/generate",
+            post=True,
+            post_data={"json": False},
+            path=str(target_path),
+        )
+
+    assert not target_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_download_image_by_url_rejects_non_200_response_after_ssl_fallback(
+    monkeypatch,
+    tmp_path,
+):
+    class FakeSSLError(Exception):
+        pass
+
+    target_path = tmp_path / "image.jpg"
+    _patch_download_sessions(
+        monkeypatch,
+        [
+            FakeSSLError(),
+            _FakeResponse(status=500, chunks=[b"server error"]),
+        ],
+    )
+    monkeypatch.setattr(io.aiohttp, "ClientConnectorSSLError", FakeSSLError)
+    monkeypatch.setattr(io.aiohttp, "ClientConnectorCertificateError", FakeSSLError)
+
+    with pytest.raises(io.DownloadFileHTTPError, match="HTTP status code: 500"):
+        await io.download_image_by_url(
+            "https://example.test/generate",
+            post=True,
+            post_data={"json": False},
+            path=str(target_path),
+        )
+
+    assert not target_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_download_image_by_url_writes_successful_post_response(
+    monkeypatch,
+    tmp_path,
+):
+    target_path = tmp_path / "image.jpg"
+    _patch_download_session(
+        monkeypatch,
+        _FakeResponse(status=200, chunks=[b"image bytes"]),
+    )
+
+    result = await io.download_image_by_url(
+        "https://example.test/generate",
+        post=True,
+        post_data={"json": False},
+        path=str(target_path),
+    )
+
+    assert result == str(target_path)
+    assert target_path.read_bytes() == b"image bytes"

--- a/tests/unit/test_io_download_file.py
+++ b/tests/unit/test_io_download_file.py
@@ -116,10 +116,12 @@ async def test_download_file_writes_successful_response(monkeypatch, tmp_path):
     assert target_path.read_bytes() == b"hello world"
 
 
+@pytest.mark.parametrize("post", [False, True])
 @pytest.mark.asyncio
-async def test_download_image_by_url_rejects_non_200_post_response(
+async def test_download_image_by_url_rejects_non_200_response(
     monkeypatch,
     tmp_path,
+    post,
 ):
     target_path = tmp_path / "image.jpg"
     _patch_download_session(
@@ -130,18 +132,20 @@ async def test_download_image_by_url_rejects_non_200_post_response(
     with pytest.raises(io.DownloadFileHTTPError, match="HTTP status code: 404"):
         await io.download_image_by_url(
             "https://example.test/generate",
-            post=True,
-            post_data={"json": False},
+            post=post,
+            post_data={"json": False} if post else None,
             path=str(target_path),
         )
 
     assert not target_path.exists()
 
 
+@pytest.mark.parametrize("post", [False, True])
 @pytest.mark.asyncio
 async def test_download_image_by_url_rejects_non_200_response_after_ssl_fallback(
     monkeypatch,
     tmp_path,
+    post,
 ):
     class FakeSSLError(Exception):
         pass
@@ -160,18 +164,20 @@ async def test_download_image_by_url_rejects_non_200_response_after_ssl_fallback
     with pytest.raises(io.DownloadFileHTTPError, match="HTTP status code: 500"):
         await io.download_image_by_url(
             "https://example.test/generate",
-            post=True,
-            post_data={"json": False},
+            post=post,
+            post_data={"json": False} if post else None,
             path=str(target_path),
         )
 
     assert not target_path.exists()
 
 
+@pytest.mark.parametrize("post", [False, True])
 @pytest.mark.asyncio
-async def test_download_image_by_url_writes_successful_post_response(
+async def test_download_image_by_url_writes_successful_response(
     monkeypatch,
     tmp_path,
+    post,
 ):
     target_path = tmp_path / "image.jpg"
     _patch_download_session(
@@ -181,8 +187,8 @@ async def test_download_image_by_url_writes_successful_post_response(
 
     result = await io.download_image_by_url(
         "https://example.test/generate",
-        post=True,
-        post_data={"json": False},
+        post=post,
+        post_data={"json": False} if post else None,
         path=str(target_path),
     )
 


### PR DESCRIPTION
﻿Reject unsuccessful HTTP image-download responses before writing them as local image files.

## What Problem This Solves

`download_image_by_url()` is used by the remote text-to-image path when `NetworkRenderStrategy.render_custom_template(..., return_url=False)` posts directly to a `/generate` endpoint and expects image bytes back.

Before this change, the helper read and saved the response body without checking `resp.status`. A failed HTTP response could therefore be persisted as if it were a valid image:

```text
NetworkRenderStrategy(..., return_url=False)
  -> download_image_by_url(..., post=True)
  -> HTTP 404 / 500 response from /generate
  -> await resp.read()
  -> save_temp_img(...) or write path
  -> caller receives a local image path containing an error body
```

That can make the later failure look like an image rendering/parsing problem instead of a download-boundary failure. This is related to the real T2I failure path reported in #7940, where remote T2I endpoints returned HTTP 404 during long-text image rendering.

## Change

This PR adds one shared image-response writer for `download_image_by_url()`:

- validate the response with the existing `_raise_for_download_status(resp, url)` helper before reading bytes
- reuse the existing `DownloadFileHTTPError` raised by `download_file()` for HTTP download failures
- preserve successful `200` behavior for both temp-image saves and caller-provided output paths
- apply the same status check to GET, POST, and the insecure SSL fallback branches

This intentionally does not change endpoint selection, retry/fallback behavior in `NetworkRenderStrategy`, or the broader `download_file()` helper that was already fixed separately.

## Evidence

Focused reproduction before the fix showed the POST path writing a JSON error body as a `.jpg` file:

```text
path_result= C:\Users\MiaoXing\AppData\Local\Temp\...\bad-image.bin
path_exists= True
path_bytes= b'{"error":"not found"}'
temp_result= D:\ZXY\Github\AstrBot\data\temp\io_temp_img_...jpg
temp_exists= True
temp_suffix= .jpg
temp_bytes= b'{"error":"not found"}'
```

The regression tests now cover both GET and POST image-download paths:

- rejecting a non-`200` GET or POST image response before creating the target file
- rejecting a non-`200` GET or POST response after the SSL fallback path
- preserving successful `200` GET and POST image writes

## Possible call chain / impact

```text
Long message text-to-image rendering
  -> NetworkRenderStrategy.render(..., return_url=False)
  -> NetworkRenderStrategy.render_custom_template(...)
  -> download_image_by_url(f"{endpoint}/generate", post=True, post_data=...)
  -> _raise_for_download_status(resp, url)
  -> save/write image bytes only for HTTP 200
```

The affected helper currently has a narrow call surface: the in-repository caller is the remote T2I image-byte path. Non-`200` responses now fail at the image download boundary so `NetworkRenderStrategy` can try the next endpoint or report that all endpoints failed. Successful image downloads keep the existing return value and file-writing behavior.

## Validation

- `uv run pytest tests/unit/test_io_download_file.py -q` -> `9 passed in 1.26s`
- `uv run ruff check astrbot/core/utils/io.py tests/unit/test_io_download_file.py` -> `All checks passed!`
- `uv run ruff format --check astrbot/core/utils/io.py tests/unit/test_io_download_file.py` -> `2 files already formatted`
- `git diff --check` -> passed

---

### Checklist / ????

- [x] ?? If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.  
  / No new feature is added; this is a narrow bug fix.

- [x] ?? My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.  
  / Focused pytest, Ruff check, Ruff format check, and `git diff --check` were run locally.

- [x] ?? I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.  
  / No new dependencies are introduced.

- [x] ?? My changes do not introduce malicious code.

## Summary by Sourcery

Validate HTTP responses in image download helper before saving content and add coverage for POST and SSL-fallback scenarios.

Bug Fixes:
- Prevent non-200 HTTP responses from being saved as image files in download_image_by_url, instead raising the existing HTTP download error.

Enhancements:
- Introduce a shared helper to validate and save image HTTP responses used by all download_image_by_url code paths.

Tests:
- Extend download tests with GET, POST, and SSL-fallback cases to ensure non-200 responses are rejected and successful 200 responses are written correctly.
