### PR TITLE
fix(webui): prevent local plugin upload from hanging

### DIFF
--- a/dashboard/src/api/v1.ts
+++ b/dashboard/src/api/v1.ts
@@ -56,7 +56,7 @@ import {
   type UpdateAccountRequest,
   type UpdateRequest,
 } from './generated/openapi-v1';
-import { apiV1Client, httpClient } from './http';
+import { apiV1Client, fetchWithAuth, httpClient } from './http';
 
 openApiV1Client.setConfig({
   axios: httpClient,
@@ -1322,12 +1322,18 @@ export const pluginApi = {
       openApiV1.replacePluginSources({ body: { sources: sources as any } }),
     );
   },
-  installUpload(formData: FormData) {
-    return typed<OpenConfig>(
-      openApiV1.installPluginFromUpload({
-        body: generatedFormData(formData),
-      }),
-    );
+  async installUpload(formData: FormData) {
+    const response = await fetchWithAuth('/api/v1/plugins/install/upload', {
+      method: 'POST',
+      body: formData,
+    });
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error(
+        data?.message || `Plugin upload failed (${response.status})`,
+      );
+    }
+    return { data } as AxiosResponse<ApiEnvelope<OpenConfig>>;
   },
   installGithub(body: OpenConfig) {
     return typed<OpenConfig>(


### PR DESCRIPTION
## Summary

- route local plugin ZIP uploads through the authenticated Fetch wrapper
- preserve the existing API response envelope and surface non-2xx upload failures
- leave generated OpenAPI files untouched so client regeneration does not overwrite the fix

## Root cause

The generated Axios multipart request could remain pending in the browser before the backend received the upload. The backend upload endpoint itself completed normally when called directly. Sending the existing `FormData` with the authenticated native Fetch path avoids the stalled multipart request.

## Impact

Local plugin uploads now complete or report an error instead of leaving the install button spinning indefinitely.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `node --test tests/*.test.mjs` (36 tests)
- `uv run ruff format .`
- `uv run ruff check .`
- real-browser verification of both successful and failed local ZIP uploads

Fixes #9405

## Summary by Sourcery

Route local plugin ZIP uploads through the authenticated fetch path to prevent stalled installs while preserving the existing API response shape.

Bug Fixes:
- Ensure local plugin uploads either complete or return an error instead of leaving the install action hanging indefinitely.

Enhancements:
- Improve error surfacing for failed local plugin uploads by propagating backend error messages from the authenticated fetch response.