### PR TITLE
fix: reject providers missing adapter type

### DIFF
--- a/astrbot/core/provider/manager.py
+++ b/astrbot/core/provider/manager.py
@@ -3,14 +3,13 @@ import copy
 import os
 import traceback
 from collections.abc import Callable
-from typing import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from astrbot.core import astrbot_config, logger, sp
 from astrbot.core.astrbot_config_mgr import AstrBotConfigManager
 from astrbot.core.db import BaseDatabase
 from astrbot.core.utils.error_redaction import safe_error
 
-from ..persona_mgr import PersonaManager
 from .entities import ProviderType
 from .provider import (
     EmbeddingProvider,
@@ -21,6 +20,9 @@ from .provider import (
     TTSProvider,
 )
 from .register import llm_tools, provider_cls_map
+
+if TYPE_CHECKING:
+    from ..persona_mgr import PersonaManager
 
 
 @runtime_checkable
@@ -33,7 +35,7 @@ class ProviderManager:
         self,
         acm: AstrBotConfigManager,
         db_helper: BaseDatabase,
-        persona_mgr: PersonaManager,
+        persona_mgr: "PersonaManager",
     ) -> None:
         self.reload_lock = asyncio.Lock()
         self.resource_lock = asyncio.Lock()
@@ -583,6 +585,29 @@ class ProviderManager:
         provider_config["key"] = resolved_keys
         return provider_config
 
+    def _require_loadable_provider_config(self, provider_config: dict) -> None:
+        merged_config = self.get_merged_provider_config(provider_config)
+        if not merged_config.get("enable", True):
+            return
+        if merged_config.get("provider_type", "") == "agent_runner":
+            return
+
+        provider_type = merged_config.get("type")
+        if isinstance(provider_type, str) and provider_type.strip():
+            return
+
+        provider_id = merged_config.get("id", "<unknown>")
+        provider_source_id = provider_config.get("provider_source_id")
+        if provider_source_id:
+            raise ValueError(
+                f"Provider {provider_id} references provider source "
+                f"{provider_source_id}, but the merged config is missing a valid "
+                "'type' field"
+            )
+        raise ValueError(
+            f"Provider {provider_id} config is missing a valid 'type' field"
+        )
+
     async def load_provider(self, provider_config: dict) -> None:
         # 如果 provider_source_id 存在且不为空，则从 provider_sources 中找到对应的配置并合并
         provider_config = self.get_merged_provider_config(provider_config)
@@ -590,44 +615,52 @@ class ProviderManager:
         if provider_config.get("provider_type", "") == "chat_completion":
             provider_config = self._resolve_env_key_list(provider_config)
 
-        if not provider_config["enable"]:
+        if not provider_config.get("enable", True):
             logger.info(f"Provider {provider_config['id']} is disabled, skipping")
             return
         if provider_config.get("provider_type", "") == "agent_runner":
             return
 
+        provider_type = provider_config.get("type")
+        if not isinstance(provider_type, str) or not provider_type.strip():
+            logger.error(
+                "Provider %s has no valid adapter type. Skipped.",
+                provider_config.get("id", "<unknown>"),
+            )
+            return
+
         logger.info(
             "Loading model %s(%s) ...",
-            provider_config["type"],
+            provider_type,
             provider_config["id"],
         )
 
         # 动态导入
         try:
-            self.dynamic_import_provider(provider_config["type"])
+            self.dynamic_import_provider(provider_type)
         except (ImportError, ModuleNotFoundError) as e:
             logger.critical(
-                f"Failed to load provider adapter {provider_config['type']}"
+                f"Failed to load provider adapter {provider_type}"
                 f"({provider_config['id']}): {e}. A dependency may be missing.",
                 exc_info=True,
             )
             return
         except Exception as e:
             logger.critical(
-                f"Failed to load provider adapter {provider_config['type']}"
+                f"Failed to load provider adapter {provider_type}"
                 f"({provider_config['id']}): {e}. Unknown cause.",
                 exc_info=True,
             )
             return
 
-        if provider_config["type"] not in provider_cls_map:
+        if provider_type not in provider_cls_map:
             logger.error(
-                f"Provider adapter not found: {provider_config['type']}({provider_config['id']}). Skipped.",
+                f"Provider adapter not found: {provider_type}({provider_config['id']}). Skipped.",
                 exc_info=True,
             )
             return
 
-        provider_metadata = provider_cls_map[provider_config["type"]]
+        provider_metadata = provider_cls_map[provider_type]
         try:
             # 按任务实例化提供商
             cls_type = provider_metadata.cls_type
@@ -868,6 +901,7 @@ class ProviderManager:
                     and provider.get("id", None) != origin_provider_id
                 ):
                     raise ValueError(f"Provider ID {npid} already exists")
+            self._require_loadable_provider_config(new_config)
             # update config
             for idx, provider in enumerate(config["provider"]):
                 if provider.get("id", None) == origin_provider_id:
@@ -889,6 +923,7 @@ class ProviderManager:
             for provider in config["provider"]:
                 if provider.get("id", None) == npid:
                     raise ValueError(f"Provider ID {npid} already exists")
+            self._require_loadable_provider_config(new_config)
             # add to config
             config["provider"].append(new_config)
             config.save_config()

