### PR TITLE
perf: enrich knowledge base embeddings with document context

### DIFF
--- a/astrbot/core/db/vec_db/base.py
+++ b/astrbot/core/db/vec_db/base.py
@@ -32,11 +32,13 @@ class BaseVecDB:
         tasks_limit: int = 3,
         max_retries: int = 3,
         progress_callback=None,
+        embedding_contents: list[str] | None = None,
     ) -> int:
         """批量插入文本和其对应向量，自动生成 ID 并保持一致性。
 
         Args:
             progress_callback: 进度回调函数，接收参数 (current, total)
+            embedding_contents: Optional enriched texts used only for embeddings.
 
         """
         ...

--- a/astrbot/core/db/vec_db/faiss_impl/vec_db.py
+++ b/astrbot/core/db/vec_db/faiss_impl/vec_db.py
@@ -65,15 +65,19 @@ class FaissVecDB(BaseVecDB):
         tasks_limit: int = 3,
         max_retries: int = 3,
         progress_callback=None,
+        embedding_contents: list[str] | None = None,
     ) -> list[int]:
         """批量插入文本和其对应向量，自动生成 ID 并保持一致性。
 
         Args:
             progress_callback: 进度回调函数，接收参数 (current, total)
+            embedding_contents: Optional enriched texts used only for embeddings.
 
         """
         metadatas = metadatas or [{} for _ in contents]
         ids = ids or [str(uuid.uuid4()) for _ in contents]
+        if embedding_contents is None:
+            embedding_contents = contents
 
         if not contents:
             logger.debug(
@@ -106,11 +110,23 @@ class FaissVecDB(BaseVecDB):
                     "actual_ids": len(ids),
                 },
             )
+        if len(embedding_contents) != content_count:
+            raise KnowledgeBaseUploadError(
+                stage="storage",
+                user_message=(
+                    f"存储失败：文本分块数量与向量化文本数量不一致（期望 {content_count}，"
+                    f"实际 {len(embedding_contents)}）。"
+                ),
+                details={
+                    "expected_contents": content_count,
+                    "actual_embedding_contents": len(embedding_contents),
+                },
+            )
 
         start = time.time()
         logger.debug(f"Generating embeddings for {len(contents)} contents...")
         vectors = await self.embedding_provider.get_embeddings_batch(
-            contents,
+            embedding_contents,
             batch_size=batch_size,
             tasks_limit=tasks_limit,
             max_retries=max_retries,

--- a/astrbot/core/knowledge_base/kb_helper.py
+++ b/astrbot/core/knowledge_base/kb_helper.py
@@ -323,16 +323,28 @@ class KBHelper:
                     await progress_callback("chunking", 0, 100)
 
                 try:
-                    # 根据文件类型选择分块器：Markdown 文件使用结构感知分块
+                    # These parsers return Markdown, so retain their heading hierarchy.
                     effective_chunker = self.chunker
                     file_ext = Path(file_name).suffix.lower() if file_name else ""
-                    if file_ext in (".md", ".markdown", ".mkd", ".mdx"):
+                    if file_ext in {
+                        ".adoc",
+                        ".docx",
+                        ".epub",
+                        ".markdown",
+                        ".md",
+                        ".mdx",
+                        ".mkd",
+                        ".rst",
+                        ".xls",
+                        ".xlsx",
+                    }:
                         effective_chunker = MarkdownChunker(
                             chunk_size=chunk_size,
                             chunk_overlap=chunk_overlap,
                         )
                         logger.info(
-                            f"检测到 Markdown 文件 '{file_name}'，使用 MarkdownChunker 进行结构化分块"
+                            f"Using MarkdownChunker for structured document "
+                            f"'{file_name}'."
                         )
 
                     chunks_text = await effective_chunker.chunk(

--- a/astrbot/core/knowledge_base/kb_helper.py
+++ b/astrbot/core/knowledge_base/kb_helper.py
@@ -380,6 +380,12 @@ class KBHelper:
                         "chunk_index": idx,
                     },
                 )
+            document_title = Path(file_name).stem.strip()
+            embedding_contents = (
+                [f"{document_title}\n\n{chunk_text}" for chunk_text in chunks_text]
+                if document_title
+                else contents
+            )
 
             if progress_callback:
                 await progress_callback("chunking", 100, 100)
