### PR TITLE
fix(dingtalk): fix command parsing and error responses caused by rich text in the DingTalk HarmonyOS client.

### DIFF
--- a/astrbot/core/pipeline/waking_check/stage.py
+++ b/astrbot/core/pipeline/waking_check/stage.py
@@ -189,9 +189,11 @@ class WakingCheckStage(Stage):
                         break
                 except Exception as e:
                     await event.send(
-                        MessageEventResult().message(
+                        MessageEventResult()
+                        .message(
                             f"插件 {star_map[handler.handler_module_path].name}: {e}",
-                        ),
+                        )
+                        .use_markdown(False),
                     )
                     event.stop_event()
                     passed = False

--- a/astrbot/core/platform/sources/dingtalk/dingtalk_adapter.py
+++ b/astrbot/core/platform/sources/dingtalk/dingtalk_adapter.py
@@ -182,12 +182,15 @@ class DingtalkPlatformAdapter(Platform):
         abm.message_id = cast(str, message.message_id)
         abm.raw_message = message
 
+        leading_at_is_self = False
         if abm.type == MessageType.GROUP_MESSAGE:
             # 处理所有被 @ 的用户（包括机器人自己，因 at_users 已包含）
             if message.at_users:
-                for user in message.at_users:
+                for index, user in enumerate(message.at_users):
                     if id := self._id_to_sid(user.dingtalk_id):
                         abm.message.append(At(qq=id))
+                        if index == 0 and id == abm.self_id:
+                            leading_at_is_self = True
             abm.group_id = message.conversation_id
             abm.session_id = abm.group_id
         else:
@@ -232,10 +235,18 @@ class DingtalkPlatformAdapter(Platform):
                 )
                 contents: list[dict] = cast(list[dict], rtc.rich_text_list)
                 plain_parts: list[str] = []
-                for content in contents:
+                for index, content in enumerate(contents):
                     if "text" in content:
                         plain_text = cast(str, content.get("text") or "")
                         if plain_text:
+                            # HarmonyOS repeats the leading bot mention as a text
+                            # segment even though atUsers already represents it.
+                            if (
+                                index == 0
+                                and leading_at_is_self
+                                and plain_text.lstrip().startswith("@")
+                            ):
+                                continue
                             plain_parts.append(plain_text)
                             abm.message.append(Plain(plain_text))
                     elif "type" in content and content["type"] == "picture":
@@ -577,13 +588,17 @@ class DingtalkPlatformAdapter(Platform):
                 text = segment.text.strip()
                 if not text and not at_str:
                     continue
-                await send_message(
-                    msg_key="sampleMarkdown",
-                    msg_param={
-                        "title": "AstrBot",
-                        "text": f"{at_str} {text}".strip(),
-                    },
-                )
+                text = f"{at_str} {text}".strip()
+                if message_chain.use_markdown_ is False:
+                    await send_message(
+                        msg_key="sampleText",
+                        msg_param={"content": text},
+                    )
+                else:
+                    await send_message(
+                        msg_key="sampleMarkdown",
+                        msg_param={"title": "AstrBot", "text": text},
+                    )
             elif isinstance(segment, Image):
                 photo_url = segment.file or segment.url or ""
                 if photo_url.startswith(("http://", "https://")):

--- a/astrbot/core/star/filter/command.py
+++ b/astrbot/core/star/filter/command.py
@@ -65,7 +65,7 @@ class CommandFilter(HandlerFilter):
 
     def init_handler_md(self, handle_md: StarHandlerMetadata) -> None:
         self.handler_md = handle_md
-        signature = inspect.signature(self.handler_md.handler)
+        signature = inspect.signature(self.handler_md.handler, eval_str=True)
         self.handler_params = {}  # 参数名 -> 参数类型，如果有默认值则为默认值
         idx = 0
         for k, v in signature.parameters.items():

