### PR TITLE
feat: expand webchat drag-and-drop upload to the whole chat area

### DIFF
--- a/dashboard/src/components/chat/Chat.vue
+++ b/dashboard/src/components/chat/Chat.vue
@@ -383,7 +383,16 @@
         v-else
         class="conversation-stack"
         :class="{ 'is-empty': isEmptyChat }"
+        v-on="dragEvents"
       >
+        <transition name="drop-fade">
+          <div v-if="isDragging" class="chat-drop-overlay">
+            <div class="chat-drop-overlay-content">
+              <v-icon size="48" color="primary">mdi-cloud-upload</v-icon>
+              <span class="chat-drop-text">{{ tm("input.dropToUpload") }}</span>
+            </div>
+          </div>
+        </transition>
         <section
           ref="messagesContainer"
           class="messages-panel"
@@ -600,6 +609,7 @@ import {
 import { useMediaHandling } from "@/composables/useMediaHandling";
 import { useRecording } from "@/composables/useRecording";
 import { useProjects } from "@/composables/useProjects";
+import { useDragUpload } from "@/composables/useDragUpload";
 import { useChatHeaderStore } from "@/stores/chatHeader";
 import { useCustomizerStore } from "@/stores/customizer";
 import ProviderChatCompletionPanel from "@/components/provider/ProviderChatCompletionPanel.vue";
@@ -668,6 +678,8 @@ const {
   clearStaged,
   cleanupMediaCache,
 } = useMediaHandling();
+
+const { isDragging, dragEvents } = useDragUpload(handleFilesSelected);
 
 type WorkspaceView = "chat" | "providers";
 
@@ -2202,6 +2214,46 @@ function toggleTheme() {
   display: flex;
   flex-direction: column;
   position: relative;
+}
+
+/* 全区域拖拽上传遮罩 */
+.chat-drop-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 100;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(var(--v-theme-primary), 0.12);
+  border: 2px dashed rgba(var(--v-theme-primary), 0.45);
+  border-radius: 16px;
+}
+
+.chat-drop-overlay-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.chat-drop-text {
+  font-size: 16px;
+  font-weight: 500;
+  color: rgb(var(--v-theme-primary));
+}
+
+.drop-fade-enter-active,
+.drop-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.drop-fade-enter-from,
+.drop-fade-leave-to {
+  opacity: 0;
 }
 
 .conversation-stack.is-empty {

--- a/dashboard/src/components/chat/Chat.vue
+++ b/dashboard/src/components/chat/Chat.vue
@@ -328,7 +328,16 @@
     <main
       class="chat-main"
       :class="{ 'empty-chat': isEmptyChat }"
+      v-on="dragEvents"
     >
+      <transition name="drop-fade">
+        <div v-if="isDragging && !isProviderWorkspace" class="chat-drop-overlay">
+          <div class="chat-drop-overlay-content">
+            <v-icon size="48" color="primary">mdi-cloud-upload</v-icon>
+            <span class="chat-drop-text">{{ tm("input.dropToUpload") }}</span>
+          </div>
+        </div>
+      </transition>
       <section v-if="isProviderWorkspace" class="provider-workspace-shell">
         <ProviderChatCompletionPanel
           class="provider-workspace-page"
@@ -383,16 +392,7 @@
         v-else
         class="conversation-stack"
         :class="{ 'is-empty': isEmptyChat }"
-        v-on="dragEvents"
       >
-        <transition name="drop-fade">
-          <div v-if="isDragging" class="chat-drop-overlay">
-            <div class="chat-drop-overlay-content">
-              <v-icon size="48" color="primary">mdi-cloud-upload</v-icon>
-              <span class="chat-drop-text">{{ tm("input.dropToUpload") }}</span>
-            </div>
-          </div>
-        </transition>
         <section
           ref="messagesContainer"
           class="messages-panel"
@@ -679,7 +679,10 @@ const {
   cleanupMediaCache,
 } = useMediaHandling();
 
-const { isDragging, dragEvents } = useDragUpload(handleFilesSelected);
+const { isDragging, dragEvents } = useDragUpload((files) => {
+  if (isProviderWorkspace.value) return;
+  handleFilesSelected(files);
+});
 
 type WorkspaceView = "chat" | "providers";
 

--- a/dashboard/src/components/chat/ChatInput.vue
+++ b/dashboard/src/components/chat/ChatInput.vue
@@ -2,9 +2,6 @@
   <div
     class="input-area fade-in"
     :class="{ 'is-dark': isDark }"
-    @dragover.prevent="handleDragOver"
-    @dragleave.prevent="handleDragLeave"
-    @drop.prevent="handleDrop"
   >
     <div
       class="input-container"
@@ -24,15 +21,6 @@
         transition: 'min-height 0.2s ease, padding 0.2s ease',
       }"
     >
