### PR TITLE
fix: WebChat子代理后台结果自动显示

### DIFF
--- a/dashboard/src/composables/useMessages.ts
+++ b/dashboard/src/composables/useMessages.ts
@@ -1552,6 +1552,6 @@ export function parseJsonSafe(value: unknown) {
   try {
     return JSON.parse(value);
   } catch {
-    return value;
+    return value
   }
 }

--- a/dashboard/src/composables/useMessages.ts
+++ b/dashboard/src/composables/useMessages.ts
@@ -1552,6 +1552,6 @@ export function parseJsonSafe(value: unknown) {
   try {
     return JSON.parse(value);
   } catch {
-    return value
+    return value;
   }
 }

--- a/dashboard/src/composables/useMessages.ts
+++ b/dashboard/src/composables/useMessages.ts
@@ -158,6 +158,7 @@ export function useMessages(options: UseMessagesOptions) {
     {},
   );
   let sessionPollTimer: number | undefined;
+  let isUnmounted = false;
 
   const activeMessages = computed(() =>
     options.currentSessionId.value
@@ -166,8 +167,10 @@ export function useMessages(options: UseMessagesOptions) {
   );
 
   onBeforeUnmount(() => {
+    isUnmounted = true;
     if (sessionPollTimer !== undefined) {
-      window.clearInterval(sessionPollTimer);
+      window.clearTimeout(sessionPollTimer);
+      sessionPollTimer = undefined;
     }
     cleanupConnections();
     for (const promise of attachmentBlobCache.values()) {
@@ -180,15 +183,22 @@ export function useMessages(options: UseMessagesOptions) {
     () => options.currentSessionId.value,
     (sessionId) => {
       if (sessionPollTimer !== undefined) {
-        window.clearInterval(sessionPollTimer);
+        window.clearTimeout(sessionPollTimer);
         sessionPollTimer = undefined;
       }
       if (!sessionId) return;
-      sessionPollTimer = window.setInterval(() => {
+
+      const poll = async () => {
         if (!isSessionRunning(sessionId)) {
-          void loadSessionMessages(sessionId, false, false);
+          await loadSessionMessages(sessionId, false, false);
         }
-      }, 2000);
+
+        if (!isUnmounted && options.currentSessionId.value === sessionId) {
+          sessionPollTimer = window.setTimeout(poll, 2000);
+        }
+      };
+
+      sessionPollTimer = window.setTimeout(poll, 2000);
     },
     { immediate: true },
   );

--- a/dashboard/src/composables/useMessages.ts
+++ b/dashboard/src/composables/useMessages.ts
@@ -1,4 +1,11 @@
-import { computed, onBeforeUnmount, reactive, ref, type Ref } from "vue";
+import {
+  computed,
+  onBeforeUnmount,
+  reactive,
+  ref,
+  watch,
+  type Ref,
+} from "vue";
 import { chatApi, fileApi } from "@/api/v1";
 import { fetchWithAuth } from "@/api/http";
 
@@ -150,6 +157,7 @@ export function useMessages(options: UseMessagesOptions) {
   const sessionProjects = reactive<Record<string, ChatSessionProject | null>>(
     {},
   );
+  let sessionPollTimer: number | undefined;
 
   const activeMessages = computed(() =>
     options.currentSessionId.value
@@ -158,12 +166,32 @@ export function useMessages(options: UseMessagesOptions) {
   );
 
   onBeforeUnmount(() => {
+    if (sessionPollTimer !== undefined) {
+      window.clearInterval(sessionPollTimer);
+    }
     cleanupConnections();
     for (const promise of attachmentBlobCache.values()) {
       promise.then((url) => URL.revokeObjectURL(url)).catch(() => {});
     }
     attachmentBlobCache.clear();
   });
+
+  watch(
+    () => options.currentSessionId.value,
+    (sessionId) => {
+      if (sessionPollTimer !== undefined) {
+        window.clearInterval(sessionPollTimer);
+        sessionPollTimer = undefined;
+      }
+      if (!sessionId) return;
+      sessionPollTimer = window.setInterval(() => {
+        if (!isSessionRunning(sessionId)) {
+          void loadSessionMessages(sessionId, false, false);
+        }
+      }, 2000);
+    },
+    { immediate: true },
+  );
 
   function isSessionRunning(sessionId: string) {
     return Object.values(activeConnections).some(


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
修复 Issue #9321：在 WebChat 中使用后台子代理执行任务时，后台任务虽然能够完成，结果也已经保存到会话历史，但用户必须再次发送消息才能看到结果。

本次修改让当前 WebChat 会话定期检查新的历史消息，使后台子代理完成后，结果能够自动显示给用户。
### Modifications / 改动点

- 为当前 WebChat 会话增加历史消息轮询，每 2 秒检查一次。
- 当普通 AI 回复正在进行时暂停轮询，避免覆盖正在进行的流式消息。
- 切换会话时清理旧会话的轮询定时器。
- 组件卸载时清理轮询定时器，避免定时器残留。
- 修改文件：`dashboard/src/composables/useMessages.ts`。
- 没有引入新的依赖。
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
修改前使用webchat调用后台子代理，图中可见时隔3分钟也没有主动消息发出：
<img width="882" height="813" alt="image" src="https://github.com/user-attachments/assets/69d2f25f-97a5-4b79-ab2e-e8da65bda2bf" />

修改后使用webchat调用后台子代理，图中可见在同一分钟内ai主动发出结论：
<img width="945" height="797" alt="image" src="https://github.com/user-attachments/assets/1dcd1860-bbdd-48c4-94d2-91b15ae63b80" />

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Poll WebChat session messages so background sub-agent results appear automatically in the current conversation.

New Features:
- Automatically refresh WebChat session messages on a timer to surface new background sub-agent outputs without requiring user input.

Enhancements:
- Start and stop a per-session polling timer based on the active session, and clear it on component unmount to avoid stale intervals.