### PR TITLE
fix: preserve per-knowledge-base sparse retrieval ranks and use them in rank fusion to avoid distorted ordering across independent FTS5 indexes

### DIFF
--- a/astrbot/core/knowledge_base/retrieval/rank_fusion.py
+++ b/astrbot/core/knowledge_base/retrieval/rank_fusion.py
@@ -66,7 +66,10 @@ class RankFusion:
         dense_ranks = {
             r.data["doc_id"]: (idx + 1) for idx, r in enumerate(dense_results)
         }  # 这里的 doc_id 实际上是 chunk_id
-        sparse_ranks = {r.chunk_id: (idx + 1) for idx, r in enumerate(sparse_results)}
+        sparse_ranks = {
+            r.chunk_id: r.rank if r.rank is not None else idx + 1
+            for idx, r in enumerate(sparse_results)
+        }
 
         # 2. 收集所有唯一的 ID
         # 需要统一为 chunk_id

--- a/astrbot/core/knowledge_base/retrieval/sparse_retriever.py
+++ b/astrbot/core/knowledge_base/retrieval/sparse_retriever.py
@@ -30,6 +30,7 @@ class SparseResult:
     kb_id: str
     content: str
     score: float
+    rank: int | None = None
 
 
 class SparseRetriever:
@@ -87,7 +88,9 @@ class SparseRetriever:
                 fallback_kb_ids.append(kb_id)
                 continue
 
-            for doc in result:
+            # BM25 scores from independent FTS5 indexes are not comparable.
+            # Preserve each index's local rank for the later RRF stage.
+            for rank, doc in enumerate(result, start=1):
                 chunk_md = json.loads(doc["metadata"])
                 fts_results.append(
                     SparseResult(
@@ -97,6 +100,7 @@ class SparseRetriever:
                         kb_id=kb_id,
                         content=doc["text"],
                         score=-float(doc["score"]),
+                        rank=rank,
                     ),
                 )
 
@@ -172,5 +176,7 @@ class SparseRetriever:
             )
 
         results.sort(key=lambda x: x.score, reverse=True)
+        for rank, result in enumerate(results, start=1):
+            result.rank = rank
         # return results[: len(results) // len(kb_ids)]
         return results[:top_k_sparse]

--- a/tests/unit/test_rank_fusion.py
+++ b/tests/unit/test_rank_fusion.py
@@ -1,0 +1,59 @@
+import pytest
+
+from astrbot.core.db.vec_db.base import Result
+from astrbot.core.knowledge_base.retrieval.rank_fusion import RankFusion
+from astrbot.core.knowledge_base.retrieval.sparse_retriever import SparseResult
+
+
+def make_dense_result(chunk_id: str, similarity: float) -> Result:
+    return Result(
+        similarity=similarity,
+        data={
+            "doc_id": chunk_id,
+            "text": chunk_id,
+            "metadata": "{}",
+        },
+    )
+
+
+def make_sparse_result(
+    chunk_id: str,
+    kb_id: str,
+    score: float,
+    rank: int,
+) -> SparseResult:
+    return SparseResult(
+        chunk_index=0,
+        chunk_id=chunk_id,
+        doc_id=f"doc-{chunk_id}",
+        kb_id=kb_id,
+        content=chunk_id,
+        score=score,
+        rank=rank,
+    )
+
+
+@pytest.mark.asyncio
+async def test_rank_fusion_uses_source_rank_for_independent_sparse_indexes():
+    dense_results = [
+        make_dense_result("small-exact", 0.99),
+        make_dense_result("large-1", 0.95),
+        make_dense_result("large-2", 0.90),
+    ]
+    sparse_results = [
+        make_sparse_result("large-1", "kb-large", 12.0, 1),
+        make_sparse_result("large-2", "kb-large", 10.0, 2),
+        make_sparse_result("small-exact", "kb-small", 0.00001, 1),
+    ]
+
+    results = await RankFusion(kb_db=None).fuse(
+        dense_results=dense_results,
+        sparse_results=sparse_results,
+    )
+
+    assert [result.chunk_id for result in results] == [
+        "small-exact",
+        "large-1",
+        "large-2",
+    ]
+    assert results[0].score == pytest.approx(2 / 61)

--- a/tests/unit/test_sparse_retriever.py
+++ b/tests/unit/test_sparse_retriever.py
@@ -6,7 +6,12 @@ import pytest
 from astrbot.core.knowledge_base.retrieval.sparse_retriever import SparseRetriever
 
 
-def make_doc(chunk_id: str, text: str, chunk_index: int = 0) -> dict:
+def make_doc(
+    chunk_id: str,
+    text: str,
+    chunk_index: int = 0,
+    kb_id: str = "kb-1",
+) -> dict:
     return {
         "doc_id": chunk_id,
         "text": text,
@@ -14,7 +19,7 @@ def make_doc(chunk_id: str, text: str, chunk_index: int = 0) -> dict:
             {
                 "chunk_index": chunk_index,
                 "kb_doc_id": f"doc-{chunk_index}",
-                "kb_id": "kb-1",
+                "kb_id": kb_id,
             },
         ),
     }
