### PR TITLE
feat: add yes option to init command

### DIFF
--- a/astrbot/cli/commands/cmd_init.py
+++ b/astrbot/cli/commands/cmd_init.py
@@ -29,12 +29,17 @@ def _initialize_config_from_env(astrbot_root: Path) -> None:
     click.echo("Initialized data/cmd_config.json with dashboard initial password.")
 
 
-async def initialize_astrbot(astrbot_root: Path) -> None:
-    """Execute AstrBot initialization logic"""
+async def initialize_astrbot(astrbot_root: Path, yes: bool = False) -> None:
+    """Execute AstrBot initialization logic.
+
+    Args:
+        astrbot_root: AstrBot root directory path.
+        yes: Whether to skip the installation confirmation.
+    """
     dot_astrbot = astrbot_root / ".astrbot"
 
     if not dot_astrbot.exists():
-        if click.confirm(
+        if yes or click.confirm(
             f"Install AstrBot to this directory? {astrbot_root}",
             default=True,
             abort=True,
@@ -59,8 +64,13 @@ async def initialize_astrbot(astrbot_root: Path) -> None:
 
 
 @click.command()
-def init() -> None:
-    """Initialize AstrBot"""
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompts")
+def init(yes: bool) -> None:
+    """Initialize AstrBot.
+
+    Args:
+        yes: Whether to skip confirmation prompts.
+    """
     from ..utils import get_astrbot_root
 
     click.echo("Initializing AstrBot...")
@@ -71,7 +81,7 @@ def init() -> None:
 
     try:
         with lock.acquire():
-            asyncio.run(initialize_astrbot(astrbot_root))
+            asyncio.run(initialize_astrbot(astrbot_root, yes=yes))
             click.echo("Done! You can now run 'astrbot run' to start AstrBot")
     except Timeout:
         raise click.ClickException(

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -1,9 +1,30 @@
 import json
 
 import pytest
+from click.testing import CliRunner
 
 from astrbot.cli.commands import cmd_init
 from astrbot.core.utils.auth_password import verify_dashboard_password
+
+
+def test_init_yes_skips_install_confirmation(monkeypatch, tmp_path):
+    async def fake_check_dashboard(_data_path):
+        return None
+
+    def fail_confirm(*_args, **_kwargs):
+        pytest.fail("-y should skip the installation confirmation")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cmd_init, "check_dashboard", fake_check_dashboard)
+    monkeypatch.setattr(cmd_init.click, "confirm", fail_confirm)
+
+    result = CliRunner().invoke(cmd_init.init, ["-y"])
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / ".astrbot").exists()
+    assert (tmp_path / "data" / "config").is_dir()
+    assert (tmp_path / "data" / "plugins").is_dir()
+    assert (tmp_path / "data" / "temp").is_dir()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add `-y`/`--yes` to `astrbot init`
- skip the installation confirmation when the option is provided while preserving the interactive default
- add CLI regression coverage for unattended initialization

## Motivation

This enables unattended AstrBot deployments that cannot respond to the installation confirmation prompt.

Closes #9498

## Testing

- `ruff format .`
- `ruff check .`
- `python -m pytest` (2073 passed)

## Summary by Sourcery

Add a non-interactive initialization option to the AstrBot CLI init command and add regression coverage for it.

New Features:
- Add a -y/--yes flag to the astrbot init CLI command to allow skipping installation confirmation prompts for unattended setups.

Tests:
- Add a CLI regression test ensuring that the -y option skips the installation confirmation while still performing full initialization.