### PR TITLE
feat(telegram): add dedicated proxy configuration

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -450,6 +450,7 @@ CONFIG_METADATA_2 = {
                         "type": "telegram",
                         "enable": True,
                         "telegram_token": "your_bot_token",
+                        "telegram_proxy": "",
                         "start_message": "Hello, I'm AstrBot!",
                         "telegram_api_base_url": "https://api.telegram.org/bot",
                         "telegram_file_base_url": "https://api.telegram.org/file/bot",
@@ -673,7 +674,12 @@ CONFIG_METADATA_2 = {
                     "telegram_token": {
                         "description": "Bot Token",
                         "type": "string",
-                        "hint": "如果你的网络环境为中国大陆，请在 `其他配置` 处设置代理或更改 api_base。",
+                        "hint": "在此处填入你的 Telegram Bot Token",
+                    },
+                    "telegram_proxy": {
+                        "description": "Telegram 代理地址",
+                        "type": "string",
+                        "hint": "可选的代理地址，如 http://ip:port 或 socks5://ip:port。仅 Telegram 适配器使用，留空则回退到全局代理设置。",
                     },
                     "mattermost_url": {
                         "description": "Mattermost URL",

--- a/astrbot/core/platform/sources/telegram/tg_adapter.py
+++ b/astrbot/core/platform/sources/telegram/tg_adapter.py
@@ -130,13 +130,18 @@ class TelegramPlatformAdapter(Platform):
         )  # max seconds - hard cap to prevent indefinite delay
 
     def _build_application(self) -> None:
-        self.application = (
+        builder = (
             ApplicationBuilder()
             .token(self.config["telegram_token"])
             .base_url(self.base_url)
             .base_file_url(self.file_base_url)
-            .build()
         )
+        proxy = self.config.get("telegram_proxy")
+        if proxy:
+            # getUpdates long-polling uses a separate request pool, so .proxy()
+            # alone would leave polling on a direct connection.
+            builder = builder.proxy(proxy).get_updates_proxy(proxy)
+        self.application = builder.build()
         message_handler = TelegramMessageHandler(
             filters=filters.ALL,
             callback=self.message_handler,

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -600,9 +600,13 @@
         "description": "Telegram Polling Restart Delay",
         "hint": "Waiting time in seconds when the polling loop needs to restart after unexpected exits. Defaults to 5s."
       },
+      "telegram_proxy": {
+        "description": "Telegram Proxy URL",
+        "hint": "Optional proxy URL, e.g. http://ip:port or socks5://ip:port. Used only by the Telegram adapter; falls back to the global proxy settings when empty."
+      },
       "telegram_token": {
         "description": "Bot Token",
-        "hint": "If you are in mainland China, set a proxy or change api_base in Other Settings."
+        "hint": "Enter your Telegram Bot Token here."
       },
       "mattermost_url": {
         "description": "Mattermost URL",

--- a/dashboard/src/i18n/locales/ru-RU/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/config-metadata.json
@@ -596,9 +596,13 @@
                 "description": "Интервал автообновления команд Telegram",
                 "hint": "Интервал автоматического обновления команд Telegram в секундах."
             },
+            "telegram_proxy": {
+                "description": "Proxy URL для Telegram",
+                "hint": "Формат: http://ip:port или socks5://ip:port. Используется только адаптером Telegram. Если поле пустое, применяются глобальные настройки прокси."
+            },
             "telegram_token": {
                 "description": "Токен бота",
-                "hint": "Если вы находитесь в материковом Китае, установите прокси или измените api_base в разделе «Другие настройки»."
+                "hint": "Введите сюда токен вашего Telegram-бота."
             },
             "mattermost_url": {
                 "description": "URL Mattermost",

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -602,9 +602,13 @@
         "description": "Telegram 轮询重启延迟",
         "hint": "当轮询意外结束尝试自动重启时的延迟时间，单位为秒。默认为 5s。"
       },
+      "telegram_proxy": {
+        "description": "Telegram 代理地址",
+        "hint": "可选的代理地址，如 http://ip:port 或 socks5://ip:port。仅 Telegram 适配器使用，留空则回退到全局代理设置。"
+      },
       "telegram_token": {
         "description": "Bot Token",
-        "hint": "如果你的网络环境为中国大陆，请在 `其他配置` 处设置代理或更改 api_base。"
+        "hint": "在此处填入你的 Telegram Bot Token"
       },
       "mattermost_url": {
         "description": "Mattermost URL",

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -492,3 +492,28 @@ async def test_telegram_proxy_is_applied_to_bot_api_and_polling_requests():
 
     builder.proxy.assert_called_once_with(proxy_url)
     builder.get_updates_proxy.assert_called_once_with(proxy_url)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("telegram_proxy", [None, ""])
+async def test_telegram_proxy_is_skipped_when_not_configured(telegram_proxy):
+    TelegramPlatformAdapter = _load_telegram_adapter()
+    module_globals = TelegramPlatformAdapter.__init__.__globals__
+
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.base_url.return_value = builder
+    builder.base_file_url.return_value = builder
+
+    with patch.dict(
+        module_globals,
+        {"ApplicationBuilder": MagicMock(return_value=builder)},
+    ):
+        TelegramPlatformAdapter(
+            make_platform_config("telegram", telegram_proxy=telegram_proxy),
+            {},
+            asyncio.Queue(),
+        )
+
+    builder.proxy.assert_not_called()
+    builder.get_updates_proxy.assert_not_called()

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -465,3 +465,30 @@ async def test_telegram_run_rebuilds_fresh_application_after_recreate_init_failu
     app_two.shutdown.assert_awaited()
     app_three.initialize.assert_awaited()
     app_three.start.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_telegram_proxy_is_applied_to_bot_api_and_polling_requests():
+    TelegramPlatformAdapter = _load_telegram_adapter()
+    module_globals = TelegramPlatformAdapter.__init__.__globals__
+    proxy_url = "http://127.0.0.1:7890"
+
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.base_url.return_value = builder
+    builder.base_file_url.return_value = builder
+    builder.proxy.return_value = builder
+    builder.get_updates_proxy.return_value = builder
+
+    with patch.dict(
+        module_globals,
+        {"ApplicationBuilder": MagicMock(return_value=builder)},
+    ):
+        TelegramPlatformAdapter(
+            make_platform_config("telegram", telegram_proxy=proxy_url),
+            {},
+            asyncio.Queue(),
+        )
+
+    builder.proxy.assert_called_once_with(proxy_url)
+    builder.get_updates_proxy.assert_called_once_with(proxy_url)


### PR DESCRIPTION
The Telegram adapter has no dedicated proxy configuration. The only proxy switch is the global `http_proxy`, which takes effect by writing the `http_proxy`/`https_proxy` environment variables into the process, so every HTTP client with `trust_env=True` shares it, while `no_proxy` can only exclude by host and offers no way to route a single adapter through a proxy on its own. A user who wants a proxy only for Telegram therefore has to turn on the global proxy, let all other outbound traffic go through it by default, and then pick hosts back out one at a time with `no_proxy`. This has already spilled over into unrelated modules (#7584). The Discord adapter already has `discord_proxy`, so this adds the matching capability for Telegram.

Closes #9343
Closes #7444
Closes #8180

### Modifications / 改动点

Modified `astrbot/core/platform/sources/telegram/tg_adapter.py`:
- `_build_application()` reads the `telegram_proxy` config entry and, when it is not empty, passes it to `ApplicationBuilder` through `.proxy()` and `.get_updates_proxy()`, which apply to Bot API requests and `getUpdates` long polling respectively

Modified `astrbot/core/config/default.py`:
- Added the default value `"telegram_proxy": ""` to the Telegram `config_template`, so that existing adapter instances also get the field filled in
- Added the field schema to `items`, so the WebUI can render the title and the description
- The `telegram_token` description used to carry the proxy guidance, and the place it pointed at is no longer correct, since the global proxy now lives under `Settings > Network`. It now describes only the token itself, which keeps it consistent with `discord_token`

Modified `dashboard/src/i18n/locales/{zh-CN,en-US,ru-RU}/features/config-metadata.json`:
- Added the `telegram_proxy` description and hint in all three languages, and mirrored the `telegram_token` description change above

Modified `tests/test_telegram_adapter.py`:
- Added `test_telegram_proxy_is_applied_to_bot_api_and_polling_requests`, which asserts that both `.proxy()` and `.get_updates_proxy()` receive the configured proxy address
- Added `test_telegram_proxy_is_skipped_when_not_configured`, parametrized over `None` and `""`, which asserts that neither method is called

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

With a working proxy `http://127.0.0.1:7897` configured, messages are sent and received normally:

<img width="1001" height="221" alt="代理正确" src="https://github.com/user-attachments/assets/f60d4356-08b5-4ea7-a5e2-fb78006a7fde" />

```
[23:58:26] [INFO] [telegram.tg_adapter:254]: Starting Telegram polling...
[23:58:26] [INFO] [telegram.tg_adapter:256]: Telegram Platform Adapter is running.
[23:59:56] [INFO] [core.event_bus:74]: [telegram(telegram)] <user>: test
[23:59:59] [INFO] [respond.stage:206]: Prepare to send - <user>: Hello! Test received ...
```

With a bad proxy `http://127.0.0.1:9` configured, the adapter can no longer reach Telegram, which shows that the traffic really does go through the configured proxy rather than falling back to a direct connection

<img width="993" height="71" alt="代理错误" src="https://github.com/user-attachments/assets/be09e719-ca53-4c41-a41e-ab598364e90b" />

```
[00:00:45] [ERRO] [telegram.tg_adapter:281]: Telegram polling crashed with exception:
NetworkError: httpx.ConnectError: All connection attempts failed. Retrying in 5.0s.
  ...
  File ".../httpcore/_async/http_proxy.py", line 288, in handle_async_request
    connect_response = await self._connection.handle_async_request(
  ...
httpcore.ConnectError: All connection attempts failed

The above exception was the direct cause of the following exception:
  ...
  File ".../astrbot/core/platform/sources/telegram/tg_adapter.py", line 154, in _start_application
    await self.application.initialize()
  ...
  File ".../telegram/_bot.py", line 865, in initialize
    await self.get_me()
  ...
telegram.error.NetworkError: httpx.ConnectError: All connection attempts failed
```

Regarding `.get_updates_proxy()`

python-telegram-bot keeps two independent request objects, one for `getUpdates` and one for the rest of the Bot API endpoints:

```python
# telegram/_bot.py:738
request = self._request[0] if endpoint == "getUpdates" else self._request[1]
```

`.proxy()` only configures the latter, `.get_updates_proxy()` configures the former.

The startup failure above happens in `Application.initialize()` → `Bot.get_me()`, which goes through `_request[1]`, so it can only prove that `.proxy()` works. The traceback below was captured after polling was already running, and it goes through `_request[0]`:

```
  File ".../telegram/ext/_updater.py", line 340, in polling_action_cb
    updates = await self.bot.get_updates(
  ...
  File ".../httpcore/_async/http_proxy.py", line 343, in handle_async_request
    return await self._connection.handle_async_request(request)
  ...
httpx.RemoteProtocolError: Server disconnected without sending a response.
```

`get_updates` and `httpcore._async.http_proxy` appear in the same call stack, which means the long polling request itself went through the proxy tunnel. The global `http_proxy` was empty for this run, and `core_lifecycle.py` actively deletes `http_proxy`/`https_proxy` from the environment variables when that setting is empty, so httpx's `trust_env` has no proxy to pick up. The proxy on this request can only have come from `.get_updates_proxy()`. The error itself is the connection being closed by the peer while long polling was waiting for a response, a common transient network error that has nothing to do with this change.

Screenshot of the settings page after the change

<img width="1279" height="670" alt="修复后设置页截图" src="https://github.com/user-attachments/assets/4950dda7-ae7f-430b-b957-1a68004c009c" />

When the field is left empty or not filled in at all, both builder calls are skipped, existing deployments behave exactly as before, and the global proxy setting still applies.

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Add dedicated proxy configuration support for the Telegram platform adapter and ensure it is applied to all Telegram HTTP and polling requests.

New Features:
- Introduce a telegram_proxy configuration option scoped to the Telegram adapter, with dashboard metadata and defaults.
- Apply the configured telegram_proxy to both standard Bot API traffic and long-polling getUpdates requests for Telegram.

Tests:
- Add a Telegram adapter test verifying that telegram_proxy is propagated to both proxy and get_updates_proxy on the ApplicationBuilder.
