### PR TITLE
fix: warn when an explicitly configured WebUI dist is stale

### DIFF
--- a/astrbot/core/dashboard_assets.py
+++ b/astrbot/core/dashboard_assets.py
@@ -141,15 +141,16 @@ def resolve_dashboard_dist(webui_dir: str | Path | None = None) -> Path | None:
         Explicit, managed, bundled, or stale fallback dist in priority order;
         None when an existing managed dist is incomplete.
     """
-    if webui_dir and Path(webui_dir).exists():
-        explicit_dist = Path(webui_dir).absolute()
+    explicit_dist = Path(webui_dir).absolute() if webui_dir else None
+    if explicit_dist is not None and explicit_dist.exists():
         if not _is_dist_compatible(explicit_dist, VERSION):
+            explicit_version = _read_dashboard_version(explicit_dist) or "unknown"
             logger.warning(
                 "Serving the explicitly configured WebUI directory even though it "
                 "does not declare a version matching core: %s, expected v%s (%s). "
                 "Some dashboard features may not work until matching assets are "
                 "available.",
-                _read_dashboard_version(explicit_dist) or "unknown",
+                explicit_version,
                 VERSION,
                 explicit_dist,
             )

--- a/astrbot/core/dashboard_assets.py
+++ b/astrbot/core/dashboard_assets.py
@@ -142,7 +142,18 @@ def resolve_dashboard_dist(webui_dir: str | Path | None = None) -> Path | None:
         None when an existing managed dist is incomplete.
     """
     if webui_dir and Path(webui_dir).exists():
-        return Path(webui_dir).absolute()
+        explicit_dist = Path(webui_dir).absolute()
+        if not _is_dist_compatible(explicit_dist, VERSION):
+            logger.warning(
+                "Serving the explicitly configured WebUI directory even though it "
+                "does not declare a version matching core: %s, expected v%s (%s). "
+                "Some dashboard features may not work until matching assets are "
+                "available.",
+                _read_dashboard_version(explicit_dist) or "unknown",
+                VERSION,
+                explicit_dist,
+            )
+        return explicit_dist
 
     user_dist = Path(get_astrbot_data_path()) / "dist"
     bundled_dist = _get_bundled_dist_path()

--- a/tests/unit/test_dashboard_dist_resolution.py
+++ b/tests/unit/test_dashboard_dist_resolution.py
@@ -1,0 +1,70 @@
+"""Tests for resolve_dashboard_dist() when an explicit WebUI directory is used."""
+
+import logging
+
+import pytest
+
+from astrbot.core.config.default import VERSION
+from astrbot.core.dashboard_assets import resolve_dashboard_dist
+
+WARNING_FRAGMENT = "does not declare a version matching core"
+
+
+def _make_dist(root, version: str | None) -> str:
+    assets = root / "assets"
+    assets.mkdir(parents=True)
+    (root / "index.html").write_text("<html></html>", encoding="utf-8")
+    if version is not None:
+        (assets / "version").write_text(version, encoding="utf-8")
+    return str(root)
+
+
+class TestExplicitWebuiDir:
+    def test_matching_version_is_served_quietly(self, tmp_path, caplog):
+        """The happy path must not add startup noise."""
+        dist = _make_dist(tmp_path / "webui", f"v{VERSION}")
+
+        with caplog.at_level(logging.WARNING):
+            resolved = resolve_dashboard_dist(dist)
+
+        assert resolved is not None
+        assert str(resolved) == str(tmp_path / "webui")
+        assert WARNING_FRAGMENT not in caplog.text
+
+    def test_mismatched_version_warns_but_is_still_served(self, tmp_path, caplog):
+        """A stale packaged WebUI must not be swapped in silently."""
+        dist = _make_dist(tmp_path / "webui", "v0.0.1")
+
+        with caplog.at_level(logging.WARNING):
+            resolved = resolve_dashboard_dist(dist)
+
+        assert resolved is not None  # behaviour unchanged: still served
+        assert WARNING_FRAGMENT in caplog.text
+        assert "v0.0.1" in caplog.text
+        assert VERSION in caplog.text
+
+    def test_missing_version_marker_warns_as_unknown(self, tmp_path, caplog):
+        """Assets without a version marker cannot be verified, so say so."""
+        dist = _make_dist(tmp_path / "webui", None)
+
+        with caplog.at_level(logging.WARNING):
+            resolved = resolve_dashboard_dist(dist)
+
+        assert resolved is not None
+        assert WARNING_FRAGMENT in caplog.text
+        assert "unknown" in caplog.text
+
+    def test_nonexistent_dir_falls_through(self, tmp_path, caplog):
+        """A path that does not exist must not be reported as a stale dist."""
+        with caplog.at_level(logging.WARNING):
+            resolve_dashboard_dist(str(tmp_path / "does-not-exist"))
+
+        assert WARNING_FRAGMENT not in caplog.text
+
+    @pytest.mark.parametrize("empty", ["", None])
+    def test_no_explicit_dir_falls_through(self, empty, caplog):
+        """Without --webui-dir the managed/bundled resolution path is used."""
+        with caplog.at_level(logging.WARNING):
+            resolve_dashboard_dist(empty)
+
+        assert WARNING_FRAGMENT not in caplog.text


