### PR TITLE
fix: reorder fake tool call messages at tail to correct timing

### DIFF
--- a/astrbot/core/agent/message.py
+++ b/astrbot/core/agent/message.py
@@ -341,11 +341,19 @@ def bind_checkpoint_messages(history: list[dict]) -> list[Message]:
         message = Message.model_validate(item)
         if item.get("_no_save"):
             message._no_save = True
-        if item.get("_from_real_tool_call"):
+        if item.get(FROM_REAL_TOOL_CALL_KEY):
             message._from_real_tool_call = True
         messages.append(message)
 
     return messages
+
+
+FROM_REAL_TOOL_CALL_KEY = "_from_real_tool_call"
+"""``Message → dict`` 序列化时携带真实工具调用标记的键名。
+
+与 ``Message._from_real_tool_call`` 属性对应；所有读/写该键的地方统一引用此常量，
+避免键名拼写漂移导致误伤防护静默失效。
+"""
 
 
 def message_to_dict_with_marker(message: Message) -> dict:
@@ -357,7 +365,7 @@ def message_to_dict_with_marker(message: Message) -> dict:
     """
     data = message.model_dump()
     if message._from_real_tool_call:
-        data["_from_real_tool_call"] = True
+        data[FROM_REAL_TOOL_CALL_KEY] = True
     return data
 
 

--- a/astrbot/core/agent/message.py
+++ b/astrbot/core/agent/message.py
@@ -214,6 +214,10 @@ class Message(BaseModel):
 
     _no_save: bool = PrivateAttr(default=False)
     _checkpoint_after: CheckpointData | None = PrivateAttr(default=None)
+    _from_real_tool_call: bool = PrivateAttr(default=False)
+    """Whether this message was produced by real tool execution. Marked pairs
+    are never moved by the fake tool call reorder; plugin-injected raw dicts
+    never carry this flag."""
 
     @model_validator(mode="after")
     def check_content_required(self):
@@ -337,6 +341,8 @@ def bind_checkpoint_messages(history: list[dict]) -> list[Message]:
         message = Message.model_validate(item)
         if item.get("_no_save"):
             message._no_save = True
+        if item.get("_from_real_tool_call"):
+            message._from_real_tool_call = True
         messages.append(message)
 
     return messages
@@ -347,6 +353,8 @@ def dump_messages_with_checkpoints(messages: list[Message]) -> list[dict]:
     dumped: list[dict] = []
     for message in messages:
         message_data = message.model_dump()
+        if message._from_real_tool_call:
+            message_data["_from_real_tool_call"] = True
         if isinstance(message.content, list):
             message_data["content"] = [
                 part.model_dump()

--- a/astrbot/core/agent/message.py
+++ b/astrbot/core/agent/message.py
@@ -348,13 +348,24 @@ def bind_checkpoint_messages(history: list[dict]) -> list[Message]:
     return messages
 
 
+def message_to_dict_with_marker(message: Message) -> dict:
+    """Serialize a Message to dict, carrying the real-tool-call marker.
+
+    ``_from_real_tool_call`` is a ``PrivateAttr`` so it never appears in
+    ``model_dump()`` output; this helper re-injects it so the fake tool call
+    reorder's misfire protection survives every serialization path.
+    """
+    data = message.model_dump()
+    if message._from_real_tool_call:
+        data["_from_real_tool_call"] = True
+    return data
+
+
 def dump_messages_with_checkpoints(messages: list[Message]) -> list[dict]:
     """Dump runtime messages and reinsert bound checkpoint segments."""
     dumped: list[dict] = []
     for message in messages:
-        message_data = message.model_dump()
-        if message._from_real_tool_call:
-            message_data["_from_real_tool_call"] = True
+        message_data = message_to_dict_with_marker(message)
         if isinstance(message.content, list):
             message_data["content"] = [
                 part.model_dump()

--- a/astrbot/core/provider/__init__.py
+++ b/astrbot/core/provider/__init__.py
@@ -1,9 +1,15 @@
 from .entities import ProviderMetaData
-from .provider import Provider, STTProvider, reorder_tailing_tool_call_user
+from .provider import (
+    Provider,
+    STTProvider,
+    reorder_tailing_tool_call_user,
+    strip_internal_markers,
+)
 
 __all__ = [
     "Provider",
     "ProviderMetaData",
     "STTProvider",
     "reorder_tailing_tool_call_user",
+    "strip_internal_markers",
 ]

--- a/astrbot/core/provider/__init__.py
+++ b/astrbot/core/provider/__init__.py
@@ -1,4 +1,9 @@
 from .entities import ProviderMetaData
-from .provider import Provider, STTProvider
+from .provider import Provider, STTProvider, reorder_tailing_tool_call_user
 
-__all__ = ["Provider", "ProviderMetaData", "STTProvider"]
+__all__ = [
+    "Provider",
+    "ProviderMetaData",
+    "STTProvider",
+    "reorder_tailing_tool_call_user",
+]

--- a/astrbot/core/provider/entities.py
+++ b/astrbot/core/provider/entities.py
@@ -72,15 +72,18 @@ class ToolCallsResult:
     """函数调用的结果"""
 
     def to_openai_messages(self) -> list[dict]:
-        ret = [
-            self.tool_calls_info.model_dump(),
-            *[item.model_dump() for item in self.tool_calls_result],
-        ]
+        ret: list[dict] = []
+        for item in self.to_openai_messages_model():
+            data = item.model_dump()
+            data["_from_real_tool_call"] = True
+            ret.append(data)
         return ret
 
     def to_openai_messages_model(
         self,
     ) -> list[AssistantMessageSegment | ToolCallMessageSegment]:
+        for item in [self.tool_calls_info, *self.tool_calls_result]:
+            item._from_real_tool_call = True
         return [
             self.tool_calls_info,
             *self.tool_calls_result,

--- a/astrbot/core/provider/entities.py
+++ b/astrbot/core/provider/entities.py
@@ -19,6 +19,7 @@ from astrbot.core.agent.message import (
     ToolCall,
     ToolCallMessageSegment,
     is_checkpoint_message,
+    message_to_dict_with_marker,
 )
 from astrbot.core.agent.tool import ToolSet
 from astrbot.core.db.po import Conversation
@@ -72,12 +73,10 @@ class ToolCallsResult:
     """函数调用的结果"""
 
     def to_openai_messages(self) -> list[dict]:
-        ret: list[dict] = []
-        for item in self.to_openai_messages_model():
-            data = item.model_dump()
-            data["_from_real_tool_call"] = True
-            ret.append(data)
-        return ret
+        return [
+            message_to_dict_with_marker(item)
+            for item in self.to_openai_messages_model()
+        ]
 
     def to_openai_messages_model(
         self,

--- a/astrbot/core/provider/entities.py
+++ b/astrbot/core/provider/entities.py
@@ -81,6 +81,15 @@ class ToolCallsResult:
     def to_openai_messages_model(
         self,
     ) -> list[AssistantMessageSegment | ToolCallMessageSegment]:
+        """返回 assistant(tool_use) + tool_result 段，并就地打上真实工具调用标记。
+
+        Note:
+            就地打标（``_from_real_tool_call = True``）是有意为之：agent runner 会把
+            本方法返回的段对象直接并入对话历史（``run_context.messages``），标记须随
+            对象经 ``message_to_dict_with_marker`` 序列化持久化，跨轮次的伪造对重排
+            误伤防护才成立。不可改为克隆——克隆会使历史中的真实对失去标记，导致
+            后续回合被当作伪造对误重排。
+        """
         for item in [self.tool_calls_info, *self.tool_calls_result]:
             item._from_real_tool_call = True
         return [

--- a/astrbot/core/provider/modalities.py
+++ b/astrbot/core/provider/modalities.py
@@ -28,7 +28,10 @@ class ContextSanitizeStats:
 
 def _message_to_dict(message: dict[str, Any] | Message) -> dict[str, Any] | None:
     if isinstance(message, Message):
-        return dict(message.model_dump())
+        data = dict(message.model_dump())
+        if message._from_real_tool_call:
+            data["_from_real_tool_call"] = True
+        return data
     if isinstance(message, dict):
         return dict(copy.deepcopy(message))
     return None

--- a/astrbot/core/provider/modalities.py
+++ b/astrbot/core/provider/modalities.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from astrbot import logger
-from astrbot.core.agent.message import Message
+from astrbot.core.agent.message import Message, message_to_dict_with_marker
 
 
 @dataclass(slots=True)
@@ -28,10 +28,7 @@ class ContextSanitizeStats:
 
 def _message_to_dict(message: dict[str, Any] | Message) -> dict[str, Any] | None:
     if isinstance(message, Message):
-        data = dict(message.model_dump())
-        if message._from_real_tool_call:
-            data["_from_real_tool_call"] = True
-        return data
+        return message_to_dict_with_marker(message)
     if isinstance(message, dict):
         return dict(copy.deepcopy(message))
     return None

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -216,6 +216,8 @@ class Provider(AbstractProvider):
 
 def _is_valid_tool_pair(asst_msg: dict[str, Any], tool_msg: dict[str, Any]) -> bool:
     """判断 assistant(tool_calls) 与 tool 是否为 tool_call_id 匹配的一对。"""
+    if not isinstance(asst_msg, dict) or not isinstance(tool_msg, dict):
+        return False
     if asst_msg.get("role") != "assistant" or tool_msg.get("role") != "tool":
         return False
     tool_calls = asst_msg.get("tool_calls")
@@ -263,6 +265,19 @@ def reorder_tailing_tool_call_user(messages: list[dict[str, Any]]) -> None:
 
     # 重排：user → assistant_1, tool_1 → ... → assistant_N, tool_N
     messages[i + 1 :] = [last] + [m for pair in reversed(pairs) for m in pair]
+
+
+def strip_internal_markers(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """返回剥离 ``_from_real_tool_call`` 标记的消息副本，不改动原列表。
+
+    标记只在发送前对副本剥离，payload 中的标记保留供重试时重排继续做误伤防护。
+    """
+    return [
+        {k: v for k, v in msg.items() if k != "_from_real_tool_call"}
+        if isinstance(msg, dict)
+        else msg
+        for msg in messages
+    ]
 
 
 class STTProvider(AbstractProvider):

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -225,7 +225,12 @@ def _is_valid_tool_pair(asst_msg: dict[str, Any], tool_msg: dict[str, Any]) -> b
     tool_calls = asst_msg.get("tool_calls")
     if not tool_calls:
         return False
-    tc_ids = {tc.get("id") for tc in tool_calls if isinstance(tc, dict)}
+    # 仅收集非 None 的 tool_call_id，避免缺失 ID 被误判为有效匹配
+    tc_ids = {
+        tc_id
+        for tc in tool_calls
+        if isinstance(tc, dict) and (tc_id := tc.get("id")) is not None
+    }
     return tool_msg.get("tool_call_id") in tc_ids
 
 

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -240,8 +240,7 @@ def _is_fake_tool_pair(asst_msg: dict[str, Any], tool_msg: dict[str, Any]) -> bo
     if tool_msg.get("tool_call_id") not in tc_ids:
         return False
     return not bool(
-        asst_msg.get(FROM_REAL_TOOL_CALL_KEY)
-        or tool_msg.get(FROM_REAL_TOOL_CALL_KEY)
+        asst_msg.get(FROM_REAL_TOOL_CALL_KEY) or tool_msg.get(FROM_REAL_TOOL_CALL_KEY)
     )
 
 

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -2,7 +2,7 @@ import abc
 import asyncio
 import os
 from collections.abc import AsyncGenerator
-from typing import Literal, TypeAlias, Union
+from typing import Any, Literal, TypeAlias, Union
 
 from astrbot.core.agent.message import ContentPart, Message, is_checkpoint_message
 from astrbot.core.agent.tool import ToolSet
@@ -211,7 +211,18 @@ class Provider(AbstractProvider):
         )
 
 
-def reorder_tailing_tool_call_user(messages: list) -> None:
+def _is_valid_tool_pair(asst_msg: dict[str, Any], tool_msg: dict[str, Any]) -> bool:
+    """判断 assistant(tool_calls) 与 tool 是否为 tool_call_id 匹配的一对。"""
+    if asst_msg.get("role") != "assistant" or tool_msg.get("role") != "tool":
+        return False
+    tool_calls = asst_msg.get("tool_calls")
+    if not tool_calls:
+        return False
+    tc_ids = {tc.get("id") for tc in tool_calls if isinstance(tc, dict)}
+    return tool_msg.get("tool_call_id") in tc_ids
+
+
+def reorder_tailing_tool_call_user(messages: list[dict[str, Any]]) -> None:
     """重排因伪造工具调用导致尾部 assistant(tc) → tool → user 乱序的消息。
 
     此为轻量妥协修复。未来若实现专用的上下文操作钩子或伪造工具调用钩子，
@@ -220,44 +231,30 @@ def reorder_tailing_tool_call_user(messages: list) -> None:
     if not isinstance(messages, list) or len(messages) < 2:
         return
 
-    # 从尾部弹出 user 消息
-    if messages[-1].get("role") != "user":
+    last = messages[-1]
+    if last.get("role") != "user":
         return
-    user_msg = messages.pop()
 
-    # 从新尾部持续收集 assistant(tool_calls) + tool 成对消息
-    pairs: list[tuple[dict, dict]] = []
-    while len(messages) >= 2:
-        tool_msg = messages[-1]
-        asst_msg = messages[-2]
-
-        if asst_msg.get("role") != "assistant" or tool_msg.get("role") != "tool":
+    # 从最后一个非 user 元素向前扫描 assistant(tool_calls) + tool 成对消息
+    pairs: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    i = len(messages) - 2
+    while i >= 1:
+        if not _is_valid_tool_pair(messages[i - 1], messages[i]):
             break
-
-        tool_calls = asst_msg.get("tool_calls")
-        if not tool_calls:
-            break
-
-        tc_ids = {tc.get("id") for tc in tool_calls if isinstance(tc, dict)}
-        if tool_msg.get("tool_call_id") not in tc_ids:
-            break
-
-        # 确认是一对，弹出
-        messages.pop()  # tool
-        messages.pop()  # assistant
-        pairs.append((asst_msg, tool_msg))
+        pairs.append((messages[i - 1], messages[i]))
+        i -= 2
 
     if not pairs:
-        # 没有伪造对，把 user 放回去
-        messages.append(user_msg)
         return
 
     # 重排：user → assistant_1, tool_1 → ... → assistant_N, tool_N
-    # pairs 是从外到内收集的（N, N-1, ..., 1），反转后按 1..N 顺序回插
-    messages.append(user_msg)
+    # pairs 从内到外收集（N, N-1, ..., 1），反转后按 1..N 顺序回插
+    new_tail: list[dict[str, Any]] = [last]
     for asst_msg, tool_msg in reversed(pairs):
-        messages.append(asst_msg)
-        messages.append(tool_msg)
+        new_tail.append(asst_msg)
+        new_tail.append(tool_msg)
+
+    messages[:] = messages[: i + 1] + new_tail
 
 
 class STTProvider(AbstractProvider):

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -211,6 +211,55 @@ class Provider(AbstractProvider):
         )
 
 
