### PR TITLE
feat: add MiniMax voice design to TTS

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1799,6 +1799,11 @@ CONFIG_METADATA_2 = {
                         "minimax-voice-pitch": 0,
                         "minimax-is-timber-weight": False,
                         "minimax-voice-id": "female-shaonv",
+                        "minimax-voice-design-prompt": "",
+                        "minimax-voice-design-preview-text": "",
+                        "minimax-voice-design-voice-id": "",
+                        "minimax-voice-design-prompt-audio": "",
+                        "minimax-voice-design-api-base": "https://api.minimaxi.com/v1",
                         "minimax-timber-weight": '[\n    {\n        "voice_id": "Chinese (Mandarin)_Warm_Girl",\n        "weight": 25\n    },\n    {\n        "voice_id": "Chinese (Mandarin)_BashfulGirl",\n        "weight": 50\n    }\n]',
                         "minimax-voice-emotion": "auto",
                         "minimax-voice-latex": False,
@@ -2591,6 +2596,35 @@ CONFIG_METADATA_2 = {
                         "type": "string",
                         "description": "单一音色",
                         "hint": "单一音色编号, 详见官网文档",
+                    },
+                    "minimax-voice-design-prompt": {
+                        "type": "string",
+                        "description": "音色设计提示词",
+                        "hint": "描述目标音色的文本。设置后将在合成前通过音色设计 API 创建自定义音色。",
+                    },
+                    "minimax-voice-design-preview-text": {
+                        "type": "string",
+                        "description": "音色设计预览文本",
+                        "hint": "用于生成音色设计预览音频的文本。音色设计 API 要求必填。",
+                    },
+                    "minimax-voice-design-voice-id": {
+                        "type": "string",
+                        "description": "音色设计音色 ID",
+                        "hint": "为设计的音色指定的自定义 ID。留空则由 API 自动生成。",
+                    },
+                    "minimax-voice-design-prompt-audio": {
+                        "type": "string",
+                        "description": "音色设计提示音频路径",
+                        "hint": "本地 .mp3, .m4a, 或 .wav 参考音频, 以 prompt_audio 用途上传, 用于增强音色相似度和稳定性。",
+                    },
+                    "minimax-voice-design-api-base": {
+                        "type": "string",
+                        "description": "音色设计 API 地址",
+                        "options": [
+                            "https://api.minimax.io/v1",
+                            "https://api.minimaxi.com/v1",
+                        ],
+                        "hint": "用于提示音频上传和音色设计的区域化 MiniMax API 地址。",
                     },
                     "minimax-voice-emotion": {
                         "type": "string",

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -2609,8 +2609,8 @@ CONFIG_METADATA_2 = {
                     },
                     "minimax-voice-design-voice-id": {
                         "type": "string",
-                        "description": "音色设计音色 ID",
-                        "hint": "为设计的音色指定的自定义 ID。留空则由 API 自动生成。",
+                        "description": "Voice design voice ID",
+                        "hint": "Required custom voice ID for the designed voice.",
                     },
                     "minimax-voice-design-prompt-audio": {
                         "type": "string",

--- a/astrbot/core/provider/sources/minimax_tts_api_source.py
+++ b/astrbot/core/provider/sources/minimax_tts_api_source.py
@@ -131,6 +131,10 @@ class ProviderMiniMaxTTSAPI(TTSProvider):
                 raise ValueError(
                     "MiniMax voice design requires 'minimax-voice-design-preview-text'.",
                 )
+            if not self.voice_design_voice_id:
+                raise ValueError(
+                    "MiniMax voice design requires 'minimax-voice-design-voice-id'.",
+                )
 
             if self.voice_design_prompt_audio:
                 audio_path = Path(self.voice_design_prompt_audio).expanduser()
@@ -206,9 +210,8 @@ class ProviderMiniMaxTTSAPI(TTSProvider):
             design_body: dict[str, object] = {
                 "prompt": self.voice_design_prompt,
                 "preview_text": self.voice_design_preview_text,
+                "voice_id": self.voice_design_voice_id,
             }
-            if self.voice_design_voice_id:
-                design_body["voice_id"] = self.voice_design_voice_id
 
             try:
                 async with aiohttp.ClientSession() as session:
@@ -239,11 +242,7 @@ class ProviderMiniMaxTTSAPI(TTSProvider):
                 )
 
             design_result = design_data.get("data") or {}
-            voice_id = (
-                design_data.get("voice_id")
-                or design_result.get("voice_id")
-                or self.voice_design_voice_id
-            )
+            voice_id = design_data.get("voice_id") or design_result.get("voice_id")
             if not voice_id:
                 raise RuntimeError(
                     "MiniMax voice design returned no voice_id.",

--- a/astrbot/core/provider/sources/minimax_tts_api_source.py
+++ b/astrbot/core/provider/sources/minimax_tts_api_source.py
@@ -1,6 +1,8 @@
+import asyncio
 import json
 import os
 from collections.abc import AsyncIterator
+from pathlib import Path
 
 import aiohttp
 
@@ -32,6 +34,23 @@ class ProviderMiniMaxTTSAPI(TTSProvider):
         )
         self.group_id: str = provider_config.get("minimax-group-id", "")
         self.set_model(provider_config.get("model", ""))
+        self.voice_design_prompt: str = str(
+            provider_config.get("minimax-voice-design-prompt") or "",
+        ).strip()
+        self.voice_design_preview_text: str = str(
+            provider_config.get("minimax-voice-design-preview-text") or "",
+        ).strip()
+        self.voice_design_voice_id: str = str(
+            provider_config.get("minimax-voice-design-voice-id") or "",
+        ).strip()
+        self.voice_design_prompt_audio: str = str(
+            provider_config.get("minimax-voice-design-prompt-audio") or "",
+        ).strip()
+        self.voice_design_api_base: str = str(
+            provider_config.get("minimax-voice-design-api-base") or "",
+        ).strip()
+        self._voice_design_ready = False
+        self._voice_design_lock = asyncio.Lock()
         self.lang_boost: str = provider_config.get("minimax-langboost", "auto")
         self.is_timber_weight: bool = provider_config.get(
             "minimax-is-timber-weight",
@@ -83,6 +102,163 @@ class ProviderMiniMaxTTSAPI(TTSProvider):
             "accept": "application/json, text/plain, */*",
             "content-type": "application/json",
         }
+
+    def _voice_design_url(self, path: str) -> str:
+        """Build a MiniMax voice-design endpoint URL."""
+        if self.voice_design_api_base:
+            api_base = self.voice_design_api_base
+        else:
+            api_base = self.api_base.rstrip("/")
+            if not api_base.endswith("/v1"):
+                api_base = api_base.rsplit("/", 1)[0]
+        return f"{api_base.rstrip('/')}/{path.lstrip('/')}"
+
+    async def _ensure_voice_design(self) -> None:
+        """Design the configured voice before the first synthesis request."""
+        if not self.voice_design_prompt:
+            return
+        if self._voice_design_ready:
+            return
+
+        async with self._voice_design_lock:
+            if self._voice_design_ready:
+                return
+            if self.is_timber_weight:
+                raise ValueError(
+                    "MiniMax voice design cannot be combined with mixed voices.",
+                )
+            if not self.voice_design_preview_text:
+                raise ValueError(
+                    "MiniMax voice design requires 'minimax-voice-design-preview-text'.",
+                )
+
+            if self.voice_design_prompt_audio:
+                audio_path = Path(self.voice_design_prompt_audio).expanduser()
+                if not audio_path.is_file():
+                    raise FileNotFoundError(
+                        f"MiniMax voice-design prompt audio file does not exist: {audio_path}",
+                    )
+
+                content_type = {
+                    ".m4a": "audio/mp4",
+                    ".mp3": "audio/mpeg",
+                    ".wav": "audio/wav",
+                }.get(audio_path.suffix.lower())
+                if content_type is None:
+                    raise ValueError(
+                        "MiniMax voice design supports only .mp3, .m4a, and .wav prompt audio files.",
+                    )
+
+                try:
+                    async with aiohttp.ClientSession() as session:
+                        form = aiohttp.FormData()
+                        with audio_path.open("rb") as audio_file:
+                            form.add_field(
+                                "file",
+                                audio_file,
+                                filename=audio_path.name,
+                                content_type=content_type,
+                            )
+                            form.add_field("purpose", "prompt_audio")
+                            async with session.post(
+                                self._voice_design_url("files/upload"),
+                                headers={
+                                    "Authorization": self.headers["Authorization"]
+                                },
+                                data=form,
+                                timeout=aiohttp.ClientTimeout(total=60),
+                            ) as response:
+                                if response.status >= 400:
+                                    error_text = (await response.text())[:1024]
+                                    raise RuntimeError(
+                                        "MiniMax voice-design prompt audio upload failed: "
+                                        f"HTTP {response.status}: {error_text}",
+                                    )
+                                upload_data = await response.json(content_type=None)
+
+                        upload_base_resp = upload_data.get("base_resp", {})
+                        upload_status_code = upload_base_resp.get("status_code")
+                        if upload_status_code not in (None, 0, "0"):
+                            status_msg = upload_base_resp.get(
+                                "status_msg",
+                                "unknown error",
+                            )
+                            raise RuntimeError(
+                                f"MiniMax voice-design prompt audio upload failed: {status_msg}",
+                            )
+
+                        file_data = upload_data.get("file") or {}
+                        nested_data = upload_data.get("data") or {}
+                        file_id = (
+                            upload_data.get("file_id")
+                            or file_data.get("file_id")
+                            or nested_data.get("file_id")
+                        )
+                        if not file_id:
+                            raise RuntimeError(
+                                "MiniMax voice-design prompt audio upload returned no file_id.",
+                            )
+                except aiohttp.ClientError as exc:
+                    raise RuntimeError(
+                        f"MiniMax voice-design prompt audio upload request failed: {exc!s}",
+                    ) from exc
+
+            design_body: dict[str, object] = {
+                "prompt": self.voice_design_prompt,
+                "preview_text": self.voice_design_preview_text,
+            }
+            if self.voice_design_voice_id:
+                design_body["voice_id"] = self.voice_design_voice_id
+
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(
+                        self._voice_design_url("voice_design"),
+                        headers=self.headers,
+                        json=design_body,
+                        timeout=aiohttp.ClientTimeout(total=60),
+                    ) as response:
+                        if response.status >= 400:
+                            error_text = (await response.text())[:1024]
+                            raise RuntimeError(
+                                "MiniMax voice design failed: "
+                                f"HTTP {response.status}: {error_text}",
+                            )
+                        design_data = await response.json(content_type=None)
+            except aiohttp.ClientError as exc:
+                raise RuntimeError(
+                    f"MiniMax voice design request failed: {exc!s}",
+                ) from exc
+
+            base_resp = design_data.get("base_resp", {})
+            status_code = base_resp.get("status_code")
+            if status_code not in (None, 0, "0"):
+                status_msg = base_resp.get("status_msg", "unknown error")
+                raise RuntimeError(
+                    f"MiniMax voice design failed: {status_msg}",
+                )
+
+            design_result = design_data.get("data") or {}
+            voice_id = (
+                design_data.get("voice_id")
+                or design_result.get("voice_id")
+                or self.voice_design_voice_id
+            )
+            if not voice_id:
+                raise RuntimeError(
+                    "MiniMax voice design returned no voice_id.",
+                )
+            self.voice_setting["voice_id"] = voice_id
+            self._voice_design_ready = True
+
+    async def design_voice(self) -> str:
+        """Design the configured MiniMax voice and return its voice ID."""
+        await self._ensure_voice_design()
+        if not self.voice_design_prompt:
+            raise ValueError(
+                "MiniMax voice design requires 'minimax-voice-design-prompt'.",
+            )
+        return self.voice_setting["voice_id"]
 
     def _build_tts_stream_body(self, text: str):
         """构建流式请求体"""
@@ -154,6 +330,7 @@ class ProviderMiniMaxTTSAPI(TTSProvider):
         return b"".join(chunks)
 
     async def get_audio(self, text: str) -> str:
+        await self._ensure_voice_design()
         temp_dir = get_astrbot_temp_path()
         os.makedirs(temp_dir, exist_ok=True)
         path = os.path.join(temp_dir, f"minimax_tts_api_{generate_timestamp_id()}.wav")

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -1574,7 +1574,7 @@
       },
       "minimax-voice-design-voice-id": {
         "description": "Voice design voice ID",
-        "hint": "Custom voice ID for the designed voice. Leave empty to let the API generate one."
+        "hint": "Required custom voice ID for the designed voice."
       },
       "minimax-voice-design-prompt-audio": {
         "description": "Voice design prompt audio path",

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -1564,6 +1564,26 @@
         "description": "Single voice",
         "hint": "Single voice ID; see the official documentation."
       },
+      "minimax-voice-design-prompt": {
+        "description": "Voice design prompt",
+        "hint": "Text description of the desired voice. When set, a custom voice is created via the Voice Design API before synthesis."
+      },
+      "minimax-voice-design-preview-text": {
+        "description": "Voice design preview text",
+        "hint": "Text used to generate the preview audio sample for voice design. Required by the Voice Design API."
+      },
+      "minimax-voice-design-voice-id": {
+        "description": "Voice design voice ID",
+        "hint": "Custom voice ID for the designed voice. Leave empty to let the API generate one."
+      },
+      "minimax-voice-design-prompt-audio": {
+        "description": "Voice design prompt audio path",
+        "hint": "Local .mp3, .m4a, or .wav reference audio uploaded with purpose 'prompt_audio' to enhance voice similarity and stability."
+      },
+      "minimax-voice-design-api-base": {
+        "description": "Voice design API base",
+        "hint": "Regional MiniMax API base for prompt audio upload and voice design."
+      },
       "minimax-voice-emotion": {
         "description": "Emotion",
         "hint": "Controls emotion of synthesized speech. When set to auto, it selects emotion based on text."

--- a/dashboard/src/i18n/locales/ru-RU/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/config-metadata.json
@@ -1561,6 +1561,26 @@
                 "description": "Одиночный голос",
                 "hint": "ID одиночного голоса; см. официальную документацию."
             },
+            "minimax-voice-design-prompt": {
+                "description": "Описание голоса для дизайна",
+                "hint": "Текстовое описание желаемого голоса. При задании перед синтезом будет создан кастомный голос через API Voice Design."
+            },
+            "minimax-voice-design-preview-text": {
+                "description": "Текст предпросмотра голоса",
+                "hint": "Текст для генерации предпросмотра аудио при дизайне голоса. Обязателен для API Voice Design."
+            },
+            "minimax-voice-design-voice-id": {
+                "description": "ID голоса для дизайна",
+                "hint": "Пользовательский ID для создаваемого голоса. Оставьте пустым, чтобы API сгенерировал его автоматически."
+            },
+            "minimax-voice-design-prompt-audio": {
+                "description": "Путь к аудио подсказки",
+                "hint": "Локальный файл .mp3, .m4a или .wav, загружаемый с целью prompt_audio для повышения схожести и стабильности голоса."
+            },
+            "minimax-voice-design-api-base": {
+                "description": "API base для дизайна голоса",
+                "hint": "Региональный базовый URL MiniMax для загрузки аудио и дизайна голоса."
+            },
             "minimax-voice-emotion": {
                 "description": "Эмоция",
                 "hint": "Эмоция речи. 'auto' выбирает эмоцию на основе текста."

--- a/dashboard/src/i18n/locales/ru-RU/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/config-metadata.json
@@ -1570,8 +1570,8 @@
                 "hint": "Текст для генерации предпросмотра аудио при дизайне голоса. Обязателен для API Voice Design."
             },
             "minimax-voice-design-voice-id": {
-                "description": "ID голоса для дизайна",
-                "hint": "Пользовательский ID для создаваемого голоса. Оставьте пустым, чтобы API сгенерировал его автоматически."
+                "description": "Voice design voice ID",
+                "hint": "Required custom voice ID for the designed voice."
             },
             "minimax-voice-design-prompt-audio": {
                 "description": "Путь к аудио подсказки",

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -1575,8 +1575,8 @@
         "hint": "用于生成音色设计预览音频的文本。音色设计 API 要求必填。"
       },
       "minimax-voice-design-voice-id": {
-        "description": "音色设计音色 ID",
-        "hint": "为设计的音色指定的自定义 ID。留空则由 API 自动生成。"
+        "description": "Voice design voice ID",
+        "hint": "Required custom voice ID for the designed voice."
       },
       "minimax-voice-design-prompt-audio": {
         "description": "音色设计提示音频路径",

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -1566,6 +1566,26 @@
         "description": "单一音色",
         "hint": "单一音色编号, 详见官网文档"
       },
+      "minimax-voice-design-prompt": {
+        "description": "音色设计提示词",
+        "hint": "描述目标音色的文本。设置后将在合成前通过音色设计 API 创建自定义音色。"
+      },
+      "minimax-voice-design-preview-text": {
+        "description": "音色设计预览文本",
+        "hint": "用于生成音色设计预览音频的文本。音色设计 API 要求必填。"
+      },
+      "minimax-voice-design-voice-id": {
+        "description": "音色设计音色 ID",
+        "hint": "为设计的音色指定的自定义 ID。留空则由 API 自动生成。"
+      },
+      "minimax-voice-design-prompt-audio": {
+        "description": "音色设计提示音频路径",
+        "hint": "本地 .mp3、.m4a 或 .wav 参考音频, 以 prompt_audio 用途上传, 用于增强音色相似度和稳定性。"
+      },
+      "minimax-voice-design-api-base": {
+        "description": "音色设计 API 地址",
+        "hint": "用于提示音频上传和音色设计的区域化 MiniMax API 地址。"
+      },
       "minimax-voice-emotion": {
         "description": "情绪",
         "hint": "控制合成语音的情绪。当为 auto 时，将根据文本内容自动选择情绪。"

--- a/tests/test_minimax_tts_api_voice_design.py
+++ b/tests/test_minimax_tts_api_voice_design.py
@@ -1,0 +1,208 @@
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from astrbot.core.provider.sources.minimax_tts_api_source import (
+    ProviderMiniMaxTTSAPI,
+)
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict, status: int = 200) -> None:
+        self.payload = payload
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args) -> None:
+        return None
+
+    async def json(self, **_kwargs) -> dict:
+        return self.payload
+
+    async def text(self) -> str:
+        return json.dumps(self.payload)
+
+
+class _FakeSession:
+    def __init__(self, responses: list[_FakeResponse]) -> None:
+        self.responses = responses
+        self.posts: list[tuple[str, dict]] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args) -> None:
+        return None
+
+    def post(self, url: str, **kwargs):
+        self.posts.append((url, kwargs))
+        return self.responses.pop(0)
+
+
+class _FakeFormData:
+    last: "_FakeFormData | None" = None
+
+    def __init__(self) -> None:
+        self.fields: list[tuple[str, object, dict]] = []
+        self.__class__.last = self
+
+    def add_field(self, name: str, value: object, **kwargs) -> None:
+        self.fields.append((name, value, kwargs))
+
+
+def _make_provider(**overrides) -> ProviderMiniMaxTTSAPI:
+    config = {
+        "id": "test-minimax-tts",
+        "type": "minimax_tts_api",
+        "api_key": "test-key",
+        "api_base": "https://api.minimaxi.com/v1/t2a_v2",
+        "model": "speech-02-turbo",
+        "minimax-voice-design-prompt": "A warm and friendly female voice",
+        "minimax-voice-design-preview-text": "Hello, this is a preview.",
+        "minimax-voice-design-voice-id": "designed-voice",
+        "minimax-voice-design-prompt-audio": "",
+        "minimax-voice-design-api-base": "https://api.minimaxi.com/v1",
+    }
+    config.update(overrides)
+    return ProviderMiniMaxTTSAPI(config, {})
+
+
+@pytest.mark.asyncio
+async def test_design_voice_uploads_prompt_audio_and_uses_returned_voice_id(
+    monkeypatch,
+    tmp_path,
+):
+    audio_path = tmp_path / "reference.wav"
+    audio_path.write_bytes(b"wav data")
+    provider = _make_provider(**{"minimax-voice-design-prompt-audio": str(audio_path)})
+    session = _FakeSession(
+        [
+            _FakeResponse({"file": {"file_id": "file-123"}}),
+            _FakeResponse({"data": {"voice_id": "created-voice"}}),
+        ]
+    )
+    monkeypatch.setattr(
+        "astrbot.core.provider.sources.minimax_tts_api_source.aiohttp.ClientSession",
+        lambda: session,
+    )
+    monkeypatch.setattr(
+        "astrbot.core.provider.sources.minimax_tts_api_source.aiohttp.FormData",
+        _FakeFormData,
+    )
+
+    assert await provider.design_voice() == "created-voice"
+    assert provider.voice_setting["voice_id"] == "created-voice"
+    assert (
+        json.loads(provider._build_tts_stream_body("hello"))["voice_setting"][
+            "voice_id"
+        ]
+        == "created-voice"
+    )
+    assert len(session.posts) == 2
+    assert session.posts[0][0] == "https://api.minimaxi.com/v1/files/upload"
+    assert session.posts[0][1]["headers"] == {"Authorization": "Bearer test-key"}
+    assert session.posts[1][0] == "https://api.minimaxi.com/v1/voice_design"
+    assert session.posts[1][1]["json"] == {
+        "prompt": "A warm and friendly female voice",
+        "preview_text": "Hello, this is a preview.",
+        "voice_id": "designed-voice",
+    }
+    assert _FakeFormData.last is not None
+    assert [field[0] for field in _FakeFormData.last.fields] == ["file", "purpose"]
+    assert _FakeFormData.last.fields[1][1] == "prompt_audio"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "api_base",
+    ["https://api.minimax.io/v1", "https://api.minimaxi.com/v1"],
+)
+async def test_design_voice_supports_both_regional_api_bases(
+    monkeypatch,
+    api_base,
+):
+    provider = _make_provider(**{"minimax-voice-design-api-base": api_base})
+    session = _FakeSession([_FakeResponse({"voice_id": "created-voice"})])
+    monkeypatch.setattr(
+        "astrbot.core.provider.sources.minimax_tts_api_source.aiohttp.ClientSession",
+        lambda: session,
+    )
+
+    assert await provider.design_voice() == "created-voice"
+    assert [post[0] for post in session.posts] == [f"{api_base}/voice_design"]
+
+
+@pytest.mark.asyncio
+async def test_design_voice_is_single_flight(monkeypatch):
+    provider = _make_provider()
+    session = _FakeSession([_FakeResponse({"voice_id": "created-voice"})])
+    monkeypatch.setattr(
+        "astrbot.core.provider.sources.minimax_tts_api_source.aiohttp.ClientSession",
+        lambda: session,
+    )
+
+    assert await asyncio.gather(provider.design_voice(), provider.design_voice()) == [
+        "created-voice",
+        "created-voice",
+    ]
+    assert len(session.posts) == 1
+
+
+@pytest.mark.asyncio
+async def test_design_voice_omits_voice_id_when_not_configured(monkeypatch):
+    provider = _make_provider(**{"minimax-voice-design-voice-id": ""})
+    session = _FakeSession([_FakeResponse({"voice_id": "auto-voice"})])
+    monkeypatch.setattr(
+        "astrbot.core.provider.sources.minimax_tts_api_source.aiohttp.ClientSession",
+        lambda: session,
+    )
+
+    assert await provider.design_voice() == "auto-voice"
+    assert "voice_id" not in session.posts[0][1]["json"]
+
+
+@pytest.mark.asyncio
+async def test_design_voice_validates_configuration_and_audio_format(tmp_path):
+    provider = _make_provider(**{"minimax-voice-design-preview-text": ""})
+    with pytest.raises(ValueError, match="minimax-voice-design-preview-text"):
+        await provider.design_voice()
+
+    audio_path = tmp_path / "reference.txt"
+    audio_path.write_text("not audio")
+    provider = _make_provider(
+        **{"minimax-voice-design-prompt-audio": str(audio_path)},
+    )
+    with pytest.raises(ValueError, match="\\.mp3"):
+        await provider.design_voice()
+
+
+@pytest.mark.asyncio
+async def test_design_voice_requires_prompt(monkeypatch):
+    provider = _make_provider(**{"minimax-voice-design-prompt": ""})
+    session = _FakeSession([])
+    monkeypatch.setattr(
+        "astrbot.core.provider.sources.minimax_tts_api_source.aiohttp.ClientSession",
+        lambda: session,
+    )
+
+    with pytest.raises(ValueError, match="minimax-voice-design-prompt"):
+        await provider.design_voice()
+    assert session.posts == []
+
+
+@pytest.mark.asyncio
+async def test_design_voice_rejects_mixed_voices(monkeypatch):
+    provider = _make_provider(**{"minimax-is-timber-weight": True})
+    session = _FakeSession([])
+    monkeypatch.setattr(
+        "astrbot.core.provider.sources.minimax_tts_api_source.aiohttp.ClientSession",
+        lambda: session,
+    )
+
+    with pytest.raises(ValueError, match="mixed voices"):
+        await provider.design_voice()
+    assert session.posts == []

