### PR TITLE
fix: preserve streaming response tail

### DIFF
--- a/dashboard/src/components/chat/ThreadPanel.vue
+++ b/dashboard/src/components/chat/ThreadPanel.vue
@@ -276,7 +276,18 @@ function processPayload(botRecord: ChatRecord, userRecord: ChatRecord, payload: 
   if (type === "complete" || type === "break") {
     markMessageStarted(botRecord);
     const finalText = payloadText(data);
-    if (finalText && !hasPlainText(botRecord)) {
+    const existingText = botRecord.content.message
+      .filter((part) => part.type === "plain")
+      .map((part) => part.text || "")
+      .join("");
+    const missingText = finalText.slice(existingText.length);
+    if (
+      type === "complete" &&
+      missingText &&
+      finalText.startsWith(existingText)
+    ) {
+      appendPlain(botRecord, missingText);
+    } else if (finalText && !hasPlainText(botRecord)) {
       appendPlain(botRecord, finalText, false);
     }
     return;

--- a/dashboard/src/composables/useMessages.ts
+++ b/dashboard/src/composables/useMessages.ts
@@ -1089,7 +1089,18 @@ export function useMessages(options: UseMessagesOptions) {
     if (msgType === "complete" || msgType === "break") {
       markMessageStarted(botRecord);
       const finalText = payloadText(data);
-      if (finalText && !hasPlainText(botRecord)) {
+      const existingText = botRecord.content.message
+        .filter((part) => part.type === "plain")
+        .map((part) => part.text || "")
+        .join("");
+      const missingText = finalText.slice(existingText.length);
+      if (
+        msgType === "complete" &&
+        missingText &&
+        finalText.startsWith(existingText)
+      ) {
+        appendPlain(botRecord, missingText);
+      } else if (finalText && !hasPlainText(botRecord)) {
         appendPlain(botRecord, finalText, false);
       }
       return;


### PR DESCRIPTION
Fixes #9437.

### Modifications / 改动点

- Updated both ChatUI streaming reducers to append only the suffix missing from a cumulative `complete` event.
- This preserves the final visible plain-text segment after reasoning or tool-call chunks without duplicating already rendered text.
- No dependencies were added.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```text
$ uv run ruff format --check .
483 files already formatted

$ uv run ruff check .
All checks passed!

$ pnpm typecheck
$ vue-tsc --noEmit

$ uv run pytest
1953 passed, 6 warnings in 69.83s
```

Manual live ChatUI test:

Streaming response with multiple tool calls:

<img width="1191" height="708" alt="Screenshot 2026-07-29 at 17 47 30" src="https://github.com/user-attachments/assets/242c2944-36d5-4e97-9e5a-64f311d40fe7" />

Final response tail:

<img width="1189" height="713" alt="Screenshot 2026-07-29 at 17 47 43" src="https://github.com/user-attachments/assets/0d034b72-40da-415b-8e2c-05b4c0a0648c" />

- Multiple tool calls completed and `STREAM_TAIL_9437_OK` was visible at the end of the streamed response.
- After a hard browser refresh and reopening the conversation, `STREAM_TAIL_9437_OK` was still visible.
- This validates live streaming and persisted history rendering; it does not force a dropped frontend delta.

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. (N/A: bug fix)
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。（不适用：Bug 修复）

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Prevent duplicated or missing plain-text tails when handling cumulative `complete` streaming events in ChatUI reducers.