### PR TITLE
fix(qqofficial): @mentions not working in proactive messages

### DIFF
--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -25,7 +25,7 @@ from tenacity import (
 
 from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent, MessageChain
-from astrbot.api.message_components import File, Image, Plain, Record, Video
+from astrbot.api.message_components import At, File, Image, Plain, Record, Video
 from astrbot.api.platform import AstrBotMessage, PlatformMetadata
 from astrbot.core.utils.media_utils import MediaResolver, file_uri_to_path, is_file_uri
 
@@ -785,6 +785,12 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                     file_source = file_path
                 elif i.url:
                     file_source = i.url
+            elif isinstance(i, At):
+                qq_value = str(i.qq)
+                if qq_value == "all":
+                    plain_text += "@everyone"
+                else:
+                    plain_text += f"<@!{qq_value}>"
             else:
                 logger.debug(f"qq_official 忽略 {i.type}")
         return (

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -787,10 +787,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                     file_source = i.url
             elif isinstance(i, At):
                 qq_value = str(i.qq)
-                if qq_value == "all":
-                    plain_text += "@everyone"
-                else:
-                    plain_text += f"<@!{qq_value}>"
+                plain_text += f"<@!{qq_value}>"
             else:
                 logger.debug(f"qq_official 忽略 {i.type}")
         return (

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
@@ -384,6 +384,7 @@ class QQOfficialPlatformAdapter(Platform):
         payload: dict[str, Any] = {}
         if has_mentions:
             payload["markdown"] = MarkdownPayload(content=plain_text)
+            # QQ Official account message type for markdown content
             payload["msg_type"] = 2
         else:
             payload["content"] = plain_text

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
@@ -14,6 +14,7 @@ import botpy.message
 from botpy import Client
 from botpy.connection import ConnectionState
 from botpy.gateway import BotWebSocket
+from botpy.types.message import MarkdownPayload
 
 from astrbot import logger
 from astrbot.api.event import MessageChain
@@ -379,7 +380,13 @@ class QQOfficialPlatformAdapter(Platform):
             )
             return
 
-        payload: dict[str, Any] = {"content": plain_text}
+        has_mentions = any(isinstance(c, At) for c in message_chain.chain)
+        payload: dict[str, Any] = {}
+        if has_mentions:
+            payload["markdown"] = MarkdownPayload(content=plain_text)
+            payload["msg_type"] = 2
+        else:
+            payload["content"] = plain_text
         if msg_id and not allow_group_proactive_send:
             payload["msg_id"] = msg_id
         ret: Any = None


### PR DESCRIPTION
## Problem

When the LLM uses `send_message_to_user` tool with `mention_user` type, the @mention was not producing real @mentions on QQ Official platform. Instead, it rendered as literal `<@!12A6C597...>` text.

## Root Cause

Two issues:

1. **`_parse_to_qqofficial` ignored `At` components** — The method in `qqofficial_message_event.py` had a `logger.debug` skip for `At` components, so they were silently dropped from the message chain.

2. **`_send_by_session_common` always used plain text mode** — Even after converting `At` to `<@!openid>` syntax, the message was sent as `msg_type: 0` (plain text). QQ Official API only parses `<@!openid>` syntax in `msg_type: 2` (markdown) mode.

## Fix

- **`qqofficial_message_event.py`**: Convert `At` components to `<@!openid>` format (and `@everyone` for `At(qq="all")`)
- **`qqofficial_platform_adapter.py`**: Detect `At` components in the message chain and switch to markdown mode (`msg_type: 2`) when mentions are present

## Testing

Tested on a live QQ Official bot. @mentions now render correctly as real mentions in group messages.

## Summary by Sourcery

Ensure QQ Official proactive messages correctly render user mentions by converting mention components to QQ-compatible syntax and sending them in markdown mode when needed.

Bug Fixes:
- Fix dropped @mention components in QQ Official message parsing by mapping At elements to QQ mention syntax.
- Fix QQ Official proactive messages sending mentions as plain text by switching to markdown msg_type when mentions are present.