### PR TITLE
fix: sanitize MCP tool names for LLM API

### DIFF
--- a/astrbot/core/agent/mcp_client.py
+++ b/astrbot/core/agent/mcp_client.py
@@ -797,8 +797,13 @@ class MCPTool(FunctionTool, Generic[TContext]):
     def __init__(
         self, mcp_tool: mcp.Tool, mcp_client: MCPClient, mcp_server_name: str, **kwargs
     ) -> None:
+        # LLM providers restrict tool names to [a-zA-Z0-9_-], but MCP servers
+        # may expose names containing e.g. '.'. Expose a sanitized name to the
+        # LLM while keeping the original in self.mcp_tool.name for the actual
+        # MCP call in call().
+        llm_tool_name = re.sub(r"[^A-Za-z0-9_-]+", "_", mcp_tool.name)
         super().__init__(
-            name=mcp_tool.name,
+            name=llm_tool_name,
             description=mcp_tool.description or "",
             parameters=_normalize_mcp_input_schema(mcp_tool.inputSchema),
         )

--- a/tests/unit/test_mcp_client_schema.py
+++ b/tests/unit/test_mcp_client_schema.py
@@ -115,3 +115,18 @@ class TestMCPToolSchemaNormalization:
         assert tool.parameters["required"] == ["stock_code"]
         assert "required" not in tool.parameters["properties"]["stock_code"]
         assert "required" not in tool.parameters["properties"]["market"]
+
+    def test_mcp_tool_sanitizes_llm_facing_name_but_keeps_original_for_call(self):
+        mcp_tool = SimpleNamespace(
+            name="t_drive.create_doc",
+            description="Create a doc",
+            inputSchema={"type": "object", "properties": {}},
+        )
+
+        tool = MCPTool(mcp_tool, MagicMock(), "tencent-docs")
+
+        # The name exposed to the LLM must match the OpenAI/Anthropic
+        # [a-zA-Z0-9_-] pattern; the original dotted name is preserved for the
+        # actual MCP call.
+        assert tool.name == "t_drive_create_doc"
+        assert tool.mcp_tool.name == "t_drive.create_doc"


### PR DESCRIPTION
### Modifications / 改动点

Fixes #9533. MCP servers may expose tool names containing `.` (e.g. Tencent Docs). LLM providers (OpenAI/Anthropic) require tool names to match `^[a-zA-Z0-9_-]+$`, so such names cause a 400 `Invalid 'tools[].name'` error during chat.

This change sanitizes the **LLM-facing** tool name in `MCPTool.__init__` (characters outside `[a-zA-Z0-9_-]` are replaced with `_`), while the original name is kept in `mcp_tool.name` — which `call()` already uses to invoke the actual MCP server tool — so MCP callbacks are unaffected.

Files changed:
- `astrbot/core/agent/mcp_client.py`: expose a sanitized tool name to the LLM.
- `tests/unit/test_mcp_client_schema.py`: add `test_mcp_tool_sanitizes_llm_facing_name_but_keeps_original_for_call`.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```bash
$ uv run pytest tests/unit/test_mcp_client_schema.py -q
6 passed, 1 warning in 0.36s

$ uv run pytest
2095 passed, 72 warnings in 75.30s

$ ruff format --check astrbot/core/agent/mcp_client.py tests/unit/test_mcp_client_schema.py
2 files already formatted

$ ruff check .
All checks passed!
```

The name sanitization and original-name preservation are asserted by the new unit test
`test_mcp_tool_sanitizes_llm_facing_name_but_keeps_original_for_call`
(`tests/unit/test_mcp_client_schema.py`). The full-suite warnings are pre-existing
`DeprecationWarning`s unrelated to this change.

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。*(No new features; fix discussed in #9533.)*

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Sanitize MCP tool names before exposing them to LLM providers to avoid invalid tool name errors while preserving the original names for MCP calls.

Bug Fixes:
- Prevent 400 errors from LLM providers by replacing invalid characters in MCP tool names with underscores for the LLM-facing name.

Tests:
- Add a unit test ensuring MCPTool exposes a sanitized name to the LLM while retaining the original MCP tool name for server invocation.

## Summary by Sourcery

Sanitize MCP tool names before exposing them to LLM providers to avoid invalid tool name errors while preserving original names for MCP calls.

Bug Fixes:
- Prevent 400 errors from LLM providers by sanitizing MCP tool names to conform to allowed character patterns while keeping the original MCP tool name for server invocation.

Tests:
- Add a unit test verifying MCPTool exposes a sanitized LLM-facing name and retains the original MCP tool name for actual MCP server calls.