### PR TITLE
fix: re-apply llm tool inactivation state after plugin initialize()

### DIFF
--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -1417,6 +1417,14 @@ class PluginManager:
                 if hasattr(metadata.star_cls, "initialize") and metadata.star_cls:
                     await metadata.star_cls.initialize()
 
+                # 在 initialize() 之后重新应用工具失活状态，以便捕获
+                # 在 initialize() 内通过 add_llm_tools() 注册的工具。
+                if metadata.module_path:
+                    for ft in llm_tools.func_list:
+                        if self._is_plugin_llm_tool(ft, metadata.module_path):
+                            if ft.name in inactivated_llm_tools:
+                                ft.active = False
+
                 # 触发插件加载事件
                 handlers = star_handlers_registry.get_handlers_by_event_type(
                     EventType.OnPluginLoadedEvent,


### PR DESCRIPTION
fix: re-apply llm tool inactivation state after plugin initialize() to prevent tools registered via add_llm_tools() from being auto-enabled on reload

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
**Background**

When a plugin registers its LLM function-calling tools via `context.add_llm_tools()` inside its `initialize()` method (e.g., `FunctionTool` subclass pattern), and a user disables one of those tools through the management panel, the tool's name is recorded in the `inactivated_llm_tools` list in persistent storage. However, upon reloading that specific plugin (single-plugin reload), the framework's existing inactivation logic — which runs *before* `initialize()` — fails to catch these tools because they haven't been added to `llm_tools.func_list` yet. Consequently, the newly registered tools start with `active=True` and become re-enabled automatically, ignoring the user's previous choice.

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
A new post-initialize inactivation re-application is added immediately after the `initialize()` call, inside the per-plugin loading loop. It iterates `llm_tools.func_list`, checks whether each tool belongs to the current plugin (`_is_plugin_llm_tool`), and sets `ft.active = False` if the tool's name is in `inactivated_llm_tools`. This runs for every plugin regardless of reload type (single or full), closing the gap.

- **Modified file**: `astrbot/core/star/star_manager.py` (+8 lines)
- **Location**: After `await metadata.star_cls.initialize()` (line ~1418), before the `OnPluginLoadedEvent` trigger

```python
if metadata.module_path:
    for ft in llm_tools.func_list:
        if self._is_plugin_llm_tool(ft, metadata.module_path):
            if ft.name in inactivated_llm_tools:
                ft.active = False
```
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Prevent LLM tools registered during plugin initialize() from being re-enabled on plugin reload when users have previously inactivated them.