### PR TITLE
fix(kb): resolve kb_id path parameter in dashboard retrieve endpoint

### DIFF
--- a/astrbot/dashboard/services/knowledge_base_service.py
+++ b/astrbot/dashboard/services/knowledge_base_service.py
@@ -769,6 +769,15 @@ class KnowledgeBaseService:
         if not query:
             raise KnowledgeBaseServiceError("缺少参数 query")
         kb_manager = self.get_kb_manager()
+        if not kb_names:
+            # The REST route identifies the knowledge base with the kb_id path
+            # parameter, so resolve it into the kb_names the manager expects.
+            kb_id = payload.get("kb_id")
+            if kb_id:
+                kb_helper = await kb_manager.get_kb(kb_id)
+                if not kb_helper:
+                    raise KnowledgeBaseServiceError("知识库不存在")
+                kb_names = [kb_helper.kb.kb_name]
         if not kb_names or not isinstance(kb_names, list):
             raise KnowledgeBaseServiceError("缺少参数 kb_names 或格式错误")
 

--- a/astrbot/dashboard/services/knowledge_base_service.py
+++ b/astrbot/dashboard/services/knowledge_base_service.py
@@ -761,6 +761,26 @@ class KnowledgeBaseService:
         )
 
     async def retrieve(self, data: object) -> dict[str, Any]:
+        """Retrieve chunks from one or more knowledge bases.
+
+        Args:
+            data: Request payload. ``query`` is required. The knowledge bases
+                are taken from ``kb_names`` when present, which is how the
+                legacy ``POST /api/kb/retrieve`` endpoint targets several bases
+                at once; otherwise the ``kb_id`` that the REST route reads from
+                its path is resolved to the matching name. ``top_k`` defaults
+                to 5, and ``debug`` additionally renders a t-SNE plot.
+
+        Returns:
+            A dict with the ``results`` list, its ``total`` and the ``query``
+            that produced it, plus ``visualization`` (or ``visualization_error``)
+            when ``debug`` is set.
+
+        Raises:
+            KnowledgeBaseServiceError: If ``query`` is missing, the given
+                ``kb_id`` does not exist, or neither ``kb_names`` nor ``kb_id``
+                identifies a knowledge base.
+        """
         payload = self._payload(data)
         query = payload.get("query")
         kb_names = payload.get("kb_names")