+def reorder_tailing_tool_call_user(messages: list) -> None:
+    """重排因伪造工具调用导致尾部 assistant(tc) → tool → user 乱序的消息。
+
+    此为轻量妥协修复。未来若实现专用的上下文操作钩子或伪造工具调用钩子，
+    可考虑移除此函数。
+    """
+    if not isinstance(messages, list) or len(messages) < 2:
+        return
+
+    # 从尾部弹出 user 消息
+    if messages[-1].get("role") != "user":
+        return
+    user_msg = messages.pop()
+
+    # 从新尾部持续收集 assistant(tool_calls) + tool 成对消息
+    pairs: list[tuple[dict, dict]] = []
+    while len(messages) >= 2:
+        tool_msg = messages[-1]
+        asst_msg = messages[-2]
+
+        if asst_msg.get("role") != "assistant" or tool_msg.get("role") != "tool":
+            break
+
+        tool_calls = asst_msg.get("tool_calls")
+        if not tool_calls:
+            break
+
+        tc_ids = {tc.get("id") for tc in tool_calls if isinstance(tc, dict)}
+        if tool_msg.get("tool_call_id") not in tc_ids:
+            break
+
+        # 确认是一对，弹出
+        messages.pop()  # tool
+        messages.pop()  # assistant
+        pairs.append((asst_msg, tool_msg))
+
+    if not pairs:
+        # 没有伪造对，把 user 放回去
+        messages.append(user_msg)
+        return
+
+    # 重排：user → assistant_1, tool_1 → ... → assistant_N, tool_N
+    # pairs 是从外到内收集的（N, N-1, ..., 1），反转后按 1..N 顺序回插
+    messages.append(user_msg)
+    for asst_msg, tool_msg in reversed(pairs):
+        messages.append(asst_msg)
+        messages.append(tool_msg)
+
+
 class STTProvider(AbstractProvider):
     def __init__(self, provider_config: dict, provider_settings: dict) -> None:
         super().__init__(provider_config)

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -5,6 +5,7 @@ from collections.abc import AsyncGenerator
 from typing import Any, Literal, TypeAlias, Union
 
 from astrbot.core.agent.message import (
+    FROM_REAL_TOOL_CALL_KEY,
     ContentPart,
     Message,
     is_checkpoint_message,
@@ -216,8 +217,13 @@ class Provider(AbstractProvider):
         )
 
 
-def _is_valid_tool_pair(asst_msg: dict[str, Any], tool_msg: dict[str, Any]) -> bool:
-    """判断 assistant(tool_calls) 与 tool 是否为 tool_call_id 匹配的一对。"""
+def _is_fake_tool_pair(asst_msg: dict[str, Any], tool_msg: dict[str, Any]) -> bool:
+    """判断一对 assistant(tool_calls) / tool 是否为需要重排的伪造对。
+
+    先校验结构（角色与 ``tool_call_id`` 匹配，忽略缺失 ID），再排除真实工具执行
+    产生的对——真实对带 ``_from_real_tool_call`` 标记（见 ``ToolCallsResult`` 与
+    ``Message``），插件注入的伪造对是裸 dict，永远不会有该标记。
+    """
     if not isinstance(asst_msg, dict) or not isinstance(tool_msg, dict):
         return False
     if asst_msg.get("role") != "assistant" or tool_msg.get("role") != "tool":
@@ -231,18 +237,37 @@ def _is_valid_tool_pair(asst_msg: dict[str, Any], tool_msg: dict[str, Any]) -> b
         for tc in tool_calls
         if isinstance(tc, dict) and (tc_id := tc.get("id")) is not None
     }
