### PR TITLE
fix: persist terminal tool history and token usage

### DIFF
--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -484,11 +484,12 @@ class InternalAgentSubStage(Stage):
                     ).model_dump()
                 )
             if has_checkpoint or (llm_response is None and req.tool_calls_result):
+                token_usage = None if has_checkpoint else req.conversation.token_usage
                 await self.conv_manager.update_conversation(
                     event.unified_msg_origin,
                     req.conversation.cid,
                     history=message_to_save,
-                    token_usage=None,
+                    token_usage=token_usage,
                 )
             return
 

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -472,16 +472,18 @@ class InternalAgentSubStage(Stage):
             messages_to_save.append(message)
 
         checkpoint_id = event.get_extra("llm_checkpoint_id")
+        has_checkpoint = isinstance(checkpoint_id, str) and bool(checkpoint_id)
         message_to_save = dump_messages_with_checkpoints(messages_to_save)
         if not user_aborted and (
             llm_response is None or llm_response.role != "assistant"
         ):
-            if isinstance(checkpoint_id, str) and checkpoint_id:
+            if has_checkpoint:
                 message_to_save.append(
                     CheckpointMessageSegment(
                         content=CheckpointData(id=checkpoint_id),
                     ).model_dump()
                 )
+            if has_checkpoint or (llm_response is None and req.tool_calls_result):
                 await self.conv_manager.update_conversation(
                     event.unified_msg_origin,
                     req.conversation.cid,

--- a/tests/agent/test_context_manager.py
+++ b/tests/agent/test_context_manager.py
@@ -530,6 +530,23 @@ class TestContextManager:
         assert len(result) <= len(messages)
 
     @pytest.mark.asyncio
+    async def test_trusted_usage_triggers_compression_before_provider_call(self):
+        config = ContextConfig(max_context_tokens=100, truncate_turns=1)
+        manager = ContextManager(config)
+        messages = [self.create_message("user", "short")]
+        compressed = [self.create_message("user", "compressed")]
+        mock_compressor = AsyncMock(return_value=compressed)
+        mock_compressor.should_compress = MagicMock(side_effect=[True, False])
+        manager.compressor = mock_compressor
+
+        result = await manager.process(messages, trusted_token_usage=83)
+
+        first_check = mock_compressor.should_compress.call_args_list[0]
+        assert first_check.args == (messages, 83, 100)
+        mock_compressor.assert_awaited_once_with(messages)
+        assert result == compressed
+
+    @pytest.mark.asyncio
     async def test_token_compression_with_zero_max_tokens(self):
         """Test that compression is skipped when max_context_tokens is 0."""
         config = ContextConfig(max_context_tokens=0)

--- a/tests/test_conversation_checkpoint.py
+++ b/tests/test_conversation_checkpoint.py
@@ -234,6 +234,7 @@ async def test_terminal_tool_result_persists_history_without_checkpoint():
             platform_id="qq",
             user_id="qq:GroupMessage:test",
             cid="conversation-1",
+            token_usage=1234,
         ),
         tool_calls_result=ToolCallsResult(
             tool_calls_info=assistant_message,
@@ -278,7 +279,7 @@ async def test_terminal_tool_result_persists_history_without_checkpoint():
                 "tool_call_id": "call-1",
             },
         ],
-        token_usage=None,
+        token_usage=1234,
     )
 
 

--- a/tests/test_conversation_checkpoint.py
+++ b/tests/test_conversation_checkpoint.py
@@ -4,10 +4,13 @@ from unittest.mock import AsyncMock
 import pytest
 
 from astrbot.core.agent.message import (
+    AssistantMessageSegment,
     CheckpointData,
     CheckpointMessageSegment,
     Message,
     TextPart,
+    ToolCall,
+    ToolCallMessageSegment,
     bind_checkpoint_messages,
     dump_messages_with_checkpoints,
     get_checkpoint_id,
@@ -17,7 +20,7 @@ from astrbot.core.db.po import Conversation
 from astrbot.core.pipeline.process_stage.method.agent_sub_stages.internal import (
     InternalAgentSubStage,
 )
-from astrbot.core.provider.entities import LLMResponse, ProviderRequest
+from astrbot.core.provider.entities import LLMResponse, ProviderRequest, ToolCallsResult
 from astrbot.core.provider.provider import Provider
 from astrbot.dashboard.services.chat_service import find_turn_range
 
@@ -206,3 +209,102 @@ async def test_failed_llm_response_persists_checkpoint_for_retry():
         ],
         token_usage=None,
     )
