### PR TITLE
refactor: reduce path token usage

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -1656,11 +1656,14 @@ async def build_main_agent(
                 event.unified_msg_origin,
                 plugin_context,
             )
-            workspace_prompt = f"\nCurrent workspace you can use: `{workspace_root}`\n"
             tool_prompt += (
-                workspace_prompt
-                + "Unless the user explicitly specifies a different directory, "
-                "perform all file-related operations in this workspace.\n"
+                f"\nCurrent workspace: `{workspace_root}`. "
+                "`astrbot_execute_shell` and `astrbot_execute_python` use it as "
+                "their working directory. `astrbot_file_read_tool`, "
+                "`astrbot_file_write_tool`, `astrbot_file_edit_tool`, and "
+                "`astrbot_grep_tool` resolve relative paths from it. Prefer relative "
+                "paths within the workspace; do not assume this behavior for other "
+                "tools.\n"
             )
 
         req.system_prompt += f"\n{tool_prompt}\n"

--- a/astrbot/core/platform/sources/webchat/message_parts_helper.py
+++ b/astrbot/core/platform/sources/webchat/message_parts_helper.py
@@ -1,7 +1,6 @@
 import json
 import mimetypes
 import shutil
-import uuid
 from collections.abc import Awaitable, Callable, Sequence
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -17,6 +16,7 @@ from astrbot.core.message.components import (
     Video,
 )
 from astrbot.core.message.message_event_result import MessageChain
+from astrbot.core.utils.datetime_utils import generate_timestamp_id
 from astrbot.core.utils.media_utils import MediaResolver
 
 AttachmentGetter = Callable[[str], Awaitable[Attachment | None]]
