### PR TITLE
fix: handle legacy kb_ids in global knowledge base config

### DIFF
--- a/astrbot/core/knowledge_base/kb_mgr.py
+++ b/astrbot/core/knowledge_base/kb_mgr.py
@@ -154,9 +154,6 @@ class KnowledgeBaseManager:
         Returns:
             The matched knowledge base instance, or None when not found.
         """
-        for kb_helper in self.kb_insts.values():
-            if kb_helper.kb.kb_name == kb_name:
-                return kb_helper
         if kb_name in self.kb_insts:
             logger.warning(
                 "[Knowledge Base] Detected legacy kb_id %s in config and "
@@ -164,6 +161,9 @@ class KnowledgeBaseManager:
                 kb_name,
             )
             return self.kb_insts[kb_name]
+        for kb_helper in self.kb_insts.values():
+            if kb_helper.kb.kb_name == kb_name:
+                return kb_helper
         return None
 
     async def delete_kb(self, kb_id: str) -> bool:

--- a/astrbot/core/knowledge_base/kb_mgr.py
+++ b/astrbot/core/knowledge_base/kb_mgr.py
@@ -141,15 +141,29 @@ class KnowledgeBaseManager:
             raise
 
     async def get_kb(self, kb_id: str) -> KBHelper | None:
-        """获取知识库实例"""
+        """Get a knowledge base instance by ID."""
         if kb_id in self.kb_insts:
             return self.kb_insts[kb_id]
 
     async def get_kb_by_name(self, kb_name: str) -> KBHelper | None:
-        """通过名称获取知识库实例"""
+        """Get a knowledge base instance by name.
+
+        Args:
+            kb_name: Knowledge base name, or a legacy kb_id stored by mistake.
+
+        Returns:
+            The matched knowledge base instance, or None when not found.
+        """
         for kb_helper in self.kb_insts.values():
             if kb_helper.kb.kb_name == kb_name:
                 return kb_helper
+        if kb_name in self.kb_insts:
+            logger.warning(
+                "[Knowledge Base] Detected legacy kb_id %s in config and "
+                "resolved it as a fallback.",
+                kb_name,
+            )
+            return self.kb_insts[kb_name]
         return None
 
     async def delete_kb(self, kb_id: str) -> bool:

--- a/astrbot/core/tools/knowledge_base_tools.py
+++ b/astrbot/core/tools/knowledge_base_tools.py
@@ -15,7 +15,14 @@ _KNOWLEDGE_BASE_TOOL_CONFIG = {
 
 
 def check_all_kb(kb_list: list[KBHelper | None]) -> bool:
-    """检查是否所有的知识库都为空"""
+    """Check whether all loaded knowledge bases are empty.
+
+    Args:
+        kb_list: Resolved knowledge base instances. Unresolved entries are None.
+
+    Returns:
+        True when no non-empty knowledge base is available, otherwise False.
+    """
     return not any(
         kb and (kb.kb.doc_count != 0 or kb.kb.chunk_count != 0) for kb in kb_list
     )
@@ -26,7 +33,16 @@ async def retrieve_knowledge_base(
     umo: str,
     context: Context,
 ) -> str | None:
-    """Retrieve knowledge base context for the given query."""
+    """Retrieve knowledge base context for the given query.
+
+    Args:
+        query: User query text used for retrieval.
+        umo: Unified message origin of the current session.
+        context: Runtime context that provides config and knowledge base manager.
+
+    Returns:
+        Retrieved context text, or None when no usable knowledge base matches.
+    """
     kb_mgr = context.kb_manager
     config = context.get_config(umo=umo)
 
@@ -34,7 +50,10 @@ async def retrieve_knowledge_base(
     if session_config and "kb_ids" in session_config:
         kb_ids = session_config.get("kb_ids", [])
         if not kb_ids:
-            logger.info(f"[知识库] 会话 {umo} 已被配置为不使用知识库")
+            logger.info(
+                "[Knowledge Base] Session %s is configured to skip knowledge bases.",
+                umo,
+            )
             return None
 
         top_k = session_config.get("top_k", 5)
@@ -45,34 +64,73 @@ async def retrieve_knowledge_base(
             if kb_helper:
                 kb_names.append(kb_helper.kb.kb_name)
             else:
-                logger.warning(f"[知识库] 知识库不存在或未加载: {kb_id}")
+                logger.warning(
+                    "[Knowledge Base] Knowledge base %s does not exist or is not loaded.",
+                    kb_id,
+                )
                 invalid_kb_ids.append(kb_id)
 
         if invalid_kb_ids:
             logger.warning(
-                f"[知识库] 会话 {umo} 配置的以下知识库无效: {invalid_kb_ids}",
+                "[Knowledge Base] Session %s references invalid knowledge base IDs: %s",
+                umo,
+                invalid_kb_ids,
             )
         if not kb_names:
             return None
-        logger.debug(f"[知识库] 使用会话级配置，知识库数量: {len(kb_names)}")
+        logger.debug(
+            "[Knowledge Base] Session %s uses session-scoped config with %s "
+            "knowledge bases.",
+            umo,
+            len(kb_names),
+        )
     else:
         kb_names = config.get("kb_names", [])
         top_k = config.get("kb_final_top_k", 5)
-        logger.debug(f"[知识库] 使用全局配置，知识库数量: {len(kb_names)}")
+        logger.debug(
+            "[Knowledge Base] Session %s uses global config with %s knowledge bases.",
+            umo,
+            len(kb_names),
+        )
 
     top_k_fusion = config.get("kb_fusion_top_k", 20)
     if not kb_names:
         return None
 
-    all_kbs = [await kb_mgr.get_kb_by_name(kb) for kb in kb_names]
+    resolved_kb_names = []
+    all_kbs = []
+    invalid_kb_names = []
+    for kb_name in kb_names:
+        kb_helper = await kb_mgr.get_kb_by_name(kb_name)
+        if kb_helper:
+            resolved_kb_names.append(kb_helper.kb.kb_name)
+            all_kbs.append(kb_helper)
+            continue
+        invalid_kb_names.append(kb_name)
+
+    if invalid_kb_names:
+        logger.warning(
+            "[Knowledge Base] Session %s references missing or unloaded "
+            "knowledge bases: %s",
+            umo,
+            invalid_kb_names,
+        )
+    if not resolved_kb_names:
+        return None
     if check_all_kb(all_kbs):
-        logger.debug("所配置的所有知识库全为空，跳过检索过程")
+        logger.debug(
+            "[Knowledge Base] All resolved knowledge bases are empty; skipping retrieval.",
+        )
         return None
 
-    logger.debug(f"[知识库] 开始检索知识库，数量: {len(kb_names)}, top_k={top_k}")
+    logger.debug(
+        "[Knowledge Base] Starting retrieval across %s knowledge bases with top_k=%s.",
+        len(resolved_kb_names),
+        top_k,
+    )
     kb_context = await kb_mgr.retrieve(
         query=query,
-        kb_names=kb_names,
+        kb_names=resolved_kb_names,
         top_k_fusion=top_k_fusion,
         top_m_final=top_k,
     )
@@ -82,7 +140,11 @@ async def retrieve_knowledge_base(
     formatted = kb_context.get("context_text", "")
     if formatted:
         results = kb_context.get("results", [])
-        logger.debug(f"[知识库] 为会话 {umo} 注入了 {len(results)} 条相关知识块")
+        logger.debug(
+            "[Knowledge Base] Injected %s relevant chunks into session %s.",
+            len(results),
+            umo,
+        )
         return formatted
     return None
 

--- a/tests/unit/test_knowledge_base_tools.py
+++ b/tests/unit/test_knowledge_base_tools.py
@@ -20,7 +20,11 @@ async def test_get_kb_by_name_falls_back_to_kb_id():
         result = await kb_manager.get_kb_by_name("kb-uuid-1")
 
     assert result is kb_helper
-    warning.assert_called_once()
+    warning.assert_called_once_with(
+        "[Knowledge Base] Detected legacy kb_id %s in config and "
+        "resolved it as a fallback.",
+        "kb-uuid-1",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_knowledge_base_tools.py
+++ b/tests/unit/test_knowledge_base_tools.py
@@ -1,0 +1,106 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from astrbot.core.knowledge_base.kb_mgr import KnowledgeBaseManager
+from astrbot.core.tools import knowledge_base_tools
+
+
+@pytest.mark.asyncio
+async def test_get_kb_by_name_falls_back_to_kb_id():
+    kb_manager = KnowledgeBaseManager(provider_manager=MagicMock())
+    kb_helper = SimpleNamespace(
+        kb=SimpleNamespace(kb_id="kb-uuid-1", kb_name="Docs"),
+        init_error=None,
+    )
+    kb_manager.kb_insts = {"kb-uuid-1": kb_helper}
+
+    with patch("astrbot.core.knowledge_base.kb_mgr.logger.warning") as warning:
+        result = await kb_manager.get_kb_by_name("kb-uuid-1")
+
+    assert result is kb_helper
+    warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_retrieve_knowledge_base_uses_resolved_names_for_global_uuid_config():
+    kb_helper = SimpleNamespace(
+        kb=SimpleNamespace(
+            kb_id="kb-uuid-1",
+            kb_name="Docs",
+            doc_count=1,
+            chunk_count=1,
+        ),
+        init_error=None,
+    )
+    kb_manager = MagicMock()
+    kb_manager.get_kb_by_name = AsyncMock(return_value=kb_helper)
+    kb_manager.retrieve = AsyncMock(
+        return_value={"context_text": "knowledge context", "results": [object()]},
+    )
+    context = SimpleNamespace(
+        kb_manager=kb_manager,
+        get_config=lambda umo: {
+            "kb_names": ["kb-uuid-1"],
+            "kb_final_top_k": 3,
+            "kb_fusion_top_k": 6,
+        },
+    )
+
+    with patch.object(
+        knowledge_base_tools.sp,
+        "session_get",
+        new=AsyncMock(return_value={}),
+    ):
+        result = await knowledge_base_tools.retrieve_knowledge_base(
+            query="what is this",
+            umo="umo:test",
+            context=context,
+        )
+
+    assert result == "knowledge context"
+    kb_manager.retrieve.assert_awaited_once_with(
+        query="what is this",
+        kb_names=["Docs"],
+        top_k_fusion=6,
+        top_m_final=3,
+    )
+
+
+@pytest.mark.asyncio
+async def test_retrieve_knowledge_base_warns_for_invalid_global_kb_config():
+    kb_manager = MagicMock()
+    kb_manager.get_kb_by_name = AsyncMock(return_value=None)
+    kb_manager.retrieve = AsyncMock()
+    context = SimpleNamespace(
+        kb_manager=kb_manager,
+        get_config=lambda umo: {
+            "kb_names": ["missing-kb"],
+            "kb_final_top_k": 3,
+            "kb_fusion_top_k": 6,
+        },
+    )
+
+    with (
+        patch.object(
+            knowledge_base_tools.sp,
+            "session_get",
+            new=AsyncMock(return_value={}),
+        ),
+        patch.object(knowledge_base_tools.logger, "warning") as warning,
+    ):
+        result = await knowledge_base_tools.retrieve_knowledge_base(
+            query="what is this",
+            umo="umo:test",
+            context=context,
+        )
+
+    assert result is None
+    warning.assert_called_once_with(
+        "[Knowledge Base] Session %s references missing or unloaded "
+        "knowledge bases: %s",
+        "umo:test",
+        ["missing-kb"],
+    )
+    kb_manager.retrieve.assert_not_called()


### PR DESCRIPTION
## Summary
- fix the global knowledge base config path so legacy `kb_ids` stored in `kb_names` can still resolve correctly
- keep the session-scoped knowledge base path unchanged while adding warnings for missing or unloaded global knowledge bases
- add regression tests for legacy ID fallback and invalid global knowledge base configuration

## Test plan
- [ ] Run `uv run pytest tests/unit/test_knowledge_base_tools.py`
- [ ] Run `uv run ruff format .`
- [ ] Run `uv run ruff check .`
- [ ] Verify that session-scoped knowledge base config still uses `kb_ids -> get_kb(kb_id)`
- [ ] Verify that global config with legacy UUID values in `kb_names` can retrieve knowledge correctly

Fixes #9529

## Summary by Sourcery

Improve knowledge base retrieval to support legacy global configurations while keeping session-scoped behavior unchanged.

New Features:
- Add fallback in global knowledge base name resolution to treat legacy kb_id values stored in kb_names as valid knowledge bases.

Bug Fixes:
- Ensure global knowledge base configs using legacy UUIDs in kb_names correctly resolve and retrieve knowledge.
- Prevent retrieval from running when globally configured knowledge bases are missing, unloaded, or all empty.

Enhancements:
- Improve logging and docstrings around knowledge base resolution and retrieval, including warnings for invalid session and global configurations.

Tests:
- Add unit tests covering legacy kb_id fallback in get_kb_by_name and global UUID-based knowledge base retrieval.
- Add unit test ensuring invalid global knowledge base configurations emit warnings and skip retrieval.