### PR TITLE
fix(ci): align workflow Python version with requires-python

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,7 +246,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install uv
         shell: bash

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Run sync unit tests
         working-directory: docs


### PR DESCRIPTION
## Why
Package metadata declares `requires-python` / `.python-version` as `>=3.12`, but CI workflows still pin `python-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `python-version` pins so they satisfy `>=3.12` (using `3.12` where a concrete pin is needed).

- `.github/workflows/release.yml`
  - `python-version: "3.10"` → `python-version: "3.12"`
- `.github/workflows/sync-wiki.yml`
  - `python-version: '3.11'` → `python-version: '3.12'`

## Test plan
- [ ] Package `requires-python` / `.python-version` is still `>=3.12`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.

## Summary by Sourcery

Align CI workflows with the project’s declared minimum Python version.

CI:
- Update release workflow to run on Python 3.12.
- Update sync-wiki workflow to run on Python 3.12.