--- a/tests/test_command_filter.py
+++ b/tests/test_command_filter.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from astrbot.core.star.filter.command import CommandFilter
+
+
+async def postponed_annotations_handler(
+    self,
+    event,
+    machine: str,
+    retries: int = 1,
+) -> None:
+    pass
+
+
+def test_command_filter_resolves_postponed_annotations():
+    command_filter = CommandFilter(
+        "probe",
+        handler_md=SimpleNamespace(handler=postponed_annotations_handler),
+    )
+
+    assert command_filter.handler_params == {"machine": str, "retries": 1}
+    assert command_filter.validate_and_convert_params(
+        ["server-1", "2"],
+        command_filter.handler_params,
+    ) == {"machine": "server-1", "retries": 2}
+
+
+def test_command_filter_rejects_missing_postponed_required_param():
+    command_filter = CommandFilter(
+        "probe",
+        handler_md=SimpleNamespace(handler=postponed_annotations_handler),
+    )
+
+    with pytest.raises(ValueError, match="必要参数缺失"):
+        command_filter.validate_and_convert_params([], command_filter.handler_params)

--- a/tests/test_dingtalk_adapter.py
+++ b/tests/test_dingtalk_adapter.py
@@ -1,8 +1,11 @@
 import asyncio
 import threading
 
+import dingtalk_stream
 import pytest
 
