### PR TITLE
fix: restore missing WebChat sessions

### DIFF
--- a/astrbot/core/db/migration/migra_webchat_session.py
+++ b/astrbot/core/db/migration/migra_webchat_session.py
@@ -12,7 +12,7 @@ Changes:
 from sqlalchemy import func, select
 from sqlmodel import col
 
-from astrbot.api import logger, sp
+from astrbot.api import logger
 from astrbot.core.db import BaseDatabase
 from astrbot.core.db.po import ConversationV2, PlatformMessageHistory, PlatformSession
 
@@ -23,13 +23,6 @@ async def migrate_webchat_session(db_helper: BaseDatabase) -> None:
     This migration extracts all unique user_ids from platform_message_history
     where platform_id='webchat' and creates corresponding PlatformSession records.
     """
-    # 检查是否已经完成迁移
-    migration_done = await db_helper.get_preference(
-        "global", "global", "migration_done_webchat_session_1"
-    )
-    if migration_done:
-        return
-
     logger.info("开始执行数据库迁移（WebChat 会话迁移）...")
 
     try:
@@ -52,9 +45,6 @@ async def migrate_webchat_session(db_helper: BaseDatabase) -> None:
 
             if not webchat_users:
                 logger.info("没有找到需要迁移的 WebChat 数据")
-                await sp.put_async(
-                    "global", "global", "migration_done_webchat_session_1", True
-                )
                 return
 
             logger.info(f"找到 {len(webchat_users)} 个 WebChat 会话需要迁移")
@@ -122,9 +112,6 @@ async def migrate_webchat_session(db_helper: BaseDatabase) -> None:
                 )
             else:
                 logger.info("没有新会话需要迁移")
-
-        # 标记迁移完成
-        await sp.put_async("global", "global", "migration_done_webchat_session_1", True)
 
     except Exception as e:
         logger.error(f"迁移过程中发生错误: {e}", exc_info=True)

--- a/astrbot/dashboard/services/chat_service.py
+++ b/astrbot/dashboard/services/chat_service.py
@@ -1115,6 +1115,25 @@ class ChatService:
                 "Message content is empty (reply only is not allowed)"
             )
 
+        if platform_history_id == "webchat":
+            try:
+                platform_session = await self.db.get_platform_session_by_id(
+                    webchat_conv_id
+                )
+                if platform_session is None:
+                    await self.db.create_platform_session(
+                        creator=username,
+                        platform_id="webchat",
+                        session_id=webchat_conv_id,
+                        is_group=0,
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to ensure WebChat platform session %s: %s",
+                    webchat_conv_id,
+                    exc,
+                )
+
         message_id = str(uuid.uuid4())
         llm_checkpoint_id = post_data.get("_llm_checkpoint_id") or str(uuid.uuid4())
         skip_user_history = bool(post_data.get("_skip_user_history"))

--- a/tests/test_chat_route.py
+++ b/tests/test_chat_route.py
@@ -27,7 +27,12 @@ def chat_service_instance(monkeypatch, tmp_path):
         platform_message_history_manager=platform_history_mgr,
         umop_config_router=Mock(),
     )
-    service = ChatService(Mock(), core_lifecycle)
+    db = Mock()
+    db.get_platform_session_by_id = AsyncMock(
+        return_value=SimpleNamespace(session_id="existing-session")
+    )
+    db.create_platform_session = AsyncMock()
+    service = ChatService(db, core_lifecycle)
     service.build_user_message_parts = AsyncMock(
         return_value=[{"type": "plain", "text": "hello"}]
     )
@@ -38,6 +43,36 @@ def chat_service_instance(monkeypatch, tmp_path):
         )
     )
     return service
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_creates_missing_webchat_platform_session(
+    chat_service_instance,
+):
+    service = chat_service_instance
+    session_id = "missing-platform-session"
+    service.db.get_platform_session_by_id.return_value = None
+
+    stream = await service.build_chat_stream(
+        "alice",
+        {"message": "hello", "session_id": session_id},
+    )
+    run = next(iter(service.chat_runs.values()))
+
+    try:
+        service.db.get_platform_session_by_id.assert_awaited_once_with(session_id)
+        service.db.create_platform_session.assert_awaited_once_with(
+            creator="alice",
+            platform_id="webchat",
+            session_id=session_id,
+            is_group=0,
+        )
+    finally:
+        await stream.aclose()
+        if run.task and not run.task.done():
+            run.task.cancel()
+            await asyncio.gather(run.task, return_exceptions=True)
+        chat_service.webchat_queue_mgr.remove_queues(session_id)
 
 
 def _decode_sse_event(event: str) -> dict:


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

Fix #9605 issue

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

修复了后端消息入口直接写入 `platform_message_history`，没有查询或补建 `platform_sessions`导致的 sidebar 相关问题。对应代码在[chat_service.py (line 1090)]()

Fix WebChat conversations that have message history but are missing from the sidebar because no corresponding `platform_sessions` record exists.

- Ensure a WebChat platform session exists when processing a message.
- Make the existing WebChat session migration run idempotently on every startup.
- Preserve normal message delivery if session backfilling fails.
- Add a focused regression test based on the existing ChatService test fixture.


- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

在 `test_chat_route.py` 中添加了相关的新测试。

Commands：

- `ruff format .`
- `ruff check .`
- `pytest tests/test_chat_route.py -q` — 10 passed

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

1. 生成一个对话
<img width="2382" height="874" alt="image" src="https://github.com/user-attachments/assets/483ef5db-3828-4015-a3b5-ff6557d78702" />

2. 人为复现issue里的历史
<img width="2382" height="874" alt="image" src="https://github.com/user-attachments/assets/22ad9bc1-ba1d-478e-ab15-757e6ca42ec8" />

3. 重新查询，修复后的预期结果是 1
<img width="2384" height="872" alt="image" src="https://github.com/user-attachments/assets/9d7145a3-ddda-41db-85ae-98b2af6d29a3" />

4. UI也正常
<img width="2560" height="924" alt="image" src="https://github.com/user-attachments/assets/4acffbf9-be43-46bd-b456-3c9e38f2a3ca" />


---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

PTAL!

## Summary by Sourcery

Ensure WebChat conversations are correctly surfaced by creating missing platform sessions at message processing time and making the WebChat session migration rerunnable.

Bug Fixes:
- Restore WebChat conversations that had message history but were missing from the sidebar due to absent platform session records.
- Prevent failures in WebChat session backfilling from disrupting normal message delivery.

Enhancements:
- Make the WebChat platform session migration idempotent so it can safely run on every startup.

Tests:
- Add an async regression test verifying that processing a WebChat message creates a missing platform_session entry.