### PR TITLE
fix: prevent capability chip styles from leaking into dark theme

### DIFF
--- a/dashboard/src/components/shared/CapabilitySourceChip.vue
+++ b/dashboard/src/components/shared/CapabilitySourceChip.vue
@@ -57,23 +57,23 @@ defineProps({
   color: #00695c !important;
 }
 
-:global(.v-theme--PurpleThemeDark) .capability-source-chip--plugin {
+:global(.v-theme--PurpleThemeDark .capability-source-chip--plugin) {
   color: #64b5f6 !important;
 }
 
-:global(.v-theme--PurpleThemeDark) .capability-source-chip--mcp {
+:global(.v-theme--PurpleThemeDark .capability-source-chip--mcp) {
   color: #ffab91 !important;
 }
 
-:global(.v-theme--PurpleThemeDark) .capability-source-chip--local {
+:global(.v-theme--PurpleThemeDark .capability-source-chip--local) {
   color: #a5d6a7 !important;
 }
 
-:global(.v-theme--PurpleThemeDark) .capability-source-chip--preset {
+:global(.v-theme--PurpleThemeDark .capability-source-chip--preset) {
   color: #ce93d8 !important;
 }
 
-:global(.v-theme--PurpleThemeDark) .capability-source-chip--mixed {
+:global(.v-theme--PurpleThemeDark .capability-source-chip--mixed) {
   color: #80cbc4 !important;
 }
 </style>


### PR DESCRIPTION
AstrBot v4.27.1 can render WebUI text and icons in teal after switching to dark mode. The dark-mode overrides in `CapabilitySourceChip.vue` used `:global()` only around the theme ancestor. With the currently locked Vue 3.3.4 compiler, selectors such as:

```css
:global(.v-theme--PurpleThemeDark) .capability-source-chip--mixed
```

were emitted as a bare `.v-theme--PurpleThemeDark` selector. The last override therefore applied `color: #80cbc4 !important` to the entire dark theme container instead of only the mixed capability source chip.

### Modifications / 改动点

- Wrap the complete dark-theme ancestor and capability chip descendant selector in `:global()` for the `plugin`, `mcp`, `local`, `preset`, and `mixed` tones.
- Preserve all existing chip colors while preventing them from being inherited by unrelated WebUI content.
- Keep the light theme, theme color definitions, public APIs, dependencies, and generated files unchanged.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

<img width="2556" height="1220" alt="5bbc592a5a8fd834d2bb3c6edabd9826" src="https://github.com/user-attachments/assets/dc9d675f-5c8b-4f65-8e4a-815f85d14e0d" />


Manual verification on Windows:

- Light mode retains its existing blue color scheme.
- Dark mode text and icons no longer inherit the mixed chip's teal color.
- Dark mode primary elements use the configured blue theme color.
- Repeated light-to-dark theme switching does not leave stale colors.

Automated and build verification:

```text
node --test tests/*.test.mjs
36 tests passed, 0 failed

npx -y pnpm@10.28.2 run build
Production build completed successfully (3,793 modules transformed)
```

The generated `CapabilitySourceChip-*.css` contains all five descendant selectors, contains no bare `.v-theme--PurpleThemeDark { color: ... }` rule, and applies `#80cbc4` only to `.capability-source-chip--mixed`.

---

### Checklist / 检查清单

- [x] N/A: this PR fixes a regression and does not add a new feature.
- [x] The change has been tested, and the verification steps and results are provided above.
- [x] No new dependencies are introduced.
- [x] The change does not introduce malicious code.
