### PR TITLE
fix(telegram): use static thumbnail for animated stickers

### DIFF
--- a/astrbot/core/platform/sources/telegram/tg_adapter.py
+++ b/astrbot/core/platform/sources/telegram/tg_adapter.py
@@ -596,10 +596,18 @@ class TelegramPlatformAdapter(Platform):
 
         elif update.message.sticker:
             # 将sticker当作图片处理
-            file = await update.message.sticker.get_file()
-            message.message.append(Comp.Image(file=file.file_path, url=file.file_path))
-            if update.message.sticker.emoji:
-                sticker_text = f"Sticker: {update.message.sticker.emoji}"
+            sticker = update.message.sticker
+            if sticker.is_animated or sticker.is_video:
+                # .tgs/.webm stickers are not bitmaps; use the static thumbnail.
+                file = await sticker.thumbnail.get_file() if sticker.thumbnail else None
+            else:
+                file = await sticker.get_file()
+            if file:
+                message.message.append(
+                    Comp.Image(file=file.file_path, url=file.file_path)
+                )
+            if sticker.emoji:
+                sticker_text = f"Sticker: {sticker.emoji}"
                 message.message_str = sticker_text
                 message.message.append(Comp.Plain(sticker_text))
 

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -215,6 +215,78 @@ async def test_telegram_video_caption_populates_message_text_and_plain():
     )
 
 
+_STICKER_URL = "https://api.telegram.org/file/test/sticker_1.webp"
+_ANIMATED_URL = "https://api.telegram.org/file/test/sticker_1.tgs"
+_VIDEO_URL = "https://api.telegram.org/file/test/sticker_1.webm"
+_THUMBNAIL_URL = "https://api.telegram.org/file/test/thumb_1.webp"
+
+
+def _make_sticker(
+    file_path: str,
+    *,
+    is_animated: bool = False,
+    is_video: bool = False,
+    thumbnail_path: str | None = None,
+):
+    sticker = create_mock_file(file_path)
+    sticker.emoji = "🙄"
+    sticker.is_animated = is_animated
+    sticker.is_video = is_video
+    sticker.thumbnail = (
+        create_mock_file(thumbnail_path) if thumbnail_path is not None else None
+    )
+    return sticker
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("file_path", "flags", "expected_url"),
+    [
+        (_STICKER_URL, {}, _STICKER_URL),
+        (_ANIMATED_URL, {"is_animated": True}, _THUMBNAIL_URL),
+        (_VIDEO_URL, {"is_video": True}, _THUMBNAIL_URL),
+    ],
+    ids=["static", "animated", "video"],
+)
+async def test_telegram_sticker_uses_thumbnail_only_when_animated(
+    file_path, flags, expected_url
+):
+    TelegramPlatformAdapter = _load_telegram_adapter()
+    adapter = TelegramPlatformAdapter(
+        make_platform_config("telegram"),
+        {},
+        asyncio.Queue(),
+    )
+    sticker = _make_sticker(file_path, thumbnail_path=_THUMBNAIL_URL, **flags)
+    update = create_mock_update(message_text=None, sticker=sticker)
+
+    result = await adapter.convert_message(update, _build_context())
+
+    assert result is not None
+    images = [c for c in result.message if isinstance(c, Comp.Image)]
+    assert len(images) == 1
+    assert images[0].url == expected_url
+    assert result.message_str == "Sticker: 🙄"
+
+
+@pytest.mark.asyncio
+async def test_telegram_animated_sticker_without_thumbnail_skips_image():
+    TelegramPlatformAdapter = _load_telegram_adapter()
+    adapter = TelegramPlatformAdapter(
+        make_platform_config("telegram"),
+        {},
+        asyncio.Queue(),
+    )
+    sticker = _make_sticker(_ANIMATED_URL, is_animated=True, thumbnail_path=None)
+    update = create_mock_update(message_text=None, sticker=sticker)
+
+    result = await adapter.convert_message(update, _build_context())
+
+    assert result is not None
+    assert not any(isinstance(c, Comp.Image) for c in result.message)
+    assert result.message_str == "Sticker: 🙄"
+
+
 @pytest.mark.asyncio
 async def test_telegram_voice_message_creates_record_component(tmp_path):
     TelegramPlatformAdapter = _load_telegram_adapter()