+
+
+@pytest.mark.asyncio
+async def test_terminal_tool_result_persists_history_without_checkpoint():
+    conversation_manager = AsyncMock()
+    stage = InternalAgentSubStage()
+    stage.conv_manager = conversation_manager
+    event = SimpleNamespace(
+        unified_msg_origin="qq:GroupMessage:test",
+        get_extra=lambda _key: None,
+    )
+    tool_call = ToolCall(
+        id="call-1",
+        function=ToolCall.FunctionBody(name="stay_silent", arguments="{}"),
+    )
+    assistant_message = AssistantMessageSegment(tool_calls=[tool_call])
+    tool_message = ToolCallMessageSegment(
+        content="The tool has no return value.",
+        tool_call_id="call-1",
+    )
+    request = ProviderRequest(
+        conversation=Conversation(
+            platform_id="qq",
+            user_id="qq:GroupMessage:test",
+            cid="conversation-1",
+        ),
+        tool_calls_result=ToolCallsResult(
+            tool_calls_info=assistant_message,
+            tool_calls_result=[tool_message],
+        ),
+    )
+
+    await stage._save_to_history(
+        event,
+        request,
+        None,
+        [
+            Message(role="user", content="latest group observation"),
+            assistant_message,
+            tool_message,
+        ],
+        runner_stats=None,
+    )
+
+    conversation_manager.update_conversation.assert_awaited_once_with(
+        "qq:GroupMessage:test",
+        "conversation-1",
+        history=[
+            {"role": "user", "content": "latest group observation"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "id": "call-1",
+                        "function": {
+                            "name": "stay_silent",
+                            "arguments": "{}",
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": "The tool has no return value.",
+                "tool_call_id": "call-1",
+            },
+        ],
+        token_usage=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_response_without_tool_result_skips_history_save():
+    conversation_manager = AsyncMock()
+    stage = InternalAgentSubStage()
+    stage.conv_manager = conversation_manager
+    event = SimpleNamespace(
+        unified_msg_origin="qq:GroupMessage:test",
+        get_extra=lambda _key: None,
+    )
+    request = ProviderRequest(
+        conversation=Conversation(
+            platform_id="qq",
+            user_id="qq:GroupMessage:test",
+            cid="conversation-1",
+        )
+    )
+
+    await stage._save_to_history(
+        event,
+        request,
+        None,
+        [Message(role="user", content="latest group observation")],
+        runner_stats=None,
+    )
+
+    conversation_manager.update_conversation.assert_not_awaited()

--- a/tests/test_conversation_checkpoint.py
+++ b/tests/test_conversation_checkpoint.py
@@ -284,6 +284,79 @@ async def test_terminal_tool_result_persists_history_without_checkpoint():
 
 
 @pytest.mark.asyncio
+async def test_terminal_tool_result_with_checkpoint_uses_none_token_usage():
+    conversation_manager = AsyncMock()
+    stage = InternalAgentSubStage()
+    stage.conv_manager = conversation_manager
+    event = SimpleNamespace(
+        unified_msg_origin="qq:GroupMessage:test",
+        get_extra=lambda key: {"llm_checkpoint_id": "cp-1"}.get(key),
+    )
+    tool_call = ToolCall(
+        id="call-1",
+        function=ToolCall.FunctionBody(name="stay_silent", arguments="{}"),
+    )
+    assistant_message = AssistantMessageSegment(tool_calls=[tool_call])
+    tool_message = ToolCallMessageSegment(
+        content="The tool has no return value.",
+        tool_call_id="call-1",
+    )
+    request = ProviderRequest(
+        conversation=Conversation(
+            platform_id="qq",
+            user_id="qq:GroupMessage:test",
+            cid="conversation-1",
+            token_usage=1234,
+        ),
+        tool_calls_result=ToolCallsResult(
+            tool_calls_info=assistant_message,
+            tool_calls_result=[tool_message],
+        ),
+    )
+
+    await stage._save_to_history(
+        event,
+        request,
+        None,
+        [
+            Message(role="user", content="latest group observation"),
+            assistant_message,
+            tool_message,
+        ],
+        runner_stats=None,
+    )
+
+    conversation_manager.update_conversation.assert_awaited_once_with(
+        "qq:GroupMessage:test",
+        "conversation-1",
+        history=[
+            {"role": "user", "content": "latest group observation"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "id": "call-1",
+                        "function": {
+                            "name": "stay_silent",
+                            "arguments": "{}",
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": "The tool has no return value.",
+                "tool_call_id": "call-1",
+            },
+            {"role": "_checkpoint", "content": {"id": "cp-1"}},
+        ],
+        token_usage=None,
+    )
+
+
+@pytest.mark.asyncio
 async def test_empty_response_without_tool_result_skips_history_save():
     conversation_manager = AsyncMock()
     stage = InternalAgentSubStage()


### PR DESCRIPTION
### Motivation / 动机

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

When an internal agent finishes tool execution without a terminal assistant response, the history-save path only persists the conversation when a retry checkpoint exists. The assistant tool call and tool result can therefore be absent from the next model request context, leading to a situation where **actual external changes have occurred but the model is unaware of them**.

This fix is a requirement for the plugin I am developing, [astrbot_plugin_group_agent_flow](https://github.com/xiaoxuan010/astrbot_plugin_group_agent_flow/tree/feat/autonomous-group-agent), which aims to address the issue of the model being unaware of prior tool calls and tool results when the plugin's final output is empty.

当内部 Agent 在工具执行后未产生最终 assistant 响应时，历史保存路径仅在存在重试 checkpoint 时写入会话。后续模型请求可能缺少 assistant 工具调用与工具结果上下文，导致**实际外部变更已产生但模型无法感知**。

本次修复是我正在开发中的插件 [astrbot_plugin_group_agent_flow](https://github.com/xiaoxuan010/astrbot_plugin_group_agent_flow/tree/feat/autonomous-group-agent) 的一个需求，旨在解决插件最终输出为空时，模型无法感知先前工具调用与工具结果的情况。

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- Persist assistant tool-call messages and tool-result messages when `llm_response` is absent and terminal tool results exist.
  / 当 `llm_response` 为空且存在终止工具结果时，持久化 assistant 工具调用消息与工具结果消息。

- Preserve the conversation's trusted token usage for this history-save path, allowing the next context-management pass to make the correct compression decision.
  / 在该历史保存路径保留会话的可信 token 用量，使下一次上下文管理能够正确决定压缩时机。

- Preserve checkpoint retry behavior: checkpoint history continues to be saved with `token_usage=None`.
  / 保持 checkpoint 重试行为：checkpoint 历史仍以 `token_usage=None` 保存。

- Add regression coverage for terminal tool-result persistence and trusted token usage triggering context compression.
  / 新增终止工具结果持久化及可信 token 用量触发上下文压缩的回归测试。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

<img width="460" height="420" alt="image" src="https://github.com/user-attachments/assets/5d4293bf-2e21-42dd-a0ba-03a4ffe459ba" />


---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure terminal tool-call interactions are persisted to conversation history when no assistant response is produced, while preserving checkpoint semantics and token usage for downstream context management.

New Features:
- Persist assistant tool-call and tool-result messages to conversation history when terminal tools run without an assistant reply.

Bug Fixes:
- Prevent loss of tool-call and tool-result context in subsequent model requests when terminal tools complete without an assistant response.

Enhancements:
- Propagate trusted token usage through the non-checkpoint history-save path so context compression can be correctly triggered before provider calls.
- Keep checkpoint-based retries writing history with null token usage to maintain existing retry behavior.

Tests:
- Add regression tests covering terminal tool-result history persistence and skipping history updates when responses and tool results are both absent.
- Add tests verifying that trusted token usage triggers pre-call context compression in the context manager.