+from astrbot.api.message_components import At, Plain
+from astrbot.core.message.message_event_result import MessageChain
 from astrbot.core.platform.sources.dingtalk import dingtalk_adapter
 from astrbot.core.platform.sources.dingtalk.dingtalk_adapter import (
     DINGTALK_RECONNECT_INITIAL_DELAY,
@@ -10,6 +13,29 @@ from astrbot.core.platform.sources.dingtalk.dingtalk_adapter import (
     DingtalkPlatformAdapter,
     _dingtalk_reconnect_delay,
 )
+
+
+def _dingtalk_group_message(**payload) -> dingtalk_stream.ChatbotMessage:
+    """Build a DingTalk group callback message for adapter tests.
+
+    Args:
+        **payload: Callback fields that vary between test cases.
+
+    Returns:
+        A parsed DingTalk chatbot message.
+    """
+    return dingtalk_stream.ChatbotMessage.from_dict(
+        {
+            "conversationId": "conversation",
+            "conversationType": "2",
+            "createAt": 1_700_000_000_000,
+            "msgId": "message",
+            "senderId": "sender",
+            "senderNick": "sender",
+            "chatbotUserId": "bot",
+            **payload,
+        }
+    )
 
 
 def test_dingtalk_reconnect_delay_uses_exponential_backoff():
@@ -76,3 +102,120 @@ async def test_dingtalk_reconnect_delay_wakes_on_terminate(monkeypatch):
             await adapter.terminate()
             run_task.cancel()
             await asyncio.gather(run_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("use_markdown", "expected_key", "expected_param"),
+    [
+        (None, "sampleMarkdown", {"title": "AstrBot", "text": "first\nsecond"}),
+        (False, "sampleText", {"content": "first\nsecond"}),
+    ],
+)
+async def test_dingtalk_text_respects_markdown_mode(
+    use_markdown,
+    expected_key,
+    expected_param,
+):
+    sent = []
+    adapter = DingtalkPlatformAdapter.__new__(DingtalkPlatformAdapter)
+
+    async def capture_message(open_conversation_id, robot_code, msg_key, msg_param):
+        sent.append((open_conversation_id, robot_code, msg_key, msg_param))
+
+    adapter._send_group_message = capture_message
+    chain = MessageChain().message("first\nsecond").use_markdown(use_markdown)
+
+    await adapter._send_message_chain("group", "conversation", "robot", chain)
+
+    assert sent == [("conversation", "robot", expected_key, expected_param)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "atUsers": [{"dingtalkId": "bot"}],
+            "isInAtList": True,
+            "msgtype": "text",
+            "text": {"content": " /server"},
+        },
+        {
+            "atUsers": [{"dingtalkId": "bot"}],
+            "isInAtList": True,
+            "msgtype": "richText",
+            "content": {
+                "richText": [
+                    {"text": "@ExampleBot"},
+                    {"text": "/server"},
+                ]
+            },
+        },
+    ],
+)
+async def test_dingtalk_self_mention_produces_consistent_command_text(payload):
+    adapter = DingtalkPlatformAdapter.__new__(DingtalkPlatformAdapter)
+
+    result = await adapter.convert_msg(_dingtalk_group_message(**payload))
+
+    assert result.message_str == "/server"
+    assert len(result.message) == 2
+    assert isinstance(result.message[0], At)
+    assert result.message[0].qq == "bot"
+    assert isinstance(result.message[1], Plain)
+    assert result.message[1].text == "/server"
+
+
+@pytest.mark.asyncio
+async def test_dingtalk_rich_text_preserves_non_self_mention_text():
+    adapter = DingtalkPlatformAdapter.__new__(DingtalkPlatformAdapter)
+    message = _dingtalk_group_message(
+        atUsers=[{"dingtalkId": "another-user"}],
+        isInAtList=False,
+        msgtype="richText",
+        content={
+            "richText": [
+                {"text": "@AnotherUser"},
+                {"text": "/server"},
+            ]
+        },
+    )
+
+    result = await adapter.convert_msg(message)
+
+    assert result.message_str == "@AnotherUser/server"
+    assert len(result.message) == 3
+    assert isinstance(result.message[0], At)
+    assert result.message[0].qq == "another-user"
+    assert isinstance(result.message[1], Plain)
+    assert result.message[1].text == "@AnotherUser"
+    assert isinstance(result.message[2], Plain)
+    assert result.message[2].text == "/server"
+
+
+@pytest.mark.asyncio
+async def test_dingtalk_rich_text_preserves_other_leading_mention():
+    adapter = DingtalkPlatformAdapter.__new__(DingtalkPlatformAdapter)
+    message = _dingtalk_group_message(
+        atUsers=[{"dingtalkId": "another-user"}, {"dingtalkId": "bot"}],
+        isInAtList=True,
+        msgtype="richText",
+        content={
+            "richText": [
+                {"text": "@AnotherUser"},
+                {"text": "@ExampleBot"},
+                {"text": "/server"},
+            ]
+        },
+    )
+
+    result = await adapter.convert_msg(message)
+
+    assert result.message_str == "@AnotherUser@ExampleBot/server"
+    assert isinstance(result.message[0], At)
+    assert result.message[0].qq == "another-user"
+    assert isinstance(result.message[1], At)
+    assert result.message[1].qq == "bot"
+    assert isinstance(result.message[2], Plain)
+    assert result.message[2].text == "@AnotherUser"


### PR DESCRIPTION
不同钉钉客户端会用不同的消息格式表示界面上看起来相同的群聊指令。以用户发送 `@机器人 /server` 为例：

macOS、Linux 客户端发送的是 `text` 消息，机器人 mention 只记录在 `atUsers` 中：

```text
atUsers: [机器人]
text.content: " /server"
```

旧适配器将其解析为 `[At(机器人), Plain("/server")]`。唤醒检查移除开头的机器人 `At` 后，交给指令过滤器的内容是 `/server`，因此能够正确调用插件。

鸿蒙客户端发送的则是 `richText` 消息。除了 `atUsers`，首个富文本片段还会再次包含机器人名称：

```text
atUsers: [机器人]
content.richText: [{"text": "@机器人"}, {"text": "/server"}]
```

旧适配器同时保留了这两种 mention，将其解析为 `[At(机器人), Plain("@机器人"), Plain("/server")]`。唤醒检查只能移除结构化的 `At`，剩余文本会拼成 `@机器人/server`。由于 `/server` 不再位于消息开头，指令过滤器无法识别该插件指令，消息继而进入 LLM 对话流程。

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

