### PR TITLE
fix: validate provider type before persisting config

### DIFF
--- a/astrbot/core/provider/manager.py
+++ b/astrbot/core/provider/manager.py
@@ -596,6 +596,12 @@ class ProviderManager:
         if provider_config.get("provider_type", "") == "agent_runner":
             return
 
+        if not provider_config.get("type"):
+            raise ValueError(
+                f"Provider {provider_config['id']} is missing the 'type' field; "
+                "its provider source may be invalid or incomplete."
+            )
+
         logger.info(
             "Loading model %s(%s) ...",
             provider_config["type"],
@@ -889,11 +895,11 @@ class ProviderManager:
             for provider in config["provider"]:
                 if provider.get("id", None) == npid:
                     raise ValueError(f"Provider ID {npid} already exists")
-            # add to config
+            # load instance first so an invalid config is not persisted
+            await self.load_provider(new_config)
+            # add to config and save only after a successful load
             config["provider"].append(new_config)
             config.save_config()
-            # load instance
-            await self.load_provider(new_config)
             # sync in-memory config for API queries (e.g., embedding provider list)
             self.providers_config = astrbot_config["provider"]
 


### PR DESCRIPTION
Fixes #9399.

When creating a provider whose merged config lacks a `type` field (its `provider_source` is missing or incomplete), `load_provider` accessed `provider_config["type"]` directly and raised a `KeyError`, returning a 500 to the dashboard. Worse, `create_provider` appended the new config and called `save_config()` **before** loading it, so the invalid config was already persisted to disk when the load failed. This left the UI in an inconsistent state: the second save reported "Provider ID already exists", and cancelling then saving again surfaced the leaked, never-successfully-saved model id.

### Modifications / 改动点

- `astrbot/core/provider/manager.py`:
  - `load_provider`: validate that `type` exists before use, raising a clear `ValueError` ("... is missing the 'type' field; its provider source may be invalid or incomplete.") instead of a bare `KeyError`.
  - `create_provider`: load the instance first and only `append` + `save_config()` after a successful load, so an invalid config is never persisted.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Real-backend verification against the `/api/v1/provider-sources/providers` endpoint, using the issue's scenario (a source that yields a merged config without `type`). The pre-fix behavior was reproduced by temporarily reverting the change.

Before the fix:
```
HTTP 500 {"status":"error","message":"Internal server error"}
persisted provider ids: [..., 'deepseek_1/deepseek-v4-flash']   # bad config leaked to disk
```

After the fix:
```
HTTP 400 {"status":"error","message":"Provider deepseek_1/deepseek-v4-flash is missing the 'type' field; its provider source may be invalid or incomplete."}
persisted provider ids: [...]   # bad config NOT persisted, state stays consistent
```

Existing tests pass (`pytest tests/unit/test_provider_stats.py tests/test_fastapi_v1_dashboard.py` → 73 passed); `ruff format --check` and `ruff check` pass on the changed file.

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. (N/A — bug fix only)
- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 I have ensured that no new dependencies are introduced.
- [x] 😮 My changes do not introduce malicious code.

## Summary

Validate provider configuration before loading and persisting it to prevent invalid providers from leaking into stored config.

Bug Fixes:
- Return a clear 400-style error when a provider config is missing its required type field instead of raising an internal KeyError and 500.
- Ensure provider creation only appends to and saves the config after a successful load so invalid provider configs are never persisted.

Enhancements:
- Add explicit validation of the provider type field in the provider loading workflow to guard against incomplete or bad provider sources.