### PR TITLE
fix: lazily import BM25 dependency

### DIFF
--- a/astrbot/core/knowledge_base/retrieval/sparse_retriever.py
+++ b/astrbot/core/knowledge_base/retrieval/sparse_retriever.py
@@ -8,8 +8,6 @@ import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from rank_bm25 import BM25Okapi
-
 from astrbot.core.knowledge_base.kb_db_sqlite import KBSQLiteDatabase
 from astrbot.core.knowledge_base.retrieval.tokenizer import (
     load_stopwords,
@@ -154,6 +152,8 @@ class SparseRetriever:
         tokenized_corpus = [tokenize_text(doc, self.hit_stopwords) for doc in corpus]
 
         # 3. 构建 BM25 索引
+        from rank_bm25 import BM25Okapi
+
         bm25 = BM25Okapi(tokenized_corpus)
 
         # 4. 执行检索

--- a/tests/unit/test_sparse_retriever.py
+++ b/tests/unit/test_sparse_retriever.py
@@ -1,8 +1,11 @@
+import importlib
 import json
+import sys
 from types import SimpleNamespace
 
 import pytest
 
+from astrbot.core.knowledge_base.retrieval import sparse_retriever
 from astrbot.core.knowledge_base.retrieval.sparse_retriever import SparseRetriever
 
 
@@ -73,10 +76,11 @@ class StaticFTSStorage:
 
 
 @pytest.mark.asyncio
-async def test_sparse_retriever_uses_fts5_when_available():
+async def test_sparse_retriever_uses_fts5_without_importing_bm25(monkeypatch):
     storage = FTSStorage()
     vec_db = SimpleNamespace(document_storage=storage)
     retriever = SparseRetriever(kb_db=None)
+    monkeypatch.setitem(sys.modules, "rank_bm25", None)
 
     results = await retriever.retrieve(
         query="apple",
@@ -87,6 +91,12 @@ async def test_sparse_retriever_uses_fts5_when_available():
     assert [result.chunk_id for result in results] == ["chunk-1"]
     assert storage.search_sparse_calls == 1
     assert storage.get_documents_calls == 0
+
+
+def test_sparse_retriever_module_import_does_not_load_bm25(monkeypatch):
+    monkeypatch.setitem(sys.modules, "rank_bm25", None)
+
+    importlib.reload(sparse_retriever)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- defer `rank_bm25` import until the BM25 fallback is actually used
- keep AstrBot startup and the FTS5 sparse retrieval path independent of NumPy
- add regression coverage for module import and FTS5 retrieval without `rank_bm25`

## Root cause

`rank_bm25` was imported at module load time and immediately imported NumPy. On Hygon C86 systems where the bundled NumPy build requires unsupported X86_V2 instructions, this aborted AstrBot startup even when BM25 fallback retrieval was not needed.

## Impact

AstrBot can start and use FTS5 sparse retrieval without loading `rank_bm25` or NumPy. Systems that actually enter the BM25 fallback path still require a NumPy build compatible with their CPU.

## Validation

- `uv run pytest tests/unit/test_sparse_retriever.py -q` (4 passed)
- `uv run ruff format --check .`
- `uv run ruff check .`

Closes #9434

## Summary by Sourcery

Defer the BM25 dependency import so AstrBot can start and use FTS5-based sparse retrieval without requiring NumPy unless the BM25 fallback path is actually executed.

Bug Fixes:
- Prevent AstrBot startup from failing on systems with incompatible NumPy builds by avoiding eager import of the BM25 library.

Enhancements:
- Make the sparse retriever’s BM25 fallback path lazily import its BM25 dependency only when needed.

Tests:
- Add tests ensuring FTS5-based sparse retrieval operates without importing the BM25 module and that importing the sparse retriever module does not load BM25 eagerly.