-    return tool_msg.get("tool_call_id") in tc_ids
-
-
-def _is_fake_tool_pair(asst_msg: dict[str, Any], tool_msg: dict[str, Any]) -> bool:
-    """判断一对 assistant(tool_calls) / tool 是否为需要重排的伪造对。
-
-    真实工具执行产生的消息带 ``_from_real_tool_call`` 标记（见 ``ToolCallsResult``
-    与 ``Message``），插件注入的伪造对是裸 dict，永远不会有该标记。
-    """
-    return _is_valid_tool_pair(asst_msg, tool_msg) and not bool(
-        asst_msg.get("_from_real_tool_call") or tool_msg.get("_from_real_tool_call")
+    if tool_msg.get("tool_call_id") not in tc_ids:
+        return False
+    return not bool(
+        asst_msg.get(FROM_REAL_TOOL_CALL_KEY)
+        or tool_msg.get(FROM_REAL_TOOL_CALL_KEY)
     )
+
+
+def _collect_tailing_fake_pairs(
+    messages: list[dict[str, Any]],
+) -> tuple[int, list[tuple[dict[str, Any], dict[str, Any]]]]:
+    """返回尾部伪造对块的起始索引及按外层到内层顺序排列的对。
+
+    从尾部向前收集连续的伪造对（内层优先），遇非对或真实标记对即停止。
+    起始索引是重排前缀（不参与重排部分）的长度；无匹配时返回整个列表长度与空列表。
+    """
+    if not isinstance(messages, list) or len(messages) < 2:
+        # messages 可能为 None 等无长度对象；此时 pairs 必为空，起始索引无意义
+        return 0, []
+
+    last = messages[-1]
+    if not isinstance(last, dict) or last.get("role") != "user":
+        return len(messages), []
+
+    pairs: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    i = len(messages) - 2
+    while i >= 1 and _is_fake_tool_pair(messages[i - 1], messages[i]):
+        pairs.append((messages[i - 1], messages[i]))
+        i -= 2
+
+    return i + 1, list(reversed(pairs))
 
 
 def reorder_tailing_tool_call_user(messages: list[dict[str, Any]]) -> None:
@@ -260,25 +285,14 @@ def reorder_tailing_tool_call_user(messages: list[dict[str, Any]]) -> None:
     - 仅当末尾消息为 ``user`` 时触发，且只收集尾部连续的最内层伪造对块；
       其余情况静默 no-op。
     """
-    if not isinstance(messages, list) or len(messages) < 2:
-        return
-
-    last = messages[-1]
-    if not isinstance(last, dict) or last.get("role") != "user":
-        return
-
-    # 从尾部向前收集连续的伪造对（内层优先），遇真实对即停止
-    pairs: list[tuple[dict[str, Any], dict[str, Any]]] = []
-    i = len(messages) - 2
-    while i >= 1 and _is_fake_tool_pair(messages[i - 1], messages[i]):
-        pairs.append((messages[i - 1], messages[i]))
-        i -= 2
-
+    start_idx, pairs = _collect_tailing_fake_pairs(messages)
     if not pairs:
         return
 
-    # 重排：user → assistant_1, tool_1 → ... → assistant_N, tool_N
-    messages[i + 1 :] = [last] + [m for pair in reversed(pairs) for m in pair]
+    last_user = messages[-1]
+    fake_block = [m for pair in pairs for m in pair]
+    # 重排：prefix → user → assistant_1, tool_1 → ... → assistant_N, tool_N
+    messages[:] = messages[:start_idx] + [last_user] + fake_block
 
 
 def strip_internal_markers(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -287,7 +301,7 @@ def strip_internal_markers(messages: list[dict[str, Any]]) -> list[dict[str, Any
     标记只在发送前对副本剥离，payload 中的标记保留供重试时重排继续做误伤防护。
     """
     return [
-        {k: v for k, v in msg.items() if k != "_from_real_tool_call"}
+        {k: v for k, v in msg.items() if k != FROM_REAL_TOOL_CALL_KEY}
         if isinstance(msg, dict)
         else msg
         for msg in messages

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -289,7 +289,10 @@ def reorder_tailing_tool_call_user(messages: list[dict[str, Any]]) -> None:
     Constraints:
     - ``messages`` 必须为 OpenAI 风格 dict 列表（``role`` / ``content`` /
       ``tool_calls`` / ``tool_call_id`` 字段）；非 dict 条目安全跳过。
-    - 就地修改 ``messages``，返回 ``None``。
+    - **就地修改** ``messages``，返回 ``None``：调用方须使用重排后的列表，
+      不得假定原顺序保留。就地是刻意的——各 provider 在重排点之后立即读取
+      同一列表做格式转换（Anthropic / Gemini / Responses 的转换函数），OpenAI
+      路径也依赖 payload 中的保序标记消息供重试时重复 sanitize 不误伤。
     - 仅当末尾消息为 ``user`` 时触发，且只收集尾部连续的最内层伪造对块；
       其余情况静默 no-op。
     """
@@ -303,10 +306,12 @@ def reorder_tailing_tool_call_user(messages: list[dict[str, Any]]) -> None:
     messages[:] = messages[:start_idx] + [last_user] + fake_block
 
 
-def strip_internal_markers(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def strip_internal_markers(messages: list[Any]) -> list[Any]:
     """返回剥离 ``_from_real_tool_call`` 标记的消息副本，不改动原列表。
 
-    标记只在发送前对副本剥离，payload 中的标记保留供重试时重排继续做误伤防护。
+    仅对 dict 消息剥离标记，非 dict 元素原样保留——返回值可能混合多种元素类型，
+    故类型标注为 ``Any``。标记只在发送前对副本剥离，payload 中的标记保留供
+    重试时重排继续做误伤防护。
     """
     return [
         {k: v for k, v in msg.items() if k != FROM_REAL_TOOL_CALL_KEY}

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -198,7 +198,10 @@ class Provider(AbstractProvider):
             if is_checkpoint_message(message):
                 continue
             if isinstance(message, Message):
-                dicts.append(message.model_dump())
+                data = message.model_dump()
+                if message._from_real_tool_call:
+                    data["_from_real_tool_call"] = True
+                dicts.append(data)
             else:
                 dicts.append(message)
 
@@ -222,9 +225,22 @@ def _is_valid_tool_pair(asst_msg: dict[str, Any], tool_msg: dict[str, Any]) -> b
     return tool_msg.get("tool_call_id") in tc_ids
 
 
+def _is_fake_tool_pair(asst_msg: dict[str, Any], tool_msg: dict[str, Any]) -> bool:
+    """判断一对 assistant(tool_calls) / tool 是否为需要重排的伪造对。
+
+    真实工具执行产生的消息带 ``_from_real_tool_call`` 标记（见 ``ToolCallsResult``
+    与 ``Message``），插件注入的伪造对是裸 dict，永远不会有该标记。
+    """
+    return _is_valid_tool_pair(asst_msg, tool_msg) and not bool(
+        asst_msg.get("_from_real_tool_call") or tool_msg.get("_from_real_tool_call")
+    )
+
+
 def reorder_tailing_tool_call_user(messages: list[dict[str, Any]]) -> None:
     """重排因伪造工具调用导致尾部 assistant(tc) → tool → user 乱序的消息。
 
+    真实工具执行产生的对带 ``_from_real_tool_call`` 标记，扫描遇到即停止，
+    避免误伤紧随其后的真实 user 消息（图片复核、max steps 收尾、跨轮次历史）。
     此为轻量妥协修复。未来若实现专用的上下文操作钩子或伪造工具调用钩子，
     可考虑移除此函数。
     """
@@ -235,12 +251,10 @@ def reorder_tailing_tool_call_user(messages: list[dict[str, Any]]) -> None:
     if last.get("role") != "user":
         return
 
-    # 从最后一个非 user 元素向前扫描 assistant(tool_calls) + tool 成对消息
+    # 从尾部向前收集连续的伪造对（内层优先），遇真实对即停止
     pairs: list[tuple[dict[str, Any], dict[str, Any]]] = []
     i = len(messages) - 2
-    while i >= 1:
-        if not _is_valid_tool_pair(messages[i - 1], messages[i]):
-            break
+    while i >= 1 and _is_fake_tool_pair(messages[i - 1], messages[i]):
         pairs.append((messages[i - 1], messages[i]))
         i -= 2
 
@@ -248,13 +262,7 @@ def reorder_tailing_tool_call_user(messages: list[dict[str, Any]]) -> None:
         return
 
     # 重排：user → assistant_1, tool_1 → ... → assistant_N, tool_N
-    # pairs 从内到外收集（N, N-1, ..., 1），反转后按 1..N 顺序回插
-    new_tail: list[dict[str, Any]] = [last]
-    for asst_msg, tool_msg in reversed(pairs):
-        new_tail.append(asst_msg)
-        new_tail.append(tool_msg)
-
-    messages[:] = messages[: i + 1] + new_tail
+    messages[i + 1 :] = [last] + [m for pair in reversed(pairs) for m in pair]
 
 
 class STTProvider(AbstractProvider):

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -4,7 +4,12 @@ import os
 from collections.abc import AsyncGenerator
 from typing import Any, Literal, TypeAlias, Union
 
-from astrbot.core.agent.message import ContentPart, Message, is_checkpoint_message
+from astrbot.core.agent.message import (
+    ContentPart,
+    Message,
+    is_checkpoint_message,
+    message_to_dict_with_marker,
+)
 from astrbot.core.agent.tool import ToolSet
 from astrbot.core.provider.entities import (
     LLMResponse,
@@ -198,10 +203,7 @@ class Provider(AbstractProvider):
             if is_checkpoint_message(message):
                 continue
             if isinstance(message, Message):
-                data = message.model_dump()
-                if message._from_real_tool_call:
-                    data["_from_real_tool_call"] = True
-                dicts.append(data)
+                dicts.append(message_to_dict_with_marker(message))
             else:
                 dicts.append(message)
 
@@ -245,12 +247,19 @@ def reorder_tailing_tool_call_user(messages: list[dict[str, Any]]) -> None:
     避免误伤紧随其后的真实 user 消息（图片复核、max steps 收尾、跨轮次历史）。
     此为轻量妥协修复。未来若实现专用的上下文操作钩子或伪造工具调用钩子，
     可考虑移除此函数。
+
+    Constraints:
+    - ``messages`` 必须为 OpenAI 风格 dict 列表（``role`` / ``content`` /
+      ``tool_calls`` / ``tool_call_id`` 字段）；非 dict 条目安全跳过。
+    - 就地修改 ``messages``，返回 ``None``。
+    - 仅当末尾消息为 ``user`` 时触发，且只收集尾部连续的最内层伪造对块；
+      其余情况静默 no-op。
     """
     if not isinstance(messages, list) or len(messages) < 2:
         return
 
     last = messages[-1]
-    if last.get("role") != "user":
+    if not isinstance(last, dict) or last.get("role") != "user":
         return
 
     # 从尾部向前收集连续的伪造对（内层优先），遇真实对即停止

--- a/astrbot/core/provider/provider.py
+++ b/astrbot/core/provider/provider.py
@@ -226,22 +226,31 @@ def _is_fake_tool_pair(asst_msg: dict[str, Any], tool_msg: dict[str, Any]) -> bo
     """
     if not isinstance(asst_msg, dict) or not isinstance(tool_msg, dict):
         return False
+
     if asst_msg.get("role") != "assistant" or tool_msg.get("role") != "tool":
         return False
+
     tool_calls = asst_msg.get("tool_calls")
     if not tool_calls:
         return False
+
     # 仅收集非 None 的 tool_call_id，避免缺失 ID 被误判为有效匹配
-    tc_ids = {
-        tc_id
-        for tc in tool_calls
-        if isinstance(tc, dict) and (tc_id := tc.get("id")) is not None
-    }
+    tc_ids: set[str] = set()
+    for tc in tool_calls:
+        if not isinstance(tc, dict):
+            continue
+        tc_id = tc.get("id")
+        if tc_id is not None:
+            tc_ids.add(tc_id)
+
     if tool_msg.get("tool_call_id") not in tc_ids:
         return False
-    return not bool(
-        asst_msg.get(FROM_REAL_TOOL_CALL_KEY) or tool_msg.get(FROM_REAL_TOOL_CALL_KEY)
-    )
+
+    # 排除真实工具执行产生的对
+    if asst_msg.get(FROM_REAL_TOOL_CALL_KEY) or tool_msg.get(FROM_REAL_TOOL_CALL_KEY):
+        return False
+
+    return True
 
 
 def _collect_tailing_fake_pairs(

--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -790,7 +790,6 @@ class ProviderAnthropic(Provider):
                 for tool_call_result in tool_calls_result:
                     context_query.extend(tool_call_result.to_openai_messages())
 
-        # 伪造工具调用对需前置到用户消息之后，与真实工具调用时序对齐
         reorder_tailing_tool_call_user(context_query)
         system_prompt, new_messages = self._prepare_payload(context_query)
 
@@ -864,7 +863,6 @@ class ProviderAnthropic(Provider):
                 for tool_call_result in tool_calls_result:
                     context_query.extend(tool_call_result.to_openai_messages())
 
-        # 伪造工具调用对需前置到用户消息之后，与真实工具调用时序对齐
         reorder_tailing_tool_call_user(context_query)
         system_prompt, new_messages = self._prepare_payload(context_query)
 

--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -14,6 +14,7 @@ from astrbot import logger
 from astrbot.api.provider import Provider
 from astrbot.core.agent.message import AudioURLPart, ContentPart, ImageURLPart, TextPart
 from astrbot.core.exceptions import EmptyModelOutputError
+from astrbot.core.provider import reorder_tailing_tool_call_user
 from astrbot.core.provider.entities import LLMResponse, TokenUsage
 from astrbot.core.provider.func_tool_manager import ToolSet
 from astrbot.core.utils.media_utils import (
@@ -789,6 +790,8 @@ class ProviderAnthropic(Provider):
                 for tool_call_result in tool_calls_result:
                     context_query.extend(tool_call_result.to_openai_messages())
 
+        # 伪造工具调用对需前置到用户消息之后，与真实工具调用时序对齐
+        reorder_tailing_tool_call_user(context_query)
         system_prompt, new_messages = self._prepare_payload(context_query)
 
         model = model or self.get_model()
@@ -861,6 +864,8 @@ class ProviderAnthropic(Provider):
                 for tool_call_result in tool_calls_result:
                     context_query.extend(tool_call_result.to_openai_messages())
 
+        # 伪造工具调用对需前置到用户消息之后，与真实工具调用时序对齐
+        reorder_tailing_tool_call_user(context_query)
         system_prompt, new_messages = self._prepare_payload(context_query)
 
         model = model or self.get_model()

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -858,8 +858,7 @@ class ProviderGoogleGenAI(Provider):
                 for tcr in tool_calls_result:
                     context_query.extend(tcr.to_openai_messages())
 
-        # 伪造工具调用对需前置到用户消息之后，与真实工具调用时序对齐。
-        # Gemini API 要求 functionCall 回合必须紧跟 user 回合，否则返回 400。
+        # Gemini API 要求 functionCall 回合紧跟 user 回合，否则返回 400。
         reorder_tailing_tool_call_user(context_query)
 
         model = model or self.get_model()
@@ -929,8 +928,7 @@ class ProviderGoogleGenAI(Provider):
                 for tcr in tool_calls_result:
                     context_query.extend(tcr.to_openai_messages())
 
-        # 伪造工具调用对需前置到用户消息之后，与真实工具调用时序对齐。
-        # Gemini API 要求 functionCall 回合必须紧跟 user 回合，否则返回 400。
+        # Gemini API 要求 functionCall 回合紧跟 user 回合，否则返回 400。
         reorder_tailing_tool_call_user(context_query)
 
         model = model or self.get_model()

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -17,6 +17,7 @@ from astrbot.api.provider import Provider
 from astrbot.core.agent.message import AudioURLPart, ContentPart, ImageURLPart, TextPart
 from astrbot.core.exceptions import EmptyModelOutputError
 from astrbot.core.message.message_event_result import MessageChain
+from astrbot.core.provider import reorder_tailing_tool_call_user
 from astrbot.core.provider.entities import LLMResponse, TokenUsage
 from astrbot.core.provider.func_tool_manager import ToolSet
 from astrbot.core.utils.media_utils import (
@@ -857,6 +858,10 @@ class ProviderGoogleGenAI(Provider):
                 for tcr in tool_calls_result:
                     context_query.extend(tcr.to_openai_messages())
 
+        # 伪造工具调用对需前置到用户消息之后，与真实工具调用时序对齐。
+        # Gemini API 要求 functionCall 回合必须紧跟 user 回合，否则返回 400。
+        reorder_tailing_tool_call_user(context_query)
+
         model = model or self.get_model()
 
         payloads = {"messages": context_query, "model": model}
@@ -923,6 +928,10 @@ class ProviderGoogleGenAI(Provider):
             else:
                 for tcr in tool_calls_result:
                     context_query.extend(tcr.to_openai_messages())
+
+        # 伪造工具调用对需前置到用户消息之后，与真实工具调用时序对齐。
+        # Gemini API 要求 functionCall 回合必须紧跟 user 回合，否则返回 400。
+        reorder_tailing_tool_call_user(context_query)
 
         model = model or self.get_model()
 

--- a/astrbot/core/provider/sources/openai_responses_source.py
+++ b/astrbot/core/provider/sources/openai_responses_source.py
@@ -12,6 +12,7 @@ from astrbot.core.agent.message import ContentPart, Message
 from astrbot.core.agent.tool import ToolSet
 from astrbot.core.exceptions import EmptyModelOutputError
 from astrbot.core.message.message_event_result import MessageChain
+from astrbot.core.provider import reorder_tailing_tool_call_user
 from astrbot.core.provider.entities import LLMResponse, TokenUsage, ToolCallsResult
 
 from ..register import register_provider_adapter
@@ -280,6 +281,8 @@ class ProviderOpenAIResponses(ProviderOpenAIOfficial):
             else:
                 for result in tool_calls_result:
                     context_query.extend(result.to_openai_messages())
+
+        reorder_tailing_tool_call_user(context_query)
 
         if self._context_contains_image(context_query):
             context_query = await self._materialize_context_image_parts(context_query)

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -28,7 +28,7 @@ from astrbot.core.agent.message import (
 from astrbot.core.agent.tool import ToolSet
 from astrbot.core.exceptions import EmptyModelOutputError
 from astrbot.core.message.message_event_result import MessageChain
-from astrbot.core.provider import reorder_tailing_tool_call_user
+from astrbot.core.provider import reorder_tailing_tool_call_user, strip_internal_markers
 from astrbot.core.provider.entities import LLMResponse, TokenUsage, ToolCallsResult
 from astrbot.core.utils.media_utils import (
     describe_media_ref,
@@ -531,11 +531,6 @@ class ProviderOpenAIOfficial(Provider):
 
         reorder_tailing_tool_call_user(payloads["messages"])
 
-        # _from_real_tool_call 是内部标记，剥离后不能出现在发往 API 的请求里
-        for msg in payloads["messages"]:
-            if isinstance(msg, dict):
-                msg.pop("_from_real_tool_call", None)
-
     async def _query(
         self,
         payloads: dict,
@@ -573,10 +568,14 @@ class ProviderOpenAIOfficial(Provider):
 
         self._sanitize_assistant_messages(payloads)
 
+        send_payloads = {
+            **payloads,
+            "messages": strip_internal_markers(payloads["messages"]),
+        }
         completion = await retry_provider_request(
             "OpenAI",
             lambda: self.client.chat.completions.create(
-                **payloads,
+                **send_payloads,
                 stream=False,
                 extra_body=extra_body,
             ),
@@ -631,10 +630,14 @@ class ProviderOpenAIOfficial(Provider):
 
         self._sanitize_assistant_messages(payloads)
 
+        send_payloads = {
+            **payloads,
+            "messages": strip_internal_markers(payloads["messages"]),
+        }
         stream = await retry_provider_request(
             "OpenAI",
             lambda: self.client.chat.completions.create(
-                **payloads,
+                **send_payloads,
                 stream=True,
                 extra_body=extra_body,
                 stream_options={"include_usage": True},

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -528,6 +528,58 @@ class ProviderOpenAIOfficial(Provider):
             )
         payloads["messages"] = final
 
+        ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+
+    @staticmethod
+    def _reorder_tailing_tool_call_user(payloads: dict) -> None:
+        """重排因伪造工具调用导致尾部 assistant(tc) → tool → user 乱序的消息。
+
+        此为轻量妥协修复。未来若实现专用的上下文操作钩子或伪造工具调用钩子，
+        可考虑移除此方法。
+        """
+        messages = payloads.get("messages")
+        if not isinstance(messages, list) or len(messages) < 2:
+            return
+
+        # 从尾部弹出 user 消息
+        if messages[-1].get("role") != "user":
+            return
+        user_msg = messages.pop()
+
+        # 从新尾部持续收集 assistant(tool_calls) + tool 成对消息
+        pairs: list[tuple[dict, dict]] = []
+        while len(messages) >= 2:
+            tool_msg = messages[-1]
+            asst_msg = messages[-2]
+
+            if asst_msg.get("role") != "assistant" or tool_msg.get("role") != "tool":
+                break
+
+            tool_calls = asst_msg.get("tool_calls")
+            if not tool_calls:
+                break
+
+            tc_ids = {tc.get("id") for tc in tool_calls if isinstance(tc, dict)}
+            if tool_msg.get("tool_call_id") not in tc_ids:
+                break
+
+            # 确认是一对，弹出
+            messages.pop()  # tool
+            messages.pop()  # assistant
+            pairs.append((asst_msg, tool_msg))
+
+        if not pairs:
+            # 没有伪造对，把 user 放回去
+            messages.append(user_msg)
+            return
+
+        # 重排：user → assistant_1, tool_1 → ... → assistant_N, tool_N
+        # pairs 是从外到内收集的（N, N-1, ..., 1），反转后按 1..N 顺序回插
+        messages.append(user_msg)
+        for asst_msg, tool_msg in reversed(pairs):
+            messages.append(asst_msg)
+            messages.append(tool_msg)
+
     async def _query(
         self,
         payloads: dict,

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -531,6 +531,11 @@ class ProviderOpenAIOfficial(Provider):
 
         reorder_tailing_tool_call_user(payloads["messages"])
 
+        # _from_real_tool_call 是内部标记，剥离后不能出现在发往 API 的请求里
+        for msg in payloads["messages"]:
+            if isinstance(msg, dict):
+                msg.pop("_from_real_tool_call", None)
+
     async def _query(
         self,
         payloads: dict,

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -28,6 +28,7 @@ from astrbot.core.agent.message import (
 from astrbot.core.agent.tool import ToolSet
 from astrbot.core.exceptions import EmptyModelOutputError
 from astrbot.core.message.message_event_result import MessageChain
+from astrbot.core.provider import reorder_tailing_tool_call_user
 from astrbot.core.provider.entities import LLMResponse, TokenUsage, ToolCallsResult
 from astrbot.core.utils.media_utils import (
     describe_media_ref,
@@ -528,57 +529,7 @@ class ProviderOpenAIOfficial(Provider):
             )
         payloads["messages"] = final
 
-        ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
-
-    @staticmethod
-    def _reorder_tailing_tool_call_user(payloads: dict) -> None:
-        """重排因伪造工具调用导致尾部 assistant(tc) → tool → user 乱序的消息。
-
-        此为轻量妥协修复。未来若实现专用的上下文操作钩子或伪造工具调用钩子，
-        可考虑移除此方法。
-        """
-        messages = payloads.get("messages")
-        if not isinstance(messages, list) or len(messages) < 2:
-            return
-
-        # 从尾部弹出 user 消息
-        if messages[-1].get("role") != "user":
-            return
-        user_msg = messages.pop()
-
-        # 从新尾部持续收集 assistant(tool_calls) + tool 成对消息
-        pairs: list[tuple[dict, dict]] = []
-        while len(messages) >= 2:
-            tool_msg = messages[-1]
-            asst_msg = messages[-2]
-
-            if asst_msg.get("role") != "assistant" or tool_msg.get("role") != "tool":
-                break
-
-            tool_calls = asst_msg.get("tool_calls")
-            if not tool_calls:
-                break
-
-            tc_ids = {tc.get("id") for tc in tool_calls if isinstance(tc, dict)}
-            if tool_msg.get("tool_call_id") not in tc_ids:
-                break
-
-            # 确认是一对，弹出
-            messages.pop()  # tool
-            messages.pop()  # assistant
-            pairs.append((asst_msg, tool_msg))
-
-        if not pairs:
-            # 没有伪造对，把 user 放回去
-            messages.append(user_msg)
-            return
-
-        # 重排：user → assistant_1, tool_1 → ... → assistant_N, tool_N
-        # pairs 是从外到内收集的（N, N-1, ..., 1），反转后按 1..N 顺序回插
-        messages.append(user_msg)
-        for asst_msg, tool_msg in reversed(pairs):
-            messages.append(asst_msg)
-            messages.append(tool_msg)
+        reorder_tailing_tool_call_user(payloads["messages"])
 
     async def _query(
         self,

--- a/tests/fixtures/fake_tool_call.py
+++ b/tests/fixtures/fake_tool_call.py
@@ -4,6 +4,8 @@
 assistant(tool_calls) + tool 消息对，避免场景漂移。
 """
 
+from astrbot.core.agent.message import FROM_REAL_TOOL_CALL_KEY
+
 FAKE_TOOL_CALL_CONTEXTS = [
     {
         "role": "assistant",
@@ -56,5 +58,5 @@ def make_fake_pair(
     ]
     if marked:
         for message in pair:
-            message["_from_real_tool_call"] = True
+            message[FROM_REAL_TOOL_CALL_KEY] = True
     return pair

--- a/tests/fixtures/fake_tool_call.py
+++ b/tests/fixtures/fake_tool_call.py
@@ -1,0 +1,23 @@
+"""伪造工具调用（fake tool call）共享测试数据。
+
+各 provider 测试（OpenAI / Anthropic / Gemini 格式）共用同一组伪造
+assistant(tool_calls) + tool 消息对，避免场景漂移。
+"""
+
+FAKE_TOOL_CALL_CONTEXTS = [
+    {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "fake_recall_abc",
+                "type": "function",
+                "function": {
+                    "name": "recall_long_term_memory",
+                    "arguments": '{"query": "我的名字是？", "k": 5}',
+                },
+            }
+        ],
+    },
+    {"role": "tool", "tool_call_id": "fake_recall_abc", "content": "memory json"},
+]

--- a/tests/fixtures/fake_tool_call.py
+++ b/tests/fixtures/fake_tool_call.py
@@ -21,3 +21,40 @@ FAKE_TOOL_CALL_CONTEXTS = [
     },
     {"role": "tool", "tool_call_id": "fake_recall_abc", "content": "memory json"},
 ]
+
+
+def make_fake_pair(
+    tool_call_id: str = "fake_call_01",
+    name: str = "recall_long_term_memory",
+    arguments: str = "{}",
+    content: str = "mem result",
+    marked: bool = False,
+) -> list[dict]:
+    """构造一对伪造（或带真实标记的）assistant(tool_calls) + tool 消息。
+
+    Args:
+        tool_call_id: assistant 与 tool 共享的调用 ID。
+        name: 工具名。
+        arguments: 工具参数 JSON 字符串。
+        content: 工具返回内容。
+        marked: True 时给消息对打上 ``_from_real_tool_call`` 标记，
+            模拟真实工具执行产生的消息。
+    """
+    pair = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": tool_call_id,
+                    "type": "function",
+                    "function": {"name": name, "arguments": arguments},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": tool_call_id, "content": content},
+    ]
+    if marked:
+        for message in pair:
+            message["_from_real_tool_call"] = True
+    return pair

