### PR TITLE
fix: accept bearer token for backup downloads

### DIFF
--- a/astrbot/dashboard/api/backups.py
+++ b/astrbot/dashboard/api/backups.py
@@ -295,9 +295,14 @@ async def get_dashboard_backup_progress(
 @router.get("/backups/{filename:path}")
 async def download_backup(
     filename: str,
+    request: Request,
     token: str | None = Query(default=None),
     service: BackupService = Depends(get_service),
 ):
+    if not token:
+        auth_header = request.headers.get("Authorization", "").strip()
+        if auth_header.startswith("Bearer "):
+            token = auth_header.removeprefix("Bearer ").strip() or None
     return _download_backup(filename=filename, token=token, service=service)
 
 

--- a/astrbot/dashboard/api/backups.py
+++ b/astrbot/dashboard/api/backups.py
@@ -301,8 +301,9 @@ async def download_backup(
 ):
     if not token:
         auth_header = request.headers.get("Authorization", "").strip()
-        if auth_header.startswith("Bearer "):
-            token = auth_header.removeprefix("Bearer ").strip() or None
+        scheme, separator, credentials = auth_header.partition(" ")
+        if separator and scheme.lower() == "bearer":
+            token = credentials.strip() or None
     return _download_backup(filename=filename, token=token, service=service)
 
 

--- a/tests/test_fastapi_v1_dashboard.py
+++ b/tests/test_fastapi_v1_dashboard.py
@@ -3,17 +3,19 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import httpx
 import jwt
 import pytest
 import pytest_asyncio
 from fastapi import FastAPI, Request
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import FileResponse, PlainTextResponse
 
 import astrbot.dashboard.services.config_service as config_service
 from astrbot.core import file_token_service
 from astrbot.dashboard.api.app import create_dashboard_asgi_app
+from astrbot.dashboard.api.backups import download_backup as download_backup_route
 from astrbot.dashboard.asgi_runtime import (
     FastAPIAppAdapter,
     g,
@@ -24,6 +26,7 @@ from astrbot.dashboard.asgi_runtime import (
 from astrbot.dashboard.responses import ok
 from astrbot.dashboard.services.api_key_service import ApiKeyService
 from astrbot.dashboard.services.auth_service import DASHBOARD_JWT_COOKIE_NAME
+from astrbot.dashboard.services.backup_service import BackupDownload
 from astrbot.dashboard.services.plugin_service import (
     PLUGIN_UPDATE_SOURCE_REQUIRED_MESSAGE,
     PluginServiceError,
@@ -1178,6 +1181,43 @@ async def test_dashboard_static_dist_files_are_served(
     assert missing_response.status_code == 404
     assert traversal_response.status_code == 404
     assert api_response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_v1_backup_download_accepts_bearer_token(
+    tmp_path: Path,
+):
+    filename = "desktop-backup.zip"
+    backup_path = tmp_path / filename
+    backup_path.write_bytes(b"PK\x03\x04desktop-backup-content")
+    prepare_download = Mock(
+        return_value=BackupDownload(path=str(backup_path), filename=filename)
+    )
+    service = SimpleNamespace(
+        config={"dashboard": {"jwt_secret": JWT_SECRET}},
+        prepare_download=prepare_download,
+    )
+    request = Request(
+        {
+            "type": "http",
+            "headers": [(b"authorization", b"Bearer desktop-session-token")],
+        }
+    )
+
+    response = await download_backup_route(
+        filename=filename,
+        request=request,
+        token=None,
+        service=service,
+    )
+
+    assert isinstance(response, FileResponse)
+    assert response.path == str(backup_path)
+    prepare_download.assert_called_once_with(
+        filename=filename,
+        token="desktop-session-token",
+        jwt_secret=JWT_SECRET,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_fastapi_v1_dashboard.py
+++ b/tests/test_fastapi_v1_dashboard.py
@@ -1200,7 +1200,7 @@ async def test_v1_backup_download_accepts_bearer_token(
     request = Request(
         {
             "type": "http",
-            "headers": [(b"authorization", b"Bearer desktop-session-token")],
+            "headers": [(b"authorization", b"bEaReR   desktop-session-token")],
         }
     )
 


### PR DESCRIPTION
### Motivation / 修改动机

Fixes #9524.

AstrBot Desktop sends the dashboard JWT through the `Authorization: Bearer`
header when downloading a backup. The AstrBot backup download endpoint
previously accepted only the `token` query parameter, so it returned a JSON
error response that the desktop client saved as an unusable ZIP file.

### Modifications / 改动点

- Updated the v1 backup download route to use the Bearer token from the
  `Authorization` header when the existing query token is absent.
- Preserved compatibility with the existing `token` query parameter and legacy
  download route.
- Added a regression test covering the Bearer-token download flow used by
  AstrBot Desktop.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
### Screenshots or Test Results / 运行截图或测试结果


---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Allow v1 backup downloads to authenticate using JWT bearer tokens in the Authorization header when no query token is provided, while preserving existing token-based behavior.

Bug Fixes:
- Ensure desktop clients that send the dashboard JWT in the Authorization: Bearer header can successfully download backup ZIP files instead of receiving JSON error responses.

Tests:
- Add a regression test verifying that the v1 backup download endpoint accepts a bearer token from the Authorization header and returns the requested backup file.