### PR TITLE
fix: use current favicon on login page

### DIFF
--- a/dashboard/src/views/authentication/auth/LoginPage.vue
+++ b/dashboard/src/views/authentication/auth/LoginPage.vue
@@ -165,7 +165,7 @@ onMounted(async () => {
     <v-card class="login-card" elevation="1">
       <v-card-title>
         <div class="d-flex justify-space-between align-center w-100">
-          <img width="80" src="@/assets/images/icon-no-shadow.svg" alt="AstrBot Logo">
+          <img width="80" src="/favicon.svg" alt="AstrBot Logo">
           <div class="d-flex align-center gap-1">
             <LanguageSwitcher />
             <v-divider vertical class="mx-1"


### PR DESCRIPTION
### Modifications / 改动点

The login page still displayed the outdated icon after AstrBot switched to the current blue-star logo. This change points the login page logo at the official icon (`/favicon.svg`, the `#2f86bd` star used by the browser-tab favicon, the README banner, and the GitHub avatar) instead of the legacy `@/assets/images/icon-no-shadow.svg`.

- Core file modified: `dashboard/src/views/authentication/auth/LoginPage.vue` (one-line change).
- No related issue — this is a small, self-contained fix, so no issue was filed.
- Note: the old asset `dashboard/src/assets/images/icon-no-shadow.svg` has **not** been deleted; it is left in place since it is no longer referenced.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

**Before / 修复前:**

<img width="518" height="582" alt="Screenshot 2026-08-04 at 07 55 43" src="https://github.com/user-attachments/assets/4a82d18a-16e8-4d3b-8ea6-2492da152d3d" />

**After / 修复后:**

<img width="498" height="572" alt="Screenshot 2026-08-04 at 08 05 04" src="https://github.com/user-attachments/assets/979fe12d-1478-47be-a9d5-620ae1439bc1" />

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Update the login page to use the current favicon instead of the outdated legacy logo asset.

## Summary by Sourcery

Bug Fixes:
- Align the login page logo with the official favicon used elsewhere in the application.