### PR TITLE
fix: use current provider selection when regenerating chat message

### DIFF
--- a/dashboard/src/components/chat/Chat.vue
+++ b/dashboard/src/components/chat/Chat.vue
@@ -1459,11 +1459,12 @@ async function handleRegenerateMessage(
 ) {
   if (!currSessionId.value || isUserMessage(message)) return;
   message.threads = [];
+  const effectiveSelection = selection ?? getSelectedProviderSelection();
   await regenerateMessage(
     currSessionId.value,
     message,
-    selection?.providerId || "",
-    selection?.modelName || "",
+    effectiveSelection?.providerId || "",
+    effectiveSelection?.modelName || "",
     enableStreaming.value,
   );
 }


### PR DESCRIPTION
Fixes #9400.

On the chat page, clicking the basic **Retry** button did not read the provider currently selected in the UI. It emitted a `retry` event with no selection, so `handleRegenerateMessage` passed empty strings as `selected_provider` / `selected_model`. The backend then fell back to the provider persisted for the session (`provider_perf_chat_completion`), which was the original failing/renamed provider — so switching to a valid provider and retrying still failed with `未找到指定的提供商`.

Sending a new message already resolves the current selection via `getSelectedProviderSelection()`; regenerate now does the same when no explicit selection is passed.

### Modifications / 改动点

- `dashboard/src/components/chat/Chat.vue`: in `handleRegenerateMessage`, fall back to `getSelectedProviderSelection()` (current UI selection) when no explicit `selection` is provided. The "retry with a specific model" path (`retryWithModel`, which passes an explicit selection) is unchanged, and the fallback is evaluated lazily so its side effects don't run on that path.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

End-to-end verification with a real backend + WebUI in a headless browser, intercepting the actual `regenerate` request body. Two chat providers were configured; the UI had `good_provider` selected.

Before the fix (reverted temporarily to confirm reproduction):
```
INTERCEPTED regenerate body: {"selected_provider":"","selected_model":"",...}
FAIL: basic retry sent selected_provider="" (expected "good_provider")
```

After the fix:
```
INTERCEPTED regenerate body: {"selected_provider":"good_provider","selected_model":"",...}
PASS: basic retry sent the currently-selected provider
```

`vue-tsc --noEmit` passes.

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. (N/A — bug fix only)
- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 I have ensured that no new dependencies are introduced.
- [x] 😮 My changes do not introduce malicious code.

## Summary

Bug Fixes:
- Fix basic chat retry so regenerated messages use the active provider selection instead of falling back to an empty or outdated provider.