### PR TITLE
fix: improve ChatUI composer behavior

### DIFF
--- a/dashboard/src/components/chat/Chat.vue
+++ b/dashboard/src/components/chat/Chat.vue
@@ -428,7 +428,7 @@
           </div>
         </section>
 
-        <section class="composer-shell">
+        <section ref="composerShell" class="composer-shell">
           <ChatInput
             ref="inputRef"
             v-model:prompt="draft"
@@ -694,6 +694,7 @@ const tokenProviderConfigs = ref<TokenProviderConfig[]>([]);
 const tokenModelMetadata = ref<Record<string, ProviderModelMetadata>>({});
 const selectedTokenProviderId = ref("");
 const messagesContainer = ref<HTMLElement | null>(null);
+const composerShell = ref<HTMLElement | null>(null);
 const inputRef = ref<InstanceType<typeof ChatInput> | null>(null);
 const shouldStickToBottom = ref(true);
 const replyTarget = ref<ChatRecord | null>(null);
@@ -722,6 +723,7 @@ const threadSelection = reactive<{
 });
 const enableStreaming = ref(true);
 const sendShortcut = ref<"enter" | "shift_enter">("enter");
+let composerResizeObserver: ResizeObserver | null = null;
 const {
   isRecording,
   startRecording: startRecorder,
@@ -964,6 +966,19 @@ watch(
 );
 
 onMounted(async () => {
+  if (typeof ResizeObserver !== "undefined") {
+    composerResizeObserver = new ResizeObserver(([entry]) => {
+      const container = messagesContainer.value;
+      if (!entry || !container) return;
+      const height = Math.ceil(entry.target.getBoundingClientRect().height);
+      container.style.setProperty("--chat-composer-height", `${height}px`);
+      if (shouldStickToBottom.value) scrollToBottom();
+    });
+    if (composerShell.value) {
+      composerResizeObserver.observe(composerShell.value);
+    }
+  }
+
   loadingSessions.value = true;
   try {
     await Promise.all([getSessions(), getProjects(), loadTokenProviders()]);
@@ -979,8 +994,15 @@ onMounted(async () => {
 });
 
 onBeforeUnmount(() => {
+  composerResizeObserver?.disconnect();
   chatHeader.CLEAR_CONTEXT();
   cleanupMediaCache();
+});
+
+watch(composerShell, (element, previousElement) => {
+  if (!composerResizeObserver) return;
+  if (previousElement) composerResizeObserver.unobserve(previousElement);
+  if (element) composerResizeObserver.observe(element);
 });
 
 watch(
@@ -1630,7 +1652,7 @@ function removeThreadFromMessages(threadId: string) {
   }
 }
 
-async function handleFilesSelected(files: FileList) {
+async function handleFilesSelected(files: FileList | File[]) {
   const selectedFiles = Array.from(files || []);
   for (const file of selectedFiles) {
     if (file.type.startsWith("image/")) {
@@ -2189,8 +2211,8 @@ function toggleTheme() {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding: 24px 0 116px;
-  scroll-padding-bottom: 116px;
+  padding: 24px 0 calc(var(--chat-composer-height, 82px) + 34px);
+  scroll-padding-bottom: calc(var(--chat-composer-height, 82px) + 34px);
 }
 
 .conversation-stack.is-empty .messages-panel {
@@ -2332,8 +2354,8 @@ kbd {
   }
 
   .messages-panel {
-    padding: 18px 0 92px;
-    scroll-padding-bottom: 92px;
+    padding: 18px 0 calc(var(--chat-composer-height, 72px) + 20px);
+    scroll-padding-bottom: calc(var(--chat-composer-height, 72px) + 20px);
   }
 
   .conversation-stack.is-empty .messages-panel {

--- a/dashboard/src/components/chat/ChatInput.vue
+++ b/dashboard/src/components/chat/ChatInput.vue
@@ -400,7 +400,7 @@ const emit = defineEmits<{
   startRecording: [];
   stopRecording: [];
   pasteImage: [event: ClipboardEvent];
-  fileSelect: [files: FileList];
+  fileSelect: [files: FileList | File[]];
   clearReply: [];
   openLiveMode: [];
 }>();
@@ -421,6 +421,7 @@ const isDragging = ref(false);
 const isComposing = ref(false);
 const inputIsMultiline = ref(false);
 const lastCompositionEndAt = ref<number | null>(null);
+const longPasteThreshold = 10_000;
 let dragLeaveTimeout: number | null = null;
 
 // 命令提示相关状态
@@ -895,6 +896,16 @@ function handleKeyUp(e: KeyboardEvent) {
 
 function handlePaste(e: ClipboardEvent) {
   const pastedText = e.clipboardData?.getData("text/plain") || "";
+  if (pastedText.length > longPasteThreshold) {
+    e.preventDefault();
+    emit("fileSelect", [
+      new File([pastedText], `pasted-text-${Date.now()}.txt`, {
+        type: "text/plain;charset=utf-8",
+      }),
+    ]);
+    return;
+  }
+
   if (!inputIsMultiline.value && pastedText.includes("\n")) {
     e.preventDefault();
     const target = e.target as HTMLInputElement;
@@ -1143,7 +1154,7 @@ defineExpose({
   border-color: #f0f0f0 !important;
   border-radius: 999px !important;
   background: #fff !important;
-  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.08) !important;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06) !important;
 }
 
 .input-container.is-multiline {

--- a/dashboard/src/components/chat/StandaloneChat.vue
+++ b/dashboard/src/components/chat/StandaloneChat.vue
@@ -401,7 +401,7 @@ async function stopCurrentSession() {
   await stopSession(currSessionId.value);
 }
 
-async function handleFilesSelected(files: FileList) {
+async function handleFilesSelected(files: FileList | File[]) {
   const selectedFiles = Array.from(files || []);
   for (const file of selectedFiles) {
     if (file.type.startsWith("image/")) {


### PR DESCRIPTION
## Summary

- reserve message-list space from the live composer height so expanded text, replies, and attachments no longer cover conversation content
- convert pasted text over 10,000 characters into a uniquely named UTF-8 `.txt` attachment
- soften the light-theme composer shadow

## Root cause

The non-empty ChatUI composer is absolutely positioned, while the message list previously reserved a fixed 116px on desktop and 92px on mobile. The textarea can grow far beyond those values, so it overlapped the latest messages. A `ResizeObserver` now keeps the message-list padding aligned with the actual composer height and preserves bottom-pinned scrolling.

Fixes #9478.

## Validation

- `pnpm typecheck`
- `pnpm exec vite build`
- `uv run ruff format --check .`
- `uv run ruff check .`

## Summary by Sourcery

Improve ChatUI composer layout behavior and handling of long pasted text while slightly adjusting light theme styling.

New Features:
- Convert pasted text over 10,000 characters into a UTF-8 .txt attachment added via the existing file attachment flow.

Bug Fixes:
- Dynamically reserve space for the ChatUI composer so expanded text, replies, and attachments no longer overlap the latest messages and preserve bottom-pinned scrolling.

Enhancements:
- Relax the light-theme composer box shadow for a softer visual appearance.