### PR TITLE
fix(qq_official): propagate QQ media upload failures

### DIFF
--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -627,8 +627,23 @@ class QQOfficialMessageEvent(AstrMessageEvent):
         srv_send_msg: bool = False,
         file_name: str | None = None,
         **kwargs,
-    ) -> Media | None:
-        """上传媒体文件"""
+    ) -> Media:
+        """Upload media to a QQ group or C2C session.
+
+        Args:
+            file_source: Local file path or remote URL to upload.
+            file_type: QQ media type identifier.
+            srv_send_msg: Whether QQ should send the media immediately.
+            file_name: Optional display name for the uploaded file.
+            **kwargs: Recipient identifier as ``openid`` or ``group_openid``.
+
+        Returns:
+            Metadata for the uploaded media.
+
+        Raises:
+            ValueError: No supported recipient identifier was provided.
+            Exception: The upload request fails or returns an invalid response.
+        """
         # 构建基础payload
         payload: dict = {"file_type": file_type, "srv_send_msg": srv_send_msg}
         if file_name:
@@ -657,7 +672,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                 group_openid=kwargs["group_openid"],
             )
         else:
-            return None
+            raise ValueError("Invalid upload parameters")
 
         @_qqofficial_retry()
         async def _do_upload():
@@ -669,25 +684,29 @@ class QQOfficialMessageEvent(AstrMessageEvent):
 
         try:
             result = await _do_upload()
-
-            if result:
-                if not isinstance(result, dict):
-                    logger.error(f"上传文件响应格式错误: {result}")
-                    return None
-
-                return Media(
-                    file_uuid=result["file_uuid"],
-                    file_info=result["file_info"],
-                    ttl=result.get("ttl", 0),
-                )
         except APIReturnNoneError:
-            logger.warning(f"上传文件API返回None，共尝试5次后放弃: {file_source}")
+            logger.warning(
+                "Media upload API returned None after 5 attempts: %s",
+                file_source,
+            )
+            raise
         except (botpy.errors.ServerError, botpy.errors.SequenceNumberError):
-            logger.error(f"上传媒体文件失败，共尝试5次后放弃: {file_source}")
-        except Exception as e:
-            logger.error(f"上传请求错误: {e}")
+            logger.error("Media upload failed after 5 attempts: %s", file_source)
+            raise
+        except Exception as exc:
+            logger.error("Media upload request failed: %s", exc)
+            raise
 
