### PR TITLE
fix: treat empty config schema as no config items

### DIFF
--- a/astrbot/core/config/astrbot_config.py
+++ b/astrbot/core/config/astrbot_config.py
@@ -57,6 +57,7 @@ class AstrBotConfig(dict):
         object.__setattr__(self, "_save_revision", 0)
         object.__setattr__(self, "_save_committed_revision", 0)
 
+        # An empty schema ({}) is falsy but valid: zero config items, not the global defaults.
         if schema is not None:
             default_config = self._config_schema_to_default_config(schema)
 

--- a/astrbot/core/config/astrbot_config.py
+++ b/astrbot/core/config/astrbot_config.py
@@ -57,7 +57,7 @@ class AstrBotConfig(dict):
         object.__setattr__(self, "_save_revision", 0)
         object.__setattr__(self, "_save_committed_revision", 0)
 
-        if schema:
+        if schema is not None:
             default_config = self._config_schema_to_default_config(schema)
 
         if not self.check_exist():


### PR DESCRIPTION
Fixes #9608

### Modifications / 改动点

When a plugin ships an empty `_conf_schema.json` (i.e. `{}`), `AstrBotConfig.__init__` checked the schema with a truthiness test (`if schema:`). An explicitly-empty schema is falsy, so the plugin loader's call `AstrBotConfig(config_path=..., schema=...)` fell back to the global `DEFAULT_CONFIG`. This seeded the plugin's config file with the entire global configuration (45 top-level keys) and generated a fresh dashboard password hash into it. Because the schema was empty, the dashboard applied no field filtering, exposing the whole polluted config in the WebUI.

Changed `if schema:` to `if schema is not None:` so an explicitly-empty schema resolves to zero config items instead of falling back to the global defaults. `schema=None` (no schema) keeps the previous behavior.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Reproduced locally using the `helloworld` plugin template with `_conf_schema.json` = `{}`:

- Before: `data/config/<plugin>_config.json` contained the full global config (45 top-level keys), including a generated `dashboard.pbkdf2_password`.
- After: the file contains `{}`.

Verification:
- `pytest tests/unit/test_config.py` → 46 passed
- `ruff check astrbot/core/config/astrbot_config.py` → passed
- Live restart of a local instance: the previously-polluted plugin config file was cleaned to `{}`

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Prevent empty plugin config schemas from being populated with the full global configuration and dashboard password when loading configs.