### PR TITLE
fix(core): recreate tool image cache directory after cleanup

### DIFF
--- a/astrbot/core/agent/tool_image_cache.py
+++ b/astrbot/core/agent/tool_image_cache.py
@@ -90,8 +90,9 @@ class ToolImageCache:
         file_name = f"{tool_call_id}_{index}{ext}"
         file_path = os.path.join(self._cache_dir, file_name)
 
-        # Decode and save the image
         try:
+            # Runtime cache cleanup may remove empty subdirectories.
+            os.makedirs(self._cache_dir, exist_ok=True)
             image_bytes = base64.b64decode(base64_data)
             with open(file_path, "wb") as f:
                 f.write(image_bytes)

--- a/tests/test_storage_cleaner.py
+++ b/tests/test_storage_cleaner.py
@@ -1,5 +1,7 @@
+import base64
 from pathlib import Path
 
+from astrbot.core.agent.tool_image_cache import tool_image_cache
 from astrbot.core.utils.storage_cleaner import StorageCleaner
 
 
@@ -83,3 +85,29 @@ def test_storage_cleaner_cleanup_truncates_active_log_and_removes_cache(tmp_path
     assert not (temp_dir / "nested").exists()
     assert result["status"]["logs"]["size_bytes"] == 0
     assert result["status"]["cache"]["size_bytes"] == 0
+
+
+def test_tool_image_cache_recovers_after_storage_cleanup(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    temp_dir = data_dir / "temp"
+    cache_dir = temp_dir / tool_image_cache.CACHE_DIR_NAME
+    image_bytes = b"generated-image"
+
+    _write_bytes(cache_dir / "stale.png", 32)
+    monkeypatch.setattr(tool_image_cache, "_cache_dir", str(cache_dir))
+
+    cleaner = StorageCleaner({}, data_dir=data_dir, temp_dir=temp_dir)
+    cleaner.cleanup("cache")
+
+    assert not cache_dir.exists()
+
+    cached_image = tool_image_cache.save_image(
+        base64_data=base64.b64encode(image_bytes).decode("ascii"),
+        tool_call_id="call-test",
+        tool_name="test-tool",
+        mime_type="image/jpeg",
+    )
+    cached_path = Path(cached_image.file_path)
+
+    assert cached_path == cache_dir / "call-test_0.jpg"
+    assert cached_path.read_bytes() == image_bytes


### PR DESCRIPTION
修复 Dashboard 清理缓存后 `tool_images` 目录被删除，导致工具图片无法写入的问题。

### Modifications / 改动点

  - 保存工具图片前自动重建缓存目录。
  - 添加清理缓存后继续保存图片的回归测试。

  - [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

  ```text
  uv run pytest -q
  2045 passed, 72 warnings

  uv run ruff check astrbot/core/agent/tool_image_cache.py tests/test_storage_cleaner.py
  All checks passed!
```

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

  - [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
    / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

  - [x] 👀 My changes have been well-tested, and "Verification Steps" and "Screenshots" have been provided above.
    / 我的更改经过了良好的测试，并已在上方提供了“验证步骤”和“运行截图”。

  - [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added
    to the appropriate locations in requirements.txt and pyproject.toml.
    / 我确保没有引入新依赖库，或者引入新依赖库的同时将其添加到 requirements.txt 和 pyproject.toml 文件相应位置。

  - [x] 😮 My changes do not introduce malicious code.
    / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure tool image cache directory is recreated when saving images after cache cleanup so tool images remain writable.

Bug Fixes:
- Fix failure to save tool images when the cache directory is removed by storage cleanup.

Tests:
- Add regression test verifying tool image cache recovers correctly after storage cleaner removes its directory.