-        return None
+        if not isinstance(result, dict):
+            raise RuntimeError(
+                f"Failed to upload media, response is not dict: {result}"
+            )
+
+        return Media(
+            file_uuid=result["file_uuid"],
+            file_info=result["file_info"],
+            ttl=result.get("ttl", 0),
+        )
 
     async def post_c2c_message(
         self,

--- a/astrbot/core/tools/message_tools.py
+++ b/astrbot/core/tools/message_tools.py
@@ -335,7 +335,15 @@ class SendMessageToUserTool(FunctionTool[AstrAgentContext]):
                 return f"error: invalid session: {session}"
 
         message_chain = MessageChain(chain=components)
-        await context.context.context.send_message(target_session, message_chain)
+        try:
+            sent = await context.context.context.send_message(
+                target_session,
+                message_chain,
+            )
+        except Exception as exc:
+            return f"error: failed to send message to session {target_session}: {exc}"
+        if not sent:
+            return f"error: failed to find platform for session {target_session}."
         if str(target_session) == current_session:
             context.context.event._has_send_oper = True
             sent_plain_text = message_chain.get_plain_text().strip()

--- a/tests/test_qqofficial_group_message_create.py
+++ b/tests/test_qqofficial_group_message_create.py
@@ -26,6 +26,9 @@ from astrbot.core.platform.sources.qqofficial.qqofficial_platform_adapter import
 from astrbot.core.platform.sources.qqofficial.qqofficial_platform_adapter import (
     botClient as QQOfficialBotClient,
 )
+from astrbot.core.platform.sources.qqofficial.qqofficial_message_event import (
+    QQOfficialMessageEvent,
+)
 from astrbot.core.platform.sources.qqofficial_webhook.qo_webhook_adapter import (
     QQOfficialWebhookPlatformAdapter,
 )
@@ -305,6 +308,31 @@ async def test_ws_group_send_by_session_with_cached_msg_id_still_omits_msg_id():
     assert kwargs["content"] == "proactive with cache"
     assert "msg_id" not in kwargs
     assert "msg_seq" in kwargs
+
+
+@pytest.mark.asyncio
+async def test_media_upload_propagates_qq_api_error(monkeypatch):
+    """QQ upload errors propagate so callers cannot report a false success."""
+    request = AsyncMock(
+        side_effect=botpy.errors.ServerError("413 Request Entity Too Large")
+    )
+    send_helper = SimpleNamespace(
+        bot=SimpleNamespace(
+            api=SimpleNamespace(_http=SimpleNamespace(request=request))
+        )
+    )
+    monkeypatch.setattr(
+        "astrbot.core.platform.sources.qqofficial.qqofficial_message_event._qqofficial_retry",
+        lambda *args, **kwargs: lambda func: func,
+    )
+
+    with pytest.raises(botpy.errors.ServerError, match="413 Request Entity Too Large"):
+        await QQOfficialMessageEvent.upload_group_and_c2c_media(
+            send_helper,
+            "https://example.com/large.bin",
+            QQOfficialMessageEvent.FILE_FILE_TYPE,
+            group_openid="group-1",
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_message_tools.py
+++ b/tests/unit/test_message_tools.py
@@ -154,6 +154,27 @@ async def test_send_message_defaults_to_current_session():
 
 
 @pytest.mark.asyncio
+async def test_send_message_returns_platform_error_to_tool_result():
+    """Platform send failures are returned to the agent as tool errors."""
+    tool = SendMessageToUserTool()
+    ctx = _make_context(current_session="qq_official:GroupMessage:group-1")
+    ctx.context.context.send_message.side_effect = RuntimeError(
+        "413 Request Entity Too Large"
+    )
+
+    result = await tool.call(
+        ctx,
+        messages=[{"type": "plain", "text": "hello"}],
+    )
+
+    assert result == (
+        "error: failed to send message to session "
+        "qq_official:GroupMessage:group-1: 413 Request Entity Too Large"
+    )
+    assert ctx.context.event._has_send_oper is False
+
+
+@pytest.mark.asyncio
 async def test_send_message_other_session_does_not_record_current_text():
     """Messages sent to another session do not affect current-session dedupe."""
     tool = SendMessageToUserTool()


### PR DESCRIPTION
## Summary

- propagate QQ Official media upload errors after retries instead of returning `None`
- return platform send failures as `error:` results from `send_message_to_user`
- avoid marking failed sends as delivered
- add regression coverage for QQ HTTP 413 failures

## Root cause

`upload_group_and_c2c_media` logged exhausted upload retries and returned `None`. The send path then continued without an exception, so `send_message_to_user` unconditionally reported that the message had been sent.

## Impact

When QQ rejects a media upload, including `413 Request Entity Too Large`, the tool now receives an actionable error result instead of a false success response.

## Validation

- `uv run pytest -q tests/unit/test_message_tools.py tests/test_qqofficial_group_message_create.py` (29 passed)
- `uv run ruff format .`
- `uv run ruff check .`

## Summary by Sourcery

Ensure QQ media upload and message sending failures surface as errors instead of false successes.

Bug Fixes:
- Propagate QQ Official media upload failures by raising errors instead of returning None and silently continuing.
- Return platform send failures from the send-message tool as error results and avoid marking unsuccessful sends as delivered.

Enhancements:
- Clarify QQ media upload behavior with a more explicit API contract and stricter response validation.

Tests:
- Add regression tests to verify QQ media upload errors (including HTTP 413) are propagated to callers.
- Add tests to ensure send-message tool surfaces platform errors and does not record failed sends as successful operations.