### PR TITLE
fix: ignore face-attached text when matching wake prefix

### DIFF
--- a/astrbot/core/pipeline/waking_check/stage.py
+++ b/astrbot/core/pipeline/waking_check/stage.py
@@ -1,7 +1,7 @@
 from collections.abc import AsyncGenerator, Callable
 
 from astrbot import logger
-from astrbot.core.message.components import At, AtAll, Reply
+from astrbot.core.message.components import At, AtAll, Face, Reply
 from astrbot.core.message.message_event_result import MessageChain, MessageEventResult
 from astrbot.core.platform.astr_message_event import AstrMessageEvent
 from astrbot.core.platform.message_type import MessageType
@@ -112,6 +112,15 @@ class WakingCheckStage(Stage):
                     and str(messages[0].qq) != "all"
                 ):
                     # 如果是群聊，且第一个消息段是 At 消息，但不是 At 机器人或 At 全体成员，则不唤醒
+                    break
+                first_content_seg = next(
+                    (seg for seg in messages if not isinstance(seg, (At, Reply))),
+                    None,
+                )
+                if isinstance(first_content_seg, Face):
+                    # 部分 OneBot 实现会把手机端发送的 QQ 表情序列化为 face 段 + "/表情名"
+                    # 文本段，message_str 因此以表情名开头。若前导 At/引用之后的第一个消息段
+                    # 是表情，说明该前缀来自表情附带文本而非用户输入的指令，不唤醒 (#9341)
                     break
                 is_wake = True
                 event.is_at_or_wake_command = True

