### PR TITLE
feat(session_waiter): allow session_waiter handler to return MessageEventResult

### DIFF
--- a/astrbot/builtin_stars/astrbot/main.py
+++ b/astrbot/builtin_stars/astrbot/main.py
@@ -9,7 +9,7 @@ from astrbot.api.event import AstrMessageEvent, filter
 from astrbot.api.message_components import Image, Plain
 from astrbot.api.provider import LLMResponse, ProviderRequest
 from astrbot.core import logger
-from astrbot.core.message.message_event_result import MessageChain
+from astrbot.core.message.message_event_result import MessageChain, MessageEventResult
 from astrbot.core.platform.message_type import MessageType
 from astrbot.core.utils.session_waiter import (
     FILTERS,
@@ -42,12 +42,14 @@ class Main(star.Star):
             logger.error(f"group chat context init failed: {e}")
 
     @filter.event_message_type(filter.EventMessageType.ALL, priority=maxsize)
-    async def handle_session_control_agent(self, event: AstrMessageEvent) -> None:
+    async def handle_session_control_agent(self, event: AstrMessageEvent):
         """会话控制代理"""
         for session_filter in FILTERS:
             session_id = session_filter.filter(event)
             if session_id in USER_SESSIONS:
-                await SessionWaiter.trigger(session_id, event)
+                result = await SessionWaiter.trigger(session_id, event)
+                if isinstance(result, MessageEventResult):
+                    yield result
                 event.stop_event()
 
     @filter.event_message_type(filter.EventMessageType.ALL, priority=maxsize - 1)

--- a/astrbot/core/platform/astr_message_event.py
+++ b/astrbot/core/platform/astr_message_event.py
@@ -343,17 +343,13 @@ class AstrMessageEvent(abc.ABC):
     def stop_event(self) -> None:
         """终止事件传播。"""
         self._force_stopped = True
-        if self._result is None:
-            self.set_result(MessageEventResult().stop_event())
-        else:
+        if self._result is not None:
             self._result.stop_event()
 
     def continue_event(self) -> None:
         """继续事件传播。"""
         self._force_stopped = False
-        if self._result is None:
-            self.set_result(MessageEventResult().continue_event())
-        else:
+        if self._result is not None:
             self._result.continue_event()
 
     def is_stopped(self) -> bool:

--- a/astrbot/core/utils/session_waiter.py
+++ b/astrbot/core/utils/session_waiter.py
@@ -151,11 +151,11 @@ class SessionWaiter:
         self.session_controller.stop(error)
 
     @classmethod
-    async def trigger(cls, session_id: str, event: AstrMessageEvent) -> None:
+    async def trigger(cls, session_id: str, event: AstrMessageEvent) -> Any:
         """外部输入触发会话处理"""
         session = USER_SESSIONS.get(session_id)
         if not session or session.session_controller.future.done():
-            return
+            return None
 
         async with session._lock:
             if not session.session_controller.future.done():
@@ -166,9 +166,10 @@ class SessionWaiter:
                 try:
                     # TODO: 这里使用 create_task，跟踪 task，防止超时后这里 handler 仍然在执行
                     assert session.handler is not None
-                    await session.handler(session.session_controller, event)
+                    return await session.handler(session.session_controller, event)
                 except Exception as e:
                     session.session_controller.stop(e)
+        return None
 
 
 def session_waiter(timeout: int = 30, record_history_chains: bool = False):

--- a/docs/en/dev/star/guides/session-control.md
+++ b/docs/en/dev/star/guides/session-control.md
@@ -20,15 +20,7 @@ Import:
 
 ```py
 import astrbot.api.message_components as Comp
-from astrbot.core.utils.session_waiter import (
-    session_waiter,
-    SessionController,
-)
-```
-
-Code within the handler can be written as follows:
-
-```python
+from astrbot.api.utils import SessionController, session_waiter
 from astrbot.api.event import filter, AstrMessageEvent
 
 @filter.command("idiom-chain")
@@ -40,27 +32,22 @@ async def handle_empty_mention(self, event: AstrMessageEvent):
         # How to use the session controller
         @session_waiter(timeout=60, record_history_chains=False) # Register a session controller with a 60-second timeout, without recording message history
         async def empty_mention_waiter(controller: SessionController, event: AstrMessageEvent):
-            idiom = event.message_str # The idiom sent by the user, e.g., "one horse takes the lead"
+            idiom = event.message_str # The idiom sent by the user, e.g., "一马当先"
 
             if idiom == "exit":   # If the user wants to exit the idiom chain game by typing "exit"
-                await event.send(event.plain_result("Exited the idiom chain game~"))
                 controller.stop()    # Stop the session controller, which will end immediately.
-                return
+                return event.plain_result("Exited the idiom chain game~")
 
             if len(idiom) != 4:   # If the user's input is not a 4-character idiom
-                await event.send(event.plain_result("The idiom must be four characters~"))  # Send a reply, cannot use yield
-                return
                 # Exit the current method without executing subsequent logic, but the session is not interrupted; subsequent user input will still enter the current session
+                return event.plain_result("The idiom must be four characters~")
 
             # ...
-            message_result = event.make_result()
-            message_result.chain = [Comp.Plain("Foresight")] # import astrbot.api.message_components as Comp
-            await event.send(message_result) # Send a reply, cannot use yield
-
             controller.keep(timeout=60, reset_timeout=True) # Reset timeout to 60s. If not reset, it will continue the previous timeout countdown.
 
             # controller.stop() # Stop the session controller, which will end immediately.
             # If history chains are recorded, you can retrieve them via controller.get_history_chains()
+            return event.plain_result("先见之明")  # Send a reply
 
         try:
             await empty_mention_waiter(event)
@@ -73,6 +60,10 @@ async def handle_empty_mention(self, event: AstrMessageEvent):
     except Exception as e:
         logger.error("handle_empty_mention error: " + str(e))
 ```
+
+> [!TIP]
+> Inside the session controller handler, you **cannot use `yield`**, but you can `return` a `MessageEventResult`. The returned result is automatically sent through the framework's message decoration pipeline, behaving the same as a regular command reply.\
+> If you call `event.send()` directly, the message bypasses the decoration pipeline and is sent directly.
 
 Once the session controller is activated, messages subsequently sent by that sender will first be processed by the `empty_mention_waiter` function you defined above, until the session controller is stopped or times out.
 
@@ -92,7 +83,7 @@ By default, the AstrBot session controller uses `sender_id` (the sender's ID) as
 
 ```py
 import astrbot.api.message_components as Comp
-from astrbot.core.utils.session_waiter import (
+from astrbot.api.utils import (
     session_waiter,
     SessionFilter,
     SessionController,

--- a/docs/en/dev/star/guides/session-control.md
+++ b/docs/en/dev/star/guides/session-control.md
@@ -20,7 +20,7 @@ Import:
 
 ```py
 import astrbot.api.message_components as Comp
-from astrbot.api.utils import SessionController, session_waiter
+from astrbot.api.util import SessionController, session_waiter
 from astrbot.api.event import filter, AstrMessageEvent
 
 @filter.command("idiom-chain")

--- a/docs/zh/dev/star/guides/session-control.md
+++ b/docs/zh/dev/star/guides/session-control.md
@@ -18,7 +18,7 @@ AstrBot 提供了开箱即用的会话控制功能：
 
 ```py
 import astrbot.api.message_components as Comp
-from astrbot.api.utils import SessionController, session_waiter
+from astrbot.api.util import SessionController, session_waiter
 from astrbot.api.event import filter, AstrMessageEvent
 
 @filter.command("成语接龙")

--- a/docs/zh/dev/star/guides/session-control.md
+++ b/docs/zh/dev/star/guides/session-control.md
@@ -16,19 +16,9 @@
 
 AstrBot 提供了开箱即用的会话控制功能：
 
-导入：
-
 ```py
 import astrbot.api.message_components as Comp
-from astrbot.core.utils.session_waiter import (
-    session_waiter,
-    SessionController,
-)
-```
-
-handler 内的代码可以如下：
-
-```python
+from astrbot.api.utils import SessionController, session_waiter
 from astrbot.api.event import filter, AstrMessageEvent
 
 @filter.command("成语接龙")
@@ -43,24 +33,18 @@ async def handle_empty_mention(self, event: AstrMessageEvent):
             idiom = event.message_str # 用户发来的成语，假设是 "一马当先"
 
             if idiom == "退出":   # 假设用户想主动退出成语接龙，输入了 "退出"
-                await event.send(event.plain_result("已退出成语接龙~"))
                 controller.stop()    # 停止会话控制器，会立即结束。
-                return
+                return event.plain_result("已退出成语接龙~")
 
             if len(idiom) != 4:   # 假设用户输入的不是4字成语
-                await event.send(event.plain_result("成语必须是四个字的呢~"))  # 发送回复，不能使用 yield
-                return
-                # 退出当前方法，不执行后续逻辑，但此会话并未中断，后续的用户输入仍然会进入当前会话
+                return event.plain_result("成语必须是四个字的呢~")  # 返回后不执行后续逻辑，但此会话并未中断，后续的用户输入仍然会进入当前会话
 
             # ...
-            message_result = event.make_result()
-            message_result.chain = [Comp.Plain("先见之明")] # import astrbot.api.message_components as Comp
-            await event.send(message_result) # 发送回复，不能使用 yield
-
             controller.keep(timeout=60, reset_timeout=True) # 重置超时时间为 60s，如果不重置，则会继续之前的超时时间计时。
 
             # controller.stop() # 停止会话控制器，会立即结束。
             # 如果记录了历史消息链，可以通过 controller.get_history_chains() 获取历史消息链
+            return event.plain_result("先见之明")  # 发送回复
 
         try:
             await empty_mention_waiter(event)
@@ -73,6 +57,10 @@ async def handle_empty_mention(self, event: AstrMessageEvent):
     except Exception as e:
         logger.error("handle_empty_mention error: " + str(e))
 ```
+
+> [!TIP]
+> 会话控制器处理函数内**不能使用 `yield`**，但可以 `return` 一个 `MessageEventResult`。返回的结果会被框架自动送入消息装饰流程后再发送，与普通指令回复的行为一致。\
+> 如果直接调用 `event.send()`，消息会绕过装饰流程直接发送。
 
 当激活会话控制器后，该发送人之后发送的消息会首先经过上面你定义的 `empty_mention_waiter` 函数处理，直到会话控制器被停止或者超时。
 
@@ -92,7 +80,7 @@ async def handle_empty_mention(self, event: AstrMessageEvent):
 
 ```py
 import astrbot.api.message_components as Comp
-from astrbot.core.utils.session_waiter import (
+from astrbot.api.utils import (
     session_waiter,
     SessionFilter,
     SessionController,

--- a/tests/unit/test_astr_message_event.py
+++ b/tests/unit/test_astr_message_event.py
@@ -415,11 +415,15 @@ class TestSetResult:
 class TestStopContinueEvent:
     """Tests for stop_event and continue_event methods."""
 
-    def test_stop_event_creates_result_if_none(self, astr_message_event):
-        """Test stop_event creates result if none exists."""
+    def test_stop_event_does_not_create_result_if_none(self, astr_message_event):
+        """stop_event should NOT fabricate an empty result when none exists.
+
+        Fabricating an empty MessageEventResult triggers a spurious second
+        RespondStage invocation after the real reply has been sent and cleared.
+        """
         astr_message_event.stop_event()
 
-        assert astr_message_event._result is not None
+        assert astr_message_event._result is None
         assert astr_message_event.is_stopped() is True
 
     def test_stop_event_with_existing_result(self, astr_message_event):
@@ -429,11 +433,11 @@ class TestStopContinueEvent:
 
         assert astr_message_event.is_stopped() is True
 
-    def test_continue_event_creates_result_if_none(self, astr_message_event):
-        """Test continue_event creates result if none exists."""
+    def test_continue_event_does_not_create_result_if_none(self, astr_message_event):
+        """continue_event should NOT fabricate an empty result when none exists."""
         astr_message_event.continue_event()
 
-        assert astr_message_event._result is not None
+        assert astr_message_event._result is None
         assert astr_message_event.is_stopped() is False
 
     def test_continue_event_with_existing_result(self, astr_message_event):

--- a/tests/unit/test_session_control_agent.py
+++ b/tests/unit/test_session_control_agent.py
@@ -1,0 +1,122 @@
+"""Tests for Main.handle_session_control_agent result routing.
+
+Covers the two branches introduced by the session-waiter return-value change:
+- handler returns a MessageEventResult -> yield it, then stop_event
+- handler returns None -> no yield, just stop_event
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from astrbot.core.message.message_event_result import MessageEventResult
+from astrbot.core.platform.astr_message_event import AstrMessageEvent
+from astrbot.core.platform.astrbot_message import AstrBotMessage, MessageMember
+from astrbot.core.platform.message_type import MessageType
+from astrbot.core.platform.platform_metadata import PlatformMetadata
+
+
+class _ConcreteEvent(AstrMessageEvent):
+    async def send(self, message):
+        await super().send(message)
+
+
+def _make_event() -> _ConcreteEvent:
+    meta = PlatformMetadata(name="test", description="t", id="test_id")
+    msg = AstrBotMessage()
+    msg.type = MessageType.FRIEND_MESSAGE
+    msg.self_id = "bot"
+    msg.session_id = "s"
+    msg.message_id = "m"
+    msg.sender = MessageMember(user_id="u", nickname="U")
+    msg.message_str = "hi"
+    return _ConcreteEvent("hi", msg, meta, "s")
+
+
+def _build_main():
+    """Construct a Main instance without running its heavy __init__."""
+    from astrbot.builtin_stars.astrbot.main import Main
+
+    main = Main.__new__(Main)
+    return main
+
+
+async def _collect(gen):
+    """Drain an async generator into a list of yielded values."""
+    out = []
+    async for item in gen:
+        out.append(item)
+    return out
+
+
+@pytest.mark.asyncio
+async def test_yields_message_event_result_when_trigger_returns_one():
+    """When trigger returns a MessageEventResult, the handler should yield it."""
+    main = _build_main()
+    event = _make_event()
+    expected = MessageEventResult().message("先见之明")
+
+    fake_filter = MagicMock()
+    fake_filter.filter = MagicMock(return_value="sid")
+    with (
+        patch(
+            "astrbot.builtin_stars.astrbot.main.FILTERS",
+            [fake_filter],
+        ),
+        patch(
+            "astrbot.builtin_stars.astrbot.main.USER_SESSIONS",
+            {"sid": MagicMock()},
+        ),
+        patch(
+            "astrbot.builtin_stars.astrbot.main.SessionWaiter.trigger",
+            new=AsyncMock(return_value=expected),
+        ),
+    ):
+        yielded = await _collect(main.handle_session_control_agent(event))
+
+    assert yielded == [expected]
+    assert event.is_stopped() is True
+
+
+@pytest.mark.asyncio
+async def test_no_yield_when_trigger_returns_none():
+    """When trigger returns None, the handler should not yield and should stop."""
+    main = _build_main()
+    event = _make_event()
+
+    fake_filter = MagicMock()
+    fake_filter.filter = MagicMock(return_value="sid")
+    with (
+        patch(
+            "astrbot.builtin_stars.astrbot.main.FILTERS",
+            [fake_filter],
+        ),
+        patch(
+            "astrbot.builtin_stars.astrbot.main.USER_SESSIONS",
+            {"sid": MagicMock()},
+        ),
+        patch(
+            "astrbot.builtin_stars.astrbot.main.SessionWaiter.trigger",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        yielded = await _collect(main.handle_session_control_agent(event))
+
+    assert yielded == []
+    assert event.is_stopped() is True
+
+
+@pytest.mark.asyncio
+async def test_no_op_when_no_session_matches():
+    """When no session_filter matches, nothing happens and event is not stopped."""
+    main = _build_main()
+    event = _make_event()
+
+    with (
+        patch("astrbot.builtin_stars.astrbot.main.FILTERS", []),
+        patch("astrbot.builtin_stars.astrbot.main.USER_SESSIONS", {}),
+    ):
+        yielded = await _collect(main.handle_session_control_agent(event))
+
+    assert yielded == []
+    assert event.is_stopped() is False

--- a/tests/unit/test_session_waiter.py
+++ b/tests/unit/test_session_waiter.py
@@ -1,0 +1,136 @@
+"""Tests for session_waiter.trigger return value propagation."""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from astrbot.core.message.message_event_result import MessageEventResult
+from astrbot.core.platform.astr_message_event import AstrMessageEvent
+from astrbot.core.platform.astrbot_message import AstrBotMessage, MessageMember
+from astrbot.core.platform.message_type import MessageType
+from astrbot.core.platform.platform_metadata import PlatformMetadata
+from astrbot.core.utils.session_waiter import (
+    FILTERS,
+    USER_SESSIONS,
+    SessionController,
+    SessionFilter,
+    SessionWaiter,
+    session_waiter,
+)
+
+SESSION_ID = "fixed_session_id"
+
+
+class _ConcreteEvent(AstrMessageEvent):
+    async def send(self, message):
+        await super().send(message)
+
+
+class _IdFilter(SessionFilter):
+    def filter(self, event: AstrMessageEvent) -> str:
+        return SESSION_ID
+
+
+def _make_event() -> _ConcreteEvent:
+    meta = PlatformMetadata(name="test", description="t", id="test_id")
+    msg = AstrBotMessage()
+    msg.type = MessageType.FRIEND_MESSAGE
+    msg.self_id = "bot"
+    msg.session_id = "s"
+    msg.message_id = "m"
+    msg.sender = MessageMember(user_id="u", nickname="U")
+    msg.message_str = "hi"
+    return _ConcreteEvent("hi", msg, meta, "s")
+
+
+@pytest.fixture
+def waiter_handler():
+    """Return a mutable holder so each test can install its own handler.
+
+    Also cleans up the module-global USER_SESSIONS / FILTERS so tests stay
+    isolated even if the waiter task is interrupted.
+    """
+
+    holder = {}
+
+    @session_waiter(timeout=5, record_history_chains=False)
+    async def waiter(controller: SessionController, event: AstrMessageEvent):
+        handler = holder["handler"]
+        if handler is None:
+            return None
+        return await handler(controller, event)
+
+    holder["waiter"] = waiter
+    holder["handler"] = None
+    yield holder
+    # Teardown: stop any still-pending session and clear globals.
+    for session in list(USER_SESSIONS.values()):
+        session.session_controller.stop()
+    USER_SESSIONS.clear()
+    FILTERS.clear()
+
+
+async def _start_waiter(holder) -> asyncio.Task:
+    """Register the waiter (which blocks on the controller future) in background."""
+    event = _make_event()
+    task = asyncio.create_task(holder["waiter"](event, session_filter=_IdFilter()))
+    # Yield control so the waiter registers itself in USER_SESSIONS.
+    await asyncio.sleep(0)
+    return task
+
+
+@pytest.mark.asyncio
+async def test_trigger_returns_message_event_result(waiter_handler):
+    """trigger should propagate the handler's returned MessageEventResult."""
+    expected = MessageEventResult().message("先见之明")
+    waiter_handler["handler"] = AsyncMock(return_value=expected)
+
+    task = await _start_waiter(waiter_handler)
+    result = await SessionWaiter.trigger(SESSION_ID, _make_event())
+
+    assert result is expected
+    # register_wait is still pending; stop it cleanly.
+    for session in list(USER_SESSIONS.values()):
+        session.session_controller.stop()
+    await task
+
+
+@pytest.mark.asyncio
+async def test_trigger_returns_none_when_handler_returns_none(waiter_handler):
+    """trigger should return None when the handler returns None."""
+    waiter_handler["handler"] = AsyncMock(return_value=None)
+
+    task = await _start_waiter(waiter_handler)
+    result = await SessionWaiter.trigger(SESSION_ID, _make_event())
+
+    assert result is None
+    for session in list(USER_SESSIONS.values()):
+        session.session_controller.stop()
+    await task
+
+
+@pytest.mark.asyncio
+async def test_trigger_returns_none_when_no_session():
+    """trigger should return None when there is no registered session."""
+    event = _make_event()
+    result = await SessionWaiter.trigger("nonexistent_session", event)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_trigger_returns_none_when_handler_raises(waiter_handler):
+    """trigger should return None (and stop the controller) when the handler raises.
+
+    The still-pending register_wait task will re-raise the exception after we
+    stop the controller, so we swallow it explicitly.
+    """
+    waiter_handler["handler"] = AsyncMock(side_effect=RuntimeError("boom"))
+
+    task = await _start_waiter(waiter_handler)
+    result = await SessionWaiter.trigger(SESSION_ID, _make_event())
+
+    assert result is None
+    # The controller was stopped with the exception; register_wait re-raises it.
+    with pytest.raises(RuntimeError, match="boom"):
+        await task


### PR DESCRIPTION
Resolve #9548.

### Modifications / 改动点

- [x] 这不是一个破坏性变更。

**核心改动（3 文件）**：
- `astrbot/core/utils/session_waiter.py`：`SessionWaiter.trigger` 返回 handler 的返回值（原为丢弃），返回类型 `None` → `Any`。
- `astrbot/builtin_stars/astrbot/main.py`：`handle_session_control_agent` 改为 async generator——当 trigger 返回 `MessageEventResult` 时 `yield` 它，借助 scheduler 的洋葱模型自动执行 `ResultDecorateStage` 和 `RespondStage`（发送）；否则保持原 `stop_event` 行为。
- `astrbot/core/platform/astr_message_event.py`：修复 `stop_event()` / `continue_event()` 在 `_result is None` 时凭空创建空 `MessageEventResult(chain=[])` 的行为，改为只设置 `_force_stopped` 标志。

**Bug 修复说明（`stop_event` 空发送）**：

在改 `handle_session_control_agent` 为 async generator 后，实测发现每次 waiter 返回 `MessageEventResult` 后 `RespondStage` 会触发两次：一次发送实际内容，一次发送空内容（日志 `Prepare to send - (空)`）。

根因是三个机制叠加：
1. `yield result` → `RespondStage` 发送实际内容后调 `clear_result()` → `event._result = None`。
2. 随后 `event.stop_event()` 发现 `_result is None`，**凭空造一个空 `MessageEventResult(chain=[])`** 挂回去（旧代码第 347 行 `self.set_result(MessageEventResult().stop_event())`）。
3. scheduler 的洋葱模型在 `ProcessStage` 结束后继续遍历后续 stage，`RespondStage` 看到非 None 的空 result，再次进入发送分支（chain 为空不会真正 send，但会打印日志并触发 `OnAfterMessageSentEvent` 钩子）。

`is_stopped()` 第一行就检查 `_force_stopped`，根本不需要那个空 result；`ResultDecorateStage` / `RespondStage` 入口都有 `if result is None: return` 保护。因此移除空 result 创建是安全的，且彻底消除了空发送。

**测试（3 文件，9 个用例）**：
- `tests/unit/test_session_waiter.py`：覆盖 trigger 在 handler 返回 `MessageEventResult` / `None` / 抛异常 / 无对应 session 四种情况下的返回值。
- `tests/unit/test_session_control_agent.py`：覆盖 `handle_session_control_agent` 在 trigger 返回 `MessageEventResult`（yield + stop）/ `None`（无 yield + stop）/ 无匹配 session（无操作）三种分支。
- `tests/unit/test_astr_message_event.py`：更新原有的 `test_stop_event_creates_result_if_none` / `test_continue_event_creates_result_if_none` 两个用例，断言新行为（不再创建空 result，`_result` 保持 `None`，`is_stopped()` 靠 `_force_stopped` 返回正确值）。

**工作机制**：`call_handler` 检测到 handler 是 async generator 且 `yield` 出 `MessageEventResult` 时，会自动 `event.set_result(ret)` 再向上 `yield`，触发 scheduler 递归执行后续 stage。因此 waiter handler 只需 `return event.plain_result(...)`，回复即走完整装饰流程。

**向后兼容**：
- 老插件在 waiter 内用 `event.send()` 且不 return 的，handler 返回 `None`，走原 `stop_event` 路径，行为完全不变。
- `stop_event()` 的语义不变（`is_stopped()` 仍正确返回 True），只是不再产生空 result 副作用。经全局排查，所有 `stop_event()` 调用点要么在 stage 内部（stop 后 pipeline break），要么有 `if result is None: return` 保护，无代码依赖「stop 后 `get_result()` 一定非 None」。

**文档更新**：更新会话控制文档，使用新调用方法，增加相关提示。此外顺带更新了过时的 `import`。

#### 插件侧用法示例

改前（装饰功能失效）：
```python
@session_waiter(timeout=60)
async def idiom_waiter(controller: SessionController, event: AstrMessageEvent):
    ...
    await event.send(event.plain_result("先见之明"))  # 不走 @回复 / 引用 / 分段
    controller.keep(timeout=60, reset_timeout=True)
```

改后（装饰功能生效）：
```python
@session_waiter(timeout=60)
async def idiom_waiter(controller: SessionController, event: AstrMessageEvent):
    ...
    controller.keep(timeout=60, reset_timeout=True)
    return event.plain_result("先见之明")  # 自动走 @回复 / 引用 / 分段 / TTS / 转图
```

### Screenshots or Test Results / 运行截图或测试结果

```bash
$ uv run pytest tests/unit/test_session_control_agent.py tests/unit/test_session_waiter.py tests/unit/test_astr_message_event.py -q
85 passed, 1 warning in 13.11s
```
> warning 为已有的弃用依赖警告（`audioop`），与本次 PR 无关。

用于测试此改动的插件：[Hiraeth-Wave/astrbot_plugin_test/tree/test/astrbot-feat-9551](https://github.com/Hiraeth-Wave/astrbot_plugin_test/tree/test/astrbot-feat-9551)，可下载源码压缩包后自行安装测试。

---

### Checklist / 检查清单

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。
- [x] 👀 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码。