--- a/tests/test_anthropic_kimi_code_provider.py
+++ b/tests/test_anthropic_kimi_code_provider.py
@@ -7,8 +7,9 @@ import pytest
 import astrbot.core.provider.sources.anthropic_source as anthropic_source
 import astrbot.core.provider.sources.kimi_code_source as kimi_code_source
 import astrbot.core.provider.sources.request_retry as request_retry
+from astrbot.core.agent.message import AssistantMessageSegment, ToolCallMessageSegment
 from astrbot.core.exceptions import EmptyModelOutputError
-from astrbot.core.provider.entities import LLMResponse
+from astrbot.core.provider.entities import LLMResponse, ToolCallsResult
 from tests.fixtures.fake_tool_call import FAKE_TOOL_CALL_CONTEXTS
 
 
@@ -937,3 +938,102 @@ async def test_text_chat_stream_reorders_fake_tool_call_pair(monkeypatch):
         pass
 
     assert captured["messages"] == _EXPECTED_REORDERED_MESSAGES
+
+
+# ── 真实工具调用（tool_calls_result）时序与标记 ──────────────────────────────
+
+_REAL_TOOL_CALL_EXPECTED_MESSAGES = [
+    {"role": "user", "content": "请回忆 xyz 对应的内容？"},
+    {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "tool_use",
+                "name": "recall",
+                "input": {"key": "abc"},
+                "id": "real_tool_use_1",
+            }
+        ],
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": "real_tool_use_1",
+                "content": "memory json",
+            }
+        ],
+    },
+]
+
+
+def _make_real_tool_calls_result(tool_call_id: str) -> ToolCallsResult:
+    """构造一个真实工具执行产生的 ToolCallsResult。"""
+    return ToolCallsResult(
+        tool_calls_info=AssistantMessageSegment(
+            content=None,
+            tool_calls=[
+                {
+                    "id": tool_call_id,
+                    "type": "function",
+                    "function": {"name": "recall", "arguments": '{"key": "abc"}'},
+                }
+            ],
+        ),
+        tool_calls_result=[
+            ToolCallMessageSegment(content="memory json", tool_call_id=tool_call_id)
+        ],
+    )
+
+
+def _assert_no_internal_marker_leak(messages: list[dict]) -> None:
+    """真实工具调用路径发往 Anthropic 的 payload 不应泄漏内部标记。"""
+    for msg in messages:
+        assert "_from_real_tool_call" not in msg
+        content = msg.get("content")
+        if isinstance(content, list):
+            for block in content:
+                assert "_from_real_tool_call" not in block
+
+
+@pytest.mark.asyncio
+async def test_text_chat_preserves_real_tool_call_order(monkeypatch):
+    """真实 tool_calls_result 保持 assistant(tool_use) → user(tool_result) 时序，
+    不被重排成 user 在前；内部标记不泄漏到 payload。"""
+    provider = _setup_provider_with_mock_client(monkeypatch)
+    tcr = _make_real_tool_calls_result("real_tool_use_1")
+
+    await provider.text_chat(
+        prompt="请回忆 xyz 对应的内容？",
+        tool_calls_result=tcr,
+    )
+
+    messages = _capture_payloads_create.last_kwargs["messages"]
+    assert messages == _REAL_TOOL_CALL_EXPECTED_MESSAGES
+    _assert_no_internal_marker_leak(messages)
+
+
+@pytest.mark.asyncio
+async def test_text_chat_stream_preserves_real_tool_call_order(monkeypatch):
+    """流式路径同样保持真实 tool_calls_result 的时序且无标记泄漏。"""
+    provider = _setup_provider_with_mock_client(monkeypatch)
+    tcr = _make_real_tool_calls_result("real_tool_use_1")
+
+    captured: dict[str, object] = {}
+
+    async def fake_query_stream(payloads, tools, *, request_max_retries=None):
+        captured["messages"] = payloads["messages"]
+        return
+        yield  # pragma: no cover  # 保持 async generator 形态
+
+    monkeypatch.setattr(provider, "_query_stream", fake_query_stream)
+
+    async for _ in provider.text_chat_stream(
+        prompt="请回忆 xyz 对应的内容？",
+        tool_calls_result=tcr,
+    ):
+        pass
+
+    assert captured["messages"] == _REAL_TOOL_CALL_EXPECTED_MESSAGES
+    _assert_no_internal_marker_leak(captured["messages"])

--- a/tests/test_anthropic_kimi_code_provider.py
+++ b/tests/test_anthropic_kimi_code_provider.py
@@ -9,6 +9,7 @@ import astrbot.core.provider.sources.kimi_code_source as kimi_code_source
 import astrbot.core.provider.sources.request_retry as request_retry
 from astrbot.core.exceptions import EmptyModelOutputError
 from astrbot.core.provider.entities import LLMResponse
+from tests.fixtures.fake_tool_call import FAKE_TOOL_CALL_CONTEXTS
 
 
 class _FakeAsyncAnthropic:
@@ -868,28 +869,6 @@ async def test_tool_choice_empty_tool_list_skips_tool_choice(monkeypatch):
 
 # ── fake tool call 重排 ───────────────────────────────────────────────────────
 
-_FAKE_TOOL_CALL_CONTEXTS = [
-    {
-        "role": "assistant",
-        "content": None,
-        "tool_calls": [
-            {
-                "id": "fake_recall_abc",
-                "type": "function",
-                "function": {
-                    "name": "recall_long_term_memory",
-                    "arguments": '{"query": "我的名字是？", "k": 5}',
-                },
-            }
-        ],
-    },
-    {
-        "role": "tool",
-        "tool_call_id": "fake_recall_abc",
-        "content": "memory json",
-    },
-]
-
 _EXPECTED_REORDERED_MESSAGES = [
     {"role": "user", "content": "我的名字是？"},
     {
@@ -921,7 +900,7 @@ async def test_text_chat_reorders_fake_tool_call_pair(monkeypatch):
     """伪造工具调用对应重排到用户消息之后，与真实工具调用时序对齐。"""
     provider = _setup_provider_with_mock_client(monkeypatch)
 
-    await provider.text_chat(prompt="我的名字是？", contexts=_FAKE_TOOL_CALL_CONTEXTS)
+    await provider.text_chat(prompt="我的名字是？", contexts=FAKE_TOOL_CALL_CONTEXTS)
 
     assert _capture_payloads_create.last_kwargs["messages"] == (
         _EXPECTED_REORDERED_MESSAGES
@@ -953,7 +932,7 @@ async def test_text_chat_stream_reorders_fake_tool_call_pair(monkeypatch):
     monkeypatch.setattr(provider, "_query_stream", fake_query_stream)
 
     async for _ in provider.text_chat_stream(
-        prompt="我的名字是？", contexts=_FAKE_TOOL_CALL_CONTEXTS
+        prompt="我的名字是？", contexts=FAKE_TOOL_CALL_CONTEXTS
     ):
         pass
 

--- a/tests/test_anthropic_kimi_code_provider.py
+++ b/tests/test_anthropic_kimi_code_provider.py
@@ -864,3 +864,97 @@ async def test_tool_choice_empty_tool_list_skips_tool_choice(monkeypatch):
     kwargs = _capture_payloads_create.last_kwargs
     assert "tools" not in kwargs
     assert "tool_choice" not in kwargs
+
+
+# ── fake tool call 重排 ───────────────────────────────────────────────────────
+
+_FAKE_TOOL_CALL_CONTEXTS = [
+    {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "fake_recall_abc",
+                "type": "function",
+                "function": {
+                    "name": "recall_long_term_memory",
+                    "arguments": '{"query": "我的名字是？", "k": 5}',
+                },
+            }
+        ],
+    },
+    {
+        "role": "tool",
+        "tool_call_id": "fake_recall_abc",
+        "content": "memory json",
+    },
+]
+
+_EXPECTED_REORDERED_MESSAGES = [
+    {"role": "user", "content": "我的名字是？"},
+    {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "tool_use",
+                "name": "recall_long_term_memory",
+                "input": {"query": "我的名字是？", "k": 5},
+                "id": "fake_recall_abc",
+            }
+        ],
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": "fake_recall_abc",
+                "content": "memory json",
+            }
+        ],
+    },
+]
+
+
+@pytest.mark.asyncio
+async def test_text_chat_reorders_fake_tool_call_pair(monkeypatch):
+    """伪造工具调用对应重排到用户消息之后，与真实工具调用时序对齐。"""
+    provider = _setup_provider_with_mock_client(monkeypatch)
+
+    await provider.text_chat(prompt="我的名字是？", contexts=_FAKE_TOOL_CALL_CONTEXTS)
+
+    assert _capture_payloads_create.last_kwargs["messages"] == (
+        _EXPECTED_REORDERED_MESSAGES
+    )
+
+
+@pytest.mark.asyncio
+async def test_text_chat_stream_reorders_fake_tool_call_pair(monkeypatch):
+    """流式路径同样应将伪造工具调用对重排到用户消息之后。"""
+    monkeypatch.setattr(anthropic_source, "AsyncAnthropic", _FakeAsyncAnthropic)
+
+    provider = anthropic_source.ProviderAnthropic(
+        provider_config={
+            "id": "anthropic-test",
+            "type": "anthropic_chat_completion",
+            "model": "claude-test",
+            "key": ["test-key"],
+        },
+        provider_settings={},
+    )
+
+    captured: dict[str, object] = {}
+
+    async def fake_query_stream(payloads, tools, *, request_max_retries=None):
+        captured["messages"] = payloads["messages"]
+        return
+        yield  # pragma: no cover  # 保持 async generator 形态
+
+    monkeypatch.setattr(provider, "_query_stream", fake_query_stream)
+
+    async for _ in provider.text_chat_stream(
+        prompt="我的名字是？", contexts=_FAKE_TOOL_CALL_CONTEXTS
+    ):
+        pass
+
+    assert captured["messages"] == _EXPECTED_REORDERED_MESSAGES

--- a/tests/test_gemini_source.py
+++ b/tests/test_gemini_source.py
@@ -3,8 +3,8 @@ from types import SimpleNamespace
 import httpx
 import pytest
 
-from astrbot.core.exceptions import EmptyModelOutputError
 import astrbot.core.provider.sources.request_retry as request_retry
+from astrbot.core.exceptions import EmptyModelOutputError
 from astrbot.core.provider.entities import LLMResponse
 from astrbot.core.provider.sources.gemini_source import ProviderGoogleGenAI
 
@@ -31,6 +31,90 @@ def test_gemini_reasoning_only_output_is_allowed():
         response_id="resp_reasoning",
         finish_reason="STOP",
     )
+
+
+_FAKE_TOOL_CALL_CONTEXTS = [
+    {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "fake_recall_abc",
+                "type": "function",
+                "function": {
+                    "name": "recall_long_term_memory",
+                    "arguments": '{"query": "我的名字是？", "k": 5}',
+                },
+            }
+        ],
+    },
+    {"role": "tool", "tool_call_id": "fake_recall_abc", "content": "memory json"},
+]
+
+
+def _make_provider() -> ProviderGoogleGenAI:
+    provider = ProviderGoogleGenAI.__new__(ProviderGoogleGenAI)
+    provider.api_keys = [""]
+    provider.model_name = ""
+    return provider
+
+
+def _assert_reordered_tail(messages: list[dict]) -> None:
+    assert messages[-3]["role"] == "user"
+    assert messages[-3]["content"] == "我的名字是？"
+    assert messages[-2]["role"] == "assistant"
+    assert messages[-2]["tool_calls"][0]["id"] == "fake_recall_abc"
+    assert (
+        messages[-2]["tool_calls"][0]["function"]["name"] == "recall_long_term_memory"
+    )
+    assert messages[-1]["role"] == "tool"
+    assert messages[-1]["tool_call_id"] == "fake_recall_abc"
+
+
+@pytest.mark.asyncio
+async def test_text_chat_reorders_fake_tool_call_pair(monkeypatch):
+    captured = {}
+
+    async def fake_query(payloads, tools, *, request_max_retries=None):
+        captured["payloads"] = payloads
+        return LLMResponse(role="assistant")
+
+    provider = _make_provider()
+    monkeypatch.setattr(provider, "_query", fake_query)
+
+    await provider.text_chat(prompt="我的名字是？", contexts=_FAKE_TOOL_CALL_CONTEXTS)
+
+    messages = captured["payloads"]["messages"]
+    _assert_reordered_tail(messages)
+
+    # 转换后的 contents 应为 user → model(functionCall) → user(functionResponse)
+    contents = provider._prepare_conversation(captured["payloads"])
+    assert [content.role for content in contents] == ["user", "model", "user"]
+    assert contents[0].parts[0].text == "我的名字是？"
+    assert contents[1].parts[0].function_call.name == "recall_long_term_memory"
+    assert contents[2].parts[0].function_response.name == "fake_recall_abc"
+
+
+@pytest.mark.asyncio
+async def test_text_chat_stream_reorders_fake_tool_call_pair(monkeypatch):
+    captured = {}
+
+    async def fake_query_stream(payloads, tools, *, request_max_retries=None):
+        captured["payloads"] = payloads
+        return
+        yield  # pragma: no cover
+
+    provider = _make_provider()
+    monkeypatch.setattr(provider, "_query_stream", fake_query_stream)
+
+    async for _ in provider.text_chat_stream(
+        prompt="我的名字是？",
+        contexts=_FAKE_TOOL_CALL_CONTEXTS,
+    ):
+        pass
+
+    messages = captured["payloads"]["messages"]
+    _assert_reordered_tail(messages)
 
 
 @pytest.mark.asyncio

--- a/tests/test_gemini_source.py
+++ b/tests/test_gemini_source.py
@@ -7,6 +7,7 @@ import astrbot.core.provider.sources.request_retry as request_retry
 from astrbot.core.exceptions import EmptyModelOutputError
 from astrbot.core.provider.entities import LLMResponse
 from astrbot.core.provider.sources.gemini_source import ProviderGoogleGenAI
+from tests.fixtures.fake_tool_call import FAKE_TOOL_CALL_CONTEXTS
 
 
 def test_gemini_empty_output_raises_empty_model_output_error():
@@ -31,25 +32,6 @@ def test_gemini_reasoning_only_output_is_allowed():
         response_id="resp_reasoning",
         finish_reason="STOP",
     )
-
-
-_FAKE_TOOL_CALL_CONTEXTS = [
-    {
-        "role": "assistant",
-        "content": None,
-        "tool_calls": [
-            {
-                "id": "fake_recall_abc",
-                "type": "function",
-                "function": {
-                    "name": "recall_long_term_memory",
-                    "arguments": '{"query": "我的名字是？", "k": 5}',
-                },
-            }
-        ],
-    },
-    {"role": "tool", "tool_call_id": "fake_recall_abc", "content": "memory json"},
-]
 
 
 def _make_provider() -> ProviderGoogleGenAI:
@@ -82,7 +64,7 @@ async def test_text_chat_reorders_fake_tool_call_pair(monkeypatch):
     provider = _make_provider()
     monkeypatch.setattr(provider, "_query", fake_query)
 
