### PR TITLE
fix: isolate local shell sessions by sender

### DIFF
--- a/astrbot/core/computer/booters/local.py
+++ b/astrbot/core/computer/booters/local.py
@@ -98,6 +98,9 @@ class _LocalShellSession:
 
     session_id: str
     owner_id: str
+    creator_id: str
+    creator_is_admin: bool
+    sandboxed: bool
     process: asyncio.subprocess.Process
     output_path: Path
     started_at: float
@@ -212,6 +215,9 @@ class LocalShellComponent(ShellComponent):
         command: str,
         *,
         owner_id: str,
+        creator_id: str,
+        creator_is_admin: bool,
+        sandboxed: bool,
         cwd: str | None = None,
         env: dict[str, str] | None = None,
         timeout: int | None = None,
@@ -222,7 +228,10 @@ class LocalShellComponent(ShellComponent):
 
         Args:
             command: Shell command to execute.
-            owner_id: Unified message origin that owns the process.
+            owner_id: Unified message origin containing the process.
+            creator_id: Sender ID that created the session.
+            creator_is_admin: Whether the creator was an administrator.
+            sandboxed: Whether the process is isolated from the host.
             cwd: Working directory for the process.
             env: Additional environment variables.
             timeout: Hard process lifetime in seconds. None disables it.
@@ -316,6 +325,9 @@ class LocalShellComponent(ShellComponent):
         session = _LocalShellSession(
             session_id=session_id,
             owner_id=owner_id,
+            creator_id=creator_id,
+            creator_is_admin=creator_is_admin,
+            sandboxed=sandboxed,
             process=process,
             output_path=output_path,
             started_at=time.time(),
@@ -360,26 +372,43 @@ class LocalShellComponent(ShellComponent):
 
         return await self.poll_session(
             owner_id=owner_id,
+            requester_id=creator_id,
+            requester_is_admin=creator_is_admin,
             session_id=session_id,
             cursor=0,
             yield_time_ms=0,
             max_output_chars=max_output_chars,
         )
 
-    async def list_sessions(self, owner_id: str) -> dict[str, Any]:
-        """List managed shell sessions owned by one conversation.
+    async def list_sessions(
+        self,
+        *,
+        owner_id: str,
+        requester_id: str,
+        requester_is_admin: bool,
+    ) -> dict[str, Any]:
+        """List managed shell sessions visible to one requester.
 
         Args:
-            owner_id: Unified message origin that owns the sessions.
+            owner_id: Unified message origin containing the sessions.
+            requester_id: Sender ID requesting the session list.
+            requester_is_admin: Whether the requester is an administrator.
 
         Returns:
-            Session summaries scoped to the owner.
+            Session summaries scoped to the conversation and requester.
         """
         async with self._sessions_lock:
             sessions = [
                 session
                 for session in self._sessions.values()
                 if session.owner_id == owner_id
+                and (
+                    requester_is_admin
+                    or (
+                        not session.creator_is_admin
+                        and session.creator_id == requester_id
+                    )
+                )
             ]
 
         items = []
@@ -409,6 +438,7 @@ class LocalShellComponent(ShellComponent):
                     "status": status,
                     "exit_code": exit_code,
                     "started_at": session.started_at,
+                    "sandboxed": session.sandboxed,
                     "unread_output_bytes": max(output_size - session.cursor, 0),
                 }
             )
@@ -418,6 +448,8 @@ class LocalShellComponent(ShellComponent):
         self,
         *,
         owner_id: str,
+        requester_id: str,
+        requester_is_admin: bool,
         session_id: str,
         cursor: int | None = None,
         yield_time_ms: int = 0,
@@ -426,7 +458,9 @@ class LocalShellComponent(ShellComponent):
         """Read new output and status from a managed shell session.
 
         Args:
-            owner_id: Unified message origin that owns the session.
+            owner_id: Unified message origin containing the session.
+            requester_id: Sender ID requesting the output.
+            requester_is_admin: Whether the requester is an administrator.
             session_id: Managed shell session identifier.
             cursor: Byte offset to read from. Defaults to the last returned offset.
             yield_time_ms: Maximum wait for new output or process completion.
@@ -443,7 +477,12 @@ class LocalShellComponent(ShellComponent):
         if max_output_chars < 1:
             raise ValueError("`max_output_chars` must be greater than 0.")
 
-        session = await self._get_owned_session(owner_id, session_id)
+        session = await self._get_owned_session(
+            owner_id,
+            requester_id,
+            requester_is_admin,
+            session_id,
+        )
         read_cursor = session.cursor if cursor is None else cursor
         if read_cursor < 0:
             raise ValueError("`cursor` must be greater than or equal to 0.")
@@ -534,13 +573,17 @@ class LocalShellComponent(ShellComponent):
         self,
         *,
         owner_id: str,
+        requester_id: str,
+        requester_is_admin: bool,
         session_id: str,
         chars: str,
     ) -> dict[str, Any]:
         """Write text to the stdin pipe of a managed shell session.
 
         Args:
-            owner_id: Unified message origin that owns the session.
+            owner_id: Unified message origin containing the session.
+            requester_id: Sender ID writing to the process.
+            requester_is_admin: Whether the requester is an administrator.
             session_id: Managed shell session identifier.
             chars: Text to write verbatim.
 
@@ -550,7 +593,12 @@ class LocalShellComponent(ShellComponent):
         Raises:
             ValueError: If the session is unavailable or no longer accepts input.
         """