--- a/tests/test_waking_check_stage.py
+++ b/tests/test_waking_check_stage.py
@@ -1,0 +1,144 @@
+"""Tests for the wake-prefix decision in WakingCheckStage.
+
+Regression tests for #9341: mobile QQ yellow-face emojis are serialized by
+some OneBot implementations as a ``face`` segment followed by a text segment
+holding the face's display name (e.g. ``/干饭``). Because ``message_str`` only
+concatenates text segments, that face-attached text used to be mistaken for a
+wake prefix and woke the LLM.
+"""
+
+import pytest
+import pytest_asyncio
+
+from astrbot.core.message.components import At, Face, Image, Plain, Reply
+from astrbot.core.pipeline.waking_check import stage as waking_stage
+from astrbot.core.platform.astr_message_event import AstrMessageEvent
+from astrbot.core.platform.astrbot_message import AstrBotMessage, MessageMember
+from astrbot.core.platform.message_type import MessageType
+from astrbot.core.platform.platform_metadata import PlatformMetadata
+
+SELF_ID = "123456"
+
+
+class FakeContext:
+    """Minimal PipelineContext substitute for WakingCheckStage."""
+
+    def __init__(self) -> None:
+        self.astrbot_config = {
+            "platform_settings": {},
+            "admins_id": [],
+            "wake_prefix": ["/"],
+            "plugin_set": ["*"],
+        }
+        self.plugin_manager = None
+
+
+def make_event(
+    components: list,
+    message_str: str,
+    message_type: MessageType = MessageType.GROUP_MESSAGE,
+) -> AstrMessageEvent:
+    abm = AstrBotMessage()
+    abm.type = message_type
+    abm.self_id = SELF_ID
+    abm.session_id = "test-session"
+    abm.message_id = "1"
+    abm.sender = MessageMember(user_id="10000", nickname="tester")
+    abm.message = components
+    abm.message_str = message_str
+    abm.raw_message = None
+    if message_type == MessageType.GROUP_MESSAGE:
+        abm.group_id = "654321"
+    meta = PlatformMetadata(name="aiocqhttp", description="test", id="aiocqhttp")
+    return AstrMessageEvent(
+        message_str=message_str,
+        message_obj=abm,
+        platform_meta=meta,
+        session_id="test-session",
+    )
+
+
+@pytest_asyncio.fixture
+async def stage(monkeypatch) -> waking_stage.WakingCheckStage:
+    inst = waking_stage.WakingCheckStage()
+    await inst.initialize(FakeContext())
+
+    async def passthrough(event, handlers):
+        return handlers
+
+    monkeypatch.setattr(
+        waking_stage.star_handlers_registry,
+        "get_handlers_by_event_type",
+        lambda *args, **kwargs: [],
+    )
+    monkeypatch.setattr(
+        waking_stage.SessionPluginManager,
+        "filter_handlers_by_session",
+        passthrough,
+    )
+    return inst
+
+
+@pytest.mark.asyncio
+async def test_face_attached_text_does_not_wake(stage):
+    """A face segment's auto-attached name text must not count as a prefix."""
+    event = make_event([Face(id=475), Plain("/干饭")], "/干饭")
+    await stage.process(event)
+    assert not event.is_wake
+    assert not event.is_at_or_wake_command
+
+
+@pytest.mark.asyncio
+async def test_reply_then_face_attached_text_does_not_wake(stage):
+    """Replying to a non-bot message with a face emoji must not wake either."""
+    event = make_event(
+        [Reply(id="42", sender_id="20000"), Face(id=475), Plain("/干饭")],
+        "/干饭",
+    )
+    await stage.process(event)
+    assert not event.is_wake
+
+
+@pytest.mark.asyncio
+async def test_plain_command_still_wakes(stage):
+    event = make_event([Plain("/help")], "/help")
+    await stage.process(event)
+    assert event.is_wake
+    assert event.message_str == "help"
+
+
+@pytest.mark.asyncio
+async def test_media_with_command_caption_still_wakes(stage):
+    """Pasting an image and then typing a command must keep waking the bot."""
+    event = make_event([Image(file="a.png"), Plain("/ocr")], "/ocr")
+    await stage.process(event)
+    assert event.is_wake
+    assert event.message_str == "ocr"
+
+
+@pytest.mark.asyncio
+async def test_at_bot_then_command_still_wakes(stage):
+    event = make_event([At(qq=SELF_ID), Plain("/help")], "/help")
+    await stage.process(event)
+    assert event.is_wake
+
+
+@pytest.mark.asyncio
+async def test_face_after_command_text_still_wakes(stage):
+    """A trailing face emoji after a real command must not block waking."""
+    event = make_event([Plain("/help"), Face(id=475)], "/help")
+    await stage.process(event)
+    assert event.is_wake
+
+
+@pytest.mark.asyncio
+async def test_private_face_attached_text_needs_no_false_wake(stage):
+    """With friend_message_needs_wake_prefix, face text must not satisfy it."""
+    stage.friend_message_needs_wake_prefix = True
+    event = make_event(
+        [Face(id=475), Plain("/干饭")],
+        "/干饭",
+        message_type=MessageType.FRIEND_MESSAGE,
+    )
+    await stage.process(event)
+    assert not event.is_wake

--- a/tests/test_waking_check_stage.py
+++ b/tests/test_waking_check_stage.py
@@ -124,6 +124,31 @@ async def test_at_bot_then_command_still_wakes(stage):
 
 
 @pytest.mark.asyncio
+async def test_face_text_then_at_bot_still_wakes(stage):
+    """`[表情] 你好 @bot`: the prefix path skips the face text, yet the At
+    branch must still wake the bot."""
+    event = make_event(
+        [Face(id=475), Plain("/干饭 你好"), At(qq=SELF_ID)],
+        "/干饭 你好",
+    )
+    await stage.process(event)
+    assert event.is_wake
+    assert event.is_at_or_wake_command
+
+
+@pytest.mark.asyncio
+async def test_face_text_then_at_other_does_not_wake(stage):
+    """`[表情] 你好 @someone-else`: face-attached text is not a command and
+    the At targets another member, so the bot must stay asleep."""
+    event = make_event(
+        [Face(id=475), Plain("/干饭 你好"), At(qq="99999")],
+        "/干饭 你好",
+    )
+    await stage.process(event)
+    assert not event.is_wake
+
+
+@pytest.mark.asyncio
 async def test_face_after_command_text_still_wakes(stage):
     """A trailing face emoji after a real command must not block waking."""
     event = make_event([Plain("/help"), Face(id=475)], "/help")