-    await provider.text_chat(prompt="我的名字是？", contexts=_FAKE_TOOL_CALL_CONTEXTS)
+    await provider.text_chat(prompt="我的名字是？", contexts=FAKE_TOOL_CALL_CONTEXTS)
 
     messages = captured["payloads"]["messages"]
     _assert_reordered_tail(messages)
@@ -109,7 +91,7 @@ async def test_text_chat_stream_reorders_fake_tool_call_pair(monkeypatch):
 
     async for _ in provider.text_chat_stream(
         prompt="我的名字是？",
-        contexts=_FAKE_TOOL_CALL_CONTEXTS,
+        contexts=FAKE_TOOL_CALL_CONTEXTS,
     ):
         pass
 

--- a/tests/test_openai_responses_source.py
+++ b/tests/test_openai_responses_source.py
@@ -8,6 +8,7 @@ from astrbot.core.config.default import CONFIG_METADATA_2
 from astrbot.core.provider.sources.openai_responses_source import (
     ProviderOpenAIResponses,
 )
+from tests.fixtures.fake_tool_call import make_fake_pair
 
 
 def _make_provider(overrides: dict | None = None) -> ProviderOpenAIResponses:
@@ -397,3 +398,144 @@ async def test_parse_failed_response_raises_provider_error():
 
     with pytest.raises(RuntimeError, match="server_error: failed"):
         await provider._parse_response(response, tools=None)
+
+
+@pytest.mark.asyncio
+async def test_responses_reorders_fake_pair_before_conversion():
+    """插件注入的伪造对在 Responses 路径同样需要前置到用户消息之后。
+
+    转换后的 input 应为 user → function_call → function_call_output，
+    与 OpenAI Chat Completions / Anthropic / Gemini 对齐。
+    """
+    provider = _make_provider()
+    payloads, context = await provider._prepare_chat_payload(
+        prompt="帮我处理",
+        contexts=[
+            {"role": "user", "content": "hello"},
+            *make_fake_pair(tool_call_id="fake_call_01"),
+        ],
+    )
+
+    assert [m["role"] for m in context] == ["user", "user", "assistant", "tool"]
+    assert [item["type"] for item in payloads["input"]] == [
+        "message",
+        "message",
+        "function_call",
+        "function_call_output",
+    ]
+    assert payloads["input"][2]["name"] == "recall_long_term_memory"
+    assert payloads["input"][3]["call_id"] == "fake_call_01"
+
+
+@pytest.mark.parametrize(
+    "tail_user_content",
+    [
+        "请根据图片分析结果继续",  # cached_images 图片复核消息
+        "Maximum tool call limit reached.",  # max_steps 收尾提示
+        "下一个问题",  # 跨轮次历史后用户新消息
+    ],
+    ids=["cached_images", "max_steps", "cross_turn"],
+)
+@pytest.mark.asyncio
+async def test_responses_reorder_skips_marked_real_pair(tail_user_content):
+    """带 _from_real_tool_call 标记的真实工具对在 Responses 路径不被重排。"""
+    provider = _make_provider()
+    payloads, context = await provider._prepare_chat_payload(
+        prompt=tail_user_content,
+        contexts=[
+            {"role": "user", "content": "帮我查一下"},
+            *make_fake_pair(
+                tool_call_id="real_call_01", content="real result", marked=True
+            ),
+        ],
+    )
+
+    assert [m["role"] for m in context] == ["user", "assistant", "tool", "user"]
+    assert [item["type"] for item in payloads["input"]] == [
+        "message",
+        "function_call",
+        "function_call_output",
+        "message",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_responses_real_tool_calls_result_not_reordered_and_no_marker_leak():
+    """经 ToolCallsResult 进入的真实工具结果带标记，不被重排，且标记不泄漏到 input。"""
+    from astrbot.core.agent.message import (
+        AssistantMessageSegment,
+        ToolCallMessageSegment,
+    )
+    from astrbot.core.provider.entities import ToolCallsResult
+
+    provider = _make_provider()
+    tcr = ToolCallsResult(
+        tool_calls_info=AssistantMessageSegment(
+            content=None,
+            tool_calls=[
+                {
+                    "id": "real_call_01",
+                    "type": "function",
+                    "function": {"name": "search_web", "arguments": "{}"},
+                }
+            ],
+        ),
+        tool_calls_result=[
+            ToolCallMessageSegment(content="real result", tool_call_id="real_call_01")
+        ],
+    )
+    payloads, context = await provider._prepare_chat_payload(
+        prompt="请根据图片分析结果继续",
+        contexts=[{"role": "user", "content": "帮我查一下"}],
+        tool_calls_result=tcr,
+    )
+
+    # tool_calls_result 追加在 prompt 之后，尾部是 tool 消息，重排天然 no-op
+    assert [m["role"] for m in context] == ["user", "user", "assistant", "tool"]
+    assert [item["type"] for item in payloads["input"]] == [
+        "message",
+        "message",
+        "function_call",
+        "function_call_output",
+    ]
+    for item in payloads["input"]:
+        assert "_from_real_tool_call" not in item
+
+
+@pytest.mark.asyncio
+async def test_responses_mixed_real_and_fake_only_fake_reordered():
+    """真实对（标记）与伪造对（无标记）并存时，只重排尾部伪造对。"""
+    provider = _make_provider()
+    payloads, context = await provider._prepare_chat_payload(
+        prompt="尾部问题",
+        contexts=[
+            {"role": "user", "content": "开始"},
+            *make_fake_pair(
+                tool_call_id="real_call_01", content="real result", marked=True
+            ),
+            {"role": "user", "content": "中间补充"},
+            *make_fake_pair(tool_call_id="fake_call_02"),
+        ],
+    )
+
+    assert [m["role"] for m in context] == [
+        "user",
+        "assistant",
+        "tool",
+        "user",
+        "user",
+        "assistant",
+        "tool",
+    ]
+    assert [item["type"] for item in payloads["input"]] == [
+        "message",
+        "function_call",
+        "function_call_output",
+        "message",
+        "message",
+        "function_call",
+        "function_call_output",
+    ]
+    # 真实对的 call_id 在重排后仍紧跟其 function_call
+    assert payloads["input"][1]["call_id"] == "real_call_01"
+    assert payloads["input"][2]["call_id"] == "real_call_01"

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -12,6 +12,7 @@ from PIL import Image as PILImage
 import astrbot.core.provider.sources.openai_source as openai_source_module
 import astrbot.core.provider.sources.request_retry as request_retry
 from astrbot.core.exceptions import EmptyModelOutputError
+from astrbot.core.provider import reorder_tailing_tool_call_user
 from astrbot.core.provider.entities import LLMResponse
 from astrbot.core.provider.sources.groq_source import ProviderGroq
 from astrbot.core.provider.sources.longcat_source import ProviderLongCat
@@ -2201,7 +2202,7 @@ async def test_query_filters_empty_list_content_assistant_message(monkeypatch):
         await provider.terminate()
 
 
-# ── _reorder_tailing_tool_call_user ──────────────────────────────────────────
+# ── reorder_tailing_tool_call_user ───────────────────────────────────────────
 
 
 def test_reorder_single_fake_pair():
@@ -2213,7 +2214,11 @@ def test_reorder_single_fake_pair():
                 "role": "assistant",
                 "content": None,
                 "tool_calls": [
-                    {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+                    {
+                        "id": "call_01",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    }
                 ],
             },
             {"role": "tool", "tool_call_id": "call_01", "content": "mem result"},
@@ -2221,7 +2226,7 @@ def test_reorder_single_fake_pair():
         ]
     }
 
-    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+    reorder_tailing_tool_call_user(payloads["messages"])
 
     assert payloads["messages"] == [
         {"role": "user", "content": "hello"},
@@ -2230,7 +2235,11 @@ def test_reorder_single_fake_pair():
             "role": "assistant",
             "content": None,
             "tool_calls": [
-                {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+                {
+                    "id": "call_01",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
             ],
         },
         {"role": "tool", "tool_call_id": "call_01", "content": "mem result"},
@@ -2246,7 +2255,11 @@ def test_reorder_multiple_fake_pairs():
                 "role": "assistant",
                 "content": None,
                 "tool_calls": [
-                    {"id": "call_01", "type": "function", "function": {"name": "plugin_a", "arguments": "{}"}}
+                    {
+                        "id": "call_01",
+                        "type": "function",
+                        "function": {"name": "plugin_a", "arguments": "{}"},
+                    }
                 ],
             },
             {"role": "tool", "tool_call_id": "call_01", "content": "result_a"},
@@ -2254,7 +2267,11 @@ def test_reorder_multiple_fake_pairs():
                 "role": "assistant",
                 "content": None,
                 "tool_calls": [
-                    {"id": "call_02", "type": "function", "function": {"name": "plugin_b", "arguments": "{}"}}
+                    {
+                        "id": "call_02",
+                        "type": "function",
+                        "function": {"name": "plugin_b", "arguments": "{}"},
+                    }
                 ],
             },
             {"role": "tool", "tool_call_id": "call_02", "content": "result_b"},
@@ -2262,7 +2279,7 @@ def test_reorder_multiple_fake_pairs():
         ]
     }
 
-    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+    reorder_tailing_tool_call_user(payloads["messages"])
 
     assert payloads["messages"] == [
         {"role": "user", "content": "hello"},
@@ -2271,7 +2288,11 @@ def test_reorder_multiple_fake_pairs():
             "role": "assistant",
             "content": None,
             "tool_calls": [
-                {"id": "call_01", "type": "function", "function": {"name": "plugin_a", "arguments": "{}"}}
+                {
+                    "id": "call_01",
+                    "type": "function",
+                    "function": {"name": "plugin_a", "arguments": "{}"},
+                }
             ],
         },
         {"role": "tool", "tool_call_id": "call_01", "content": "result_a"},
@@ -2279,7 +2300,11 @@ def test_reorder_multiple_fake_pairs():
             "role": "assistant",
             "content": None,
             "tool_calls": [
-                {"id": "call_02", "type": "function", "function": {"name": "plugin_b", "arguments": "{}"}}
+                {
+                    "id": "call_02",
+                    "type": "function",
+                    "function": {"name": "plugin_b", "arguments": "{}"},
+                }
             ],
         },
         {"role": "tool", "tool_call_id": "call_02", "content": "result_b"},
@@ -2297,7 +2322,7 @@ def test_reorder_noop_when_no_fake_pair():
     }
     expected = payloads["messages"][:]
 
-    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+    reorder_tailing_tool_call_user(payloads["messages"])
 
     assert payloads["messages"] == expected
 
@@ -2310,7 +2335,11 @@ def test_reorder_noop_when_tool_call_id_mismatch():
                 "role": "assistant",
                 "content": None,
                 "tool_calls": [
-                    {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+                    {
+                        "id": "call_01",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    }
                 ],
             },
             {"role": "tool", "tool_call_id": "call_99", "content": "mismatched id"},
@@ -2319,7 +2348,7 @@ def test_reorder_noop_when_tool_call_id_mismatch():
     }
     expected = payloads["messages"][:]
 
-    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+    reorder_tailing_tool_call_user(payloads["messages"])
 
     assert payloads["messages"] == expected
 
@@ -2334,7 +2363,7 @@ def test_reorder_noop_when_assistant_has_no_tool_calls():
     }
     expected = payloads["messages"][:]
 
-    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+    reorder_tailing_tool_call_user(payloads["messages"])
 
     assert payloads["messages"] == expected
 
@@ -2349,7 +2378,7 @@ def test_reorder_noop_when_no_trailing_user():
     }
     expected = payloads["messages"][:]
 
-    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+    reorder_tailing_tool_call_user(payloads["messages"])
 
     assert payloads["messages"] == expected
 
@@ -2357,9 +2386,7 @@ def test_reorder_noop_when_no_trailing_user():
 def test_reorder_noop_on_empty_or_short_list():
     """Empty or too-short messages list — no-op, no crash."""
     for msgs in [None, [], [{"role": "user", "content": "hi"}]]:
-        payloads = {"messages": msgs}
-        ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
-        assert payloads.get("messages") is msgs
+        reorder_tailing_tool_call_user(msgs)
 
 
 def test_reorder_real_tool_call_not_affected():
@@ -2371,7 +2398,11 @@ def test_reorder_real_tool_call_not_affected():
                 "role": "assistant",
                 "content": None,
                 "tool_calls": [
-                    {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+                    {
+                        "id": "call_01",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    }
                 ],
             },
             {"role": "tool", "tool_call_id": "call_01", "content": "results"},
@@ -2381,7 +2412,7 @@ def test_reorder_real_tool_call_not_affected():
     }
     expected = payloads["messages"][:]
 
-    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+    reorder_tailing_tool_call_user(payloads["messages"])
 
     assert payloads["messages"] == expected
 
@@ -2408,7 +2439,11 @@ def test_reorder_applied_through_inherited_sanitize(provider_cls):
                 "role": "assistant",
                 "content": None,
                 "tool_calls": [
-                    {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+                    {
+                        "id": "call_01",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    }
                 ],
             },
             {"role": "tool", "tool_call_id": "call_01", "content": "mem result"},
@@ -2425,7 +2460,11 @@ def test_reorder_applied_through_inherited_sanitize(provider_cls):
             "role": "assistant",
             "content": None,
             "tool_calls": [
-                {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+                {
+                    "id": "call_01",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
             ],
         },
         {"role": "tool", "tool_call_id": "call_01", "content": "mem result"},
@@ -2440,7 +2479,11 @@ def test_reorder_stops_at_first_non_pair():
                 "role": "assistant",
                 "content": None,
                 "tool_calls": [
-                    {"id": "call_01", "type": "function", "function": {"name": "plugin_a", "arguments": "{}"}}
+                    {
+                        "id": "call_01",
+                        "type": "function",
+                        "function": {"name": "plugin_a", "arguments": "{}"},
+                    }
                 ],
             },
             {"role": "tool", "tool_call_id": "call_01", "content": "result_a"},
@@ -2449,7 +2492,11 @@ def test_reorder_stops_at_first_non_pair():
                 "role": "assistant",
                 "content": None,
                 "tool_calls": [
-                    {"id": "call_02", "type": "function", "function": {"name": "plugin_b", "arguments": "{}"}}
+                    {
+                        "id": "call_02",
+                        "type": "function",
+                        "function": {"name": "plugin_b", "arguments": "{}"},
+                    }
                 ],
             },
             {"role": "tool", "tool_call_id": "call_02", "content": "result_b"},
@@ -2457,14 +2504,18 @@ def test_reorder_stops_at_first_non_pair():
         ]
     }
 
-    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+    reorder_tailing_tool_call_user(payloads["messages"])
 
     assert payloads["messages"] == [
         {
             "role": "assistant",
             "content": None,
             "tool_calls": [
-                {"id": "call_01", "type": "function", "function": {"name": "plugin_a", "arguments": "{}"}}
+                {
+                    "id": "call_01",
+                    "type": "function",
+                    "function": {"name": "plugin_a", "arguments": "{}"},
+                }
             ],
         },
         {"role": "tool", "tool_call_id": "call_01", "content": "result_a"},
@@ -2474,7 +2525,11 @@ def test_reorder_stops_at_first_non_pair():
             "role": "assistant",
             "content": None,
             "tool_calls": [
-                {"id": "call_02", "type": "function", "function": {"name": "plugin_b", "arguments": "{}"}}
+                {
+                    "id": "call_02",
+                    "type": "function",
+                    "function": {"name": "plugin_b", "arguments": "{}"},
+                }
             ],
         },
         {"role": "tool", "tool_call_id": "call_02", "content": "result_b"},

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -18,8 +18,12 @@ from astrbot.core.agent.message import (
     dump_messages_with_checkpoints,
 )
 from astrbot.core.exceptions import EmptyModelOutputError
