### PR TITLE
fix: add fallback providers to handoff subagents

### DIFF
--- a/astrbot/core/astr_agent_tool_exec.py
+++ b/astrbot/core/astr_agent_tool_exec.py
@@ -28,6 +28,7 @@ from astrbot.core.message.message_event_result import (
     MessageEventResult,
 )
 from astrbot.core.platform.message_session import MessageSession
+from astrbot.core.provider import Provider
 from astrbot.core.provider.entites import ProviderRequest
 from astrbot.core.provider.register import llm_tools
 from astrbot.core.tools.computer_tools import (
@@ -354,6 +355,36 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
                     continue
 
         prov_settings: dict = ctx.get_config(umo=umo).get("provider_settings", {})
+        fallback_ids = prov_settings.get("fallback_chat_models", [])
+        fallback_providers: list[Provider] = []
+        if not isinstance(fallback_ids, list):
+            logger.warning(
+                "fallback_chat_models setting is not a list, skip handoff fallback providers."
+            )
+        else:
+            seen_provider_ids = {prov_id} if prov_id else set()
+            for fallback_id in fallback_ids:
+                if not isinstance(fallback_id, str) or not fallback_id:
+                    continue
+                if fallback_id in seen_provider_ids:
+                    continue
+                fallback_provider = ctx.get_provider_by_id(fallback_id)
+                if fallback_provider is None:
+                    logger.warning(
+                        "Handoff fallback chat provider `%s` not found, skip.",
+                        fallback_id,
+                    )
+                    continue
+                if not isinstance(fallback_provider, Provider):
+                    logger.warning(
+                        "Handoff fallback chat provider `%s` is invalid type: %s, skip.",
+                        fallback_id,
+                        type(fallback_provider),
+                    )
+                    continue
+                fallback_providers.append(fallback_provider)
+                seen_provider_ids.add(fallback_id)
+
         agent_max_step = int(prov_settings.get("max_agent_step", 30))
         stream = prov_settings.get("streaming_response", False)
         llm_resp = await ctx.tool_loop_agent(
@@ -367,6 +398,8 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
             max_steps=agent_max_step,
             tool_call_timeout=run_context.tool_call_timeout,
             stream=stream,
+            fallback_providers=fallback_providers,
+            request_max_retries=prov_settings.get("request_max_retries", 5),
         )
         yield mcp.types.CallToolResult(
             content=[mcp.types.TextContent(type="text", text=llm_resp.completion_text)]

--- a/tests/unit/test_astr_agent_tool_exec.py
+++ b/tests/unit/test_astr_agent_tool_exec.py
@@ -366,6 +366,76 @@ async def test_execute_handoff_passes_tool_call_timeout_to_tool_loop_agent(
 
 
 @pytest.mark.asyncio
+async def test_execute_handoff_passes_valid_fallbacks_and_retries_to_tool_loop_agent(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict = {}
+
+    class _ChatProvider:
+        pass
+
+    primary = _ChatProvider()
+    fallback = _ChatProvider()
+    non_chat_provider = object()
+    providers = {
+        "primary": primary,
+        "fallback": fallback,
+        "non-chat": non_chat_provider,
+    }
+
+    async def _fake_get_current_chat_provider_id(_umo):
+        return "primary"
+
+    async def _fake_tool_loop_agent(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(completion_text="ok")
+
+    context = SimpleNamespace(
+        get_current_chat_provider_id=_fake_get_current_chat_provider_id,
+        get_provider_by_id=lambda provider_id: providers.get(provider_id),
+        tool_loop_agent=_fake_tool_loop_agent,
+        get_config=lambda **_kwargs: {
+            "provider_settings": {
+                "fallback_chat_models": [
+                    "primary",
+                    "fallback",
+                    "fallback",
+                    "missing",
+                    "non-chat",
+                ],
+                "request_max_retries": 7,
+            }
+        },
+    )
+    event = _DummyEvent([])
+    run_context = ContextWrapper(context=SimpleNamespace(event=event, context=context))
+    tool = SimpleNamespace(
+        name="transfer_to_subagent",
+        provider_id="primary",
+        agent=SimpleNamespace(
+            name="subagent",
+            tools=[],
+            instructions="subagent-instructions",
+            begin_dialogs=[],
+            run_hooks=None,
+        ),
+    )
+    monkeypatch.setattr("astrbot.core.astr_agent_tool_exec.Provider", _ChatProvider)
+
+    async for _result in FunctionToolExecutor._execute_handoff(
+        tool,
+        run_context,
+        image_urls_prepared=True,
+        input="hello",
+        image_urls=[],
+    ):
+        pass
+
+    assert captured["fallback_providers"] == [fallback]
+    assert captured["request_max_retries"] == 7
+
+
+@pytest.mark.asyncio
 async def test_background_wakeup_passes_provider_settings_to_main_agent(
     monkeypatch: pytest.MonkeyPatch,
 ):


### PR DESCRIPTION
### Motivation
Handoff subagents did not receive the configured fallback chat providers or request retry limit. When an upstream streaming connection was interrupted, a subagent could fail after its primary provider without using the same retry and fallback behavior as the main agent.

### Modifications
- Resolve configured fallback chat providers for handoff subagents.
- Skip the primary provider, duplicates, missing providers, and non-chat providers.
- Forward `request_max_retries` to the handoff tool-loop runner.
- Add a regression test covering fallback filtering and retry forwarding.

- [x] This is NOT a breaking change.

### Test Results
- `python -m pytest -q tests/unit/test_astr_agent_tool_exec.py` -> 13 passed
- `ruff format --check astrbot/core/astr_agent_tool_exec.py tests/unit/test_astr_agent_tool_exec.py`
- `ruff check astrbot/core/astr_agent_tool_exec.py tests/unit/test_astr_agent_tool_exec.py`

### Checklist
- [x] Changes have been tested and verification results are included above.
- [x] No new dependencies were introduced.
- [x] No malicious code was introduced.

## Summary by Sourcery

Ensure handoff subagents inherit appropriate fallback chat providers and retry settings from the main agent when executing tool-loop handoffs.

New Features:
- Support passing filtered fallback chat providers to handoff subagents during tool-loop execution.

Bug Fixes:
- Prevent handoff subagents from failing without using configured fallback providers and request retry limits when the primary chat provider fails.

Enhancements:
- Filter and validate configured fallback chat provider IDs to skip the primary provider, duplicates, missing providers, and non-chat providers before handoff.
- Forward request retry configuration from provider settings to the handoff tool-loop runner to align behavior with the main agent.

Tests:
- Add an async regression test verifying that execute_handoff forwards valid fallback providers and request_max_retries to the tool-loop agent.