### PR TITLE
feat: add Eden AI as a provider preset

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1340,6 +1340,18 @@ CONFIG_METADATA_2 = {
                         "proxy": "",
                         "custom_headers": {},
                     },
+                    "Eden AI": {
+                        "id": "edenai",
+                        "provider": "edenai",
+                        "type": "openai_chat_completion",
+                        "provider_type": "chat_completion",
+                        "enable": True,
+                        "key": [],
+                        "timeout": 120,
+                        "api_base": "https://api.edenai.run/v3",
+                        "proxy": "",
+                        "custom_headers": {},
+                    },
                     "OpenRouter": {
                         "id": "openrouter",
                         "provider": "openrouter",


### PR DESCRIPTION
## What

Adds [Eden AI](https://www.edenai.co/) as a built-in provider preset.

Eden AI is an OpenAI-compatible gateway (`https://api.edenai.run/v3`) that routes to many upstream providers behind a single key, so it fits the existing OpenAI-compatible chat-completion adapter — no new provider class needed, same as the NVIDIA / Azure OpenAI presets. Models are addressed as `<provider>/<model>` (e.g. `openai/gpt-5.5`, `mistral/mistral-large-latest`).

## Changes

- `astrbot/core/config/default.py`: a provider template `"Eden AI"` (`type: "openai_chat_completion"`, `api_base: "https://api.edenai.run/v3"`, `id`/`provider`: `edenai`), placed among the gateway presets.

## Testing

- `python -m py_compile` and `ruff format --check` / `ruff check` pass on the changed file.
- Verified live against `https://api.edenai.run/v3`: chat completions return 200 and tool/function calling works for `openai/gpt-5.5` and `mistral/mistral-large-latest`.

No dedicated adapter class is needed (Eden AI needs no custom header), mirroring the existing NVIDIA preset. I skipped a UI icon entry in `providerUtils.js` since Eden AI has no icon in the lobehub set yet (`getProviderIcon` falls back gracefully); happy to add one and a `docs/providers/edenai` page in a follow-up if you'd like.

## Summary by Sourcery

New Features:
- Introduce an Eden AI provider preset using the OpenAI chat-completion compatible adapter.