### PR TITLE
refactor: migrate config preferences to async

### DIFF
--- a/astrbot/core/astrbot_config_mgr.py
+++ b/astrbot/core/astrbot_config_mgr.py
@@ -48,9 +48,26 @@ class AstrBotConfigManager:
 
     async def initialize(self) -> None:
         """Load configuration profile metadata and profile files."""
-        abconf_data = await self.sp.global_get("abconf_mapping", {})
-        self.abconf_data = abconf_data if abconf_data is not None else {}
+        self.abconf_data = await self._load_abconf_mapping()
         self._load_all_configs()
+
+    async def _load_abconf_mapping(self) -> dict:
+        """Load configuration profile metadata from persistent storage.
+
+        Returns:
+            The persisted mapping, or an empty mapping when no value exists.
+        """
+        abconf_data = await self.sp.global_get("abconf_mapping", {})
+        return abconf_data if abconf_data is not None else {}
+
+    async def _persist_abconf_mapping(self, abconf_data: dict) -> None:
+        """Persist configuration profile metadata and refresh memory.
+
+        Args:
+            abconf_data: Complete configuration profile metadata mapping.
+        """
+        await self.sp.global_put("abconf_mapping", abconf_data)
+        self.abconf_data = abconf_data
 
     def _get_abconf_data(self) -> dict:
         """Return configuration profile metadata loaded during initialization.
@@ -124,16 +141,13 @@ class AstrBotConfigManager:
             abconf_id: Generated profile ID.
             abconf_name: Optional profile display name.
         """
-        abconf_data = await self.sp.global_get("abconf_mapping", {})
-        if abconf_data is None:
-            abconf_data = {}
+        abconf_data = await self._load_abconf_mapping()
         random_word = abconf_name or uuid.uuid4().hex[:8]
         abconf_data[abconf_id] = {
             "path": abconf_path,
             "name": random_word,
         }
-        await self.sp.global_put("abconf_mapping", abconf_data)
-        self.abconf_data = abconf_data
+        await self._persist_abconf_mapping(abconf_data)
 
     def get_conf(self, umo: str | MessageSession | None) -> AstrBotConfig:
         """获取指定 umo 的配置文件。如果不存在，则 fallback 到默认配置文件。"""
@@ -219,9 +233,7 @@ class AstrBotConfigManager:
 
         async with self._abconf_lock:
             # 从映射中移除
-            abconf_data = await self.sp.global_get("abconf_mapping", {})
-            if abconf_data is None:
-                abconf_data = {}
+            abconf_data = await self._load_abconf_mapping()
             if conf_id not in abconf_data:
                 logger.warning(f"配置文件 {conf_id} 不存在于映射中")
                 return False
@@ -247,8 +259,7 @@ class AstrBotConfigManager:
 
             # 从映射中移除
             del abconf_data[conf_id]
-            await self.sp.global_put("abconf_mapping", abconf_data)
-            self.abconf_data = abconf_data
+            await self._persist_abconf_mapping(abconf_data)
 
             logger.info(f"成功删除配置文件 {conf_id}")
             return True
@@ -271,9 +282,7 @@ class AstrBotConfigManager:
             raise ValueError("不能更新默认配置文件的信息")
 
         async with self._abconf_lock:
-            abconf_data = await self.sp.global_get("abconf_mapping", {})
-            if abconf_data is None:
-                abconf_data = {}
+            abconf_data = await self._load_abconf_mapping()
             if conf_id not in abconf_data:
                 logger.warning(f"配置文件 {conf_id} 不存在于映射中")
                 return False
@@ -283,8 +292,7 @@ class AstrBotConfigManager:
                 abconf_data[conf_id]["name"] = name
 
             # 保存更新
-            await self.sp.global_put("abconf_mapping", abconf_data)
-            self.abconf_data = abconf_data
+            await self._persist_abconf_mapping(abconf_data)
             logger.info(f"成功更新配置文件 {conf_id} 的信息")
             return True
 

