### PR TITLE
fix(kb): reject a zero/negative embedding dimension when creating a fresh FAISS index

### DIFF
--- a/astrbot/core/db/vec_db/faiss_impl/embedding_storage.py
+++ b/astrbot/core/db/vec_db/faiss_impl/embedding_storage.py
@@ -73,6 +73,11 @@ class EmbeddingStorage:
         if path and os.path.exists(path):
             self.index = self._read_index(path)
         else:
+            if dimension <= 0:
+                raise ValueError(
+                    f"无效的嵌入向量维度: {dimension}。请检查该知识库使用的 Embedding "
+                    "Provider 是否正确配置了 embedding_dimensions。",
+                )
             base_index = faiss.IndexFlatL2(dimension)
             self.index = faiss.IndexIDMap(base_index)
 

--- a/tests/unit/test_faiss_vec_db.py
+++ b/tests/unit/test_faiss_vec_db.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from astrbot.core.db.vec_db.faiss_impl.embedding_storage import EmbeddingStorage
 from astrbot.core.db.vec_db.faiss_impl.vec_db import FaissVecDB
 from astrbot.core.exceptions import KnowledgeBaseUploadError
 from astrbot.core.provider.provider import EmbeddingProvider
@@ -62,6 +63,22 @@ async def test_insert_batch_raises_friendly_error_for_embedding_count_mismatch()
     assert "期望 2，实际 1" in str(exc_info.value)
     vec_db.document_storage.insert_documents_batch.assert_not_awaited()
     vec_db.embedding_storage.insert_batch.assert_not_awaited()
+
+
+def test_embedding_storage_rejects_zero_dimension_for_a_fresh_index(tmp_path) -> None:
+    with pytest.raises(ValueError, match="无效的嵌入向量维度"):
+        EmbeddingStorage(0, str(tmp_path / "index.faiss"))
+
+
+def test_embedding_storage_rejects_negative_dimension_for_a_fresh_index() -> None:
+    with pytest.raises(ValueError, match="无效的嵌入向量维度"):
+        EmbeddingStorage(-1)
+
+
+def test_embedding_storage_accepts_a_valid_dimension_for_a_fresh_index() -> None:
+    storage = EmbeddingStorage(4)
+
+    assert storage.index.d == 4
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Root cause:** `EmbeddingStorage.__init__` builds a fresh FAISS index with `faiss.IndexFlatL2(dimension)` whenever no on-disk index exists yet, and `dimension` comes straight from `EmbeddingProvider.get_dim()`. For the OpenAI/Ollama/NVIDIA-compatible embedding sources, `get_dim()` returns `0` whenever `embedding_dimensions` is absent from the provider config or fails to parse as an int (`openai_embedding_source.py` `get_dim()`). `faiss.IndexFlatL2(0)` does not raise: it silently builds a valid-looking but useless 0-dim index. The failure only surfaces later, as an opaque C++ `AssertionError` with no message, the first time a real vector is inserted, at which point the knowledge base is effectively broken and the user has no indication why.

This is reachable both when a knowledge base is first created and, more commonly, every time `KnowledgeBaseManager.load_kbs()` re-initializes existing knowledge bases on startup: if a user's embedding provider config drifts (field cleared, provider swapped, typo), a previously-working KB now silently gets a 0-dim index on the next restart.

**Fix:** `EmbeddingStorage.__init__` now rejects a non-positive `dimension` before constructing the index, raising a clear `ValueError` instead of deferring to a cryptic FAISS assertion. This is the single call site that constructs `EmbeddingStorage` (`FaissVecDB.__init__`), so the fix covers both the KB-creation path and the startup reload path. `KnowledgeBaseManager.load_kbs()`/`create_kb()` already catch initialization exceptions and surface them as `init_error`, so this turns a silent, delayed corruption into an immediate, actionable error shown to the user. The existing-index (reopen) branch is untouched, since a persisted index already carries its own real dimension.

**Verified** in a clean `python:3.12-slim` Docker container against current HEAD:
- Confirmed the raw mechanism first: `faiss.IndexFlatL2(0)` constructs without error; `index.add_with_ids(...)` with a real vector then raises an unhandled `AssertionError`.
- Added `test_embedding_storage_rejects_zero_dimension_for_a_fresh_index` and `test_embedding_storage_rejects_negative_dimension_for_a_fresh_index` to `tests/unit/test_faiss_vec_db.py`. Both fail on unfixed `main` ("DID NOT RAISE ValueError") and pass with the fix. Added `test_embedding_storage_accepts_a_valid_dimension_for_a_fresh_index` as a sanity check that a normal dimension still works.
- Ran the full suite (`tests/unit/test_faiss_vec_db.py`, `tests/unit/test_kb_upload_atomicity.py`, `tests/unit/test_document_storage_fts.py`, and the full `./tests` tree): 1853 passed, no regressions.
- `ruff format --check` and `ruff check` on the changed files: clean.

Fixes #9375

## Summary by Sourcery

Guard FAISS embedding storage initialization against invalid dimensions to prevent silently corrupted knowledge base indexes.

Bug Fixes:
- Reject zero or negative embedding dimensions when creating a new FAISS index to avoid later opaque assertion failures during vector insertion.

Tests:
- Add unit tests verifying EmbeddingStorage raises for zero and negative dimensions and succeeds for valid dimensions when building a fresh index.