-from astrbot.core.provider import reorder_tailing_tool_call_user
+from astrbot.core.provider import (
+    reorder_tailing_tool_call_user,
+    strip_internal_markers,
+)
 from astrbot.core.provider.entities import LLMResponse, ToolCallsResult
+from astrbot.core.provider.modalities import sanitize_contexts_by_modalities
 from astrbot.core.provider.sources.groq_source import ProviderGroq
 from astrbot.core.provider.sources.longcat_source import ProviderLongCat
 from astrbot.core.provider.sources.oai_aihubmix_source import ProviderAIHubMix
@@ -2692,7 +2696,7 @@ def test_sanitize_reorders_unmarked_fake_pair_without_marker_in_output():
 
 
 def test_sanitize_keeps_marked_real_pair_untouched():
-    """真实对带标记时不重排，且 _sanitize_assistant_messages 剥离标记。"""
+    """真实对带标记时不重排，标记保留到发送边界才在副本上剥离。"""
     payloads = {
         "messages": [
             {"role": "user", "content": "帮我查一下"},
@@ -2711,5 +2715,76 @@ def test_sanitize_keeps_marked_real_pair_untouched():
         "tool",
         "user",
     ]
-    for msg in payloads["messages"]:
+    # 标记保留在 payload 中供重试保护
+    assert payloads["messages"][1]["_from_real_tool_call"] is True
+    assert payloads["messages"][2]["_from_real_tool_call"] is True
+    # 发送边界剥离标记（副本，不改动 payload）
+    stripped = strip_internal_markers(payloads["messages"])
+    for msg in stripped:
         assert "_from_real_tool_call" not in msg
+    assert payloads["messages"][1]["_from_real_tool_call"] is True
+
+
+def test_sanitize_repeat_calls_do_not_reorder_marked_pair():
+    """标记保留在 payload 中，重试时重复 sanitize 不会误伤真实对。"""
+    payloads = {
+        "messages": [
+            {"role": "user", "content": "帮我查一下"},
+            *make_fake_pair(
+                tool_call_id="real_call_01", content="real result", marked=True
+            ),
+            {"role": "user", "content": "请根据图片分析结果继续"},
+        ]
+    }
+
+    ProviderOpenAIOfficial._sanitize_assistant_messages(payloads)
+    # 模拟 429 / 工具不支持等重试路径复用同一 payloads
+    ProviderOpenAIOfficial._sanitize_assistant_messages(payloads)
+
+    assert [m["role"] for m in payloads["messages"]] == [
+        "user",
+        "assistant",
+        "tool",
+        "user",
+    ]
+
+
+def test_modalities_sanitize_preserves_marker():
+    """配置了 modalities 的 runner 路径经 sanitize_contexts_by_modalities 转换后
+    真实对标记不丢失，误伤防护在 agent runner 路径同样生效。"""
+    asst = AssistantMessageSegment(
+        content=None,
+        tool_calls=[
+            {
+                "id": "real_call_01",
+                "type": "function",
+                "function": {"name": "search", "arguments": "{}"},
+            }
+        ],
+    )
+    asst._from_real_tool_call = True
+    tool = ToolCallMessageSegment(content="real result", tool_call_id="real_call_01")
+    tool._from_real_tool_call = True
+
+    sanitized, _ = sanitize_contexts_by_modalities(
+        [asst, tool],
+        ["text", "tool_use"],
+    )
+
+    assert sanitized[0]["_from_real_tool_call"] is True
+    assert sanitized[1]["_from_real_tool_call"] is True
+
+
+def test_reorder_non_dict_entry_does_not_crash():
+    """contexts 中出现非 dict 条目时重排不崩溃（此前会 AttributeError）。"""
+    messages = [
+        {"role": "user", "content": "hello"},
+        "garbage-not-a-dict",
+        {"role": "tool", "tool_call_id": "x", "content": "r"},
+        {"role": "user", "content": "next"},
+    ]
+    expected = messages[:]
+
+    reorder_tailing_tool_call_user(messages)
+
+    assert messages == expected

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -14,7 +14,13 @@ import astrbot.core.provider.sources.request_retry as request_retry
 from astrbot.core.exceptions import EmptyModelOutputError
 from astrbot.core.provider.entities import LLMResponse
 from astrbot.core.provider.sources.groq_source import ProviderGroq
+from astrbot.core.provider.sources.longcat_source import ProviderLongCat
+from astrbot.core.provider.sources.oai_aihubmix_source import ProviderAIHubMix
 from astrbot.core.provider.sources.openai_source import ProviderOpenAIOfficial
+from astrbot.core.provider.sources.openrouter_source import ProviderOpenRouter
+from astrbot.core.provider.sources.xai_source import ProviderXAI
+from astrbot.core.provider.sources.xiaomi_source import ProviderXiaomi
+from astrbot.core.provider.sources.zhipu_source import ProviderZhipu
 from astrbot.core.utils.media_utils import ResolvedMediaData, file_uri_to_path
 
 
@@ -2201,3 +2207,283 @@ async def test_query_filters_empty_list_content_assistant_message(monkeypatch):
         assert messages[1] == {"role": "user", "content": "again"}
     finally:
         await provider.terminate()
+
+
+# ── _reorder_tailing_tool_call_user ──────────────────────────────────────────
+
+
+def test_reorder_single_fake_pair():
+    """Single fake tool call pair at tail: assistant(tc) → tool → user."""
+    payloads = {
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_01", "content": "mem result"},
+            {"role": "user", "content": "帮我处理"},
+        ]
+    }
+
+    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+
+    assert payloads["messages"] == [
+        {"role": "user", "content": "hello"},
+        {"role": "user", "content": "帮我处理"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_01", "content": "mem result"},
+    ]
+
+
+def test_reorder_multiple_fake_pairs():
+    """Multiple fake pairs from different plugins: asst₁→tool₁→asst₂→tool₂→user."""
+    payloads = {
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_01", "type": "function", "function": {"name": "plugin_a", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_01", "content": "result_a"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_02", "type": "function", "function": {"name": "plugin_b", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_02", "content": "result_b"},
+            {"role": "user", "content": "帮我处理"},
+        ]
+    }
+
+    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+
+    assert payloads["messages"] == [
+        {"role": "user", "content": "hello"},
+        {"role": "user", "content": "帮我处理"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_01", "type": "function", "function": {"name": "plugin_a", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_01", "content": "result_a"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_02", "type": "function", "function": {"name": "plugin_b", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_02", "content": "result_b"},
+    ]
+
+
+def test_reorder_noop_when_no_fake_pair():
+    """No fake pair: normal user message at tail, should be unchanged."""
+    payloads = {
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": "next"},
+        ]
+    }
+    expected = payloads["messages"][:]
+
+    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+
+    assert payloads["messages"] == expected
+
+
+def test_reorder_noop_when_tool_call_id_mismatch():
+    """tool_call_id does not match assistant's tool_calls — stop collecting."""
+    payloads = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_99", "content": "mismatched id"},
+            {"role": "user", "content": "hello"},
+        ]
+    }
+    expected = payloads["messages"][:]
+
+    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+
+    assert payloads["messages"] == expected
+
+
+def test_reorder_noop_when_assistant_has_no_tool_calls():
+    """Assistant has no tool_calls — stop collecting."""
+    payloads = {
+        "messages": [
+            {"role": "assistant", "content": "some reply"},
+            {"role": "user", "content": "hello"},
+        ]
+    }
+    expected = payloads["messages"][:]
+
+    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+
+    assert payloads["messages"] == expected
+
+
+def test_reorder_noop_when_no_trailing_user():
+    """Tail message is not user — no-op."""
+    payloads = {
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "reply"},
+        ]
+    }
+    expected = payloads["messages"][:]
+
+    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+
+    assert payloads["messages"] == expected
+
+
+def test_reorder_noop_on_empty_or_short_list():
+    """Empty or too-short messages list — no-op, no crash."""
+    for msgs in [None, [], [{"role": "user", "content": "hi"}]]:
+        payloads = {"messages": msgs}
+        ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+        assert payloads.get("messages") is msgs
+
+
+def test_reorder_real_tool_call_not_affected():
+    """Real tool call: tool → assistant(content) before user — should not reorder."""
+    payloads = {
+        "messages": [
+            {"role": "user", "content": "search plz"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_01", "content": "results"},
+            {"role": "assistant", "content": "here are the results"},
+            {"role": "user", "content": "thanks"},
+        ]
+    }
+    expected = payloads["messages"][:]
+
+    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+
+    assert payloads["messages"] == expected
+
+
+@pytest.mark.parametrize(
+    "provider_cls",
+    [
+        ProviderGroq,
+        ProviderLongCat,
+        ProviderAIHubMix,
+        ProviderOpenRouter,
+        ProviderXAI,
+        ProviderXiaomi,
+        ProviderZhipu,
+    ],
+)
+def test_reorder_applied_through_inherited_sanitize(provider_cls):
+    """All OpenAI-compatible subclasses inherit _sanitize_assistant_messages
+    which includes the reorder fix — verify it works on each."""
+    payloads = {
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_01", "content": "mem result"},
+            {"role": "user", "content": "帮我处理"},
+        ]
+    }
+
+    provider_cls._sanitize_assistant_messages(payloads)
+
+    assert payloads["messages"] == [
+        {"role": "user", "content": "hello"},
+        {"role": "user", "content": "帮我处理"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_01", "content": "mem result"},
+    ], f"{provider_cls.__name__} did not reorder fake tool call messages"
+
+
+def test_reorder_stops_at_first_non_pair():
+    """If a non-pair message sits between pairs, only collect from the outermost contiguous block."""
+    payloads = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_01", "type": "function", "function": {"name": "plugin_a", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_01", "content": "result_a"},
+            {"role": "assistant", "content": "intermediate reply"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_02", "type": "function", "function": {"name": "plugin_b", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_02", "content": "result_b"},
+            {"role": "user", "content": "thanks"},
+        ]
+    }
+
+    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+
+    assert payloads["messages"] == [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_01", "type": "function", "function": {"name": "plugin_a", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_01", "content": "result_a"},
+        {"role": "assistant", "content": "intermediate reply"},
+        {"role": "user", "content": "thanks"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_02", "type": "function", "function": {"name": "plugin_b", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_02", "content": "result_b"},
+    ]

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -14,7 +14,13 @@ import astrbot.core.provider.sources.request_retry as request_retry
 from astrbot.core.exceptions import EmptyModelOutputError
 from astrbot.core.provider.entities import LLMResponse
 from astrbot.core.provider.sources.groq_source import ProviderGroq
+from astrbot.core.provider.sources.longcat_source import ProviderLongCat
+from astrbot.core.provider.sources.oai_aihubmix_source import ProviderAIHubMix
 from astrbot.core.provider.sources.openai_source import ProviderOpenAIOfficial
+from astrbot.core.provider.sources.openrouter_source import ProviderOpenRouter
+from astrbot.core.provider.sources.xai_source import ProviderXAI
+from astrbot.core.provider.sources.xiaomi_source import ProviderXiaomi
+from astrbot.core.provider.sources.zhipu_source import ProviderZhipu
 from astrbot.core.utils.media_utils import ResolvedMediaData, file_uri_to_path
 
 
@@ -2193,3 +2199,283 @@ async def test_query_filters_empty_list_content_assistant_message(monkeypatch):
         assert messages[1] == {"role": "user", "content": "again"}
     finally:
         await provider.terminate()
+
+
+# ── _reorder_tailing_tool_call_user ──────────────────────────────────────────
+
+
+def test_reorder_single_fake_pair():
+    """Single fake tool call pair at tail: assistant(tc) → tool → user."""
+    payloads = {
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_01", "content": "mem result"},
+            {"role": "user", "content": "帮我处理"},
+        ]
+    }
+
+    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+
+    assert payloads["messages"] == [
+        {"role": "user", "content": "hello"},
+        {"role": "user", "content": "帮我处理"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_01", "content": "mem result"},
+    ]
+
+
+def test_reorder_multiple_fake_pairs():
+    """Multiple fake pairs from different plugins: asst₁→tool₁→asst₂→tool₂→user."""
+    payloads = {
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_01", "type": "function", "function": {"name": "plugin_a", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_01", "content": "result_a"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_02", "type": "function", "function": {"name": "plugin_b", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_02", "content": "result_b"},
+            {"role": "user", "content": "帮我处理"},
+        ]
+    }
+
+    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+
+    assert payloads["messages"] == [
+        {"role": "user", "content": "hello"},
+        {"role": "user", "content": "帮我处理"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_01", "type": "function", "function": {"name": "plugin_a", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_01", "content": "result_a"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_02", "type": "function", "function": {"name": "plugin_b", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_02", "content": "result_b"},
+    ]
+
+
+def test_reorder_noop_when_no_fake_pair():
+    """No fake pair: normal user message at tail, should be unchanged."""
+    payloads = {
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": "next"},
+        ]
+    }
+    expected = payloads["messages"][:]
+
+    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+
+    assert payloads["messages"] == expected
+
+
+def test_reorder_noop_when_tool_call_id_mismatch():
+    """tool_call_id does not match assistant's tool_calls — stop collecting."""
+    payloads = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_99", "content": "mismatched id"},
+            {"role": "user", "content": "hello"},
+        ]
+    }
+    expected = payloads["messages"][:]
+
+    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+
+    assert payloads["messages"] == expected
+
+
+def test_reorder_noop_when_assistant_has_no_tool_calls():
+    """Assistant has no tool_calls — stop collecting."""
+    payloads = {
+        "messages": [
+            {"role": "assistant", "content": "some reply"},
+            {"role": "user", "content": "hello"},
+        ]
+    }
+    expected = payloads["messages"][:]
+
+    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+
+    assert payloads["messages"] == expected
+
+
+def test_reorder_noop_when_no_trailing_user():
+    """Tail message is not user — no-op."""
+    payloads = {
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "reply"},
+        ]
+    }
+    expected = payloads["messages"][:]
+
+    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+
+    assert payloads["messages"] == expected
+
+
+def test_reorder_noop_on_empty_or_short_list():
+    """Empty or too-short messages list — no-op, no crash."""
+    for msgs in [None, [], [{"role": "user", "content": "hi"}]]:
+        payloads = {"messages": msgs}
+        ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+        assert payloads.get("messages") is msgs
+
+
+def test_reorder_real_tool_call_not_affected():
+    """Real tool call: tool → assistant(content) before user — should not reorder."""
+    payloads = {
+        "messages": [
+            {"role": "user", "content": "search plz"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_01", "content": "results"},
+            {"role": "assistant", "content": "here are the results"},
+            {"role": "user", "content": "thanks"},
+        ]
+    }
+    expected = payloads["messages"][:]
+
+    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+
+    assert payloads["messages"] == expected
+
+
+@pytest.mark.parametrize(
+    "provider_cls",
+    [
+        ProviderGroq,
+        ProviderLongCat,
+        ProviderAIHubMix,
+        ProviderOpenRouter,
+        ProviderXAI,
+        ProviderXiaomi,
+        ProviderZhipu,
+    ],
+)
+def test_reorder_applied_through_inherited_sanitize(provider_cls):
+    """All OpenAI-compatible subclasses inherit _sanitize_assistant_messages
+    which includes the reorder fix — verify it works on each."""
+    payloads = {
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_01", "content": "mem result"},
+            {"role": "user", "content": "帮我处理"},
+        ]
+    }
+
+    provider_cls._sanitize_assistant_messages(payloads)
+
+    assert payloads["messages"] == [
+        {"role": "user", "content": "hello"},
+        {"role": "user", "content": "帮我处理"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_01", "content": "mem result"},
+    ], f"{provider_cls.__name__} did not reorder fake tool call messages"
+
+
+def test_reorder_stops_at_first_non_pair():
+    """If a non-pair message sits between pairs, only collect from the outermost contiguous block."""
+    payloads = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_01", "type": "function", "function": {"name": "plugin_a", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_01", "content": "result_a"},
+            {"role": "assistant", "content": "intermediate reply"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_02", "type": "function", "function": {"name": "plugin_b", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_02", "content": "result_b"},
+            {"role": "user", "content": "thanks"},
+        ]
+    }
+
+    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+
+    assert payloads["messages"] == [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_01", "type": "function", "function": {"name": "plugin_a", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_01", "content": "result_a"},
+        {"role": "assistant", "content": "intermediate reply"},
+        {"role": "user", "content": "thanks"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_02", "type": "function", "function": {"name": "plugin_b", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_02", "content": "result_b"},
+    ]

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -2775,14 +2775,27 @@ def test_modalities_sanitize_preserves_marker():
     assert sanitized[1]["_from_real_tool_call"] is True
 
 
