### PR TITLE
fix: skip empty quoted image placeholders

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -1444,6 +1444,13 @@ async def build_main_agent(
                 if comp.chain:
                     for reply_comp in comp.chain:
                         if isinstance(reply_comp, Image):
+                            if not (reply_comp.url or reply_comp.file):
+                                logger.warning(
+                                    "Skip quoted image without file or URL for umo=%s, reply_id=%s",
+                                    event.unified_msg_origin,
+                                    getattr(comp, "id", None),
+                                )
+                                continue
                             has_embedded_image = True
                             path = await reply_comp.convert_to_file_path()
                             image_path = await _compress_image_for_provider(

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -1442,13 +1442,17 @@ async def build_main_agent(
             for comp in reply_comps:
                 has_embedded_image = False
                 if comp.chain:
-                    for reply_comp in comp.chain:
+                    for chain_index, reply_comp in enumerate(comp.chain):
                         if isinstance(reply_comp, Image):
-                            if not (reply_comp.url or reply_comp.file):
+                            if not (
+                                (reply_comp.url or "").strip()
+                                or (reply_comp.file or "").strip()
+                            ):
                                 logger.warning(
-                                    "Skip quoted image without file or URL for umo=%s, reply_id=%s",
+                                    "Skip quoted image without file or URL for umo=%s, reply_id=%s, chain_index=%s",
                                     event.unified_msg_origin,
                                     getattr(comp, "id", None),
+                                    chain_index,
                                 )
                                 continue
                             has_embedded_image = True

--- a/tests/unit/test_astr_main_agent.py
+++ b/tests/unit/test_astr_main_agent.py
@@ -801,9 +801,7 @@ class TestEnsurePersonaAndSkills:
         mock_context.persona_manager.resolve_selected_persona = AsyncMock(
             return_value=("conv-persona", persona, None, False)
         )
-        mock_event.get_extra.side_effect = (
-            lambda key: key == "enable_inline_genui"
-        )
+        mock_event.get_extra.side_effect = lambda key: key == "enable_inline_genui"
         req = ProviderRequest()
         req.conversation = MagicMock(persona_id="conv-persona")
 
@@ -818,9 +816,7 @@ class TestEnsurePersonaAndSkills:
     ):
         """Test inline GenUI instructions are added before conversation setup."""
         module = ama
-        mock_event.get_extra.side_effect = (
-            lambda key: key == "enable_inline_genui"
-        )
+        mock_event.get_extra.side_effect = lambda key: key == "enable_inline_genui"
         req = ProviderRequest()
 
         await module._ensure_persona_and_skills(req, {}, mock_context, mock_event)
@@ -1590,6 +1586,50 @@ class TestBuildMainAgent:
             for part in result.provider_request.extra_user_content_parts
         )
         mock_provider.text_chat.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_build_main_agent_skips_empty_quoted_image_and_uses_fallback(
+        self, mock_event, mock_context, mock_provider
+    ):
+        """Quoted image placeholders without a file or URL should not abort the request."""
+        module = ama
+        mock_reply = Reply(
+            id="reply-1",
+            chain=[Plain(text="quoted text"), Image(file="")],
+            sender_nickname="",
+            message_str="quoted text",
+        )
+        mock_event.message_obj.message = [Plain(text="Hello"), mock_reply]
+
+        mock_context.get_provider_by_id.return_value = None
+        mock_context.get_using_provider.return_value = mock_provider
+        mock_context.get_config.return_value = {}
+
+        conv_mgr = mock_context.conversation_manager
+        _setup_conversation_for_build(conv_mgr)
+
+        with (
+            patch("astrbot.core.astr_main_agent.AgentRunner") as mock_runner_cls,
+            patch("astrbot.core.astr_main_agent.AstrAgentContext"),
+            patch(
+                "astrbot.core.astr_main_agent.extract_quoted_message_images",
+                AsyncMock(return_value=["/tmp/fallback-quoted.jpg"]),
+            ) as mock_extract_quoted_images,
+        ):
+            mock_runner = MagicMock()
+            mock_runner.reset = AsyncMock()
+            mock_runner_cls.return_value = mock_runner
+
+            result = await module.build_main_agent(
+                event=mock_event,
+                plugin_context=mock_context,
+                config=module.MainAgentBuildConfig(tool_call_timeout=60),
+                provider=mock_provider,
+            )
+
+        assert result is not None
+        assert result.provider_request.image_urls == ["/tmp/fallback-quoted.jpg"]
+        mock_extract_quoted_images.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_build_main_agent_does_not_caption_quoted_image_twice(

--- a/tests/unit/test_astr_main_agent.py
+++ b/tests/unit/test_astr_main_agent.py
@@ -1588,14 +1588,24 @@ class TestBuildMainAgent:
         mock_provider.text_chat.assert_not_called()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "image_kwargs",
+        [
+            {"file": ""},
+            {"file": None, "url": ""},
+            {"file": "", "url": ""},
+            {"file": "   ", "url": None},
+            {"file": None, "url": "   "},
+        ],
+    )
     async def test_build_main_agent_skips_empty_quoted_image_and_uses_fallback(
-        self, mock_event, mock_context, mock_provider
+        self, mock_event, mock_context, mock_provider, image_kwargs
     ):
         """Quoted image placeholders without a file or URL should not abort the request."""
         module = ama
         mock_reply = Reply(
             id="reply-1",
-            chain=[Plain(text="quoted text"), Image(file="")],
+            chain=[Plain(text="quoted text"), Image(**image_kwargs)],
             sender_nickname="",
             message_str="quoted text",
         )
@@ -1613,7 +1623,7 @@ class TestBuildMainAgent:
             patch("astrbot.core.astr_main_agent.AstrAgentContext"),
             patch(
                 "astrbot.core.astr_main_agent.extract_quoted_message_images",
-                AsyncMock(return_value=["/tmp/fallback-quoted.jpg"]),
+                AsyncMock(return_value=["fallback-quoted-image-ref"]),
             ) as mock_extract_quoted_images,
         ):
             mock_runner = MagicMock()
