### PR TITLE
fix(qqofficial): prevent leading char loss in streaming buffer

### DIFF
--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import copy
 import logging
 import os
 import random
@@ -180,10 +181,11 @@ class QQOfficialMessageEvent(AstrMessageEvent):
         return None
 
     def _append_stream_delta(self, chain: MessageChain) -> None:
-        """Append stream delta into an owned buffer (copy Plain text).
+        """Append stream delta into an owned buffer (copy components).
 
         Holding the yielded MessageChain by reference drops leading characters
-        when upstream reuses/mutates the same chain between yields.
+        when upstream reuses/mutates the same chain between yields. Non-Plain
+        components are deep-copied for the same reason.
         """
         if not self.send_buffer:
             self.send_buffer = MessageChain(
@@ -193,9 +195,10 @@ class QQOfficialMessageEvent(AstrMessageEvent):
             )
         for comp in chain.chain:
             if isinstance(comp, Plain):
-                self.send_buffer.chain.append(Plain(text=comp.text or ""))
+                # Preserve original text value (do not coerce falsy with `or ""`).
+                self.send_buffer.chain.append(Plain(text=comp.text))
             else:
-                self.send_buffer.chain.append(comp)
+                self.send_buffer.chain.append(copy.deepcopy(comp))
 
     @staticmethod
     def _extract_response_message_id(ret) -> str | None:

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -123,11 +123,8 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                 source = self.message_obj.raw_message
 
                 if not isinstance(source, botpy.message.C2CMessage):
-                    # 非 C2C 场景：直接累积，最后统一发
-                    if not self.send_buffer:
-                        self.send_buffer = chain
-                    else:
-                        self.send_buffer.chain.extend(chain.chain)
+                    # 非 C2C 场景：直接累积，最后统一发（拷贝 delta，避免引用丢首字）
+                    self._append_stream_delta(chain)
                     continue
 
                 # ---- C2C 流式场景 ----
@@ -150,11 +147,8 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                     last_edit_time = 0
                     continue
 
-                # 累积内容
-                if not self.send_buffer:
-                    self.send_buffer = chain
-                else:
-                    self.send_buffer.chain.extend(chain.chain)
+                # 累积内容（拷贝，避免上游复用 MessageChain 改写 buffer）
+                self._append_stream_delta(chain)
 
                 # 节流：按时间间隔发送中间分片
                 current_time = asyncio.get_running_loop().time()
@@ -184,6 +178,24 @@ class QQOfficialMessageEvent(AstrMessageEvent):
             self.send_buffer = None
 
         return None
+
+    def _append_stream_delta(self, chain: MessageChain) -> None:
+        """Append stream delta into an owned buffer (copy Plain text).
+
+        Holding the yielded MessageChain by reference drops leading characters
+        when upstream reuses/mutates the same chain between yields.
+        """
+        if not self.send_buffer:
+            self.send_buffer = MessageChain(
+                use_t2i_=chain.use_t2i_,
+                use_markdown_=chain.use_markdown_,
+                type=chain.type,
+            )
+        for comp in chain.chain:
+            if isinstance(comp, Plain):
+                self.send_buffer.chain.append(Plain(text=comp.text or ""))
+            else:
+                self.send_buffer.chain.append(comp)
 
     @staticmethod
     def _extract_response_message_id(ret) -> str | None:

--- a/tests/test_qqofficial_stream_buffer_copy.py
+++ b/tests/test_qqofficial_stream_buffer_copy.py
@@ -1,0 +1,299 @@
+"""Regression tests for QQ Official streaming buffer leading-character loss.
+
+Production logs showed group streaming dropping the first delta:
+  delta#1 head='不' buf='不'
+  delta#2 head='稀' buf='稀'   # wrong, expected '不稀'
+
+Root cause: send_buffer held a reference to the yielded MessageChain; upstream
+reused/mutated that object. Fix: _append_stream_delta copies Plain text.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import botpy.message
+import pytest
+
+from astrbot.api.event import MessageChain
+from astrbot.api.message_components import Plain
+from astrbot.api.platform import (
+    AstrBotMessage,
+    MessageMember,
+    MessageType,
+    PlatformMetadata,
+)
+from astrbot.core.platform.sources.qqofficial.qqofficial_message_event import (
+    QQOfficialMessageEvent,
+)
+
+
+def _extract_send_text(kwargs: dict) -> str:
+    text = kwargs.get("content")
+    if text:
+        return str(text)
+    md = kwargs.get("markdown")
+    if isinstance(md, dict):
+        return str(md.get("content") or "")
+    if md is not None:
+        return str(getattr(md, "content", None) or "")
+    return ""
+
+
+def _make_group_event() -> QQOfficialMessageEvent:
+    raw = botpy.message.GroupMessage(
+        api=None,
+        event_id="event-1",
+        data={
+            "id": "msg-1",
+            "author": {"member_openid": "member-1"},
+            "group_openid": "group-1",
+            "content": "ping",
+            "timestamp": "0",
+        },
+    )
+    abm = AstrBotMessage()
+    abm.message_id = "msg-1"
+    abm.session_id = "group-1"
+    abm.group_id = "group-1"
+    abm.self_id = "bot-1"
+    abm.sender = MessageMember(user_id="member-1", nickname="u")
+    abm.type = MessageType.GROUP_MESSAGE
+    abm.message_str = "ping"
+    abm.message = []
+    abm.raw_message = raw
+    meta = PlatformMetadata(name="qq_official", description="t", id="qq_official")
+    bot = SimpleNamespace(api=SimpleNamespace(post_group_message=AsyncMock()))
+    return QQOfficialMessageEvent(
+        message_str="ping",
+        message_obj=abm,
+        platform_meta=meta,
+        session_id="group-1",
+        bot=bot,  # type: ignore[arg-type]
+    )
+
+
+def _make_c2c_event() -> QQOfficialMessageEvent:
+    raw = botpy.message.C2CMessage(
+        api=None,
+        event_id="event-1",
+        data={
+            "id": "msg-1",
+            "author": {"user_openid": "user-1"},
+            "content": "ping",
+            "timestamp": "0",
+        },
+    )
+    abm = AstrBotMessage()
+    abm.message_id = "msg-1"
+    abm.session_id = "user-1"
+    abm.self_id = "bot-1"
+    abm.sender = MessageMember(user_id="user-1", nickname="u")
+    abm.type = MessageType.FRIEND_MESSAGE
+    abm.message_str = "ping"
+    abm.message = []
+    abm.raw_message = raw
+    meta = PlatformMetadata(name="qq_official", description="t", id="qq_official")
+    bot = SimpleNamespace(api=SimpleNamespace())
+    return QQOfficialMessageEvent(
+        message_str="ping",
+        message_obj=abm,
+        platform_meta=meta,
+        session_id="user-1",
+        bot=bot,  # type: ignore[arg-type]
+    )
+
+
+def test_append_stream_delta_copies_plain_and_survives_source_mutation() -> None:
+    """Unit-level: owned buffer must not track later mutations of the delta."""
+    event = _make_group_event()
+    shared = MessageChain(chain=[Plain("不")])
+
+    event._append_stream_delta(shared)
+    shared.chain[0].text = "稀"  # mutate after append
+    event._append_stream_delta(shared)
+    shared.chain[0].text = "罕"
+    event._append_stream_delta(shared)
+
+    texts = [c.text for c in event.send_buffer.chain if isinstance(c, Plain)]
+    assert texts == ["不", "稀", "罕"]
+    assert "".join(texts) == "不稀罕"
+
+
+def test_append_stream_delta_old_reference_style_loses_first_char() -> None:
+    """Document the broken pre-fix behavior (reference assign + extend)."""
+    event = _make_group_event()
+    shared = MessageChain(chain=[Plain("不")])
+
+    # Pre-fix group path:
+    #   if not send_buffer: send_buffer = chain
+    #   else: send_buffer.chain.extend(chain.chain)
+    event.send_buffer = shared
+    shared.chain[0].text = "稀"
+    event.send_buffer.chain.extend(shared.chain)
+
+    # After mutation + extend-on-self, leading "不" is gone.
+    joined = "".join(c.text for c in event.send_buffer.chain if isinstance(c, Plain))
+    assert "不" not in joined
+    assert joined.startswith("稀")
+
+
+@pytest.mark.asyncio
+async def test_group_stream_keeps_first_character_when_delta_reused() -> None:
+    """End-to-end group send_streaming with reused/mutated MessageChain."""
+    event = _make_group_event()
+    captured: list[str] = []
+
+    async def capture(**kwargs):
+        captured.append(_extract_send_text(kwargs))
+        return {"id": "out-1"}
+
+    event.bot.api.post_group_message = AsyncMock(side_effect=capture)
+
+    shared = MessageChain(chain=[Plain("不")])
+
+    async def gen():
+        shared.chain[0].text = "不"
+        yield shared
+        shared.chain[0].text = "稀"
+        yield shared
+        shared.chain[0].text = "罕？"
+        yield shared
+
+    await event.send_streaming(gen())
+
+    assert len(captured) == 1
+    assert captured[0].startswith("不稀罕？")
+    assert "不" in captured[0]
+
+
+@pytest.mark.asyncio
+async def test_group_stream_accumulates_independent_delta_chains() -> None:
+    """Normal path: each yield is a fresh MessageChain (openai-style deltas)."""
+    event = _make_group_event()
+    captured: list[str] = []
+
+    async def capture(**kwargs):
+        captured.append(_extract_send_text(kwargs))
+        return {"id": "out-1"}
+
+    event.bot.api.post_group_message = AsyncMock(side_effect=capture)
+
+    async def gen():
+        yield MessageChain().message("不")
+        yield MessageChain().message("稀")
+        yield MessageChain().message("罕")
+        yield MessageChain().message("？认识。")
+
+    await event.send_streaming(gen())
+
+    assert len(captured) == 1
+    assert captured[0].startswith("不稀罕？认识。")
+
+
+@pytest.mark.asyncio
+async def test_group_stream_preserves_empty_and_multi_char_deltas() -> None:
+    event = _make_group_event()
+    captured: list[str] = []
+
+    async def capture(**kwargs):
+        captured.append(_extract_send_text(kwargs))
+        return {"id": "out-1"}
+
+    event.bot.api.post_group_message = AsyncMock(side_effect=capture)
+
+    async def gen():
+        yield MessageChain().message("你好")
+        yield MessageChain().message("\n\n")
+        yield MessageChain().message("又来了？")
+
+    await event.send_streaming(gen())
+
+    assert len(captured) == 1
+    assert captured[0] == "你好\n\n又来了？"
+
+
+@pytest.mark.asyncio
+async def test_group_stream_keeps_non_plain_components() -> None:
+    event = _make_group_event()
+    captured_kwargs: list[dict] = []
+
+    async def capture(**kwargs):
+        captured_kwargs.append(kwargs)
+        return {"id": "out-1"}
+
+    event.bot.api.post_group_message = AsyncMock(side_effect=capture)
+
+    async def gen():
+        yield MessageChain().message("前")
+        # Image may force media path; still ensure text buffer kept "前缀"
+        yield MessageChain(chain=[Plain("缀")])
+
+    await event.send_streaming(gen())
+
+    assert captured_kwargs
+    text = _extract_send_text(captured_kwargs[0])
+    assert text.startswith("前缀")
+
+
+@pytest.mark.asyncio
+async def test_c2c_stream_append_keeps_first_char_before_throttle_flush() -> None:
+    """C2C also uses _append_stream_delta; keep time <1s so only final state=10 sends."""
+    event = _make_c2c_event()
+    sent_texts: list[str] = []
+
+    async def fake_post_send(stream=None):
+        # Capture buffer text at send time (before _post_send clears it).
+        parts = []
+        if event.send_buffer:
+            for c in event.send_buffer.chain:
+                if isinstance(c, Plain) and c.text:
+                    parts.append(c.text)
+        sent_texts.append("".join(parts))
+        event.send_buffer = None
+        return {"id": f"stream-{len(sent_texts)}"}
+
+    shared = MessageChain(chain=[Plain("不")])
+
+    async def gen():
+        shared.chain[0].text = "不"
+        yield shared
+        shared.chain[0].text = "稀"
+        yield shared
+        shared.chain[0].text = "罕"
+        yield shared
+
+    from unittest.mock import patch
+
+    with (
+        patch.object(event, "_post_send", side_effect=fake_post_send),
+        patch("asyncio.get_running_loop") as mock_loop,
+    ):
+        # last_edit_time starts at 0; keep now < 1 so intermediate throttle never fires.
+        mock_loop.return_value.time.return_value = 0.5
+        await event.send_streaming(gen())
+
+    # Only final state=10 flush with full accumulated text.
+    assert len(sent_texts) == 1
+    assert sent_texts[0] == "不稀罕"
+
+
+@pytest.mark.asyncio
+async def test_group_stream_sends_once_after_all_deltas() -> None:
+    event = _make_group_event()
+    calls = 0
+
+    async def capture(**kwargs):
+        nonlocal calls
+        calls += 1
+        return {"id": f"out-{calls}"}
+
+    event.bot.api.post_group_message = AsyncMock(side_effect=capture)
+
+    async def gen():
+        for ch in "不稀罕":
+            yield MessageChain().message(ch)
+
+    await event.send_streaming(gen())
+    assert calls == 1