### PR DESCRIPTION
Animated Telegram stickers never reach the model as images: ask what a sticker shows and the model describes the emoji it is tagged with rather than the artwork. The sticker branch in `convert_message()` does not distinguish sticker types, always calling `sticker.get_file()` and wrapping the result in `Comp.Image`, but an animated sticker's payload is `.tgs` (gzipped Lottie JSON) or `.webm`, neither of which is a bitmap. `ensure_jpeg()` in the preprocess stage therefore throws at `PIL.Image.open()` and the component stays on the message chain unchanged; the provider side then fails to detect a MIME type when converting it to base64 and drops the entry. Animated stickers are common on Telegram, so any feature that needs to read the artwork fails.

The Bot API already ships a static thumbnail for these stickers, `Sticker.thumbnail`, in `.WEBP` or `.JPG`. Reading that gives us the artwork and avoids adding a new dependency.

### Modifications / 改动点

`astrbot/core/platform/sources/telegram/tg_adapter.py`:
- Sticker branch: when `is_animated` or `is_video` is set, read `sticker.thumbnail.get_file()` instead. Static stickers keep using `sticker.get_file()` and behave exactly as before.
- An animated sticker with no `thumbnail` no longer appends a `Comp.Image`.

`tests/test_telegram_adapter.py`: four new cases covering static stickers still using the sticker's own file, `is_animated` and `is_video` each switching to the thumbnail, and a missing thumbnail producing no `Comp.Image` while the text component survives.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

#### Before the fix

The sticker carries a `thumbnail`, but the `.tgs` payload is what gets fetched. An `Image` component does reach the chain (`[图片]` in the log below), and it fails twice: once in the preprocess stage, once on the provider side. The request fired when the sticker arrived carries no IMAGE entry.Asked to describe the sticker, the model answers "a clenched fist with the thumb pointing up" — the shape of the Unicode 👍, not the duck the sticker actually shows.

<details>
<summary>Log (before)</summary>

