### PR TITLE
chore: pin Ruff to 0.15.22

### DIFF
--- a/.github/workflows/code-format.yml
+++ b/.github/workflows/code-format.yml
@@ -27,8 +27,8 @@ jobs:
       
     - name: Check code formatting with ruff
       run: |
-        uvx --from ruff==0.15.15 ruff format --check .
+        uvx --from ruff==0.15.22 ruff format --check .
         
     - name: Check code style with ruff
       run: |
-        uvx --from ruff==0.15.15 ruff check .
+        uvx --from ruff==0.15.22 ruff check .

--- a/.github/workflows/code-format.yml
+++ b/.github/workflows/code-format.yml
@@ -27,8 +27,8 @@ jobs:
       
     - name: Check code formatting with ruff
       run: |
-        uv run ruff format --check .
+        uvx --from ruff==0.15.15 ruff format --check .
         
     - name: Check code style with ruff
       run: |
-        uv run ruff check .
+        uvx --from ruff==0.15.15 ruff check .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ ci:
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.15.15
+  rev: v0.15.22
   hooks:
     # Run the linter.
     - id: ruff-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ ci:
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.14.1
+  rev: v0.15.15
   hooks:
     # Run the linter.
     - id: ruff-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dev = [
   "pytest>=8.4.1",
   "pytest-asyncio>=1.1.0",
   "pytest-cov>=6.2.1",
-  "ruff==0.15.15",
+  "ruff==0.15.22",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dev = [
   "pytest>=8.4.1",
   "pytest-asyncio>=1.1.0",
   "pytest-cov>=6.2.1",
-  "ruff>=0.15.0",
+  "ruff==0.15.15",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Pin Ruff to avoid unexpected CI failures caused by automatic upgrades. Ruff 0.16.0 introduced Markdown code block formatting, resulting in inconsistent behavior between local development, pre-commit, and CI.

固定 Ruff 版本，避免自动升级导致 CI 与本地格式化行为不一致。
### Modifications / 改动点

  - Pin Ruff to  0.15.22 in pyproject.toml.
  - Update pre-commit Ruff to v 0.15.22.
  - Use Ruff  0.15.22 explicitly in the CI formatting workflow.

  统一项目依赖、pre-commit 和 CI 使用的 Ruff 版本为 0.15.22。
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<img width="666" height="103" alt="image" src="https://github.com/user-attachments/assets/191bd733-00d8-4d6a-b32f-7e15044853cb" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Pin Ruff to a specific version across the project to ensure consistent formatting and linting behavior between local development, pre-commit, and CI.

Build:
- Lock the Ruff dev dependency in pyproject.toml to version 0.15.15.

CI:
- Update the CI code-format workflow to run Ruff 0.15.15 explicitly via uvx.

Chores:
- Align the pre-commit Ruff hook version to v0.15.15 to match the project and CI configuration.