### PR TITLE
feat(provider): add iFlytek Spark provider preset

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1328,6 +1328,18 @@ CONFIG_METADATA_2 = {
                         "proxy": "",
                         "custom_headers": {},
                     },
+                    "iFlytek Spark": {
+                        "id": "iflytek_spark",
+                        "provider": "iflytek_spark",
+                        "type": "openai_chat_completion",
+                        "provider_type": "chat_completion",
+                        "enable": True,
+                        "key": [],
+                        "api_base": "https://spark-api-open.xf-yun.com/v1",
+                        "timeout": 120,
+                        "proxy": "",
+                        "custom_headers": {},
+                    },
                     "AIHubMix": {
                         "id": "aihubmix",
                         "provider": "aihubmix",

--- a/dashboard/src/utils/providerUtils.js
+++ b/dashboard/src/utils/providerUtils.js
@@ -24,6 +24,7 @@ export function getProviderIcon(type) {
     'kimi': 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/kimi.svg',
     'kimi-code': 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/kimi.svg',
     'longcat': 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/longcat-color.svg',
+    'iflytek_spark': 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/spark-color.svg',
     'ppio': 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/ppio.svg',
     'dify': 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/dify-color.svg',
     "coze": "https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@1.66.0/icons/coze.svg",


### PR DESCRIPTION
讯飞星火（iFlytek Spark）的官方接口 `https://spark-api-open.xf-yun.com/v1` 是 OpenAI 兼容的，但目前没有预设条目。用户只能选「OpenAI Compatible」后手动填写 base URL，而 DeepSeek、Moonshot、Zhipu、LongCat、MiniMax、Xiaomi 等国内厂商都已有预设。社区此前提过该需求（#3077）。

iFlytek Spark's official endpoint (`https://spark-api-open.xf-yun.com/v1`) is OpenAI-compatible but has no preset entry, so users must pick "OpenAI Compatible" and type the base URL by hand — while DeepSeek, Moonshot, Zhipu, LongCat, MiniMax and Xiaomi all ship presets. Previously requested in #3077.

### Modifications / 改动点

- `astrbot/core/config/default.py` — 在 `config_template` 中新增 `iFlytek Spark` 预设，放在 LongCat 之后、AIHubMix 之前（与其他国内厂商相邻）。字段与 DeepSeek 预设完全同构，`type` 为现有的 `openai_chat_completion`，因此**不需要新增 source 文件，也不需要改动 `manager.py` 或 `openai_source.py`**。
- `dashboard/src/utils/providerUtils.js` — 为 `iflytek_spark` 注册图标，复用 lobehub 图标库中的 `spark-color.svg`（该图标在上游标注即为「Spark (讯飞星火)」，https://xinghuo.xfyun.cn ）。

纯新增，不改动任何既有条目的行为。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

本机没有可运行的 AstrBot 实例（无法提供 UI 截图），因此改动通过对配置与前端逻辑的直接断言来验证：

**1. 配置模板（AST 解析 `default.py` 后断言）**

```
template: {'id': 'iflytek_spark', 'provider': 'iflytek_spark', 'type': 'openai_chat_completion',
           'provider_type': 'chat_completion', 'enable': True, 'key': [],
           'api_base': 'https://spark-api-open.xf-yun.com/v1', 'timeout': 120,
           'proxy': '', 'custom_headers': {}}
key shape == DeepSeek: ['api_base', 'custom_headers', 'enable', 'id', 'key',
                        'provider', 'provider_type', 'proxy', 'timeout', 'type']
templates: 60 | ids unique: True
position: 13 - after LongCat / before AIHubMix
ALL ASSERTIONS PASSED
```

断言内容：字段集合与 `DeepSeek` 预设完全一致；`id` 在 60 个模板中唯一且无重复；`type` / `provider_type` / `api_base` 取值正确。`python -m py_compile` 通过。

**2. 前端图标解析（导入 `providerUtils.js` 后调用）**

```
iflytek_spark -> https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/spark-color.svg
existing icons still resolve: OK      # longcat / deepseek / zhipu / openai 回归检查
unknown key -> ""                     # 未知 key 仍回落到空字符串
```

**3. 图标资源**：已确认 `spark-color.svg` 在 CDN 上可正常获取，且在 lobehub/lobe-icons 中的标注为 `title: Spark (讯飞星火)`。

未做：未使用真实 API key 跑通端到端对话（无可用配额）。由于该预设仅提供 base URL 默认值、完全复用既有的 `openai_chat_completion` 实现，运行时路径与手动填写 base URL 的「OpenAI Compatible」配置完全一致。

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。（社区需求见 #3077）

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced.
  / 我确保没有引入新依赖库。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Add a preset configuration and icon support for the iFlytek Spark provider.

New Features:
- Introduce an iFlytek Spark provider preset using the OpenAI-compatible chat completion endpoint.

Enhancements:
- Register a dedicated icon for the iFlytek Spark provider in the dashboard UI.