### PR TITLE
fix(provider): normalize 1-based streaming tool_call indexes and fallback missing ids (#9590)

### DIFF
--- a/astrbot/core/provider/entities.py
+++ b/astrbot/core/provider/entities.py
@@ -427,17 +427,30 @@ class LLMResponse:
         """The same as to_openai_tool_calls but return pydantic model."""
         ret = []
         for idx, tool_call_arg in enumerate(self.tools_call_args):
+            # Some OpenAI-compatible gateways return tool_calls without a valid id
+            # (e.g. streaming snapshots misaligned by non-zero-based indexes).
+            # ToolCall.id is declared as str, so passing None would raise a pydantic
+            # ValidationError and fail the whole tool-calling turn.
+            raw_id = (
+                self.tools_call_ids[idx] if idx < len(self.tools_call_ids) else None
+            )
+            func_name = (
+                self.tools_call_name[idx] if idx < len(self.tools_call_name) else None
+            )
+            call_id = raw_id
+            if not isinstance(call_id, str) or not call_id:
+                call_id = f"call_{idx}"
             ret.append(
                 ToolCall(
-                    id=self.tools_call_ids[idx],
+                    id=call_id,
                     function=ToolCall.FunctionBody(
-                        name=self.tools_call_name[idx],
+                        name=func_name or "__malformed_tool_name__",
                         arguments=json.dumps(tool_call_arg),
                     ),
                     # the extra_content will not serialize if it's None when calling ToolCall.model_dump()
-                    extra_content=self.tools_call_extra_content.get(
-                        self.tools_call_ids[idx]
-                    ),
+                    # Note: look up extra_content by the raw upstream id; the fallback id
+                    # (call_{idx}) never exists in tools_call_extra_content.
+                    extra_content=self.tools_call_extra_content.get(raw_id),
                 ),
             )
         return ret

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -638,6 +638,11 @@ class ProviderOpenAIOfficial(Provider):
 
         state = ChatCompletionStreamState()
 
+        # 上游 tool_call.index -> 规范化后的 0 起始下标。
+        # 必须是每次请求独立的局部状态，不能挂在 self 上，
+        # 否则并发请求会互相污染下标映射。
+        tool_call_index_map: dict[int, int] = {}
+
         async for chunk in stream:
             choice = chunk.choices[0] if chunk.choices else None
             delta = choice.delta if choice else None
@@ -651,6 +656,21 @@ class ProviderOpenAIOfficial(Provider):
                     # Gemini and some OpenAI-compatible proxies omit this field
                     if not hasattr(tc, "index") or tc.index is None:
                         tc.index = idx
+                    else:
+                        # Some OpenAI-compatible gateways start tool_call.index at 1
+                        # (the OpenAI spec requires 0-based indexing). The SDK streaming
+                        # snapshot accumulator uses index directly as a list subscript,
+                        # so index=1 on an empty list raises IndexError and the tool_call
+                        # name/arguments get split across misaligned slots, eventually
+                        # producing a malformed tool_call with id=None/name="" that fails
+                        # downstream ToolCall pydantic validation.
+                        # Remap upstream indexes to a contiguous 0-based sequence.
+                        remapped = tool_call_index_map.setdefault(
+                            tc.index,
+                            len(tool_call_index_map),
+                        )
+                        if remapped != tc.index:
+                            tc.index = remapped
             # 跳过 delta=None 的 chunk，避免 SDK 内部 _convert_initial_chunk_into_snapshot
             # 第 747 行 choice.delta.to_dict() 抛出 NoneType 错误。
             # refs: AstrBot#6689 / openai-python#5069 / #5047


### PR DESCRIPTION
### 问题概述

部分 OpenAI 兼容网关（如 new-api 风格的代理）在流式返回时把 `tool_call.index` 从 **1** 开始编号（OpenAI 规范要求从 0 开始）。openai SDK 的流式快照累加器直接把 index 当作列表下标使用：

- `_accumulate_chunk`：`tool_calls[tool_call_chunk.index]`
- `_build_events`：`tool_calls[tool_call_delta.index]`

于是 `index=1` 落到空列表上会抛 `IndexError: list index out of range`。AstrBot 在 `_query_stream` 中吞掉该异常（仅记录 `Saving chunk state error`），导致快照被写坏：同一个 tool_call 的 `name` 与 `arguments` 被拆到两个错位的槽位，中间多出 `id=None` / `name=""` 的幽灵条目。下游 `ToolCall(id=None)` 随即抛 pydantic `ValidationError`，整轮工具调用（如子代理委托）失败。

**只在流式 + 多个并行 tool_call 时触发**，因此表现为偶发，单工具调用复现不出来。

### 与已有 issue 的关系

- #6661 的补丁只处理 index **缺失**（`if not hasattr(tc, "index") or tc.index is None: tc.index = idx`），不处理 index **偏移**（从 1 开始）—— 本 PR 正是在该补丁基础上补上偏移分支。
- #8911 是同一根因（同样 `list index out of range` + `解析参数失败` 组合，同样经 new-api 网关），但当时只在下游 `tool_loop_agent_runner` 过滤了 `None` 名称 —— 治症状没治源头，所以换个入口又复现。
- `tool_loop_agent_runner.py` 已为畸形 **name** 兜底（`MALFORMED_TOOL_NAME_PLACEHOLDER`），`openai_source.py` 已为非法 arguments 兜底（置 `{}`），**唯独 id 从未兜底** —— 这正是本故障仍会崩的原因。

### 日志签名（按序出现）

```
ERRO sources.openai_source  Saving chunk state error: list index out of range
ERRO sources.openai_source  解析参数失败: Expecting value: line 1 column 1 (char 0)
INFO tool_loop_agent_runner  Agent 使用工具: ['real_tool', '__malformed_tool_name__']
ERRO pydantic ValidationError: ToolCall id Input should be a valid string, input_value=None
ERRO subagent_worktogether  Failed to delegate task to main agent
```

### 修复内容（两处）

1. **`openai_source.py` — index 重映射**：在 `_query_stream` 内维护每次请求独立的 `tool_call_index_map`（请求级局部变量，不能挂 `self`，否则并发请求互相污染下标映射），把上游 index 重映射为从 0 开始的连续序号。现有 #6661 补丁只处理 index 缺失，本补丁在其 `else` 分支处理偏移。

2. **`entities.py` — id/name 兜底**：`to_openai_tool_calls_model()` 中，当上游返回的 id 缺失/非法时回退为稳定的 `call_{idx}`，name 缺失时回退为 `__malformed_tool_name__`（与 tool_loop_agent_runner 的占位符一致），并做列表长度边界判断。`extra_content` 仍按上游原始 id 查询（兜底 id 不会存在于该字典中）。

### 验证

用真实上游形态的 SSE 流（index 从 1 开始、多个并行 tool_call）做 SDK 层对照测试：

- **修复前**：`handle_chunk` 失败 2 次（IndexError），最终快照 3 条 tool_call，其中 1 条 `id=None, name=None` 幽灵条目，且 arguments 错位（es_search 的 query 参数跑到了 web_search 上）。
- **修复后**：`handle_chunk` 失败 0 次，2 条 tool_call 的 id/name/arguments 全部正确合并。

entities 兜底层用例（id=None、name 空、列表比 args 短）均通过，deprecated 别名 `to_openai_to_calls_model()` 保持可用。

### 影响范围

`ProviderOpenAIOfficial` 及其 7 个子类（groq / longcat / oai_aihubmix / openrouter / xai / xiaomi / zhipu）共用 `openai_source.py`，且只有该文件使用 `ChatCompletionStreamState`，因此改一处即覆盖全部 8 个 provider。

关联 issue：#9590

## Summary by Sourcery

Normalize tool_call indexes from OpenAI-compatible streaming providers and harden ToolCall model construction against malformed upstream data.

Bug Fixes:
- Normalize non-zero-based tool_call.index values from streaming responses to contiguous 0-based indices to prevent IndexError and misaligned tool_call snapshots.
- Provide stable fallback ids and names for tool_calls missing or carrying invalid id/name fields to avoid pydantic ValidationError and failed tool-calling turns.

Enhancements:
- Guard access to tool_call id/name lists with bounds checks and use raw upstream ids only for extra_content lookup to preserve original metadata when available.