### PR TITLE
fix: resolve double scrollbar in plugin config dialog

### DIFF
--- a/dashboard/src/views/ExtensionPage.vue
+++ b/dashboard/src/views/ExtensionPage.vue
@@ -466,17 +466,15 @@ const updateDialogPluginLogo = computed(() => {
           ></v-select>
         </div>
         <v-divider class="my-4"></v-divider>
-        <div>
-          <AstrBotConfig
-            v-if="extension_config.metadata"
-            :metadata="extension_config.metadata"
-            :iterable="extension_config.config"
-            :metadataKey="curr_namespace"
-            :pluginName="curr_namespace"
-            :pluginI18n="extension_config.i18n"
-          />
-          <p v-else>{{ tm("dialogs.config.noConfig") }}</p>
-        </div>
+        <AstrBotConfig
+          v-if="extension_config.metadata"
+          :metadata="extension_config.metadata"
+          :iterable="extension_config.config"
+          :metadataKey="curr_namespace"
+          :pluginName="curr_namespace"
+          :pluginI18n="extension_config.i18n"
+        />
+        <p v-else>{{ tm("dialogs.config.noConfig") }}</p>
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>

--- a/dashboard/src/views/ExtensionPage.vue
+++ b/dashboard/src/views/ExtensionPage.vue
@@ -436,7 +436,7 @@ const updateDialogPluginLogo = computed(() => {
   </v-row>
 
   <!-- 配置对话框 -->
-  <v-dialog v-model="configDialog" max-width="900">
+  <v-dialog v-model="configDialog" max-width="900" scrollable>
     <v-card>
       <v-card-title class="text-h3 pa-4 pb-0 pl-6">{{
         tm("dialogs.config.title")
@@ -466,7 +466,7 @@ const updateDialogPluginLogo = computed(() => {
           ></v-select>
         </div>
         <v-divider class="my-4"></v-divider>
-        <div style="max-height: 60vh; overflow-y: auto; padding-right: 8px">
+        <div>
           <AstrBotConfig
             v-if="extension_config.metadata"
             :metadata="extension_config.metadata"


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
插件配置弹窗在手机上出现套娃滚动条。该回归由 #9342 引入——在弹窗顶部新增"日志级别"选择器后内容超出视口，触发页面级滚动与弹窗内部 `max-height: 60vh; overflow-y: auto` 双重滚动。

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
**ExtensionPage.vue** — 插件配置弹窗：
- 为 `v-dialog` 添加 `scrollable` prop，由 Vuetify 统一管理滚动
- 移除内部配置区 div 的 `max-height: 60vh` 和 `overflow-y: auto`，消除双重滚动条

滚动层级简化为单一滚动容器（`v-card-text`），标题和操作按钮保持固定。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

#### Before

<!-- <img width="1080" height="2400" alt="Screenshot_2026-08-01-15-55-31-131_mark via gp (compressed)" src="https://github.com/user-attachments/assets/38cc5727-cc66-4955-930f-52b11aa286cf" /> -->
<img width="1080" height="2400" alt="Screenshot_2026-08-01-15-55-31-131_mark via gp ()" src="https://github.com/user-attachments/assets/6027fc8c-7df5-473b-b998-9386b5e42d71" />

#### After

<img width="1080" height="2400" alt="Screenshot_2026-08-01-15-58-48-599_mark via gp (compressed)" src="https://github.com/user-attachments/assets/fe0807d4-e6b0-4ce4-ad60-2265bc3a12ce" />

现在“日志级别”也会滚动
<img width="1080" height="947" alt="xzScreenshot_2026-08-01-15-58-31-586_mark via gp-edit (compr)" src="https://github.com/user-attachments/assets/46ff3e89-4cc9-4250-ac53-b6a1940c3bdd" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Fix double scrollbars in the plugin configuration dialog by delegating scrolling to the dialog container instead of an inner content div.