--- a/tests/unit/test_provider_manager_config_validation.py
+++ b/tests/unit/test_provider_manager_config_validation.py
@@ -1,0 +1,85 @@
+from types import SimpleNamespace
+
+import pytest
+
+from astrbot.core.provider.manager import ProviderManager
+
+
+class SaveCountingConfig(dict[str, object]):
+    def __init__(self, initial: dict[str, object]) -> None:
+        super().__init__(initial)
+        self.save_count = 0
+
+    def save_config(self) -> None:
+        self.save_count += 1
+
+
+class FakeConfigManager:
+    def __init__(self, config: SaveCountingConfig) -> None:
+        self.confs = {"default": config}
+
+    @property
+    def default_conf(self) -> SaveCountingConfig:
+        return self.confs["default"]
+
+
+def make_manager(config: SaveCountingConfig) -> ProviderManager:
+    return ProviderManager(
+        FakeConfigManager(config),
+        db_helper=SimpleNamespace(),
+        persona_mgr=SimpleNamespace(default_persona="default"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_provider_rejects_missing_merged_type_before_saving() -> None:
+    config = SaveCountingConfig(
+        {
+            "provider_sources": [
+                {
+                    "id": "deepseek_1",
+                    "provider_type": "chat_completion",
+                    "enable": True,
+                }
+            ],
+            "provider": [],
+            "provider_settings": {},
+        }
+    )
+    manager = make_manager(config)
+
+    with pytest.raises(ValueError, match="missing a valid 'type' field"):
+        await manager.create_provider(
+            {
+                "id": "deepseek_1/deepseek-v4-flash",
+                "provider_source_id": "deepseek_1",
+                "provider_type": "chat_completion",
+                "model": "deepseek-v4-flash",
+                "enable": True,
+            }
+        )
+
+    assert config["provider"] == []
+    assert config.save_count == 0
+
+
+@pytest.mark.asyncio
+async def test_load_provider_skips_missing_type_without_keyerror() -> None:
+    config = SaveCountingConfig(
+        {
+            "provider_sources": [],
+            "provider": [],
+            "provider_settings": {},
+        }
+    )
+    manager = make_manager(config)
+
+    await manager.load_provider(
+        {
+            "id": "missing-type",
+            "provider_type": "chat_completion",
+            "enable": True,
+        }
+    )
+
+    assert manager.inst_map == {}


### PR DESCRIPTION
Fixes #9399.

### Evidence

- Issue #9399 includes a dashboard stack trace for `POST /api/v1/provider-sources/providers` ending in `KeyError('type')` at `astrbot/core/provider/manager.py` inside `load_provider`.
- Current `ProviderManager.create_provider` appends the new provider to `config["provider"]`, saves config, and only then calls `load_provider`; a missing merged `type` therefore both raises and leaves a bad provider persisted.
- The reported path matches the current code path: `astrbot/dashboard/api/providers.py` -> `ProviderConfigService.create_provider` -> `ProviderManager.create_provider` -> `load_provider`.

### Changes

- Validate enabled provider configs after provider-source merge and before create/update saves.
- Skip already-corrupt enabled provider configs missing adapter `type` during `load_provider` instead of raising `KeyError`.
- Move the `PersonaManager` annotation import behind `TYPE_CHECKING` to avoid the circular import exposed by the new core regression test.
- Add regression coverage for no-save-on-invalid-provider and no-KeyError loading behavior.

### Merge plan

- #9402 is the minimal existing fix for #9400 (`ChatUI` basic retry provider selection) and already has green checks. Merge #9402 for that issue.
- Merge this PR independently for #9399 after review/CI. It intentionally does not duplicate the #9400 frontend change.

### Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/unit/test_provider_manager_config_validation.py tests/test_fastapi_v1_dashboard.py -q` -> 74 passed
- `uv run pytest tests/unit/test_provider_manager_config_validation.py tests/test_fastapi_v1_dashboard.py::test_v1_safe_provider_routes_accept_slash_ids tests/test_chat_route.py -q` -> 12 passed
- `uv run astrbot --help`
- `cd dashboard && bunx pnpm@10.28.2 install --frozen-lockfile`
- `cd dashboard && bunx pnpm@10.28.2 run build`

Full local Windows pytest was also run with `uv run pytest --cov=astrbot tests/ -q`: 1841 passed, 28 failed. The failures are existing Windows path/newline/sandbox/file-uri/local-shell cases outside the provider files touched here; targeted provider/API tests passed. `tests/test_code_quality_typing.py` is not present on current `origin/master`, so it could not be run.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
- [x] I have ensured that no new dependencies are introduced.
- [x] My changes do not introduce malicious code.

## Summary by Sourcery

Validate provider configurations for a valid adapter type before persisting them and ensure loading skips invalid providers instead of raising errors.

Bug Fixes:
- Prevent saving new or updated providers whose merged configuration is missing a valid adapter type field.
- Avoid KeyError and other crashes when loading enabled providers that lack a valid adapter type by skipping them instead.

Enhancements:
- Guard provider creation and update with a centralized provider config validation helper.
- Adjust PersonaManager typing to avoid circular import issues exposed by tests.

Tests:
- Add unit tests covering rejection of invalid provider configs before save and safe skipping of missing-type providers during load.