### PR TITLE
fix: prevent transient project session in ChatUI session list

### DIFF
--- a/dashboard/src/components/chat/Chat.vue
+++ b/dashboard/src/components/chat/Chat.vue
@@ -1361,8 +1361,7 @@ async function sendCurrentMessage() {
         await loadProjectSessions(targetProjectId);
         selectedProjectId.value = null;
       }
-      // 会话创建（及可选的项目关联）完成后再刷新一次列表：
-      // 项目会话直接进项目、普通会话进"对话"区，避免中途状态被渲染
+      // 关联项目后再刷新，否则新会话会短暂出现在"对话"列表
       await getSessions();
     }
 

--- a/dashboard/src/components/chat/Chat.vue
+++ b/dashboard/src/components/chat/Chat.vue
@@ -1361,6 +1361,9 @@ async function sendCurrentMessage() {
         await loadProjectSessions(targetProjectId);
         selectedProjectId.value = null;
       }
+      // 会话创建（及可选的项目关联）完成后再刷新一次列表：
+      // 项目会话直接进项目、普通会话进"对话"区，避免中途状态被渲染
+      await getSessions();
     }
 
     const text = draft.value.trim();

--- a/dashboard/src/composables/useSessions.ts
+++ b/dashboard/src/composables/useSessions.ts
@@ -68,9 +68,7 @@ export function useSessions(chatboxMode: boolean = false) {
             // 更新 URL
             const basePath = chatboxMode ? '/chatbox' : '/chat';
             router.push(`${basePath}/${sessionId}`);
-            
-            await getSessions();
-            
+
             // 确保新创建的会话被选中高亮
             selectedSessions.value = [sessionId];
             


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

Fixes #9567. When a user starts a new conversation inside a project and sends its first message, the new session briefly appears in the general "Conversations" sidebar list while the AI is generating, then disappears after the reply completes. This only happens on the first message of a session.

**Root cause:** `newSession()` refreshed the session list (`getSessions()`) *before* the new session was associated with its project, so the backend still reported it in the general conversation list. When the stream ends the list is re-fetched with project sessions excluded, and the entry disappears.

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- `dashboard/src/composables/useSessions.ts`: Removed the premature `await getSessions()` from `newSession()`, so the list is no longer refreshed before the session is linked to its project.
- `dashboard/src/components/chat/Chat.vue`: In `sendCurrentMessage`, added a single `await getSessions()` after session creation (and optional project association) completes. The list is now refreshed exactly once, with the session already in its final location — project sessions land directly under the project, regular sessions land in the "Conversations" area, and no transient state is rendered.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行"验证步骤"的证据，证明此改动有效。-->

#### Before / 修复前

Before — while the first reply is generating, the new session also appears in the general "Conversations" list below.

<img width="1132" height="553" alt="Screenshot 2026-08-06 at 13 50 32" src="https://github.com/user-attachments/assets/54f5a604-1a85-4db3-a170-61fdb8d1e707" />

<img width="1134" height="551" alt="Screenshot 2026-08-06 at 13 50 44" src="https://github.com/user-attachments/assets/6e6e206e-1b09-4e76-8905-a345776264a7" />

#### After / 修复后

After — the session now appears only under its project, and no longer appears in the general "Conversations" list while the first reply is generating.

<img width="1133" height="553" alt="Screenshot 2026-08-07 at 17 59 37" src="https://github.com/user-attachments/assets/9bec2415-94b1-4672-8fb4-574d6ad6d237" />

<img width="1133" height="551" alt="Screenshot 2026-08-07 at 18 01 55" src="https://github.com/user-attachments/assets/df8e3a54-1021-4cdd-9a6d-259fd8887958" />

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Ensure newly created project sessions only appear under their project instead of briefly showing in the global conversations list while the first reply is generating.

## Summary by Sourcery

Bug Fixes:
- Prevent newly created project sessions from briefly appearing in the general conversations list before being associated with their project.