### PR TITLE
fix: handle nested OpenAI completion choices

### DIFF
--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -11,7 +11,7 @@ import httpx
 from openai import AsyncAzureOpenAI, AsyncOpenAI
 from openai._exceptions import NotFoundError
 from openai.lib.streaming.chat._completions import ChatCompletionStreamState
-from openai.types.chat.chat_completion import ChatCompletion, Choice
+from openai.types.chat.chat_completion import ChatCompletion
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
 from openai.types.completion_usage import CompletionUsage
 
@@ -838,16 +838,11 @@ class ProviderOpenAIOfficial(Provider):
 
         if not completion.choices:
             data = getattr(completion, "data", None)
-            nested_choices = data.get("choices") if isinstance(data, dict) else None
-            if isinstance(nested_choices, list):
+            if isinstance(data, dict):
                 try:
-                    choices = [
-                        Choice.model_validate(choice) for choice in nested_choices
-                    ]
+                    completion = ChatCompletion.model_validate(data)
                 except (TypeError, ValueError):
-                    choices = []
-                if choices:
-                    completion.choices = choices
+                    pass
 
         if not completion.choices:
             raise EmptyModelOutputError(

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -11,7 +11,7 @@ import httpx
 from openai import AsyncAzureOpenAI, AsyncOpenAI
 from openai._exceptions import NotFoundError
 from openai.lib.streaming.chat._completions import ChatCompletionStreamState
-from openai.types.chat.chat_completion import ChatCompletion
+from openai.types.chat.chat_completion import ChatCompletion, Choice
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
 from openai.types.completion_usage import CompletionUsage
 
@@ -835,6 +835,19 @@ class ProviderOpenAIOfficial(Provider):
     ) -> LLMResponse:
         """Parse OpenAI ChatCompletion into LLMResponse"""
         llm_response = LLMResponse("assistant")
+
+        if not completion.choices:
+            data = getattr(completion, "data", None)
+            nested_choices = data.get("choices") if isinstance(data, dict) else None
+            if isinstance(nested_choices, list):
+                try:
+                    choices = [
+                        Choice.model_validate(choice) for choice in nested_choices
+                    ]
+                except (TypeError, ValueError):
+                    choices = []
+                if choices:
+                    completion.choices = choices
 
         if not completion.choices:
             raise EmptyModelOutputError(

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -836,6 +836,7 @@ class ProviderOpenAIOfficial(Provider):
         """Parse OpenAI ChatCompletion into LLMResponse"""
         llm_response = LLMResponse("assistant")
 
+        # workaround for #9374
         if not completion.choices:
             data = getattr(completion, "data", None)
             if isinstance(data, dict):

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -1466,6 +1466,10 @@ async def test_parse_openai_completion_reads_nested_data_choices():
             model=None,
             choices=None,
             data={
+                "id": "gen_test",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "deepseek/deepseek-v4-flash",
                 "choices": [
                     {
                         "index": 0,
@@ -1475,13 +1479,22 @@ async def test_parse_openai_completion_reads_nested_data_choices():
                         },
                         "finish_reason": "stop",
                     }
-                ]
+                ],
+                "usage": {
+                    "prompt_tokens": 12,
+                    "completion_tokens": 38,
+                    "total_tokens": 50,
+                },
             },
         )
 
         response = await provider._parse_openai_completion(completion, tools=None)
 
         assert response.completion_text == "PONG"
+        assert response.id == "gen_test"
+        assert response.usage is not None
+        assert response.usage.input_other == 12
+        assert response.usage.output == 38
     finally:
         await provider.terminate()
 

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -1456,6 +1456,37 @@ async def test_parse_openai_completion_raises_empty_model_output_error():
 
 
 @pytest.mark.asyncio
+async def test_parse_openai_completion_reads_nested_data_choices():
+    provider = _make_provider()
+    try:
+        completion = ChatCompletion.model_construct(
+            id=None,
+            object="chat.completion",
+            created=None,
+            model=None,
+            choices=None,
+            data={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "PONG",
+                        },
+                        "finish_reason": "stop",
+                    }
+                ]
+            },
+        )
+
+        response = await provider._parse_openai_completion(completion, tools=None)
+
+        assert response.completion_text == "PONG"
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
 async def test_query_stream_extracts_usage_from_empty_choices_chunk(monkeypatch):
     provider = _make_provider()
     try:


### PR DESCRIPTION
### Modifications / 改动点

Fixes #9374.

- Recover non-stream OpenAI-compatible completions when the SDK leaves top-level choices empty but preserves a valid completion under data.
- Reconstruct the nested completion with the OpenAI SDK model so choices, response ID, model, and usage are retained.
- Add regression coverage for the nested response text, ID, and token usage.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

The following is copied from the local terminal after rerunning each command.

`uv run ruff format --check . && uv run ruff check .`

```text
482 files already formatted
All checks passed!
```

`uv run pytest -q tests/test_openai_source.py --disable-warnings`

```text
...............................................................          [100%]
63 passed, 1 warning in 2.02s
```

`uv run pytest -q --disable-warnings`

```text
1878 passed, 6 warnings in 66.61s (0:01:06)
```

Temporary local HTTP integration reproducing the reported nested `data` response shape:

```text
REAL HTTP INTEGRATION PASSED: PONG, id=gen_test, total_tokens=50
```

**Cline Pass limitation:** No real Cline Pass API key or account was imported or used. The live Cline Pass service was not tested; the HTTP integration above used a temporary local server.

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Handle OpenAI-compatible completions that provide choices only under nested data.choices while preserving existing empty-output validation.

Bug Fixes:
- Recover non-stream OpenAI completion choices when the SDK leaves top-level choices empty but includes valid nested data.choices.
- Maintain the EmptyModelOutputError behavior when nested choices cannot be validated as proper OpenAI Choice objects.

Tests:
- Add a regression test ensuring nested data.choices responses are parsed into assistant completion text.
