### PR TITLE
fix: capture agent end_time before emitting agent_stats

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -801,6 +801,8 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 self.stats.current_context_tokens = llm_response.usage.input
                 if self.req.conversation:
                     self.req.conversation.token_usage = llm_response.usage.total
+            # end_time must be set before the yield serializes to_dict().
+            self.stats.end_time = time.time()
             yield AgentResponse(
                 type="agent_stats",
                 data=AgentResponseData(


### PR DESCRIPTION
### Modifications / 改动点

- In `tool_loop_agent_runner.py`, capture `end_time` right before the `agent_stats` snapshot is serialized via `to_dict()`. Previously `end_time` was only set *after* the yield (inside `_complete_with_assistant_response`), so the frontend received `end_time=0` and the per-message elapsed duration (耗时) in the webchat detail panel always displayed as "-". Token counts and time-to-first-token were unaffected.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Verification Steps / 验证步骤

1. Start AstrBot and open the webchat.
2. Send a message and wait for the reply.
3. Click the detail (info) button on the assistant message and check the 耗时 (duration) row.

### Screenshots or Test Results / 运行截图或测试结果

**Before / 修复前**

<img width="300" height="192" alt="Screenshot 2026-08-08 at 11 08 27" src="https://github.com/user-attachments/assets/2c04e38d-65b6-49bc-a049-45d93ef91f75" />

**After / 修复后**

<img width="1189" height="709" alt="Screenshot 2026-08-08 at 11 09 19" src="https://github.com/user-attachments/assets/a18908ad-9c87-4a97-98e6-b7cd73f71d61" />

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。（本 PR 无新功能）

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。（截图待补充）

- [x] 🤓 I have ensured that no new dependencies are introduced.
  / 我确保没有引入新依赖库。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Fix agent_stats snapshots reporting an end_time of 0, which caused the frontend message duration to display as '-' instead of the actual elapsed time.

## Summary by Sourcery

Bug Fixes:
- Fix agent_stats responses reporting an end_time of 0 that caused the webchat message duration field to show '-' instead of the elapsed time.