### PR TITLE
fix: warn when a configured provider is silently substituted

### DIFF
--- a/astrbot/core/provider/manager.py
+++ b/astrbot/core/provider/manager.py
@@ -82,6 +82,12 @@ class ProviderManager:
             Callable[[str, ProviderType, str | None], None]
         ] = []
         self._mcp_init_task: asyncio.Task | None = None
+        self._fallback_warned: set[tuple[str, str, str]] = set()
+        """Deduplicates the "configured provider unavailable" warning.
+
+        Keyed by (provider_type, configured_id, fallback_id) so a recurring
+        request does not flood the log while the situation persists.
+        """
 
     def set_provider_change_callback(
         self,
@@ -230,6 +236,7 @@ class ProviderManager:
         """
         provider = None
         provider_id = None
+        fell_back = False
         if umo:
             provider_id = sp.get(
                 f"provider_perf_{provider_type.value}",
@@ -247,6 +254,7 @@ class ProviderManager:
                 provider = self.inst_map.get(provider_id)
                 if not provider:
                     provider = self.provider_insts[0] if self.provider_insts else None
+                    fell_back = provider is not None
             elif provider_type == ProviderType.SPEECH_TO_TEXT:
                 provider_id = config["provider_stt_settings"].get("provider_id")
                 if not config["provider_stt_settings"].get("enable"):
@@ -258,6 +266,7 @@ class ProviderManager:
                     provider = (
                         self.stt_provider_insts[0] if self.stt_provider_insts else None
                     )
+                    fell_back = provider is not None
             elif provider_type == ProviderType.TEXT_TO_SPEECH:
                 provider_id = config["provider_tts_settings"].get("provider_id")
                 if not config["provider_tts_settings"].get("enable"):
@@ -269,6 +278,7 @@ class ProviderManager:
                     provider = (
                         self.tts_provider_insts[0] if self.tts_provider_insts else None
                     )
+                    fell_back = provider is not None
             else:
                 raise ValueError(f"Unknown provider type: {provider_type}")
 
@@ -277,8 +287,40 @@ class ProviderManager:
                 f"Provider {provider_id} was not found. Its provider or model ID "
                 "may have been changed."
             )
+        elif fell_back and provider_id:
+            self._warn_provider_fallback(provider_type, provider_id, provider)
 
         return provider
+
+    def _warn_provider_fallback(
+        self,
+        provider_type: ProviderType,
+        configured_id: str,
+        fallback: Providers,
+    ) -> None:
+        """Warn that a configured provider was silently replaced.
+
+        Substituting a different provider keeps AstrBot responsive, but the
+        replacement may have completely different capabilities (for example a
+        vision-only chat model answering plain text), so the user needs to know
+        it happened. The warning is emitted once per distinct situation to avoid
+        flooding the log while the condition persists.
+        """
+        fallback_config = getattr(fallback, "provider_config", None) or {}
+        fallback_id = fallback_config.get("id") or "unknown"
+        key = (provider_type.value, str(configured_id), str(fallback_id))
+        if key in self._fallback_warned:
+            return
+        self._fallback_warned.add(key)
+        logger.warning(
+            "Configured %s provider `%s` is not available; falling back to `%s`. "
+            "This can happen while providers are still loading at startup, or "
+            "when the configured provider was renamed, disabled or removed. "
+            "The fallback may behave differently from the provider you selected.",
+            provider_type.value,
+            configured_id,
+            fallback_id,
+        )
 
     async def initialize(self) -> None:
         # 逐个初始化提供商
@@ -755,6 +797,9 @@ class ProviderManager:
 
     async def reload(self, provider_config: dict) -> None:
         async with self.reload_lock:
+            # The available providers change here, so a previously reported
+            # fallback may be resolved (or start happening again).
+            self._fallback_warned.clear()
             await self.terminate_provider(provider_config["id"])
             if provider_config["enable"]:
                 await self.load_provider(provider_config)

--- a/tests/unit/test_provider_fallback_warning.py
+++ b/tests/unit/test_provider_fallback_warning.py
@@ -1,0 +1,141 @@
+"""Tests for the warning emitted when a configured provider is substituted."""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+# astrbot.core.provider.manager and astrbot.core.star.context import each other,
+# so the package entry point has to be imported first.
+import astrbot.api  # noqa: F401
+from astrbot.core.provider.entities import ProviderType
+from astrbot.core.provider.manager import ProviderManager
+
+
+def _make_provider(provider_id: str) -> MagicMock:
+    provider = MagicMock()
+    provider.provider_config = {"id": provider_id}
+    return provider
+
+
+@pytest.fixture
+def manager() -> ProviderManager:
+    """Build a ProviderManager without running its heavy __init__."""
+    mgr = ProviderManager.__new__(ProviderManager)
+    mgr.inst_map = {}
+    mgr.provider_insts = []
+    mgr.stt_provider_insts = []
+    mgr.tts_provider_insts = []
+    mgr._fallback_warned = set()
+    mgr.acm = MagicMock()
+    return mgr
+
+
+def _set_conf(manager: ProviderManager, conf: dict) -> None:
+    manager.acm.get_conf = MagicMock(return_value=conf)
+
+
+class TestChatProviderFallbackWarning:
+    def test_warns_when_configured_provider_is_substituted(self, manager, caplog):
+        """A configured-but-missing provider must not be replaced silently."""
+        fallback = _make_provider("vision-only-model")
+        manager.provider_insts = [fallback]
+        _set_conf(manager, {"provider_settings": {"default_provider_id": "my-chat"}})
+
+        with caplog.at_level(logging.WARNING):
+            provider = manager.get_using_provider(ProviderType.CHAT_COMPLETION)
+
+        assert provider is fallback
+        assert "my-chat" in caplog.text
+        assert "vision-only-model" in caplog.text
+
+    def test_warning_is_emitted_only_once(self, manager, caplog):
+        """Repeated lookups must not flood the log."""
+        manager.provider_insts = [_make_provider("other")]
+        _set_conf(manager, {"provider_settings": {"default_provider_id": "my-chat"}})
+
+        with caplog.at_level(logging.WARNING):
+            for _ in range(5):
+                manager.get_using_provider(ProviderType.CHAT_COMPLETION)
+
+        assert caplog.text.count("is not available; falling back to") == 1
+
+    def test_no_warning_when_configured_provider_resolves(self, manager, caplog):
+        """The happy path must stay quiet."""
+        configured = _make_provider("my-chat")
+        manager.inst_map = {"my-chat": configured}
+        manager.provider_insts = [configured]
+        _set_conf(manager, {"provider_settings": {"default_provider_id": "my-chat"}})
+
+        with caplog.at_level(logging.WARNING):
+            provider = manager.get_using_provider(ProviderType.CHAT_COMPLETION)
+
+        assert provider is configured
+        assert caplog.text == ""
+
+    def test_no_warning_when_no_default_is_configured(self, manager, caplog):
+        """An unset default already has a dedicated startup warning."""
+        fallback = _make_provider("first-one")
+        manager.provider_insts = [fallback]
+        _set_conf(manager, {"provider_settings": {"default_provider_id": ""}})
+
+        with caplog.at_level(logging.WARNING):
+            provider = manager.get_using_provider(ProviderType.CHAT_COMPLETION)
+
+        assert provider is fallback
+        assert caplog.text == ""
+
+    def test_existing_not_found_warning_still_fires(self, manager, caplog):
+        """With no provider at all, the original message is kept."""
+        _set_conf(manager, {"provider_settings": {"default_provider_id": "my-chat"}})
+
+        with caplog.at_level(logging.WARNING):
+            provider = manager.get_using_provider(ProviderType.CHAT_COMPLETION)
+
+        assert provider is None
+        assert "was not found" in caplog.text
+
+
+class TestSttTtsProviderFallbackWarning:
+    def test_stt_substitution_warns(self, manager, caplog):
+        fallback = _make_provider("other-stt")
+        manager.stt_provider_insts = [fallback]
+        _set_conf(
+            manager,
+            {"provider_stt_settings": {"enable": True, "provider_id": "my-stt"}},
+        )
+
+        with caplog.at_level(logging.WARNING):
+            provider = manager.get_using_provider(ProviderType.SPEECH_TO_TEXT)
+
+        assert provider is fallback
+        assert "my-stt" in caplog.text
+        assert "other-stt" in caplog.text
+
+    def test_tts_substitution_warns(self, manager, caplog):
+        fallback = _make_provider("other-tts")
+        manager.tts_provider_insts = [fallback]
+        _set_conf(
+            manager,
+            {"provider_tts_settings": {"enable": True, "provider_id": "my-tts"}},
+        )
+
+        with caplog.at_level(logging.WARNING):
+            provider = manager.get_using_provider(ProviderType.TEXT_TO_SPEECH)
+
+        assert provider is fallback
+        assert "my-tts" in caplog.text
+        assert "other-tts" in caplog.text
+
+    def test_disabled_stt_returns_none_without_warning(self, manager, caplog):
+        manager.stt_provider_insts = [_make_provider("other-stt")]
+        _set_conf(
+            manager,
+            {"provider_stt_settings": {"enable": False, "provider_id": "my-stt"}},
+        )
+
+        with caplog.at_level(logging.WARNING):
+            provider = manager.get_using_provider(ProviderType.SPEECH_TO_TEXT)
+
+        assert provider is None
+        assert caplog.text == ""

--- a/tests/unit/test_provider_fallback_warning.py
+++ b/tests/unit/test_provider_fallback_warning.py
@@ -1,21 +1,40 @@
 """Tests for the warning emitted when a configured provider is substituted."""
 
+import asyncio
 import logging
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 # astrbot.core.provider.manager and astrbot.core.star.context import each other,
 # so the package entry point has to be imported first.
 import astrbot.api  # noqa: F401
+from astrbot.core.provider import manager as manager_module
 from astrbot.core.provider.entities import ProviderType
 from astrbot.core.provider.manager import ProviderManager
+
+FALLBACK_MESSAGE = "is not available; falling back to"
 
 
 def _make_provider(provider_id: str) -> MagicMock:
     provider = MagicMock()
     provider.provider_config = {"id": provider_id}
     return provider
+
+
+class _BareProvider:
+    """A provider stub without auto-created attributes.
+
+    MagicMock would synthesise `provider_config` on access, which hides the
+    branch that reports an unidentifiable fallback as `unknown`.
+    """
+
+    def __init__(self, provider_config=None):
+        if provider_config is not None:
+            self.provider_config = provider_config
+
+    def meta(self):
+        return MagicMock()
 
 
 @pytest.fixture
@@ -139,3 +158,71 @@ class TestSttTtsProviderFallbackWarning:
 
         assert provider is None
         assert caplog.text == ""
+
+
+class TestUnidentifiableFallback:
+    """The fallback provider may not expose a usable ID."""
+
+    @pytest.mark.parametrize(
+        "fallback",
+        [
+            pytest.param(_BareProvider(), id="no-provider-config"),
+            pytest.param(_BareProvider({}), id="empty-provider-config"),
+        ],
+    )
+    def test_reported_as_unknown(self, manager, caplog, fallback):
+        manager.provider_insts = [fallback]
+        _set_conf(manager, {"provider_settings": {"default_provider_id": "my-chat"}})
+
+        with caplog.at_level(logging.WARNING):
+            provider = manager.get_using_provider(ProviderType.CHAT_COMPLETION)
+
+        assert provider is fallback
+        assert "my-chat" in caplog.text
+        assert "`unknown`" in caplog.text
+
+    def test_unknown_key_still_deduplicates(self, manager, caplog):
+        manager.provider_insts = [_BareProvider()]
+        _set_conf(manager, {"provider_settings": {"default_provider_id": "my-chat"}})
+
+        with caplog.at_level(logging.WARNING):
+            for _ in range(3):
+                manager.get_using_provider(ProviderType.CHAT_COMPLETION)
+
+        assert caplog.text.count(FALLBACK_MESSAGE) == 1
+
+
+class TestFallbackWarningLifecycle:
+    """A substitution that comes back after a reload must be reported again."""
+
+    @pytest.mark.asyncio
+    async def test_reload_clears_the_dedup_record(self, manager, caplog):
+        manager.provider_insts = [_make_provider("other")]
+        _set_conf(manager, {"provider_settings": {"default_provider_id": "my-chat"}})
+
+        with caplog.at_level(logging.WARNING):
+            for _ in range(2):
+                manager.get_using_provider(ProviderType.CHAT_COMPLETION)
+        assert caplog.text.count(FALLBACK_MESSAGE) == 1
+
+        # Drive the real reload() so removing the clear() breaks this test.
+        manager.reload_lock = asyncio.Lock()
+        manager.terminate_provider = AsyncMock()
+        manager.provider_sources_config = []
+        manager.providers_config = []
+        manager.curr_provider_inst = None
+        manager.curr_stt_provider_inst = None
+        manager.curr_tts_provider_inst = None
+        with patch.object(
+            manager_module,
+            "astrbot_config",
+            {"provider": [], "provider_sources": []},
+        ):
+            await manager.reload({"id": "my-chat", "enable": False})
+
+        assert manager._fallback_warned == set()
+
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            manager.get_using_provider(ProviderType.CHAT_COMPLETION)
+        assert caplog.text.count(FALLBACK_MESSAGE) == 1


### PR DESCRIPTION
## Problem

`ProviderManager.get_using_provider()` falls back to the first loaded provider whenever the configured provider ID cannot be resolved. The warning that was meant to report this is placed *after* that fallback assignment, so it can never fire in the case it was written for:

```python
provider = self.inst_map.get(provider_id)
if not provider:
    provider = self.provider_insts[0] if self.provider_insts else None   # substitute; provider becomes truthy
...
if not provider and provider_id:        # so this condition is never met
    logger.warning(f"Provider {provider_id} was not found. ...")
```

It only prints when *no* provider exists at all — the one situation where the user cannot do anything about it anyway. The case that actually needs reporting ("the provider you configured is unavailable, so a different one answered") is completely silent. All three branches (chat / STT / TTS) share this shape.

## Why the silence matters

The substitute is picked by **config array order**, with no regard for capability. A vision-only model can therefore answer a plain-text chat request, and nothing in the log says so.

Two windows hit this reliably:

1. **Startup.** In `core_lifecycle.initialize()`, plugins are initialized before providers:

   ```python
   await self.plugin_manager.reload()        # plugins
   ...
   await self.provider_manager.initialize()  # providers
   ```

   An LLM call issued from a plugin's `initialize()` therefore runs against a partially populated `inst_map`. Loading a single provider is not free — one deepseek provider takes 1.3 s on my machine:

   ```
   00:56:28.285  Loading model openai_chat_completion(deepseek/deepseek-v4-pro) ...
   00:56:29.597  Loading model openai_chat_completion(dashscope/qwen-vl-max) ...
   ```

2. **Saving provider settings.** `reload()` calls `terminate_provider()`, which removes the instance from `inst_map`, before loading it again. The provider does not exist during that gap.

I ran into this myself: `default_provider_id` was correct the whole time, yet after every restart my character replied in the wrong voice. It took a long time to find that during the startup window the replies were being produced by the vision model sitting at index 0 of the provider array — there was no log line anywhere pointing at it.

## Changes

- Track whether a substitution actually happened, so the existing warning intent takes effect.
- Deduplicate by `(provider_type, configured_id, fallback_id)` so a persistent condition cannot flood the log.
- Clear that record in `reload()`, so a recurrence is reported again.

**Behaviour is unchanged** — the same provider is still returned; it is simply no longer silent:

```
Configured chat_completion provider `deepseek/deepseek-v4-pro` is not available;
falling back to `dashscope/qwen-vl-max`. This can happen while providers are
still loading at startup, or when the configured provider was renamed, disabled
or removed. The fallback may behave differently from the provider you selected.
```

## Tests

Adds `tests/unit/test_provider_fallback_warning.py` — 8 cases covering the substitution warning for chat / STT / TTS, the deduplication, and three cases that must **not** warn (configured provider resolves normally, no default configured, STT disabled).

- Reverting the `manager.py` change makes 4 of them fail; with the change all 8 pass.
- Full `tests/unit` run: 776 passed, 6 failed. Those 6 fail identically on the unmodified base — they are local Windows environment failures (shell/python execution, video attachments, sandbox paths) unrelated to this change.
- `ruff format --check .` and `ruff check .` both pass.

## Not included

The startup ordering (plugins initialized before providers) is the root cause of the first window. Swapping it may well be viable — `register_provider_adapter` is not exposed to plugins via `astrbot/api`, and the adapter registry is populated by the built-in `sources/*` modules — but that is a core lifecycle change with a much higher validation cost, so I kept it out of this PR. Happy to open a separate one if maintainers think it is worth pursuing.

## Summary by Sourcery

Add explicit logging when a configured provider is unavailable and a different provider is used as a fallback, while preserving existing provider selection behaviour.

Bug Fixes:
- Ensure the fallback-provider warning is emitted when a configured provider cannot be resolved, instead of only when no providers exist at all.

Enhancements:
- Deduplicate fallback warnings per (provider type, configured ID, fallback ID) and reset the deduplication cache on provider reload to avoid log flooding while still reporting recurring issues.

Tests:
- Add unit tests covering provider substitution warnings for chat, speech-to-text, and text-to-speech providers, including cases that should and should not emit warnings.