### PR TITLE
test: prevent updater path tests from creating stray dirs

### DIFF
--- a/tests/test_updator_socks.py
+++ b/tests/test_updator_socks.py
@@ -227,6 +227,7 @@ def _exercise_unzip_file_windows_path_normalization(
         return [".dockerignore"]
 
     monkeypatch.setattr(updater_module.os, "makedirs", lambda path, exist_ok=True: None)
+    monkeypatch.setattr(updater_module, "ensure_dir", lambda path: None)
     monkeypatch.setattr(updater_module.os.path, "join", ntpath.join)
     monkeypatch.setattr(updater_module.os.path, "normpath", ntpath.normpath)
     monkeypatch.setattr(updater_module.os.path, "commonpath", ntpath.commonpath)
@@ -984,6 +985,7 @@ def test_repo_unzip_file_rejects_archive_roots_outside_target_dir(
     monkeypatch.setattr(
         zip_updator_module.os, "makedirs", lambda path, exist_ok=True: None
     )
+    monkeypatch.setattr(zip_updator_module, "ensure_dir", lambda path: None)
     monkeypatch.setattr(zip_updator_module.os.path, "join", ntpath.join)
     monkeypatch.setattr(zip_updator_module.os.path, "normpath", ntpath.normpath)
     monkeypatch.setattr(zip_updator_module.os.path, "commonpath", ntpath.commonpath)
@@ -1020,6 +1022,7 @@ def test_repo_unzip_file_handles_archives_without_explicit_root_dir_entry(
     monkeypatch.setattr(
         zip_updator_module.os, "makedirs", lambda path, exist_ok=True: None
     )
+    monkeypatch.setattr(zip_updator_module, "ensure_dir", lambda path: None)
     monkeypatch.setattr(zip_updator_module.os.path, "join", ntpath.join)
     monkeypatch.setattr(zip_updator_module.os.path, "normpath", ntpath.normpath)
     monkeypatch.setattr(zip_updator_module.os.path, "commonpath", ntpath.commonpath)


### PR DESCRIPTION
There is no existing issue for this; the problem is described below.

The Windows path normalization tests in `tests/test_updator_socks.py` create stray directories in the current working directory whenever they run on macOS/Linux. Running `pytest tests/test_updator_socks.py -k windows_extended_length` leaves behind folders literally named:

```
\\?\C:\Users\admin\AppData\Local\AstrBot\backend\app
\\?\C:\Users\admin\AppData\Local\AstrBot\data\plugins\demo
\\?\C:\Users\admin\target
```

**Root cause:** these tests monkeypatch `os.makedirs`, but `unzip_file` actually creates the target directory via `ensure_dir()` → `Path.mkdir(parents=True)` (in `astrbot/core/utils/io.py`), which was left unpatched. On macOS/Linux the backslash is a valid filename character, so the hardcoded `\\?\C:\Users\admin\...` target strings get created as real directories in the repo working tree. Deleting them doesn't help — they reappear on the next test run.

### Modifications / 改动点

`tests/test_updator_socks.py`: patch `ensure_dir` alongside the existing `os.makedirs` mock in the three places that call `unzip_file`, so the tests stay in-memory and never touch the disk.

- The `_exercise_unzip_file_windows_path_normalization` helper
- `test_repo_unzip_file_rejects_archive_roots_outside_target_dir`
- `test_repo_unzip_file_handles_archives_without_explicit_root_dir_entry`

No production code is changed.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Ran the full test file in an isolated temp dir and confirmed no stray backslash directories are created afterwards:

```
$ cd /tmp/wintest && pytest tests/test_updator_socks.py -q
.............................                                            [100%]
29 passed, 1 warning in 1.56s
# working dir afterwards: no `\\?\C:...` folders
```

Ruff clean:

```
$ ruff format --check tests/test_updator_socks.py
1 file already formatted
$ ruff check tests/test_updator_socks.py
All checks passed!
```

Also verified the real (unmocked) `unzip_file` path still extracts, moves root-dir contents into the target, and removes the archive — behavior unchanged.

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Tests:
- Ensure updater unzip path normalization tests no longer create real directories on macOS/Linux by mocking both os.makedirs and ensure_dir.