### PR TITLE
fix: detect audio format from file content

### DIFF
--- a/astrbot/core/utils/media_utils.py
+++ b/astrbot/core/utils/media_utils.py
@@ -1127,7 +1127,10 @@ async def convert_audio_format(
     Raises:
         Exception: Raised when ffmpeg is unavailable or conversion fails.
     """
-    if audio_path.lower().endswith(f".{output_format}"):
+    source_path = Path(audio_path)
+    if source_path.suffix.lower() == f".{output_format}" and (
+        not source_path.exists() or _get_audio_magic_type(audio_path) == output_format
+    ):
         return audio_path
 
     if output_path is None:

--- a/tests/test_media_utils.py
+++ b/tests/test_media_utils.py
@@ -420,6 +420,91 @@ async def test_media_resolver_cleans_materialized_file_when_audio_conversion_fai
 
 
 @pytest.mark.asyncio
+async def test_convert_audio_format_transcodes_amr_bytes_misnamed_as_wav(
+    tmp_path, monkeypatch
+):
+    source_path = tmp_path / "voice.wav"
+    source_path.write_bytes(b"#!AMR\n" + b"\x00" * 32)
+    converted_path = tmp_path / "converted.wav"
+    calls = []
+
+    class FakeProcess:
+        returncode = 0
+
+        async def communicate(self):
+            converted_path.write_bytes(b"RIFF\x24\x00\x00\x00WAVEfmt " + b"\x00" * 16)
+            return b"", b""
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        calls.append((args, kwargs))
+        return FakeProcess()
+
+    monkeypatch.setattr(
+        media_utils.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+
+    result = await media_utils.convert_audio_format(
+        str(source_path),
+        output_format="wav",
+        output_path=str(converted_path),
+    )
+
+    assert result == str(converted_path)
+    assert calls
+    assert calls[0][0][:4] == ("ffmpeg", "-y", "-i", str(source_path))
+
+
+@pytest.mark.asyncio
+async def test_convert_audio_format_rewrites_misnamed_target_format(
+    tmp_path, monkeypatch
+):
+    source_path = tmp_path / "voice.wav"
+    source_path.write_bytes(b"#!AMR\n" + b"\x00" * 32)
+    converted_path = tmp_path / "converted.amr"
+    calls = []
+
+    class FakeProcess:
+        returncode = 0
+
+        async def communicate(self):
+            converted_path.write_bytes(b"#!AMR\n" + b"\x00" * 32)
+            return b"", b""
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        calls.append((args, kwargs))
+        return FakeProcess()
+
+    monkeypatch.setattr(
+        media_utils.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+
+    result = await media_utils.convert_audio_format(
+        str(source_path),
+        output_format="amr",
+        output_path=str(converted_path),
+    )
+
+    assert result == str(converted_path)
+    assert calls
+
+
+@pytest.mark.asyncio
+async def test_convert_audio_format_keeps_missing_target_path():
+    missing_path = "missing.wav"
+
+    result = await media_utils.convert_audio_format(
+        missing_path,
+        output_format="wav",
+    )
+
+    assert result == missing_path
+
+
+@pytest.mark.asyncio
 async def test_media_resolver_cleans_http_target_when_download_fails(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Motivation / 动机

This issue occurs when AstrBot receives a QQ voice message through a NapCat/OneBot `Record` component.

QQ multimedia voice URLs commonly have no filename extension, while their downloaded bytes are AMR. The audio resolver explicitly passes [`default_suffix=".wav"`](https://github.com/AstrBotDevs/AstrBot/blob/609e576b31eb5d7f4598eeeb4d23b67e34d0f1bf/astrbot/core/utils/media_utils.py#L920-L924). When materializing an extensionless URL, it chooses the temporary-file suffix through [`Path(parsed.path).suffix or suffix`](https://github.com/AstrBotDevs/AstrBot/blob/609e576b31eb5d7f4598eeeb4d23b67e34d0f1bf/astrbot/core/utils/media_utils.py#L447-L458). As a result, AMR bytes from a QQ voice message can be saved as a `*.wav` temporary file.

When a caller then requests WAV output, the previous `convert_audio_format()` fast path trusted only the `.wav` suffix and returned the AMR file without invoking ffmpeg. Downstream duration probing or an audio-capable Provider consequently receives AMR bytes declared as WAV, which can make probing fail or cause the Provider to reject the audio request.

该问题出现在 AstrBot 通过 NapCat/OneBot 的 `Record` 组件接收 QQ 语音消息时。

QQ 多媒体语音 URL 通常没有文件扩展名，但下载到的实际字节为 AMR。音频解析入口会传入 [`default_suffix=".wav"`](https://github.com/AstrBotDevs/AstrBot/blob/609e576b31eb5d7f4598eeeb4d23b67e34d0f1bf/astrbot/core/utils/media_utils.py#L920-L924)。实体化无扩展名 URL 时，则以 [`Path(parsed.path).suffix or suffix`](https://github.com/AstrBotDevs/AstrBot/blob/609e576b31eb5d7f4598eeeb4d23b67e34d0f1bf/astrbot/core/utils/media_utils.py#L447-L458) 选择临时文件后缀。因此，QQ 语音消息的 AMR 字节可能被保存为 `*.wav` 临时文件。

当调用方随后请求 WAV 输出时，旧版 `convert_audio_format()` 的快速路径仅依据 `.wav` 后缀直接返回该 AMR 文件，不会调用 ffmpeg。后续时长探测或音频模型因而收到“声明为 WAV、实际为 AMR”的字节，可能导致探测失败，或被 Provider 拒绝音频请求。

## Modifications / 改动点

- Only skip conversion when the source suffix matches the target format and the existing file's magic type also matches the target format.
  / 仅当文件后缀和文件头识别出的真实格式都等于目标格式时，才跳过转码。

- Preserve the existing behavior for missing source paths.
  / 保持源路径不存在时的既有直接返回行为。

- Add regression tests for AMR bytes misnamed as `.wav`, rewriting a misnamed target-format file, and preserving missing-path behavior.
  / 新增 AMR 内容误命名为 `.wav`、目标格式误命名以及缺失路径兼容行为的回归测试。

- [x] This is NOT a breaking change.
  / 这不是一个破坏性变更。

## Screenshots or Test Results / 运行截图或测试结果

<img width="305" height="218" alt="Chat screenshot: user catches Paimon lying about not hearing a voice message, Paimon admits she was caught." src="https://github.com/user-attachments/assets/5bd57ac0-8839-4b60-be75-869a513f5b60" />

```text
python -m pytest -q tests/test_media_utils.py -k "transcodes_amr_bytes_misnamed_as_wav or rewrites_misnamed_target_format or keeps_missing_target_path"
3 passed, 50 deselected

python -m ruff check astrbot/core/utils/media_utils.py tests/test_media_utils.py
All checks passed!
```

### Checklist / 检查清单

- [x] 😊 This is a bug fix and introduces no new feature or dependency.
  / 这是修复，不引入新功能或依赖。

- [x] 👀 The change has regression coverage and the relevant checks pass.
  / 已添加回归测试，相关检查通过。

- [x] 🤓 No new dependency is introduced.
  / 未引入新依赖。

- [x] 😮 This change does not introduce malicious code.
  / 未引入恶意代码。