@@ -479,7 +479,7 @@ async def _copy_file_to_attachment_part(
         return None
 
     suffix = src_path.suffix
-    target_path = attachments_dir / f"{uuid.uuid4().hex}{suffix}"
+    target_path = attachments_dir / f"{generate_timestamp_id()}{suffix}"
     shutil.copy2(src_path, target_path)
 
     mime_type, _ = mimetypes.guess_type(target_path.name)

--- a/astrbot/core/platform/sources/webchat/webchat_event.py
+++ b/astrbot/core/platform/sources/webchat/webchat_event.py
@@ -3,13 +3,13 @@ import base64
 import json
 import os
 import shutil
-import uuid
 from pathlib import Path, PurePosixPath
 
 from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent, MessageChain
 from astrbot.api.message_components import File, Image, Json, Plain, Record
 from astrbot.core.utils.astrbot_path import get_astrbot_data_path
+from astrbot.core.utils.datetime_utils import generate_timestamp_id
 from astrbot.core.utils.media_utils import (
     MEDIA_MIME_EXTENSIONS,
     detect_image_mime_type_async,
@@ -84,7 +84,7 @@ class WebChatMessageEvent(AstrMessageEvent):
                     default_mime_type=None,
                 )
                 suffix = MEDIA_MIME_EXTENSIONS.get(mime_type or "", ".jpg")
-                filename = f"{str(uuid.uuid4())}{suffix}"
+                filename = f"{generate_timestamp_id()}{suffix}"
                 path = os.path.join(attachments_dir, filename)
                 await asyncio.to_thread(Path(path).write_bytes, image_bytes)
                 data = f"[IMAGE]{filename}"
@@ -101,7 +101,7 @@ class WebChatMessageEvent(AstrMessageEvent):
                     return None
             elif isinstance(comp, Record):
                 # save record to local
-                filename = f"{str(uuid.uuid4())}.wav"
+                filename = f"{generate_timestamp_id()}.wav"
                 path = os.path.join(attachments_dir, filename)
                 record_base64 = await comp.convert_to_base64()
                 record_bytes = base64.b64decode(record_base64)
@@ -130,7 +130,7 @@ class WebChatMessageEvent(AstrMessageEvent):
                 if original_name in {"", ".", ".."}:
                     original_name = os.path.basename(file_path) or "file"
                 ext = os.path.splitext(original_name)[1] or ""
-                filename = f"{uuid.uuid4()!s}{ext}"
+                filename = f"{generate_timestamp_id()}{ext}"
                 dest_path = os.path.join(attachments_dir, filename)
                 shutil.copy2(file_path, dest_path)
                 data = f"[FILE]{filename}|{original_name}"

--- a/astrbot/core/provider/sources/azure_tts_source.py
+++ b/astrbot/core/provider/sources/azure_tts_source.py
@@ -4,7 +4,6 @@ import json
 import re
 import secrets
 import time
-import uuid
 from pathlib import Path
 from xml.sax.saxutils import escape
 
@@ -13,6 +12,7 @@ from httpx import AsyncClient, Timeout
 from astrbot import logger
 from astrbot.core.config.default import VERSION
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
+from astrbot.core.utils.datetime_utils import generate_timestamp_id
 
 from ..entities import ProviderType
 from ..provider import TTSProvider
@@ -78,7 +78,7 @@ class OTTSProvider:
         return f"{timestamp}-{nonce}-0-{hashlib.md5(f'{path}-{timestamp}-{nonce}-0-{self.skey}'.encode()).hexdigest()}"
 
     async def get_audio(self, text: str, voice_params: dict) -> str:
-        file_path = TEMP_DIR / f"otts-{uuid.uuid4()}.wav"
+        file_path = TEMP_DIR / f"otts-{generate_timestamp_id()}.wav"
         signature = await self._generate_signature()
         for attempt in range(self.retry_count):
             try:
@@ -176,7 +176,7 @@ class AzureNativeProvider(TTSProvider):
     async def get_audio(self, text: str) -> str:
         if not self.token or time.time() > self.token_expire:
             await self._refresh_token()
-        file_path = TEMP_DIR / f"azure-{uuid.uuid4()}.wav"
+        file_path = TEMP_DIR / f"azure-{generate_timestamp_id()}.wav"
         ssml = f"""<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis'
             xmlns:mstts='http://www.w3.org/2001/mstts' xml:lang='zh-CN'>
             <voice name='{escape(self.voice_params["voice"])}'>

--- a/astrbot/core/provider/sources/dashscope_tts.py
+++ b/astrbot/core/provider/sources/dashscope_tts.py
@@ -2,7 +2,6 @@ import asyncio
 import base64
 import logging
 import os
-import uuid
 
 import aiohttp
 import dashscope
@@ -16,6 +15,7 @@ except (
     MultiModalConversation = None
 
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
+from astrbot.core.utils.datetime_utils import generate_timestamp_id
 
 from ..entities import ProviderType
 from ..provider import TTSProvider
@@ -58,7 +58,7 @@ class ProviderDashscopeTTSAPI(TTSProvider):
                 "Audio synthesis failed, returned empty content. The model may not be supported or the service is unavailable.",
             )
 
-        path = os.path.join(temp_dir, f"dashscope_tts_{uuid.uuid4()}{ext}")
+        path = os.path.join(temp_dir, f"dashscope_tts_{generate_timestamp_id()}{ext}")
         with open(path, "wb") as f:
             f.write(audio_bytes)
         return path

--- a/astrbot/core/provider/sources/edge_tts_source.py
+++ b/astrbot/core/provider/sources/edge_tts_source.py
@@ -1,12 +1,12 @@
 import asyncio
 import os
 import subprocess
-import uuid
 
 import edge_tts
 
 from astrbot.core import logger
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
+from astrbot.core.utils.datetime_utils import generate_timestamp_id
 
 from ..entities import ProviderType
 from ..provider import TTSProvider
@@ -47,8 +47,10 @@ class ProviderEdgeTTS(TTSProvider):
 
     async def get_audio(self, text: str) -> str:
         temp_dir = get_astrbot_temp_path()
-        mp3_path = os.path.join(temp_dir, f"edge_tts_temp_{uuid.uuid4()}.mp3")
-        wav_path = os.path.join(temp_dir, f"edge_tts_{uuid.uuid4()}.wav")
+        mp3_path = os.path.join(
+            temp_dir, f"edge_tts_temp_{generate_timestamp_id()}.mp3"
+        )
+        wav_path = os.path.join(temp_dir, f"edge_tts_{generate_timestamp_id()}.wav")
 
         # 构建 Edge TTS 参数
         kwargs = {"text": text, "voice": self.voice}

--- a/astrbot/core/provider/sources/elevenlabs_tts_source.py
+++ b/astrbot/core/provider/sources/elevenlabs_tts_source.py
@@ -1,10 +1,10 @@
-import uuid
 from pathlib import Path
 
 import httpx
 
 from astrbot import logger
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
+from astrbot.core.utils.datetime_utils import generate_timestamp_id
 
 from ..entities import ProviderType
 from ..provider import TTSProvider
@@ -163,7 +163,8 @@ class ProviderElevenLabsTTSAPI(TTSProvider):
         temp_dir = Path(get_astrbot_temp_path())
         temp_dir.mkdir(parents=True, exist_ok=True)
         path = (
-            temp_dir / f"elevenlabs_tts_api_{uuid.uuid4()}.{self._output_extension()}"
+            temp_dir
+            / f"elevenlabs_tts_api_{generate_timestamp_id()}.{self._output_extension()}"
         )
         path.write_bytes(response.content)
         return str(path)

--- a/astrbot/core/provider/sources/fishaudio_tts_api_source.py
+++ b/astrbot/core/provider/sources/fishaudio_tts_api_source.py
@@ -1,6 +1,5 @@
 import os
 import re
-import uuid
 from typing import Annotated, Literal
 
 import ormsgpack
@@ -9,6 +8,7 @@ from pydantic import BaseModel, conint
 
 from astrbot import logger
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
+from astrbot.core.utils.datetime_utils import generate_timestamp_id
 
 from ..entities import ProviderType
 from ..provider import TTSProvider
@@ -146,7 +146,9 @@ class ProviderFishAudioTTSAPI(TTSProvider):
 
     async def get_audio(self, text: str) -> str:
         temp_dir = get_astrbot_temp_path()
-        path = os.path.join(temp_dir, f"fishaudio_tts_api_{uuid.uuid4()}.wav")
+        path = os.path.join(
+            temp_dir, f"fishaudio_tts_api_{generate_timestamp_id()}.wav"
+        )
         self.headers["content-type"] = "application/msgpack"
         request = await self._generate_request(text)
         async with AsyncClient(

--- a/astrbot/core/provider/sources/gemini_tts_source.py
+++ b/astrbot/core/provider/sources/gemini_tts_source.py
@@ -1,5 +1,4 @@
 import os
-import uuid
 import wave
 
 from google import genai
@@ -7,6 +6,7 @@ from google.genai import types
 
 from astrbot import logger
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
+from astrbot.core.utils.datetime_utils import generate_timestamp_id
 
 from ..entities import ProviderType
 from ..provider import TTSProvider
@@ -50,7 +50,7 @@ class ProviderGeminiTTSAPI(TTSProvider):
 
     async def get_audio(self, text: str) -> str:
         temp_dir = get_astrbot_temp_path()
-        path = os.path.join(temp_dir, f"gemini_tts_{uuid.uuid4()}.wav")
+        path = os.path.join(temp_dir, f"gemini_tts_{generate_timestamp_id()}.wav")
         prompt = f"{self.prefix}: {text}" if self.prefix else text
         response = await self.client.models.generate_content(
             model=self.model,

--- a/astrbot/core/provider/sources/genie_tts.py
+++ b/astrbot/core/provider/sources/genie_tts.py
@@ -1,12 +1,12 @@
 import asyncio
 import os
-import uuid
 
 from astrbot.core import logger
 from astrbot.core.provider.entities import ProviderType
 from astrbot.core.provider.provider import TTSProvider
 from astrbot.core.provider.register import register_provider_adapter
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
+from astrbot.core.utils.datetime_utils import generate_timestamp_id
 
 try:
     import genie_tts as genie  # type: ignore
@@ -56,7 +56,7 @@ class GenieTTSProvider(TTSProvider):
     async def get_audio(self, text: str) -> str:
         temp_dir = get_astrbot_temp_path()
         os.makedirs(temp_dir, exist_ok=True)
-        filename = f"genie_tts_{uuid.uuid4()}.wav"
+        filename = f"genie_tts_{generate_timestamp_id()}.wav"
         path = os.path.join(temp_dir, filename)
 
         loop = asyncio.get_running_loop()
@@ -96,7 +96,7 @@ class GenieTTSProvider(TTSProvider):
             try:
                 temp_dir = get_astrbot_temp_path()
                 os.makedirs(temp_dir, exist_ok=True)
-                filename = f"genie_tts_{uuid.uuid4()}.wav"
+                filename = f"genie_tts_{generate_timestamp_id()}.wav"
                 path = os.path.join(temp_dir, filename)
 
                 def _generate(save_path: str, t: str) -> None:

--- a/astrbot/core/provider/sources/gsv_selfhosted_source.py
+++ b/astrbot/core/provider/sources/gsv_selfhosted_source.py
@@ -1,11 +1,11 @@
 import asyncio
 import os
-import uuid
 
 import aiohttp
 
 from astrbot import logger
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
+from astrbot.core.utils.datetime_utils import generate_timestamp_id
 
 from ..entities import ProviderType
 from ..provider import TTSProvider
@@ -123,7 +123,7 @@ class ProviderGSVTTS(TTSProvider):
 
         temp_dir = get_astrbot_temp_path()
         os.makedirs(temp_dir, exist_ok=True)
-        path = os.path.join(temp_dir, f"gsv_tts_{uuid.uuid4().hex}.wav")
+        path = os.path.join(temp_dir, f"gsv_tts_{generate_timestamp_id()}.wav")
 
         logger.debug(f"[GSV TTS] 正在调用语音合成接口，参数：{params}")
 

--- a/astrbot/core/provider/sources/gsvi_tts_source.py
+++ b/astrbot/core/provider/sources/gsvi_tts_source.py
@@ -1,9 +1,9 @@
-import uuid
 from pathlib import Path
 
 import aiohttp
 
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
+from astrbot.core.utils.datetime_utils import generate_timestamp_id
 
 from ..entities import ProviderType
 from ..provider import TTSProvider
@@ -33,7 +33,7 @@ class ProviderGSVITTS(TTSProvider):
 
     async def get_audio(self, text: str) -> str:
         temp_dir = get_astrbot_temp_path()
-        path = Path(temp_dir) / f"gsvi_tts_{uuid.uuid4()}.wav"
+        path = Path(temp_dir) / f"gsvi_tts_{generate_timestamp_id()}.wav"
         url = f"{self.api_base}/infer_single"
 
         headers = {"Content-Type": "application/json"}

--- a/astrbot/core/provider/sources/mimo_tts_api_source.py
+++ b/astrbot/core/provider/sources/mimo_tts_api_source.py
@@ -1,5 +1,6 @@
 import base64
-import uuid
+
+from astrbot.core.utils.datetime_utils import generate_timestamp_id
 
 from ..entities import ProviderType
 from ..provider import TTSProvider
@@ -123,7 +124,8 @@ class ProviderMiMoTTSAPI(TTSProvider):
             raise MiMoAPIError(f"MiMo TTS API returned no audio payload: {data}")
 
         output_path = (
-            get_temp_dir() / f"mimo_tts_api_{uuid.uuid4()}.{self.audio_format}"
+            get_temp_dir()
+            / f"mimo_tts_api_{generate_timestamp_id()}.{self.audio_format}"
         )
         output_path.write_bytes(base64.b64decode(audio_data))
         return str(output_path)

--- a/astrbot/core/provider/sources/minimax_tts_api_source.py
+++ b/astrbot/core/provider/sources/minimax_tts_api_source.py
@@ -1,12 +1,12 @@
 import json
 import os
-import uuid
 from collections.abc import AsyncIterator
 
 import aiohttp
 
 from astrbot.api import logger
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
+from astrbot.core.utils.datetime_utils import generate_timestamp_id
 
 from ..entities import ProviderType
 from ..provider import TTSProvider
@@ -156,7 +156,7 @@ class ProviderMiniMaxTTSAPI(TTSProvider):
     async def get_audio(self, text: str) -> str:
         temp_dir = get_astrbot_temp_path()
         os.makedirs(temp_dir, exist_ok=True)
-        path = os.path.join(temp_dir, f"minimax_tts_api_{uuid.uuid4()}.wav")
+        path = os.path.join(temp_dir, f"minimax_tts_api_{generate_timestamp_id()}.wav")
 
         try:
             # 直接将异步生成器传递给 _audio_play 方法

--- a/astrbot/core/provider/sources/openai_tts_api_source.py
+++ b/astrbot/core/provider/sources/openai_tts_api_source.py
@@ -1,11 +1,11 @@
 import os
-import uuid
 
 import httpx
 from openai import NOT_GIVEN, AsyncOpenAI
 
 from astrbot import logger
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
+from astrbot.core.utils.datetime_utils import generate_timestamp_id
 
 from ..entities import ProviderType
 from ..provider import TTSProvider
@@ -47,7 +47,7 @@ class ProviderOpenAITTSAPI(TTSProvider):
 
     async def get_audio(self, text: str) -> str:
         temp_dir = get_astrbot_temp_path()
-        path = os.path.join(temp_dir, f"openai_tts_api_{uuid.uuid4()}.wav")
+        path = os.path.join(temp_dir, f"openai_tts_api_{generate_timestamp_id()}.wav")
         async with self.client.audio.speech.with_streaming_response.create(
             model=self.model_name,
             voice=self.voice,

--- a/astrbot/core/provider/sources/volcengine_tts.py
+++ b/astrbot/core/provider/sources/volcengine_tts.py
@@ -9,6 +9,7 @@ import aiohttp
 
 from astrbot import logger
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
+from astrbot.core.utils.datetime_utils import generate_timestamp_id
 
 from ..entities import ProviderType
 from ..provider import TTSProvider
@@ -97,7 +98,7 @@ class ProviderVolcengineTTS(TTSProvider):
                         os.makedirs(temp_dir, exist_ok=True)
                         file_path = os.path.join(
                             temp_dir,
-                            f"volcengine_tts_{uuid.uuid4()}.mp3",
+                            f"volcengine_tts_{generate_timestamp_id()}.mp3",
                         )
 
                         loop = asyncio.get_running_loop()

--- a/astrbot/core/utils/datetime_utils.py
+++ b/astrbot/core/utils/datetime_utils.py
@@ -1,4 +1,16 @@
+import uuid
 from datetime import datetime, timezone
+
+
+def generate_timestamp_id() -> str:
+    """Generate a compact timestamp-based identifier.
+
+    Returns:
+        The local time in ``YYYYMMDDHHMMSSmmm`` format followed by four random
+        hexadecimal characters.
+    """
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S%f")[:-3]
+    return f"{timestamp}_{uuid.uuid4().hex[:4]}"
 
 
 def normalize_datetime_utc(dt: datetime | None) -> datetime | None:

--- a/astrbot/core/utils/media_utils.py
+++ b/astrbot/core/utils/media_utils.py
@@ -12,7 +12,6 @@ import mimetypes
 import os
 import shutil
 import subprocess
-import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
@@ -25,6 +24,7 @@ from PIL import Image as PILImage
 
 from astrbot import logger
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
+from astrbot.core.utils.datetime_utils import generate_timestamp_id
 from astrbot.core.utils.io import download_file
 from astrbot.core.utils.tencent_record_helper import (
     tencent_silk_to_wav,
@@ -248,7 +248,7 @@ def _temp_media_path(media_type: str, suffix: str) -> Path:
     safe_media_type = "".join(
         char if char.isalnum() or char in {"_", "-"} else "_" for char in media_type
     )
-    return temp_dir / f"media_{safe_media_type}_{uuid.uuid4().hex}{suffix}"
+    return temp_dir / f"media_{safe_media_type}_{generate_timestamp_id()}{suffix}"
 
 
 def _parse_base64_data_uri(data_uri: str) -> tuple[str | None, bytes]:
@@ -1047,7 +1047,7 @@ async def convert_video_format(
         os.makedirs(temp_dir, exist_ok=True)
         output_path = os.path.join(
             temp_dir,
-            f"media_video_{uuid.uuid4().hex}.{output_format}",
+            f"media_video_{generate_timestamp_id()}.{output_format}",
         )
 
     try:
@@ -1133,7 +1133,9 @@ async def convert_audio_format(
     if output_path is None:
         temp_dir = Path(get_astrbot_temp_path())
         temp_dir.mkdir(parents=True, exist_ok=True)
-        output_path = str(temp_dir / f"media_audio_{uuid.uuid4().hex}.{output_format}")
+        output_path = str(
+            temp_dir / f"media_audio_{generate_timestamp_id()}.{output_format}"
+        )
 
     args = ["ffmpeg", "-y", "-i", audio_path]
     if output_format == "amr":
@@ -1262,7 +1264,9 @@ async def ensure_wav(audio_path: str, output_path: str | None = None) -> str:
         if output_path is None:
             temp_dir = get_astrbot_temp_path()
             os.makedirs(temp_dir, exist_ok=True)
-            output_path = os.path.join(temp_dir, f"media_audio_{uuid.uuid4().hex}.wav")
+            output_path = os.path.join(
+                temp_dir, f"media_audio_{generate_timestamp_id()}.wav"
+            )
         return await tencent_silk_to_wav(audio_path, output_path)
 
     return await convert_audio_to_wav(audio_path, output_path)
@@ -1318,7 +1322,7 @@ async def ensure_jpeg(image_path: str, output_path: str | None = None) -> str:
     if output_path is None:
         temp_dir = Path(get_astrbot_temp_path())
         temp_dir.mkdir(parents=True, exist_ok=True)
-        output_path = str(temp_dir / f"media_image_{uuid.uuid4().hex}.jpg")
+        output_path = str(temp_dir / f"media_image_{generate_timestamp_id()}.jpg")
     jpeg_output_path = output_path
 
     try:
@@ -1448,7 +1452,7 @@ async def extract_video_cover(
     if output_path is None:
         temp_dir = Path(get_astrbot_temp_path())
         temp_dir.mkdir(parents=True, exist_ok=True)
-        output_path = str(temp_dir / f"media_cover_{uuid.uuid4().hex}.jpg")
+        output_path = str(temp_dir / f"media_cover_{generate_timestamp_id()}.jpg")
 
     try:
         process = await asyncio.create_subprocess_exec(
@@ -1529,8 +1533,9 @@ def _compress_image_sync(
             if max(working_img.size) > max_size:
                 working_img.thumbnail((max_size, max_size), PILImage.Resampling.LANCZOS)
 
-            new_uuid = uuid.uuid4().hex
-            save_path = temp_dir / f"compressed_{new_uuid}{output_suffix}"
+            save_path = (
+                temp_dir / f"compressed_{generate_timestamp_id()}{output_suffix}"
+            )
             save_kwargs: dict[str, int | bool] = {"optimize": optimize}
             if output_format == "JPEG":
                 save_kwargs["quality"] = quality

--- a/astrbot/dashboard/services/chat_service.py
+++ b/astrbot/dashboard/services/chat_service.py
@@ -28,7 +28,7 @@ from astrbot.core.platform.sources.webchat.request_flags import (
 from astrbot.core.platform.sources.webchat.webchat_queue_mgr import webchat_queue_mgr
 from astrbot.core.utils.active_event_registry import active_event_registry
 from astrbot.core.utils.astrbot_path import get_astrbot_data_path
-from astrbot.core.utils.datetime_utils import to_utc_isoformat
+from astrbot.core.utils.datetime_utils import generate_timestamp_id, to_utc_isoformat
 from astrbot.core.utils.media_utils import (
     MEDIA_MIME_EXTENSIONS,
     detect_image_mime_type_async,
@@ -47,11 +47,11 @@ WEBCHAT_IMAGE_MIME_TYPES = {
 
 def sanitize_upload_filename(filename: str | None) -> str:
     if not filename:
-        return f"{uuid.uuid4()!s}"
+        return generate_timestamp_id()
     normalized = filename.replace("\\", "/")
     name = PurePosixPath(normalized).name.replace("\x00", "").strip()
     if name in ("", ".", ".."):
-        return f"{uuid.uuid4()!s}"
+        return generate_timestamp_id()
     return name
 
 
@@ -626,7 +626,8 @@ class ChatService:
                     target_path = file_path.with_suffix(detected_suffix)
                     if target_path.exists():
                         target_path = (
-                            attachments_dir / f"{uuid.uuid4().hex}{detected_suffix}"
+                            attachments_dir
+                            / f"{generate_timestamp_id()}{detected_suffix}"
                         )
                     await asyncio.to_thread(file_path.rename, target_path)
                     file_path = target_path

--- a/astrbot/dashboard/services/live_chat_service.py
+++ b/astrbot/dashboard/services/live_chat_service.py
@@ -28,7 +28,7 @@ from astrbot.core.platform.sources.webchat.request_flags import (
 )
 from astrbot.core.platform.sources.webchat.webchat_queue_mgr import webchat_queue_mgr
 from astrbot.core.utils.astrbot_path import get_astrbot_data_path, get_astrbot_temp_path
-from astrbot.core.utils.datetime_utils import to_utc_isoformat
+from astrbot.core.utils.datetime_utils import generate_timestamp_id, to_utc_isoformat
 from astrbot.dashboard.services.chat_service import (
     BotMessageAccumulator,
     build_bot_history_content,
@@ -90,7 +90,9 @@ class LiveChatSession:
         try:
             temp_dir = get_astrbot_temp_path()
             os.makedirs(temp_dir, exist_ok=True)
-            audio_path = os.path.join(temp_dir, f"live_audio_{uuid.uuid4()}.wav")
+            audio_path = os.path.join(
+                temp_dir, f"live_audio_{generate_timestamp_id()}.wav"
+            )
 
             with wave.open(audio_path, "wb") as wav_file:
                 wav_file.setnchannels(1)

--- a/tests/unit/test_timestamp_ids.py
+++ b/tests/unit/test_timestamp_ids.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+from types import SimpleNamespace
+
+from astrbot.core.utils import datetime_utils
+
+
+def test_generate_timestamp_id_uses_compact_local_time(monkeypatch):
+    class FixedDateTime:
+        @classmethod
+        def now(cls):
+            return datetime(2026, 2, 3, 13, 0, 43, 123000)
+
+    monkeypatch.setattr(datetime_utils, "datetime", FixedDateTime)
+    monkeypatch.setattr(
+        datetime_utils.uuid,
+        "uuid4",
+        lambda: SimpleNamespace(hex="abcd1234567890"),
+    )
+
+    assert datetime_utils.generate_timestamp_id() == "20260203130043123_abcd"

--- a/tests/unit/test_upload_filename_sanitization.py
+++ b/tests/unit/test_upload_filename_sanitization.py
@@ -1,5 +1,7 @@
 """Tests for upload filename sanitization."""
 
+import re
+
 from astrbot.dashboard.services.chat_service import sanitize_upload_filename
 
 
@@ -18,10 +20,7 @@ def test_sanitize_upload_filename_strips_fakepath():
 def test_sanitize_upload_filename_falls_back_for_empty_values():
     generated = sanitize_upload_filename("")
 
-    assert generated
-    assert generated not in {".", ".."}
-    assert "/" not in generated
-    assert "\\" not in generated
+    assert re.fullmatch(r"\d{17}_[0-9a-f]{4}", generated)
 
 
 def test_sanitize_upload_filename_removes_embedded_null_bytes():


### PR DESCRIPTION
## Summary

- Generate transient TTS, media, compressed-image, and attachment filenames with a compact local millisecond timestamp plus a four-character UUID suffix.
- Keep persistent Attachment and ChatUI Project IDs unchanged for compatibility.
- Clarify exactly which built-in local tools use the current workspace as their working directory or relative-path root, and prefer relative paths within it.
- Defer cleanup of regular TTS, simulated-stream TTS, and QQ Official Silk audio files to the global temp cleaner instead of deleting them when the event ends.

## Why

Long UUID-based paths consume unnecessary model context. The compact filename format remains readable and greatly reduces same-time collision risk by including milliseconds.

Outbound audio may also be registered with File Token Service for asynchronous retrieval by an external platform. Event-end deletion could invalidate an otherwise active file token before the external service downloads the file, so these files must outlive the event.

## Impact

Only newly generated filenames change format. Existing files, database records, Attachment IDs, and Project IDs require no migration. Outbound audio remains available after event completion and is reclaimed later by the global temporary-directory cleaner.

## Validation

- `uv run ruff check .`
- Path and workspace tests: 158 passed
- Deferred audio cleanup and QQ Official tests: 28 passed
