### PR TITLE
fix: convert Telegram video notes into a Video component

### DIFF
--- a/astrbot/core/platform/sources/telegram/tg_adapter.py
+++ b/astrbot/core/platform/sources/telegram/tg_adapter.py
@@ -637,6 +637,17 @@ class TelegramPlatformAdapter(Platform):
                 message.message.append(Comp.Video(file=file_path, path=file.file_path))
                 _apply_caption()
 
+        elif update.message.video_note:
+            # Video notes carry no file_name and cannot have a caption.
+            file = await update.message.video_note.get_file()
+            file_path = file.file_path
+            if file_path is None:
+                logger.warning(
+                    "Telegram video note file_path is None, cannot save the file.",
+                )
+            else:
+                message.message.append(Comp.Video(file=file_path, path=file_path))
+
         return message
 
     async def handle_media_group_message(

--- a/tests/fixtures/helpers.py
+++ b/tests/fixtures/helpers.py
@@ -99,6 +99,7 @@ def create_mock_update(
     document: MagicMock | None = None,
     voice: MagicMock | None = None,
     sticker: MagicMock | None = None,
+    video_note: MagicMock | None = None,
     reply_to_message: MagicMock | None = None,
     quote: MagicMock | None = None,
     caption: str | None = None,
@@ -122,6 +123,7 @@ def create_mock_update(
         document: 文档对象
         voice: 语音对象
         sticker: 贴纸对象
+        video_note: 圆形视频消息对象
         reply_to_message: 回复的消息
         quote: 回复消息中的部分引用
         caption: 说明文字
@@ -159,6 +161,7 @@ def create_mock_update(
     message.document = document
     message.voice = voice
     message.sticker = sticker
+    message.video_note = video_note
     message.reply_to_message = reply_to_message
     message.quote = quote
     message.caption = caption

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -288,6 +288,29 @@ async def test_telegram_animated_sticker_without_thumbnail_skips_image():
 
 
 @pytest.mark.asyncio
+async def test_telegram_video_note_becomes_video_component():
+    TelegramPlatformAdapter = _load_telegram_adapter()
+    adapter = TelegramPlatformAdapter(
+        make_platform_config("telegram"),
+        {},
+        asyncio.Queue(),
+    )
+    file_path = "https://api.telegram.org/file/test/note.mp4"
+    update = create_mock_update(
+        message_text=None,
+        video_note=create_mock_file(file_path),
+    )
+
+    result = await adapter.convert_message(update, _build_context())
+
+    assert result is not None
+    assert len(result.message) == 1
+    assert isinstance(result.message[0], Comp.Video)
+    assert result.message[0].file == file_path
+    assert result.message[0].path == file_path
+
+
+@pytest.mark.asyncio
 async def test_telegram_voice_message_creates_record_component(tmp_path):
     TelegramPlatformAdapter = _load_telegram_adapter()
     adapter = TelegramPlatformAdapter(


### PR DESCRIPTION
A Telegram video note, the round clip you record with the shortcut in the Telegram client, never makes it into the pipeline. `convert_message()` dispatches on message type and the chain of branches stops at `video`: there is no `video_note` branch, so nothing matches and `AstrBotMessage.message` goes out as an empty list. The request is then dropped in `agent_sub_stages/internal.py`, where `has_valid_message`, `has_media_content` and `has_reply` are all false. The bot stays silent, and nothing further down the pipeline ever learns that a video arrived.

### Modifications / 改动点

`astrbot/core/platform/sources/telegram/tg_adapter.py`:
- New `video_note` branch, built like the existing `video` branch, producing a `Comp.Video`.

`tests/fixtures/helpers.py`: `create_mock_update()` takes a `video_note` argument.

`tests/test_telegram_adapter.py`: one new case covering a video note becoming a `Comp.Video`.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

#### Before the fix

The video note arrives and parses fine, and the dump shows the `video_note` field. Nothing is added to the chain, though, and the request is dropped at `internal:190` without an error or a warning anywhere. On the client side the message simply looks sent; ask about it and the model says it never got a video.

<details>
<summary>Log (before)</summary>

```
[16:56:22.857] [Core] [DBUG] [telegram.tg_adapter:427]: Telegram message: Message(channel_chat_created=False, chat=Chat(first_name='<name>', id=<user_id>, type=<ChatType.PRIVATE>), date=datetime.datetime(2026, 8, 11, 7, 56, 22, tzinfo=datetime.timezone.utc), delete_chat_photo=False, from_user=User(first_name='<name>', id=<user_id>, is_bot=False, language_code='zh-hans'), group_chat_created=False, message_id=82, supergroup_chat_created=False, video_note=VideoNote(_duration=datetime.timedelta(seconds=6), api_kwargs={'thumb': {'file_id': 'AAMCBAADGQEAA1JqetWmeXKLymbXDafoJb7WwqoYywADIAAC-W3YU-9ocnOSYCC7AQAHbQADPQQ', 'file_unique_id': 'AQAEIAAC-W3YU3I', 'file_size': 13182, 'width': 320, 'height': 320}}, file_id='DQACAgQAAxkBAANSanrVpnlyi8pm1w2n6CW-1sKqGMsAAyAAAvlt2FPvaHJzkmAguz0E', file_size=682062, file_unique_id='AgAEIAAC-W3YUw', length=384, thumbnail=PhotoSize(file_id='AAMCBAADGQEAA1JqetWmeXKLymbXDafoJb7WwqoYywADIAAC-W3YU-9ocnOSYCC7AQAHbQADPQQ', file_size=13182, file_unique_id='AQAEIAAC-W3YU3I', height=320, width=320)))
[16:56:22.857] [Core] [INFO] [core.event_bus:74]: [default] [telegram(telegram)] Unknown/<user_id>:
[16:56:22.863] [Core] [DBUG] [agent_sub_stages.internal:190]: skip llm request: empty message and no provider_request
[16:56:22.864] [Core] [DBUG] [pipeline.scheduler:95]: pipeline execution completed.
[16:56:44.078] [Core] [INFO] [core.event_bus:74]: [default] [telegram(telegram)] Unknown/<user_id>: 描述视频内容
[16:56:55.130] [Core] [INFO] [respond.stage:206]: Prepare to send - Unknown/<user_id>: 您好！我目前还没有收到您发送的视频文件、视频链接或文件路径。

请通过以下方式之一提供视频：
1. **直接发送/上传视频文件**
2. **发送视频的下载链接或在线播放网址**
3. **提供视频在本地/服务器上的具体文件路径**

收到视频后，我会为您分析并详细描述视频的内容！
```

</details>

<img width="1172" height="1992" alt="修复前截图" src="https://github.com/user-attachments/assets/e2df6dc0-a6d4-4639-b2dd-4ceda84b8341" />

#### After the fix

The video note now produces a `Comp.Video`, `has_media_content` is true, and the request goes to the provider like any other video. Asked the same question, the model answers from the file it received.

<details>
<summary>Log (after)</summary>

```
[17:09:29.361] [Core] [DBUG] [telegram.tg_adapter:427]: Telegram message: Message(channel_chat_created=False, chat=Chat(first_name='<name>', id=<user_id>, type=<ChatType.PRIVATE>), date=datetime.datetime(2026, 8, 11, 8, 9, 29, tzinfo=datetime.timezone.utc), delete_chat_photo=False, from_user=User(first_name='<name>', id=<user_id>, is_bot=False, language_code='zh-hans'), group_chat_created=False, message_id=96, supergroup_chat_created=False, video_note=VideoNote(_duration=datetime.timedelta(seconds=6), api_kwargs={'thumb': {'file_id': 'AAMCBAADGQEAA2Bqeti42EPOE-ZyT5keCSF_7ynNnAACBCAAAvlt2FPQ_dDZ9ZyQRwEAB20AAz0E', 'file_unique_id': 'AQADBCAAAvlt2FNy', 'file_size': 21527, 'width': 320, 'height': 320}}, file_id='DQACAgQAAxkBAANganrYuNhDzhPmck-ZHgkhf-8pzZwAAgQgAAL5bdhT0P3Q2fWckEc9BA', file_size=492412, file_unique_id='AgADBCAAAvlt2FM', length=360, thumbnail=PhotoSize(file_id='AAMCBAADGQEAA2Bqeti42EPOE-ZyT5keCSF_7ynNnAACBCAAAvlt2FPQ_dDZ9ZyQRwEAB20AAz0E', file_size=21527, file_unique_id='AQADBCAAAvlt2FNy', height=320, width=320)))
[17:09:30.791] [Core] [INFO] [core.event_bus:74]: [default] [telegram(telegram)] Unknown/<user_id>: [ComponentType.Video]
[17:09:30.792] [Core] [INFO] [core.event_bus:74]: [default] [telegram(telegram)] Unknown/<user_id>: 描述视频内容
[17:09:30.797] [Core] [DBUG] [agent_sub_stages.internal:193]: ready to request llm provider
[17:10:18.158] [Core] [INFO] [respond.stage:206]: Prepare to send - Unknown/<user_id>: 已收到您发送的视频文件。以下是该视频的基本信息：

- **视频时长**：约 5.78 秒
- **分辨率**：360 × 360
- **帧率**：30 FPS
- **音频轨**：包含 AAC 单声道音频
…
```

</details>

<img width="1172" height="2313" alt="修复后截图" src="https://github.com/user-attachments/assets/83fad588-7535-40f5-ac84-fe31748fefde" />

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Handle Telegram video note messages by converting them into standard video components so they flow through the pipeline like other media.

New Features:
- Support Telegram video notes as video components in the messaging pipeline.

Enhancements:
- Extend Telegram mock update helper to include video_note messages for use in tests.

Tests:
- Add a Telegram adapter test ensuring video notes are converted into Comp.Video instances with correct file and path values.