--- a/astrbot/core/astrbot_config_mgr.py
+++ b/astrbot/core/astrbot_config_mgr.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import uuid
 from typing import TypedDict, TypeVar
@@ -42,17 +43,27 @@ class AstrBotConfigManager:
         self.confs: dict[str, AstrBotConfig] = {}
         """uuid / "default" -> AstrBotConfig"""
         self.confs["default"] = default_config
-        self.abconf_data = None
+        self.abconf_data: dict | None = None
+        self._abconf_lock = asyncio.Lock()
+
+    async def initialize(self) -> None:
+        """Load configuration profile metadata and profile files."""
+        abconf_data = await self.sp.global_get("abconf_mapping", {})
+        self.abconf_data = abconf_data if abconf_data is not None else {}
         self._load_all_configs()
 
     def _get_abconf_data(self) -> dict:
-        """获取所有的 abconf 数据"""
+        """Return configuration profile metadata loaded during initialization.
+
+        Returns:
+            The configuration profile metadata mapping.
+
+        Raises:
+            RuntimeError: If the manager has not been initialized.
+        """
         if self.abconf_data is None:
-            self.abconf_data = self.sp.get(
-                "abconf_mapping",
-                {},
-                scope="global",
-                scope_id="global",
+            raise RuntimeError(
+                "AstrBotConfigManager must be initialized before use.",
             )
         return self.abconf_data
 
@@ -100,25 +111,28 @@ class AstrBotConfigManager:
 
         return DEFAULT_CONFIG_CONF_INFO
 
-    def _save_conf_mapping(
+    async def _save_conf_mapping(
         self,
         abconf_path: str,
         abconf_id: str,
         abconf_name: str | None = None,
     ) -> None:
-        """保存配置文件的映射关系"""
-        abconf_data = self.sp.get(
-            "abconf_mapping",
-            {},
-            scope="global",
-            scope_id="global",
-        )
+        """Persist a new configuration profile mapping.
+
+        Args:
+            abconf_path: Profile configuration file name.
+            abconf_id: Generated profile ID.
+            abconf_name: Optional profile display name.
+        """
+        abconf_data = await self.sp.global_get("abconf_mapping", {})
+        if abconf_data is None:
+            abconf_data = {}
         random_word = abconf_name or uuid.uuid4().hex[:8]
         abconf_data[abconf_id] = {
             "path": abconf_path,
             "name": random_word,
         }
-        self.sp.put("abconf_mapping", abconf_data, scope="global", scope_id="global")
+        await self.sp.global_put("abconf_mapping", abconf_data)
         self.abconf_data = abconf_data
 
     def get_conf(self, umo: str | MessageSession | None) -> AstrBotConfig:
@@ -160,107 +174,119 @@ class AstrBotConfigManager:
         conf_list.append(DEFAULT_CONFIG_CONF_INFO)
         return conf_list
 
-    def create_conf(
+    async def create_conf(
         self,
         config: dict = DEFAULT_CONFIG,
         name: str | None = None,
     ) -> str:
-        conf_uuid = str(uuid.uuid4())
-        conf_file_name = f"abconf_{conf_uuid}.json"
-        conf_path = os.path.join(get_astrbot_config_path(), conf_file_name)
-        conf = AstrBotConfig(config_path=conf_path, default_config=config)
-        conf.save_config()
-        self._save_conf_mapping(conf_file_name, conf_uuid, abconf_name=name)
-        self.confs[conf_uuid] = conf
-        return conf_uuid
-
-    def delete_conf(self, conf_id: str) -> bool:
-        """删除指定配置文件
+        """Create and persist a configuration profile.
 
         Args:
-            conf_id: 配置文件的 UUID
+            config: Initial profile configuration.
+            name: Optional display name.
 
         Returns:
-            bool: 删除是否成功
+            The generated configuration profile ID.
+        """
+        async with self._abconf_lock:
+            conf_uuid = str(uuid.uuid4())
+            conf_file_name = f"abconf_{conf_uuid}.json"
+            conf_path = os.path.join(get_astrbot_config_path(), conf_file_name)
+            conf = AstrBotConfig(config_path=conf_path, default_config=config)
+            conf.save_config()
+            await self._save_conf_mapping(
+                conf_file_name,
+                conf_uuid,
+                abconf_name=name,
+            )
+            self.confs[conf_uuid] = conf
+            return conf_uuid
+
+    async def delete_conf(self, conf_id: str) -> bool:
+        """Delete a configuration profile.
+
+        Args:
+            conf_id: Configuration profile ID.
+
+        Returns:
+            Whether the profile was deleted.
 
         Raises:
-            ValueError: 如果试图删除默认配置文件
-
+            ValueError: If the default profile is requested.
         """
         if conf_id == "default":
             raise ValueError("不能删除默认配置文件")
 
-        # 从映射中移除
-        abconf_data = self.sp.get(
-            "abconf_mapping",
-            {},
-            scope="global",
-            scope_id="global",
-        )
-        if conf_id not in abconf_data:
-            logger.warning(f"配置文件 {conf_id} 不存在于映射中")
-            return False
+        async with self._abconf_lock:
+            # 从映射中移除
+            abconf_data = await self.sp.global_get("abconf_mapping", {})
+            if abconf_data is None:
+                abconf_data = {}
+            if conf_id not in abconf_data:
+                logger.warning(f"配置文件 {conf_id} 不存在于映射中")
+                return False
 
-        # 获取配置文件路径
-        conf_path = os.path.join(
-            get_astrbot_config_path(),
-            abconf_data[conf_id]["path"],
-        )
+            # 获取配置文件路径
+            conf_path = os.path.join(
+                get_astrbot_config_path(),
+                abconf_data[conf_id]["path"],
+            )
 
-        # 删除配置文件
-        try:
-            if os.path.exists(conf_path):
-                os.remove(conf_path)
-                logger.info(f"已删除配置文件: {conf_path}")
-        except Exception as e:
-            logger.error(f"删除配置文件 {conf_path} 失败: {e}")
-            return False
+            # 删除配置文件
+            try:
+                if os.path.exists(conf_path):
+                    os.remove(conf_path)
+                    logger.info(f"已删除配置文件: {conf_path}")
+            except Exception as e:
+                logger.error(f"删除配置文件 {conf_path} 失败: {e}")
+                return False
 
-        # 从内存中移除
-        if conf_id in self.confs:
-            del self.confs[conf_id]
+            # 从内存中移除
+            if conf_id in self.confs:
+                del self.confs[conf_id]
 
-        # 从映射中移除
-        del abconf_data[conf_id]
-        self.sp.put("abconf_mapping", abconf_data, scope="global", scope_id="global")
-        self.abconf_data = abconf_data
+            # 从映射中移除
+            del abconf_data[conf_id]
+            await self.sp.global_put("abconf_mapping", abconf_data)
+            self.abconf_data = abconf_data
 
-        logger.info(f"成功删除配置文件 {conf_id}")
-        return True
+            logger.info(f"成功删除配置文件 {conf_id}")
+            return True
 
-    def update_conf_info(self, conf_id: str, name: str | None = None) -> bool:
-        """更新配置文件信息
+    async def update_conf_info(
+        self,
+        conf_id: str,
+        name: str | None = None,
+    ) -> bool:
+        """Update configuration profile metadata.
 
         Args:
-            conf_id: 配置文件的 UUID
-            name: 新的配置文件名称 (可选)
+            conf_id: Configuration profile ID.
+            name: Optional new display name.
 
         Returns:
-            bool: 更新是否成功
-
+            Whether the profile metadata was updated.
         """
         if conf_id == "default":
             raise ValueError("不能更新默认配置文件的信息")
 
-        abconf_data = self.sp.get(
-            "abconf_mapping",
-            {},
-            scope="global",
-            scope_id="global",
-        )
-        if conf_id not in abconf_data:
-            logger.warning(f"配置文件 {conf_id} 不存在于映射中")
-            return False
+        async with self._abconf_lock:
+            abconf_data = await self.sp.global_get("abconf_mapping", {})
+            if abconf_data is None:
+                abconf_data = {}
+            if conf_id not in abconf_data:
+                logger.warning(f"配置文件 {conf_id} 不存在于映射中")
+                return False
 
-        # 更新名称
-        if name is not None:
-            abconf_data[conf_id]["name"] = name
+            # 更新名称
+            if name is not None:
+                abconf_data[conf_id]["name"] = name
 
-        # 保存更新
-        self.sp.put("abconf_mapping", abconf_data, scope="global", scope_id="global")
-        self.abconf_data = abconf_data
-        logger.info(f"成功更新配置文件 {conf_id} 的信息")
-        return True
+            # 保存更新
+            await self.sp.global_put("abconf_mapping", abconf_data)
+            self.abconf_data = abconf_data
+            logger.info(f"成功更新配置文件 {conf_id} 的信息")
+            return True
 
     def g(
         self,

--- a/astrbot/core/core_lifecycle.py
+++ b/astrbot/core/core_lifecycle.py
@@ -185,6 +185,7 @@ class AstrBotCoreLifecycle:
             ucr=self.umop_config_router,
             sp=sp,
         )
+        await self.astrbot_config_mgr.initialize()
         self.temp_dir_cleaner = TempDirCleaner(
             max_size_getter=lambda: self.astrbot_config_mgr.default_conf.get(
                 TempDirCleaner.CONFIG_KEY,

--- a/astrbot/dashboard/api/config_profiles.py
+++ b/astrbot/dashboard/api/config_profiles.py
@@ -153,7 +153,7 @@ async def rename_config_profile(
     _auth: AuthContext = Depends(require_config_scope),
     service: ConfigProfileService = Depends(get_service),
 ):
-    service.rename_profile(config_id, payload.name)
+    await service.rename_profile(config_id, payload.name)
     return ok(message="更新成功")
 
 
@@ -163,7 +163,7 @@ async def delete_config_profile(
     _auth: AuthContext = Depends(require_config_scope),
     service: ConfigProfileService = Depends(get_service),
 ):
-    service.delete_profile(config_id)
+    await service.delete_profile(config_id)
     return ok(message="删除成功")
 
 
@@ -313,7 +313,7 @@ async def delete_dashboard_alias_config_profile(
     if not config_id:
         return _alias_error("缺少配置文件 ID")
     try:
-        service.delete_profile(str(config_id))
+        await service.delete_profile(str(config_id))
         return ok(message="删除成功")
     except ValueError as exc:
         return _alias_error(str(exc))
@@ -330,7 +330,7 @@ async def rename_dashboard_alias_config_profile(
     if not config_id:
         return _alias_error("缺少配置文件 ID")
     try:
-        service.rename_profile(str(config_id), body.get("name"))
+        await service.rename_profile(str(config_id), body.get("name"))
         return ok(message="更新成功")
     except ValueError as exc:
         return _alias_error(str(exc))

--- a/astrbot/dashboard/services/config_service.py
+++ b/astrbot/dashboard/services/config_service.py
@@ -532,7 +532,10 @@ class ConfigProfileService:
                 "config:edit_admin scope is required to change admins_id",
                 status_code=403,
             )
-        conf_id = self.acm.create_conf(name=name, config=config or DEFAULT_CONFIG)
+        conf_id = await self.acm.create_conf(
+            name=name,
+            config=config or DEFAULT_CONFIG,
+        )
         await self.core_lifecycle.reload_pipeline_scheduler(conf_id)
         return {"conf_id": conf_id}
 
@@ -677,33 +680,33 @@ class ConfigProfileService:
             )
         )
 
-    def rename_profile(self, config_id: str, name: str | None) -> None:
-        if not self.acm.update_conf_info(config_id, name=name):
+    async def rename_profile(self, config_id: str, name: str | None) -> None:
+        if not await self.acm.update_conf_info(config_id, name=name):
             raise ValueError("Failed to update config profile")
 
-    def rename_profile_from_dashboard_payload(self, payload: object) -> str:
+    async def rename_profile_from_dashboard_payload(self, payload: object) -> str:
         data = payload if isinstance(payload, dict) else {}
         if not data:
             raise ValueError("缺少配置数据")
         conf_id = data.get("id")
         if not conf_id:
             raise ValueError("缺少配置文件 ID")
-        self.rename_profile(str(conf_id), name=data.get("name"))
+        await self.rename_profile(str(conf_id), name=data.get("name"))
         return "更新成功"
 
-    def delete_profile(self, config_id: str) -> None:
-        if not self.acm.delete_conf(config_id):
+    async def delete_profile(self, config_id: str) -> None:
+        if not await self.acm.delete_conf(config_id):
             raise ValueError("Failed to delete config profile")
         self.core_lifecycle.pipeline_scheduler_mapping.pop(config_id, None)
 
-    def delete_profile_from_dashboard_payload(self, payload: object) -> str:
+    async def delete_profile_from_dashboard_payload(self, payload: object) -> str:
         data = payload if isinstance(payload, dict) else {}
         if not data:
             raise ValueError("缺少配置数据")
         conf_id = data.get("id")
         if not conf_id:
             raise ValueError("缺少配置文件 ID")
-        self.delete_profile(str(conf_id))
+        await self.delete_profile(str(conf_id))
         return "删除成功"
 
 

--- a/tests/unit/test_astrbot_config_manager.py
+++ b/tests/unit/test_astrbot_config_manager.py
@@ -36,6 +36,19 @@ async def test_initialize_loads_global_profile_mapping():
 
 
 @pytest.mark.asyncio
+async def test_persist_mapping_updates_memory_only_after_storage_succeeds():
+    manager, shared_preferences = _make_manager()
+    original_mapping = {"existing": {"path": "existing.json", "name": "Existing"}}
+    manager.abconf_data = original_mapping
+    shared_preferences.global_put.side_effect = RuntimeError("storage failed")
+
+    with pytest.raises(RuntimeError, match="storage failed"):
+        await manager._persist_abconf_mapping({"new": {}})
+
+    assert manager.abconf_data is original_mapping
+
+
+@pytest.mark.asyncio
 async def test_create_conf_uses_async_global_preferences(tmp_path):
     manager, shared_preferences = _make_manager()
     manager.abconf_data = {}

--- a/tests/unit/test_astrbot_config_manager.py
+++ b/tests/unit/test_astrbot_config_manager.py
@@ -1,0 +1,117 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from astrbot.core.astrbot_config_mgr import AstrBotConfigManager
+
+
+def _make_manager():
+    """Create a config manager with mocked asynchronous preferences.
+
+    Returns:
+        The config manager and its SharedPreferences mock.
+    """
+    shared_preferences = MagicMock()
+    shared_preferences.global_get = AsyncMock()
+    shared_preferences.global_put = AsyncMock()
+    manager = AstrBotConfigManager(
+        default_config=MagicMock(),
+        ucr=MagicMock(),
+        sp=shared_preferences,
+    )
+    return manager, shared_preferences
+
+
+@pytest.mark.asyncio
+async def test_initialize_loads_global_profile_mapping():
+    manager, shared_preferences = _make_manager()
+    shared_preferences.global_get.return_value = None
+
+    with patch.object(manager, "_load_all_configs") as load_all_configs:
+        await manager.initialize()
+
+    assert manager.abconf_data == {}
+    shared_preferences.global_get.assert_awaited_once_with("abconf_mapping", {})
+    load_all_configs.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_create_conf_uses_async_global_preferences(tmp_path):
+    manager, shared_preferences = _make_manager()
+    manager.abconf_data = {}
+    shared_preferences.global_get.return_value = {}
+    profile = MagicMock()
+
+    with (
+        patch(
+            "astrbot.core.astrbot_config_mgr.get_astrbot_config_path",
+            return_value=str(tmp_path),
+        ),
+        patch(
+            "astrbot.core.astrbot_config_mgr.AstrBotConfig",
+            return_value=profile,
+        ),
+    ):
+        conf_id = await manager.create_conf(config={"timezone": "UTC"}, name="Test")
+
+    profile.save_config.assert_called_once_with()
+    assert manager.confs[conf_id] is profile
+    shared_preferences.global_get.assert_awaited_once_with("abconf_mapping", {})
+    shared_preferences.global_put.assert_awaited_once_with(
+        "abconf_mapping",
+        {
+            conf_id: {
+                "path": f"abconf_{conf_id}.json",
+                "name": "Test",
+            }
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_and_delete_conf_use_async_global_preferences(tmp_path):
+    manager, shared_preferences = _make_manager()
+    conf_id = "profile-id"
+    profile_path = tmp_path / "profile.json"
+    profile_path.write_text("{}", encoding="utf-8")
+    update_mapping = {
+        conf_id: {
+            "path": profile_path.name,
+            "name": "Before",
+        }
+    }
+    delete_mapping = {
+        conf_id: {
+            "path": profile_path.name,
+            "name": "After",
+        }
+    }
+    manager.abconf_data = update_mapping
+    manager.confs[conf_id] = MagicMock()
+    shared_preferences.global_get.side_effect = [update_mapping, delete_mapping]
+
+    assert await manager.update_conf_info(conf_id, name="After") is True
+
+    with patch(
+        "astrbot.core.astrbot_config_mgr.get_astrbot_config_path",
+        return_value=str(tmp_path),
+    ):
+        assert await manager.delete_conf(conf_id) is True
+
+    assert not profile_path.exists()
+    assert conf_id not in manager.confs
+    assert manager.abconf_data == {}
+    assert shared_preferences.global_get.await_count == 2
+    assert shared_preferences.global_put.await_args_list[0].args == (
+        "abconf_mapping",
+        {
+            conf_id: {
+                "path": profile_path.name,
+                "name": "After",
+            }
+        },
+    )
+    assert shared_preferences.global_put.await_args_list[1].args == (
+        "abconf_mapping",
+        {},
+    )

--- a/tests/unit/test_config_profile_service.py
+++ b/tests/unit/test_config_profile_service.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 from astrbot.dashboard.services.config_service import ConfigProfileService
 
@@ -23,3 +25,36 @@ def test_get_system_config_includes_effective_server_time() -> None:
     assert result["server_utc_time"] == "2026-08-07T02:31:00+00:00"
     assert result["server_utc_offset_minutes"] == 480
     assert result["config"]["timezone"] == "Asia/Shanghai"
+
+
+@pytest.mark.asyncio
+async def test_profile_mutations_await_config_manager() -> None:
+    """Verify profile mutations use the config manager's async methods."""
+    config_manager = SimpleNamespace(
+        create_conf=AsyncMock(return_value="profile-id"),
+        update_conf_info=AsyncMock(return_value=True),
+        delete_conf=AsyncMock(return_value=True),
+    )
+    lifecycle = SimpleNamespace(
+        astrbot_config_mgr=config_manager,
+        reload_pipeline_scheduler=AsyncMock(),
+        pipeline_scheduler_mapping={"profile-id": object()},
+    )
+    service = ConfigProfileService(lifecycle)
+
+    result = await service.create_profile("Profile", {"timezone": "UTC"})
+    await service.rename_profile("profile-id", "Renamed")
+    await service.delete_profile("profile-id")
+
+    assert result == {"conf_id": "profile-id"}
+    config_manager.create_conf.assert_awaited_once_with(
+        name="Profile",
+        config={"timezone": "UTC"},
+    )
+    lifecycle.reload_pipeline_scheduler.assert_awaited_once_with("profile-id")
+    config_manager.update_conf_info.assert_awaited_once_with(
+        "profile-id",
+        name="Renamed",
+    )
+    config_manager.delete_conf.assert_awaited_once_with("profile-id")
+    assert "profile-id" not in lifecycle.pipeline_scheduler_mapping

--- a/tests/unit/test_core_lifecycle.py
+++ b/tests/unit/test_core_lifecycle.py
@@ -399,6 +399,7 @@ class TestAstrBotCoreLifecycleInitialize:
         mock_umop_config_router.initialize = AsyncMock()
 
         mock_astrbot_config_mgr = MagicMock()
+        mock_astrbot_config_mgr.initialize = AsyncMock()
         mock_astrbot_config_mgr.default_conf = {}
         mock_astrbot_config_mgr.confs = {}
 
@@ -505,6 +506,9 @@ class TestAstrBotCoreLifecycleInitialize:
         # Verify UMOP config router initialized
         mock_umop_config_router.initialize.assert_awaited_once()
 
+        # Verify config manager initialized
+        mock_astrbot_config_mgr.initialize.assert_awaited_once()
+
         # Verify persona manager initialized
         mock_persona_mgr.initialize.assert_awaited_once()
 
@@ -539,6 +543,7 @@ class TestAstrBotCoreLifecycleInitialize:
         mock_umop_config_router.initialize = AsyncMock()
 
         mock_astrbot_config_mgr = MagicMock()
+        mock_astrbot_config_mgr.initialize = AsyncMock()
         mock_astrbot_config_mgr.default_conf = {}
         mock_astrbot_config_mgr.confs = {}
 


### PR DESCRIPTION
`AstrBotConfigManager` used the deprecated synchronous SharedPreferences bridge to load and update configuration profile metadata. These calls dispatched asynchronous database work to a separate event loop while sharing the main SQLAlchemy async engine, which could cause cross-event-loop connection-pool errors under contention.

This change migrates configuration profile persistence to native asynchronous SharedPreferences APIs while keeping frequently used configuration lookups as synchronous in-memory operations.

### Modifications / 改动点

- Added asynchronous initialization for `AstrBotConfigManager` and awaited it during core lifecycle startup.
- Migrated all seven `abconf_mapping` `sp.get()` / `sp.put()` calls to `global_get()` / `global_put()`.
- Kept `get_conf()`, `get_conf_info()`, and other runtime configuration lookups synchronous and memory-only.
- Converted configuration profile creation, deletion, and renaming to asynchronous internal operations.
- Added an internal lock to serialize configuration profile read-modify-write operations and prevent concurrent mapping updates from overwriting each other.
- Updated modern and legacy dashboard configuration profile routes to await the asynchronous service methods.
- Added regression coverage for initialization, global preference scope, profile CRUD operations, and core lifecycle wiring.
- Kept HTTP schemas and plugin-facing configuration lookup interfaces unchanged.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。


### Screenshots or Test Results / 运行截图或测试结果

<img width="1248" height="123" alt="image" src="https://github.com/user-attachments/assets/aaede364-2339-4548-9a5c-31a7e8a2d364" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Migrate configuration profile persistence to asynchronous SharedPreferences and integrate it into the core lifecycle while keeping runtime lookups in-memory and synchronous.

Enhancements:
- Serialize configuration profile CRUD operations with an internal async lock and use async global preference APIs for profile metadata.
- Update dashboard configuration profile service and HTTP endpoints to call async config manager methods for create, rename, and delete operations.
- Add async initialization for AstrBotConfigManager and ensure core lifecycle awaits it during startup.

Tests:
- Add unit tests covering async config manager initialization, async global preference usage for profile CRUD, and lifecycle wiring plus dashboard profile mutation flows.