### PR DESCRIPTION
## Problem

`resolve_dashboard_dist()` returns an explicitly configured `--webui-dir` immediately:

```python
if webui_dir and Path(webui_dir).exists():
    return Path(webui_dir).absolute()
```

Every other branch of the same function verifies the dist against the running core, and two of them already warn when it does not match:

| Branch | Version checked? |
| --- | --- |
| `data/dist` compatible | yes, `_is_dist_compatible` |
| bundled dist | yes, plus an info log |
| `data/dist` version mismatch | yes, warns and names both versions |
| `data/dist` incomplete | yes, warns |
| **explicit `--webui-dir`** | **no check at all** |

So the explicit directory is the only way to end up serving a dashboard that does not match the running core with no diagnostic whatsoever.

## How I hit it

I run the packaged desktop distribution, which launches the backend with `--webui-dir`. Updating took the core from 4.26.8 to 4.27.0, but the launcher kept its bundled WebUI directory untouched, so the dashboard stayed on the 4.26.8 build. The UI simply did not have the new extension/persona management pages, and there was nothing in the log to explain it — the update had reported success.

It took a byte-level comparison against `AstrBot-v4.27.0-dashboard.zip` to establish what had happened:

```
served dist   : index-8HR-5XWP.js, 569 assets, no assets/version
v4.27.0 build : index-Dez8SO42.js, 243 assets, assets/version = v4.27.0
```

Five identifiers that exist in the v4.27.0 dashboard build and not in v4.26.8 (`capability-source-chip`, `CapabilitySourceChip`, `PluginWorkspacePage`, `McpServersPage`, `PersonaCapabilitiesEditor`) were absent from the served assets.

The launcher is of course the component that should have replaced those files. But the core already knows how to detect this — `_read_dashboard_version()` and `_is_dist_compatible()` are right there and used by every other branch — so silently serving mismatched assets is a gap worth closing regardless of who packaged them.

## Change

Check the explicit directory the same way as the others and warn on a mismatch, reusing the wording of the existing stale-`data/dist` warning.

**Behaviour is unchanged** — the directory is still served, since refusing to serve a stale dashboard would be worse than serving one. It is only no longer silent:

```
Serving the explicitly configured WebUI directory even though it does not
declare a version matching core: unknown, expected v4.27.0 (D:\AstrBot\webui).
Some dashboard features may not work until matching assets are available.
```

`resolve_dashboard_dist()` is called once, from `DashboardServer.__init__`, so this is a single line at startup.

## A note on the "unknown" case

`assets/version` is written by the release workflows, not by `pnpm run build`, so a locally built dashboard passed via `--webui-dir` has no marker and will produce this warning with `unknown`. I think that is acceptable — it is one startup line, it names the directory, and it is accurate — but if you would rather keep local development silent I am happy to downgrade the missing-marker case to `info` and keep `warning` only for a marker that is present and different.

## Tests

Adds `tests/unit/test_dashboard_dist_resolution.py` — 6 cases: matching version stays quiet, mismatched version warns, missing marker warns as `unknown`, and three cases that must not warn (non-existent path, `None`, empty string).

- Reverting the `dashboard_assets.py` change makes exactly the 2 warning cases fail; the 4 must-not-warn guards pass either way.
- `tests/unit`: 799 passed, 6 failed — the same 6 fail on unmodified `master` here (Windows-local shell/python execution, video attachment and sandbox path tests), unrelated to this change.
- `ruff format --check .` and `ruff check .` both pass.

## Related

#9484 addresses the same shape of problem in `ProviderManager.get_using_provider()`: an existing warning that cannot fire in the case that actually matters, so a substitution happens silently.

## Summary by Sourcery

Warn on mismatched WebUI assets when an explicit dashboard directory is configured and add coverage for this behavior.

Enhancements:
- Validate explicitly configured WebUI directories against the core version and log a warning when the dashboard assets appear stale or unverifiable.

Tests:
- Add unit tests covering explicit WebUI directory resolution, including matching, mismatched, missing-version, and non-existent directory scenarios.