- 解析钉钉富文本时，仅当 `atUsers` 的首个用户确认为机器人自身，才忽略首个以 `@` 开头的重复文本片段；指令正文、图片及对其他用户的提及均保持不变。
- 发送钉钉文本消息时遵循 `MessageChain` 的 Markdown 设置，使纯文本指令错误通过 `sampleText` 返回并保留预期格式。
- 在校验指令参数前解析延迟求值的处理函数类型注解，并为富文本指令归一化、提及保留、消息输出模式及指令参数校验补充回归测试。

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

说明：依次从钉钉 Linux 客户端和鸿蒙客户端在同一群聊发送相同的“@机器人 /server”指令。以下标签按实际发送顺序标注；发送者、会话 ID 和机器人 ID 脱敏替换为占位符。

#### 修复前

macOS 客户端（text）正常命中指令：

```
[08:22:51.544] [Core] [DBUG] [dingtalk.dingtalk_adapter:83]: dingtalk: {'senderPlatform': 'Mac', 'atUsers': [{'dingtalkId': '<机器人ID>'}], 'text': {'content': ' /server'}, 'msgtype': 'text'}
[08:22:51.546] [Core] [INFO] [core.event_bus:74]: [default] [dingtalk(dingtalk)] <发送者>/<会话ID>: [At:<机器人ID>] /server
[08:22:54.318] [Core] [DBUG] [pipeline.scheduler:75]: Stage WakingCheckStage stopped event propagation.
```

鸿蒙客户端（richText）保留了重复 mention，并进入 LLM：

```
[08:23:07.295] [Core] [DBUG] [dingtalk.dingtalk_adapter:83]: dingtalk: {'atUsers': [{'dingtalkId': '<机器人ID>'}], 'content': {'richText': [{'text': '@<机器人>'}, {'text': '/server'}]}, 'msgtype': 'richText'}
[08:23:07.298] [Core] [INFO] [core.event_bus:74]: [default] [dingtalk(dingtalk)] <发送者>/<会话ID>: [At:<机器人ID>] @<机器人> /server
[08:23:07.314] [Core] [DBUG] [agent_sub_stages.internal:193]: ready to request llm provider
[08:23:07.314] [Core] [DBUG] [agent_sub_stages.internal:221]: acquired session lock for llm request
```

对比可见，修复前鸿蒙消息在结构化的 At 之外还残留了文本形式的 @机器人，/server 因此未命中插件指令并继续进入 LLM 流程。

#### 修复后

Linux 客户端：

```
[10:24:54.397] [Core] [INFO] [core.event_bus:74]: [default] [dingtalk(dingtalk)] <发送者>/<会话ID>: [At:<机器人ID>] /server
```

鸿蒙客户端：

```
[10:25:53.744] [Core] [INFO] [core.event_bus:74]: [default] [dingtalk(dingtalk)] <发送者>/<会话ID>: [At:<机器人ID>] /server
```

结果：两条消息被归一化为相同的 AstrBot 消息链；两个客户端均收到相同的 /server 插件响应，鸿蒙客户端消息未再进入 LLM 对话流程。

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Fix DingTalk adapter handling so HarmonyOS rich-text commands are parsed consistently with text-based clients and ensure command errors are returned as plain text when markdown is disabled.

Bug Fixes:
- Prevent HarmonyOS DingTalk rich-text messages from duplicating the bot mention in parsed command text, restoring correct command recognition.
- Ensure command parameter validation works with handlers that use postponed type annotations so required arguments are correctly enforced.

Enhancements:
- Respect the MessageChain markdown flag when sending DingTalk group text messages, choosing markdown or plain text output accordingly.
- Add regression tests covering DingTalk text/rich-text normalization, mention preservation, output modes, and command parameter validation with postponed annotations.

Tests:
- Introduce new unit tests for the DingTalk adapter to verify consistent command parsing across text and rich-text messages and correct mention handling.
- Add tests for the command filter to validate behavior with postponed annotations and required parameter checking.