### PR TITLE
test: isolate API key admin configuration

### DIFF
--- a/tests/test_api_key_open_api.py
+++ b/tests/test_api_key_open_api.py
@@ -49,6 +49,7 @@ async def core_lifecycle_td(tmp_path_factory):
     log_broker = LogBroker()
     core_lifecycle = AstrBotCoreLifecycle(log_broker, db)
     await core_lifecycle.initialize()
+    core_lifecycle.astrbot_config["admins_id"] = ["api-key-test-admin"]
     generated_password = getattr(
         core_lifecycle.astrbot_config,
         "_generated_dashboard_password",


### PR DESCRIPTION
API key OpenAPI tests currently depend on the local AstrBot configuration containing at least one administrator ID. When `admins_id` is empty, two tests fail with `IndexError`, making the test results dependent on the developer or CI environment.

This change makes the tests deterministic by providing a fixed administrator ID in the module-scoped test configuration.

### Modifications / 改动点

- Updated `tests/test_api_key_open_api.py`.
- Set a deterministic administrator ID in the shared API key test fixture.
- Removed the affected tests' dependency on the local `data/cmd_config.json` contents.
- Kept the production authentication and authorization behavior unchanged.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果
<img width="922" height="87" alt="image" src="https://github.com/user-attachments/assets/4ee370eb-d41f-4e84-8732-f1c40dbe6ae9" />


---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Tests:
- Set a deterministic administrator ID in the API key OpenAPI test fixture to remove dependence on local AstrBot configuration.