### PR TITLE
fix(kb): stabilize document search behavior

### DIFF
--- a/dashboard/src/views/knowledge-base/components/DocumentsTab.vue
+++ b/dashboard/src/views/knowledge-base/components/DocumentsTab.vue
@@ -275,6 +275,7 @@ const uploadingTasks = ref<Map<string, any>>(new Map())
 const progressPollingInterval = ref<number | null>(null)
 const tavilyConfigStatus = ref('loading') // 'loading', 'configured', 'not_configured', 'error'
 const showTavilyDialog = ref(false)
+let documentsRequestId = 0
 
 const snackbar = ref({
   show: false,
@@ -333,16 +334,17 @@ const isUploadDisabled = computed(() => {
 
 // 表格列
 const headers = [
-  { title: t('documents.name'), key: 'doc_name', sortable: true },
-  { title: t('documents.type'), key: 'file_type', sortable: true },
-  { title: t('documents.size'), key: 'file_size', sortable: true },
-  { title: t('documents.chunks'), key: 'chunk_count', sortable: true },
-  { title: t('documents.createdAt'), key: 'created_at', sortable: true },
+  { title: t('documents.name'), key: 'doc_name', sortable: false },
+  { title: t('documents.type'), key: 'file_type', sortable: false },
+  { title: t('documents.size'), key: 'file_size', sortable: false },
+  { title: t('documents.chunks'), key: 'chunk_count', sortable: false },
+  { title: t('documents.createdAt'), key: 'created_at', sortable: false },
   { title: t('documents.actions'), key: 'actions', sortable: false, align: 'end' as const }
 ]
 
 // 加载文档列表
 const loadDocuments = async () => {
+  const requestId = ++documentsRequestId
   loading.value = true
   try {
     const response = await knowledgeApi.documents(props.kbId, {
@@ -350,16 +352,20 @@ const loadDocuments = async () => {
       page_size: pageSize.value,
       search: searchQuery.value.trim() || undefined,
     })
+    if (requestId !== documentsRequestId) return
     if (response.data.status === 'ok') {
       const data = response.data.data
       documents.value = data.items || []
       total.value = data.total || 0
     }
   } catch (error) {
+    if (requestId !== documentsRequestId) return
     console.error('Failed to load documents:', error)
     showSnackbar('加载文档列表失败', 'error')
   } finally {
-    loading.value = false
+    if (requestId === documentsRequestId) {
+      loading.value = false
+    }
   }
 }
 
@@ -810,9 +816,11 @@ const onTavilyKeySet = () => {
 }
 
 // Reset to page 1 and reload when search text changes
-watch(searchQuery, () => {
+watch(searchQuery, (_value, _oldValue, onCleanup) => {
   page.value = 1
-  loadDocuments()
+  documentsRequestId += 1
+  const timeoutId = window.setTimeout(loadDocuments, 300)
+  onCleanup(() => window.clearTimeout(timeoutId))
 })
 
 onMounted(() => {
@@ -822,6 +830,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  documentsRequestId += 1
   stopProgressPolling()
 })
 </script>


### PR DESCRIPTION
Document search currently requests on every keystroke and stale responses can replace newer results. The server-side table also advertises sorting without handling sort state.

### Modifications / 改动点

- Debounced document search requests by 300 ms.
- Invalidated stale requests so older responses cannot overwrite current results.
- Prevented stale requests from clearing the active loading state.
- Disabled unsupported server-side sort controls until the API exposes sorting.
- Invalidated pending requests when the component unmounts.
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Verification steps:

- `cd dashboard && pnpm typecheck`
- `cd dashboard && node --test tests/*.test.mjs` (36 passed)
- `uv run ruff format .` (499 files unchanged)
- `uv run ruff check .` (passed)
- `git diff --check` (passed)

The existing AstrBot document table and search field styling are unchanged.

Document search filtered to one result with unsupported sort controls hidden:

<img width="1280" height="720" alt="Filtered knowledge base document search results" src="https://github.com/user-attachments/assets/42d346b0-efda-4a6e-a43c-6474ce7626fc" />

---

### Checklist / 检查清单

- [x] 😊 No new feature is introduced; issue discussion is not applicable.
- [x] 👀 The changes were self-reviewed and the verification steps and results are provided above.
- [x] 🤓 No new dependencies are introduced.
- [x] 😮 The changes do not introduce malicious code.

## Summary by Sourcery

Stabilize the knowledge base documents search by debouncing queries and guarding against stale requests while temporarily disabling unsupported table sorting.

Bug Fixes:
- Prevent stale document search responses from overwriting newer results or clearing the active loading state.
- Debounce knowledge base document search requests to avoid firing a request on every keystroke.
- Cancel in-flight or pending search requests when the component unmounts or the query changes.

Enhancements:
- Disable column sorting controls on the documents table until server-side sorting is supported.
