### PR TITLE
chore: move pnpm overrides to pnpm-workspace.yaml

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -74,11 +74,5 @@
     "vue-cli-plugin-vuetify": "2.5.8",
     "vue-tsc": "1.8.8",
     "vuetify-loader": "^2.0.0-alpha.9"
-  },
-  "pnpm": {
-    "overrides": {
-      "immutable": "4.3.8",
-      "lodash-es": "4.17.23"
-    }
   }
 }

--- a/dashboard/pnpm-workspace.yaml
+++ b/dashboard/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
 allowBuilds:
   esbuild: true
   vue-demi: true
+
+overrides:
+  immutable: 4.3.8
+  lodash-es: 4.17.23


### PR DESCRIPTION
Closes #8601

## Change

Move the `immutable` and `lodash-es` pins from the deprecated `pnpm.overrides` field in `dashboard/package.json` into `dashboard/pnpm-workspace.yaml`, alongside the `allowBuilds` settings that already live there.

## A note on the issue's premise

The issue's first acceptance criterion says pnpm prints a warning that `package.json`'s `pnpm.overrides` is ignored. I was not able to reproduce that. With both the CI-pinned pnpm 10.28.2 and pnpm 10.33.2, no such warning is printed and **the overrides are currently fully effective**: removing the `pnpm` block without adding it to `pnpm-workspace.yaml` makes the lockfile drop its `overrides:` section and `lodash-es` fall back from 4.17.23 to 4.17.21.

So this PR is not repairing broken pins. It is a forward-looking migration to the location pnpm 10+ expects, so the pins keep applying on future pnpm releases. Happy to close it if you would rather leave the pins where they are for now.

## Verification

All with the CI-pinned pnpm 10.28.2:

- `pnpm install --frozen-lockfile` succeeds
- `pnpm-lock.yaml` is byte-identical to before the move and its `overrides:` block is preserved, so the lockfile is untouched in this PR
- `pnpm run build` passes
- The installed tree still resolves `immutable@4.3.8` and `lodash-es@4.17.23`

## Summary by Sourcery

Move pnpm dependency override configuration from the dashboard package.json into the pnpm-workspace.yaml to align with current pnpm expectations while preserving existing pins.

Build:
- Relocate immutable and lodash-es version overrides from package.json pnpm.overrides into pnpm-workspace.yaml for workspace-level configuration.

Chores:
- Clean up deprecated pnpm.overrides usage in dashboard package.json.