### PR TITLE
fix: show progress when saving plugin config

### DIFF
--- a/dashboard/src/views/ExtensionPage.vue
+++ b/dashboard/src/views/ExtensionPage.vue
@@ -290,7 +290,12 @@ const {
   </v-dialog>
 
   <!-- 加载对话框 -->
-  <v-dialog v-model="loadingDialog.show" width="700" persistent>
+  <v-dialog
+    v-model="loadingDialog.show"
+    width="700"
+    persistent
+    transition="dialog-transition"
+  >
     <v-card>
       <v-card-title class="text-h5">{{ loadingDialog.title }}</v-card-title>
       <v-card-text style="max-height: calc(100vh - 200px); overflow-y: auto">
@@ -301,19 +306,24 @@ const {
           class="mb-4"
         ></v-progress-linear>
 
-        <div v-if="loadingDialog.statusCode !== 0" class="py-8 text-center">
-          <v-icon
-            class="mb-6"
-            :color="loadingDialog.statusCode === 1 ? 'success' : 'error'"
-            :icon="
-              loadingDialog.statusCode === 1
-                ? 'mdi-check-circle-outline'
-                : 'mdi-alert-circle-outline'
-            "
-            size="128"
-          ></v-icon>
-          <div class="text-h4 font-weight-bold">{{ loadingDialog.result }}</div>
-        </div>
+        <v-fade-transition>
+          <div
+            v-if="loadingDialog.statusCode !== 0"
+            class="py-8 text-center"
+          >
+            <v-icon
+              class="mb-6"
+              :color="loadingDialog.statusCode === 1 ? 'success' : 'error'"
+              :icon="
+                loadingDialog.statusCode === 1
+                  ? 'mdi-check-circle-outline'
+                  : 'mdi-alert-circle-outline'
+              "
+              size="128"
+            ></v-icon>
+            <div class="text-h4 font-weight-bold">{{ loadingDialog.result }}</div>
+          </div>
+        </v-fade-transition>
 
         <div style="margin-top: 32px">
           <h3>{{ tm("dialogs.loading.logs") }}</h3>

--- a/dashboard/src/views/extension/useExtensionPage.js
+++ b/dashboard/src/views/extension/useExtensionPage.js
@@ -1045,22 +1045,30 @@ export const useExtensionPage = () => {
   };
   
   const updateConfig = async () => {
+    loadingDialog.title = tm("status.loading");
+    loadingDialog.statusCode = 0;
+    loadingDialog.result = "";
+    loadingDialog.show = true;
     try {
       const res = await axios.post(
         "/api/config/plugin/update?plugin_name=" + curr_namespace.value,
         extension_config.config,
       );
-      if (res.data.status === "ok") {
-        toast(res.data.message, "success");
-      } else {
+      if (res.data.status !== "ok") {
         toast(res.data.message, "error");
+        onLoadingDialogResult(2, res.data.message, -1);
+        return;
       }
+
+      toast(res.data.message, "success");
+      onLoadingDialogResult(1, res.data.message);
       configDialog.value = false;
       extension_config.metadata = {};
       extension_config.config = {};
       getExtensions();
     } catch (err) {
       toast(err, "error");
+      onLoadingDialogResult(2, err.message || String(err), -1);
     }
   };
   

--- a/dashboard/src/views/extension/useExtensionPage.js
+++ b/dashboard/src/views/extension/useExtensionPage.js
@@ -1067,8 +1067,9 @@ export const useExtensionPage = () => {
       extension_config.config = {};
       getExtensions();
     } catch (err) {
-      toast(err, "error");
-      onLoadingDialogResult(2, err.message || String(err), -1);
+      const errMsg = resolveErrorMessage(err, tm("messages.operationFailed"));
+      toast(errMsg, "error");
+      onLoadingDialogResult(2, errMsg, -1);
     }
   };
   


### PR DESCRIPTION
## Motivation

Plugin configuration saves can take a noticeable amount of time while the config is persisted and the plugin is reloaded. Previously, the dashboard provided no in-progress feedback, which could make the interface appear frozen or unresponsive (issue #9323).

## Changes

- Display the existing loading dialog before submitting plugin configuration changes.
- Show a success result after a successful save, then close the configuration dialog.
- Keep the configuration dialog and entered values when the API reports an error or the request fails, so users can review and retry.

## Breaking Changes

- [x] No breaking changes.

## Verification

- Dashboard built successfully with the updated source.
- Verified the running WebUI now shows a progress dialog when clicking "Save and Close".

## Checklist

- [x] The change is scoped to the plugin configuration save flow.
- [x] No new dependencies were added.
- [x] No malicious code was introduced.

## Summary by Sourcery

Improve user feedback during plugin configuration saves in the dashboard.

Enhancements:
- Show a loading dialog while plugin configuration changes are being saved.
- Report success via the loading dialog and close the configuration dialog on successful saves.
- Preserve the configuration dialog and surface detailed errors in the loading dialog when the save fails.