@@ -1628,7 +1638,7 @@ class TestBuildMainAgent:
             )
 
         assert result is not None
-        assert result.provider_request.image_urls == ["/tmp/fallback-quoted.jpg"]
+        assert result.provider_request.image_urls == ["fallback-quoted-image-ref"]
         mock_extract_quoted_images.assert_awaited_once()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
﻿Closes #9176.

This PR prevents expired or unavailable quoted image placeholders from aborting the agent request with `No valid file or URL provided`.

### Modifications / 改动点

#### What Problem This Solves

When a user quotes an expired or unavailable image message, the adapter can still provide a `Reply` component whose embedded chain contains an `Image` placeholder, but that placeholder may have no usable `file` or `url` value.

`build_main_agent()` previously treated every embedded quoted `Image` as usable and called `convert_to_file_path()` immediately. For an empty placeholder, `Image.convert_to_file_path()` raises `ValueError("No valid file or URL provided")`, so the whole agent request can abort before the quoted-message fallback has a chance to fetch by reply id.

#### Changes

- skip quoted `Image` placeholders whose `file` and `url` values are empty or whitespace-only before calling `convert_to_file_path()`
- keep `has_embedded_image` false for skipped placeholders so the existing reply-id fallback extraction path can still run
- include the reply id and quoted-chain index in the warning log so skipped placeholders are easier to trace
- add regression coverage for empty `file`, empty `url`, both-empty, and whitespace-only quoted image placeholder shapes

This intentionally does not change `Image.convert_to_file_path()` itself. Valid quoted images still use the existing convert/compress/attachment path, and quoted audio/file/video handling is unchanged.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

#### Evidence

The regression test simulates the reachable issue shape from #9176:

```python
Reply(
    id="reply-1",
    chain=[Plain(text="quoted text"), Image(**image_kwargs)],
)
```

It now covers these invalid placeholder variants:

```python
{"file": ""}
{"file": None, "url": ""}
{"file": "", "url": ""}
{"file": "   ", "url": None}
{"file": None, "url": "   "}
```

Before this change, those placeholders could reach `convert_to_file_path()` and raise `ValueError("No valid file or URL provided")`.

After this change, the empty placeholder is skipped, `has_embedded_image` remains `False`, and the existing fallback extractor can still provide the quoted image reference:

```python
assert result.provider_request.image_urls == ["fallback-quoted-image-ref"]
mock_extract_quoted_images.assert_awaited_once()
```

#### Possible call chain / impact

```text
user quotes an expired/unavailable image message
  -> platform adapter provides Reply(chain=[Image(file="", url="")])
  -> build_main_agent() quoted message attachment loop
  -> previous behavior: convert_to_file_path()
  -> ValueError("No valid file or URL provided")
  -> agent request aborts before fallback extraction can run
```

With this PR:

```text
user quotes an expired/unavailable image message
  -> empty quoted Image placeholder is skipped
  -> has_embedded_image stays False
  -> extract_quoted_message_images(...) fallback can run
  -> valid fallback image refs are appended to provider_request.image_urls
```

Scope notes:

- affects only empty quoted `Image` placeholders in the main-agent quoted attachment loop
- does not change normal user image attachments
- does not change valid quoted image conversion/compression
- does not change quoted audio, file, or video handling
- does not change quoted-image fallback limits, dedupe, parser settings, or `Image.convert_to_file_path()`'s direct conversion contract

### Screenshots or Test Results / 运行截图或测试结果

```text
uv run ruff check astrbot/core/astr_main_agent.py tests/unit/test_astr_main_agent.py
All checks passed!

uv run ruff format --check astrbot/core/astr_main_agent.py tests/unit/test_astr_main_agent.py
2 files already formatted

git diff --check
# passed

uv run pytest tests/unit/test_astr_main_agent.py::TestBuildMainAgent::test_build_main_agent_skips_empty_quoted_image_and_uses_fallback tests/unit/test_astr_main_agent.py::TestBuildMainAgent::test_build_main_agent_skips_caption_when_main_provider_supports_images tests/unit/test_astr_main_agent.py::TestBuildMainAgent::test_build_main_agent_does_not_caption_quoted_image_twice tests/unit/test_astr_main_agent.py::TestBuildMainAgent::test_build_main_agent_does_not_retry_quoted_image_caption_when_empty -q
........                                                                 [100%]
8 passed, 1 warning in 3.21s
```

Note: `uv run pytest tests/unit/test_astr_main_agent.py -q` currently has two pre-existing Windows-only path separator expectation failures in video attachment tests (`/path/to/...` expected, `\\path\\to\\...` observed). The focused quoted-image tests above pass and cover this PR's behavior change.

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🧸 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😷 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。