```
[14:52:32.860] [Core] [DBUG] [telegram.tg_adapter:427]: Telegram message: Message(channel_chat_created=False, chat=Chat(first_name='<name>', id=<user_id>, type=<ChatType.PRIVATE>), date=datetime.datetime(2026, 8, 9, 5, 52, 32, tzinfo=datetime.timezone.utc), delete_chat_photo=False, from_user=User(first_name='<name>', id=<user_id>, is_bot=False, language_code='zh-hans'), group_chat_created=False, message_id=46, sticker=Sticker(api_kwargs={'thumb': {'file_id': 'AAMCAgADGQEAAypqeBKgYJj99Lw1IjGGwghZfDU6AwAC_gADVp29CtoEYTAu-df_AQAHbQADPQQ', 'file_unique_id': 'AQAD_gADVp29CnI', 'file_size': 4764, 'width': 128, 'height': 128}}, emoji='👍', file_id='CAACAgIAAxkBAAMqangSoGCY_fS8NSIxhsIIWXw1OgMAAv4AA1advQraBGEwLvnX_z0E', file_size=7340, file_unique_id='AgAD_gADVp29Cg', height=512, is_animated=True, is_video=False, set_name='UtyaDuck', thumbnail=PhotoSize(file_id='AAMCAgADGQEAAypqeBKgYJj99Lw1IjGGwghZfDU6AwAC_gADVp29CtoEYTAu-df_AQAHbQADPQQ', file_size=4764, file_unique_id='AQAD_gADVp29CnI', height=128, width=128), type=<StickerType.REGULAR>, width=512), supergroup_chat_created=False)
[14:52:34.293] [Core] [INFO] [core.event_bus:74]: [default] [telegram(telegram)] Unknown/<user_id>: [图片] Sticker: 👍
[14:52:37.271] [Core] [WARN] [v4.27.2] [preprocess_stage.stage:126]: Image processing failed for https URL host='api.telegram.org' file='file_9.tgs' len=99: cannot identify image file 'C:\\Users\\<user>\\Desktop\\AstrBot-repro\\data\\temp\\media_image_20260809145234300_660b.bin'
[14:52:39.252] [Core] [WARN] [v4.27.2] [provider.entities:216]: 图片预处理结果为空，将忽略。
[14:52:39.252] [Core] [DBUG] [runners.tool_loop_agent_runner:621]: [BefCompact] messages -> [2] system,user
[14:52:42.732] [Core] [DBUG] [sources.gemini_source:623]: genai result: sdk_http_response=HttpResponse(
  headers=<dict len=12>
) candidates=[Candidate(
  content=Content(
    parts=[
      Part(
        text='👍 收到！如果有其他需要随时告诉我哦！',
        thought_signature=b'\x12\xdb\t\n\xd8\t\x01\x11M2\x0fY\xfc\x90\x9bWA\x13<\x93\xb0\xd7\x1d\xdd\xd9\xf8\x13k\xeb0\xc1\xf2\xc2\xd8\xc0hmO\x1b$\x86\x87\xf3\\\x93\r9\xd1\x93\xca\xcc\x15\x93;\xb1\xbd\xe3\xa0\x95D,\xb9\xe4\x89\t]\x9b\x0b{\x0e\x8b.\xae\x1cXP\tf\x9b+D\xb9/\x19O\xc8/9<\xc8\xadj\xf0\xf4W{\xf9...'
      ),
    ],
    role='model'
  ),
  finish_reason=<FinishReason.STOP: 'STOP'>,
  index=0,
  safety_ratings=[
    SafetyRating(
      category=<HarmCategory.HARM_CATEGORY_HARASSMENT: 'HARM_CATEGORY_HARASSMENT'>,
      probability=<HarmProbability.NEGLIGIBLE: 'NEGLIGIBLE'>
    ),
    SafetyRating(
      category=<HarmCategory.HARM_CATEGORY_HATE_SPEECH: 'HARM_CATEGORY_HATE_SPEECH'>,
      probability=<HarmProbability.NEGLIGIBLE: 'NEGLIGIBLE'>
    ),
    SafetyRating(
      category=<HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT: 'HARM_CATEGORY_SEXUALLY_EXPLICIT'>,
      probability=<HarmProbability.NEGLIGIBLE: 'NEGLIGIBLE'>
    ),
    SafetyRating(
      category=<HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: 'HARM_CATEGORY_DANGEROUS_CONTENT'>,
      probability=<HarmProbability.NEGLIGIBLE: 'NEGLIGIBLE'>
    ),
  ]
)] create_time=None model_version='gemini-3.6-flash' prompt_feedback=None response_id='pxV4aoCZNPu0vr0P__zl6Qs' usage_metadata=GenerateContentResponseUsageMetadata(
  candidates_token_count=11,
  prompt_token_count=3342,
  prompt_tokens_details=[
    ModalityTokenCount(
      modality=<MediaModality.TEXT: 'TEXT'>,
      token_count=3342
    ),
  ],
  thoughts_token_count=304,
  total_token_count=3657
) model_status=None automatic_function_calling_history=None parsed=None
```

</details>

<img width="1172" height="2103" alt="before the fix" src="https://github.com/user-attachments/assets/884b581a-3066-41e9-addb-951d66af5ac9" />

#### After the fix

Same sticker (`file_unique_id` matches the run above), both warnings gone, and the thumbnail makes it into the request. The comparison is limited to the request fired when the sticker arrived: the TEXT token count is identical (3342) and the only difference is the added `IMAGE: 1089`. Asked the same question, the model now describes the picture: a round cartoon duck whose right wing is drawn as an oversized thumbs-up.

<details>
<summary>Log (after)</summary>

