### PR TITLE
fix(kb): restore complete knowledge base retrieval results

### DIFF
--- a/astrbot/core/knowledge_base/retrieval/rank_fusion.py
+++ b/astrbot/core/knowledge_base/retrieval/rank_fusion.py
@@ -28,7 +28,7 @@ class RankFusion:
 
     职责:
     - 融合稠密检索和稀疏检索的结果
-    - 在每个知识库内归一化不可直接比较的检索分数
+    - 全局归一化稠密分数，并在每个知识库内归一化稀疏分数
     - 使用 RRF 作为确定性的同分排序依据
     """
 
@@ -63,8 +63,9 @@ class RankFusion:
     ) -> list[FusedResult]:
         """融合稠密和稀疏检索结果。
 
-        每个知识库内分别对稠密相似度和 BM25 分数做 min-max 归一化，
-        再按权重合并。RRF 分数仅用于融合分数相同时的稳定排序。
+        在所有候选中对稠密相似度做 min-max 归一化，BM25 分数则在
+        每个独立知识库内归一化，再按权重合并。RRF 分数仅用于融合分数
+        相同时的稳定排序。
 
         Args:
             dense_results: 稠密检索结果
@@ -106,33 +107,24 @@ class RankFusion:
             vec_doc_id_to_dense[vec_doc_id] = r
             dense_metadata[vec_doc_id] = json.loads(r.data["metadata"])
 
-        # 3. 在每个知识库内归一化两路分数，避免跨索引直接比较 BM25。
-        dense_groups: dict[str, list[tuple[str, float]]] = {}
-        for identifier, result in vec_doc_id_to_dense.items():
-            kb_id = dense_metadata[identifier].get("kb_id")
-            if not kb_id and identifier in chunk_id_to_sparse:
-                kb_id = chunk_id_to_sparse[identifier].kb_id
-            dense_groups.setdefault(kb_id or "", []).append(
-                (identifier, result.similarity)
-            )
+        # 3. Calibrate dense scores globally while keeping independent BM25 scales.
+        normalized_dense: dict[str, float] = {}
+        if vec_doc_id_to_dense:
+            scores = [result.similarity for result in vec_doc_id_to_dense.values()]
+            minimum = min(scores)
+            score_range = max(scores) - minimum
+            for identifier, result in vec_doc_id_to_dense.items():
+                normalized_dense[identifier] = (
+                    (result.similarity - minimum) / score_range if score_range else 1.0
+                )
 
+        normalized_sparse: dict[str, float] = {}
         sparse_groups: dict[str, list[tuple[str, float]]] = {}
         for identifier, result in chunk_id_to_sparse.items():
             sparse_groups.setdefault(result.kb_id, []).append(
                 (identifier, result.score)
             )
 
-        normalized_dense: dict[str, float] = {}
-        for group in dense_groups.values():
-            scores = [score for _, score in group]
-            minimum = min(scores)
-            score_range = max(scores) - minimum
-            for identifier, score in group:
-                normalized_dense[identifier] = (
-                    (score - minimum) / score_range if score_range else 1.0
-                )
-
-        normalized_sparse: dict[str, float] = {}
         for group in sparse_groups.values():
             scores = [score for _, score in group]
             minimum = min(scores)

--- a/astrbot/core/knowledge_base/retrieval/rank_fusion.py
+++ b/astrbot/core/knowledge_base/retrieval/rank_fusion.py
@@ -65,7 +65,8 @@ class RankFusion:
 
         在所有候选中对稠密相似度做 min-max 归一化，BM25 分数则在
         每个独立知识库内归一化，再按权重合并。RRF 分数仅用于融合分数
-        相同时的稳定排序。
+        相同时的稳定排序。最终结果只去除完全相同的文本块，
+        不按来源文档去重。
 
         Args:
             dense_results: 稠密检索结果
@@ -164,9 +165,9 @@ class RankFusion:
             ),
         )
 
-        # 6. 构建融合结果，每篇来源文档只保留得分最高的块。
+        # 6. Keep distinct chunk text regardless of how many chunks share a document.
         fused_results = []
-        seen_documents: set[tuple[str, str]] = set()
+        seen_contents: set[str] = set()
         for identifier in sorted_ids:
             # 优先从稀疏检索获取完整信息
             if identifier in chunk_id_to_sparse:
@@ -194,10 +195,9 @@ class RankFusion:
             else:
                 continue
 
-            document_key = (fused_result.kb_id, fused_result.doc_id)
-            if document_key in seen_documents:
+            if fused_result.content in seen_contents:
                 continue
