### PR TITLE
perf(anthropic): cache conversation history, not just system prompt

### DIFF
--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -2,6 +2,7 @@ import base64
 import json
 from collections.abc import AsyncGenerator
 from typing import Any, Literal
+from urllib.parse import urlparse
 
 import anthropic
 import httpx
@@ -35,7 +36,44 @@ from .request_retry import retry_provider_request, retry_provider_request_contex
     "Anthropic Claude API 提供商适配器",
 )
 class ProviderAnthropic(Provider):
+    # --- prompt caching 调参区（可直接改这些常量） ------------------------
     _PROMPT_CACHE_CONTROL = {"type": "ephemeral"}
+    """cache_control 基础结构，``ttl`` 在运行时按需补上。"""
+
+    _PROMPT_CACHE_MAX_BREAKPOINTS = 4
+    """Anthropic 单次请求允许的 cache_control 断点上限（API 硬限制）。"""
+
+    _PROMPT_CACHE_TRAILING_MESSAGES = 3
+    """在消息列表尾部滚动放置的断点数量。
+
+    每轮请求通常只往历史里追加 2 条消息（assistant + user/tool_result），
+    标记最后 3 条即可保证「上一次请求的断点位置」必然与本次某个断点**完全重合**，
+    从而拿到精确命中，不依赖 API 20 个 block 的回看窗口。
+    """
+
+    _PROMPT_CACHE_MIN_CHARS = 6000
+    """小于该字符规模的请求不打断点。
+
+    prompt 前缀低于模型的最小可缓存长度时缓存会被静默忽略；而刚刚过线的一次性
+    短请求（例如会话标题生成）只会白付 1.25x 的写入费。
+    """
+
+    _PROMPT_CACHE_IMAGE_CHARS = 4000
+    """估算规模时，单个图片 block 折算的字符数。"""
+
+    _PROMPT_CACHE_LONG_TTL_HOSTS = ("api.anthropic.com",)
+    """默认启用 1h TTL 的官方域名。
+
+    IM 闲聊场景相邻两轮常常间隔超过 5 分钟，默认 5 分钟 TTL 会整段失效。
+    第三方 Anthropic 兼容端点不一定支持 ``ttl`` 字段，因此只对官方域名默认开启，
+    其余保持原有的 5 分钟行为。可用 provider 配置 ``anth_prompt_cache_ttl``
+    覆盖（``"1h"`` / ``"5m"`` / ``"off"``）。
+    """
+
+    _PROMPT_CACHE_MARKABLE_BLOCK_TYPES = frozenset(
+        {"text", "image", "tool_use", "tool_result", "document"},
+    )
+    """允许挂 cache_control 的 block 类型（``thinking`` 等不在其列）。"""
 
     @staticmethod
     def _ensure_usable_response(
@@ -436,6 +474,16 @@ class ProviderAnthropic(Provider):
         if usage is None:
             return TokenUsage()
         # https://docs.claude.com/en/docs/build-with-claude/prompt-caching#tracking-cache-performance
+        # cache_creation_input_tokens 在 TokenUsage 里没有对应字段，但它是判断
+        # 断点是否生效的唯一依据，所以至少打到 debug 日志里。
+        logger.debug(
+            "Anthropic prompt cache usage: uncached=%s cache_write=%s "
+            "cache_read=%s output=%s",
+            usage.input_tokens or 0,
+            getattr(usage, "cache_creation_input_tokens", None) or 0,
+            usage.cache_read_input_tokens or 0,
+            usage.output_tokens or 0,
+        )
         return TokenUsage(
             input_other=usage.input_tokens or 0,
             input_cached=usage.cache_read_input_tokens or 0,
@@ -481,15 +529,239 @@ class ProviderAnthropic(Provider):
         logger.warning(f"未知的 tool_choice 值: {tool_choice}，已回退为 'auto'")
         return {"type": "auto"}
 
+    def _prompt_cache_control(self) -> dict | None:
+        """解析本次请求要用的 cache_control，返回 ``None`` 表示禁用 prompt caching。"""
+        configured = (
+            str(self.provider_config.get("anth_prompt_cache_ttl", "") or "")
+            .strip()
+            .lower()
+        )
+        if configured in ("off", "none", "disable", "disabled"):
+            return None
+
+        cache_control = dict(self._PROMPT_CACHE_CONTROL)
+        if configured in ("", "auto"):
+            host = urlparse(getattr(self, "base_url", "") or "").hostname or ""
+            if host in self._PROMPT_CACHE_LONG_TTL_HOSTS:
+                cache_control["ttl"] = "1h"
+        elif configured not in ("5m", "default"):
+            cache_control["ttl"] = configured
+        return cache_control
+
     @classmethod
-    def _apply_explicit_prompt_cache_breakpoints(cls, payloads: dict) -> None:
-        system_blocks = payloads.get("system")
-        if not isinstance(system_blocks, list) or not system_blocks:
+    def _estimate_block_chars(cls, block: Any) -> int:
+        """粗略估算单个 content block 的字符规模（仅用于「值不值得缓存」判断）。"""
+        if isinstance(block, str):
+            return len(block)
+        if not isinstance(block, dict):
+            return 0
+        if block.get("type") == "image":
+            return cls._PROMPT_CACHE_IMAGE_CHARS
+
+        total = 0
+        text = block.get("text")
+        if isinstance(text, str):
+            total += len(text)
+        content = block.get("content")
+        if isinstance(content, str):
+            total += len(content)
+        elif isinstance(content, list):
+            for sub_block in content:
+                total += cls._estimate_block_chars(sub_block)
+        tool_input = block.get("input")
+        if tool_input is not None:
+            total += len(str(tool_input))
+        return total
+
+    @classmethod
+    def _estimate_cacheable_chars(cls, payloads: dict, *, stop_at: int) -> int:
+        """估算 tools + system + messages 的总字符数，达到 ``stop_at`` 即提前返回。"""
+        total = 0
+        for block in payloads.get("system") or []:
+            total += cls._estimate_block_chars(block)
+            if total >= stop_at:
+                return total
+        for tool in payloads.get("tools") or []:
+            if isinstance(tool, dict):
+                total += len(json.dumps(tool, ensure_ascii=False, default=str))
+            if total >= stop_at:
+                return total
+        for message in payloads.get("messages") or []:
+            if not isinstance(message, dict):
+                continue
+            content = message.get("content")
+            if isinstance(content, str):
+                total += len(content)
+            elif isinstance(content, list):
+                for block in content:
+                    total += cls._estimate_block_chars(block)
+            if total >= stop_at:
+                return total
+        return total
+
+    @staticmethod
+    def _count_existing_cache_breakpoints(payloads: dict) -> int:
+        """统计调用方（插件等）已经放置的 cache_control 断点数量。"""
+        count = 0
+        for section in ("system", "tools"):
+            for block in payloads.get(section) or []:
+                if isinstance(block, dict) and block.get("cache_control"):
+                    count += 1
+        for message in payloads.get("messages") or []:
+            if not isinstance(message, dict):
+                continue
+            content = message.get("content")
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("cache_control"):
+                        count += 1
+        return count
+
+    @staticmethod
+    def _normalize_message_content_blocks(payloads: dict) -> None:
+        """把字符串 content 统一规范化成单个 text block。
+
+        只有 block 才能承载 cache_control。如果只在「需要打断点的那条消息」上做转换，
+        同一条历史消息会因为在不同请求里是否被标记而呈现两种形状，前缀字节随之抖动，
+        缓存必然落空。所以这里对所有消息无条件规范化，保证形状稳定。
+        """
+        messages = payloads.get("messages")
+        if not isinstance(messages, list):
+            return
+        for index, message in enumerate(messages):
+            if not isinstance(message, dict):
+                continue
+            content = message.get("content")
+            if isinstance(content, str) and content.strip():
+                messages[index] = {
+                    **message,
+                    "content": [{"type": "text", "text": content}],
+                }
+
+    @staticmethod
+    def _with_cache_control(block: dict, cache_control: dict) -> dict:
+        """返回带 cache_control 的 block 副本（不修改调用方持有的历史对象）。"""
+        return {**block, "cache_control": dict(cache_control)}
+
+    @classmethod
+    def _message_with_cache_breakpoint(
+        cls,
+        message: dict,
+        cache_control: dict,
+    ) -> dict | None:
+        """把断点挂到 message 的最后一个 block 上，返回消息副本。
+
+        无法安全挂载时返回 ``None``（调用方应跳过该消息，不消耗断点额度）。
+        纯字符串 content 会被规范化成单个 text block —— 只有 block 才能承载
+        cache_control，且必须对所有请求保持同样的形状，否则前缀字节不一致。
+        """
+        content = message.get("content")
+        if isinstance(content, str):
+            if not content.strip():
+                return None
+            blocks: list[Any] = [{"type": "text", "text": content}]
+        elif isinstance(content, list) and content:
+            blocks = list(content)
+        else:
+            return None
+
+        last_block = blocks[-1]
+        if not isinstance(last_block, dict) or last_block.get("cache_control"):
+            return None
+        if last_block.get("type") not in cls._PROMPT_CACHE_MARKABLE_BLOCK_TYPES:
+            return None
+
+        blocks[-1] = cls._with_cache_control(last_block, cache_control)
+        return {**message, "content": blocks}
+
+    @classmethod
+    def _apply_message_cache_breakpoints(
+        cls,
+        payloads: dict,
+        cache_control: dict,
+        limit: int,
+    ) -> int:
+        """从尾部往前给最多 ``limit`` 条消息打断点，返回实际打上的数量。"""
+        if limit <= 0:
+            return 0
+        messages = payloads.get("messages")
+        if not isinstance(messages, list) or not messages:
+            return 0
+
+        marked = 0
+        for index in range(len(messages) - 1, -1, -1):
+            if marked >= limit:
+                break
+            message = messages[index]
+            if not isinstance(message, dict):
+                continue
+            updated = cls._message_with_cache_breakpoint(message, cache_control)
+            if updated is None:
+                continue
+            messages[index] = updated
+            marked += 1
+        return marked
+
+    def _apply_explicit_prompt_cache_breakpoints(self, payloads: dict) -> None:
+        """放置 prompt cache 断点。
+
+        渲染顺序是 ``tools`` → ``system`` → ``messages``，前缀里任何字节变化都会让
+        其后的缓存失效。因此：
+
+        * system 末尾放一个断点，缓存 ``tools + system``。它跨会话共享，
+          新会话 / 标题生成 / 上下文压缩之后仍然能命中。
+        * 消息尾部滚动放最多 3 个断点，把不断增长的历史也纳入缓存 ——
+          这是 IM 长对话和工具调用循环里真正在涨的那部分。
+
+        断点总数受 API 限制为 4 个，且已经被调用方占用的额度会被扣除。
+        """
+        cache_control = self._prompt_cache_control()
+        if cache_control is None:
             return
 
-        last_block = system_blocks[-1]
-        if isinstance(last_block, dict) and "cache_control" not in last_block:
-            last_block["cache_control"] = dict(cls._PROMPT_CACHE_CONTROL)
+        # 无条件执行，不受下面的规模阈值影响：同一会话在跨过阈值前后必须是同一种形状。
+        self._normalize_message_content_blocks(payloads)
+
+        min_chars = self._PROMPT_CACHE_MIN_CHARS
+        if self._estimate_cacheable_chars(payloads, stop_at=min_chars) < min_chars:
+            return
+
+        budget = self._PROMPT_CACHE_MAX_BREAKPOINTS - (
+            self._count_existing_cache_breakpoints(payloads)
+        )
+        if budget <= 0:
+            return
+
+        # 插件如果自己在 system 里放了断点，说明它想自己控制切分位置，我们不再插手。
+        system_blocks = payloads.get("system")
+        system_markable = (
+            isinstance(system_blocks, list)
+            and bool(system_blocks)
+            and isinstance(system_blocks[-1], dict)
+            and not any(
+                isinstance(block, dict) and block.get("cache_control")
+                for block in system_blocks
+            )
+        )
+        system_slot = 1 if system_markable else 0
+
+        message_slots = max(
+            0,
+            min(budget - system_slot, self._PROMPT_CACHE_TRAILING_MESSAGES),
+        )
+        used = self._apply_message_cache_breakpoints(
+            payloads,
+            cache_control,
+            message_slots,
+        )
+
+        if system_slot and used + system_slot <= budget:
+            new_system_blocks = list(system_blocks)  # type: ignore[arg-type]
+            new_system_blocks[-1] = self._with_cache_control(
+                new_system_blocks[-1],
+                cache_control,
+            )
+            payloads["system"] = new_system_blocks
 
     async def _query(
         self,
@@ -509,9 +781,10 @@ class ProviderAnthropic(Provider):
 
         if "max_tokens" not in payloads:
             payloads["max_tokens"] = 65536
-        self._apply_explicit_prompt_cache_breakpoints(payloads)
         self._apply_thinking_config(payloads)
         self._sanitize_assistant_messages(payloads)
+        # 必须在 sanitize 之后：那一步会合并/重排消息，断点位置只有在最终消息列表上才有意义。
+        self._apply_explicit_prompt_cache_breakpoints(payloads)
 
         try:
             completion = await retry_provider_request(
@@ -611,9 +884,10 @@ class ProviderAnthropic(Provider):
 
         if "max_tokens" not in payloads:
             payloads["max_tokens"] = 65536
-        self._apply_explicit_prompt_cache_breakpoints(payloads)
         self._apply_thinking_config(payloads)
         self._sanitize_assistant_messages(payloads)
+        # 必须在 sanitize 之后：那一步会合并/重排消息，断点位置只有在最终消息列表上才有意义。
+        self._apply_explicit_prompt_cache_breakpoints(payloads)
 
         async with retry_provider_request_context(
             "Anthropic",

--- a/tests/test_anthropic_kimi_code_provider.py
+++ b/tests/test_anthropic_kimi_code_provider.py
@@ -1,4 +1,6 @@
 import builtins
+import copy
+import json
 from types import SimpleNamespace
 
 import httpx
@@ -864,3 +866,250 @@ async def test_tool_choice_empty_tool_list_skips_tool_choice(monkeypatch):
     kwargs = _capture_payloads_create.last_kwargs
     assert "tools" not in kwargs
     assert "tool_choice" not in kwargs
+
+
+# --------------------------------------------------------------------------- #
+# Prompt caching breakpoints
+# --------------------------------------------------------------------------- #
+
+_BIG_SYSTEM = "You are a helpful assistant. " * 400
+
+
+def _make_cache_provider(
+    base_url: str = "https://api.anthropic.com",
+    **config,
+) -> anthropic_source.ProviderAnthropic:
+    provider = anthropic_source.ProviderAnthropic.__new__(
+        anthropic_source.ProviderAnthropic
+    )
+    provider.provider_config = config
+    provider.base_url = base_url
+    return provider
+
+
+def _breakpoint_positions(payloads: dict) -> list[tuple[int, int]]:
+    positions = []
+    for msg_index, message in enumerate(payloads.get("messages") or []):
+        content = message.get("content")
+        if isinstance(content, list):
+            for block_index, block in enumerate(content):
+                if isinstance(block, dict) and block.get("cache_control"):
+                    positions.append((msg_index, block_index))
+    return positions
+
+
+def _rendered_prefix(payloads: dict, msg_index: int, block_index: int) -> str:
+    """Serialize the prompt prefix up to a breakpoint, ignoring cache metadata."""
+
+    def strip(obj):
+        if isinstance(obj, dict):
+            return {k: strip(v) for k, v in obj.items() if k != "cache_control"}
+        if isinstance(obj, list):
+            return [strip(v) for v in obj]
+        return obj
+
+    parts = [strip(payloads.get("tools")), strip(payloads.get("system"))]
+    for index, message in enumerate(payloads["messages"]):
+        if index > msg_index:
+            break
+        message = strip(message)
+        if index == msg_index:
+            message = {**message, "content": message["content"][: block_index + 1]}
+        parts.append(message)
+    return json.dumps(parts, sort_keys=True, ensure_ascii=False)
+
+
+def _build_cached_payloads(provider, messages: list[dict]) -> dict:
+    payloads = {
+        "model": "claude-test",
+        "system": [{"type": "text", "text": _BIG_SYSTEM}],
+        "messages": copy.deepcopy(messages),
+    }
+    anthropic_source.ProviderAnthropic._sanitize_assistant_messages(payloads)
+    provider._apply_explicit_prompt_cache_breakpoints(payloads)
+    return payloads
+
+
+_CHAT_TURN_1 = [
+    {"role": "user", "content": "hi <system_reminder>10:00</system_reminder>"},
+    {"role": "assistant", "content": [{"type": "text", "text": "hello"}]},
+    {"role": "user", "content": "how are you <system_reminder>10:05</system_reminder>"},
+]
+_CHAT_TURN_2 = [
+    *_CHAT_TURN_1,
+    {"role": "assistant", "content": [{"type": "text", "text": "fine"}]},
+    {
+        "role": "user",
+        "content": "a joke please <system_reminder>10:12</system_reminder>",
+    },
+]
+
+
+def test_prompt_cache_marks_system_and_trailing_messages():
+    provider = _make_cache_provider()
+
+    payloads = _build_cached_payloads(provider, _CHAT_TURN_1)
+
+    assert payloads["system"][-1]["cache_control"] == {
+        "type": "ephemeral",
+        "ttl": "1h",
+    }
+    assert _breakpoint_positions(payloads) == [(0, 0), (1, 0), (2, 0)]
+
+
+def test_prompt_cache_never_exceeds_api_breakpoint_limit():
+    provider = _make_cache_provider()
+
+    payloads = _build_cached_payloads(provider, _CHAT_TURN_2)
+
+    total = anthropic_source.ProviderAnthropic._count_existing_cache_breakpoints(
+        payloads
+    )
+    assert total <= anthropic_source.ProviderAnthropic._PROMPT_CACHE_MAX_BREAKPOINTS
+
+
+def test_prompt_cache_prefix_is_reused_by_the_next_request():
+    """上一次请求的断点前缀必须在下一次请求里逐字节重现，否则拿不到缓存命中。"""
+    provider = _make_cache_provider()
+
+    first = _build_cached_payloads(provider, _CHAT_TURN_1)
+    second = _build_cached_payloads(provider, _CHAT_TURN_2)
+
+    last_msg, last_block = _breakpoint_positions(first)[-1]
+    previous_prefix = _rendered_prefix(first, last_msg, last_block)
+    current_prefixes = {
+        _rendered_prefix(second, msg_index, block_index)
+        for msg_index, block_index in _breakpoint_positions(second)
+    }
+
+    assert previous_prefix in current_prefixes
+
+
+def test_prompt_cache_prefix_is_reused_across_a_tool_call_round():
+    provider = _make_cache_provider()
+
+    tool_round = [
+        *_CHAT_TURN_2,
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "tool_use", "id": f"tu{i}", "name": "read", "input": {"i": i}}
+                for i in range(4)
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": f"tu{i}", "content": "R" * 3000}
+                for i in range(4)
+            ],
+        },
+    ]
+
+    before = _build_cached_payloads(provider, _CHAT_TURN_2)
+    after = _build_cached_payloads(provider, tool_round)
+
+    last_msg, last_block = _breakpoint_positions(before)[-1]
+    previous_prefix = _rendered_prefix(before, last_msg, last_block)
+    current_prefixes = {
+        _rendered_prefix(after, msg_index, block_index)
+        for msg_index, block_index in _breakpoint_positions(after)
+    }
+
+    assert previous_prefix in current_prefixes
+
+
+def test_prompt_cache_skips_short_requests():
+    """会话标题生成这类短请求缓存不会生效，不应白付写入成本。"""
+    provider = _make_cache_provider()
+    payloads = {
+        "system": [{"type": "text", "text": "Generate a short title."}],
+        "messages": [{"role": "user", "content": "hello there"}],
+    }
+
+    provider._apply_explicit_prompt_cache_breakpoints(payloads)
+
+    assert (
+        anthropic_source.ProviderAnthropic._count_existing_cache_breakpoints(payloads)
+        == 0
+    )
+
+
+def test_prompt_cache_omits_ttl_for_non_official_endpoints():
+    provider = _make_cache_provider(base_url="https://api.moonshot.cn/anthropic")
+
+    payloads = _build_cached_payloads(provider, _CHAT_TURN_1)
+
+    assert payloads["system"][-1]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_prompt_cache_can_be_disabled_via_provider_config():
+    provider = _make_cache_provider(anth_prompt_cache_ttl="off")
+
+    payloads = _build_cached_payloads(provider, _CHAT_TURN_1)
+
+    assert (
+        anthropic_source.ProviderAnthropic._count_existing_cache_breakpoints(payloads)
+        == 0
+    )
+    assert "cache_control" not in payloads["system"][-1]
+
+
+def test_prompt_cache_does_not_mutate_caller_history():
+    provider = _make_cache_provider()
+    history = copy.deepcopy(_CHAT_TURN_2)
+    snapshot = json.dumps(history, sort_keys=True)
+
+    payloads = {
+        "system": [{"type": "text", "text": _BIG_SYSTEM}],
+        "messages": history,
+    }
+    anthropic_source.ProviderAnthropic._sanitize_assistant_messages(payloads)
+    provider._apply_explicit_prompt_cache_breakpoints(payloads)
+
+    assert json.dumps(history, sort_keys=True) == snapshot
+
+
+def test_prompt_cache_defers_to_plugin_placed_system_breakpoints():
+    provider = _make_cache_provider()
+    payloads = {
+        "system": [
+            {
+                "type": "text",
+                "text": _BIG_SYSTEM,
+                "cache_control": {"type": "ephemeral"},
+            },
+            {"type": "text", "text": "volatile plugin tail"},
+        ],
+        "messages": copy.deepcopy(_CHAT_TURN_1),
+    }
+
+    provider._apply_explicit_prompt_cache_breakpoints(payloads)
+
+    assert "cache_control" not in payloads["system"][-1]
+    assert (
+        anthropic_source.ProviderAnthropic._count_existing_cache_breakpoints(payloads)
+        <= anthropic_source.ProviderAnthropic._PROMPT_CACHE_MAX_BREAKPOINTS
+    )
+
+
+def test_prompt_cache_skips_messages_ending_in_a_thinking_block():
+    provider = _make_cache_provider()
+    payloads = {
+        "system": [{"type": "text", "text": _BIG_SYSTEM}],
+        "messages": [
+            {"role": "user", "content": "question"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "hmm", "signature": "sig"}
+                ],
+            },
+        ],
+    }
+
+    provider._apply_explicit_prompt_cache_breakpoints(payloads)
+
+    assert all(
+        "cache_control" not in block for block in payloads["messages"][1]["content"]
+    )