--- a/tests/unit/test_knowledge_base_service_contract.py
+++ b/tests/unit/test_knowledge_base_service_contract.py
@@ -7,9 +7,11 @@ from fastapi import Request
 from astrbot.core.provider.provider import EmbeddingProvider
 from astrbot.dashboard.api.knowledge_bases import (
     list_knowledge_bases,
+    retrieve_knowledge_base,
 )
 from astrbot.dashboard.schemas import (
     KnowledgeBaseRequest,
+    KnowledgeBaseRetrieveRequest,
 )
 from astrbot.dashboard.services.knowledge_base_service import (
     KnowledgeBaseService,
@@ -252,6 +254,88 @@ async def test_create_kb_raises_when_embedding_provider_is_missing():
 
     with pytest.raises(KnowledgeBaseServiceError, match="缺少参数 embedding_provider_id"):
         await service.create_kb({"kb_name": "Test KB"})
+
+
+@pytest.mark.asyncio
+async def test_retrieve_resolves_kb_id_from_path_parameter():
+    kb = make_kb("kb-1", "Docs")
+    kb_manager = MagicMock()
+    kb_manager.get_kb = AsyncMock(return_value=SimpleNamespace(kb=kb))
+    kb_manager.retrieve = AsyncMock(return_value={"results": [{"chunk_id": "c-1"}]})
+    service = make_service(kb_manager)
+
+    result = await service.retrieve({"kb_id": "kb-1", "query": "hello", "top_k": 3})
+
+    kb_manager.get_kb.assert_awaited_once_with("kb-1")
+    kb_manager.retrieve.assert_awaited_once_with(
+        query="hello",
+        kb_names=["Docs"],
+        top_m_final=3,
+    )
+    assert result == {
+        "results": [{"chunk_id": "c-1"}],
+        "total": 1,
+        "query": "hello",
+    }
+
+
+@pytest.mark.asyncio
+async def test_retrieve_route_passes_kb_id_to_service():
+    kb = make_kb("kb-1", "Docs")
+    kb_manager = MagicMock()
+    kb_manager.get_kb = AsyncMock(return_value=SimpleNamespace(kb=kb))
+    kb_manager.retrieve = AsyncMock(return_value={"results": []})
+    service = make_service(kb_manager)
+
+    response = await retrieve_knowledge_base(
+        "kb-1",
+        KnowledgeBaseRetrieveRequest(query="hello"),
+        _auth=object(),
+        service=service,
+    )
+
+    assert response["status"] == "ok"
+    kb_manager.retrieve.assert_awaited_once_with(
+        query="hello",
+        kb_names=["Docs"],
+        top_m_final=5,
+    )
+
+
+@pytest.mark.asyncio
+async def test_retrieve_still_accepts_explicit_kb_names():
+    kb_manager = MagicMock()
+    kb_manager.get_kb = AsyncMock()
+    kb_manager.retrieve = AsyncMock(return_value={"results": []})
+    service = make_service(kb_manager)
+
+    await service.retrieve({"query": "hello", "kb_names": ["Docs", "Notes"]})
+
+    kb_manager.get_kb.assert_not_awaited()
+    kb_manager.retrieve.assert_awaited_once_with(
+        query="hello",
+        kb_names=["Docs", "Notes"],
+        top_m_final=5,
+    )
+
+
+@pytest.mark.asyncio
+async def test_retrieve_raises_when_kb_id_is_unknown():
+    kb_manager = MagicMock()
+    kb_manager.get_kb = AsyncMock(return_value=None)
+    service = make_service(kb_manager)
+
+    with pytest.raises(KnowledgeBaseServiceError, match="知识库不存在"):
+        await service.retrieve({"kb_id": "missing", "query": "hello"})
+
+
+@pytest.mark.asyncio
+async def test_retrieve_raises_when_no_knowledge_base_is_specified():
+    kb_manager = MagicMock()
+    service = make_service(kb_manager)
+
+    with pytest.raises(KnowledgeBaseServiceError, match="缺少参数 kb_names 或格式错误"):
+        await service.retrieve({"query": "hello"})
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The knowledge base retrieval panel in the WebUI is completely unusable: every
search fails with `缺少参数 kb_names 或格式错误`.

`POST /api/v1/knowledge-bases/{kb_id}/retrieve` identifies the knowledge base
with the `kb_id` **path parameter**, and the route already forwards it:

```python
# astrbot/dashboard/api/knowledge_bases.py:295
@router.post("/knowledge-bases/{kb_id}/retrieve")
async def retrieve_knowledge_base(kb_id: str, payload: KnowledgeBaseRetrieveRequest, ...):
    body = payload.model_dump(exclude_none=True)
    return await _run(lambda: service.retrieve({"kb_id": kb_id, **body}), prefix="检索失败")
```

But `KnowledgeBaseService.retrieve()` only ever read `kb_names`, which this
route never supplies (`KnowledgeBaseRetrieveRequest` has no such field, and the
dashboard client sends only `query` / `top_k` / `score_threshold`). So `kb_names`
was structurally always `None` and the request was rejected before any lookup
happened — reproducible 100% of the time, for any knowledge base and any query.

The service's `retrieve()` was written for the legacy `POST /api/kb/retrieve`
endpoint, which does pass `kb_names` in the body. When the v1 REST route was
introduced in #8688, the `kb_id` → `kb_names` translation was never added.

### Modifications / 改动点

`astrbot/dashboard/services/knowledge_base_service.py` — when `kb_names` is
absent, resolve the `kb_id` the route already passes into the `kb_names` the
manager expects:

```python
if not kb_names:
    # The REST route identifies the knowledge base with the kb_id path
    # parameter, so resolve it into the kb_names the manager expects.
    kb_id = payload.get("kb_id")
    if kb_id:
        kb_helper = await kb_manager.get_kb(kb_id)
        if not kb_helper:
            raise KnowledgeBaseServiceError("知识库不存在")
        kb_names = [kb_helper.kb.kb_name]
```

Resolving through the name is safe because `KnowledgeBaseManager.create_kb()`
already enforces unique `kb_name` (`知识库名称 '{kb_name}' 已存在`).

An explicit `kb_names` still takes precedence, so the legacy
`POST /api/kb/retrieve` endpoint keeps working unchanged.

`tests/unit/test_knowledge_base_service_contract.py` — 4 regression tests:
resolution from `kb_id`, the route→service binding, the legacy `kb_names` path,
and the two error cases.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

The new tests fail on `master` and pass with the fix (same test code both runs):

```
# master, with the new tests applied but WITHOUT the source fix
$ uv run pytest tests/unit/test_knowledge_base_service_contract.py -q
FAILED tests/unit/test_knowledge_base_service_contract.py::test_retrieve_resolves_kb_id_from_path_parameter
FAILED tests/unit/test_knowledge_base_service_contract.py::test_retrieve_route_passes_kb_id_to_service
FAILED tests/unit/test_knowledge_base_service_contract.py::test_retrieve_raises_when_kb_id_is_unknown
3 failed, 15 passed in 4.70s

# with the fix
$ uv run pytest tests/unit/test_knowledge_base_service_contract.py -q
18 passed, 1 warning in 3.91s
```

Surrounding suites, no new failures:

```
$ uv run pytest tests/unit/test_kb_manager_resilience.py tests/unit/test_kb_document_cleanup.py \
    tests/unit/test_kb_upload_atomicity.py tests/unit/test_dashboard_util.py \
    tests/test_fastapi_v1_dashboard.py tests/test_dashboard.py tests/test_kb_import.py -q
3 failed, 186 passed in 62.87s
```

The 3 failures are the pre-existing `tests/test_dashboard.py::test_t2i_*` cases;
they fail identically on a clean `master` checkout and are unrelated to this change.

```
$ uv run ruff format --check .
483 files already formatted
$ uv run ruff check .
All checks passed!
```

No API schema or OpenAPI definition changed, so no frontend client regeneration
is needed.

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。 <!-- bug fix, no new feature -->

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Fix knowledge base retrieval to work with the v1 dashboard endpoint by resolving kb_id path parameters into kb_names and enforcing proper error handling when no knowledge base is specified.

Bug Fixes:
- Resolve kb_id from the dashboard retrieve endpoint into kb_names so knowledge base searches succeed instead of failing with missing-parameter errors.
- Return a clear error when the provided kb_id does not exist or when no knowledge base identifier is supplied.

Tests:
- Add regression tests covering kb_id-to-kb_names resolution, route-to-service integration, explicit kb_names behavior, and error cases for unknown or missing knowledge base identifiers.