-def test_reorder_non_dict_entry_does_not_crash():
+@pytest.mark.parametrize(
+    "messages",
+    [
+        # 中部非 dict 条目
+        [
+            {"role": "user", "content": "hello"},
+            "garbage-not-a-dict",
+            {"role": "tool", "tool_call_id": "x", "content": "r"},
+            {"role": "user", "content": "next"},
+        ],
+        # 尾部非 dict 条目（last.get 无 isinstance 防护时会 AttributeError）
+        [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "ok"},
+            "garbage-at-tail",
+        ],
+    ],
+    ids=["middle_non_dict", "tail_non_dict"],
+)
+def test_reorder_non_dict_entry_does_not_crash(messages):
     """contexts 中出现非 dict 条目时重排不崩溃（此前会 AttributeError）。"""
-    messages = [
-        {"role": "user", "content": "hello"},
-        "garbage-not-a-dict",
-        {"role": "tool", "tool_call_id": "x", "content": "r"},
-        {"role": "user", "content": "next"},
-    ]
     expected = messages[:]
 
     reorder_tailing_tool_call_user(messages)

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -11,9 +11,15 @@ from PIL import Image as PILImage
 
 import astrbot.core.provider.sources.openai_source as openai_source_module
 import astrbot.core.provider.sources.request_retry as request_retry
+from astrbot.core.agent.message import (
+    AssistantMessageSegment,
+    ToolCallMessageSegment,
+    bind_checkpoint_messages,
+    dump_messages_with_checkpoints,
+)
 from astrbot.core.exceptions import EmptyModelOutputError
 from astrbot.core.provider import reorder_tailing_tool_call_user
-from astrbot.core.provider.entities import LLMResponse
+from astrbot.core.provider.entities import LLMResponse, ToolCallsResult
 from astrbot.core.provider.sources.groq_source import ProviderGroq
 from astrbot.core.provider.sources.longcat_source import ProviderLongCat
 from astrbot.core.provider.sources.oai_aihubmix_source import ProviderAIHubMix
@@ -23,6 +29,7 @@ from astrbot.core.provider.sources.xai_source import ProviderXAI
 from astrbot.core.provider.sources.xiaomi_source import ProviderXiaomi
 from astrbot.core.provider.sources.zhipu_source import ProviderZhipu
 from astrbot.core.utils.media_utils import ResolvedMediaData, file_uri_to_path
+from tests.fixtures.fake_tool_call import make_fake_pair
 
 
 class _ErrorWithBody(Exception):
@@ -2319,26 +2326,17 @@ def test_reorder_multiple_fake_pairs():
     ]
 
 
-def test_reorder_noop_when_no_fake_pair():
-    """No fake pair: normal user message at tail, should be unchanged."""
-    payloads = {
-        "messages": [
+@pytest.mark.parametrize(
+    "messages",
+    [
+        # 无伪造对
+        [
             {"role": "user", "content": "hello"},
             {"role": "assistant", "content": "ok"},
             {"role": "user", "content": "next"},
-        ]
-    }
-    expected = payloads["messages"][:]
-
-    reorder_tailing_tool_call_user(payloads["messages"])
-
-    assert payloads["messages"] == expected
-
-
-def test_reorder_noop_when_tool_call_id_mismatch():
-    """tool_call_id does not match assistant's tool_calls — stop collecting."""
-    payloads = {
-        "messages": [
+        ],
+        # tool_call_id 与 assistant 不匹配
+        [
             {
                 "role": "assistant",
                 "content": None,
@@ -2352,49 +2350,42 @@ def test_reorder_noop_when_tool_call_id_mismatch():
             },
             {"role": "tool", "tool_call_id": "call_99", "content": "mismatched id"},
             {"role": "user", "content": "hello"},
-        ]
-    }
-    expected = payloads["messages"][:]
-
-    reorder_tailing_tool_call_user(payloads["messages"])
-
-    assert payloads["messages"] == expected
-
-
-def test_reorder_noop_when_assistant_has_no_tool_calls():
-    """Assistant has no tool_calls — stop collecting."""
-    payloads = {
-        "messages": [
+        ],
+        # assistant 无 tool_calls
+        [
             {"role": "assistant", "content": "some reply"},
             {"role": "user", "content": "hello"},
-        ]
-    }
-    expected = payloads["messages"][:]
-
-    reorder_tailing_tool_call_user(payloads["messages"])
-
-    assert payloads["messages"] == expected
-
-
-def test_reorder_noop_when_no_trailing_user():
-    """Tail message is not user — no-op."""
-    payloads = {
-        "messages": [
+        ],
+        # 尾部不是 user
+        [
             {"role": "user", "content": "hello"},
             {"role": "assistant", "content": "reply"},
-        ]
-    }
-    expected = payloads["messages"][:]
+        ],
+        # 空 / 过短列表
+        [],
+        [{"role": "user", "content": "hi"}],
+    ],
+    ids=[
+        "no_pair",
+        "id_mismatch",
+        "no_tool_calls",
+        "no_trailing_user",
+        "empty",
+        "short",
+    ],
+)
+def test_reorder_noop(messages):
+    """尾部不存在可重排的伪造对时，消息保持不变。"""
+    expected = messages[:]
 
-    reorder_tailing_tool_call_user(payloads["messages"])
+    reorder_tailing_tool_call_user(messages)
 
-    assert payloads["messages"] == expected
+    assert messages == expected
 
 
-def test_reorder_noop_on_empty_or_short_list():
-    """Empty or too-short messages list — no-op, no crash."""
-    for msgs in [None, [], [{"role": "user", "content": "hi"}]]:
-        reorder_tailing_tool_call_user(msgs)
+def test_reorder_noop_on_none():
+    """None 入参直接返回，不崩溃。"""
+    reorder_tailing_tool_call_user(None)
 
 
 def test_reorder_real_tool_call_not_affected():
@@ -2437,46 +2428,14 @@ def test_reorder_real_tool_call_not_affected():
         ProviderZhipu,
     ],
 )
-def test_reorder_applied_through_inherited_sanitize(provider_cls):
-    """All OpenAI-compatible subclasses inherit _sanitize_assistant_messages
-    which includes the reorder fix — verify it works on each."""
-    payloads = {
-        "messages": [
-            {"role": "user", "content": "hello"},
-            {
-                "role": "assistant",
-                "content": None,
-                "tool_calls": [
-                    {
-                        "id": "call_01",
-                        "type": "function",
-                        "function": {"name": "search", "arguments": "{}"},
-                    }
-                ],
-            },
-            {"role": "tool", "tool_call_id": "call_01", "content": "mem result"},
-            {"role": "user", "content": "帮我处理"},
-        ]
-    }
-
-    provider_cls._sanitize_assistant_messages(payloads)
-
-    assert payloads["messages"] == [
-        {"role": "user", "content": "hello"},
-        {"role": "user", "content": "帮我处理"},
-        {
-            "role": "assistant",
-            "content": None,
-            "tool_calls": [
-                {
-                    "id": "call_01",
-                    "type": "function",
-                    "function": {"name": "search", "arguments": "{}"},
-                }
-            ],
-        },
-        {"role": "tool", "tool_call_id": "call_01", "content": "mem result"},
-    ], f"{provider_cls.__name__} did not reorder fake tool call messages"
+def test_sanitize_reorder_inherited_by_subclasses(provider_cls):
+    """OpenAI 兼容子类都直接继承含重排修复的 _sanitize_assistant_messages，
+    行为由父类测试（test_sanitize_reorders_unmarked_fake_pair_without_marker_in_output）
+    覆盖。"""
+    assert (
+        provider_cls._sanitize_assistant_messages
+        is ProviderOpenAIOfficial._sanitize_assistant_messages
+    )
 
 
 def test_reorder_stops_at_first_non_pair():
@@ -2542,3 +2501,215 @@ def test_reorder_stops_at_first_non_pair():
         },
         {"role": "tool", "tool_call_id": "call_02", "content": "result_b"},
     ]
+
+
+@pytest.mark.parametrize(
+    "tail_user_content",
+    [
+        "请根据图片分析结果继续",  # cached_images 图片复核消息
+        "最多还能进行 2 步，请继续",  # max_steps 收尾提示
+        "下一个问题",  # 跨轮次历史后用户新消息
+    ],
+    ids=["cached_images", "max_steps", "cross_turn"],
+)
+def test_reorder_skips_marked_real_pair(tail_user_content):
+    """真实工具调用对带 `_from_real_tool_call` 标记时，重排必须停止。
+
+    三类误伤场景（图片复核 / max steps 收尾 / 跨轮次历史）尾部都是
+    ``[assistant(tc), tool, user]`` 形状，其中的 assistant/tool 是真实工具
+    执行产生的，不应被当作伪造对挪到 user 之后。
+    """
+    real_pair = make_fake_pair(
+        tool_call_id="real_call_01", content="real result", marked=True
+    )
+    payloads = {
+        "messages": [
+            {"role": "user", "content": "帮我查一下"},
+            *real_pair,
+            {"role": "user", "content": tail_user_content},
+        ]
+    }
+    expected = payloads["messages"][:]
+
+    reorder_tailing_tool_call_user(payloads["messages"])
+
+    assert payloads["messages"] == expected
+
+
+@pytest.mark.parametrize(
+    "marked_side",
+    [
+        "assistant",
+        "tool",
+    ],
+)
+def test_reorder_stops_when_either_side_marked(marked_side):
+    """只要对中任意一侧带标记，即视为真实对并停止收集。"""
+    real_pair = make_fake_pair(
+        tool_call_id="real_call_01", content="real result", marked=True
+    )
+    if marked_side == "assistant":
+        real_pair[1].pop("_from_real_tool_call")
+    else:
+        real_pair[0].pop("_from_real_tool_call")
+    payloads = {
+        "messages": [
+            {"role": "user", "content": "帮我查一下"},
+            *real_pair,
+            {"role": "user", "content": "继续"},
+        ]
+    }
+    expected = payloads["messages"][:]
+
+    reorder_tailing_tool_call_user(payloads["messages"])
+
+    assert payloads["messages"] == expected
+
+
+def test_reorder_fake_pair_reordered_while_marked_real_pair_stays():
+    """真实对（标记）与伪造对（无标记）并存：只重排尾部伪造对，真实对原地不动。"""
+    real_pair = make_fake_pair(
+        tool_call_id="real_call_01", content="real result", marked=True
+    )
+    payloads = {
+        "messages": [
+            {"role": "user", "content": "开始"},
+            *real_pair,
+            {"role": "user", "content": "中间补充"},
+            *make_fake_pair(tool_call_id="fake_call_02", name="recall_memory"),
+            {"role": "user", "content": "尾部问题"},
+        ]
+    }
+
+    reorder_tailing_tool_call_user(payloads["messages"])
+
+    assert payloads["messages"] == [
+        {"role": "user", "content": "开始"},
+        *real_pair,
+        {"role": "user", "content": "中间补充"},
+        {"role": "user", "content": "尾部问题"},
+        *make_fake_pair(tool_call_id="fake_call_02", name="recall_memory"),
+    ]
+
+
+def test_tool_calls_result_marks_messages():
+    """ToolCallsResult 转换出的 dict / segment 都带真实工具调用标记。"""
+    tcr = ToolCallsResult(
+        tool_calls_info=AssistantMessageSegment(
+            content=None,
+            tool_calls=[
+                {
+                    "id": "real_call_01",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
+            ],
+        ),
+        tool_calls_result=[
+            ToolCallMessageSegment(content="real result", tool_call_id="real_call_01")
+        ],
+    )
+
+    dicts = tcr.to_openai_messages()
+    assert dicts[0]["_from_real_tool_call"] is True
+    assert dicts[1]["_from_real_tool_call"] is True
+
+    # 幂等：重复调用不会影响
+    dicts_again = tcr.to_openai_messages()
+    assert dicts_again[0]["_from_real_tool_call"] is True
+
+    segments = tcr.to_openai_messages_model()
+    assert segments[0]._from_real_tool_call is True
+    assert segments[1]._from_real_tool_call is True
+
+
+def test_marker_survives_dump_and_bind_roundtrip():
+    """标记字段经 dump_messages_with_checkpoints / bind_checkpoint_messages 往返不丢失。"""
+    asst = AssistantMessageSegment(
+        content=None,
+        tool_calls=[
+            {
+                "id": "real_call_01",
+                "type": "function",
+                "function": {"name": "search", "arguments": "{}"},
+            }
+        ],
+    )
+    asst._from_real_tool_call = True
+    tool = ToolCallMessageSegment(content="real result", tool_call_id="real_call_01")
+    tool._from_real_tool_call = True
+
+    dumped = dump_messages_with_checkpoints([asst, tool])
+    assert dumped[0]["_from_real_tool_call"] is True
+    assert dumped[1]["_from_real_tool_call"] is True
+
+    rebound = bind_checkpoint_messages(dumped)
+    assert rebound[0]._from_real_tool_call is True
+    assert rebound[1]._from_real_tool_call is True
+
+
+def test_sanitize_reorders_unmarked_fake_pair_without_marker_in_output():
+    """无标记伪造对经 _sanitize_assistant_messages 重排，且输出不含内部标记键。"""
+    payloads = {
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "fake_call_01",
+                        "type": "function",
+                        "function": {"name": "recall_memory", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "fake_call_01", "content": "mem result"},
+            {"role": "user", "content": "帮我处理"},
+        ]
+    }
+
+    ProviderOpenAIOfficial._sanitize_assistant_messages(payloads)
+
+    assert payloads["messages"] == [
+        {"role": "user", "content": "hello"},
+        {"role": "user", "content": "帮我处理"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "fake_call_01",
+                    "type": "function",
+                    "function": {"name": "recall_memory", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "fake_call_01", "content": "mem result"},
+    ]
+    for msg in payloads["messages"]:
+        assert "_from_real_tool_call" not in msg
+
+
+def test_sanitize_keeps_marked_real_pair_untouched():
+    """真实对带标记时不重排，且 _sanitize_assistant_messages 剥离标记。"""
+    payloads = {
+        "messages": [
+            {"role": "user", "content": "帮我查一下"},
+            *make_fake_pair(
+                tool_call_id="real_call_01", content="real result", marked=True
+            ),
+            {"role": "user", "content": "请根据图片分析结果继续"},
+        ]
+    }
+
+    ProviderOpenAIOfficial._sanitize_assistant_messages(payloads)
+
+    assert [m["role"] for m in payloads["messages"]] == [
+        "user",
+        "assistant",
+        "tool",
+        "user",
+    ]
+    for msg in payloads["messages"]:
+        assert "_from_real_tool_call" not in msg

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -12,6 +12,7 @@ from PIL import Image as PILImage
 import astrbot.core.provider.sources.openai_source as openai_source_module
 import astrbot.core.provider.sources.request_retry as request_retry
 from astrbot.core.exceptions import EmptyModelOutputError
+from astrbot.core.provider import reorder_tailing_tool_call_user
 from astrbot.core.provider.entities import LLMResponse
 from astrbot.core.provider.sources.groq_source import ProviderGroq
 from astrbot.core.provider.sources.longcat_source import ProviderLongCat
@@ -2209,7 +2210,7 @@ async def test_query_filters_empty_list_content_assistant_message(monkeypatch):
         await provider.terminate()
 
 
-# ── _reorder_tailing_tool_call_user ──────────────────────────────────────────
+# ── reorder_tailing_tool_call_user ───────────────────────────────────────────
 
 
 def test_reorder_single_fake_pair():
@@ -2221,7 +2222,11 @@ def test_reorder_single_fake_pair():
                 "role": "assistant",
                 "content": None,
                 "tool_calls": [
-                    {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+                    {
+                        "id": "call_01",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    }
                 ],
             },
             {"role": "tool", "tool_call_id": "call_01", "content": "mem result"},
@@ -2229,7 +2234,7 @@ def test_reorder_single_fake_pair():
         ]
     }
 
