### PR TITLE
fix: defer cleanup of outbound audio files

### DIFF
--- a/astrbot/core/astr_agent_run_util.py
+++ b/astrbot/core/astr_agent_run_util.py
@@ -3,7 +3,6 @@ import re
 import time
 import traceback
 from collections.abc import AsyncGenerator
-from typing import Any
 
 from astrbot.core import logger
 from astrbot.core.agent.message import Message
@@ -441,7 +440,6 @@ async def run_live_agent(
                 tts_provider,
                 text_queue,
                 audio_queue,
-                agent_runner.run_context.context.event,
             )
         )
 
@@ -593,7 +591,6 @@ async def _simulated_stream_tts(
     tts_provider: TTSProvider,
     text_queue: asyncio.Queue[str | None],
     audio_queue: "asyncio.Queue[bytes | tuple[str, bytes] | None]",
-    astr_event: Any,
 ) -> None:
     """模拟流式 TTS 分句生成音频.
 
@@ -601,8 +598,6 @@ async def _simulated_stream_tts(
         tts_provider: Provider used to synthesize audio files.
         text_queue: Text chunks to synthesize. ``None`` ends the worker.
         audio_queue: Synthesized audio bytes output queue.
-        astr_event: Current event used to cleanup generated TTS files after the
-            event finishes.
     """
 
     try:
@@ -617,7 +612,6 @@ async def _simulated_stream_tts(
                 if audio_path:
                     with open(audio_path, "rb") as f:
                         audio_data = f.read()
-                    astr_event.track_temporary_local_file(audio_path)
                     await audio_queue.put((text, audio_data))
             except Exception as e:
                 logger.error(

--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -324,8 +324,6 @@ class ResultDecorateStage(Stage):
                                 new_chain.append(comp)
                                 continue
 
-                            event.track_temporary_local_file(audio_path)
-
                             use_file_service = self.ctx.astrbot_config[
                                 "provider_tts_settings"
                             ]["use_file_service"]

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -288,8 +288,6 @@ class QQOfficialMessageEvent(AstrMessageEvent):
             file_source,
             file_name,
         ) = await QQOfficialMessageEvent._parse_to_qqofficial(message_to_send)
-        if record_file_path:
-            self.track_temporary_local_file(record_file_path)
 
         # C2C 流式仅用于文本分片，富媒体时降级为普通发送，避免平台侧流式校验报错。
         if stream and (

--- a/tests/test_astr_agent_run_util.py
+++ b/tests/test_astr_agent_run_util.py
@@ -1,9 +1,10 @@
+import asyncio
 from types import SimpleNamespace
 
 import pytest
 
 from astrbot.core.agent.response import AgentResponse
-from astrbot.core.astr_agent_run_util import run_agent
+from astrbot.core.astr_agent_run_util import _simulated_stream_tts, run_agent
 from astrbot.core.message.message_event_result import MessageChain
 
 
@@ -72,3 +73,25 @@ async def test_run_agent_replaces_malformed_streaming_provider_error():
 
     assert len(chains) == 1
     assert chains[0].get_plain_text() == "Error occurred during AI execution."
+
+
+@pytest.mark.asyncio
+async def test_simulated_stream_tts_leaves_audio_for_deferred_cleanup(tmp_path):
+    audio_path = tmp_path / "speech.wav"
+    audio_path.write_bytes(b"audio")
+
+    class _TTSProvider:
+        async def get_audio(self, text: str) -> str:
+            assert text == "hello"
+            return str(audio_path)
+
+    text_queue: asyncio.Queue[str | None] = asyncio.Queue()
+    audio_queue: asyncio.Queue[bytes | tuple[str, bytes] | None] = asyncio.Queue()
+    await text_queue.put("hello")
+    await text_queue.put(None)
+
+    await _simulated_stream_tts(_TTSProvider(), text_queue, audio_queue)
+
+    assert await audio_queue.get() == ("hello", b"audio")
+    assert await audio_queue.get() is None
+    assert audio_path.exists()


### PR DESCRIPTION
## Summary

- Stop registering regular TTS output for event-end deletion.
- Stop registering simulated-stream TTS output for event-end deletion and remove the now-unused event parameter.
- Stop registering QQ Official Tencent Silk conversions for event-end deletion.
- Leave these files to the global temporary-directory cleaner and add a regression test for simulated-stream audio persistence.

## Root cause

Outbound audio can be registered with File Token Service and downloaded asynchronously by an external platform. Event cleanup ran immediately after processing and could delete the file while its token was still valid, causing the later download to fail.

## Impact

TTS and QQ Official outbound audio remain available after the event completes. They are still reclaimed by the global temp cleaner, so this does not make the files permanent.

## Validation

- `uv run ruff check .`
- `uv run pytest -q tests/test_astr_agent_run_util.py tests/test_platform_audio_media_resolver.py tests/test_qqofficial_stream_buffer_copy.py tests/test_qqofficial_group_message_create.py` (28 passed)

Follow-up to #9505.

## Summary by Sourcery

Defer cleanup of outbound TTS and QQ Official audio files to the global temporary-directory cleaner to avoid premature deletion while they may still be downloaded.

Bug Fixes:
- Stop registering regular TTS output files for event-end deletion so externally downloaded audio remains available until global cleanup.
- Stop registering simulated-stream TTS output files for event-end deletion and remove the unused event parameter.
- Stop registering QQ Official Tencent Silk conversion files for event-end deletion to prevent failures when accessed after the event completes.

Tests:
- Add an async regression test ensuring simulated-stream TTS leaves synthesized audio files on disk for deferred cleanup.