### PR DESCRIPTION
Fixes #9341.

When a QQ yellow-face emoji is sent from the mobile client, some OneBot implementations (SnowLuma v1.12.5, NapCat ≤ 4.17.x) serialize it as a `face` segment **plus a text segment holding the face's display name**, e.g. `[face:475] + "/干饭"`. Since `message_str` is built by concatenating only text segments, such a message produces `message_str = "/干饭"`, which starts with the default wake prefix `/` — so a plain emoji message falsely wakes the bot and triggers an LLM reply.

`WakingCheckStage` already guards against a related case (first segment is an At to someone else), but any other non-text leading segment slipped through. The wake prefix should only match text the user actually typed at the head of the message, not text attached to a leading face segment.

### Modifications / 改动点

- `astrbot/core/pipeline/waking_check/stage.py`: in the wake-prefix branch, locate the first message segment that is not a leading `At`/`Reply`. If that segment is a `Face`, the prefix match comes from face-attached text rather than a user-typed command, so the prefix does not wake the bot. All other wake paths (@bot, reply-to-bot, private chat, plugin handler filters) are untouched.
- `tests/test_waking_check_stage.py`: new unit tests covering the regression and guarding against over-reach:
  - `[Face(475), "/干饭"]` (group) → no wake ✅ (the reported bug)
  - `[Reply, Face(475), "/干饭"]` (replying to a member with an emoji) → no wake ✅
  - `[Face(475), "/干饭"]` in private chat with `friend_message_needs_wake_prefix` → no wake ✅
  - `["/help"]`, `[Image, "/ocr"]` (image pasted, then command typed), `[At(bot), "/help"]`, `["/help", Face]` → still wake, prefix stripped as before ✅

The scope is deliberately narrow: only a **leading** face segment suppresses the prefix match, so commands that carry media (e.g. an image pasted before `/ocr`) and trailing emojis keep working exactly as today. The desktop client serializes the same emoji as `[干饭]` (no `/` prefix), which never matched a wake prefix and is unaffected.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

**Verification steps**

1. Construct the exact message shape reported in the issue (`[face:475]` + text `"/干饭"`, as logged by the reporter: `[表情:475] /干饭`) and run it through `WakingCheckStage` with `wake_prefix = ["/"]`.
2. Before the fix, the reported case wakes the bot; after the fix it does not, while typed-command cases keep waking.

**RED — on current master, the new tests reproduce the bug (3 failing cases are the false wakes):**

```
$ uv run pytest tests/test_waking_check_stage.py -q
FAILED tests/test_waking_check_stage.py::test_face_attached_text_does_not_wake
FAILED tests/test_waking_check_stage.py::test_reply_then_face_attached_text_does_not_wake
FAILED tests/test_waking_check_stage.py::test_private_face_attached_text_needs_no_false_wake
3 failed, 4 passed, 1 warning in 2.76s
```

**GREEN — with the fix:**

```
$ uv run pytest tests/test_waking_check_stage.py -q
7 passed, 1 warning in 2.50s
```

**Full local CI-style validation (`make pr-test-neo`):**

```
==> Running Ruff format check
482 files already formatted
==> Running Ruff lint check
All checks passed!
==> Running pytest
............                                                             [100%]
12 passed, 1 warning in 4.36s
==> Starting smoke test on http://localhost:6185
==> Smoke test passed
==> PR checks completed successfully
```

Neighboring pipeline-stage tests also pass (`tests/test_preprocess_stage.py`, `tests/test_rate_limit_stage.py`, 10 passed total with the new file).

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Prevent wake-prefix detection from triggering on QQ face-attached text while preserving normal command wake behavior.

Bug Fixes:
- Stop group and private messages consisting of a leading face emoji plus attached text from incorrectly waking the bot.

Tests:
- Add WakingCheckStage regression tests for face-attached text in group and private messages and for valid command scenarios to ensure wake behavior remains correct.