### PR TITLE
fix: use favicon as default plugin icon

### DIFF
--- a/dashboard/src/components/shared/ExtensionCard.vue
+++ b/dashboard/src/components/shared/ExtensionCard.vue
@@ -5,7 +5,7 @@ import { useModuleI18n } from "@/i18n/composables";
 import UninstallConfirmDialog from "./UninstallConfirmDialog.vue";
 import PluginPlatformChip from "./PluginPlatformChip.vue";
 import StyledMenu from "./StyledMenu.vue";
-import defaultPluginIcon from "@/assets/images/plugin_icon.png";
+import defaultPluginIcon from "/favicon.svg";
 import { usePluginI18n } from "@/utils/pluginI18n";
 
 const props = defineProps({

--- a/dashboard/src/views/ExtensionPage.vue
+++ b/dashboard/src/views/ExtensionPage.vue
@@ -6,7 +6,7 @@ import ProxySelector from "@/components/shared/ProxySelector.vue";
 import UninstallConfirmDialog from "@/components/shared/UninstallConfirmDialog.vue";
 import { useExtensionPage } from "./extension/useExtensionPage";
 import { computed, defineAsyncComponent } from "vue";
-import defaultPluginIcon from "@/assets/images/plugin_icon.png";
+import defaultPluginIcon from "/favicon.svg";
 import { usePluginI18n } from "@/utils/pluginI18n";
 
 const props = defineProps({

--- a/dashboard/src/views/extension/MarketPluginsTab.vue
+++ b/dashboard/src/views/extension/MarketPluginsTab.vue
@@ -1,7 +1,7 @@
 <script setup>
 import MarketPluginCard from "@/components/extension/MarketPluginCard.vue";
 import PluginSortControl from "@/components/extension/PluginSortControl.vue";
-import defaultPluginIcon from "@/assets/images/plugin_icon.png";
+import defaultPluginIcon from "/favicon.svg";
 import { computed } from "vue";
 import { normalizeTextInput } from "@/utils/inputValue";
 

--- a/dashboard/src/views/extension/PluginDetailPage.vue
+++ b/dashboard/src/views/extension/PluginDetailPage.vue
@@ -10,7 +10,7 @@ import {
 import axios from "axios";
 import DOMPurify from "dompurify";
 import MarkdownIt from "markdown-it";
-import defaultPluginIcon from "@/assets/images/plugin_icon.png";
+import defaultPluginIcon from "/favicon.svg";
 import { pluginApi } from "@/api/v1";
 import { usePluginI18n } from "@/utils/pluginI18n";
 import PluginPlatformChip from "@/components/shared/PluginPlatformChip.vue";


### PR DESCRIPTION
### Modifications / 改动点

The default placeholder icon for plugins still used the legacy `plugin_icon.png` after AstrBot switched to the current blue-star logo. This change points the default plugin icon at the official favicon (`/favicon.svg`) for plugins that do not ship their own `logo.png`.

- Core files modified (one-line change each, `import defaultPluginIcon from "@/assets/images/plugin_icon.png"` → `import defaultPluginIcon from "/favicon.svg"`):
  - `dashboard/src/components/shared/ExtensionCard.vue`
  - `dashboard/src/views/ExtensionPage.vue`
  - `dashboard/src/views/extension/MarketPluginsTab.vue`
  - `dashboard/src/views/extension/PluginDetailPage.vue`
- No related issue — this is a small, self-contained fix, so no issue was filed.
- Note: the old asset `dashboard/src/assets/images/plugin_icon.png` has **not** been deleted; it is still used as the brand logo in `Logo.vue` and `SetupPage.vue`.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果


**Before / 修复前:**

<img width="1455" height="691" alt="Screenshot 2026-08-04 at 18 43 44" src="https://github.com/user-attachments/assets/cb9c0167-04e1-4cc5-81eb-b79e967f8466" />

**After / 修复后:**

<img width="1465" height="625" alt="Screenshot 2026-08-04 at 18 28 35" src="https://github.com/user-attachments/assets/c5033e3f-7026-4807-9a0c-3bb04bb043ab" />

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Correct the fallback plugin icon to reference the current favicon instead of the legacy plugin_icon asset.

## Summary by Sourcery

Bug Fixes:
- Correct fallback plugin icons across extension-related views to reference the current favicon instead of the legacy plugin icon asset.