### PR TITLE
fix: preserve user content in dict-type config items

### DIFF
--- a/astrbot/core/config/astrbot_config.py
+++ b/astrbot/core/config/astrbot_config.py
@@ -195,6 +195,10 @@ class AstrBotConfig(dict):
                     # 类型不匹配，使用默认值
                     new_conf[key] = value
                     has_new = True
+                elif not value:
+                    # 参考值为空 dict（如 dict 类型的自由键值对配置项），
+                    # 保留用户的全部键值对，不进行递归清理
+                    new_conf[key] = conf[key]
                 else:
                     # 递归检查并同步顺序
                     child_has_new = self.check_config_integrity(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -518,6 +518,44 @@ class TestConfigValidation:
         assert "level2" in config.nested["level1"]
         assert config.nested["level1"]["level2"]["value"] == 42
 
+    def test_preserve_dict_type_user_content(self, temp_config_path):
+        """Test that dict-type config items keep user key-value pairs across reloads."""
+        schema = {
+            "custom_groups": {
+                "type": "dict",
+                "default": {},
+            },
+        }
+        config = AstrBotConfig(config_path=temp_config_path, schema=schema)
+        config.custom_groups = {"group_a": ["platform:type:id"]}
+        config.save_config()
+
+        config2 = AstrBotConfig(config_path=temp_config_path, schema=schema)
+
+        assert config2.custom_groups == {"group_a": ["platform:type:id"]}
+
+    def test_preserve_nested_dict_type_user_content(self, temp_config_path):
+        """Test that user content nested inside dict-type items survives reloads."""
+        schema = {
+            "custom_groups": {
+                "type": "object",
+                "items": {
+                    "enable": {"type": "bool", "default": True},
+                    "share_groups": {"type": "dict", "default": {}},
+                },
+            },
+        }
+        config = AstrBotConfig(config_path=temp_config_path, schema=schema)
+        config.custom_groups["share_groups"] = {"group_a": ["platform:type:id"]}
+        config.save_config()
+
+        config2 = AstrBotConfig(config_path=temp_config_path, schema=schema)
+
+        assert config2.custom_groups["enable"] is True
+        assert config2.custom_groups["share_groups"] == {
+            "group_a": ["platform:type:id"]
+        }
+
     def test_integrity_log_does_not_include_inserted_secret_value(
         self, temp_config_path, monkeypatch
     ):


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
fix #9512
### Modifications / 改动点
- astrbot/core/config/astrbot_config.py — 修复 check_config_integrity()：当参考值为空 dict（即 dict 类型自由键值对配置项）时，保留用户的全部键值对，不再递归清理。此前重载插件会清空 dict 类型配置项下用户添加的所有键。
- tests/unit/test_config.py — 新增两个回归测试，覆盖顶层及嵌套 dict 类型配置项，确保用户内容在重载后保留。
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x]  🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Preserve user-defined key-value pairs in dict-type configuration items when reloading configs whose reference value is an empty dict.

Bug Fixes:
- Fix config integrity check so dict-type items with empty default dictionaries retain all user-defined keys instead of being recursively cleaned on reload.

Tests:
- Add regression tests ensuring top-level and nested dict-type configuration items keep user-defined content across config reloads.