```
[14:56:31.687] [Core] [DBUG] [telegram.tg_adapter:427]: Telegram message: Message(channel_chat_created=False, chat=Chat(first_name='<name>', id=<user_id>, type=<ChatType.PRIVATE>), date=datetime.datetime(2026, 8, 9, 5, 56, 31, tzinfo=datetime.timezone.utc), delete_chat_photo=False, from_user=User(first_name='<name>', id=<user_id>, is_bot=False, language_code='zh-hans'), group_chat_created=False, message_id=52, sticker=Sticker(api_kwargs={'thumb': {'file_id': 'AAMCAgADGQEAAypqeBKgYJj99Lw1IjGGwghZfDU6AwAC_gADVp29CtoEYTAu-df_AQAHbQADPQQ', 'file_unique_id': 'AQAD_gADVp29CnI', 'file_size': 4764, 'width': 128, 'height': 128}}, emoji='👍', file_id='CAACAgIAAxkBAAMqangSoGCY_fS8NSIxhsIIWXw1OgMAAv4AA1advQraBGEwLvnX_z0E', file_size=7340, file_unique_id='AgAD_gADVp29Cg', height=512, is_animated=True, is_video=False, set_name='UtyaDuck', thumbnail=PhotoSize(file_id='AAMCAgADGQEAAypqeBKgYJj99Lw1IjGGwghZfDU6AwAC_gADVp29CtoEYTAu-df_AQAHbQADPQQ', file_size=4764, file_unique_id='AQAD_gADVp29CnI', height=128, width=128), type=<StickerType.REGULAR>, width=512), supergroup_chat_created=False)
[14:56:32.803] [Core] [INFO] [core.event_bus:74]: [default] [telegram(telegram)] Unknown/<user_id>: [图片] Sticker: 👍
[14:56:35.943] [Core] [DBUG] [runners.tool_loop_agent_runner:621]: [BefCompact] messages -> [2] system,user
[14:56:38.807] [Core] [DBUG] [sources.gemini_source:623]: genai result: sdk_http_response=HttpResponse(
  headers=<dict len=12>
) candidates=[Candidate(
  content=Content(
    parts=[
      Part(
        text="""收到！这是一个超萌的小黄鸭点赞表情包 🐥👍

有什么需要我帮忙的吗？随时告诉我哦！""",
        thought_signature=b'\x12\xe5\x02\n\xe2\x02\x01\x11M2\x0f2\xa6G\xbf\xd4\xac\xaac{\x9fD$\xbb\xeby\xe5\xc5\x02b\xc4w\xe4Hf1\xe3KS\xa7y\xa5f%{\x8f\x9dxTX\xb6\xb3\xe2\x90\xd6\x80\xd6\xffov\x00-\x13$\xee)\x83]f\xd8i\x10\x86\xd4\x0b\xe9\xb4\x87\x84\x11 $\x9e#f\x89\x9fX\xfe8\xca\x7f\x9e\xb0b\xab#...'
      ),
    ],
    role='model'
  ),
  finish_reason=<FinishReason.STOP: 'STOP'>,
  index=0,
  safety_ratings=[
    SafetyRating(
      category=<HarmCategory.HARM_CATEGORY_HARASSMENT: 'HARM_CATEGORY_HARASSMENT'>,
      probability=<HarmProbability.NEGLIGIBLE: 'NEGLIGIBLE'>
    ),
    SafetyRating(
      category=<HarmCategory.HARM_CATEGORY_HATE_SPEECH: 'HARM_CATEGORY_HATE_SPEECH'>,
      probability=<HarmProbability.NEGLIGIBLE: 'NEGLIGIBLE'>
    ),
    SafetyRating(
      category=<HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT: 'HARM_CATEGORY_SEXUALLY_EXPLICIT'>,
      probability=<HarmProbability.NEGLIGIBLE: 'NEGLIGIBLE'>
    ),
    SafetyRating(
      category=<HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: 'HARM_CATEGORY_DANGEROUS_CONTENT'>,
      probability=<HarmProbability.NEGLIGIBLE: 'NEGLIGIBLE'>
    ),
  ]
)] create_time=None model_version='gemini-3.6-flash' prompt_feedback=None response_id='lBZ4aqnKLLej1e8P5_C96Qo' usage_metadata=GenerateContentResponseUsageMetadata(
  candidates_token_count=28,
  prompt_token_count=4431,
  prompt_tokens_details=[
    ModalityTokenCount(
      modality=<MediaModality.TEXT: 'TEXT'>,
      token_count=3342
    ),
    ModalityTokenCount(
      modality=<MediaModality.IMAGE: 'IMAGE'>,
      token_count=1089
    ),
  ],
  thoughts_token_count=65,
  total_token_count=4524
) model_status=None automatic_function_calling_history=None parsed=None
```

</details>

<img width="1172" height="2128" alt="after the fix" src="https://github.com/user-attachments/assets/54219e21-88e7-4a44-b174-251fcc74f5f7" />

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Handle Telegram animated/video stickers using their static thumbnails so sticker artwork reaches image-aware features without errors.

Bug Fixes:
- Prevent failures when processing animated or video Telegram stickers whose payloads are non-bitmap formats by using their static thumbnails instead.
- Avoid creating image components for animated stickers that lack thumbnails, while preserving the text representation.

Tests:
- Add tests verifying static stickers still use their own file, animated and video stickers use thumbnails, and animated stickers without thumbnails skip image creation.