### PR TITLE
fix: inherit configured timezone for cron jobs

### DIFF
--- a/astrbot/dashboard/services/cron_service.py
+++ b/astrbot/dashboard/services/cron_service.py
@@ -63,7 +63,14 @@ class CronService:
             session = str(payload.get("session") or "").strip()
             persona_id = payload.get("persona_id")
             provider_id = payload.get("provider_id")
-            timezone_name = payload.get("timezone")
+            timezone_name = str(payload.get("timezone") or "").strip()
+            if not timezone_name:
+                timezone_name = str(
+                    self.core_lifecycle.astrbot_config_mgr.get_conf(
+                        session or None
+                    ).get("timezone")
+                    or ""
+                ).strip()
             enabled = bool(payload.get("enabled", True))
             run_once = bool(payload.get("run_once", False))
             run_at = payload.get("run_at")
@@ -92,7 +99,7 @@ class CronService:
                 cron_expression=cron_expression,
                 payload=job_payload,
                 description=note,
-                timezone=timezone_name,
+                timezone=timezone_name or None,
                 enabled=enabled,
                 run_once=run_once,
                 run_at=run_at_dt,

--- a/tests/unit/test_cron_service.py
+++ b/tests/unit/test_cron_service.py
@@ -1,0 +1,100 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from astrbot.dashboard.services.cron_service import CronService
+
+
+@pytest.mark.parametrize(
+    (
+        "include_timezone",
+        "payload_timezone",
+        "config_timezone",
+        "session",
+        "expected_timezone",
+        "should_read_config",
+    ),
+    [
+        (
+            True,
+            "America/New_York",
+            "Asia/Shanghai",
+            "test:private:session",
+            "America/New_York",
+            False,
+        ),
+        (
+            True,
+            "",
+            "Asia/Shanghai",
+            "test:private:session",
+            "Asia/Shanghai",
+            True,
+        ),
+        (
+            False,
+            None,
+            "Asia/Shanghai",
+            "test:private:session",
+            "Asia/Shanghai",
+            True,
+        ),
+        (False, None, "UTC", "", "UTC", True),
+        (False, None, "", "", None, True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_create_job_resolves_default_timezone(
+    include_timezone: bool,
+    payload_timezone: str | None,
+    config_timezone: str,
+    session: str,
+    expected_timezone: str | None,
+    should_read_config: bool,
+) -> None:
+    """Verify that new cron jobs inherit the configured timezone by default.
+
+    Args:
+        include_timezone: Whether the request includes the timezone field.
+        payload_timezone: Timezone value supplied by the request.
+        config_timezone: Timezone returned by the applicable AstrBot config.
+        session: Target session supplied by the request.
+        expected_timezone: Timezone expected by the cron manager.
+        should_read_config: Whether configuration lookup should occur.
+    """
+    job = SimpleNamespace(
+        job_id="job-1",
+        name="test-job",
+        payload={"note": "test"},
+        run_once=False,
+    )
+    cron_manager = SimpleNamespace(
+        add_active_job=AsyncMock(return_value=job),
+    )
+    config_manager = SimpleNamespace(
+        get_conf=MagicMock(return_value={"timezone": config_timezone}),
+    )
+    service = CronService(
+        SimpleNamespace(
+            cron_manager=cron_manager,
+            astrbot_config_mgr=config_manager,
+        )
+    )
+    payload = {
+        "name": "test-job",
+        "note": "test",
+        "cron_expression": "0 9 * * *",
+        "session": session,
+    }
+    if include_timezone:
+        payload["timezone"] = payload_timezone
+
+    await service.create_job(payload)
+
+    call_kwargs = cron_manager.add_active_job.await_args.kwargs
+    assert call_kwargs["timezone"] == expected_timezone
+    if should_read_config:
+        config_manager.get_conf.assert_called_once_with(session or None)
+    else:
+        config_manager.get_conf.assert_not_called()


### PR DESCRIPTION
WebUI-created recurring tasks previously submitted an empty `timezone` value. The backend passed that value directly to the scheduler, causing the task to fall back to the server's local timezone instead of the timezone configured for the target AstrBot session. This could make recurring tasks run at an unexpected time when the server timezone differed from the AstrBot configuration.

This change aligns the default behavior with tasks created through the LLM `future_task` tool while preserving support for explicitly supplied API timezones.

### Modifications / 改动点

- Updated `CronService.create_job()` to inherit the target session's AstrBot timezone when the request timezone is empty or omitted.
- Kept explicitly supplied non-empty API timezones as the highest-priority value.
- Preserved the existing system-timezone fallback when neither the applicable AstrBot configuration nor the request provides a timezone.
- Added parameterized unit tests covering explicit timezones, empty and omitted values, session configuration inheritance, global configuration fallback, and the final system-timezone fallback.
- Verified the change with 55 related tests and the project-wide Ruff formatter and linter.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。


### Screenshots or Test Results / 运行截图或测试结果

<img width="1416" height="149" alt="image" src="https://github.com/user-attachments/assets/754e96f2-4c7c-44c5-8e48-94be03cc2175" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Align cron job timezone resolution with AstrBot configuration when WebUI-created recurring tasks omit or provide empty timezones.

Bug Fixes:
- Ensure WebUI-created recurring tasks inherit the configured AstrBot session or global timezone instead of silently falling back to the server timezone when the request timezone is empty or missing.

Tests:
- Add parameterized unit tests covering explicit request timezones, empty and omitted timezone values, session and global configuration inheritance, and final system-timezone fallback behavior.