### PR TITLE
fix(stats): report process CPU usage without blocking the event loop

### DIFF
--- a/astrbot/dashboard/services/stat_service.py
+++ b/astrbot/dashboard/services/stat_service.py
@@ -215,7 +215,8 @@ class StatService:
 
             stat_dict = stat.__dict__
 
-            cpu_percent = psutil.cpu_percent(interval=0.5)
+            process_cpu = await asyncio.to_thread(psutil.Process().cpu_percent, 0.5)
+            cpu_percent = process_cpu / (psutil.cpu_count() or 1)
             thread_count = threading.active_count()
 
             plugins = self.core_lifecycle.star_context.get_all_stars()


### PR DESCRIPTION
The dashboard stats endpoint called `psutil.cpu_percent(interval=0.5)` directly inside an async coroutine, which blocks the event loop for 0.5s on every stats refresh, and it reported system-wide CPU usage rather than AstrBot's own consumption — making the figure misleading on shared or multi-tenant hosts.
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
### Modifications / 改动点
- `astrbot/dashboard/services/stat_service.py`: Sample CPU usage for the current AstrBot process via `psutil.Process().cpu_percent`, run it in a worker thread with `asyncio.to_thread` so the sampling interval no longer blocks the event loop, and normalize the result by the logical CPU count so the reported percentage stays within 0–100%.
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Adjust dashboard CPU stats reporting to use non-blocking, per-process sampling and normalized percentages.

Bug Fixes:
- Stop blocking the event loop when sampling CPU usage in the dashboard stats endpoint.
- Report CPU usage for the AstrBot process rather than system-wide CPU usage to avoid misleading values.
- Normalize reported CPU percentage by logical CPU count so values remain within a 0–100% range.