### PR TITLE
fix: simplify completed shell command output

### DIFF
--- a/astrbot/core/tools/computer_tools/shell.py
+++ b/astrbot/core/tools/computer_tools/shell.py
@@ -4,6 +4,7 @@ import shlex
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
+from time import monotonic
 from typing import Any
 
 from astrbot.api import FunctionTool
@@ -122,6 +123,7 @@ class ExecuteShellTool(FunctionTool):
                 creator_id = context.context.event.get_sender_id()
                 if not creator_id:
                     return "Error executing command: sender identity is unavailable."
+                started_at = monotonic()
                 result = await sb.shell.exec_managed(
                     command,
                     owner_id=context.context.event.unified_msg_origin,
@@ -133,11 +135,15 @@ class ExecuteShellTool(FunctionTool):
                     timeout=timeout,
                     yield_time_ms=0 if background else yield_time_ms,
                 )
+                elapsed_seconds = monotonic() - started_at
                 if result.get("session_closed") and result.get("status") in {
                     "completed",
                     "failed",
                 }:
-                    message = f"Command completed with exit code {result['exit_code']}."
+                    message = (
+                        f"Command completed with exit code {result['exit_code']} "
+                        f"(wall time: {elapsed_seconds:.2f}s)."
+                    )
                     output = f"{result['stdout']}{result['stderr']}"
                     return f"{message}\n{output}" if output else message
                 return json.dumps(result, ensure_ascii=False)

--- a/astrbot/core/tools/computer_tools/shell.py
+++ b/astrbot/core/tools/computer_tools/shell.py
@@ -137,9 +137,9 @@ class ExecuteShellTool(FunctionTool):
                     "completed",
                     "failed",
                 }:
-                    result = {
-                        key: result[key] for key in ("stdout", "stderr", "exit_code")
-                    }
+                    message = f"Command completed with exit code {result['exit_code']}."
+                    output = f"{result['stdout']}{result['stderr']}"
+                    return f"{message}\n{output}" if output else message
                 return json.dumps(result, ensure_ascii=False)
 
             effective_background = background and not _is_self_detached_command(command)
