### PR TITLE
docs: clarify desktop launcher and app positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,17 +105,17 @@ For users familiar with containers and looking for a more stable, production-rea
 
 Please refer to the official documentation: [Deploy AstrBot with Docker](https://docs.astrbot.app/deploy/astrbot/docker.html#%E4%BD%BF%E7%94%A8-docker-%E9%83%A8%E7%BD%B2-astrbot).
 
-### Desktop Application Deployment
+### Desktop Launcher
 
-For users who want to use AstrBot on desktop and mainly use ChatUI, we recommend AstrBot App.
+For users who want the standard AstrBot experience on their computer, we recommend AstrBot Desktop Launcher (formerly AstrBot Launcher). It supports quick setup and isolated multiple instances while preserving the standard AstrBot experience.
 
-Visit [AstrBot-desktop](https://github.com/AstrBotDevs/AstrBot-desktop) to download and install; this method is designed for desktop usage and is not recommended for server scenarios.
+Visit [AstrBot Desktop Launcher](https://github.com/Raven95676/astrbot-launcher) to download and install.
 
-### Launcher Deployment
+### AstrBot App
 
-For desktop users who also want fast deployment and isolated multi-instance usage, we recommend AstrBot Launcher.
+AstrBot App is an independent desktop product for exploring new interactions and capabilities beyond AstrBot's current feature set. Its experience may evolve with these explorations rather than strictly reproducing the standard AstrBot experience.
 
-Visit [AstrBot Launcher](https://github.com/Raven95676/astrbot-launcher) to download and install.
+To use AstrBot as-is on desktop, choose AstrBot Desktop Launcher above. To try these new directions, visit [AstrBot App](https://github.com/AstrBotDevs/AstrBot-desktop) to download and install.
 
 ### Deploy on Replit
 

--- a/README_es.md
+++ b/README_es.md
@@ -110,17 +110,17 @@ Para usuarios que desean un despliegue en un clic y no quieren administrar servi
 
 [![Desplegar en RainYun](https://rainyun-apps.cn-nb1.rains3.com/materials/deploy-on-rainyun-en.svg)](https://app.rainyun.com/apps/rca/store/5994?ref=NjU1ODg0)
 
-### Despliegue como aplicación de escritorio
+### Launcher de escritorio
 
-Para usuarios que quieran usar AstrBot en el escritorio y principalmente usen ChatUI, recomendamos AstrBot App.
+Para quienes quieran usar AstrBot tal cual en su equipo, recomendamos AstrBot Desktop Launcher (antes AstrBot Launcher). Mantiene la experiencia estándar de AstrBot y permite una instalación rápida, entornos aislados y varias instancias.
 
-Visita [AstrBot-desktop](https://github.com/AstrBotDevs/AstrBot-desktop) para descargar e instalar; este método está diseñado para uso en escritorio y no se recomienda para escenarios de servidor.
+Visita [AstrBot Desktop Launcher](https://github.com/Raven95676/astrbot-launcher) para descargarlo e instalarlo.
 
-### Despliegue con Launcher
+### AstrBot App
 
-Para usuarios de escritorio que también desean un despliegue rápido y uso aislado de múltiples instancias, recomendamos AstrBot Launcher.
+AstrBot App es un producto de escritorio independiente para explorar nuevas interacciones y funciones más allá de las capacidades actuales de AstrBot. Su experiencia puede evolucionar con estas exploraciones, en lugar de reproducir estrictamente la experiencia estándar de AstrBot.
 
-Visita [AstrBot Launcher](https://github.com/Raven95676/astrbot-launcher) para descargar e instalar.
+Para usar AstrBot tal cual, elige AstrBot Desktop Launcher arriba. Para probar estas nuevas ideas, visita [AstrBot App](https://github.com/AstrBotDevs/AstrBot-desktop) para descargarlo e instalarlo.
 
 ### Desplegar en Replit
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -109,17 +109,17 @@ Pour les utilisateurs qui souhaitent déployer AstrBot en un clic sans gérer le
 
 [![Deploy on RainYun](https://rainyun-apps.cn-nb1.rains3.com/materials/deploy-on-rainyun-en.svg)](https://app.rainyun.com/apps/rca/store/5994?ref=NjU1ODg0)
 
-### Déploiement de l'application de bureau
+### Lanceur de bureau
 
-Pour les utilisateurs qui veulent utiliser AstrBot sur desktop et passer principalement par ChatUI, nous recommandons AstrBot App.
+Pour utiliser AstrBot tel quel sur un ordinateur, nous recommandons AstrBot Desktop Launcher (anciennement AstrBot Launcher). Il conserve l'expérience AstrBot standard tout en facilitant l'installation, l'isolation des environnements et l'exécution de plusieurs instances.
 
-Accédez à [AstrBot-desktop](https://github.com/AstrBotDevs/AstrBot-desktop) pour télécharger et installer l'application ; cette méthode est conçue pour un usage desktop et n'est pas recommandée pour les scénarios serveur.
+Accédez à [AstrBot Desktop Launcher](https://github.com/Raven95676/astrbot-launcher) pour le télécharger et l'installer.
 
-### Déploiement avec le lanceur
+### AstrBot App
 
-Également sur desktop, pour les utilisateurs qui souhaitent un déploiement rapide avec isolation d'environnement et multi-instances, nous recommandons AstrBot Launcher.
+AstrBot App est un produit de bureau indépendant conçu pour explorer de nouvelles interactions et fonctionnalités au-delà des capacités actuelles d'AstrBot. Son expérience peut évoluer avec ces explorations plutôt que de reproduire strictement l'expérience AstrBot standard.
 
-Accédez à [AstrBot Launcher](https://github.com/Raven95676/astrbot-launcher) pour télécharger et installer.
+Pour utiliser AstrBot tel quel, choisissez AstrBot Desktop Launcher ci-dessus. Pour essayer ces nouvelles orientations, accédez à [AstrBot App](https://github.com/AstrBotDevs/AstrBot-desktop) afin de le télécharger et de l'installer.
 
 ### Déployer sur Replit
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -109,17 +109,17 @@ AstrBot をワンクリックでデプロイしたく、サーバーを自分で
 
 [![Deploy on RainYun](https://rainyun-apps.cn-nb1.rains3.com/materials/deploy-on-rainyun-en.svg)](https://app.rainyun.com/apps/rca/store/5994?ref=NjU1ODg0)
 
-### デスクトップアプリのデプロイ
+### デスクトップランチャー
 
-デスクトップで AstrBot を使い、主に ChatUI を入口として利用するユーザーには、AstrBot App をおすすめします。
+パソコンで AstrBot をそのまま使いたいユーザーには、AstrBot デスクトップランチャー（旧 AstrBot Launcher）をおすすめします。標準の AstrBot 体験を保ちながら、素早いセットアップ、環境の分離、多重起動に対応します。
 
-[AstrBot-desktop](https://github.com/AstrBotDevs/AstrBot-desktop) からダウンロードしてインストールしてください。この方式はデスクトップ向けであり、サーバー用途には推奨されません。
+[AstrBot デスクトップランチャー](https://github.com/Raven95676/astrbot-launcher) からダウンロードしてインストールしてください。
 
-### ランチャーのデプロイ
+### AstrBot App
 
-同じくデスクトップで、素早くデプロイしつつ環境を分離して多重起動したいユーザーには、AstrBot Launcher をおすすめします。
+AstrBot App は、AstrBot の現在の機能を超える新しい操作方法や機能を探るための独立したデスクトップアプリです。標準の AstrBot 体験をそのまま再現することだけを目的とせず、探索に合わせて体験も進化していきます。
 
-[AstrBot Launcher](https://github.com/Raven95676/astrbot-launcher) からダウンロードしてインストールしてください。
+AstrBot をそのまま使いたい場合は、上記の AstrBot デスクトップランチャーを選んでください。新しい方向性を試す場合は、[AstrBot App](https://github.com/AstrBotDevs/AstrBot-desktop) からダウンロードしてインストールしてください。
 
 ### Replit でのデプロイ
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -109,17 +109,17 @@ uv tool upgrade astrbot --python 3.12
 
 [![Deploy on RainYun](https://rainyun-apps.cn-nb1.rains3.com/materials/deploy-on-rainyun-en.svg)](https://app.rainyun.com/apps/rca/store/5994?ref=NjU1ODg0)
 
-### Развёртывание десктопного приложения
+### Десктопный лаунчер
 
-Для пользователей, которые хотят использовать AstrBot на десктопе и в основном работают через ChatUI, мы рекомендуем AstrBot App.
+Тем, кто хочет использовать AstrBot на компьютере в его исходном виде, мы рекомендуем AstrBot Desktop Launcher (ранее AstrBot Launcher). Он сохраняет стандартный опыт AstrBot и поддерживает быструю установку, изоляцию окружений и несколько экземпляров.
 
-Перейдите в [AstrBot-desktop](https://github.com/AstrBotDevs/AstrBot-desktop), скачайте и установите приложение; этот вариант предназначен для десктопа и не рекомендуется для серверных сценариев.
+Перейдите в [AstrBot Desktop Launcher](https://github.com/Raven95676/astrbot-launcher), чтобы скачать и установить его.
 
-### Развёртывание через лаунчер
+### AstrBot App
 
-Также на десктопе, для пользователей, которым нужен быстрый запуск и мультиинстанс с изоляцией окружений, мы рекомендуем AstrBot Launcher.
+AstrBot App — самостоятельный настольный продукт для экспериментов с новыми способами взаимодействия и возможностями за пределами текущего набора функций AstrBot. По мере этих экспериментов его интерфейс и возможности могут развиваться, а не строго повторять стандартный AstrBot.
 
-Перейдите в [AstrBot Launcher](https://github.com/Raven95676/astrbot-launcher), чтобы скачать и установить.
+Чтобы использовать AstrBot в исходном виде, выберите AstrBot Desktop Launcher выше. Чтобы попробовать новые направления, перейдите в [AstrBot App](https://github.com/AstrBotDevs/AstrBot-desktop), скачайте и установите приложение.
 
 ### Развёртывание на Replit
 

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -109,17 +109,17 @@ uv tool upgrade astrbot --python 3.12
 
 [![Deploy on RainYun](https://rainyun-apps.cn-nb1.rains3.com/materials/deploy-on-rainyun-en.svg)](https://app.rainyun.com/apps/rca/store/5994?ref=NjU1ODg0)
 
-### 桌面客戶端部署
+### 桌面啟動器
 
-對於希望在桌面端使用 AstrBot、並以 ChatUI 為主要入口的使用者，我們推薦使用 AstrBot App。
+對於希望在電腦上原樣使用 AstrBot 的使用者，我們推薦使用 AstrBot 桌面啟動器（原 AstrBot Launcher）。它提供標準的 AstrBot 使用體驗，並支援快速部署、環境隔離與多開。
 
-前往 [AstrBot-desktop](https://github.com/AstrBotDevs/AstrBot-desktop) 下載並安裝；此方式面向桌面使用，不建議伺服器場景。
+前往 [AstrBot 桌面啟動器](https://github.com/Raven95676/astrbot-launcher) 下載並安裝。
 
-### 啟動器部署
+### AstrBot App
 
-同樣在桌面端，對於希望快速部署並實現環境隔離多開的使用者，我們推薦使用 AstrBot Launcher。
+AstrBot App 是面向桌面場景的獨立應用程式，用於探索 AstrBot 現有能力之外的新互動與新功能。它的體驗可能隨著這些探索持續演進，不以重現標準 AstrBot 體驗為唯一目標。
 
-前往 [AstrBot Launcher](https://github.com/Raven95676/astrbot-launcher) 下載並安裝。
+如果你希望原樣使用 AstrBot，請選擇上方的 AstrBot 桌面啟動器。想體驗這些探索方向，可前往 [AstrBot App](https://github.com/AstrBotDevs/AstrBot-desktop) 下載並安裝。
 
 ### 在 Replit 上部署
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -109,17 +109,17 @@ uv tool upgrade astrbot --python 3.12
 
 [![Deploy on RainYun](https://rainyun-apps.cn-nb1.rains3.com/materials/deploy-on-rainyun-en.svg)](https://app.rainyun.com/apps/rca/store/5994?ref=NjU1ODg0)
 
-### 桌面客户端部署
+### 桌面启动器
 
-对于希望在桌面端使用 AstrBot、并以 ChatUI 为主要入口的用户，我们推荐使用 AstrBot App。
+对于希望在电脑上原样使用 AstrBot 的用户，我们推荐使用 AstrBot 桌面启动器（原 AstrBot Launcher）。它提供标准的 AstrBot 使用体验，并支持快速部署、环境隔离和多开。
 
-前往 [AstrBot-desktop](https://github.com/AstrBotDevs/AstrBot-desktop) 下载并安装；该方式面向桌面使用，不推荐服务器场景。
+前往 [AstrBot 桌面启动器](https://github.com/Raven95676/astrbot-launcher) 下载并安装。
 
-### 启动器部署
+### AstrBot App
 
-同样在桌面端，希望快速部署并实现环境隔离多开的用户，我们推荐使用 AstrBot Launcher。
+AstrBot App 是面向桌面场景的独立应用，用于探索 AstrBot 现有能力之外的新交互和新功能。它的体验可能随着这些探索不断演进，不以复刻标准 AstrBot 体验为唯一目标。
 
-前往 [AstrBot Launcher](https://github.com/Raven95676/astrbot-launcher) 下载并安装。
+如果你希望原样使用 AstrBot，请选择上方的 AstrBot 桌面启动器。想体验这些探索方向，可前往 [AstrBot App](https://github.com/AstrBotDevs/AstrBot-desktop) 下载并安装。
 
 ### 在 Replit 上部署
 

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -45,8 +45,8 @@ export default defineConfig({
             items: [
               { text: "包管理器部署", link: "/astrbot/package" },
               { text: "雨云一键云部署", link: "/astrbot/rainyun" },
-              { text: "桌面客户端部署", link: "/astrbot/desktop" },
-              { text: "启动器一键部署", link: "/astrbot/launcher" },
+              { text: "桌面启动器", link: "/astrbot/launcher" },
+              { text: "AstrBot App", link: "/astrbot/desktop" },
               { text: "Docker 部署", link: "/astrbot/docker" },
               { text: "Kubernetes 部署", link: "/astrbot/kubernetes" },
               { text: "宝塔面板部署", link: "/astrbot/btpanel" },
@@ -298,8 +298,8 @@ export default defineConfig({
             collapsed: false,
             items: [
               { text: "Package Manager", link: "/astrbot/package" },
-              { text: "Desktop Client", link: "/astrbot/desktop" },
-              { text: "One-click Launcher", link: "/astrbot/launcher" },
+              { text: "Desktop Launcher", link: "/astrbot/launcher" },
+              { text: "AstrBot App", link: "/astrbot/desktop" },
               { text: "Docker", link: "/astrbot/docker" },
               { text: "Kubernetes", link: "/astrbot/kubernetes" },
               { text: "BT Panel", link: "/astrbot/btpanel" },

--- a/docs/en/deploy/astrbot/desktop.md
+++ b/docs/en/deploy/astrbot/desktop.md
@@ -1,33 +1,31 @@
-# Deploy with AstrBot Desktop Client
+# AstrBot App
 
-`AstrBot-desktop` is designed for quick local deployment of AstrBot on your personal computer, supporting Windows, macOS, and Linux.
+`AstrBot-desktop` is an independent desktop product for Windows, macOS, and Linux. It explores new interactions and capabilities beyond AstrBot's current feature set rather than strictly reproducing the standard AstrBot experience. Its experience may evolve with these explorations.
 
-Among the various deployment options, the desktop client is best suited for personal local use. It is not recommended for long-term server operation or production environments. For production deployments, consider [Docker](/en/deploy/astrbot/docker) or [Kubernetes](/en/deploy/astrbot/kubernetes) instead.
-
-Compared to command-line or container-based solutions, the desktop client offers an out-of-the-box experience, ideal for users who want to get started without dealing with environment setup.
+To use AstrBot as-is on your computer, choose [AstrBot Desktop Launcher](/en/deploy/astrbot/launcher). For long-running servers or production deployments, use [Docker](/en/deploy/astrbot/docker) or [Kubernetes](/en/deploy/astrbot/kubernetes).
 
 Repository: [AstrBotDevs/AstrBot-desktop](https://github.com/AstrBotDevs/AstrBot-desktop)
 
 ## Who Is It For
 
-- Users who want quick local deployment with a graphical interface.
-- Beginners who don't want to manually manage Docker / Python environments.
-- Personal devices that stay online, primarily for individual or small team daily use.
+- Users who want to try new features and interactions beyond AstrBot's current capabilities.
+- Users who primarily use ChatUI and want a more integrated desktop application experience.
+- Users comfortable with an evolving product that may differ from standard AstrBot.
 
 ## Key Features
 
 - Multi-platform installers, ready to use after download.
-- GUI-based configuration, lowering the barrier for first-time deployment.
-- Suitable as a locally resident client.
+- An integrated graphical interface designed for desktop use.
+- A place for product experiments beyond AstrBot's current feature boundaries.
 
 ## Download and Install
 
 1. Open [AstrBot-desktop Releases](https://github.com/AstrBotDevs/AstrBot-desktop/releases).
 2. Download the installer for your operating system (e.g. `.exe`, `.dmg`, `.rpm`, `.deb`).
-3. Launch the desktop client after installation and follow the setup wizard to complete initialization.
+3. Launch AstrBot App after installation and follow the setup wizard to complete initialization.
 
-## Difference from Launcher Deployment
+## Difference from AstrBot Desktop Launcher
 
-- Desktop client: focuses on an out-of-the-box GUI experience.
-- Launcher deployment: focuses on automated script-based startup, suitable for users who prefer a traditional deployment workflow.
-- See [Launcher Deployment](/en/deploy/astrbot/launcher).
+- AstrBot Desktop Launcher provides the standard AstrBot experience on your computer.
+- AstrBot App explores interactions and capabilities beyond AstrBot's current feature set, so its experience may differ from standard AstrBot.
+- If you simply want to use the original AstrBot experience on your computer, choose [AstrBot Desktop Launcher](/en/deploy/astrbot/launcher).

--- a/docs/en/deploy/astrbot/launcher.md
+++ b/docs/en/deploy/astrbot/launcher.md
@@ -1,8 +1,10 @@
-# Deploy AstrBot with AstrBot Launcher
+# Deploy AstrBot with AstrBot Desktop Launcher
 
-## Recommended Method 1: AstrBot One-Click Launcher
+AstrBot Desktop Launcher (formerly AstrBot Launcher) is the standard desktop entry point for users who want to run AstrBot as-is on a personal computer. It also supports isolated environments and multiple instances.
 
-AstrBot One-Click Launcher supports Windows, macOS, and Linux.
+## Install AstrBot Desktop Launcher
+
+AstrBot Desktop Launcher supports Windows, macOS, and Linux.
 
 0. Open [AstrBotDevs/astrbot-launcher](https://github.com/AstrBotDevs/astrbot-launcher)
 1. **Optional but recommended**: give this project a [**Star ⭐**](https://github.com/AstrBotDevs/astrbot-launcher). Your support helps maintainers keep improving it.
@@ -19,11 +21,11 @@ For macOS users, if you see "damaged and can't be opened", it is caused by macOS
 1. Open Terminal.
 2. Run:
    `xattr -dr com.apple.quarantine /Applications/AstrBot\ Launcher.app`
-3. Reopen AstrBot Launcher.
+3. Reopen AstrBot Desktop Launcher.
 
 ## Method 2: Legacy Windows Installer
 
-We still recommend the One-Click Launcher above because it is simpler, more automated, and better for most users.
+We still recommend AstrBot Desktop Launcher above because it is simpler, more automated, and better for most users.
 
 The legacy installer is a `PowerShell` script, very small (<20KB). It requires `PowerShell` (usually built in on `Windows 10` and newer).
 

--- a/docs/en/others/diagnostics.md
+++ b/docs/en/others/diagnostics.md
@@ -72,7 +72,7 @@ When reading this file, focus on the top frames. Useful clues often include plug
 When filing an issue, include as much of the following as possible:
 
 - Approximate time of the incident and timezone.
-- AstrBot version, deployment method (Docker, manual deployment, desktop client, etc.), and operating system.
+- AstrBot version, deployment method (Docker, manual deployment, AstrBot Desktop Launcher, AstrBot App, etc.), and operating system.
 - Trigger path: startup, normal chat, group chat, platform callback, scheduled task, MCP tool, plugin feature, etc.
 - Scope: all sessions, one platform, one group, one user, or one plugin.
 - Logs from `data/logs/astrbot.log` for 1 to 3 minutes around the incident.

--- a/docs/zh/deploy/astrbot/desktop.md
+++ b/docs/zh/deploy/astrbot/desktop.md
@@ -1,33 +1,31 @@
-# 使用 AstrBot 桌面客户端部署
+# AstrBot App
 
-`AstrBot-desktop` 适合在本地电脑快速部署和使用 AstrBot，支持 Windows、macOS、Linux。
+`AstrBot-desktop` 是面向桌面场景的独立应用，支持 Windows、macOS 和 Linux。它用于探索 AstrBot 现有能力之外的新交互和新功能，不以复刻标准 AstrBot 体验为唯一目标，具体体验可能随着这些探索不断演进。
 
-在多种部署方式中，桌面客户端更适合个人本地快速使用，不建议用于服务器长期运行或生产环境；如需生产部署，建议优先考虑 [Docker 部署](/deploy/astrbot/docker) 或 [Kubernetes 部署](/deploy/astrbot/kubernetes)。
-
-相比命令行或容器方案，桌面客户端更偏向「开箱即用」体验，适合希望少折腾环境、直接开始使用的用户。
+如果你希望在电脑上原样使用 AstrBot，请选择 [AstrBot 桌面启动器](/deploy/astrbot/launcher)。如需服务器长期运行或生产部署，建议使用 [Docker 部署](/deploy/astrbot/docker) 或 [Kubernetes 部署](/deploy/astrbot/kubernetes)。
 
 仓库地址：[AstrBotDevs/AstrBot-desktop](https://github.com/AstrBotDevs/AstrBot-desktop)
 
 ## 适合谁
 
-- 想快速本地部署，优先使用图形化界面的用户。
-- 不想手动维护 Docker / Python 运行环境的新手用户。
-- 个人设备长期在线，主要用于个人或小团队日常使用的场景。
+- 想体验 AstrBot 现有能力之外的新功能和新交互的用户。
+- 以 ChatUI 为主要入口，希望尝试更完整桌面应用体验的用户。
+- 接受产品持续探索、体验可能与标准 AstrBot 不同的用户。
 
 ## 主要特点
 
 - 多平台安装包，下载后可直接安装使用。
-- 图形化界面配置，降低首次部署成本。
-- 适合作为本地常驻客户端。
+- 面向桌面场景的一体化图形界面。
+- 承载超越 AstrBot 现有功能边界的产品尝试。
 
 ## 下载并安装
 
 1. 打开 [AstrBot-desktop Releases](https://github.com/AstrBotDevs/AstrBot-desktop/releases)。
 2. 下载与你系统对应的安装包（如 `.exe`、`.dmg`、`.rpm`、`.deb`）。
-3. 安装完成后启动桌面客户端，按向导完成初始化。
+3. 安装完成后启动 AstrBot App，按向导完成初始化。
 
-## 与启动器部署的区别
+## 与 AstrBot 桌面启动器的区别
 
-- 桌面客户端：更偏向开箱即用的 GUI 体验。
-- 启动器部署：更偏向自动化脚本拉起，适合希望保持传统部署流程的用户。
-- 参考 [启动器部署](/deploy/astrbot/launcher)。
+- AstrBot 桌面启动器：在电脑上提供原样的标准 AstrBot 体验。
+- AstrBot App：探索 AstrBot 现有能力之外的新交互和新功能，体验可能与标准 AstrBot 不同。
+- 如果你只是想在电脑上使用原版 AstrBot，请选择 [AstrBot 桌面启动器](/deploy/astrbot/launcher)。

--- a/docs/zh/deploy/astrbot/launcher.md
+++ b/docs/zh/deploy/astrbot/launcher.md
@@ -1,8 +1,10 @@
-# 使用 AstrBot 启动器部署 AstrBot
+# 使用 AstrBot 桌面启动器部署 AstrBot
 
-## AstrBot 一键启动器
+AstrBot 桌面启动器（原 AstrBot Launcher）面向希望在个人电脑上原样使用 AstrBot 的用户，是标准 AstrBot 体验的桌面入口，并支持环境隔离和多开。
 
-AstrBot 一键启动器支持 Windows、MacOS、Linux 等多端部署。
+## 安装 AstrBot 桌面启动器
+
+AstrBot 桌面启动器支持 Windows、macOS、Linux。
 
 0. 打开 [AstrBotDevs/astrbot-launcher](https://github.com/AstrBotDevs/astrbot-launcher)
 1.  **(可选但推荐)** 给本项目点个 [**Star ⭐**](https://github.com/AstrBotDevs/astrbot-launcher)，你的支持是作者更新和维护的动力！
@@ -15,7 +17,7 @@ MacOS 用户下载安装好后，可能会遇到 "已损坏，无法打开" 的�
 1. 打开终端
 2. 输入以下命令并回车：
    `xattr -dr com.apple.quarantine /Applications/AstrBot\ Launcher.app`
-3. 重新尝试打开 AstrBot Launcher 应用
+3. 重新尝试打开 AstrBot 桌面启动器
 
 ## 旧版本 Windows 安装器（不推荐）
 
@@ -24,7 +26,7 @@ MacOS 用户下载安装好后，可能会遇到 "已损坏，无法打开" 的�
 > 需要您的电脑上预先安装好 Python 环境（3.10 - 3.13），并且将 Python 添加到环境变量中，否则安装器将无法正常工作。
 
 
-推荐使用上面提到的 AstrBot 一键启动器来部署 AstrBot，因为它更简单、更自动化、更现代化，适合大多数用户。
+推荐使用上面提到的 AstrBot 桌面启动器来部署 AstrBot，因为它更简单、更自动化、更现代化，适合大多数用户。
 
 安装器是一个使用 `Powershell` 编写的脚本，体积小巧，<20KB。需要您的电脑上安装有 `Powershell`，一般 `Windows 10` 及以上版本的设备都会自带这个工具。
 

--- a/docs/zh/faq.md
+++ b/docs/zh/faq.md
@@ -98,18 +98,18 @@ Set dashboard.host in data/cmd_config.json to enable remote access.
 > AstrBot 为了安全起见，运行环境选择 `local` 时，默认仅允许 AstrBot 管理员使用电脑能力。
 > 运行环境可以选择 `sandbox`，此时所有用户都可以使用电脑能力（在一个隔离的沙箱中）。详情请看 [AstrBot 沙箱环境](/use/astrbot-agent-sandbox.md)
 
-### 通过 AstrBot 桌面客户端安装的 AstrBot，data 目录在哪？
+### 通过 AstrBot App 安装的 AstrBot，data 目录在哪？
 
 在家目录下的 `.astrbot` 目录下。
 
 - Windows: `C:\Users\你的用户名\.astrbot`
 - MacOS / Linux: `/Users/你的用户名/.astrbot` 或者 `/home/你的用户名/.astrbot`
 
-### 通过 AstrBot Launcher 安装的 AstrBot，data 目录在哪？
+### 通过 AstrBot 桌面启动器安装的 AstrBot，data 目录在哪？
 
-如果是旧版本的 AstrBot Launcher（Powershell），data 目录就在 Launcher bat 脚本的同级目录下。
+如果是旧版 AstrBot Launcher（Powershell 脚本），data 目录就在 Launcher bat 脚本的同级目录下。
 
-如果是新版本的 AstrBot Launcher（可视化），data 目录在家目录下的 `.astrbot_launcher` 目录下。
+如果是新版 AstrBot 桌面启动器（可视化应用），data 目录在家目录下的 `.astrbot_launcher` 目录下。
 
 - Windows: `C:\Users\你的用户名\.astrbot_launcher`
 - MacOS / Linux: `/Users/你的用户名/.astrbot_launcher` 或者 `/home/你的用户名/.astrbot_launcher`

--- a/docs/zh/others/diagnostics.md
+++ b/docs/zh/others/diagnostics.md
@@ -72,7 +72,7 @@ data/logs/event_loop_watchdog.log
 提交问题时，请尽量提供以下信息：
 
 - 问题发生的大致时间点和时区。
-- AstrBot 版本、部署方式（Docker、手动部署、桌面客户端等）、操作系统。
+- AstrBot 版本、部署方式（Docker、手动部署、AstrBot 桌面启动器、AstrBot App 等）、操作系统。
 - 触发方式：启动、普通聊天、群聊、平台回调、定时任务、MCP 工具、插件功能等。
 - 影响范围：所有会话、某个平台、某个群、某个用户，还是某个插件。
 - `data/logs/astrbot.log` 中问题发生前后 1 到 3 分钟的日志。


### PR DESCRIPTION
## What changed

- Reposition AstrBot Desktop Launcher as the standard way to use AstrBot as-is on a personal computer.
- Reposition AstrBot App as an independent desktop product for exploring interactions and capabilities beyond AstrBot's current feature set.
- Update README translations, documentation navigation, deployment pages, FAQ wording, and diagnostics guidance to use the same product terminology.

## Why

The previous wording treated both products as equivalent desktop deployment options, which made their roles unclear. This change separates the standard AstrBot desktop experience from the more exploratory AstrBot App experience.

## User impact

Users looking for the original AstrBot experience are directed to AstrBot Desktop Launcher, while users interested in new desktop experiments are directed to AstrBot App.

## Validation

- `pnpm docs:build`
- `uv run ruff format .`
- `uv run ruff check .`
- `git diff --check`

## Summary by Sourcery

Clarify desktop deployment positioning by treating AstrBot Desktop Launcher as the standard way to run AstrBot on personal computers and AstrBot App as an experimental, separate desktop product.

Documentation:
- Update English and Chinese deployment guides to describe AstrBot App as an exploratory desktop product and direct users seeking the standard AstrBot experience to AstrBot Desktop Launcher.
- Rename and reorganize desktop deployment sections and navigation labels across multilingual READMEs and docs to distinguish AstrBot Desktop Launcher from AstrBot App.
- Adjust FAQ and diagnostics documentation to reference AstrBot Desktop Launcher and AstrBot App explicitly in data directory paths and deployment method descriptions.