### PR DESCRIPTION
Copy stream deltas into an owned buffer instead of holding references to yielded MessageChain/Plain objects. Upstream reuse/mutation dropped the first character(s) on group (and C2C) streaming accumulation.

Add regression tests covering reference-mutation, independent deltas, and C2C path.

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
Fixes QQ Official streaming dropping the first character(s) when accumulating deltas (especially group chat; C2C accumulation uses the same helper).

Root cause / 根因：  
send_streaming used send_buffer = chain (reference). Upstream can reuse/mutate the same MessageChain/Plain between yields, so the first char was lost on the next delta.

bug日志截图：
<img width="2005" height="790" alt="2db614b0d0cf786237a0c5261b865afb" src="https://github.com/user-attachments/assets/3357fb0d-3bc3-4bb5-8d6d-0aa2dab0dd53" />
<img width="2013" height="696" alt="431d41890de36df0763ca17ec8df821d" src="https://github.com/user-attachments/assets/47a9bb13-f417-4883-8905-439ca917fc4e" />
<img width="2024" height="861" alt="f8723a6b59f8dca80a152a98cf3c7a6b" src="https://github.com/user-attachments/assets/048616a5-a272-4c5b-8f3c-bad443ebe0d6" />

fix: #9440 


### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
- astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
- Add _append_stream_delta(): copy Plain text into an owned buffer
- Group (non-C2C) and C2C accumulation both use this helper (no more bare reference assign)
- tests/test_qqofficial_stream_buffer_copy.py
- Regression tests: reference-mutation bug repro, independent deltas, multi-char/\n\n, C2C path, single final group send

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->
修复后的验证截图：
<img width="2010" height="778" alt="d5f1201ac42de6df04e11497a21daf1b" src="https://github.com/user-attachments/assets/96babf3b-b2d6-4158-b7a1-f072a5221557" />
<img width="2026" height="776" alt="233f6df560a36bd6e08eb4c1b94ec2d7" src="https://github.com/user-attachments/assets/9491a36d-3b06-421e-ae16-9c34c11418ae" />
首字不再被吞掉
---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x ] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x ] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [ x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure QQ Official streaming accumulates text deltas in an owned buffer to avoid leading-character loss when upstream reuses MessageChain objects.

Bug Fixes:
- Fix QQ Official group and C2C streaming where the first character(s) of accumulated deltas could be dropped due to holding mutable MessageChain references.

Enhancements:
- Introduce a helper to append streaming deltas into a dedicated MessageChain, copying Plain text while preserving non-text components.

Tests:
- Add regression tests covering buffer behavior under upstream MessageChain mutation, independent delta chains, multi-character and newline deltas, C2C streaming path, and single final group send semantics.