### PR TITLE
fix: correct double-escaped regex in Discord slash command validation

### DIFF
--- a/astrbot/core/platform/sources/discord/discord_platform_adapter.py
+++ b/astrbot/core/platform/sources/discord/discord_platform_adapter.py
@@ -565,7 +565,7 @@ class DiscordPlatformAdapter(Platform):
             return None
 
         # Discord 斜杠指令名称规范
-        if cmd_name != cmd_name.lower() or not re.match(r"^[-_'\\w]{1,32}$", cmd_name):
+        if cmd_name != cmd_name.lower() or not re.match(r"^[-_'\w]{1,32}$", cmd_name):
             logger.debug(f"[Discord] Skipping invalid slash command format: {cmd_name}")
             return None
 


### PR DESCRIPTION
Fixes #9410

The regex used to validate Discord slash command names at `discord_platform_adapter.py:568` was double-escaped: `r"^[-_'\\w]{1,32}$"` makes the regex engine treat `\\` as a literal backslash followed by a literal `w`, instead of the intended `\w` (Unicode word character) shorthand. As a result the character class only matched the literal characters `-`, `_`, `'`, `\`, `w`, so almost every real command name (including plain English ones like `help`, `neko`, `sid`) failed validation and no slash commands were ever registered.

This was introduced by #9102 while fixing #9101.

Per Discord's official application command naming spec (`^[-_'\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$`, Unicode letters/numbers plus `-_'`), Python's `\w` (Unicode-aware by default in Python 3) is a reasonable native-`re` approximation, so no further character-class changes are needed.

### Modifications / 改动点

- `astrbot/core/platform/sources/discord/discord_platform_adapter.py`: fixed the double-escaped regex from `r"^[-_'\\w]{1,32}$"` to `r"^[-_'\w]{1,32}$"`.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Verified locally against every command name from the issue's reproduction log (Chinese and English), plus edge cases (uppercase, empty string, >32 chars):

```
'今日小猪'                 lower_ok=True  regex_ok=True  overall_valid=True
'pjsk猜卡面'              lower_ok=True  regex_ok=True  overall_valid=True
'测试猜卡'                 lower_ok=True  regex_ok=True  overall_valid=True
'猜卡面帮助'                lower_ok=True  regex_ok=True  overall_valid=True
'猜卡面分数'                lower_ok=True  regex_ok=True  overall_valid=True
'猜卡面自定义名称'             lower_ok=True  regex_ok=True  overall_valid=True
'重置猜卡面次数'              lower_ok=True  regex_ok=True  overall_valid=True
'猜卡面排行榜'               lower_ok=True  regex_ok=True  overall_valid=True
'neko'                 lower_ok=True  regex_ok=True  overall_valid=True
'help'                 lower_ok=True  regex_ok=True  overall_valid=True
'sid'                  lower_ok=True  regex_ok=True  overall_valid=True
'name'                 lower_ok=True  regex_ok=True  overall_valid=True
'reset'                lower_ok=True  regex_ok=True  overall_valid=True
'stop'                 lower_ok=True  regex_ok=True  overall_valid=True
'new'                  lower_ok=True  regex_ok=True  overall_valid=True
'stats'                lower_ok=True  regex_ok=True  overall_valid=True
'provider'             lower_ok=True  regex_ok=True  overall_valid=True
'dashboard_update'     lower_ok=True  regex_ok=True  overall_valid=True
'set'                  lower_ok=True  regex_ok=True  overall_valid=True
'unset'                lower_ok=True  regex_ok=True  overall_valid=True
'Help'                 lower_ok=False regex_ok=True  overall_valid=False  (correctly rejected: mixed case)
''                     lower_ok=True  regex_ok=False overall_valid=False  (correctly rejected: empty)
'a' * 33               lower_ok=True  regex_ok=False overall_valid=False  (correctly rejected: too long)
```

`ruff format --check` and `ruff check` pass on the modified file.

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Fix slash command name regex so valid command names are accepted and registered instead of being incorrectly rejected.