### PR TITLE
fix: lazy import faiss in embedding_storage.py

### DIFF
--- a/astrbot/core/db/vec_db/faiss_impl/embedding_storage.py
+++ b/astrbot/core/db/vec_db/faiss_impl/embedding_storage.py
@@ -1,14 +1,14 @@
-try:
-    import faiss
-except ImportError:
-    raise ImportError(
-        "faiss 未安装。请使用 'pip install faiss-cpu' 或 'pip install faiss-gpu' 安装。",
-    )
+from __future__ import annotations
+
 import os
 import shutil
 import tempfile
+from typing import TYPE_CHECKING
 
 import numpy as np
+
+if TYPE_CHECKING:
+    import faiss
 
 # ── Faiss C++ fopen() 在 Windows 上使用 ANSI codepage ──
 # Python 传给 Faiss 的路径是 UTF-8 字节，但 Windows fopen 期望 ANSI 编码，
@@ -61,6 +61,12 @@ def _make_temp_file(prefix: str) -> str:
 
 class EmbeddingStorage:
     def __init__(self, dimension: int, path: str | None = None) -> None:
+        try:
+            import faiss
+        except ImportError:
+            raise ImportError(
+                "faiss 未安装。请使用 'pip install faiss-cpu' 或 'pip install faiss-gpu' 安装。",
+            )
         self.dimension = dimension
         self.path = path
         self.index = None
@@ -71,8 +77,10 @@ class EmbeddingStorage:
             self.index = faiss.IndexIDMap(base_index)
 
     @staticmethod
-    def _read_index(path: str) -> "faiss.Index":
+    def _read_index(path: str) -> faiss.Index:
         """读取 Faiss 索引，兼容含非 ASCII 字符的 Windows 路径。"""
+        import faiss
+
         try:
             return faiss.read_index(path)
         except RuntimeError:
@@ -91,8 +99,10 @@ class EmbeddingStorage:
                     pass
 
     @staticmethod
-    def _write_index(index: "faiss.Index", path: str) -> None:
+    def _write_index(index: faiss.Index, path: str) -> None:
         """保存 Faiss 索引，兼容含非 ASCII 字符的 Windows 路径。"""
+        import faiss
+
         dirname = os.path.dirname(path)
         if dirname:
             os.makedirs(dirname, exist_ok=True)


### PR DESCRIPTION
## Summary

采用与 #8695 一致的懒加载方式处理 `embedding_storage.py` 中的 `import faiss`。

## Changes

将 `import faiss` 从模块顶层移至 `__init__()` 和方法内部，避免 faiss-cpu 1.14.2 C 库在模块加载时触发 CPU 特性检测死锁。

| Location | Before | After |
|----------|:------:|:-----:|
| Module top | `import faiss` | 移除；`TYPE_CHECKING` 守卫类型注解 |
| `__init__()` | 直接使用 `faiss.` | `import faiss` 在 try/except 内 |
| `_read_index()` | 直接使用 `faiss.` | 方法内 `import faiss` |
| `_write_index()` | 直接使用 `faiss.` | 方法内 `import faiss` |

ASCII 临时文件桥接逻辑（`_needs_bridge`、`_safe_temp_dir`、`_make_temp_file`）保持不变。

## Related

- #8695, #8696
- 保留 #8323（Windows 非 ASCII 路径 Faiss I/O 修复）
