### PR TITLE
fix: add model config for FishAudio TTS provider

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1725,6 +1725,7 @@ CONFIG_METADATA_2 = {
                         "enable": False,
                         "api_key": "",
                         "api_base": "https://api.fish.audio/v1",
+                        "model": "s2-pro",
                         "fishaudio-tts-character": "可莉",
                         "fishaudio-tts-reference-id": "",
                         "timeout": "20",

--- a/astrbot/core/provider/sources/fishaudio_tts_api_source.py
+++ b/astrbot/core/provider/sources/fishaudio_tts_api_source.py
@@ -67,7 +67,10 @@ class ProviderFishAudioTTSAPI(TTSProvider):
         self.headers = {
             "Authorization": f"Bearer {self.chosen_api_key}",
         }
-        self.set_model(provider_config.get("model", ""))
+        # FishAudio API 要求 model 作为 HTTP header 发送，而非请求体字段
+        # 参考: https://github.com/fishaudio/fish-audio-python/blob/main/src/fishaudio/resources/tts.py
+        self.set_model(provider_config.get("model", "s2-pro"))
+        self.headers["model"] = self.get_model()
 
     async def _get_reference_id_by_character(self, character: str) -> str | None:
         """获取角色的reference_id


### PR DESCRIPTION
### Motivation / 动机

FishAudio TTS provider 缺少 `model` 配置项。虽然源码中通过 `self.set_model(provider_config.get("model", ""))` 读取了 `model` 字段，但配置模板 `default.py` 中 `FishAudio TTS(API)` 未定义该字段，导致用户无法在面板上配置 TTS 引擎模型，且 `model` 未被实际发送到 API。

根据官方 FishAudio Python SDK 源码（https://github.com/fishaudio/fish-audio-python/blob/main/src/fishaudio/resources/tts.py ），`model` 是 `POST /v1/tts` 的 **HTTP header**，而非请求体字段：

```python
headers={"Content-Type": "application/msgpack", "model": model}
```

本 PR 在配置模板中添加 `model` 字段（默认 `s2-pro`），并在 `__init__` 中将其写入 `self.headers["model"]`，使每次 TTS 请求都携带正确的 model header。

Resubmitting #9344 with model sent as HTTP header per review feedback, instead of request body field.

### Modifications / 改动点

修改 2 个文件，+5 -1 行：

**`astrbot/core/config/default.py`**
- 在 `FishAudio TTS(API)` 配置模板中添加 `"model": "s2-pro"`，复用已有的标准 `model` schema

**`astrbot/core/provider/sources/fishaudio_tts_api_source.py`**
- 默认值从 `""` 改为 `"s2-pro"`（官方 SDK 默认值）
- 将 model 写入 `self.headers["model"]`，随 HTTP 请求头发送，而非放入 `ServeTTSRequest` 请求体

```diff
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1725,6 +1725,7 @@
                         "api_base": "https://api.fish.audio/v1",
+                        "model": "s2-pro",
                         "fishaudio-tts-character": "可莉",

--- a/astrbot/core/provider/sources/fishaudio_tts_api_source.py
+++ b/astrbot/core/provider/sources/fishaudio_tts_api_source.py
@@ -67,7 +67,10 @@
-        self.set_model(provider_config.get("model", ""))
+        # FishAudio API 要求 model 作为 HTTP header 发送，而非请求体字段
+        # 参考: https://github.com/fishaudio/fish-audio-python/blob/main/src/fishaudio/resources/tts.py
+        self.set_model(provider_config.get("model", "s2-pro"))
+        self.headers["model"] = self.get_model()
```

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Verification / 验证

1. 启动 AstrBot，在 WebUI「模型提供商 → 文字转语音」中新增 FishAudio TTS(API)，确认面板显示 `model` 配置项，默认值为 `s2-pro`
2. 配置 API Key 和 reference_id 后调用 TTS，确认请求 header 中携带 `model: s2-pro`，请求体（msgpack）中不含 model 字段

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Configure FishAudio TTS model support in both the default config and HTTP client so the selected model is sent in request headers.

New Features:
- Expose a configurable FishAudio TTS model in the default configuration with a default of s2-pro.

Bug Fixes:
- Ensure the FishAudio TTS model value is included as an HTTP header on requests instead of being omitted.