-        session = await self._get_owned_session(owner_id, session_id)
+        session = await self._get_owned_session(
+            owner_id,
+            requester_id,
+            requester_is_admin,
+            session_id,
+        )
         if session.process.returncode is not None or session.process.stdin is None:
             raise ValueError(f"Shell session {session_id} is not accepting input.")
         session.process.stdin.write(chars.encode("utf-8"))
@@ -566,6 +614,8 @@ class LocalShellComponent(ShellComponent):
         self,
         *,
         owner_id: str,
+        requester_id: str,
+        requester_is_admin: bool,
         session_id: str,
         yield_time_ms: int = 1_000,
         max_output_chars: int = 10_000,
@@ -573,7 +623,9 @@ class LocalShellComponent(ShellComponent):
         """Send an interrupt signal to a managed shell process group.
 
         Args:
-            owner_id: Unified message origin that owns the session.
+            owner_id: Unified message origin containing the session.
+            requester_id: Sender ID requesting the interrupt.
+            requester_is_admin: Whether the requester is an administrator.
             session_id: Managed shell session identifier.
             yield_time_ms: Maximum wait for output or exit after the signal.
             max_output_chars: Maximum output bytes returned after the signal.
@@ -581,7 +633,12 @@ class LocalShellComponent(ShellComponent):
         Returns:
             Incremental output and status after sending the interrupt.
         """