-    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+    reorder_tailing_tool_call_user(payloads["messages"])
 
     assert payloads["messages"] == [
         {"role": "user", "content": "hello"},
@@ -2238,7 +2243,11 @@ def test_reorder_single_fake_pair():
             "role": "assistant",
             "content": None,
             "tool_calls": [
-                {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+                {
+                    "id": "call_01",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
             ],
         },
         {"role": "tool", "tool_call_id": "call_01", "content": "mem result"},
@@ -2254,7 +2263,11 @@ def test_reorder_multiple_fake_pairs():
                 "role": "assistant",
                 "content": None,
                 "tool_calls": [
-                    {"id": "call_01", "type": "function", "function": {"name": "plugin_a", "arguments": "{}"}}
+                    {
+                        "id": "call_01",
+                        "type": "function",
+                        "function": {"name": "plugin_a", "arguments": "{}"},
+                    }
                 ],
             },
             {"role": "tool", "tool_call_id": "call_01", "content": "result_a"},
@@ -2262,7 +2275,11 @@ def test_reorder_multiple_fake_pairs():
                 "role": "assistant",
                 "content": None,
                 "tool_calls": [
-                    {"id": "call_02", "type": "function", "function": {"name": "plugin_b", "arguments": "{}"}}
+                    {
+                        "id": "call_02",
+                        "type": "function",
+                        "function": {"name": "plugin_b", "arguments": "{}"},
+                    }
                 ],
             },
             {"role": "tool", "tool_call_id": "call_02", "content": "result_b"},
@@ -2270,7 +2287,7 @@ def test_reorder_multiple_fake_pairs():
         ]
     }
 
-    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+    reorder_tailing_tool_call_user(payloads["messages"])
 
     assert payloads["messages"] == [
         {"role": "user", "content": "hello"},
@@ -2279,7 +2296,11 @@ def test_reorder_multiple_fake_pairs():
             "role": "assistant",
             "content": None,
             "tool_calls": [
-                {"id": "call_01", "type": "function", "function": {"name": "plugin_a", "arguments": "{}"}}
+                {
+                    "id": "call_01",
+                    "type": "function",
+                    "function": {"name": "plugin_a", "arguments": "{}"},
+                }
             ],
         },
         {"role": "tool", "tool_call_id": "call_01", "content": "result_a"},
@@ -2287,7 +2308,11 @@ def test_reorder_multiple_fake_pairs():
             "role": "assistant",
             "content": None,
             "tool_calls": [
-                {"id": "call_02", "type": "function", "function": {"name": "plugin_b", "arguments": "{}"}}
+                {
+                    "id": "call_02",
+                    "type": "function",
+                    "function": {"name": "plugin_b", "arguments": "{}"},
+                }
             ],
         },
         {"role": "tool", "tool_call_id": "call_02", "content": "result_b"},
@@ -2305,7 +2330,7 @@ def test_reorder_noop_when_no_fake_pair():
     }
     expected = payloads["messages"][:]
 
-    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+    reorder_tailing_tool_call_user(payloads["messages"])
 
     assert payloads["messages"] == expected
 
@@ -2318,7 +2343,11 @@ def test_reorder_noop_when_tool_call_id_mismatch():
                 "role": "assistant",
                 "content": None,
                 "tool_calls": [
-                    {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+                    {
+                        "id": "call_01",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    }
                 ],
             },
             {"role": "tool", "tool_call_id": "call_99", "content": "mismatched id"},
@@ -2327,7 +2356,7 @@ def test_reorder_noop_when_tool_call_id_mismatch():
     }
     expected = payloads["messages"][:]
 
-    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+    reorder_tailing_tool_call_user(payloads["messages"])
 
     assert payloads["messages"] == expected
 
@@ -2342,7 +2371,7 @@ def test_reorder_noop_when_assistant_has_no_tool_calls():
     }
     expected = payloads["messages"][:]
 
-    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+    reorder_tailing_tool_call_user(payloads["messages"])
 
     assert payloads["messages"] == expected
 
@@ -2357,7 +2386,7 @@ def test_reorder_noop_when_no_trailing_user():
     }
     expected = payloads["messages"][:]
 
-    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+    reorder_tailing_tool_call_user(payloads["messages"])
 
     assert payloads["messages"] == expected
 
@@ -2365,9 +2394,7 @@ def test_reorder_noop_when_no_trailing_user():
 def test_reorder_noop_on_empty_or_short_list():
     """Empty or too-short messages list — no-op, no crash."""
     for msgs in [None, [], [{"role": "user", "content": "hi"}]]:
-        payloads = {"messages": msgs}
-        ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
-        assert payloads.get("messages") is msgs
+        reorder_tailing_tool_call_user(msgs)
 
 
 def test_reorder_real_tool_call_not_affected():
@@ -2379,7 +2406,11 @@ def test_reorder_real_tool_call_not_affected():
                 "role": "assistant",
                 "content": None,
                 "tool_calls": [
-                    {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+                    {
+                        "id": "call_01",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    }
                 ],
             },
             {"role": "tool", "tool_call_id": "call_01", "content": "results"},
@@ -2389,7 +2420,7 @@ def test_reorder_real_tool_call_not_affected():
     }
     expected = payloads["messages"][:]
 
-    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+    reorder_tailing_tool_call_user(payloads["messages"])
 
     assert payloads["messages"] == expected
 
@@ -2416,7 +2447,11 @@ def test_reorder_applied_through_inherited_sanitize(provider_cls):
                 "role": "assistant",
                 "content": None,
                 "tool_calls": [
-                    {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+                    {
+                        "id": "call_01",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    }
                 ],
             },
             {"role": "tool", "tool_call_id": "call_01", "content": "mem result"},
@@ -2433,7 +2468,11 @@ def test_reorder_applied_through_inherited_sanitize(provider_cls):
             "role": "assistant",
             "content": None,
             "tool_calls": [
-                {"id": "call_01", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+                {
+                    "id": "call_01",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
             ],
         },
         {"role": "tool", "tool_call_id": "call_01", "content": "mem result"},
@@ -2448,7 +2487,11 @@ def test_reorder_stops_at_first_non_pair():
                 "role": "assistant",
                 "content": None,
                 "tool_calls": [
-                    {"id": "call_01", "type": "function", "function": {"name": "plugin_a", "arguments": "{}"}}
+                    {
+                        "id": "call_01",
+                        "type": "function",
+                        "function": {"name": "plugin_a", "arguments": "{}"},
+                    }
                 ],
             },
             {"role": "tool", "tool_call_id": "call_01", "content": "result_a"},
@@ -2457,7 +2500,11 @@ def test_reorder_stops_at_first_non_pair():
                 "role": "assistant",
                 "content": None,
                 "tool_calls": [
-                    {"id": "call_02", "type": "function", "function": {"name": "plugin_b", "arguments": "{}"}}
+                    {
+                        "id": "call_02",
+                        "type": "function",
+                        "function": {"name": "plugin_b", "arguments": "{}"},
+                    }
                 ],
             },
             {"role": "tool", "tool_call_id": "call_02", "content": "result_b"},
@@ -2465,14 +2512,18 @@ def test_reorder_stops_at_first_non_pair():
         ]
     }
 
-    ProviderOpenAIOfficial._reorder_tailing_tool_call_user(payloads)
+    reorder_tailing_tool_call_user(payloads["messages"])
 
     assert payloads["messages"] == [
         {
             "role": "assistant",
             "content": None,
             "tool_calls": [
-                {"id": "call_01", "type": "function", "function": {"name": "plugin_a", "arguments": "{}"}}
+                {
+                    "id": "call_01",
+                    "type": "function",
+                    "function": {"name": "plugin_a", "arguments": "{}"},
+                }
             ],
         },
         {"role": "tool", "tool_call_id": "call_01", "content": "result_a"},
@@ -2482,7 +2533,11 @@ def test_reorder_stops_at_first_non_pair():
             "role": "assistant",
             "content": None,
             "tool_calls": [
-                {"id": "call_02", "type": "function", "function": {"name": "plugin_b", "arguments": "{}"}}
+                {
+                    "id": "call_02",
+                    "type": "function",
+                    "function": {"name": "plugin_b", "arguments": "{}"},
+                }
             ],
         },
         {"role": "tool", "tool_call_id": "call_02", "content": "result_b"},

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -2355,6 +2355,21 @@ def test_reorder_multiple_fake_pairs():
             {"role": "tool", "tool_call_id": "call_99", "content": "mismatched id"},
             {"role": "user", "content": "hello"},
         ],
+        # 双方 ID 均缺失：残缺对不应被当作有效匹配重排
+        [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "content": "missing ids"},
+            {"role": "user", "content": "hello"},
+        ],
         # assistant 无 tool_calls
         [
             {"role": "assistant", "content": "some reply"},
@@ -2372,6 +2387,7 @@ def test_reorder_multiple_fake_pairs():
     ids=[
         "no_pair",
         "id_mismatch",
+        "missing_id_both_sides",
         "no_tool_calls",
         "no_trailing_user",
         "empty",


### PR DESCRIPTION
### Motivation / 动机

通过向 `req.contexts` 尾部注入 `assistant(tool_calls) → tool(result)` 消息对，可以**强制** LLM 认为自己已经调用了某个工具并拿到了结果，从而：

- 跳过 LLM 自身的工具调用决策，**节省 token**
- **降低延迟**（不需要等 LLM 生成工具调用）
- **增加确定性**（固定或规则触发，不受模型输出波动影响，增强确定性）

这是一种通用手法，已在 LivingMemory 插件中长期记忆注入中使用，未来可能被更多插件用于各种确定性工具调用场景。

但在 `OpenAI_Provider._prepare_chat_payload()` 中，处理顺序是：

1. `deepcopy(contexts)` —— 此时尾部已含伪造工具调用对
2. `append(new_record)` —— 追加当前用户消息

最终发给 LLM API 的 messages 序列为：

```
... assistant(tool_calls=...), tool(result), user("...")
```

LLM 视角下，assistant 在用户提问之前就"预知"了查询内容。正确顺序应为：

```
... user("..."), assistant(tool_calls=...), tool(result)
```

该问题影响所有使用该手法的插件，以及所有走 `OpenAI_Provider` 的 LLM 路径

  Refs: #9450

  ### Modifications / 改动点

  **`astrbot/core/provider/sources/openai_source.py`**

  在 `_sanitize_assistant_messages()` 末尾新增检测与重排逻辑：

  1. 从尾部弹出 `user` 消息
  2. 用 while 循环收集所有 `assistant(tool_calls) + tool` 成对消息（验证 `tool_call_id` 匹配）
  3. 重排为 `user → assistant₁, tool₁ → ... → assistant_N, tool_N`

  支持多插件各自注入多轮伪造对的场景。

  - 不依赖具体插件实现，通用模式检测
  - 不改动 `req` 对象，不破坏其他 `on_llm_request` handler
  - 覆盖 `_query` / `_query_streaming` 全部路径
  - 真实工具调用场景下 `tool` 后不会直接跟 `user`，不会误杀

  此为轻量妥协修复。未来若实现专用的上下文操作钩子或伪造工具调用钩子，可考虑移除此方法。

  - [x] This is NOT a breaking change. / 这不是一个破坏性变更。

  ### Test Results / 测试结果

  逻辑验证（手动）：
  - 无伪造对：不触发，不变
  - 单对：`..., asst(tc), tool, user` → `..., user, asst(tc), tool`
  - 多对：`..., asst₁, tool₁, asst₂, tool₂, user` → `..., user, asst₁, tool₁, asst₂, tool₂`
  - 真实工具调用：`..., asst(tc), tool, asst(content), user` → 不变，不误杀

  ---

  ### Checklist / 检查清单

  - [ ] 😊 新功能已通过 Issue 与作者讨论
  - [x] 👀 我的更改经过了充分测试，测试结果已在上方提供
  - [x] 🤓 无新依赖引入
  - [x] 😮 无恶意代码

## Summary by Sourcery

Ensure fake tool call assistant/tool/user message sequences are reordered so user messages precede injected tool call pairs, while preserving real tool call ordering and markers across all compatible providers and serialization paths.

Bug Fixes:
- Correct message ordering when plugins inject fake assistant(tool_calls) and tool messages at the tail so the LLM sees user queries before tool call pairs.
- Prevent crashes and misordering when message lists contain non-dict entries or incomplete/mismatched tool call IDs.
- Avoid reordering and protect timing of real tool calls by marking them and excluding marked pairs from fake-tool-call reordering.
- Ensure internal real-tool-call markers are stripped from outbound payloads so provider APIs never receive internal flags.

Enhancements:
- Share a reusable fake tool call fixture across provider tests to keep scenarios consistent.
- Propagate and persist real-tool-call markers through Message serialization, ToolCallsResult conversion, modalities sanitization, and checkpoint roundtrips to support robust reordering logic.
- Apply the fake-tool-call reorder logic to OpenAI, Anthropic, Gemini, and OpenAI Responses providers, including both streaming and non-streaming code paths.
- Add comprehensive tests across providers to validate reordering behavior, marker preservation, and mixed real/fake tool call scenarios.

Tests:
- Extend unit tests for OpenAI, Anthropic, Gemini, and OpenAI Responses providers to cover fake tool call reordering, real tool call protection, marker stripping, and edge cases such as mixed pairs and malformed messages.