### PR TITLE
feat: add OrcaRouter chat completion provider

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1377,6 +1377,18 @@ CONFIG_METADATA_2 = {
                         "proxy": "",
                         "custom_headers": {},
                     },
+                    "OrcaRouter": {
+                        "id": "orcarouter",
+                        "provider": "orcarouter",
+                        "type": "orcarouter_chat_completion",
+                        "provider_type": "chat_completion",
+                        "enable": True,
+                        "key": [],
+                        "timeout": 120,
+                        "api_base": "https://api.orcarouter.ai/v1",
+                        "proxy": "",
+                        "custom_headers": {},
+                    },
                     "NVIDIA": {
                         "id": "nvidia",
                         "provider": "nvidia",

--- a/astrbot/core/provider/sources/orcarouter_source.py
+++ b/astrbot/core/provider/sources/orcarouter_source.py
@@ -1,0 +1,19 @@
+from ..register import register_provider_adapter
+from .openai_source import ProviderOpenAIOfficial
+
+
+@register_provider_adapter(
+    "orcarouter_chat_completion", "OrcaRouter Chat Completion Provider Adapter"
+)
+class ProviderOrcaRouter(ProviderOpenAIOfficial):
+    def __init__(
+        self,
+        provider_config: dict,
+        provider_settings: dict,
+    ) -> None:
+        super().__init__(provider_config, provider_settings)
+        # Reference to: https://www.orcarouter.ai
+        self.client._custom_headers["HTTP-Referer"] = (  # type: ignore
+            "https://github.com/AstrBotDevs/AstrBot"
+        )
+        self.reasoning_key = "reasoning"

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -132,6 +132,7 @@ export default defineConfig({
                 items: [
                   { text: "NewAPI", link: "/newapi" },
                   { text: "AIHubMix", link: "/aihubmix" },
+                  { text: "OrcaRouter", link: "/orcarouter" },
                   { text: "PPIO 派欧云", link: "/ppio" },
                   { text: "硅基流动", link: "/siliconflow" },
                   { text: "小马算力", link: "/tokenpony" },
@@ -391,6 +392,7 @@ export default defineConfig({
                 items: [
                   { text: "NewAPI", link: "/newapi" },
                   { text: "AIHubMix", link: "/aihubmix" },
+                  { text: "OrcaRouter", link: "/orcarouter" },
                   { text: "PPIO Cloud", link: "/ppio" },
                   { text: "SiliconFlow", link: "/siliconflow" },
                   { text: "TokenPony", link: "/tokenpony" },

--- a/docs/en/providers/orcarouter.md
+++ b/docs/en/providers/orcarouter.md
@@ -1,0 +1,25 @@
+# Connect OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is a unified AI gateway that provides access to OpenAI, Anthropic, Google, DeepSeek, Kimi and more through a single API key, in a fully OpenAI-compatible format. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+## Get an API Key
+
+1. Sign up at [OrcaRouter](https://www.orcarouter.ai)
+2. Go to Console → API Keys to create a new key (keys start with `sk-orca-`)
+
+## Configure in AstrBot
+
+AstrBot ships with a built-in OrcaRouter provider. Open the AstrBot dashboard, click **Providers → Add Provider → OrcaRouter**.
+
+The API Base URL is pre-filled for you. Fill in the following:
+
+| Field | Value |
+|-------|-------|
+| API Base URL | `https://api.orcarouter.ai/v1` |
+| API Key | Your OrcaRouter key |
+
+After saving, click the provider card to add models.
+
+## Models
+
+OrcaRouter provides unified access to a wide range of models, including OpenAI GPT, Anthropic Claude, Google Gemini, DeepSeek, Kimi and more. Click **Get Model List** in the provider panel to browse the models available to your account, or see the full model list in the [OrcaRouter documentation](https://www.orcarouter.ai).

--- a/docs/en/providers/start.md
+++ b/docs/en/providers/start.md
@@ -21,6 +21,7 @@ For example, you may choose to connect model services provided by (but not limit
 - Official Anthropic model services ([Anthropic](https://www.anthropic.com/))
 - Google's Gemini model services via Google Cloud ([Google Cloud](https://cloud.google.com/))
 - OpenRouter model services ([OpenRouter](https://openrouter.ai/))
+- OrcaRouter model services ([OrcaRouter](https://www.orcarouter.ai/))
 
 ## Integration Steps Using DeepSeek as an Example
 

--- a/docs/zh/providers/orcarouter.md
+++ b/docs/zh/providers/orcarouter.md
@@ -1,0 +1,25 @@
+# 接入 OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) 是一个统一的 AI 网关，通过单个 API Key 即可访问 OpenAI、Anthropic、Google、DeepSeek、Kimi 等多种模型，且完全兼容 OpenAI API 格式。同时，它还在同一端点上为 AI 智能体提供网关级的零信任安全能力——对每一次提示词/响应进行筛查，并以默认拒绝的方式管控每一次工具调用，无需修改任何应用代码。
+
+## 获取 API Key
+
+1. 在 [OrcaRouter](https://www.orcarouter.ai) 注册账号
+2. 进入控制台 → API Keys，创建一个新的 Key（Key 以 `sk-orca-` 开头）
+
+## 在 AstrBot 中配置
+
+AstrBot 内置了 OrcaRouter 提供商。打开 AstrBot 控制台，点击**服务提供商 → 新增提供商 → OrcaRouter**。
+
+API Base URL 已为您预填。填写以下内容：
+
+| 字段 | 值 |
+|------|------|
+| API Base URL | `https://api.orcarouter.ai/v1` |
+| API Key | 您的 OrcaRouter Key |
+
+保存后，点击该提供商卡片即可添加模型。
+
+## 模型
+
+OrcaRouter 提供对 OpenAI GPT、Anthropic Claude、Google Gemini、DeepSeek、Kimi 等多种模型的统一访问。在提供商面板中点击**获取模型列表**即可浏览您的账户可用的模型，完整模型列表请参阅 [OrcaRouter 文档](https://www.orcarouter.ai)。

--- a/docs/zh/providers/start.md
+++ b/docs/zh/providers/start.md
@@ -21,6 +21,7 @@ AstrBot 适配了 OpenAI、Google GenAI、Anthropic 三种原生 API 格式。�
 - Anthropic 官方提供的模型服务（[Anthropic 官方网站](https://www.anthropic.com/)）
 - Google 提供的 Gemini 模型服务（[Google Cloud 官方网站](https://cloud.google.com/)）
 - OpenRouter 提供的模型服务（[OpenRouter 官方网站](https://openrouter.ai/)）
+- OrcaRouter 提供的模型服务（[OrcaRouter 官方网站](https://www.orcarouter.ai/)）
 
 ## 以 DeepSeek 为例的接入步骤
 


### PR DESCRIPTION
This PR registers [OrcaRouter](https://www.orcarouter.ai) the same way the existing `OpenRouter` provider is wired, so the provider picker, config reference and docs stay consistent. OrcaRouter is an OpenAI-compatible gateway: one API key (keys start with `sk-orca-`) unlocks 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single `https://api.orcarouter.ai/v1` endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

### Modifications / 改动点

- **New provider adapter**: `astrbot/core/provider/sources/orcarouter_source.py` registers `orcarouter_chat_completion` via `@register_provider_adapter`, mirroring `openrouter_source.py` (subclasses `ProviderOpenAIOfficial`, sets `HTTP-Referer`, uses `reasoning_key = "reasoning"`).
- **WebUI config template**: adds the `OrcaRouter` entry to `CONFIG_METADATA_2["provider_group"]` in `astrbot/core/config/default.py` with `api_base` `https://api.orcarouter.ai/v1`, so it appears as a selectable provider card under **Providers → Add Provider** (the dashboard filters `config_template` by `provider_type`; no frontend changes needed).
- **Docs**: adds `docs/en/providers/orcarouter.md` and `docs/zh/providers/orcarouter.md`, lists OrcaRouter in `docs/en/providers/start.md` and `docs/zh/providers/start.md`, and registers both pages in the docs sidebar `docs/.vitepress/config.mjs`.

No new dependencies are introduced.

### Screenshots or Test Results / 运行截图或测试结果

Verification performed locally (Python 3.12):

1. `python -m py_compile` on `orcarouter_source.py` and `default.py` — **passed**.
2. Imported the new module and asserted `orcarouter_chat_completion` is registered in `provider_cls_map` / `provider_registry` with `ProviderOrcaRouter`, and that the `OrcaRouter` config-template entry exists with `api_base = https://api.orcarouter.ai/v1` — **passed**.
3. `ruff format --check` and `ruff check` on the changed files — **passed**.
4. L3 live test against `https://api.orcarouter.ai/v1` with a real OrcaRouter key: listed models via the provider (`get_models()`) and ran a chat completion through `ProviderOrcaRouter.text_chat()` — **passed**, see log below.

```
BASE_URL: https://api.orcarouter.ai/v1
API_KEY_PREFIX: sk-orca-...
MODELS_COUNT: 192
CHOSEN_MODEL: deepseek/deepseek-chat
CHAT_COMPLETION_TEXT: PONG
LIVE_TEST_PASSED
```

### Checklist / 检查清单

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**. / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。
- [x] 🤓 I have ensured that no new dependencies are introduced. / 我确保没有引入新依赖库。
- [x] 😮 My changes do not introduce malicious code. / 我的更改没有引入恶意代码。

## Summary by Sourcery

Add OrcaRouter as a first-class chat completion provider and integrate it into configuration and documentation.

New Features:
- Introduce the OrcaRouter chat completion provider adapter based on the OpenAI-compatible provider implementation.
- Expose OrcaRouter as a selectable provider in the AstrBot configuration with its default API base URL.
- Add English and Chinese provider documentation pages for OrcaRouter and include them in the provider overview and docs sidebar.