### PR TITLE
fix(provider): add proxy support for rerank providers

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1896,6 +1896,7 @@ CONFIG_METADATA_2 = {
                         "rerank_api_suffix": "/v1/rerank",
                         "rerank_model": "BAAI/bge-reranker-base",
                         "timeout": 20,
+                        "proxy": "",
                     },
                     "Xinference Rerank": {
                         "id": "xinference_rerank",
@@ -1921,6 +1922,7 @@ CONFIG_METADATA_2 = {
                         "timeout": 30,
                         "return_documents": False,
                         "instruct": "",
+                        "proxy": "",
                     },
                     "NVIDIA Rerank": {
                         "id": "nvidia_rerank",
@@ -1934,6 +1936,7 @@ CONFIG_METADATA_2 = {
                         "nvidia_rerank_model_endpoint": "/reranking",
                         "timeout": 20,
                         "nvidia_rerank_truncate": "",
+                        "proxy": "",
                     },
                     "TEI Rerank": {
                         "id": "tei_rerank",
@@ -1948,6 +1951,7 @@ CONFIG_METADATA_2 = {
                         "tei_rerank_truncation_direction": "Right",
                         "tei_rerank_raw_scores": False,
                         "tei_rerank_return_text": False,
+                        "proxy": "",
                     },
                     "Xinference STT": {
                         "id": "xinference_stt",

--- a/astrbot/core/provider/sources/bailian_rerank_source.py
+++ b/astrbot/core/provider/sources/bailian_rerank_source.py
@@ -52,6 +52,7 @@ class BailianRerankProvider(RerankProvider):
         self.timeout = provider_config.get("timeout", 30)
         self.return_documents = provider_config.get("return_documents", False)
         self.instruct = provider_config.get("instruct", "")
+        self.proxy = provider_config.get("proxy", "") or None
 
         self.base_url = provider_config.get(
             "rerank_api_base",
@@ -232,7 +233,9 @@ class BailianRerankProvider(RerankProvider):
             )
 
             # 发送请求
-            async with self.client.post(self.base_url, json=payload) as response:
+            async with self.client.post(
+                self.base_url, json=payload, proxy=self.proxy
+            ) as response:
                 response.raise_for_status()
                 response_data = await response.json()
 

--- a/astrbot/core/provider/sources/nvidia_rerank_source.py
+++ b/astrbot/core/provider/sources/nvidia_rerank_source.py
@@ -25,6 +25,7 @@ class NvidiaRerankProvider(RerankProvider):
             "nvidia_rerank_model_endpoint", "/reranking"
         )
         self.truncate = provider_config.get("nvidia_rerank_truncate", "")
+        self.proxy = provider_config.get("proxy", "") or None
 
         self.client = None
         self.set_model(self.model)
@@ -130,7 +131,9 @@ class NvidiaRerankProvider(RerankProvider):
             payload = self._build_payload(query, documents)
             request_url = self._get_endpoint()
 
-            async with client.post(request_url, json=payload) as response:
+            async with client.post(
+                request_url, json=payload, proxy=self.proxy
+            ) as response:
                 if response.status != 200:
                     try:
                         response_data = await response.json()

--- a/astrbot/core/provider/sources/tei_rerank_source.py
+++ b/astrbot/core/provider/sources/tei_rerank_source.py
@@ -30,6 +30,7 @@ class TEIRerankProvider(RerankProvider):
         ).lower()
         self.raw_scores = provider_config.get("tei_rerank_raw_scores", False)
         self.return_text = provider_config.get("tei_rerank_return_text", False)
+        self.proxy = provider_config.get("proxy", "") or None
 
         h = {}
         if self.api_key:
@@ -75,7 +76,9 @@ class TEIRerankProvider(RerankProvider):
                 f"[TEI Rerank] Request: query='{query[:50]}...', "
                 f"doc_count={len(documents)}"
             )
-            async with self.client.post(rerank_url, json=payload) as response:
+            async with self.client.post(
+                rerank_url, json=payload, proxy=self.proxy
+            ) as response:
                 if response.status != 200:
                     try:
                         error_data = await response.json()
@@ -128,7 +131,7 @@ class TEIRerankProvider(RerankProvider):
 
         health_url = f"{self.base_url}/health"
         try:
-            async with self.client.get(health_url) as response:
+            async with self.client.get(health_url, proxy=self.proxy) as response:
                 if response.status != 200:
                     raise Exception(
                         f"TEI service health check failed at {self.base_url}: "

--- a/astrbot/core/provider/sources/vllm_rerank_source.py
+++ b/astrbot/core/provider/sources/vllm_rerank_source.py
@@ -27,6 +27,7 @@ class VLLMRerankProvider(RerankProvider):
             self.api_suffix = "/" + self.api_suffix
         self.timeout = provider_config.get("timeout", 20)
         self.model = provider_config.get("rerank_model", "BAAI/bge-reranker-base")
+        self.proxy = provider_config.get("proxy", "") or None
 
         h = {}
         if self.auth_key:
@@ -54,6 +55,7 @@ class VLLMRerankProvider(RerankProvider):
         async with self.client.post(
             rerank_url,
             json=payload,
+            proxy=self.proxy,
         ) as response:
             response_data = await response.json()
             results = response_data.get("results", [])


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

Fixes #9383

Rerank 提供商使用 `aiohttp.ClientSession` 发起 HTTP 请求，但创建时未传入代理参数，也未设置 `trust_env=True`，导致配置了代理的用户无法通过代理访问外部 Rerank API（请求超时或仅能直连）。

本次修复为 4 个 aiohttp-based Rerank 提供商添加了与其他提供商一致的 `proxy` 配置支持。

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- `astrbot/core/config/default.py` — 为 vLLM、百炼、NVIDIA、TEI 四个 Rerank 提供商配置模板添加 `"proxy": ""` 字段
- `astrbot/core/provider/sources/vllm_rerank_source.py` — 读取 proxy 配置并传入 `session.post(proxy=...)`
- `astrbot/core/provider/sources/bailian_rerank_source.py` — 同上
- `astrbot/core/provider/sources/nvidia_rerank_source.py` — 同上
- `astrbot/core/provider/sources/tei_rerank_source.py` — 同上，包括 `test()` 方法中的 GET 请求

> 注：Xinference Rerank 使用 xinference SDK 内部 HTTP 客户端，不直接使用 aiohttp，因此未做修改。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行"验证步骤"的证据，证明此改动有效。-->

```
$ uv run ruff check astrbot/core/provider/sources/vllm_rerank_source.py astrbot/core/provider/sources/bailian_rerank_source.py astrbot/core/provider/sources/nvidia_rerank_source.py astrbot/core/provider/sources/tei_rerank_source.py astrbot/core/config/default.py
All checks passed!
```

代码变更量极小（每个文件 +2 行），仅在 `__init__` 中读取 proxy 配置，在请求调用中传递 proxy 参数，不改变任何现有行为。

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Add proxy configuration support to aiohttp-based rerank providers to allow external rerank APIs to be accessed via user-configured proxies.

Bug Fixes:
- Ensure vLLM, Bailian, NVIDIA, and TEI rerank HTTP requests respect configured proxy settings instead of bypassing user proxy configuration.

Enhancements:
- Extend default provider config templates with a proxy field for aiohttp-based rerank providers to keep configuration options consistent across providers.