### PR TITLE
feat: add MiniMax Token Plan model fallback

### DIFF
--- a/astrbot/core/provider/sources/minimax_token_plan_source.py
+++ b/astrbot/core/provider/sources/minimax_token_plan_source.py
@@ -5,6 +5,8 @@ from astrbot.core.provider.sources.anthropic_source import ProviderAnthropic
 
 from ..register import register_provider_adapter
 
+_MINIMAX_TOKEN_PLAN_FALLBACK_MODELS = ("MiniMax-M3", "MiniMax-M2.7")
+
 
 @register_provider_adapter(
     "minimax_token_plan",
@@ -16,6 +18,7 @@ class ProviderMiniMaxTokenPlan(ProviderAnthropic):
     The model list is fetched dynamically from the MiniMax API's /v1/models
     endpoint, so newly released models are automatically discovered without
     a code change. The default model is MiniMax-M3, the current flagship.
+    Current models remain available when dynamic discovery is unavailable.
     """
 
     def __init__(
@@ -41,11 +44,16 @@ class ProviderMiniMaxTokenPlan(ProviderAnthropic):
         self.set_model(configured_model)
 
     async def get_models(self) -> list[str]:
-        """Dynamically fetch available models from the MiniMax API."""
+        """Fetch available models from the MiniMax API.
+
+        Returns:
+            The dynamically discovered models, or the current fallback models
+            when discovery is unavailable.
+        """
         key = self.chosen_api_key
         if not key:
             logger.warning("No API key configured for MiniMax Token Plan.")
-            return []
+            return list(_MINIMAX_TOKEN_PLAN_FALLBACK_MODELS)
         try:
             async with httpx.AsyncClient() as client:
                 resp = await client.get(
@@ -55,7 +63,17 @@ class ProviderMiniMaxTokenPlan(ProviderAnthropic):
                 )
                 resp.raise_for_status()
                 data = resp.json()
-                return [m["id"] for m in data.get("data", [])]
-        except Exception as e:
+                items = data.get("data", []) if isinstance(data, dict) else []
+                if not isinstance(items, list):
+                    items = []
+                models = [
+                    model["id"]
+                    for model in items
+                    if isinstance(model, dict) and isinstance(model.get("id"), str)
+                ]
+                if models:
+                    return models
+                logger.warning("MiniMax model discovery returned no models.")
+        except (httpx.HTTPError, ValueError) as e:
             logger.error(f"Failed to fetch MiniMax model list: {e}")
-            return []
+        return list(_MINIMAX_TOKEN_PLAN_FALLBACK_MODELS)

--- a/tests/test_minimax_token_plan_source.py
+++ b/tests/test_minimax_token_plan_source.py
@@ -1,0 +1,88 @@
+from typing import Any
+
+import httpx
+import pytest
+
+from astrbot.core.provider.sources.minimax_token_plan_source import (
+    _MINIMAX_TOKEN_PLAN_FALLBACK_MODELS,
+    ProviderMiniMaxTokenPlan,
+)
+
+
+class _FakeResponse:
+    def __init__(self, payload: Any) -> None:
+        self.payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> Any:
+        return self.payload
+
+
+class _FakeClient:
+    def __init__(
+        self,
+        response: _FakeResponse | None = None,
+        error: httpx.HTTPError | None = None,
+    ) -> None:
+        self.response = response
+        self.error = error
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def get(self, *_args: Any, **_kwargs: Any) -> _FakeResponse:
+        if self.error:
+            raise self.error
+        assert self.response is not None
+        return self.response
+
+
+def _provider(api_key: str = "") -> ProviderMiniMaxTokenPlan:
+    provider = ProviderMiniMaxTokenPlan.__new__(ProviderMiniMaxTokenPlan)
+    provider.chosen_api_key = api_key
+    return provider
+
+
+@pytest.mark.asyncio
+async def test_get_models_returns_fallback_without_api_key() -> None:
+    models = await _provider().get_models()
+
+    assert models == list(_MINIMAX_TOKEN_PLAN_FALLBACK_MODELS)
+
+
+@pytest.mark.asyncio
+async def test_get_models_prefers_discovered_models(monkeypatch) -> None:
+    discovered_models = [*list(_MINIMAX_TOKEN_PLAN_FALLBACK_MODELS), "server-model"]
+    client = _FakeClient(
+        _FakeResponse({"data": [{"id": m} for m in discovered_models]})
+    )
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: client)
+
+    models = await _provider("test-key").get_models()
+
+    assert models == discovered_models
+
+
+@pytest.mark.asyncio
+async def test_get_models_returns_fallback_for_empty_response(monkeypatch) -> None:
+    client = _FakeClient(_FakeResponse({"data": []}))
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: client)
+
+    models = await _provider("test-key").get_models()
+
+    assert models == list(_MINIMAX_TOKEN_PLAN_FALLBACK_MODELS)
+
+
+@pytest.mark.asyncio
+async def test_get_models_returns_fallback_for_request_error(monkeypatch) -> None:
+    client = _FakeClient(error=httpx.ConnectError("connection failed"))
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: client)
+
+    models = await _provider("test-key").get_models()
+
+    assert models == list(_MINIMAX_TOKEN_PLAN_FALLBACK_MODELS)


### PR DESCRIPTION
Reason: MiniMax Token Plan model discovery leaves the model picker empty when no API key is configured or the model request fails.

Changes:
- Return the current model IDs as a fallback when dynamic discovery is unavailable or empty.
- Keep a successful dynamic model list authoritative.
- Cover missing credentials, successful discovery, empty responses, and request failures.

Checks:
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest tests/test_minimax_token_plan_source.py`

## Summary by Sourcery

Add a reliable MiniMax Token Plan model list by falling back to current known models whenever dynamic discovery is unavailable or returns no results.

New Features:
- Provide a fallback MiniMax Token Plan model list when no API key is configured or dynamic discovery fails.

Bug Fixes:
- Ensure MiniMax Token Plan model discovery no longer leaves the model picker empty on missing credentials, empty responses, or request errors.

Enhancements:
- Harden MiniMax Token Plan model parsing and logging around malformed or unexpected discovery responses.

Tests:
- Add async tests covering fallback behavior, successful discovery, empty responses, and HTTP request failures for MiniMax Token Plan model fetching.