### PR TITLE
chore: bump version to 4.27.1

### DIFF
--- a/astrbot/__init__.py
+++ b/astrbot/__init__.py
@@ -1,4 +1,4 @@
 import logging
 
-__version__ = "4.27.0"
+__version__ = "4.27.1"
 logger = logging.getLogger("astrbot")

--- a/changelogs/v4.27.1.md
+++ b/changelogs/v4.27.1.md
@@ -1,0 +1,33 @@
+## [4.27.1] - 2026-08-02
+
+### Added
+
+- Added `-y` / `--yes` to `astrbot init` so unattended deployments can skip the installation confirmation prompt. (#9514)
+- Added an independent stateless Responses API provider for OpenAI-compatible endpoints, including OpenAI and DeepSeek templates, full-history replay for reasoning and tool calls, and Responses API as the default for new xAI providers. (#9515)
+
+### Fixed
+
+- Included the built-in `skill-creator`, `documents`, `pdf`, and `spreadsheets` Skills announced in v4.27.0 in source and Docker distributions, with read-only preset discovery and local override support. (#9517)
+- Corrected capability chip colors in dark mode.
+
+### Maintenance
+
+- Kept Responses API test fixtures compatible with the latest OpenAI SDK token-usage schema.
+
+## 中文
+
+### 新增
+
+- 为 `astrbot init` 新增 `-y` / `--yes` 选项，便于无人值守部署跳过安装确认提示。 (#9514)
+- 新增独立、无状态的 OpenAI 兼容 Responses API 供应商，提供 OpenAI 和 DeepSeek 模板，支持完整重放推理与工具调用历史，并将 Responses API 设为新建 xAI 供应商的默认接口。 (#9515)
+
+### 修复
+
+- 将 v4.27.0 公告中的内置 `skill-creator`、`documents`、`pdf` 和 `spreadsheets` Skills 实际加入源码与 Docker 发行版，支持作为只读预置能力自动发现，并允许同名本地 Skill 覆盖。 (#9517)
+- 修正深色模式下的能力标签颜色。
+
+### 维护
+
+- 使 Responses API 测试数据兼容最新 OpenAI SDK 的 Token 用量结构。
+
+[4.27.1]: https://github.com/AstrBotDevs/AstrBot/compare/v4.27.0...v4.27.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AstrBot"
-version = "4.27.0"
+version = "4.27.1"
 description = "Easy-to-use multi-platform LLM chatbot and development framework"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }

--- a/tests/test_openai_responses_source.py
+++ b/tests/test_openai_responses_source.py
@@ -34,7 +34,10 @@ def _make_response(output: list[dict], **overrides) -> Response:
         "output": output,
         "usage": {
             "input_tokens": 10,
-            "input_tokens_details": {"cached_tokens": 3},
+            "input_tokens_details": {
+                "cached_tokens": 3,
+                "cache_write_tokens": 0,
+            },
             "output_tokens": 4,
             "output_tokens_details": {"reasoning_tokens": 2},
             "total_tokens": 14,


### PR DESCRIPTION
## Summary

- bump the AstrBot package version to 4.27.1
- add an incremental v4.27.1 changelog while preserving the v4.27.0 changelog
- document the changes merged between v4.27.0 and v4.27.1, including the bundled built-in Skills
- keep Responses API tests compatible with the latest OpenAI SDK usage schema

## Why

v4.27.0 announced the built-in `skill-creator`, `documents`, `pdf`, and `spreadsheets` Skills before their implementation was merged. v4.27.1 ships the actual bundled Skills and the additional changes merged since v4.27.0.

## Validation

- `uv run --with openai==2.52.0 pytest -q tests/test_openai_responses_source.py` — 8 passed
- full test suite with OpenAI SDK 2.52.0 — 2066 passed
- `uv run ruff format .` — 499 files unchanged
- `uv run ruff check .` — passed
- `git diff --check` — passed
- `uv build` — wheel and source distribution built successfully
- verified all four built-in Skill packages are present in both the wheel and source distribution

## Summary by Sourcery

Release AstrBot 4.27.1 with updated version metadata, changelog, and token usage test fixtures aligned to the latest OpenAI SDK.

New Features:
- Document new CLI and Responses API provider capabilities introduced in version 4.27.1 in the incremental changelog.

Enhancements:
- Add a dedicated v4.27.1 changelog file while preserving the existing v4.27.0 entry.

Tests:
- Update Responses API usage fixtures to include the latest token usage fields for compatibility with newer OpenAI SDKs.