### PR TITLE
fix: improve dark theme text contrast

### DIFF
--- a/dashboard/src/components/platform/AddNewPlatform.vue
+++ b/dashboard/src/components/platform/AddNewPlatform.vue
@@ -2016,7 +2016,7 @@ export default {
 .creation-mode-title {
   font-size: 14px;
   font-weight: 600;
-  color: rgba(0, 0, 0, 0.78);
+  color: rgba(var(--v-theme-on-surface), 0.88);
 }
 
 .route-source-cell {

--- a/dashboard/src/components/platform/PlatformRegistrationAction.vue
+++ b/dashboard/src/components/platform/PlatformRegistrationAction.vue
@@ -353,7 +353,7 @@ export default {
   font-size: 14px;
   font-weight: 600;
   text-align: left;
-  color: rgba(0, 0, 0, 0.78);
+  color: rgba(var(--v-theme-on-surface), 0.88);
 }
 
 .registration-scan-content {
@@ -393,7 +393,7 @@ export default {
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid rgba(0, 0, 0, 0.12);
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
   border-radius: 8px;
 }
 
@@ -421,7 +421,7 @@ export default {
   width: 190px;
   text-align: center;
   font-size: 13px;
-  color: rgba(0, 0, 0, 0.72);
+  color: rgba(var(--v-theme-on-surface), 0.72);
   word-break: break-word;
 }
 </style>

--- a/dashboard/src/views/authentication/auth/SetupPage.vue
+++ b/dashboard/src/views/authentication/auth/SetupPage.vue
@@ -161,7 +161,7 @@ onMounted(async () => {
 
 .setup-title {
   margin-top: 8px;
-  color: #000000;
+  color: rgba(var(--v-theme-on-surface), 0.92);
   font-size: 26px;
   font-weight: 600;
   line-height: 1.2;
@@ -169,7 +169,7 @@ onMounted(async () => {
 
 .setup-subtitle {
   margin-top: 6px;
-  color: grey;
+  color: rgba(var(--v-theme-on-surface), 0.62);
   font-size: 14px;
   line-height: 1.35;
 }

--- a/dashboard/src/views/authentication/authForms/AuthSetup.vue
+++ b/dashboard/src/views/authentication/authForms/AuthSetup.vue
@@ -101,7 +101,7 @@ async function validate(values: any, { setErrors }: any) {
   .setup-hint {
     display: block;
     margin-top: 8px;
-    color: grey;
+    color: rgba(var(--v-theme-on-surface), 0.62);
   }
 
   .setup-btn {


### PR DESCRIPTION
## Summary

- make account setup headings, subtitles, and password hints follow Vuetify theme colors
- make platform registration mode headings, QR instructions, status text, and loading borders readable in dark mode

## Root cause

Several labels used hard-coded black or gray colors, so they did not adapt when the dashboard switched to the dark theme.

## Impact

Account setup and QR-based platform registration text now remains readable in both light and dark themes.

## Validation

- `pnpm build`
- `git diff --check`

## Summary by Sourcery

Align dashboard account setup and platform registration text and borders with Vuetify theme colors to improve readability in dark mode.

Bug Fixes:
- Ensure account setup titles, subtitles, and password hints remain readable in dark theme by using theme-based text colors.
- Ensure platform registration titles, QR instructions, and loading borders adapt to dark theme by using Vuetify on-surface colors instead of hard-coded blacks and greys.