### PR TITLE
fix: allow subagents to use web search tools

### DIFF
--- a/astrbot/core/astr_agent_tool_exec.py
+++ b/astrbot/core/astr_agent_tool_exec.py
@@ -45,6 +45,18 @@ from astrbot.core.tools.computer_tools import (
     PythonTool,
 )
 from astrbot.core.tools.message_tools import SendMessageToUserTool
+from astrbot.core.tools.web_search_tools import (
+    BaiduWebSearchTool,
+    BochaWebSearchTool,
+    BraveWebSearchTool,
+    ExaGetContentsTool,
+    ExaWebSearchTool,
+    FirecrawlExtractWebPageTool,
+    FirecrawlWebSearchTool,
+    TavilyExtractWebPageTool,
+    TavilyWebSearchTool,
+    normalize_legacy_web_search_config,
+)
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
 from astrbot.core.utils.history_saver import persist_agent_history
 from astrbot.core.utils.image_ref_utils import is_supported_image_ref
@@ -241,6 +253,37 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
         return {}
 
     @classmethod
+    def _get_web_search_tools(
+        cls,
+        cfg: dict,
+        tool_mgr,
+    ) -> list:
+        normalize_legacy_web_search_config(cfg)
+        prov_settings = cfg.get("provider_settings", {})
+
+        if not prov_settings.get("web_search", False):
+            return []
+
+        provider = prov_settings.get("websearch_provider", "tavily")
+        result: list = []
+        if provider == "tavily":
+            result.append(tool_mgr.get_builtin_tool(TavilyWebSearchTool))
+            result.append(tool_mgr.get_builtin_tool(TavilyExtractWebPageTool))
+        elif provider == "bocha":
+            result.append(tool_mgr.get_builtin_tool(BochaWebSearchTool))
+        elif provider == "brave":
+            result.append(tool_mgr.get_builtin_tool(BraveWebSearchTool))
+        elif provider == "firecrawl":
+            result.append(tool_mgr.get_builtin_tool(FirecrawlWebSearchTool))
+            result.append(tool_mgr.get_builtin_tool(FirecrawlExtractWebPageTool))
+        elif provider == "baidu_ai_search":
+            result.append(tool_mgr.get_builtin_tool(BaiduWebSearchTool))
+        elif provider == "exa":
+            result.append(tool_mgr.get_builtin_tool(ExaWebSearchTool))
+            result.append(tool_mgr.get_builtin_tool(ExaGetContentsTool))
+        return result
+
+    @classmethod
     def _build_handoff_toolset(
         cls,
         run_context: ContextWrapper[AstrAgentContext],
@@ -261,6 +304,7 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
             tool_mgr,
             provider_settings.get("sandbox", {}).get("booter"),
         )
+        web_search_tools = cls._get_web_search_tools(cfg, tool_mgr)
 
         # Keep persona semantics aligned with the main agent: tools=None means
         # "all tools", including runtime computer-use tools.
@@ -278,6 +322,8 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
                     toolset.add_tool(registered_tool)
             for runtime_tool in runtime_computer_tools.values():
                 toolset.add_tool(runtime_tool)
+            for web_tool in web_search_tools:
+                toolset.add_tool(web_tool)
             return None if toolset.empty() else toolset
 
         if not tools:
@@ -293,6 +339,13 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
                 runtime_tool = runtime_computer_tools.get(tool_name_or_obj)
                 if runtime_tool:
                     toolset.add_tool(runtime_tool)
+                    continue
+                web_tool = next(
+                    (t for t in web_search_tools if t.name == tool_name_or_obj),
+                    None,
+                )
+                if web_tool:
+                    toolset.add_tool(web_tool)
             elif isinstance(tool_name_or_obj, FunctionTool):
                 toolset.add_tool(tool_name_or_obj)
         return None if toolset.empty() else toolset


### PR DESCRIPTION
修复 #9354

### Modifications / 改动点

移植 `astrbot/core/astr_main_agent.py` 中 `_apply_web_search_tools` 方法到 `astrbot/core/astr_agent_tool_exec.py`，调用这个方法添加配置中启用的网络搜索工具。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

这个 PR 引入了一些重复，因为原始的 `_apply_web_search_tools` 需要 `event` 参数，`astr_agent_tool_exec.py` 没有，为了复用创建一个假 event 太别扭了

另外，这个 PR 没有实现其他由 `_apply_*_tools` 提供的工具，涉及安全问题，我希望维护者来决定是否引入

### Screenshots or Test Results / 运行截图或测试结果

WebUI 对话询问：

> 你可以使用哪些工具？另外，用 `transfer_to_test_sub` 工具问一下 `test_sub` 可以用哪些工具。

改动前：

<img width="500" src="https://github.com/user-attachments/assets/6df75caf-2dd9-41d4-a835-f39c4876f047" />

改动后：

<img width="500" src="https://github.com/user-attachments/assets/b4005bbd-c1e4-4d6f-b761-23051b488c64" />

---

### Checklist / 检查清单

- [ ] 😊 ~~If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。~~（不适用）

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Ensure sub-agents receive the same configured web search tools as the main agent when building handoff toolsets.