@@ -59,6 +64,14 @@ class FallbackStorage:
         ]
 
 
+class StaticFTSStorage:
+    def __init__(self, documents: list[dict]):
+        self.documents = documents
+
+    async def search_sparse(self, query_tokens: list[str], limit: int):
+        return self.documents[:limit]
+
+
 @pytest.mark.asyncio
 async def test_sparse_retriever_uses_fts5_when_available():
     storage = FTSStorage()
@@ -91,3 +104,51 @@ async def test_sparse_retriever_falls_back_to_bm25_when_fts5_is_unavailable():
     assert [result.chunk_id for result in results] == ["chunk-1"]
     assert storage.search_sparse_calls == 1
     assert storage.get_documents_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_sparse_retriever_preserves_per_kb_fts_ranks():
+    large_storage = StaticFTSStorage(
+        [
+            {
+                **make_doc("large-1", "管理员账号安全说明", 0, "kb-large"),
+                "score": -12.0,
+            },
+            {
+                **make_doc("large-2", "密码策略说明", 1, "kb-large"),
+                "score": -10.0,
+            },
+        ],
+    )
+    small_storage = StaticFTSStorage(
+        [
+            {
+                **make_doc(
+                    "small-exact",
+                    "如何重置管理员密码？",
+                    0,
+                    "kb-small",
+                ),
+                "score": -0.00001,
+            },
+        ],
+    )
+    retriever = SparseRetriever(kb_db=None)
+
+    results = await retriever.retrieve(
+        query="如何重置管理员密码？",
+        kb_ids=["kb-large", "kb-small"],
+        kb_options={
+            "kb-large": {
+                "vec_db": SimpleNamespace(document_storage=large_storage),
+                "top_k_sparse": 2,
+            },
+            "kb-small": {
+                "vec_db": SimpleNamespace(document_storage=small_storage),
+                "top_k_sparse": 1,
+            },
+        },
+    )
+
+    ranks = {result.chunk_id: result.rank for result in results}
+    assert ranks == {"large-1": 1, "large-2": 2, "small-exact": 1}


### PR DESCRIPTION
修复多个知识库各自使用独立 FTS5 索引时，直接按原始 BM25 分数合并候选导致的排序失真。

不同 FTS5 索引的 BM25 分数受各自语料规模、词频和文档长度统计影响，不能直接跨索引比较。此前合并后的位置被当作稀疏检索排名传入 RRF，可能使小知识库中的高相关结果被大知识库候选压低。

Fixes #9425

### Modifications / 改动点

- 为 `SparseResult` 增加可选的来源排名 `rank`。
- FTS5 检索时保留候选在各知识库独立索引中的局部排名，RRF 使用该排名计算贡献。
- 内存 BM25 回退路径仍在统一候选集上排序，并记录全局排名，保持原有语义。
- 对未提供 `rank` 的旧调用保留按列表顺序计算排名的兼容行为。
- 增加跨知识库稀疏检索和 RRF 融合回归测试，测试数据均为虚构内容。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

验证步骤：

```bash
.venv/bin/ruff format --check astrbot/core/knowledge_base/retrieval/sparse_retriever.py astrbot/core/knowledge_base/retrieval/rank_fusion.py tests/unit/test_sparse_retriever.py tests/unit/test_rank_fusion.py
.venv/bin/ruff check astrbot/core/knowledge_base/retrieval/sparse_retriever.py astrbot/core/knowledge_base/retrieval/rank_fusion.py tests/unit/test_sparse_retriever.py tests/unit/test_rank_fusion.py
.venv/bin/python -m pytest -q tests/unit/test_sparse_retriever.py tests/unit/test_rank_fusion.py tests/test_kb_import.py tests/unit/test_kb_document_cleanup.py tests/unit/test_kb_manager_resilience.py tests/unit/test_kb_upload_atomicity.py tests/unit/test_knowledge_base_service_contract.py
```

结果：

```text
4 files already formatted
All checks passed!
43 passed, 4 warnings in 129.61s
```

4 条警告来自既有 `aiosqlite` 原子性测试在线程结束时访问已关闭的事件循环，与本次改动无关。

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。
- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。
- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Preserve per-knowledge-base sparse retrieval ranks and use them in rank fusion to avoid distorted ordering across independent FTS5 indexes.

Bug Fixes:
- Fix cross-knowledge-base sparse retrieval ranking by using local FTS5 ranks instead of raw BM25 scores when fusing results.
- Ensure BM25 in-memory fallback path assigns and propagates global ranks consistently for rank fusion.

Enhancements:
- Extend SparseResult with an optional rank field and make rank fusion backward-compatible with callers that do not provide ranks.

Tests:
- Add unit tests to verify sparse retriever preserves per-knowledge-base FTS ranks and that rank fusion prioritizes high-relevance results from smaller knowledge bases.