### PR DESCRIPTION
The Anthropic adapter only placed a single cache_control breakpoint on the last system block, so the cache covered `tools + system` and nothing else. Message history was re-billed uncached on every request, which is exactly the part that grows in both supported usage patterns (long IM chats and tool-calling loops).

- Roll up to 3 breakpoints across the trailing messages, in addition to the system one. Marking the last 3 messages guarantees the previous request's write position coincides exactly with one of this request's breakpoints (a round appends 2 messages), so hits do not depend on the API's 20-block lookback window even when a turn adds many tool_result blocks.
- Normalize string message content to a single text block unconditionally. Only blocks can carry cache_control, and a message that changes shape depending on whether it happens to be marked would break prefix matching.
- Default to a 1h TTL on api.anthropic.com. IM sessions routinely idle past the 5-minute default. Third-party Anthropic-compatible endpoints keep the previous plain ephemeral control since they may reject `ttl`.
- Skip breakpoints entirely for requests too small to cache (conversation title generation), which would otherwise only pay the write premium.
- Apply breakpoints after _sanitize_assistant_messages, which merges and reorders messages; positions are only meaningful on the final list.
- Copy blocks on write so caller-owned conversation history is untouched, and defer to cache_control a plugin placed itself.
- Log cache_creation_input_tokens at debug; TokenUsage has no field for it, and it is the only way to tell whether the breakpoints took effect.


Claude-Session: https://claude.ai/code/session_01FjCx2QtZX4jvJwhQ8LKRfm

## Summary by Sourcery

Improve Anthropic provider prompt caching by caching conversation history in addition to tools and system prompts, while keeping cache behavior configurable and safe for third-party endpoints.

Enhancements:
- Introduce configurable prompt cache TTL with longer defaults for official Anthropic endpoints and the ability to disable caching.
- Estimate request size and skip prompt caching for short conversations where caching would not be beneficial.
- Normalize message content into text blocks and avoid mutating caller-owned history when applying cache breakpoints.
- Add logic to place cache_control breakpoints across trailing messages and system blocks within API limits, deferring to plugin-defined breakpoints when present.
- Ensure prompt cache breakpoints are applied after assistant message sanitization so they reflect the final message ordering.
- Log prompt cache token usage details at debug level to help observe cache effectiveness.

Tests:
- Add a comprehensive test suite covering prompt cache breakpoint placement, TTL behavior across endpoints, cache disabling, non-mutation of caller history, and handling of special message types such as thinking blocks.