-      <!-- 拖拽上传遮罩 -->
-      <transition name="fade">
-        <div v-if="isDragging" class="drop-overlay">
-          <div class="drop-overlay-content">
-            <v-icon size="48" color="primary">mdi-cloud-upload</v-icon>
-            <span class="drop-text">{{ tm("input.dropToUpload") }}</span>
-          </div>
-        </div>
-      </transition>
       <!-- 引用预览区 -->
       <transition name="slideReply" @after-leave="handleReplyAfterLeave">
         <div class="reply-preview" v-if="props.replyTo && !isReplyClosing">
@@ -418,12 +406,10 @@ const providerModelMenuRef = ref<InstanceType<typeof ProviderModelMenu> | null>(
 );
 const providerSelectorAvailable = ref(true);
 const isReplyClosing = ref(false);
-const isDragging = ref(false);
 const isComposing = ref(false);
 const inputIsMultiline = ref(false);
 const lastCompositionEndAt = ref<number | null>(null);
 const longPasteThreshold = 10_000;
-let dragLeaveTimeout: number | null = null;
 
 // 命令提示相关状态
 const allCommands = ref<CommandItem[]>([]);
@@ -927,35 +913,6 @@ function handlePaste(e: ClipboardEvent) {
   emit("pasteImage", e);
 }
 
-function handleDragOver(e: DragEvent) {
-  // 清除之前的 leave timeout
-  if (dragLeaveTimeout) {
-    clearTimeout(dragLeaveTimeout);
-    dragLeaveTimeout = null;
-  }
-
-  // 检查是否有文件
-  if (e.dataTransfer?.types.includes("Files")) {
-    isDragging.value = true;
-  }
-}
-
-function handleDragLeave(e: DragEvent) {
-  // 使用 timeout 避免在子元素间移动时闪烁
-  dragLeaveTimeout = window.setTimeout(() => {
-    isDragging.value = false;
-  }, 50);
-}
-
-function handleDrop(e: DragEvent) {
-  isDragging.value = false;
-
-  const files = e.dataTransfer?.files;
-  if (files && files.length > 0) {
-    emit("fileSelect", files);
-  }
-}
-
 function triggerImageInput() {
   imageInputRef.value?.click();
 }