@@ -178,8 +178,9 @@ class LocalExecuteShellTool(ExecuteShellTool):
     """Local shell tool that automatically yields long-running commands."""
 
     description: str = (
-        "Execute a command in the shell. If it is still running after "
-        "yield_time_ms, the tool returns a managed shell session ID."
+        "Execute a command in the shell. Commands that finish within yield_time_ms "
+        "return a plain-text completion message and output. Commands still running "
+        "return managed shell session JSON."
     )
     parameters: dict = field(
         default_factory=lambda: {

--- a/astrbot/core/tools/computer_tools/shell.py
+++ b/astrbot/core/tools/computer_tools/shell.py
@@ -178,9 +178,8 @@ class LocalExecuteShellTool(ExecuteShellTool):
     """Local shell tool that automatically yields long-running commands."""
 
     description: str = (
-        "Execute a command in the shell. Commands that finish within yield_time_ms "
-        "return a plain-text completion message and output. Commands still running "
-        "return managed shell session JSON."
+        "Execute a command in the shell. If it is still running after "
+        "yield_time_ms, the tool returns a managed shell session ID."
     )
     parameters: dict = field(
         default_factory=lambda: {

--- a/astrbot/core/tools/computer_tools/shell.py
+++ b/astrbot/core/tools/computer_tools/shell.py
@@ -122,20 +122,25 @@ class ExecuteShellTool(FunctionTool):
                 creator_id = context.context.event.get_sender_id()
                 if not creator_id:
                     return "Error executing command: sender identity is unavailable."
-                return json.dumps(
-                    await sb.shell.exec_managed(
-                        command,
-                        owner_id=context.context.event.unified_msg_origin,
-                        creator_id=creator_id,
-                        creator_is_admin=context.context.event.role == "admin",
-                        sandboxed=False,
-                        cwd=cwd,
-                        env=env,
-                        timeout=timeout,
-                        yield_time_ms=0 if background else yield_time_ms,
-                    ),
-                    ensure_ascii=False,
+                result = await sb.shell.exec_managed(
+                    command,
+                    owner_id=context.context.event.unified_msg_origin,
+                    creator_id=creator_id,
+                    creator_is_admin=context.context.event.role == "admin",
+                    sandboxed=False,
+                    cwd=cwd,
+                    env=env,
+                    timeout=timeout,
+                    yield_time_ms=0 if background else yield_time_ms,
                 )
+                if result.get("session_closed") and result.get("status") in {
+                    "completed",
+                    "failed",
+                }:
+                    result = {
+                        key: result[key] for key in ("stdout", "stderr", "exit_code")
+                    }
+                return json.dumps(result, ensure_ascii=False)
 
             effective_background = background and not _is_self_detached_command(command)
 

--- a/astrbot/core/tools/computer_tools/shell.py
+++ b/astrbot/core/tools/computer_tools/shell.py
@@ -145,7 +145,7 @@ class ExecuteShellTool(FunctionTool):
                         f"(wall time: {elapsed_seconds:.2f}s)."
                     )
                     output = f"{result['stdout']}{result['stderr']}"
-                    return f"{message}\n{output}" if output else message
+                    return f"{message}\nOutput:\n{output}"
                 return json.dumps(result, ensure_ascii=False)
 
             effective_background = background and not _is_self_detached_command(command)

--- a/tests/unit/test_func_tool_manager.py
+++ b/tests/unit/test_func_tool_manager.py
@@ -130,6 +130,8 @@ async def test_local_execute_shell_manages_running_and_closed_results(
         "workspace_root_for_context",
         AsyncMock(return_value=tmp_path),
     )
+    monotonic_values = iter((10.0, 10.5, 20.0, 21.234, 30.0, 32.346))
+    monkeypatch.setattr(shell_tools, "monotonic", lambda: next(monotonic_values))
 
     result = await LocalExecuteShellTool().call(
         FakeWrapper(),
@@ -149,7 +151,10 @@ async def test_local_execute_shell_manages_running_and_closed_results(
         timeout=None,
         yield_time_ms=250,
     )
-    for status, exit_code in (("completed", 0), ("failed", 1)):
+    for status, exit_code, wall_time in (
+        ("completed", 0, "1.23"),
+        ("failed", 1, "2.35"),
+    ):
         shell.exec_managed.return_value = {
             "session_id": "sh_test",
             "pid": 12345,
@@ -167,7 +172,10 @@ async def test_local_execute_shell_manages_running_and_closed_results(
             command="echo done",
         )
 
-        assert result == f"Command completed with exit code {exit_code}.\ndone\n"
+        assert result == (
+            f"Command completed with exit code {exit_code} "
+            f"(wall time: {wall_time}s).\ndone\n"
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_func_tool_manager.py
+++ b/tests/unit/test_func_tool_manager.py
@@ -174,7 +174,7 @@ async def test_local_execute_shell_manages_running_and_closed_results(
 
         assert result == (
             f"Command completed with exit code {exit_code} "
-            f"(wall time: {wall_time}s).\ndone\n"
+            f"(wall time: {wall_time}s).\nOutput:\ndone\n"
         )
 
 

--- a/tests/unit/test_func_tool_manager.py
+++ b/tests/unit/test_func_tool_manager.py
@@ -79,7 +79,10 @@ def test_shell_session_schema_supports_line_writes():
 
 
 @pytest.mark.asyncio
-async def test_local_execute_shell_uses_managed_session(monkeypatch, tmp_path):
+async def test_local_execute_shell_manages_running_and_closed_results(
+    monkeypatch,
+    tmp_path,
+):
     from astrbot.core.tools.computer_tools import shell as shell_tools
 
     shell = LocalShellComponent()
@@ -146,6 +149,29 @@ async def test_local_execute_shell_uses_managed_session(monkeypatch, tmp_path):
         timeout=None,
         yield_time_ms=250,
     )
+    for status, exit_code in (("completed", 0), ("failed", 1)):
+        shell.exec_managed.return_value = {
+            "session_id": "sh_test",
+            "pid": 12345,
+            "status": status,
+            "stdout": "done\n",
+            "stderr": "",
+            "exit_code": exit_code,
+            "cursor": 5,
+            "has_more": False,
+            "session_closed": True,
+        }
+
+        result = await LocalExecuteShellTool().call(
+            FakeWrapper(),
+            command="echo done",
+        )
+
+        assert json.loads(result) == {
+            "stdout": "done\n",
+            "stderr": "",
+            "exit_code": exit_code,
+        }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_func_tool_manager.py
+++ b/tests/unit/test_func_tool_manager.py
@@ -167,11 +167,7 @@ async def test_local_execute_shell_manages_running_and_closed_results(
             command="echo done",
         )
 
-        assert json.loads(result) == {
-            "stdout": "done\n",
-            "stderr": "",
-            "exit_code": exit_code,
-        }
+        assert result == f"Command completed with exit code {exit_code}.\ndone\n"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- return a concise plain-text completion message for local commands that finish within the initial wait and whose output is fully drained
- include the exit code, measured wall time, an `Output:` label, and command output in that message
- keep the full managed-session JSON for running commands, unread output, and timeout states
- leave the shell tool description unchanged

## Root cause

The local execute tool returned the raw `poll_session()` result for every command. That shape is useful while a process or unread output still needs a managed session, but it exposed an unusable session ID, PID, cursor, and lifecycle flags after `session_closed` had already removed the session.

## Result

A completed command now returns output like:

```text
Command completed with exit code 0 (wall time: 1.23s).
Output:
saved
```

Long-running commands continue to return JSON with the session ID and polling metadata.

## Validation

- `uv run pytest tests/unit/test_func_tool_manager.py tests/test_local_shell_component.py -q` (44 passed)
- `uv run ruff format .`
- `uv run ruff check .`

## Summary by Sourcery

Return concise plain-text output for locally executed shell commands that have fully completed, while preserving JSON responses for long-running or active sessions.

New Features:
- Provide a human-readable completion message for local shell commands that finish during the initial wait and have fully drained output.

Enhancements:
- Include exit code, wall time, and combined stdout/stderr in the simplified completion message for closed shell sessions.
- Measure wall-clock execution time for local shell commands using monotonic timing.

Tests:
- Expand local shell tool manager tests to cover both running session behavior and the new simplified output for completed and failed commands.