### PR TITLE
chore: bump version to 4.26.8

### DIFF
--- a/astrbot/__init__.py
+++ b/astrbot/__init__.py
@@ -1,4 +1,4 @@
 import logging
 
-__version__ = "4.26.7"
+__version__ = "4.26.8"
 logger = logging.getLogger("astrbot")

--- a/changelogs/v4.26.8.md
+++ b/changelogs/v4.26.8.md
@@ -1,0 +1,91 @@
+## [4.26.8] - 2026-07-28
+
+Il faut cultiver notre jardin.
+
+我们必须耕种自己的花园。
+
+### Added
+
+- Added per-plugin log level controls to the dashboard and plugin API. (#9342)
+- Added model configuration support for the FishAudio TTS provider. (#9381)
+- Added platform log categorization and a console toggle for hiding user chat entries. (#9165)
+- Added a DashScope embedding provider with multimodal model support. (#9137)
+- Added a workspace file browser to ChatUI (projects only). (#9432)
+
+### Changed
+
+- Honored partial reply quotes in Telegram messages. (#9236)
+- Reported process CPU usage without blocking the event loop. (#9367)
+- Added the default value mapping for dictionary configuration fields. (#9414)
+
+### Fixed
+
+- Fixed FAISS access on Windows paths containing non-ASCII characters, restored lazy imports to prevent startup hangs, and rejected invalid dimensions for new indexes. (#8323, #9350, #9385)
+- Refreshed timestamps while holding the relevant lock and decoupled cron scheduler state from database synchronization so persistent jobs always load. (#9349, #9419)
+- Preserved checkpoints after failed LLM requests, maintained embedding batch result order, and used the current provider when regenerating messages. (#9358, #9359, #9241, #9402)
+- Checked quoted text for content safety, respected zero-valued forward parser limits, and removed trailing separators from message outlines. (#9232, #9394, #9390)
+- Resolved Tavily date-filter conflicts, nested OpenAI completion choices, and Bailian rerank protocol incompatibilities. (#9234, #9386, #9413)
+- Handled DingTalk command errors and rich-text mentions, returned correct WebChat image MIME types, and corrected Discord slash command validation. (#9389, #9319, #9411)
+- Displayed plugin configuration save progress, prevented accidental persona dialog closure, removed duplicate scrollbars, and prevented local plugin uploads from hanging. (#9327, #9238, #9382, #9406)
+- Improved conversation list performance and prevented stale asynchronous updates. (#9226)
+- Updated the default MiMo TTS model to `mimo-v2.5-tts`. (#9428)
+- Ignored system proxy variables when no proxy is configured, preventing local API requests from being intercepted. (#8897)
+- Preserved per-knowledge-base sparse retrieval ranks during rank fusion to avoid distorted ordering across independent FTS5 indexes. (#9426)
+- Guarded C extension reloads to prevent process crashes. (#9148)
+
+### Documentation
+
+- Updated the README banners and recommended the official QQ bot integration.
+- Added a Windows Docker Desktop deployment guide. (#9339)
+- Expanded the English and Chinese plugin publishing guides. (#9415)
+
+### Maintenance
+
+- Updated grouped GitHub Actions dependencies and `docker/login-action`. (#9333, #9416)
+- Pinned Ruff to 0.15.22. (#9369)
+- Prevented updater path tests from creating stray directories. (#9376)
+
+## 中文
+
+### 新增
+
+- 在控制台和插件 API 中新增按插件调整日志级别的能力。 (#9342)
+- 为 FishAudio TTS 提供商新增模型配置支持。 (#9381)
+- 新增平台日志分类，以及在控制台中隐藏用户聊天记录的开关。 (#9165)
+- 新增支持多模态模型的 DashScope Embedding 提供商。 (#9137)
+- 为 ChatUI 新增工作区文件浏览器（仅限项目）。 (#9432)
+
+### 变更
+
+- Telegram 消息支持保留局部回复引用。 (#9236)
+- 进程 CPU 使用率统计不再阻塞事件循环。 (#9367)
+- 为字典类型配置字段补充默认值映射。 (#9414)
+
+### 修复
+
+- 修复 Windows 非 ASCII 路径下的 FAISS 读写，恢复延迟导入以避免启动卡死，并拒绝为新索引配置无效维度。 (#8323, #9350, #9385)
+- 在持锁期间刷新时间戳，并解耦 Cron 调度器状态与数据库同步状态，确保始终加载持久化任务。 (#9349, #9419)
+- 在 LLM 请求失败后保留检查点，维持嵌入批处理结果顺序，并在重新生成消息时使用当前提供商。 (#9358, #9359, #9241, #9402)
+- 对引用文本执行内容安全检查，正确处理值为零的转发解析限制，并移除消息概要末尾的分隔符。 (#9232, #9394, #9390)
+- 修复 Tavily 日期筛选参数冲突、嵌套 OpenAI completion choices 以及百炼重排序协议兼容问题。 (#9234, #9386, #9413)
+- 修复钉钉命令错误与富文本提及处理、WebChat 图片 MIME 类型以及 Discord 斜杠命令名称校验。 (#9389, #9319, #9411)
+- 显示插件配置保存进度，避免误关人格编辑弹窗，移除重复滚动条，并防止本地插件上传卡住。 (#9327, #9238, #9382, #9406)
+- 提升会话列表性能，并避免异步请求产生陈旧更新。 (#9226)
+- 将 MiMo TTS 默认模型更新为 `mimo-v2.5-tts`。 (#9428)
+- 未配置代理时忽略系统代理变量，避免本地 API 请求被拦截。 (#8897)
+- 在排名融合时保留各知识库的稀疏检索排名，避免独立 FTS5 索引之间的结果顺序失真。 (#9426)
+- 为 C 扩展重载增加保护，避免进程崩溃。 (#9148)
+
+### 文档
+
+- 更新 README 横幅，并推荐使用 QQ 官方机器人接入。
+- 新增 Windows Docker Desktop 部署指南。 (#9339)
+- 扩充中英文插件发布指南。 (#9415)
+
+### 维护
+
+- 更新 GitHub Actions 依赖组和 `docker/login-action`。 (#9333, #9416)
+- 将 Ruff 固定为 0.15.22。 (#9369)
+- 避免更新器路径测试创建残留目录。 (#9376)
+
+[4.26.8]: https://github.com/AstrBotDevs/AstrBot/compare/v4.26.7...v4.26.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AstrBot"
-version = "4.26.7"
+version = "4.26.8"
 description = "Easy-to-use multi-platform LLM chatbot and development framework"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }


### PR DESCRIPTION
## Summary

- bump the project and package versions from 4.26.7 to 4.26.8
- add polished English and Chinese release notes for changes since v4.26.7
- prepare the required release branch for review before tagging

## Why

This prepares the 4.26.8 patch release using the repository's documented release workflow.

## Impact

After this PR is merged, `master` will report version 4.26.8 and can be tagged as `v4.26.8`.

## Validation

- `uv run python scripts/prepare_release.py 4.26.8`
- `uv run ruff format .`
- `uv run ruff check .`
- `git diff --check`

## Summary by Sourcery

Prepare the 4.26.8 patch release by updating version metadata and adding release notes.

Documentation:
- Add bilingual English and Chinese changelog for version 4.26.8 summarizing new features, fixes, and maintenance changes.

Chores:
- Bump project and package version identifiers from 4.26.7 to 4.26.8.