### PR TITLE
fix(dashboard): text color display abnormality in dark mode

### DIFF
--- a/dashboard/src/components/shared/CapabilitySourceChip.vue
+++ b/dashboard/src/components/shared/CapabilitySourceChip.vue
@@ -57,6 +57,10 @@ defineProps({
   color: #00695c !important;
 }
 
+/* NOTE: The descendant selector MUST stay inside :global(). If split out as
+   `:global(.v-theme--PurpleThemeDark) .capability-source-chip--xxx`, the Vue
+   SFC compiler drops the descendant part and emits a bare `.v-theme--PurpleThemeDark`
+   rule that leaks the color to the entire app root via CSS inheritance. */
 :global(.v-theme--PurpleThemeDark .capability-source-chip--plugin) {
   color: #64b5f6 !important;
 }

--- a/dashboard/src/components/shared/CapabilitySourceChip.vue
+++ b/dashboard/src/components/shared/CapabilitySourceChip.vue
@@ -57,23 +57,23 @@ defineProps({
   color: #00695c !important;
 }
 
-:global(.v-theme--PurpleThemeDark) .capability-source-chip--plugin {
+:global(.v-theme--PurpleThemeDark .capability-source-chip--plugin) {
   color: #64b5f6 !important;
 }
 
-:global(.v-theme--PurpleThemeDark) .capability-source-chip--mcp {
+:global(.v-theme--PurpleThemeDark .capability-source-chip--mcp) {
   color: #ffab91 !important;
 }
 
-:global(.v-theme--PurpleThemeDark) .capability-source-chip--local {
+:global(.v-theme--PurpleThemeDark .capability-source-chip--local) {
   color: #a5d6a7 !important;
 }
 
-:global(.v-theme--PurpleThemeDark) .capability-source-chip--preset {
+:global(.v-theme--PurpleThemeDark .capability-source-chip--preset) {
   color: #ce93d8 !important;
 }
 
-:global(.v-theme--PurpleThemeDark) .capability-source-chip--mixed {
+:global(.v-theme--PurpleThemeDark .capability-source-chip--mixed) {
   color: #80cbc4 !important;
 }
 </style>


### PR DESCRIPTION
fix #9521 

### Modifications / 改动点

修复深色模式下 WebUI 文字颜色异常（全部变为 #80CBC4 青绿色）的问题。

**根因**：`CapabilitySourceChip.vue` 的 `<style scoped>` 中使用了 `:global(.v-theme--PurpleThemeDark) .capability-source-chip--xxx` 写法。Vue SFC 编译器在处理 `:global()` 时会丢弃其后的后代选择器，导致编译结果从预期的 `.v-theme--PurpleThemeDark .capability-source-chip--mixed` 变为裸的 `.v-theme--PurpleThemeDark`。该选择器匹配 `<div class="v-application v-theme--PurpleThemeDark">`（整个 WebUI 根元素），配合 `color: #80cbc4 !important`，通过 CSS 继承和 `!important` 覆盖了深色模式下几乎所有文字颜色。

**修复**：将后代选择器移入 `:global()` 内部，从 `:global(.a) .b` 改为 `:global(.a .b)`，使编译器保留完整选择器。

修改文件：
- `dashboard/src/components/shared/CapabilitySourceChip.vue`（5 条 CSS 规则的选择器写法调整，无功能变更）

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

**验证步骤**：
1. 启动 AstrBot，浏览器打开 WebUI 并切换到深色模式
2. 通过浏览器 DevTools 检查 `.v-application` 元素的 computed color
3. 检查侧栏菜单项的文字颜色

**修复前**：

<img width="2160" height="1211" alt="image" src="https://github.com/user-attachments/assets/91332bca-d03c-475c-b95f-a07fd9a2e694" />

**修复后**：

<img width="2160" height="1211" alt="image" src="https://github.com/user-attachments/assets/389c1822-150c-4a2c-891d-7648a9a3e0ad" />

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Prevent global text color in dark mode from being overridden to #80cbc4 by narrowing the PurpleThemeDark capability chip selectors to the intended elements.