### PR TITLE
fix: convert mislabeled audio before STT

### DIFF
--- a/astrbot/core/utils/media_utils.py
+++ b/astrbot/core/utils/media_utils.py
@@ -1127,7 +1127,7 @@ async def convert_audio_format(
     Raises:
         Exception: Raised when ffmpeg is unavailable or conversion fails.
     """
-    detected_format = _get_audio_magic_type(audio_path)
+    detected_format = await asyncio.to_thread(_get_audio_magic_type, audio_path)
     if audio_path.lower().endswith(f".{output_format}") and (
         detected_format == output_format
         or (output_format == "ogg" and detected_format == "opus")

--- a/astrbot/core/utils/media_utils.py
+++ b/astrbot/core/utils/media_utils.py
@@ -1127,7 +1127,11 @@ async def convert_audio_format(
     Raises:
         Exception: Raised when ffmpeg is unavailable or conversion fails.
     """
-    if audio_path.lower().endswith(f".{output_format}"):
+    detected_format = _get_audio_magic_type(audio_path)
+    if audio_path.lower().endswith(f".{output_format}") and (
+        detected_format == output_format
+        or (output_format == "ogg" and detected_format == "opus")
+    ):
         return audio_path
 
     if output_path is None:

--- a/tests/test_media_utils.py
+++ b/tests/test_media_utils.py
@@ -400,6 +400,34 @@ async def test_media_resolver_accepts_unpadded_base64_payloads(tmp_path, monkeyp
 
 
 @pytest.mark.asyncio
+async def test_ensure_wav_converts_non_wav_bytes_with_wav_suffix(tmp_path, monkeypatch):
+    monkeypatch.setattr(media_utils, "get_astrbot_temp_path", lambda: str(tmp_path))
+    source_path = tmp_path / "voice.wav"
+    source_path.write_bytes(b"#!AMR\n" + b"\x00" * 64)
+
+    class _Process:
+        returncode = 0
+
+        async def communicate(self):
+            return b"", b""
+
+    async def fake_create_subprocess_exec(*args, **_kwargs):
+        Path(args[-1]).write_bytes(b"RIFF\x24\x00\x00\x00WAVEfmt " + b"\x00" * 16)
+        return _Process()
+
+    monkeypatch.setattr(
+        media_utils.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+
+    resolved_path = await media_utils.ensure_wav(str(source_path))
+
+    assert resolved_path != str(source_path)
+    assert Path(resolved_path).read_bytes().startswith(b"RIFF")
+
+
+@pytest.mark.asyncio
 async def test_media_resolver_cleans_materialized_file_when_audio_conversion_fails(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary

- verify audio magic bytes before skipping same-extension conversion
- convert non-WAV payloads that were materialized with a `.wav` suffix
- preserve the existing Ogg/Opus no-op behavior
- add regression coverage for AMR bytes stored under a `.wav` filename

## Root cause

`MediaResolver` can materialize extensionless or base64 audio with the default `.wav` suffix. `ensure_wav()` correctly detects that the bytes are not WAV and requests WAV conversion, but `convert_audio_format()` previously returned early based only on the filename suffix. The unchanged non-RIFF payload was then rejected by the MiMo STT boundary validation.

This change keeps the fast path only when both the suffix and detected audio format match the requested output format.

Follow-up to #9113 and #9118.

## Validation

- `uv run pytest tests/test_media_utils.py -q -k "not test_file_uri_to_path_supports_localhost_and_encoded_paths"` ? 50 passed, 1 Windows-specific path test deselected
- `uv run pytest tests/test_mimo_api_sources.py -q` ? 19 passed
- `uv run ruff check astrbot/core/utils/media_utils.py tests/test_media_utils.py`
- `uv run ruff format --check astrbot/core/utils/media_utils.py tests/test_media_utils.py`
- manual Windows verification with aiocqhttp + MiMo STT: a QQ voice message was converted, transcribed correctly, and produced the expected `111` response

## Summary by Sourcery

Ensure audio format conversion validates the underlying magic bytes instead of relying solely on file extensions before speech-to-text processing.

Bug Fixes:
- Fix WAV conversion for non-WAV audio payloads that were materialized with a `.wav` suffix to avoid STT boundary rejection.

Tests:
- Add regression test verifying `ensure_wav` converts non-WAV AMR bytes stored under a `.wav` filename and produces a valid RIFF/WAV output.