### PR TITLE
fix: issue where the issue template does not display the bug report category

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report_en.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report_en.yml
@@ -76,7 +76,7 @@ body:
         Other supplementary information related to the issue, such as reproduction videos or complete log files. Please upload images in the description.<br>
         If the logs you want to provide are too long to fit in the previous field, you can paste only the key logs there and upload the complete log file here.
     validations:
-      accept: ".txt,.log,.mp4,.mov,.webm,.zip,.gz,.tar.gz"
+      accept: ".txt,.log,.mp4,.mov,.webm,.zip,.gz"
 
   - type: checkboxes
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report_zh.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report_zh.yml
@@ -75,7 +75,7 @@ body:
         与问题相关的其他辅助信息，例如复现视频、完整日志文件。图片请在问题描述中上传。<br>
         如果您要提供的日志过长以至不适合直接填写到上一栏，您可以选择只在上一栏贴关键日志，将完整的日志文件上传到这里。
     validations:
-      accept: ".txt,.log,.mp4,.mov,.webm,.zip,.gz,.tar.gz"
+      accept: ".txt,.log,.mp4,.mov,.webm,.zip,.gz"
 
   - type: checkboxes
     attributes:


### PR DESCRIPTION
# 紧急修复了 Bug report 模板消失的问题。

GitHub 这官方文档坑我。。
<img width="1897" height="686" alt="image" src="https://github.com/user-attachments/assets/c59d8ab4-5a93-41ad-85dd-930be94a9497" />

### Screenshots or Test Results / 运行截图或测试结果

#### 修复前

<img width="1770" height="891" alt="image" src="https://github.com/user-attachments/assets/59b737dc-65a9-43f2-84e1-d20b9de07ecf" />

#### 修复后(Test)

<img width="1791" height="988" alt="image" src="https://github.com/user-attachments/assets/ed8cd18a-1b51-4507-b83a-7d0a822c1fc7" />


---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Restore proper display and functionality of the GitHub bug report issue templates by correcting their file upload validation configuration.

Bug Fixes:
- Fix bug report issue templates so the bug report category appears correctly in GitHub.
- Adjust file upload validation in bug report templates to use a supported list of accepted file extensions.