-            seen_documents.add(document_key)
+            seen_contents.add(fused_result.content)
             fused_results.append(fused_result)
             if len(fused_results) >= top_k:
                 break

--- a/tests/unit/test_rank_fusion.py
+++ b/tests/unit/test_rank_fusion.py
@@ -11,16 +11,18 @@ def make_dense_result(
     chunk_id: str,
     similarity: float,
     kb_id: str = "kb",
+    doc_id: str | None = None,
+    content: str | None = None,
 ) -> Result:
     return Result(
         similarity=similarity,
         data={
             "doc_id": chunk_id,
-            "text": chunk_id,
+            "text": content if content is not None else chunk_id,
             "metadata": json.dumps(
                 {
                     "chunk_index": 0,
-                    "kb_doc_id": f"doc-{chunk_id}",
+                    "kb_doc_id": doc_id or f"doc-{chunk_id}",
                     "kb_id": kb_id,
                 }
             ),
@@ -34,13 +36,14 @@ def make_sparse_result(
     score: float,
     rank: int,
     doc_id: str | None = None,
+    content: str | None = None,
 ) -> SparseResult:
     return SparseResult(
         chunk_index=0,
         chunk_id=chunk_id,
         doc_id=doc_id or f"doc-{chunk_id}",
         kb_id=kb_id,
-        content=chunk_id,
+        content=content if content is not None else chunk_id,
         score=score,
         rank=rank,
     )
@@ -161,26 +164,72 @@ async def test_rank_fusion_does_not_overvalue_low_rank_source_overlap():
 
 
 @pytest.mark.asyncio
-async def test_rank_fusion_keeps_only_the_best_chunk_per_document():
+async def test_rank_fusion_keeps_distinct_chunks_from_the_same_document():
     dense_results = [
-        make_dense_result("doc-a-best", 0.99),
-        make_dense_result("doc-a-second", 0.98),
+        make_dense_result("doc-a-best", 0.99, doc_id="doc-a"),
+        make_dense_result("doc-a-second", 0.98, doc_id="doc-a"),
+        make_dense_result("doc-a-third", 0.97, doc_id="doc-a"),
         make_dense_result("doc-b", 0.97),
     ]
     sparse_results = [
         make_sparse_result("doc-a-best", "kb", 10.0, 1, doc_id="doc-a"),
         make_sparse_result("doc-a-second", "kb", 9.0, 2, doc_id="doc-a"),
-        make_sparse_result("doc-b", "kb", 8.0, 3, doc_id="doc-b"),
+        make_sparse_result("doc-a-third", "kb", 8.0, 3, doc_id="doc-a"),
+        make_sparse_result("doc-b", "kb", 7.0, 4, doc_id="doc-b"),
     ]
 
     results = await RankFusion(kb_db=None).fuse(
         dense_results=dense_results,
         sparse_results=sparse_results,
-        top_k=2,
+        top_k=4,
     )
 
-    assert [result.chunk_id for result in results] == ["doc-a-best", "doc-b"]
-    assert [result.doc_id for result in results] == ["doc-a", "doc-b"]
+    assert [result.chunk_id for result in results] == [
+        "doc-a-best",
+        "doc-a-second",
+        "doc-a-third",
+        "doc-b",
+    ]
+    assert [result.doc_id for result in results] == [
+        "doc-a",
+        "doc-a",
+        "doc-a",
+        "doc-b",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_rank_fusion_deduplicates_only_exact_chunk_text():
+    dense_results = [
+        make_dense_result("duplicate-best", 0.99, content="same text"),
+        make_dense_result("duplicate-second", 0.98, content="same text"),
+        make_dense_result("near-duplicate", 0.97, content="same text "),
+        make_dense_result("unique", 0.96),
+    ]
+    sparse_results = [
+        make_sparse_result("duplicate-best", "kb", 10.0, 1, content="same text"),
+        make_sparse_result(
+            "duplicate-second",
+            "kb",
+            9.0,
+            2,
+            content="same text",
+        ),
+        make_sparse_result("near-duplicate", "kb", 8.0, 3, content="same text "),
+        make_sparse_result("unique", "kb", 7.0, 4),
+    ]
+
+    results = await RankFusion(kb_db=None).fuse(
+        dense_results=dense_results,
+        sparse_results=sparse_results,
+        top_k=4,
+    )
+
+    assert [result.chunk_id for result in results] == [
+        "duplicate-best",
+        "near-duplicate",
+        "unique",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_rank_fusion.py
+++ b/tests/unit/test_rank_fusion.py
@@ -7,7 +7,11 @@ from astrbot.core.knowledge_base.retrieval.rank_fusion import RankFusion
 from astrbot.core.knowledge_base.retrieval.sparse_retriever import SparseResult
 
 
-def make_dense_result(chunk_id: str, similarity: float) -> Result:
+def make_dense_result(
+    chunk_id: str,
+    similarity: float,
+    kb_id: str = "kb",
+) -> Result:
     return Result(
         similarity=similarity,
         data={
@@ -17,7 +21,7 @@ def make_dense_result(chunk_id: str, similarity: float) -> Result:
                 {
                     "chunk_index": 0,
                     "kb_doc_id": f"doc-{chunk_id}",
-                    "kb_id": "kb",
+                    "kb_id": kb_id,
                 }
             ),
         },
@@ -177,3 +181,29 @@ async def test_rank_fusion_keeps_only_the_best_chunk_per_document():
 
     assert [result.chunk_id for result in results] == ["doc-a-best", "doc-b"]
     assert [result.doc_id for result in results] == ["doc-a", "doc-b"]
+
+
+@pytest.mark.asyncio
+async def test_rank_fusion_does_not_promote_a_single_low_scoring_kb_result():
+    dense_results = [
+        make_dense_result("strong", 0.99, kb_id="kb-large"),
+        make_dense_result("moderate", 0.80, kb_id="kb-large"),
+        make_dense_result("weak", 0.10, kb_id="kb-small"),
+    ]
+    sparse_results = [
+        make_sparse_result("strong", "kb-large", 10.0, 1),
+        make_sparse_result("moderate", "kb-large", 5.0, 2),
+        make_sparse_result("weak", "kb-small", 0.01, 1),
+    ]
+
+    results = await RankFusion(kb_db=None).fuse(
+        dense_results=dense_results,
+        sparse_results=sparse_results,
+    )
+
+    assert [result.chunk_id for result in results] == [
+        "strong",
+        "moderate",
+        "weak",
+    ]
+    assert results[-1].score == pytest.approx(0.1)


### PR DESCRIPTION
Fixes #9613.

PR #9455 introduced document-level deduplication and per-knowledge-base dense score normalization. In long-document and multi-knowledge-base retrieval, those behaviors discarded relevant sibling chunks and promoted low-scoring singleton knowledge bases.

### Modifications / 改动点

- Normalize dense similarity scores across the complete fusion candidate set so a singleton knowledge base does not automatically receive the maximum dense contribution.
- Keep BM25 normalization scoped to each knowledge base because scores from independent FTS5 indexes are not directly comparable.
- Replace source-document deduplication with exact chunk-text deduplication using `set[str]`, allowing distinct relevant chunks from the same document to remain in the fused results.
- Add regression coverage for long-document chunks, exact versus near-duplicate text, and low-scoring singleton knowledge bases.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Verification steps:

```bash
uv run pytest -q tests/unit/test_rank_fusion.py tests/unit/test_sparse_retriever.py tests/test_kb_import.py tests/unit/test_kb_document_cleanup.py tests/unit/test_kb_manager_resilience.py tests/unit/test_kb_upload_atomicity.py tests/unit/test_knowledge_base_service_contract.py
uv run ruff format .
uv run ruff check .
```

Results:

- 59 tests passed.
- 499 files already formatted.
- Ruff checks passed.

Cached `mteb/DuRetrieval` benchmark:

- 2,000 queries / 100,001 documents / 119,965 chunks
- Exact-text deduplication: Recall@5 `0.7073`, HitRate@5 `0.9615`, MRR@5 `0.9039`, nDCG@5 `0.8039`
- The document-level benchmark favors one-chunk-per-document diversification (`0.7181` Recall@5), while the regression tests cover the long-document behavior reported in #9613: distinct sibling chunks remain eligible for every fused result slot.

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我确保我的更改不会引入恶意代码。

## Summary by Sourcery

Adjust rank fusion scoring and deduplication to correctly retain relevant sibling chunks and avoid overvaluing singleton knowledge bases.

Enhancements:
- Normalize dense similarity scores globally across all fusion candidates while keeping BM25 normalization scoped per knowledge base.
- Change rank fusion to deduplicate only by exact chunk text instead of source document, allowing multiple distinct chunks from the same document in results.

Tests:
- Extend rank fusion tests to cover long-document sibling chunks, exact versus near-duplicate text deduplication, and low-scoring singleton knowledge base behavior.