### PR TITLE
fix: isolate empty-mention waiter by sender without changing default session scope

### DIFF
--- a/astrbot/builtin_stars/astrbot/main.py
+++ b/astrbot/builtin_stars/astrbot/main.py
@@ -12,6 +12,7 @@ from astrbot.core import logger
 from astrbot.core.utils.session_waiter import (
     FILTERS,
     USER_SESSIONS,
+    SenderSessionFilter,
     SessionController,
     SessionWaiter,
     session_waiter,
@@ -126,7 +127,24 @@ class Main(star.Star):
                 controller.stop()
 
             try:
-                await empty_mention_waiter(event)
+                # The empty-mention waiter semantically belongs to the person
+                # who sent the empty mention, so it must be isolated by sender;
+                # otherwise in group chats the next message from any other
+                # member is mistaken for the follow-up content. Skip waiting
+                # when no reliable sender id is available, to avoid silently
+                # degrading back to group scope.
+                if event.get_sender_id():
+                    await empty_mention_waiter(
+                        event,
+                        session_filter=SenderSessionFilter(),
+                    )
+                else:
+                    logger.warning(
+                        "empty mention: no sender id available for %s, "
+                        "skipping the follow-up wait to avoid falling back "
+                        "to a group-wide waiter",
+                        event.unified_msg_origin,
+                    )
             except TimeoutError:
                 pass
             except Exception as e:

--- a/astrbot/core/utils/session_waiter.py
+++ b/astrbot/core/utils/session_waiter.py
@@ -101,6 +101,41 @@ class DefaultSessionFilter(SessionFilter):
         return event.unified_msg_origin
 
 
+class SenderSessionFilter(SessionFilter):
+    """Scope a session by conversation origin plus sender.
+
+    In group chats unified_msg_origin is identical for every member, so with
+    DefaultSessionFilter the next message from any member hits a waiter created
+    by someone else. This filter appends the sender id so a waiter only responds
+    to the person who started it, while keeping the conversation origin so the
+    same user's messages in other conversations (other groups / DMs) do not
+    match either.
+
+    This is an opt-in filter and does not change the default behavior. Callers
+    that need per-sender isolation (e.g. the empty-mention waiter) should pass
+    it explicitly.
+    """
+
+    def filter(self, event: AstrMessageEvent) -> str:
+        """Build a session key scoped to both conversation and sender.
+
+        A length-prefixed encoding is used instead of plain concatenation:
+        both unified_msg_origin and the sender id are arbitrary platform
+        strings (e.g. Telegram topic-group origins contain "#"), so joining
+        them with a separator allows constructible key collisions
+        ("a#b" + "c" equals "a" + "b#c"), defeating the isolation. The length
+        prefix makes the encoding uniquely decodable.
+
+        Args:
+            event: The current message event.
+
+        Returns:
+            An unambiguous session key of the form "{len(umo)}:{umo}:{sender_id}".
+        """
+        umo = event.unified_msg_origin
+        return f"{len(umo)}:{umo}:{event.get_sender_id()}"
+
+
 class SessionWaiter:
     def __init__(
         self,

--- a/astrbot/core/utils/session_waiter.py
+++ b/astrbot/core/utils/session_waiter.py
@@ -126,14 +126,19 @@ class SenderSessionFilter(SessionFilter):
         ("a#b" + "c" equals "a" + "b#c"), defeating the isolation. The length
         prefix makes the encoding uniquely decodable.
 
+        The key is also namespaced with a leading "!" so it can never equal a
+        raw unified_msg_origin produced by DefaultSessionFilter, since both
+        filters share the USER_SESSIONS registry and platform ids may not
+        contain "!" (see PlatformManager._is_valid_platform_id).
+
         Args:
             event: The current message event.
 
         Returns:
-            An unambiguous session key of the form "{len(umo)}:{umo}:{sender_id}".
+            A session key of the form "!sender:{len(umo)}:{umo}:{sender_id}".
         """
         umo = event.unified_msg_origin
-        return f"{len(umo)}:{umo}:{event.get_sender_id()}"
+        return f"!sender:{len(umo)}:{umo}:{event.get_sender_id()}"
 
 
 class SessionWaiter:

--- a/tests/test_session_waiter_cross_user.py
+++ b/tests/test_session_waiter_cross_user.py
@@ -236,6 +236,13 @@ def test_sender_filter_key_is_collision_free():
     key_d = f.filter(FakeEvent("p:GroupMessage:g", "x:y", ""))
     assert key_c != key_d
 
+    # The registry is shared with DefaultSessionFilter, so a sender key must
+    # never be parseable as a raw unified_msg_origin either. Platform ids may
+    # not contain "!", so the namespace prefix guarantees that.
+    sender_key = f.filter(FakeEvent("GroupMessage:FriendMessage:x", "y", ""))
+    assert sender_key.startswith("!"), "sender keys must be namespaced"
+    assert sender_key != "GroupMessage:FriendMessage:x"
+
 
 @pytest.mark.asyncio
 async def test_sender_filter_isolates_users_with_hash_in_umo(waiter_mod):

--- a/tests/test_session_waiter_cross_user.py
+++ b/tests/test_session_waiter_cross_user.py
@@ -1,0 +1,288 @@
+"""Session-key isolation tests for the empty-mention waiter (issue #9377).
+
+The fix is scoped: DefaultSessionFilter keeps its group-level
+unified_msg_origin semantics (third-party plugins rely on it), and only the
+built-in empty-mention waiter opts into the new SenderSessionFilter.
+
+This file therefore locks down two things:
+1. The default behavior is unchanged — DefaultSessionFilter still returns
+   unified_msg_origin (including a regression guard that mirrors a real
+   plugin's manual-registration pattern);
+2. The new behavior is correct — SenderSessionFilter only responds to the
+   original sender, without leaking across conversations and without
+   constructible key collisions.
+
+The module under test is loaded from its file path with its two imports
+stubbed, so validating pure key logic does not require the full astrbot
+dependency tree. Production wiring of Main.handle_empty_mention is covered
+separately in tests/unit/test_empty_mention_sender_scope.py.
+"""
+
+import asyncio
+import importlib.util
+import pathlib
+import sys
+import types
+
+import pytest
+
+_SRC = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "astrbot"
+    / "core"
+    / "utils"
+    / "session_waiter.py"
+)
+
+
+def _load_session_waiter():
+    """Load session_waiter from its file path with stubbed imports.
+
+    Returns:
+        The loaded session_waiter module object (cached in sys.modules).
+    """
+    if "_sw_under_test" in sys.modules:
+        return sys.modules["_sw_under_test"]
+
+    class BaseMessageComponent: ...
+
+    class AstrMessageEvent: ...
+
+    names = (
+        "astrbot",
+        "astrbot.core",
+        "astrbot.core.message",
+        "astrbot.core.message.components",
+        "astrbot.core.platform",
+    )
+    saved = {k: sys.modules.get(k) for k in names}
+    stubs = {k: types.ModuleType(k) for k in names}
+    stubs["astrbot.core.message.components"].BaseMessageComponent = BaseMessageComponent
+    stubs["astrbot.core.platform"].AstrMessageEvent = AstrMessageEvent
+    # `import a.b.c as x` requires child modules as parent attributes.
+    stubs["astrbot"].core = stubs["astrbot.core"]
+    stubs["astrbot.core"].message = stubs["astrbot.core.message"]
+    stubs["astrbot.core"].platform = stubs["astrbot.core.platform"]
+    stubs["astrbot.core.message"].components = stubs["astrbot.core.message.components"]
+    sys.modules.update(stubs)
+    try:
+        spec = importlib.util.spec_from_file_location("_sw_under_test", _SRC)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["_sw_under_test"] = mod
+        spec.loader.exec_module(mod)
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = v
+    return mod
+
+
+class FakeEvent:
+    """Implements only the interface used by SessionFilter / handlers."""
+
+    def __init__(self, umo: str, sender_id: str, text: str) -> None:
+        self.unified_msg_origin = umo
+        self._sender_id = sender_id
+        self.message_str = text
+
+    def get_sender_id(self) -> str:
+        return self._sender_id
+
+    def get_messages(self) -> list:
+        return []
+
+
+@pytest.fixture
+def waiter_mod():
+    mod = _load_session_waiter()
+    mod.USER_SESSIONS.clear()
+    mod.FILTERS.clear()
+    yield mod
+    mod.USER_SESSIONS.clear()
+    mod.FILTERS.clear()
+
+
+GROUP = "napcat2:GroupMessage:984306989"
+GROUP2 = "napcat2:GroupMessage:111222333"
+ALICE = "3878611411"  # the member who sent the empty mention
+BOB = "3781884259"  # an unrelated member of the same group
+
+
+async def _run_with_sender_filter(mod, incoming):
+    """Start ALICE's waiter with SenderSessionFilter and feed it events.
+
+    Mirrors the empty-mention call site: ALICE sends an empty mention to start
+    the waiter, then each event in `incoming` goes through the dispatch loop.
+
+    Args:
+        mod: The loaded session_waiter module.
+        incoming: FakeEvent instances fed to the dispatch loop in order.
+
+    Returns:
+        List of (sender_id, unified_msg_origin) tuples the waiter captured.
+    """
+    captured = []
+
+    @mod.session_waiter(5)
+    async def waiter(controller, event):
+        if not event.message_str.strip():
+            return
+        captured.append((event.get_sender_id(), event.unified_msg_origin))
+        controller.stop()
+
+    trigger = FakeEvent(GROUP, ALICE, "")
+    task = asyncio.create_task(
+        waiter(trigger, session_filter=mod.SenderSessionFilter())
+    )
+    await asyncio.sleep(0)  # let the waiter finish registration
+
+    for ev in incoming:
+        for f in list(mod.FILTERS):
+            sid = f.filter(ev)
+            if sid in mod.USER_SESSIONS:
+                await mod.SessionWaiter.trigger(sid, ev)
+
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass  # only swallow the cancellation itself; unexpected errors must fail
+    return captured
+
+
+# --- Default semantics unchanged (third-party plugin compatibility) ---
+
+
+def test_default_filter_returns_umo_unchanged():
+    """DefaultSessionFilter must keep returning unified_msg_origin."""
+    f = _load_session_waiter().DefaultSessionFilter()
+    assert f.filter(FakeEvent(GROUP, ALICE, "")) == GROUP
+    # Same group, same key, regardless of sender.
+    assert f.filter(FakeEvent(GROUP, BOB, "")) == GROUP
+
+
+@pytest.mark.asyncio
+async def test_default_manual_umo_registration_still_triggers(waiter_mod):
+    """Regression guard mirroring astrbot_plugin_kimi_datasource_api usage.
+
+    That plugin registers a waiter manually with the raw unified_msg_origin as
+    the key while adding a DefaultSessionFilter to FILTERS. Because this fix
+    leaves the default filter untouched, the lookup key still equals the
+    registration key and the waiter must keep triggering. (If the default were
+    changed to include the sender, registration key UMO would never match
+    lookup key UMO+sender and the waiter could never trigger — this test exists
+    to catch exactly that breakage.)
+    """
+    mod = waiter_mod
+    triggered = []
+
+    waiter = mod.SessionWaiter(mod.DefaultSessionFilter(), GROUP, False)
+
+    async def handler(controller, event):
+        triggered.append(event.get_sender_id())
+        controller.stop()
+
+    waiter.handler = handler
+    mod.FILTERS.append(waiter.session_filter)
+    mod.USER_SESSIONS[GROUP] = waiter  # registration key = raw UMO
+
+    incoming = FakeEvent(GROUP, BOB, "login code")
+    for f in list(mod.FILTERS):
+        sid = f.filter(incoming)
+        if sid in mod.USER_SESSIONS:
+            await mod.SessionWaiter.trigger(sid, incoming)
+
+    assert triggered == [BOB], "manually UMO-registered waiter must still trigger"
+
+
+# --- New behavior correct (per-sender isolation) ---
+
+
+@pytest.mark.asyncio
+async def test_sender_filter_isolates_users_in_group(waiter_mod):
+    """Primary goal: another member's message is not intercepted."""
+    captured = await _run_with_sender_filter(
+        waiter_mod, [FakeEvent(GROUP, BOB, "just chatting")]
+    )
+    assert captured == [], f"BOB's message must not be captured, got {captured}"
+
+
+@pytest.mark.asyncio
+async def test_sender_filter_accepts_original_sender(waiter_mod):
+    """Happy path: the original sender's follow-up is still captured."""
+    captured = await _run_with_sender_filter(
+        waiter_mod, [FakeEvent(GROUP, ALICE, "write me a script")]
+    )
+    assert captured == [(ALICE, GROUP)]
+
+
+def test_sender_filter_key_is_collision_free():
+    """Keys must be unambiguous when UMO / sender contain separator chars.
+
+    With plain concatenation ("umo#sender"), ("p:GroupMessage:g#x", "y") and
+    ("p:GroupMessage:g", "x#y") produce the same key, defeating the isolation.
+    The length-prefixed encoding must keep them distinct. Telegram topic-group
+    origins genuinely contain "#", so this is not hypothetical.
+    """
+    f = _load_session_waiter().SenderSessionFilter()
+    key_a = f.filter(FakeEvent("p:GroupMessage:g#x", "y", ""))
+    key_b = f.filter(FakeEvent("p:GroupMessage:g", "x#y", ""))
+    assert key_a != key_b, "distinct (conversation, sender) pairs collided"
+
+    # Pairs constructed with ":" must not collide either.
+    key_c = f.filter(FakeEvent("p:GroupMessage:g:x", "y", ""))
+    key_d = f.filter(FakeEvent("p:GroupMessage:g", "x:y", ""))
+    assert key_c != key_d
+
+
+@pytest.mark.asyncio
+async def test_sender_filter_isolates_users_with_hash_in_umo(waiter_mod):
+    """Isolation holds for Telegram topic-group style origins containing "#"."""
+    mod = waiter_mod
+    topic_umo = "telegram:GroupMessage:-100123#42"
+    captured = []
+
+    @mod.session_waiter(5)
+    async def waiter(controller, event):
+        captured.append(event.get_sender_id())
+        controller.stop()
+
+    task = asyncio.create_task(
+        waiter(
+            FakeEvent(topic_umo, ALICE, ""),
+            session_filter=mod.SenderSessionFilter(),
+        )
+    )
+    await asyncio.sleep(0)
+
+    intruder = FakeEvent(topic_umo, BOB, "butting in")
+    for f in list(mod.FILTERS):
+        sid = f.filter(intruder)
+        if sid in mod.USER_SESSIONS:
+            await mod.SessionWaiter.trigger(sid, intruder)
+    assert captured == [], "another member must not be captured in a topic group"
+
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_sender_filter_does_not_leak_across_conversations(waiter_mod):
+    """SenderSessionFilter keeps the conversation part of the key.
+
+    ALICE's messages in another group or in DMs must not be captured by the
+    waiter she started in GROUP.
+    """
+    captured = await _run_with_sender_filter(
+        waiter_mod,
+        [
+            FakeEvent(GROUP2, ALICE, "talking in another group"),
+            FakeEvent(f"napcat2:FriendMessage:{ALICE}", ALICE, "talking in DM"),
+        ],
+    )
+    assert captured == [], f"cross-conversation messages captured: {captured}"

--- a/tests/unit/test_empty_mention_sender_scope.py
+++ b/tests/unit/test_empty_mention_sender_scope.py
@@ -1,0 +1,189 @@
+"""Production-wiring tests for empty-mention per-sender isolation (#9377).
+
+Unlike tests/test_session_waiter_cross_user.py, which exercises the session-key
+logic in isolation, these tests drive the real `Main.handle_empty_mention` and
+`Main.handle_session_control_agent` handlers. They fail if the production
+wiring is reverted (waiter registered without SenderSessionFilter, or the
+empty-sender guard removed).
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import astrbot.builtin_stars.astrbot.main as main_module
+from astrbot.api.message_components import At, Plain
+from astrbot.builtin_stars.astrbot.main import Main
+from astrbot.core.utils.session_waiter import FILTERS, USER_SESSIONS
+
+BOT_ID = "3878611411"
+GROUP_UMO = "napcat2:GroupMessage:984306989"
+ALICE = "1111"  # the member who sends the empty mention
+BOB = "2222"  # an unrelated member of the same group
+
+
+@pytest.fixture(autouse=True)
+def _clean_session_state():
+    USER_SESSIONS.clear()
+    FILTERS.clear()
+    yield
+    USER_SESSIONS.clear()
+    FILTERS.clear()
+
+
+class FakeEvent:
+    """Minimal real object (not a MagicMock) so copy.copy() behaves natively."""
+
+    def __init__(self, sender_id: str, text: str, components: list) -> None:
+        self.unified_msg_origin = GROUP_UMO
+        self.message_str = text
+        self.message_obj = SimpleNamespace(message=list(components))
+        self.stop_event_calls = 0
+        self._sender_id = sender_id
+
+    def get_messages(self) -> list:
+        return self.message_obj.message
+
+    def get_self_id(self) -> str:
+        return BOT_ID
+
+    def get_sender_id(self) -> str:
+        return self._sender_id
+
+    def stop_event(self) -> None:
+        self.stop_event_calls += 1
+
+
+def make_main() -> Main:
+    main = Main.__new__(Main)
+    main.context = MagicMock()
+    main.context.get_config.return_value = {
+        "platform_settings": {
+            "empty_mention_waiting": True,
+            # Skip the LLM reply so the handler goes straight to waiting.
+            "empty_mention_waiting_need_reply": False,
+        },
+        "wake_prefix": [],
+    }
+    return main
+
+
+@pytest.mark.asyncio
+async def test_other_members_message_passes_through():
+    """BOB's message must not be stopped, modified, or re-enqueued."""
+    main = make_main()
+    queue = main.context.get_event_queue.return_value
+    trigger = FakeEvent(ALICE, "", [At(qq=BOT_ID, name=BOT_ID)])
+
+    async def drain() -> None:
+        async for _ in main.handle_empty_mention(trigger):
+            pass
+
+    task = asyncio.create_task(drain())
+    await asyncio.sleep(0.05)  # let the handler reach (or skip) the waiter
+    assert len(USER_SESSIONS) == 1, "waiter should be registered"
+
+    bob_event = FakeEvent(BOB, "just chatting", [Plain("just chatting")])
+    await main.handle_session_control_agent(bob_event)
+
+    assert bob_event.stop_event_calls == 0, "BOB's event must not be stopped"
+    queue.put_nowait.assert_not_called()
+    assert isinstance(bob_event.message_obj.message[0], Plain), (
+        "no At component may be injected into BOB's message"
+    )
+    assert len(USER_SESSIONS) == 1, "the waiter must still be waiting for ALICE"
+
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_original_senders_followup_is_redispatched():
+    """ALICE's follow-up gets the bot At injected, is stopped and re-enqueued."""
+    main = make_main()
+    queue = main.context.get_event_queue.return_value
+    trigger = FakeEvent(ALICE, "", [At(qq=BOT_ID, name=BOT_ID)])
+
+    async def drain() -> None:
+        async for _ in main.handle_empty_mention(trigger):
+            pass
+
+    task = asyncio.create_task(drain())
+    await asyncio.sleep(0.05)  # let the handler reach (or skip) the waiter
+
+    followup = FakeEvent(ALICE, "hello bot", [Plain("hello bot")])
+    await main.handle_session_control_agent(followup)
+
+    assert followup.stop_event_calls > 0, "the consumed follow-up must be stopped"
+    queue.put_nowait.assert_called_once()
+    injected = followup.message_obj.message[0]
+    assert isinstance(injected, At) and str(injected.qq) == BOT_ID
+    await task  # controller.stop() lets the handler complete
+    assert USER_SESSIONS == {}, "the waiter must be cleaned up after consuming"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_sender", [None, 0, False, [], b""])
+async def test_unusable_sender_id_skips_waiting(monkeypatch, bad_sender):
+    """A sender id that is not a non-empty string must not start a waiter.
+
+    A truthiness check on ``str(sender_id)`` would pass here: ``str(None)`` is
+    ``"None"``, which is truthy, so the waiter would register under a key like
+    ``...:None``. The guard must therefore check the type as well.
+    """
+    main = make_main()
+    trigger = FakeEvent(bad_sender, "", [At(qq=BOT_ID, name=BOT_ID)])
+    monkeypatch.setattr(main_module.logger, "warning", lambda *a, **k: None)
+
+    async def drain() -> None:
+        async for _ in main.handle_empty_mention(trigger):
+            pass
+
+    task = asyncio.create_task(drain())
+    await asyncio.sleep(0.05)  # let the handler reach (or skip) the waiter
+
+    assert task.done(), f"handler must not wait for sender id {bad_sender!r}"
+    assert USER_SESSIONS == {}, f"no waiter may register for {bad_sender!r}"
+    assert FILTERS == []
+
+
+@pytest.mark.asyncio
+async def test_empty_sender_id_skips_waiting(monkeypatch):
+    """Without a reliable sender id no waiter may be registered at all.
+
+    Skipping fails closed: the feature is unavailable for that message rather
+    than falling back to a group-wide key that another member could satisfy.
+    A warning must be emitted so the situation stays observable.
+
+    The warning is asserted through a patched logger rather than pytest's
+    caplog because astrbot's logger sets ``propagate = False`` (records are
+    forwarded to loguru), so they never reach the root handler caplog installs.
+    """
+    main = make_main()
+    trigger = FakeEvent("", "", [At(qq=BOT_ID, name=BOT_ID)])
+
+    warnings = []
+    monkeypatch.setattr(
+        main_module.logger,
+        "warning",
+        lambda msg, *args, **kwargs: warnings.append(msg % args if args else msg),
+    )
+
+    async def drain() -> None:
+        async for _ in main.handle_empty_mention(trigger):
+            pass
+
+    task = asyncio.create_task(drain())
+    await asyncio.sleep(0.05)  # let the handler reach (or skip) the waiter
+
+    assert task.done(), "handler must finish immediately instead of waiting"
+    assert USER_SESSIONS == {}, "no waiter may be registered without a sender id"
+    assert FILTERS == []
+    assert any("no sender id" in w for w in warnings), (
+        f"skipping the wait must be logged, not silent; got {warnings}"
+    )


### PR DESCRIPTION
<!-- PR title (conventional commit):
fix: isolate empty-mention waiter by sender without changing default session scope
-->

Fixes #9377

In group chats, an empty mention (`@bot` with no text) starts a 60s
`session_waiter` to wait for follow-up content. The waiter is registered with
`DefaultSessionFilter`, whose key is `unified_msg_origin` (group-level) and does
not include the sender. As a result, the first non-empty message from **any
other member** during the wait window is intercepted, gets a bot `At` prepended,
and is re-dispatched — producing a reply to the wrong user / wrong context. Full
analysis, reproduction and captured logs are in #9377.

This PR fixes the empty-mention flow **without changing the default session
scope**, so third-party plugins that rely on the current group-level default are
unaffected.

### Why not simply change `DefaultSessionFilter`

Changing the default from `unified_msg_origin` to include the sender would
change the default runtime behavior of `session_waiter`, which is exported to
plugins through `astrbot.api.util`. The group-level default has been in place
since v3.5.4 (~15 months, 138 version tags) and is relied upon by real
plugins that omit `session_filter=`, for example:

- `astrbot_plugin_kimi_datasource_api` registers a waiter manually with
  `SessionWaiter(DefaultSessionFilter(), event.unified_msg_origin, ...)`. The
  registration key is the raw UMO while lookups go through
  `DefaultSessionFilter.filter(event)`. If the default changed, the keys would no
  longer match and its login waiter would **never trigger**.
- `astrbot_plugin_decision_roulette` and `astrbot_plugin_TurtleSoup` use the
  default filter to collect input from multiple group members; a per-sender
  default would only accept the initiator.

So the fix is scoped to the one place that actually needs per-sender isolation.

### Modifications

- `astrbot/core/utils/session_waiter.py`: add `SenderSessionFilter`, a new
  optional `SessionFilter` keyed by `unified_msg_origin` + `sender_id`.
  `DefaultSessionFilter` is **unchanged**, and no new names are added to the
  public `astrbot.api.util` surface. This is purely additive.
  The key uses a length-prefixed encoding (`f"{len(umo)}:{umo}:{sender}"`)
  rather than plain concatenation: both the UMO and the sender id are arbitrary
  platform strings (e.g. Telegram topic-group UMOs contain `#`), so a plain
  separator would allow constructible key collisions that defeat the isolation.
- `astrbot/builtin_stars/astrbot/main.py`: the empty-mention waiter now passes
  `session_filter=SenderSessionFilter()`. When the sender id is unavailable it
  skips waiting entirely, to avoid silently degrading back to group scope.
- `tests/test_session_waiter_cross_user.py` (new): 7 session-key regression
  tests (module loaded standalone).
- `tests/unit/test_empty_mention_sender_scope.py` (new): 3 production-wiring
  tests driving the real `Main.handle_empty_mention` and
  `Main.handle_session_control_agent` (following the existing
  `Main.__new__(Main)` pattern in `tests/unit/test_group_chat_context_wiring.py`).

The other issues noted in #9377 (empty-`message_str` messages being swallowed
during the wait window; `_cleanup` / `FILTERS` behavior with same-key waiters)
are independent of the session key and will be handled in separate PRs.

### Screenshots or Test Results

```
$ ruff format --check <changed files + test files> && ruff check <same>
All checks passed!

$ pytest tests/test_session_waiter_cross_user.py \
         tests/unit/test_empty_mention_sender_scope.py -o asyncio_mode=auto -q
..........                                                               [100%]
10 passed
```

Session-key coverage (`tests/test_session_waiter_cross_user.py`):

1. `test_default_filter_returns_umo_unchanged` — the default filter still returns
   `unified_msg_origin` (locks the default semantics in place);
2. `test_default_manual_umo_registration_still_triggers` — reproduces the
   `kimi_datasource_api` manual-registration pattern and asserts it still
   triggers (guards against regressing plugins that depend on the group default);
3. `test_sender_filter_isolates_users_in_group` — another member's message is no
   longer intercepted (primary goal);
4. `test_sender_filter_accepts_original_sender` — the original sender's follow-up
   is still captured;
5. `test_sender_filter_key_is_collision_free` — UMOs / sender ids containing
   separator characters (`#`, `:`) cannot produce colliding keys;
6. `test_sender_filter_isolates_users_with_hash_in_umo` — isolation holds for
   Telegram topic-group style UMOs that contain `#`;
7. `test_sender_filter_does_not_leak_across_conversations` — the same user's
   messages in other groups / DMs are not intercepted.

Production-wiring coverage (`tests/unit/test_empty_mention_sender_scope.py`,
drives the real handlers rather than a re-implementation):

8. `test_other_members_message_passes_through` — BOB's message is not stopped,
   not modified, and not re-enqueued while ALICE's waiter is active;
9. `test_original_senders_followup_is_redispatched` — ALICE's follow-up gets the
   bot `At` injected, is stopped and re-enqueued, and the waiter is cleaned up;
10. `test_empty_sender_id_skips_waiting` — with no reliable sender id the
    handler finishes immediately and registers no waiter.

Verified that the wiring tests actually guard the fix: with the `main.py`
change reverted to master, tests 8 and 10 fail; with the fix in place all 10
pass.

---

- [x] This is NOT a breaking change.

> The default session scope is unchanged; only the built-in empty-mention waiter
> opts into per-sender isolation. `SenderSessionFilter` is an additive core
> utility and is not exported through `astrbot.api.util`.

### Checklist

- [x] 😊 If new features are added, they have been discussed with the authors
  via issues/emails. (Bug fix, proposed in #9377.)
- [x] 👀 My changes have been well-tested, with verification steps and results
  provided above.
- [x] 🤓 No new dependencies are introduced.
- [x] 😮 My changes do not introduce malicious code.

## Summary by Sourcery

Fix empty-mention session handling in group chats by isolating the waiter per sender while preserving existing group-level session semantics.

Bug Fixes:
- Prevent empty-mention waiters in group chats from intercepting follow-up messages from other members and replying in the wrong context.
- Ensure empty-mention handling skips session waiting when no reliable sender ID is available to avoid unintended group-scoped behavior.

Enhancements:
- Introduce an optional SenderSessionFilter that scopes session keys by conversation origin and sender using a collision-safe encoding without changing the default session filter.
- Strengthen session key behavior with explicit guarantees against key collisions and cross-conversation leakage.

Tests:
- Add regression tests that lock in DefaultSessionFilter behavior and validate SenderSessionFilter isolation, collision safety, and cross-conversation separation.
- Add production wiring tests for empty-mention handling to verify correct per-sender redispatch, non-interference with other members, and behavior when sender ID is missing.