### PR TITLE
fix: refresh in-memory provider config after deleting provider

### DIFF
--- a/astrbot/core/provider/manager.py
+++ b/astrbot/core/provider/manager.py
@@ -864,6 +864,8 @@ class ProviderManager:
                     prov for prov in config["provider"] if prov.get("id") != tpid
                 ]
             config.save_config()
+            # sync in-memory config for API queries (e.g., provider list)
+            self.providers_config = config["provider"]
             logger.info(f"Providers {target_prov_ids} were removed from configuration.")
 
     async def update_provider(self, origin_provider_id: str, new_config: dict) -> None:


### PR DESCRIPTION
### Modifications / 改动点

`ProviderManager.delete_provider()` removes the provider from the persisted config and terminates its instance, but it never syncs the in-memory `providers_config`. As a result, the dashboard's provider list (which reads `provider_manager.providers_config`) keeps showing the deleted provider until the process restarts or another operation triggers a reload.

This change syncs `providers_config` with the just-saved config immediately after deletion (same pattern already used in `create_provider`), covering both delete-by-`provider_id` and delete-by-`provider_source_id` paths.

- Modified: `astrbot/core/provider/manager.py` (`delete_provider`)

### Screenshots or Test Results / 运行截图或测试结果

Verified in a fully-synced dev environment:

- Regression test (`tests/unit/test_provider_manager_delete.py`) for this fix: `2 passed`.
- Reverse check: with the fix removed, the same test fails (confirms it reproduces the stale-list bug); restoring the fix makes it pass again.
- Related existing unit tests (`test_provider_stats.py`, `test_config.py`, `test_core_lifecycle.py`, `test_star_context.py`): `78 passed`.
- `ruff check` and `ruff format --check` pass on the modified file.

Note: 3 `t2i` template tests in `tests/test_dashboard.py` fail, but they also fail on a clean checkout of `master` and are unrelated to this change.

### Checklist / 检查清单

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
- [x] My changes have been well-tested, and "Verification Steps" and "Screenshots" have been provided above.
- [x] No new dependencies are introduced.
- [x] My changes do not introduce malicious code.

## Summary by Sourcery

Ensure provider deletions immediately refresh the in-memory provider configuration to keep API consumers in sync with persisted config.

Bug Fixes:
- Fix stale provider list after deleting a provider by reloading the in-memory providers configuration from the saved config.

Tests:
- Add a regression unit test verifying that deleting a provider updates the in-memory provider list and prevents stale entries from appearing.