@@ -397,6 +403,7 @@ class KBHelper:
                     tasks_limit=tasks_limit,
                     max_retries=max_retries,
                     progress_callback=embedding_progress_callback,
+                    embedding_contents=embedding_contents,
                 )
             except KnowledgeBaseUploadError:
                 raise

--- a/tests/unit/test_faiss_vec_db.py
+++ b/tests/unit/test_faiss_vec_db.py
@@ -65,6 +65,41 @@ async def test_insert_batch_raises_friendly_error_for_embedding_count_mismatch()
     vec_db.embedding_storage.insert_batch.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_insert_batch_embeds_context_but_stores_original_contents() -> None:
+    vec_db = FaissVecDB.__new__(FaissVecDB)
+    vec_db.embedding_provider = AsyncMock()
+    vec_db.embedding_provider.get_embeddings_batch.return_value = [
+        [0.1, 0.2],
+        [0.3, 0.4],
+    ]
+    vec_db.document_storage = AsyncMock()
+    vec_db.document_storage.insert_documents_batch.return_value = [11, 12]
+    vec_db.embedding_storage = AsyncMock()
+    vec_db.embedding_storage.dimension = 2
+
+    await FaissVecDB.insert_batch(
+        vec_db,
+        contents=["chunk one", "chunk two"],
+        metadatas=[{}, {}],
+        ids=["doc-1", "doc-2"],
+        embedding_contents=["guide\n\nchunk one", "guide\n\nchunk two"],
+    )
+
+    vec_db.embedding_provider.get_embeddings_batch.assert_awaited_once_with(
+        ["guide\n\nchunk one", "guide\n\nchunk two"],
+        batch_size=32,
+        tasks_limit=3,
+        max_retries=3,
+        progress_callback=None,
+    )
+    vec_db.document_storage.insert_documents_batch.assert_awaited_once_with(
+        ["doc-1", "doc-2"],
+        ["chunk one", "chunk two"],
+        [{}, {}],
+    )
+
+
 def test_embedding_storage_rejects_zero_dimension_for_a_fresh_index(tmp_path) -> None:
     with pytest.raises(ValueError, match="无效的嵌入向量维度"):
         EmbeddingStorage(0, str(tmp_path / "index.faiss"))

--- a/tests/unit/test_faiss_vec_db.py
+++ b/tests/unit/test_faiss_vec_db.py
@@ -66,7 +66,20 @@ async def test_insert_batch_raises_friendly_error_for_embedding_count_mismatch()
 
 
 @pytest.mark.asyncio
-async def test_insert_batch_embeds_context_but_stores_original_contents() -> None:
+@pytest.mark.parametrize(
+    ("embedding_contents", "expected_embedding_contents"),
+    [
+        (None, ["chunk one", "chunk two"]),
+        (
+            ["guide\n\nchunk one", "guide\n\nchunk two"],
+            ["guide\n\nchunk one", "guide\n\nchunk two"],
+        ),
+    ],
+)
+async def test_insert_batch_uses_embedding_contents_without_changing_storage(
+    embedding_contents: list[str] | None,
+    expected_embedding_contents: list[str],
+) -> None:
     vec_db = FaissVecDB.__new__(FaissVecDB)
     vec_db.embedding_provider = AsyncMock()
     vec_db.embedding_provider.get_embeddings_batch.return_value = [
@@ -83,11 +96,11 @@ async def test_insert_batch_embeds_context_but_stores_original_contents() -> Non
         contents=["chunk one", "chunk two"],
         metadatas=[{}, {}],
         ids=["doc-1", "doc-2"],
-        embedding_contents=["guide\n\nchunk one", "guide\n\nchunk two"],
+        embedding_contents=embedding_contents,
     )
 
     vec_db.embedding_provider.get_embeddings_batch.assert_awaited_once_with(
-        ["guide\n\nchunk one", "guide\n\nchunk two"],
+        expected_embedding_contents,
         batch_size=32,
         tasks_limit=3,
         max_retries=3,
@@ -98,6 +111,31 @@ async def test_insert_batch_embeds_context_but_stores_original_contents() -> Non
         ["chunk one", "chunk two"],
         [{}, {}],
     )
