### PR TITLE
fix: respect zero values for forward parser depth/fetch limits

### DIFF
--- a/astrbot/core/utils/quoted_message/extractor.py
+++ b/astrbot/core/utils/quoted_message/extractor.py
@@ -53,7 +53,7 @@ async def _collect_text_and_images_from_forward_ids(
             if nested_id not in seen:
                 pending.append(nested_id)
 
-    if pending:
+    if pending and max_fetch > 0:
         logger.warning(
             "quoted_message_parser: stop fetching nested forward messages after %d hops",
             max_fetch,

--- a/astrbot/core/utils/quoted_message/settings.py
+++ b/astrbot/core/utils/quoted_message/settings.py
@@ -21,7 +21,7 @@ def _read_int_mapping(
         value = int(raw)
     except (TypeError, ValueError):
         return default
-    if value <= 0:
+    if value < 0:
         return default
     return value
 


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
_read_int_mapping in quoted_message/settings.py treated 0 as invalid and fell back to the default value (4/6/32), making it impossible for users to disable forward message parsing by setting all limits to 0 in WebUI.
### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
- astrbot/core/utils/quoted_message/settings.py:24 — value <= 0 → value < 0, allowing 0 to pass through as a valid value.
- astrbot/core/utils/quoted_message/extractor.py:56 — skip WARN log when max_fetch=0 (user intentionally disabled fetching).
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Respect zero values in quoted message forward parsing limits and avoid warning logs when users intentionally disable fetching.

Bug Fixes:
- Treat 0 as a valid configuration value for forward parser depth/fetch limits instead of falling back to defaults.
- Skip nested forward fetching warnings when max_fetch is explicitly set to 0 to disable fetching.