### PR TITLE
fix: preserve group image context order

### DIFF
--- a/astrbot/builtin_stars/astrbot/group_chat_context.py
+++ b/astrbot/builtin_stars/astrbot/group_chat_context.py
@@ -143,9 +143,10 @@ class GroupChatContext:
 
         umo = event.unified_msg_origin
         cfg = self.cfg(event)
-        final_message = await self._format_message(event, cfg)
 
+        # Caption and append atomically so later messages cannot overtake images.
         async with self._get_lock(umo):
+            final_message = await self._format_message(event, cfg)
             records = self.raw_records[umo]
             record_ids = self._record_ids[umo]
             record_id = uuid.uuid4().hex
@@ -215,6 +216,7 @@ class GroupChatContext:
                         parts.append(f" [Image: {caption}]")
                     except Exception as e:
                         logger.error(f"获取图片描述失败: {e}")
+                        parts.append(" [Image]")
                 else:
                     parts.append(" [Image]")
             elif isinstance(comp, At):

--- a/tests/unit/test_group_chat_context_wiring.py
+++ b/tests/unit/test_group_chat_context_wiring.py
@@ -1,10 +1,12 @@
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from astrbot.api.message_components import Plain
-from astrbot.api.provider import LLMResponse
+from astrbot.api.message_components import Image, Plain
+from astrbot.api.provider import LLMResponse, ProviderRequest
+from astrbot.builtin_stars.astrbot.group_chat_context import GroupChatContext
 from astrbot.builtin_stars.astrbot.main import Main
 from astrbot.core.message.message_event_result import MessageChain
 from astrbot.core.platform.message_type import MessageType
@@ -45,6 +47,40 @@ def make_event(
     event.get_extra.side_effect = get_extra
     event.set_extra.side_effect = set_extra
     return event
+
+
+def make_group_context_event(message, nickname="user"):
+    event = MagicMock()
+    event.unified_msg_origin = "aiocqhttp:GroupMessage:user_123_group_456"
+    event.message_obj = SimpleNamespace(
+        message=message,
+        sender=SimpleNamespace(nickname=nickname),
+    )
+    event.get_message_type.return_value = MessageType.GROUP_MESSAGE
+    event.get_messages.return_value = message
+
+    store, get_extra, set_extra = _make_extras_store()
+    event.get_extra.side_effect = get_extra
+    event.set_extra.side_effect = set_extra
+    return event
+
+
+def make_group_chat_context():
+    context = MagicMock()
+    context.get_config.return_value = {
+        "provider_ltm_settings": {
+            "group_message_max_cnt": 1000,
+            "image_caption": True,
+            "image_caption_provider_id": "vision-provider",
+            "active_reply": {
+                "enable": False,
+                "method": "possibility_reply",
+                "possibility_reply": 0,
+            },
+        },
+        "provider_settings": {"image_caption_prompt": "Describe the image."},
+    }
+    return GroupChatContext(MagicMock(), context)
 
 
 @pytest.mark.asyncio
@@ -170,6 +206,55 @@ async def test_on_message_skips_recording_when_command_handler_matched():
 
     main.group_chat_context.need_active_reply.assert_awaited_once_with(event)
     main.group_chat_context.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_group_context_preserves_message_order_while_captioning_image():
+    group_context = make_group_chat_context()
+    caption_started = asyncio.Event()
+    release_caption = asyncio.Event()
+
+    async def delayed_caption(*_args):
+        caption_started.set()
+        await release_caption.wait()
+        return "a driving test conversation"
+
+    group_context.get_image_caption = delayed_caption
+    image_event = make_group_context_event([Image.fromURL("https://example.com/a.jpg")])
+    text_event = make_group_context_event([Plain("I think I might fail")])
+
+    image_task = asyncio.create_task(group_context.handle_message(image_event))
+    await caption_started.wait()
+    text_task = asyncio.create_task(group_context.handle_message(text_event))
+    await asyncio.sleep(0)
+    text_completed_before_caption = text_task.done()
+
+    release_caption.set()
+    await asyncio.gather(image_task, text_task)
+
+    req = ProviderRequest()
+    await group_context.on_req_llm(text_event, req)
+
+    assert not text_completed_before_caption
+    assert len(req.extra_user_content_parts) == 1
+    assert (
+        "[Image: a driving test conversation]" in req.extra_user_content_parts[0].text
+    )
+
+
+@pytest.mark.asyncio
+async def test_group_context_keeps_image_placeholder_when_caption_fails():
+    group_context = make_group_chat_context()
+    group_context.get_image_caption = AsyncMock(
+        side_effect=RuntimeError("caption failed")
+    )
+    image_event = make_group_context_event([Image.fromURL("https://example.com/a.jpg")])
+
+    await group_context.handle_message(image_event)
+
+    records = list(group_context.raw_records[image_event.unified_msg_origin])
+    assert len(records) == 1
+    assert records[0].endswith(":  [Image]")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #9634.

Built-in group chat context formatting waits for image captioning before appending a message. Because the event bus processes incoming messages concurrently, a following text message could append first and trigger an LLM request without the preceding image context.

### Modifications / 改动点

- Hold the existing per-session group context lock while formatting and appending each message, preventing later messages in the same group session from overtaking an image caption request.
- Keep an `[Image]` placeholder when caption generation fails instead of storing an empty sender/timestamp record.
- Add deterministic async regression coverage for image/text ordering and caption failure fallback.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Verification steps:

```text
$ uv run pytest -q tests/unit/test_group_chat_context_wiring.py tests/unit/test_event_bus.py
.......................                                                  [100%]
23 passed, 1 warning in 3.62s
```

```text
$ uv run ruff check .
All checks passed!

$ uv run ruff format --check .
499 files already formatted
```

The concurrency regression test starts an image event, pauses its caption request, and then starts a text event for the same group session. It verifies that the text event cannot complete before the image caption and that the text-triggered LLM request receives the image record.

---

### Checklist / 检查清单

- [x] 😊 No new feature is introduced; this is a bug fix tracked by #9634.
- [x] 👀 My changes have been well-tested, **and "Verification Steps" and test results have been provided above**.
- [x] 🤓 No new dependencies are introduced.
- [x] 😮 My changes do not introduce malicious code.

## Summary by Sourcery

Ensure group chat image messages are formatted and recorded atomically so subsequent text messages cannot overtake them in concurrent processing.

Bug Fixes:
- Prevent text messages in a group session from triggering LLM requests before preceding image caption context is recorded.
- Preserve an explicit image placeholder when caption generation fails instead of storing an empty record.

Enhancements:
- Add deterministic handling of image caption failures to keep group context consistent.

Tests:
- Add async regression tests verifying image/text ordering under concurrent events and the fallback image placeholder when captioning fails.