-        session = await self._get_owned_session(owner_id, session_id)
+        session = await self._get_owned_session(
+            owner_id,
+            requester_id,
+            requester_is_admin,
+            session_id,
+        )
         if session.process.returncode is None:
             if os.name == "nt":
                 session.process.send_signal(
@@ -594,6 +651,8 @@ class LocalShellComponent(ShellComponent):
                     pass
         return await self.poll_session(
             owner_id=owner_id,
+            requester_id=requester_id,
+            requester_is_admin=requester_is_admin,
             session_id=session_id,
             yield_time_ms=yield_time_ms,
             max_output_chars=max_output_chars,
@@ -603,24 +662,35 @@ class LocalShellComponent(ShellComponent):
         self,
         *,
         owner_id: str,
+        requester_id: str,
+        requester_is_admin: bool,
         session_id: str,
         max_output_chars: int = 10_000,
     ) -> dict[str, Any]:
         """Terminate a managed shell process group.
 
         Args:
-            owner_id: Unified message origin that owns the session.
+            owner_id: Unified message origin containing the session.
+            requester_id: Sender ID requesting termination.
+            requester_is_admin: Whether the requester is an administrator.
             session_id: Managed shell session identifier.
             max_output_chars: Maximum remaining output bytes to return.
 
         Returns:
             Remaining output and final process status.
         """
-        session = await self._get_owned_session(owner_id, session_id)
+        session = await self._get_owned_session(
+            owner_id,
+            requester_id,
+            requester_is_admin,
+            session_id,
+        )
         session.terminated = True
         await self._terminate_process(session)
         return await self.poll_session(
             owner_id=owner_id,
+            requester_id=requester_id,
+            requester_is_admin=requester_is_admin,
             session_id=session_id,
             yield_time_ms=0,
             max_output_chars=max_output_chars,
@@ -653,12 +723,16 @@ class LocalShellComponent(ShellComponent):
     async def _get_owned_session(
         self,
         owner_id: str,
+        requester_id: str,
+        requester_is_admin: bool,
         session_id: str,
     ) -> _LocalShellSession:
-        """Resolve a shell session while enforcing conversation ownership.
+        """Resolve a shell session while enforcing requester ownership.
 
         Args:
-            owner_id: Unified message origin that must own the session.
+            owner_id: Unified message origin that must contain the session.
+            requester_id: Sender ID requesting access.
+            requester_is_admin: Whether the requester is an administrator.
             session_id: Managed shell session identifier.
 
         Returns:
@@ -669,7 +743,14 @@ class LocalShellComponent(ShellComponent):
         """
         async with self._sessions_lock:
             session = self._sessions.get(session_id)
-        if session is None or session.owner_id != owner_id:
+        if (
+            session is None
+            or session.owner_id != owner_id
+            or (
+                not requester_is_admin
+                and (session.creator_is_admin or session.creator_id != requester_id)
+            )
+        ):
             raise ValueError(f"Shell session {session_id} was not found.")
         return session
 

--- a/astrbot/core/tools/computer_tools/shell.py
+++ b/astrbot/core/tools/computer_tools/shell.py
@@ -119,10 +119,16 @@ class ExecuteShellTool(FunctionTool):
                     return (
                         "Error executing command: local shell component is unavailable."
                     )
+                creator_id = context.context.event.get_sender_id()
+                if not creator_id:
+                    return "Error executing command: sender identity is unavailable."
                 return json.dumps(
                     await sb.shell.exec_managed(
                         command,
                         owner_id=context.context.event.unified_msg_origin,
+                        creator_id=creator_id,
+                        creator_is_admin=context.context.event.role == "admin",
+                        sandboxed=False,
                         cwd=cwd,
                         env=env,
                         timeout=timeout,
@@ -239,7 +245,8 @@ class ShellSessionTool(FunctionTool):
     name: str = "astrbot_shell_session"
     description: str = (
         "List, poll, write to, interrupt, or terminate managed shell sessions. "
-        "Sessions are isolated to the current conversation."
+        "Sessions are isolated to the current conversation and sender. "
+        "Administrators can manage all sessions in the conversation."
     )
     parameters: dict = field(
         default_factory=lambda: {
@@ -293,7 +300,7 @@ class ShellSessionTool(FunctionTool):
         yield_time_ms: int = 5_000,
         max_output_chars: int = 10_000,
     ) -> ToolExecResult:
-        """Perform a conversation-scoped local shell session operation.
+        """Perform an identity-scoped local shell session operation.
 
         Args:
             context: Current agent tool context.
@@ -324,8 +331,16 @@ class ShellSessionTool(FunctionTool):
                 return "Error managing shell session: local shell component is unavailable."
 
             owner_id = context.context.event.unified_msg_origin
+            requester_id = context.context.event.get_sender_id()
+            if not requester_id:
+                return "Error managing shell session: sender identity is unavailable."
+            requester_is_admin = context.context.event.role == "admin"
             if action == "list":
-                result = await sb.shell.list_sessions(owner_id)
+                result = await sb.shell.list_sessions(
+                    owner_id=owner_id,
+                    requester_id=requester_id,
+                    requester_is_admin=requester_is_admin,
+                )
             else:
                 if not session_id:
                     return (
@@ -335,6 +350,8 @@ class ShellSessionTool(FunctionTool):
                 if action == "poll":
                     result = await sb.shell.poll_session(
                         owner_id=owner_id,
+                        requester_id=requester_id,
+                        requester_is_admin=requester_is_admin,
                         session_id=session_id,
                         cursor=cursor,
                         yield_time_ms=yield_time_ms,
@@ -343,12 +360,16 @@ class ShellSessionTool(FunctionTool):
                 elif action == "write":
                     result = await sb.shell.write_session(
                         owner_id=owner_id,
+                        requester_id=requester_id,
+                        requester_is_admin=requester_is_admin,
                         session_id=session_id,
                         chars=chars,
                     )
                 elif action == "interrupt":
                     result = await sb.shell.interrupt_session(
                         owner_id=owner_id,
+                        requester_id=requester_id,
+                        requester_is_admin=requester_is_admin,
                         session_id=session_id,
                         yield_time_ms=yield_time_ms,
                         max_output_chars=max_output_chars,
@@ -356,6 +377,8 @@ class ShellSessionTool(FunctionTool):
                 elif action == "terminate":
                     result = await sb.shell.terminate_session(
                         owner_id=owner_id,
+                        requester_id=requester_id,
+                        requester_is_admin=requester_is_admin,
                         session_id=session_id,
                         max_output_chars=max_output_chars,
                     )

--- a/tests/test_local_shell_component.py
+++ b/tests/test_local_shell_component.py
@@ -136,6 +136,9 @@ async def test_managed_shell_uses_windows_powershell(monkeypatch, tmp_path):
     result = await LocalShellComponent().exec_managed(
         "Get-ChildItem",
         owner_id="owner-a",
+        creator_id="user-a",
+        creator_is_admin=False,
+        sandboxed=False,
         cwd=str(tmp_path),
         yield_time_ms=5_000,
     )
@@ -254,6 +257,9 @@ async def test_managed_shell_returns_completed_output_without_open_session():
     result = await shell.exec_managed(
         _python_command("print('hello')"),
         owner_id="owner-a",
+        creator_id="user-a",
+        creator_is_admin=False,
+        sandboxed=False,
         yield_time_ms=5_000,
     )
 
@@ -261,15 +267,22 @@ async def test_managed_shell_returns_completed_output_without_open_session():
     assert result["stdout"] == "hello\n"
     assert result["exit_code"] == 0
     assert result["session_closed"] is True
-    assert await shell.list_sessions("owner-a") == {"sessions": []}
+    assert await shell.list_sessions(
+        owner_id="owner-a",
+        requester_id="user-a",
+        requester_is_admin=False,
+    ) == {"sessions": []}
 
 
 @pytest.mark.asyncio
-async def test_managed_shell_lists_and_terminates_running_session():
+async def test_managed_shell_allows_creator_and_conversation_admin():
     shell = LocalShellComponent()
     result = await shell.exec_managed(
         _python_command("import time; print('ready', flush=True); time.sleep(30)"),
         owner_id="owner-a",
+        creator_id="user-a",
+        creator_is_admin=False,
+        sandboxed=True,
         yield_time_ms=200,
     )
 
@@ -277,19 +290,135 @@ async def test_managed_shell_lists_and_terminates_running_session():
         assert result["status"] == "running"
         assert result["stdout"] == "ready\n"
         session_id = result["session_id"]
-        assert (await shell.list_sessions("owner-b"))["sessions"] == []
-        sessions = (await shell.list_sessions("owner-a"))["sessions"]
+        assert (
+            await shell.list_sessions(
+                owner_id="owner-b",
+                requester_id="user-a",
+                requester_is_admin=False,
+            )
+        )["sessions"] == []
+        sessions = (
+            await shell.list_sessions(
+                owner_id="owner-a",
+                requester_id="user-a",
+                requester_is_admin=False,
+            )
+        )["sessions"]
         assert [item["session_id"] for item in sessions] == [session_id]
+        assert sessions[0]["sandboxed"] is True
 
+        admin_sessions = (
+            await shell.list_sessions(
+                owner_id="owner-a",
+                requester_id="admin-user",
+                requester_is_admin=True,
+            )
+        )["sessions"]
+        assert [item["session_id"] for item in admin_sessions] == [session_id]
         stopped = await shell.terminate_session(
             owner_id="owner-a",
+            requester_id="admin-user",
+            requester_is_admin=True,
             session_id=session_id,
         )
 
         assert stopped["status"] == "terminated"
         assert stopped["exit_code"] is not None
         assert stopped["session_closed"] is True
-        assert await shell.list_sessions("owner-a") == {"sessions": []}
+        assert await shell.list_sessions(
+            owner_id="owner-a",
+            requester_id="user-a",
+            requester_is_admin=False,
+        ) == {"sessions": []}
+    finally:
+        await shell.shutdown_sessions()
+
+
+@pytest.mark.asyncio
+async def test_managed_shell_rejects_cross_user_session_access():
+    shell = LocalShellComponent()
+    result = await shell.exec_managed(
+        _python_command("import time; input(); time.sleep(30)"),
+        owner_id="group-umo",
+        creator_id="admin-user",
+        creator_is_admin=True,
+        sandboxed=False,
+        yield_time_ms=100,
+    )
+
+    try:
+        session_id = result["session_id"]
+        member_access = {
+            "owner_id": "group-umo",
+            "requester_id": "member-user",
+            "requester_is_admin": False,
+        }
+        demoted_creator_access = {
+            "owner_id": "group-umo",
+            "requester_id": "admin-user",
+            "requester_is_admin": False,
+        }
+        other_conversation_admin_access = {
+            "owner_id": "other-group-umo",
+            "requester_id": "other-admin",
+            "requester_is_admin": True,
+        }
+
+        assert await shell.list_sessions(**member_access) == {"sessions": []}
+        assert await shell.list_sessions(**demoted_creator_access) == {"sessions": []}
+        assert await shell.list_sessions(**other_conversation_admin_access) == {
+            "sessions": []
+        }
+        with pytest.raises(ValueError, match="was not found"):
+            await shell.poll_session(
+                **member_access,
+                session_id=session_id,
+                cursor=0,
+            )
+        with pytest.raises(ValueError, match="was not found"):
+            await shell.write_session(
+                **member_access,
+                session_id=session_id,
+                chars="attacker-input\n",
+            )
+        with pytest.raises(ValueError, match="was not found"):
+            await shell.interrupt_session(
+                **member_access,
+                session_id=session_id,
+            )
+        with pytest.raises(ValueError, match="was not found"):
+            await shell.poll_session(
+                **demoted_creator_access,
+                session_id=session_id,
+                cursor=0,
+            )
+        with pytest.raises(ValueError, match="was not found"):
+            await shell.terminate_session(
+                **other_conversation_admin_access,
+                session_id=session_id,
+            )
+        with pytest.raises(ValueError, match="was not found"):
+            await shell.terminate_session(
+                **member_access,
+                session_id=session_id,
+            )
+
+        assert shell._sessions[session_id].process.returncode is None
+        admin_sessions = await shell.list_sessions(
+            owner_id="group-umo",
+            requester_id="admin-user",
+            requester_is_admin=True,
+        )
+        assert [item["session_id"] for item in admin_sessions["sessions"]] == [
+            session_id
+        ]
+        stopped = await shell.terminate_session(
+            owner_id="group-umo",
+            requester_id="admin-user",
+            requester_is_admin=True,
+            session_id=session_id,
+        )
+        assert stopped["status"] == "terminated"
     finally:
         await shell.shutdown_sessions()
 
@@ -300,6 +429,9 @@ async def test_managed_shell_accepts_stdin_and_polls_incremental_output():
     result = await shell.exec_managed(
         _python_command("value = input(); print(f'got:{value}', flush=True)"),
         owner_id="owner-a",
+        creator_id="user-a",
+        creator_is_admin=False,
+        sandboxed=True,
         yield_time_ms=100,
     )
 
@@ -307,11 +439,15 @@ async def test_managed_shell_accepts_stdin_and_polls_incremental_output():
         assert result["status"] == "running"
         await shell.write_session(
             owner_id="owner-a",
+            requester_id="user-a",
+            requester_is_admin=False,
             session_id=result["session_id"],
             chars="hello\n",
         )
         completed = await shell.poll_session(
             owner_id="owner-a",
+            requester_id="user-a",
+            requester_is_admin=False,
             session_id=result["session_id"],
             yield_time_ms=5_000,
         )
@@ -319,6 +455,8 @@ async def test_managed_shell_accepts_stdin_and_polls_incremental_output():
         if completed["status"] == "running":
             completed = await shell.poll_session(
                 owner_id="owner-a",
+                requester_id="user-a",
+                requester_is_admin=False,
                 session_id=result["session_id"],
                 yield_time_ms=5_000,
             )
@@ -337,6 +475,9 @@ async def test_managed_shell_hard_timeout_terminates_session():
     result = await shell.exec_managed(
         _python_command("import time; time.sleep(30)"),
         owner_id="owner-a",
+        creator_id="user-a",
+        creator_is_admin=False,
+        sandboxed=False,
         timeout=1,
         yield_time_ms=0,
     )
@@ -344,6 +485,8 @@ async def test_managed_shell_hard_timeout_terminates_session():
     try:
         timed_out = await shell.poll_session(
             owner_id="owner-a",
+            requester_id="user-a",
+            requester_is_admin=False,
             session_id=result["session_id"],
             yield_time_ms=3_000,
         )
@@ -361,6 +504,9 @@ async def test_managed_shell_keeps_completed_session_until_output_is_drained():
     result = await shell.exec_managed(
         _python_command("print('x' * 25000)"),
         owner_id="owner-a",
+        creator_id="user-a",
+        creator_is_admin=False,
+        sandboxed=False,
         yield_time_ms=5_000,
         max_output_chars=10_000,
     )
@@ -372,6 +518,8 @@ async def test_managed_shell_keeps_completed_session_until_output_is_drained():
         while result["has_more"]:
             result = await shell.poll_session(
                 owner_id="owner-a",
+                requester_id="user-a",
+                requester_is_admin=False,
                 session_id=result["session_id"],
                 max_output_chars=10_000,
             )
@@ -379,6 +527,10 @@ async def test_managed_shell_keeps_completed_session_until_output_is_drained():
 
         assert output == f"{'x' * 25000}\n"
         assert result["session_closed"] is True
-        assert await shell.list_sessions("owner-a") == {"sessions": []}
+        assert await shell.list_sessions(
+            owner_id="owner-a",
+            requester_id="user-a",
+            requester_is_admin=False,
+        ) == {"sessions": []}
     finally:
         await shell.shutdown_sessions()

--- a/tests/unit/test_func_tool_manager.py
+++ b/tests/unit/test_func_tool_manager.py
@@ -97,6 +97,10 @@ async def test_local_execute_shell_uses_managed_session(monkeypatch, tmp_path):
         unified_msg_origin = "umo"
         role = "admin"
 
+        @staticmethod
+        def get_sender_id():
+            return "admin-user"
+
     class FakeAstrContext:
         context = FakeConfig()
         event = FakeEvent()
@@ -124,11 +128,75 @@ async def test_local_execute_shell_uses_managed_session(monkeypatch, tmp_path):
     shell.exec_managed.assert_awaited_once_with(
         "python server.py",
         owner_id="umo",
+        creator_id="admin-user",
+        creator_is_admin=True,
+        sandboxed=False,
         cwd=str(tmp_path),
         env={},
         timeout=None,
         yield_time_ms=250,
     )
+
+
+@pytest.mark.asyncio
+async def test_local_shell_tools_fail_closed_without_sender_identity(
+    monkeypatch,
+    tmp_path,
+):
+    from astrbot.core.tools.computer_tools import shell as shell_tools
+
+    shell = LocalShellComponent()
+    shell.exec_managed = AsyncMock()
+    shell.list_sessions = AsyncMock()
+
+    class FakeBooter:
+        pass
+
+    booter = FakeBooter()
+    booter.shell = shell
+
+    class FakeConfig:
+        def get_config(self, umo):
+            return {"provider_settings": {"computer_use_runtime": "local"}}
+
+    class FakeEvent:
+        unified_msg_origin = "umo"
+        role = "admin"
+
+        @staticmethod
+        def get_sender_id():
+            return ""
+
+    class FakeAstrContext:
+        context = FakeConfig()
+        event = FakeEvent()
+
+    class FakeWrapper:
+        context = FakeAstrContext()
+
+    async def fake_get_booter(context, session_id):
+        return booter
+
+    monkeypatch.setattr(shell_tools, "get_booter", fake_get_booter)
+    monkeypatch.setattr(
+        shell_tools,
+        "workspace_root_for_context",
+        AsyncMock(return_value=tmp_path),
+    )
+
+    execute_result = await LocalExecuteShellTool().call(
+        FakeWrapper(),
+        command="python server.py",
+    )
+    session_result = await ShellSessionTool().call(FakeWrapper(), action="list")
+
+    assert execute_result == "Error executing command: sender identity is unavailable."
+    assert (
+        session_result
+        == "Error managing shell session: sender identity is unavailable."
+    )
+    shell.exec_managed.assert_not_awaited()
+    shell.list_sessions.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -154,6 +222,10 @@ async def test_shell_session_tool_lists_sessions_for_current_owner(monkeypatch):
         unified_msg_origin = "umo"
         role = "admin"
 
+        @staticmethod
+        def get_sender_id():
+            return "admin-user"
+
     class FakeAstrContext:
         context = FakeConfig()
         event = FakeEvent()
@@ -169,7 +241,71 @@ async def test_shell_session_tool_lists_sessions_for_current_owner(monkeypatch):
     result = await ShellSessionTool().call(FakeWrapper(), action="list")
 
     assert json.loads(result)["sessions"][0]["session_id"] == "sh_test"
-    shell.list_sessions.assert_awaited_once_with("umo")
+    shell.list_sessions.assert_awaited_once_with(
+        owner_id="umo",
+        requester_id="admin-user",
+        requester_is_admin=True,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["poll", "write", "interrupt", "terminate"])
+async def test_shell_session_tool_passes_member_identity_to_session_actions(
+    monkeypatch,
+    action,
+):
+    from astrbot.core.tools.computer_tools import shell as shell_tools
+
+    shell = LocalShellComponent()
+    operation = AsyncMock(return_value={"session_id": "sh_test", "status": "running"})
+    setattr(shell, f"{action}_session", operation)
+
+    class FakeBooter:
+        pass
+
+    booter = FakeBooter()
+    booter.shell = shell
+
+    class FakeConfig:
+        def get_config(self, umo):
+            return {
+                "provider_settings": {
+                    "computer_use_runtime": "local",
+                    "computer_use_require_admin": False,
+                }
+            }
+
+    class FakeEvent:
+        unified_msg_origin = "group-umo"
+        role = "member"
+
+        @staticmethod
+        def get_sender_id():
+            return "member-user"
+
+    class FakeAstrContext:
+        context = FakeConfig()
+        event = FakeEvent()
+
+    class FakeWrapper:
+        context = FakeAstrContext()
+
+    async def fake_get_booter(context, session_id):
+        return booter
+
+    monkeypatch.setattr(shell_tools, "get_booter", fake_get_booter)
+
+    result = await ShellSessionTool().call(
+        FakeWrapper(),
+        action=action,
+        session_id="sh_test",
+        chars="input",
+    )
+
+    assert json.loads(result)["session_id"] == "sh_test"
+    assert operation.await_args.kwargs["owner_id"] == "group-umo"
+    assert operation.await_args.kwargs["requester_id"] == "member-user"
+    assert operation.await_args.kwargs["requester_is_admin"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- bind every managed Local shell session to its conversation UMO and creator sender ID
- record whether the creator was an administrator and whether the process was sandboxed
- require caller identity and current administrator status for list, poll, write, interrupt, and terminate operations
- allow ordinary members to manage only their own non-admin sessions, while preserving administrator management within the same conversation
- fail closed when a local shell caller has no sender identity and return the same not-found error for inaccessible and nonexistent sessions

## Security impact

Managed shell sessions previously used only the conversation UMO as their owner. Different senders in the same group therefore shared the same authorization scope when member computer use was enabled. A member could enumerate an administrator's session, read its captured output, write bytes to its stdin, or signal and terminate its process.

The authorization boundary now combines the conversation with the authenticated event sender. The component stores immutable creation metadata and checks it before every externally reachable session operation. Administrators retain conversation-scoped control; non-admin callers cannot access administrator-created sessions even if the same sender ID later loses the administrator role.

## Validation

- pre-fix reproducer: a second sender using the same group UMO listed the session and injected `attacker-input` into a waiting process
- post-fix reproducer: the member list is empty, write returns `Shell session ... was not found`, and the administrator process remains running
- regression coverage rejects cross-user list, poll-from-zero, write, interrupt, and terminate operations
- regression coverage verifies creator access, same-conversation administrator access, cross-conversation denial, administrator demotion, sandbox metadata, and missing-identity fail-closed behavior
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run pytest -q tests/test_local_shell_component.py tests/unit/test_func_tool_manager.py` — 42 passed
- `uv run pytest -q tests` — 1986 passed

## Summary by Sourcery

Strengthen authorization for managed local shell sessions by scoping them to both conversation and sender identity, and propagate requester metadata through shell tools and core component APIs.

New Features:
- Track creator identity, administrator status, and sandbox state for each managed local shell session.
- Expose sandbox metadata in session listings and allow conversation administrators to manage all sessions in the conversation.

Bug Fixes:
- Prevent non-admin and cross-user callers from listing, reading, writing to, interrupting, or terminating shell sessions they do not own, returning a uniform not-found error for inaccessible sessions.
- Fail closed when shell tools are invoked without a valid sender identity, avoiding creation or listing of sessions in that case.

Enhancements:
- Update shell session tool semantics and documentation to describe identity-scoped operations and administrator capabilities.
- Extend local shell component APIs to require requester identity and role for all session operations, aligning tests and tooling with the new contract.

Tests:
- Add regression tests covering cross-user denial, administrator access within a conversation, admin demotion behavior, sandbox metadata exposure, and missing-identity fail-closed semantics.
- Update existing local shell and function tool manager tests to assert the new identity and role parameters for session creation and management.