### PR TITLE
refactor: rename LLMResponse.to_openai_to_calls_model to to_openai_tool_calls_model

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -950,7 +950,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 parts = None
             tool_calls_result = ToolCallsResult(
                 tool_calls_info=AssistantMessageSegment(
-                    tool_calls=llm_resp.to_openai_to_calls_model(),
+                    tool_calls=llm_resp.to_openai_tool_calls_model(),
                     content=parts,
                 ),
                 tool_calls_result=tool_call_result_blocks,

--- a/astrbot/core/provider/entities.py
+++ b/astrbot/core/provider/entities.py
@@ -401,9 +401,9 @@ class LLMResponse:
         else:
             self._completion_text = value
 
-    @deprecated(reason="Use to_openai_to_calls_model instead.")
+    @deprecated(reason="Use to_openai_tool_calls_model instead.")
     def to_openai_tool_calls(self) -> list[dict]:
-        """Convert to OpenAI tool calls format. Deprecated, use to_openai_to_calls_model instead."""
+        """Convert to OpenAI tool calls format. Deprecated, use to_openai_tool_calls_model instead."""
         ret = []
         for idx, tool_call_arg in enumerate(self.tools_call_args):
             payload = {
@@ -421,7 +421,7 @@ class LLMResponse:
             ret.append(payload)
         return ret
 
-    def to_openai_to_calls_model(self) -> list[ToolCall]:
+    def to_openai_tool_calls_model(self) -> list[ToolCall]:
         """The same as to_openai_tool_calls but return pydantic model."""
         ret = []
         for idx, tool_call_arg in enumerate(self.tools_call_args):
@@ -439,6 +439,11 @@ class LLMResponse:
                 ),
             )
         return ret
+
+    @deprecated(reason="Use to_openai_tool_calls_model instead.")
+    def to_openai_to_calls_model(self) -> list[ToolCall]:
+        """Deprecated alias of to_openai_tool_calls_model (legacy misspelled name)."""
+        return self.to_openai_tool_calls_model()
 
 
 @dataclass


### PR DESCRIPTION
The method name was misspelled since its introduction in #3234 ('to_calls' instead of 'tool_calls'); the correctly spelled name has never existed in the codebase.

- Rename the method to to_openai_tool_calls_model
- Keep the old name as a @deprecated alias for backward compatibility (ProviderResult/LLMResponse is part of the plugin-facing API surface)
- Update the only internal caller (tool_loop_agent_runner.py)
- Point the to_openai_tool_calls deprecation reason at the new name

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
<img width="613" height="102" alt="image" src="https://github.com/user-attachments/assets/f9392ca5-5120-449d-9128-2a33fd1dcedd" />


---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Rename the LLMResponse OpenAI tool-call conversion method to a correctly spelled name while preserving backward compatibility.

Enhancements:
- Add a deprecated alias for the legacy misspelled method name to maintain plugin-facing API compatibility.
- Update the internal tool loop agent runner to use the new to_openai_tool_calls_model method name.
- Fix deprecation messages and docstrings to point to the new method name.