--- a/tests/test_minimax_tts_api_voice_design.py
+++ b/tests/test_minimax_tts_api_voice_design.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-from pathlib import Path
 
 import pytest
 
@@ -153,16 +152,17 @@ async def test_design_voice_is_single_flight(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_design_voice_omits_voice_id_when_not_configured(monkeypatch):
+async def test_design_voice_requires_voice_id(monkeypatch):
     provider = _make_provider(**{"minimax-voice-design-voice-id": ""})
-    session = _FakeSession([_FakeResponse({"voice_id": "auto-voice"})])
+    session = _FakeSession([])
     monkeypatch.setattr(
         "astrbot.core.provider.sources.minimax_tts_api_source.aiohttp.ClientSession",
         lambda: session,
     )
 
-    assert await provider.design_voice() == "auto-voice"
-    assert "voice_id" not in session.posts[0][1]["json"]
+    with pytest.raises(ValueError, match="minimax-voice-design-voice-id"):
+        await provider.design_voice()
+    assert session.posts == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Reason: MiniMax voice design (POST /v1/voice_design with prompt and voice_id, plus POST /v1/files/upload with purpose=prompt_audio) is not yet implemented in the MiniMax TTS provider.

## Changes
- Add MiniMax voice design configuration fields (prompt, preview text, custom voice id, optional prompt audio path, regional API base) to `astrbot/core/config/default.py` and the dashboard metadata locales (en-US, ru-RU, zh-CN).
- Implement voice design in `minimax_tts_api_source.py`: `_ensure_voice_design()` creates the configured voice via the Voice Design API before the first synthesis request, optionally uploading prompt audio with purpose `prompt_audio` first; `design_voice()` exposes the created voice id, and the designed voice is used as the TTS `voice_id`.
- Add tests covering prompt-audio upload, both regional API bases, single-flight behavior, optional voice id, and configuration validation.

## Checks
- `ruff check` (0.15.22) on the changed Python files: passed.
- JSON parse of the changed dashboard metadata files: passed.
- `python -m py_compile` of the changed Python files: passed.
- Isolated verification of the new voice design flow (stubbed aiohttp): 20 checks passed.

## Summary by Sourcery

Add support for MiniMax voice design in the TTS provider, including configuration, API integration, and tests.

New Features:
- Introduce configurable MiniMax voice design options (prompt, preview text, custom voice ID, optional prompt audio, regional API base) in core config and dashboard metadata.
- Support designing MiniMax custom voices via the voice design API, including optional prompt-audio upload, and using the resulting voice ID for synthesis.
- Expose a design_voice API on the MiniMax TTS provider to trigger voice creation and retrieve the configured voice ID.

Enhancements:
- Ensure MiniMax voice design runs once per provider instance with single-flight locking before the first synthesis request.
- Support both MiniMax regional API bases for voice design and prompt-audio upload endpoints.

Tests:
- Add unit tests covering prompt-audio upload handling, regional API base selection, single-flight behavior, optional custom voice ID, and configuration/format validation for MiniMax voice design.