### PR TITLE
fix: update MiMo TTS default model

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1636,7 +1636,7 @@ CONFIG_METADATA_2 = {
                         "enable": False,
                         "api_key": "",
                         "api_base": "https://api.xiaomimimo.com/v1",
-                        "model": "mimo-v2-tts",
+                        "model": "mimo-v2.5-tts",
                         "mimo-tts-voice": "mimo_default",
                         "mimo-tts-format": "wav",
                         "mimo-tts-style-prompt": "",

--- a/astrbot/core/provider/sources/mimo_api_common.py
+++ b/astrbot/core/provider/sources/mimo_api_common.py
@@ -8,7 +8,7 @@ from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
 from astrbot.core.utils.media_utils import MediaResolver, describe_media_ref
 
 DEFAULT_MIMO_API_BASE = "https://api.xiaomimimo.com/v1"
-DEFAULT_MIMO_TTS_MODEL = "mimo-v2-tts"
+DEFAULT_MIMO_TTS_MODEL = "mimo-v2.5-tts"
 DEFAULT_MIMO_TTS_VOICE = "mimo_default"
 DEFAULT_MIMO_TTS_SEED_TEXT = "Hello, MiMo, have you had lunch?"
 # The MiMo-V2 series went offline on 2026-06-30; mimo-v2.5-asr is the


### PR DESCRIPTION
Fixes #9427.

### Modifications / 改动点

- Updated the MiMo TTS runtime fallback model from `mimo-v2-tts` to `mimo-v2.5-tts`.
- Updated the `MiMo TTS(API)` WebUI provider template to use `mimo-v2.5-tts`.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```text
$ uv run pytest -q
1925 passed, 7 warnings in 185.12s (0:03:05)

$ uv run ruff format --check .
482 files already formatted

$ uv run ruff check .
All checks passed!
```

No live MiMo API request was made because this change only updates the default model identifiers.

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Update MiMo TTS defaults to use the newer v2.5 model across configuration and provider runtime.

Bug Fixes:
- Switch the MiMo TTS runtime fallback model from mimo-v2-tts to the updated mimo-v2.5-tts endpoint.

Enhancements:
- Align the MiMo TTS WebUI provider template default model with the newer mimo-v2.5-tts variant.