### PR TITLE
chore: bump version to 4.27.0

### DIFF
--- a/astrbot/__init__.py
+++ b/astrbot/__init__.py
@@ -1,4 +1,4 @@
 import logging
 
-__version__ = "4.26.8"
+__version__ = "4.27.0"
 logger = logging.getLogger("astrbot")

--- a/changelogs/v4.27.0.md
+++ b/changelogs/v4.27.0.md
@@ -1,5 +1,7 @@
 ## [4.27.0] - 2026-08-02
 
+Per aspera ad astra.
+
 ### Added
 
 - Added persistent group message history with configurable retention, normalized storage, and an LLM tool for searching and retrieving messages from the current group. (#9465)

--- a/changelogs/v4.27.0.md
+++ b/changelogs/v4.27.0.md
@@ -5,6 +5,7 @@
 - Added persistent group message history with configurable retention, normalized storage, and an LLM tool for searching and retrieving messages from the current group. (#9465)
 - Added managed local shell sessions with incremental output, stdin writes, interruption, termination, timeouts, and lifecycle cleanup; Windows sessions now use PowerShell and line-oriented programs support explicit line writes. (#9470, #9471, #9501)
 - Added a unified extension and persona management experience with shared capability selectors, routed plugin workspaces, and clearer MCP server, tool, and Skill provenance and status. (#9499)
+- Added built-in `skill-creator`, `documents`, `pdf`, and `spreadsheets` Skills for creating reusable Skills and working with office documents, PDFs, and spreadsheets.
 - Added installation and updates for plugins hosted in generic HTTP(S), SSH, and SCP-style Git repositories. (#9493)
 - Converted ChatUI pastes longer than 10,000 characters into text attachments. (#9496)
 - Added sensitive API key sub-scopes for administrator chat access and administrator configuration changes, plus generated scope-to-endpoint reference documentation. (#9503)
@@ -48,6 +49,7 @@
 - 新增可配置保留数量的群消息历史持久化能力，支持标准化存储，并提供供 LLM 搜索和读取当前群历史消息的工具。 (#9465)
 - 新增本地托管 Shell 会话，支持增量输出、标准输入、打断、终止、超时和生命周期清理；Windows 会话改用 PowerShell，并支持显式按行写入。 (#9470, #9471, #9501)
 - 统一扩展与人格管理体验，提供共享的能力选择器、路由化插件工作区，以及更清晰的 MCP 服务、工具和 Skill 来源与状态展示。 (#9499)
+- 新增内置的 `skill-creator`、`documents`、`pdf` 和 `spreadsheets` Skills，支持创建可复用 Skill，以及处理办公文档、PDF 和电子表格。
 - 支持从通用 HTTP(S)、SSH 和 SCP 风格 Git 仓库安装和更新插件。 (#9493)
 - ChatUI 粘贴超过 10,000 字符的文本时，自动转换为文本附件。 (#9496)
 - 新增管理员聊天访问和管理员配置修改的敏感 API Key 子权限，并生成权限到接口的参考文档。 (#9503)

--- a/changelogs/v4.27.0.md
+++ b/changelogs/v4.27.0.md
@@ -1,0 +1,87 @@
+## [4.27.0] - 2026-08-02
+
+### Added
+
+- Added persistent group message history with configurable retention, normalized storage, and an LLM tool for searching and retrieving messages from the current group. (#9465)
+- Added managed local shell sessions with incremental output, stdin writes, interruption, termination, timeouts, and lifecycle cleanup; Windows sessions now use PowerShell and line-oriented programs support explicit line writes. (#9470, #9471, #9501)
+- Added a unified extension and persona management experience with shared capability selectors, routed plugin workspaces, and clearer MCP server, tool, and Skill provenance and status. (#9499)
+- Added installation and updates for plugins hosted in generic HTTP(S), SSH, and SCP-style Git repositories. (#9493)
+- Converted ChatUI pastes longer than 10,000 characters into text attachments. (#9496)
+- Added sensitive API key sub-scopes for administrator chat access and administrator configuration changes, plus generated scope-to-endpoint reference documentation. (#9503)
+
+### Changed
+
+- Improved knowledge base retrieval quality with normalized dense/sparse relative-score fusion and source-document diversification. (#9455)
+- Enriched knowledge base embeddings with document context and preserved heading paths. (#9457)
+- Centralized core, dashboard, and plugin update flows behind a safer updater architecture with package and metadata verification. (#9493)
+- Formalized existing deprecated APIs with runtime warnings and corrected the OpenAI tool-call conversion method name while retaining a backward-compatible alias. (#9468, #9469)
+- Refined the Skills cards, persona management, extension workspace, and project chat composer layouts.
+- Used compact timestamp-based transient filenames and clearer workspace-relative path guidance to reduce tool path token usage. (#9505)
+- Returned concise plain-text results for completed local shell commands while retaining managed-session metadata for active commands. (#9507)
+
+### Fixed
+
+- Deferred the BM25 dependency import so AstrBot can start and use FTS5 retrieval on CPUs incompatible with the installed NumPy build. (#9435)
+- Made knowledge base rank fusion deterministic and surfaced vLLM rerank response failures. (#9454)
+- Preserved ChatUI streaming response tails and prevented QQ Official streaming buffers from losing leading characters. (#9439, #9444)
+- Localized future task timestamps with the system timezone. (#9462)
+- Isolated managed local shell sessions by sender, while allowing conversation administrators to manage sessions in their conversation. (#9479)
+- Hardened API key authorization boundaries for administrator identities, sensitive configuration, and project workspace paths. (#9503)
+- Persisted terminal tool calls, results, and trusted token usage when no assistant response is produced. (#9500)
+- Prevented expanded ChatUI composers, replies, and attachments from overlapping the latest messages. (#9496)
+- Removed the double scrollbar from the mobile plugin configuration dialog. (#9491)
+- Recreated the tool image cache directory after storage cleanup so new images can still be saved. (#9490)
+- Kept outbound TTS and QQ Official audio available until global temporary-file cleanup so asynchronous downloads do not fail. (#9506)
+
+### Documentation
+
+- Added QQ community groups 15 and 16 to the community documentation.
+
+### Maintenance
+
+- Removed an unused tool image cleanup path in favor of the global temporary-directory cleaner. (#9504)
+
+## 中文
+
+### 新增
+
+- 新增可配置保留数量的群消息历史持久化能力，支持标准化存储，并提供供 LLM 搜索和读取当前群历史消息的工具。 (#9465)
+- 新增本地托管 Shell 会话，支持增量输出、标准输入、打断、终止、超时和生命周期清理；Windows 会话改用 PowerShell，并支持显式按行写入。 (#9470, #9471, #9501)
+- 统一扩展与人格管理体验，提供共享的能力选择器、路由化插件工作区，以及更清晰的 MCP 服务、工具和 Skill 来源与状态展示。 (#9499)
+- 支持从通用 HTTP(S)、SSH 和 SCP 风格 Git 仓库安装和更新插件。 (#9493)
+- ChatUI 粘贴超过 10,000 字符的文本时，自动转换为文本附件。 (#9496)
+- 新增管理员聊天访问和管理员配置修改的敏感 API Key 子权限，并生成权限到接口的参考文档。 (#9503)
+
+### 变更
+
+- 通过归一化稠密/稀疏相对分数融合和来源文档去重，提升知识库检索质量。 (#9455)
+- 使用文档上下文增强知识库 Embedding，并保留标题层级路径。 (#9457)
+- 将核心、Dashboard 和插件更新流程统一到更安全的更新架构中，并增加安装包与元数据校验。 (#9493)
+- 为已有废弃 API 增加运行时警告，修正 OpenAI 工具调用转换方法名，同时保留向后兼容别名。 (#9468, #9469)
+- 优化 Skill 卡片、人格管理、扩展工作区和项目聊天输入区的布局。
+- 使用紧凑的时间戳临时文件名并明确工作区相对路径指引，减少工具路径占用的 Token。 (#9505)
+- 对已完成的本地 Shell 命令返回精简纯文本结果，对运行中的命令继续保留托管会话元数据。 (#9507)
+
+### 修复
+
+- 延迟导入 BM25 依赖，使安装的 NumPy 与 CPU 不兼容时，AstrBot 仍可启动并使用 FTS5 检索。 (#9435)
+- 确保知识库排名融合结果稳定，并正确暴露 vLLM 重排序响应错误。 (#9454)
+- 保留 ChatUI 流式响应末尾内容，并避免 QQ 官方机器人流式缓冲丢失开头字符。 (#9439, #9444)
+- 使用系统时区处理未来任务时间。 (#9462)
+- 按发送者隔离本地托管 Shell 会话，同时允许会话管理员管理所在会话中的 Shell 会话。 (#9479)
+- 加固 API Key 对管理员身份、敏感配置和项目工作区路径的授权边界。 (#9503)
+- 在没有助手回复时，仍持久化终端工具调用、结果和可信 Token 用量。 (#9500)
+- 避免展开后的 ChatUI 输入区、回复和附件遮挡最新消息。 (#9496)
+- 移除移动端插件配置弹窗中的双重滚动条。 (#9491)
+- 存储清理后自动重建工具图片缓存目录，确保仍可保存新图片。 (#9490)
+- 将 TTS 和 QQ 官方机器人出站音频保留到全局临时文件清理，避免异步下载失败。 (#9506)
+
+### 文档
+
+- 在社区文档中新增 QQ 群 15 和 16。
+
+### 维护
+
+- 移除未使用的工具图片独立清理逻辑，统一交由全局临时目录清理器管理。 (#9504)
+
+[4.27.0]: https://github.com/AstrBotDevs/AstrBot/compare/v4.26.8...v4.27.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AstrBot"
-version = "4.26.8"
+version = "4.27.0"
 description = "Easy-to-use multi-platform LLM chatbot and development framework"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }


### PR DESCRIPTION
## Summary

- bump the project and package versions from `4.26.8` to `4.27.0`
- add polished English and Chinese release notes for all changes through #9455
- prepare the release branch from the latest `master`

## Validation

- `uv run ruff format .` — 486 files left unchanged
- `uv run ruff check .` — passed
- `uv run pytest -q tests/unit/test_rank_fusion.py` — 8 passed
- `git diff --check` — passed

## Release handling

This PR is intentionally a draft. Do not merge it or create/push `v4.27.0` until explicitly requested.

## Summary by Sourcery

Prepare the 4.27.0 release by updating version metadata and adding release notes.

Build:
- Update project version from 4.26.8 to 4.27.0 in package metadata and runtime __version__ constant.

Documentation:
- Add English and Chinese changelog for version 4.27.0, covering new features, changes, fixes, documentation updates, and maintenance notes.