### PR TITLE
fix: support line writes for managed shell sessions

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -457,8 +457,10 @@ def _build_local_mode_prompt() -> str:
         f"{shell_hint} "
         "Local shell commands automatically return a managed session when they "
         "outlive the initial wait. Use `astrbot_shell_session` to list, poll, "
-        "write to, interrupt, or terminate those sessions. Do not add `&`, "
-        "`nohup`, or another detachment wrapper for ordinary long-running commands."
+        "write raw text or complete lines to, interrupt, or terminate those sessions. "
+        "Use its `write_line` action for line-oriented programs so the session receives "
+        "a real line feed. Do not add `&`, `nohup`, or another detachment wrapper for "
+        "ordinary long-running commands."
     )
 
 

--- a/astrbot/core/tools/computer_tools/shell.py
+++ b/astrbot/core/tools/computer_tools/shell.py
@@ -244,7 +244,8 @@ class ShellSessionTool(FunctionTool):
 
     name: str = "astrbot_shell_session"
     description: str = (
-        "List, poll, write to, interrupt, or terminate managed shell sessions. "
+        "List, poll, write raw text or complete lines to, interrupt, or terminate "
+        "managed shell sessions. "
         "Sessions are isolated to the current conversation and sender. "
         "Administrators can manage all sessions in the conversation."
     )
@@ -254,7 +255,14 @@ class ShellSessionTool(FunctionTool):
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["list", "poll", "write", "interrupt", "terminate"],
+                    "enum": [
+                        "list",
+                        "poll",
+                        "write",
+                        "write_line",
+                        "interrupt",
+                        "terminate",
+                    ],
                     "description": "Session operation to perform.",
                 },
                 "session_id": {
@@ -263,7 +271,10 @@ class ShellSessionTool(FunctionTool):
                 },
                 "chars": {
                     "type": "string",
-                    "description": "Text written verbatim when action is write.",
+                    "description": (
+                        "Text sent verbatim by write. For write_line, provide one "
+                        "line without a line ending; a real LF is appended automatically."
+                    ),
                     "default": "",
                 },
                 "cursor": {
@@ -306,7 +317,7 @@ class ShellSessionTool(FunctionTool):
             context: Current agent tool context.
             action: Session operation to perform.
             session_id: Managed session identifier, except for list.
-            chars: Text written for the write action.
+            chars: Text written verbatim for write or with a trailing LF for write_line.
             cursor: Optional output byte cursor.
             yield_time_ms: Maximum wait for output or process exit.
             max_output_chars: Maximum output bytes to return.
@@ -357,13 +368,13 @@ class ShellSessionTool(FunctionTool):
                         yield_time_ms=yield_time_ms,
                         max_output_chars=max_output_chars,
                     )
-                elif action == "write":
+                elif action in {"write", "write_line"}:
                     result = await sb.shell.write_session(
                         owner_id=owner_id,
                         requester_id=requester_id,
                         requester_is_admin=requester_is_admin,
                         session_id=session_id,
-                        chars=chars,
+                        chars=f"{chars}\n" if action == "write_line" else chars,
                     )
                 elif action == "interrupt":
                     result = await sb.shell.interrupt_session(

--- a/tests/unit/test_func_tool_manager.py
+++ b/tests/unit/test_func_tool_manager.py
@@ -68,6 +68,16 @@ def test_local_execute_shell_schema_replaces_background_with_yield():
     assert "background" not in inspect.signature(tool.call).parameters
 
 
+def test_shell_session_schema_supports_line_writes():
+    tool = ShellSessionTool()
+
+    assert "write_line" in tool.parameters["properties"]["action"]["enum"]
+    assert (
+        "LF is appended automatically"
+        in tool.parameters["properties"]["chars"]["description"]
+    )
+
+
 @pytest.mark.asyncio
 async def test_local_execute_shell_uses_managed_session(monkeypatch, tmp_path):
     from astrbot.core.tools.computer_tools import shell as shell_tools
@@ -249,16 +259,26 @@ async def test_shell_session_tool_lists_sessions_for_current_owner(monkeypatch):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("action", ["poll", "write", "interrupt", "terminate"])
+@pytest.mark.parametrize(
+    ("action", "component_action"),
+    [
+        ("poll", "poll"),
+        ("write", "write"),
+        ("write_line", "write"),
+        ("interrupt", "interrupt"),
+        ("terminate", "terminate"),
+    ],
+)
 async def test_shell_session_tool_passes_member_identity_to_session_actions(
     monkeypatch,
     action,
+    component_action,
 ):
     from astrbot.core.tools.computer_tools import shell as shell_tools
 
     shell = LocalShellComponent()
     operation = AsyncMock(return_value={"session_id": "sh_test", "status": "running"})
-    setattr(shell, f"{action}_session", operation)
+    setattr(shell, f"{component_action}_session", operation)
 
     class FakeBooter:
         pass
@@ -306,6 +326,9 @@ async def test_shell_session_tool_passes_member_identity_to_session_actions(
     assert operation.await_args.kwargs["owner_id"] == "group-umo"
     assert operation.await_args.kwargs["requester_id"] == "member-user"
     assert operation.await_args.kwargs["requester_is_admin"] is False
+    if component_action == "write":
+        expected_chars = "input\n" if action == "write_line" else "input"
+        assert operation.await_args.kwargs["chars"] == expected_chars
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add a `write_line` action that appends a real LF before writing to managed-session stdin
- preserve the existing `write` action's verbatim behavior
- clarify the tool schema and local-agent prompt so line-oriented programs use `write_line`

## Root cause

Models can double-escape `\n` while constructing tool arguments. The managed shell then receives the literal backslash and `n` characters, so line-oriented programs such as the Python REPL keep waiting for an actual line feed and polling returns no new output.

## Impact

Agents can submit complete lines without encoding the line ending themselves, while callers that need exact byte-oriented text retain the existing behavior.

## Validation

- `uv run pytest tests/unit/test_func_tool_manager.py tests/test_local_shell_component.py -q` (44 passed)
- `uv run pytest tests/unit/test_astr_main_agent.py -q` (99 passed)
- `uv run ruff format .`
- `uv run ruff check .`

## Summary by Sourcery

Add explicit support for line-oriented writes in managed shell sessions and clarify guidance for using the shell session tool in local mode.

New Features:
- Introduce a write_line action for managed shell sessions that appends a real line feed to input before writing to stdin.

Enhancements:
- Update the shell session tool schema and descriptions to distinguish raw text writes from complete line writes and document automatic LF handling.
- Refine the local-mode agent prompt to direct line-oriented programs to use the write_line action for managed shell sessions.

Tests:
- Extend shell session tool tests to cover the new write_line action, updated schema, and correct forwarding of line-terminated input to the underlying shell component.