@@ -1316,47 +1273,6 @@ defineExpose({
 .input-area:not(.is-dark) .input-action-btn:disabled {
   background: #f2f5f3 !important;
   color: rgba(0, 0, 0, 0.18) !important;
-}
-
-/* 拖拽上传遮罩 */
-.drop-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(var(--v-theme-primary), 0.12);
-  border: 2px dashed rgba(var(--v-theme-primary), 0.45);
-  border-radius: 24px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 100;
-  pointer-events: none;
-}
-
-.drop-overlay-content {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-}
-
-.drop-text {
-  font-size: 16px;
-  font-weight: 500;
-  color: rgb(var(--v-theme-primary));
-}
-
-/* Fade transition for drop overlay */
-.fade-enter-active,
-.fade-leave-active {
-  transition: opacity 0.2s ease;
-}
-
-.fade-enter-from,
-.fade-leave-to {
-  opacity: 0;
 }
 
 .reply-preview {

--- a/dashboard/src/components/chat/StandaloneChat.vue
+++ b/dashboard/src/components/chat/StandaloneChat.vue
@@ -1,5 +1,13 @@
 <template>
-  <div class="standalone-chat">
+  <div class="standalone-chat" v-on="dragEvents">
+    <transition name="drop-fade">
+      <div v-if="isDragging" class="chat-drop-overlay">
+        <div class="chat-drop-overlay-content">
+          <v-icon size="48" color="primary">mdi-cloud-upload</v-icon>
+          <span class="chat-drop-text">{{ tm("input.dropToUpload") }}</span>
+        </div>
+      </div>
+    </transition>
     <section ref="messagesContainer" class="standalone-messages">
       <div v-if="initializing" class="standalone-state">
         <v-progress-circular indeterminate size="28" width="3" />
@@ -208,6 +216,7 @@ import {
 } from "vue";
 import { chatApi, configRouteApi, fileApi } from "@/api/v1";
 import ChatInput from "@/components/chat/ChatInput.vue";
+import { useDragUpload } from "@/composables/useDragUpload";
 import {
   CHAT_MARKDOWN_CUSTOM_TAGS,
   registerChatMarkdownComponents,
@@ -271,6 +280,8 @@ const {
   clearStaged,
   cleanupMediaCache,
 } = useMediaHandling();
+
+const { isDragging, dragEvents } = useDragUpload(handleFilesSelected);
 
 const {
   sending,
@@ -502,7 +513,48 @@ function closeImage() {
   min-height: 0;
   display: flex;
   flex-direction: column;
+  position: relative;
   background: rgb(var(--v-theme-background));
+}
+
+/* 全区域拖拽上传遮罩 */
+.chat-drop-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 100;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(var(--v-theme-primary), 0.12);
+  border: 2px dashed rgba(var(--v-theme-primary), 0.45);
+  border-radius: 16px;
+}
+
+.chat-drop-overlay-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.chat-drop-text {
+  font-size: 16px;
+  font-weight: 500;
+  color: rgb(var(--v-theme-primary));
+}
+
+.drop-fade-enter-active,
+.drop-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.drop-fade-enter-from,
+.drop-fade-leave-to {
+  opacity: 0;
 }
 
 .standalone-messages {

--- a/dashboard/src/composables/useDragUpload.ts
+++ b/dashboard/src/composables/useDragUpload.ts
@@ -1,0 +1,41 @@
+import { ref } from 'vue';
+
+/**
+ * 拖拽上传热区:管理拖拽遮罩显隐与 drop 事件。
+ * 事件挂在聊天区域容器上,drop 时把文件交给 onDrop 回调走现有上传链路。
+ */
+export function useDragUpload(onDrop: (files: FileList) => void) {
+    const isDragging = ref(false);
+    let dragLeaveTimeout: number | null = null;
+
+    const dragEvents = {
+        dragover(e: DragEvent) {
+            if (dragLeaveTimeout) {
+                clearTimeout(dragLeaveTimeout);
+                dragLeaveTimeout = null;
+            }
+            if (!e.dataTransfer?.types.includes('Files')) return;
+            e.preventDefault();
+            isDragging.value = true;
+        },
+        dragleave() {
+            dragLeaveTimeout = window.setTimeout(() => {
+                isDragging.value = false;
+            }, 50);
+        },
+        drop(e: DragEvent) {
+            e.preventDefault();
+            isDragging.value = false;
+            if (dragLeaveTimeout) {
+                clearTimeout(dragLeaveTimeout);
+                dragLeaveTimeout = null;
+            }
+            const files = e.dataTransfer?.files;
+            if (files && files.length > 0) {
+                onDrop(files);
+            }
+        },
+    };
+
+    return { isDragging, dragEvents };
+}

--- a/dashboard/src/composables/useDragUpload.ts
+++ b/dashboard/src/composables/useDragUpload.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue';
+import { onScopeDispose, ref } from 'vue';
 
 /**
  * 拖拽上传热区:管理拖拽遮罩显隐与 drop 事件。
@@ -7,6 +7,13 @@ import { ref } from 'vue';
 export function useDragUpload(onDrop: (files: FileList) => void) {
     const isDragging = ref(false);
     let dragLeaveTimeout: number | null = null;
+
+    onScopeDispose(() => {
+        if (dragLeaveTimeout !== null) {
+            clearTimeout(dragLeaveTimeout);
+            dragLeaveTimeout = null;
+        }
+    });
 
     const dragEvents = {
         dragover(e: DragEvent) {


### PR DESCRIPTION
### Motivation / 动机

Drag-and-drop file/image upload in the webchat/ChatUI currently only works when dropping onto the small input composer bar. The hot zone is too small, so dragging onto the message area gives no response and the feature is easy to miss. This PR expands the drop zone to the whole right-side chat area (message list + composer). Fixes #9561.

### Modifications / 改动点

- Added `useDragUpload` composable (`dashboard/src/composables/useDragUpload.ts`) encapsulating the drag state, overlay visibility, and drop handling.
- `ChatInput.vue`: removed its own drag handlers/overlay so a single drop is not uploaded twice via event bubbling.
- `Chat.vue`: wired `dragEvents` and a full-area drop overlay onto `.conversation-stack`.
- `StandaloneChat.vue`: same handling on the root container.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

#### Before / 改动前

Dragging a file onto the message area currently shows no overlay and does not upload — the hot zone is limited to the bottom input bar.

<img width="917" height="550" alt="Screenshot 2026-08-06 at 10 21 41" src="https://github.com/user-attachments/assets/5eed2e01-563e-4c33-98a6-4c6a0be85bba" />

Dropping onto the message area does nothing.

<img width="920" height="550" alt="Screenshot 2026-08-06 at 10 22 51" src="https://github.com/user-attachments/assets/94732163-31cb-4859-b6ee-17735f410a0b" />

The hot zone is only the input bar.

#### After / 改动后

Dropping anywhere in the right-side chat area shows the full-area upload overlay and triggers the same upload flow.

<img width="918" height="554" alt="Screenshot 2026-08-06 at 11 26 36" src="https://github.com/user-attachments/assets/91fed4ad-aed9-4f15-a85d-271fdc3a600d" />

Full-area upload overlay on drop.

<img width="1184" height="710" alt="Screenshot 2026-08-06 at 11 27 04" src="https://github.com/user-attachments/assets/6330c999-9365-44d2-a24b-26040a9a9b0b" />

Image upload verified — the model reads the uploaded image correctly.

#### Verification Steps / 验证步骤

- [x] Drag a file/image onto the message-list blank area → full-area overlay appears and the file is uploaded.
- [x] Drag onto the input bar → still works, no duplicate upload.
- [x] Drag selected text → no overlay, normal text drag unaffected.
- [x] `vue-tsc --noEmit` and `vite build` pass.

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。
- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。
- [x] 🤓 No new dependencies introduced.
  / 我确保没有引入新依赖库。
- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Expand drag-and-drop file upload to cover the entire chat area in both embedded and standalone chat views using a shared composable.

New Features:
- Enable full-area drag-and-drop upload across the chat conversation area instead of only the input bar.

Enhancements:
- Introduce a reusable useDragUpload composable to centralize drag state and file drop handling for chat components.
- Unify and relocate the upload overlay UI from the input bar to the main chat containers in Chat and StandaloneChat.

## Summary by Sourcery

Expand drag-and-drop upload to cover the entire chat area in embedded and standalone webchat views using a shared composable.

New Features:
- Allow files and images to be uploaded via drag-and-drop across the full chat conversation area, not just the input bar.

Enhancements:
- Introduce a reusable useDragUpload composable to centralize drag state and drop handling for chat containers.
- Move the upload overlay UI from the input bar to full-area overlays in Chat and StandaloneChat for clearer visual feedback.