### PR TITLE
fix(cron): decouple the cron scheduler running state from the database sync state to ensure persistent jobs are always loaded, even when the scheduler is started early

### DIFF
--- a/astrbot/core/cron/manager.py
+++ b/astrbot/core/cron/manager.py
@@ -103,15 +103,18 @@ class CronJobManager:
         self._basic_handlers: dict[str, Callable[..., Any]] = {}
         self._lock = asyncio.Lock()
         self._started = False
+        self._db_synced = False
 
     async def start(self, ctx: "Context") -> None:
         self.ctx: Context = ctx  # star context
         async with self._lock:
-            if self._started:
+            if self._db_synced:
                 return
-            self.scheduler.start()
-            self._started = True
+            if not self._started:
+                self.scheduler.start()
+                self._started = True
             await self.sync_from_db()
+            self._db_synced = True
 
     async def shutdown(self) -> None:
         async with self._lock:

--- a/astrbot/core/cron/manager.py
+++ b/astrbot/core/cron/manager.py
@@ -103,6 +103,7 @@ class CronJobManager:
         self._basic_handlers: dict[str, Callable[..., Any]] = {}
         self._lock = asyncio.Lock()
         self._started = False
+        # The scheduler may start early via _schedule_job; track DB sync separately.
         self._db_synced = False
 
     async def start(self, ctx: "Context") -> None:
@@ -121,7 +122,9 @@ class CronJobManager:
             if not self._started:
                 return
             self.scheduler.shutdown(wait=False)
+            await asyncio.sleep(0)
             self._started = False
+            self._db_synced = False
 
     async def sync_from_db(self) -> None:
         jobs = await self.db.list_cron_jobs()

--- a/tests/unit/test_cron_manager.py
+++ b/tests/unit/test_cron_manager.py
@@ -95,6 +95,31 @@ class TestCronJobManagerStart:
         # Should only sync once
         assert mock_db.list_cron_jobs.call_count == 1
 
+    @pytest.mark.asyncio
+    async def test_start_syncs_after_scheduler_started_early(
+        self, cron_manager, mock_db, mock_context, sample_cron_job
+    ):
+        """Test that early scheduler startup does not skip database sync."""
+        mock_db.create_cron_job.return_value = sample_cron_job
+        mock_db.list_cron_jobs.return_value = [sample_cron_job]
+
+        await cron_manager.add_basic_job(
+            name="Early Job",
+            cron_expression="0 9 * * *",
+            handler=MagicMock(),
+            enabled=True,
+            persistent=False,
+        )
+
+        await cron_manager.start(mock_context)
+
+        assert cron_manager._started is True
+        assert cron_manager._db_synced is True
+        assert cron_manager.scheduler.get_job(sample_cron_job.job_id) is not None
+        assert mock_db.list_cron_jobs.call_count == 1
+
+        await cron_manager.shutdown()
+
 
 class TestCronJobManagerShutdown:
     """Tests for CronJobManager.shutdown method."""

--- a/tests/unit/test_cron_manager.py
+++ b/tests/unit/test_cron_manager.py
@@ -69,6 +69,7 @@ class TestCronJobManagerInit:
         assert manager.db == mock_db
         assert manager._basic_handlers == {}
         assert manager._started is False
+        assert manager._db_synced is False
 
 
 class TestCronJobManagerStart:
@@ -94,6 +95,27 @@ class TestCronJobManagerStart:
 
         # Should only sync once
         assert mock_db.list_cron_jobs.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_start_resyncs_after_shutdown(
+        self, cron_manager, mock_db, mock_context
+    ):
+        """Test that restarting the manager resyncs the database."""
+        mock_db.list_cron_jobs.return_value = []
+
+        await cron_manager.start(mock_context)
+        await cron_manager.shutdown()
+
+        assert cron_manager._started is False
+        assert cron_manager._db_synced is False
+
+        await cron_manager.start(mock_context)
+
+        assert mock_db.list_cron_jobs.call_count == 2
+        assert cron_manager._started is True
+        assert cron_manager._db_synced is True
+
+        await cron_manager.shutdown()
 
     @pytest.mark.asyncio
     async def test_start_syncs_after_scheduler_started_early(


### PR DESCRIPTION
修复了插件在核心启动前通过 `add_basic_job(enabled=True)` 注册 BasicCronJob 时，导致 `CronJobManager.start()` 跳过 `sync_from_db()`，数据库中已启用的持久化 CronJob 未加载到 APScheduler 的问题。

**根因**：`_started` 变量同时兼任两个职责——"APScheduler 是否已运行"和"`sync_from_db()` 是否已执行"。插件在 `plugin_manager.reload()` 阶段调用 `add_basic_job()` 时，`_schedule_job()` 会提前启动 scheduler 并置 `_started = True`；随后核心生命周期调用 `start()` 看到 `_started` 为真直接返回，`sync_from_db()` 被永久跳过。

关联 issue： #9418 

### Modifications / 改动点

- **`astrbot/core/cron/manager.py`**：引入独立状态 `_db_synced`，将"APScheduler 运行状态"与"数据库同步状态"解耦。
  - `start()` 的提前返回条件改为 `_db_synced`，而非 `_started`。
  - scheduler 启动仍受 `_started` 保护，避免重复调用 `scheduler.start()`。
  - `sync_from_db()` 完成后才置 `_db_synced = True`，确保无论 scheduler 是否被提前启动，数据库中的持久化任务都能被加载。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

修复前（上次重启）：cost_control 注册 CronJob → `_started=True` → `start()` 直接 return → `sync_from_db()` 未执行，所有持久化 job 的 `updated_at` 未被更新，原有定时任务静默错过。

修复后（本次重启验证）：
```
日志序列：
  01:37:40  [cost_control] CronJob 注册完成          ← 插件 init 调用 add_basic_job，_started=True
  01:37:53  AstrBot started.                         ← start() 执行，_started 已为 True 但 _db_synced=False

数据库验证（updated_at 全部更新到 01:37:53，确认 sync_from_db 已执行）：
  [一次性测试任务]            ✓ updated 17:37:53
  [定时提醒任务A]             ✓ updated 17:37:53  ← 之前卡住未恢复的任务
  [定时提醒任务B]             ✓ updated 17:37:53
  [定时提醒任务C]             ✓ updated 17:37:53
  [定时天气播报任务]           ✓ updated 17:37:53
  [定时提醒任务D]             ✓ updated 17:37:53
  [定时提醒任务E]             ✓ updated 17:37:53
  [定时提醒任务F]             ✓ updated 17:37:53
  [一次性提醒任务]            ✓ updated 17:37:53
  [已禁用的语音播报任务]       ✗ disabled，被跳过
```
（时间戳为 UTC，日志为 CST；数据库使用 sqlite3 直查确认。）


---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Decouple the cron scheduler running state from the database sync state to ensure persistent jobs are always loaded, even when the scheduler is started early.

Bug Fixes:
- Ensure database-synced persistent cron jobs are loaded into the scheduler when basic jobs start the scheduler before the core start sequence.

Tests:
- Add a regression test verifying that early scheduler startup does not cause the cron manager to skip syncing jobs from the database.