+
+
+@pytest.mark.asyncio
+async def test_insert_batch_rejects_embedding_content_count_mismatch() -> None:
+    vec_db = FaissVecDB.__new__(FaissVecDB)
+    vec_db.embedding_provider = AsyncMock()
+    vec_db.document_storage = AsyncMock()
+    vec_db.embedding_storage = AsyncMock()
+
+    with pytest.raises(KnowledgeBaseUploadError) as exc_info:
+        await FaissVecDB.insert_batch(
+            vec_db,
+            contents=["chunk one", "chunk two"],
+            metadatas=[{}, {}],
+            ids=["doc-1", "doc-2"],
+            embedding_contents=["guide\n\nchunk one"],
+        )
+
+    assert exc_info.value.stage == "storage"
+    assert exc_info.value.details == {
+        "expected_contents": 2,
+        "actual_embedding_contents": 1,
+    }
+    vec_db.embedding_provider.get_embeddings_batch.assert_not_awaited()
+    vec_db.document_storage.insert_documents_batch.assert_not_awaited()
 
 
 def test_embedding_storage_rejects_zero_dimension_for_a_fresh_index(tmp_path) -> None:

--- a/tests/unit/test_kb_upload_atomicity.py
+++ b/tests/unit/test_kb_upload_atomicity.py
@@ -384,6 +384,14 @@ async def test_upload_document_cleans_up_on_metadata_failure(
 
     assert exc_info.value.stage == "metadata"
     helper.vec_db.insert_batch.assert_awaited_once()
+    assert helper.vec_db.insert_batch.await_args.kwargs["contents"] == [
+        "chunk a",
+        "chunk b",
+    ]
+    assert helper.vec_db.insert_batch.await_args.kwargs["embedding_contents"] == [
+        "demo\n\nchunk a",
+        "demo\n\nchunk b",
+    ]
     helper.vec_db.delete_documents.assert_awaited()
 
 

--- a/tests/unit/test_kb_upload_atomicity.py
+++ b/tests/unit/test_kb_upload_atomicity.py
@@ -350,6 +350,76 @@ async def test_upload_document_cleans_up_on_storage_failure(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("file_name", "file_type"),
+    [
+        ("guide.docx", "docx"),
+        ("guide.xlsx", "xlsx"),
+        ("guide.xls", "xls"),
+        ("guide.rst", "rst"),
+        ("guide.adoc", "adoc"),
+        ("guide.epub", "epub"),
+    ],
+)
+async def test_upload_document_preserves_markdown_heading_paths(
+    file_name: str,
+    file_type: str,
+    tmp_path: Path,
+    stub_provider_manager_module,
+) -> None:
+    """Structured parser output should retain parent headings in embeddings."""
+    KBHelper = _import_kb_helper()
+
+    helper = KBHelper.__new__(KBHelper)
+    helper.kb = KnowledgeBase(
+        kb_name="Test KB",
+        description="",
+        embedding_provider_id="emb",
+    )
+    helper.kb_db = MagicMock()
+    helper.kb_db.get_db = _failing_get_db()
+    helper.vec_db = AsyncMock()
+    helper.vec_db.insert_batch.side_effect = RuntimeError("stop after chunking")
+    helper.vec_db.delete_documents = AsyncMock()
+    helper.kb_medias_dir = tmp_path / "medias"
+    helper.chunker = AsyncMock()
+
+    parse_result = MagicMock(
+        text=(
+            "# Handbook\n\nOverview.\n\n"
+            "## Installation\n\nInstall the package.\n\n"
+            "### Linux\n\nRun the command."
+        ),
+        media=[],
+    )
+
+    with (
+        patch(
+            "astrbot.core.knowledge_base.kb_helper.select_parser",
+            new=AsyncMock(
+                return_value=MagicMock(parse=AsyncMock(return_value=parse_result)),
+            ),
+        ),
+        patch.object(helper, "_ensure_vec_db", new=AsyncMock()),
+        pytest.raises(KnowledgeBaseUploadError) as exc_info,
+    ):
+        await helper.upload_document(
+            file_name=file_name,
+            file_content=b"structured document",
+            file_type=file_type,
+        )
+
+    assert exc_info.value.stage == "storage"
+    helper.chunker.chunk.assert_not_awaited()
+    contents = helper.vec_db.insert_batch.await_args.kwargs["contents"]
+    embedding_contents = helper.vec_db.insert_batch.await_args.kwargs[
+        "embedding_contents"
+    ]
+    assert "Handbook > Installation\n\n### Linux" in contents[2]
+    assert embedding_contents[2] == f"guide\n\n{contents[2]}"
+
+
+@pytest.mark.asyncio
 async def test_upload_document_cleans_up_on_metadata_failure(
     stub_provider_manager_module,
 ) -> None:


### PR DESCRIPTION
Short knowledge base chunks often lose the document and section context needed to match user queries. This PR enriches embedding inputs with the document title and preserves heading paths for formats that are parsed into Markdown, while keeping vector storage and returned chunk behavior compatible.

### Modifications / 改动点

- Allow vector insertion to use enriched embedding text separately from stored chunk text.
- Prefix chunk embedding inputs with the source document title.
- Apply the existing structure-aware Markdown chunker to DOCX, XLS/XLSX, RST, AsciiDoc, and EPUB parser output.
- Preserve parent heading paths such as `Handbook > Installation` for nested sections.
- Keep plain-text fallback behavior when parsed output contains no headings.
- Do not add adjacent passage text: the held-out experiment showed a substantial regression.
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

#### Document title experiment

- Public dataset: MIRACL Chinese development split
- Corpus revision: `d921ec7e349ce0d28daf30b2da9da5ee698bef0d`
- Fixed split seed: `astrbot-kb-context-v1`
- Corpus: 50,000 passages
- Queries: 196 development / 197 held-out test
- Embedding model: `baai/bge-m3`

Held-out fusion metrics:

| Embedding input | Recall@5 | HitRate@5 | nDCG@5 |
| --- | ---: | ---: | ---: |
| Passage body | 0.9419 | 0.9898 | 0.9284 |
| Document title + passage body | **0.9594** | **1.0000** | **0.9600** |

#### Heading path and adjacent context experiment

To recover real heading paths, MIRACL passages were joined with public Chinese Wikipedia revisions. The candidate set contained all 22,230 passages from the 783 relevant articles, with 393 queries and 994 positive labels. This experiment is a separate corpus and its absolute scores are not directly comparable to the title experiment.

Held-out fusion metrics:

| Embedding input | Recall@5 | HitRate@5 | nDCG@5 |
| --- | ---: | ---: | ---: |
| Document title + passage | 0.7320 | 0.9086 | 0.7445 |
| Document title + heading path + passage | **0.7489** | **0.9239** | **0.7623** |
| Heading path + previous/next 128 characters | 0.4548 | 0.7107 | 0.4569 |

The heading-only variant was selected on the development split and improved every held-out top-five metric. Adjacent context diluted the target passage and was intentionally excluded. Benchmark datasets and generated results remain local and are not included in this PR.

Verification steps:

```bash
uv run pytest -q tests/unit/test_faiss_vec_db.py tests/unit/test_kb_manager_resilience.py tests/unit/test_kb_upload_atomicity.py tests/unit/test_kb_document_cleanup.py tests/unit/test_knowledge_base_service_contract.py tests/test_epub_parser.py
uv run ruff format --check .
uv run ruff check .
```

Results:

- 53 tests passed.
- All 483 Python files passed Ruff formatting checks.
- Ruff lint checks passed.

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。
- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。
- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Enrich knowledge base embeddings with document and section context while keeping stored chunks unchanged and maintaining upload atomicity guarantees.

New Features:
- Support passing separate enriched embedding texts alongside stored chunk contents when inserting batches into the vector database.
- Prefix chunk embedding inputs with the source document title to improve retrieval quality.
- Apply the structure-aware Markdown chunker to additional structured formats including DOCX, XLS/XLSX, RST, AsciiDoc, and EPUB to preserve heading hierarchies in chunks.

Bug Fixes:
- Ensure heading paths from structured parser output are preserved in uploaded document chunks and their corresponding embeddings.
- Validate that the number of embedding texts matches the number of content chunks, raising a user-friendly error on mismatch to avoid inconsistent storage.

Tests:
- Add unit tests verifying that upload_document uses MarkdownChunker for structured formats and preserves heading paths and document titles in embedding contents.
- Add a unit test ensuring FaissVecDB embeds using enriched texts but stores the original chunk contents unchanged.

