### PR TITLE
feat: console 日志时间戳增加日期(YYYY-MM-DD)

### DIFF
--- a/astrbot/core/log.py
+++ b/astrbot/core/log.py
@@ -229,7 +229,7 @@ class LogManager:
             colorize=True,
             filter=lambda record: not record["extra"].get("is_trace", False),
             format=(
-                "<green>[{time:HH:mm:ss.SSS}]</green> {extra[plugin_tag]} "
+                "<green>[{time:YYYY-MM-DD HH:mm:ss.SSS}]</green> {extra[plugin_tag]} "
                 "<level>[{extra[short_levelname]}]</level>{extra[astrbot_version_tag]} "
                 "[{extra[source_file]}:{extra[source_line]}]: <level>{message}</level>"
             ),


### PR DESCRIPTION
## 问题
backend.log（桌面端捕获的后端 console 输出）时间戳只有时分秒（HH:mm:ss.SSS），没有日期。日志文件跨多天轮转后，无法区分事件发生在哪天，排查问题时极易混淆（例如 7-24 的 [11:19:19.110] 与 8-10 的 [11:19:19.534] 仅差毫秒级，实际相隔 17 天）。

## 修改
仅改 log.py 第 232 行 console sink 的 format：`{time:HH:mm:ss.SSS}` → `{time:YYYY-MM-DD HH:mm:ss.SSS}`。file sink（astrbot.log）本身已有日期，不做改动。

## 效果
console 输出（WebUI 控制台 / 桌面端 backend.log）每条日志自带日期，不再跨天混淆。

## 影响面
仅日志展示格式，无任何功能逻辑变更。

## Summary by Sourcery

Enhancements:
- Update console logging format to include full date (YYYY-MM-DD) alongside time in timestamps for Web UI and desktop backend logs.