### PR TITLE
fix: adapt provider icons to dark mode

### DIFF
--- a/dashboard/src/components/provider/AddNewProvider.vue
+++ b/dashboard/src/components/provider/AddNewProvider.vue
@@ -233,10 +233,6 @@ export default {
     object-fit: contain;
 }
 
-:global(.v-theme--PurpleThemeDark .provider-icon--monochrome) {
-    filter: brightness(0) invert(1);
-}
-
 .provider-logo-fallback {
     width: 50px;
     height: 50px;

--- a/dashboard/src/components/provider/AddNewProvider.vue
+++ b/dashboard/src/components/provider/AddNewProvider.vue
@@ -45,7 +45,11 @@
                                         </div>
                                         <div class="provider-card-logo">
                                             <img :src="getProviderIcon(template.provider)"
-                                                v-if="getProviderIcon(template.provider)" class="provider-logo-img">
+                                                v-if="getProviderIcon(template.provider)"
+                                                :class="[
+                                                    'provider-logo-img',
+                                                    { 'provider-icon--monochrome': isMonochromeProviderIcon(template.provider) }
+                                                ]">
                                             <div v-else class="provider-logo-fallback">
                                                 {{ name[0].toUpperCase() }}
                                             </div>
@@ -72,7 +76,7 @@
 
 <script>
 import { useModuleI18n } from '@/i18n/composables';
-import { getProviderIcon, getProviderDescription } from '@/utils/providerUtils';
+import { getProviderIcon, getProviderDescription, isMonochromeProviderIcon } from '@/utils/providerUtils';
 
 const AVAILABLE_PROVIDER_TABS = ['agent_runner', 'speech_to_text', 'text_to_speech', 'embedding', 'rerank'];
 
@@ -151,6 +155,7 @@ export default {
 
         // 从工具函数导入
         getProviderIcon,
+        isMonochromeProviderIcon,
 
         // 获取提供商简介
         getProviderDescription(template, name) {
@@ -226,6 +231,10 @@ export default {
     height: 60px;
     opacity: 0.6;
     object-fit: contain;
+}
+
+:global(.v-theme--PurpleThemeDark .provider-icon--monochrome) {
+    filter: brightness(0) invert(1);
 }
 
 .provider-logo-fallback {

--- a/dashboard/src/components/provider/ProviderChatCompletionPanel.vue
+++ b/dashboard/src/components/provider/ProviderChatCompletionPanel.vue
@@ -11,6 +11,7 @@
           :available-source-types="availableSourceTypes"
           :tm="tm"
           :resolve-source-icon="resolveSourceIcon"
+          :is-monochrome-source-icon="isMonochromeSourceIcon"
           :get-source-display-name="getSourceDisplayName"
           @add-provider-source="addProviderSource"
           @select-provider-source="selectProviderSource"
@@ -230,6 +231,7 @@ const {
   advancedSourceConfig,
   manualProviderId,
   resolveSourceIcon,
+  isMonochromeSourceIcon,
   getSourceDisplayName,
   supportsImageInput,
   supportsAudioInput,

--- a/dashboard/src/components/provider/ProviderSourcesPanel.vue
+++ b/dashboard/src/components/provider/ProviderSourcesPanel.vue
@@ -346,10 +346,6 @@ const selectSourceByValue = (value) => {
   background: transparent !important;
 }
 
-:global(.v-theme--PurpleThemeDark .provider-icon--monochrome) {
-  filter: brightness(0) invert(1);
-}
-
 .provider-source-item__content {
   min-width: 0;
   flex: 1;

--- a/dashboard/src/components/provider/ProviderSourcesPanel.vue
+++ b/dashboard/src/components/provider/ProviderSourcesPanel.vue
@@ -25,6 +25,7 @@
                   <v-img
                     v-if="item.raw.source?.provider"
                     :src="resolveSourceIcon(item.raw.source)"
+                    :class="{ 'provider-icon--monochrome': isMonochromeSourceIcon(item.raw.source) }"
                     alt="provider logo"
                     cover
                   ></v-img>
@@ -44,6 +45,7 @@
                     <v-img
                       v-if="item.raw.source?.provider"
                       :src="resolveSourceIcon(item.raw.source)"
+                      :class="{ 'provider-icon--monochrome': isMonochromeSourceIcon(item.raw.source) }"
                       alt="provider logo"
                       cover
                     ></v-img>
@@ -92,6 +94,7 @@
                 <v-img
                   v-if="sourceType.icon"
                   :src="sourceType.icon"
+                  :class="{ 'provider-icon--monochrome': sourceType.isMonochrome }"
                   alt="provider icon"
                   cover
                 ></v-img>
@@ -121,6 +124,7 @@
           <v-img
             v-if="source?.provider"
             :src="resolveSourceIcon(source)"
+            :class="{ 'provider-icon--monochrome': isMonochromeSourceIcon(source) }"
             alt="provider logo"
             cover
           ></v-img>
@@ -179,6 +183,10 @@ const props = defineProps({
     required: true
   },
   resolveSourceIcon: {
+    type: Function,
+    required: true
+  },
+  isMonochromeSourceIcon: {
     type: Function,
     required: true
   },
@@ -336,6 +344,10 @@ const selectSourceByValue = (value) => {
 
 .provider-source-avatar {
   background: transparent !important;
+}
+
+:global(.v-theme--PurpleThemeDark .provider-icon--monochrome) {
+  filter: brightness(0) invert(1);
 }
 
 .provider-source-item__content {

--- a/dashboard/src/components/shared/ItemCard.vue
+++ b/dashboard/src/components/shared/ItemCard.vue
@@ -63,6 +63,7 @@
     <div class="d-flex justify-end align-center" style="position: absolute; bottom: 16px; right: 16px; opacity: 0.2;" v-if="bglogo">
       <v-img
         :src="bglogo"
+        :class="{ 'provider-icon--monochrome': bglogoMonochrome }"
         contain
         width="120"
         height="120"
@@ -96,6 +97,10 @@ export default {
     bglogo: {
       type: String,
       default: null
+    },
+    bglogoMonochrome: {
+      type: Boolean,
+      default: false
     },
     loading: {
       type: Boolean,
@@ -169,5 +174,9 @@ export default {
 
 .item-status-indicator.active {
   background-color: #4caf50;
+}
+
+:global(.v-theme--PurpleThemeDark .provider-icon--monochrome) {
+  filter: brightness(0) invert(1);
 }
 </style>

--- a/dashboard/src/components/shared/ItemCard.vue
+++ b/dashboard/src/components/shared/ItemCard.vue
@@ -176,7 +176,4 @@ export default {
   background-color: #4caf50;
 }
 
-:global(.v-theme--PurpleThemeDark .provider-icon--monochrome) {
-  filter: brightness(0) invert(1);
-}
 </style>

--- a/dashboard/src/composables/useProviderSources.ts
+++ b/dashboard/src/composables/useProviderSources.ts
@@ -10,6 +10,17 @@ export interface UseProviderSourcesOptions {
   showMessage: (message: string, color?: string) => void
 }
 
+interface ProviderSourceType {
+  value: string
+  label: string
+  icon: string
+  isMonochrome: boolean
+}
+
+interface ProviderIconSource {
+  provider?: string
+}
+
 export function resolveDefaultTab(value?: string) {
   const normalized = (value || '').toLowerCase()
 
@@ -84,7 +95,7 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
       return []
     }
 
-    const types: Array<{ value: string; label: string; icon: string; isMonochrome: boolean }> = []
+    const types: ProviderSourceType[] = []
     for (const [templateName, template] of Object.entries(providerTemplates.value)) {
       if (template.provider_type === selectedProviderType.value) {
         types.push({
@@ -292,13 +303,13 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
     return type.includes(providerType)
   }
 
-  function resolveSourceIcon(source: any) {
+  function resolveSourceIcon(source: ProviderIconSource | null | undefined) {
     if (!source) return ''
-    return getProviderIcon(source.provider) || ''
+    return getProviderIcon(source.provider || '') || ''
   }
 
-  function isMonochromeSourceIcon(source: any) {
-    return Boolean(source && isMonochromeProviderIcon(source.provider))
+  function isMonochromeSourceIcon(source: ProviderIconSource | null | undefined) {
+    return Boolean(source && isMonochromeProviderIcon(source.provider || ''))
   }
 
   function getSourceDisplayName(source: any) {

--- a/dashboard/src/composables/useProviderSources.ts
+++ b/dashboard/src/composables/useProviderSources.ts
@@ -1,6 +1,6 @@
 import { ref, computed, onMounted, nextTick, watch } from 'vue'
 import { providerApi } from '@/api/v1'
-import { getProviderIcon } from '@/utils/providerUtils'
+import { getProviderIcon, isMonochromeProviderIcon } from '@/utils/providerUtils'
 import { askForConfirmation as askForConfirmationDialog, useConfirmDialog } from '@/utils/confirmDialog'
 import { normalizeTextInput } from '@/utils/inputValue'
 
@@ -84,13 +84,14 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
       return []
     }
 
-    const types: Array<{ value: string; label: string; icon: string }> = []
+    const types: Array<{ value: string; label: string; icon: string; isMonochrome: boolean }> = []
     for (const [templateName, template] of Object.entries(providerTemplates.value)) {
       if (template.provider_type === selectedProviderType.value) {
         types.push({
           value: templateName,
           label: templateName,
-          icon: getProviderIcon(template.provider)
+          icon: getProviderIcon(template.provider),
+          isMonochrome: isMonochromeProviderIcon(template.provider)
         })
       }
     }
@@ -294,6 +295,10 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
   function resolveSourceIcon(source: any) {
     if (!source) return ''
     return getProviderIcon(source.provider) || ''
+  }
+
+  function isMonochromeSourceIcon(source: any) {
+    return Boolean(source && isMonochromeProviderIcon(source.provider))
   }
 
   function getSourceDisplayName(source: any) {
@@ -767,6 +772,7 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
 
     // helpers
     resolveSourceIcon,
+    isMonochromeSourceIcon,
     getSourceDisplayName,
     getModelMetadata,
     supportsImageInput,

--- a/dashboard/src/scss/_override.scss
+++ b/dashboard/src/scss/_override.scss
@@ -130,3 +130,7 @@ pre, code, .markdown pre, .markdown code, .release-notes pre, .release-notes cod
     color: rgb(var(--v-theme-primary));
   }
 }
+
+.v-theme--PurpleThemeDark .provider-icon--monochrome {
+  filter: brightness(0) invert(1);
+}

--- a/dashboard/src/utils/providerUtils.js
+++ b/dashboard/src/utils/providerUtils.js
@@ -54,6 +54,40 @@ export function getProviderIcon(type) {
 }
 
 /**
+ * Determine whether a provider icon is a monochrome SVG.
+ *
+ * These icons need to be inverted in the dark theme because they are loaded as
+ * external images and cannot inherit the page text color.
+ *
+ * @param {string} type - Provider type
+ * @returns {boolean} Whether the icon should be theme-inverted
+ */
+export function isMonochromeProviderIcon(type) {
+  return [
+    'openai',
+    'azure',
+    'xai',
+    'anthropic',
+    'ollama',
+    'deepseek',
+    'modelscope',
+    'zhipu',
+    'siliconflow',
+    'moonshot',
+    'kimi',
+    'kimi-code',
+    'ppio',
+    'lm_studio',
+    'minimax',
+    'minimax-token-plan',
+    'mimo',
+    'xiaomi',
+    'xiaomi-token-plan',
+    'openrouter'
+  ].includes(type);
+}
+
+/**
  * 获取提供商简介
  * @param {Object} template - 模板对象
  * @param {string} name - 提供商名称

--- a/dashboard/src/views/ProviderPage.vue
+++ b/dashboard/src/views/ProviderPage.vue
@@ -45,6 +45,7 @@
               :available-source-types="availableSourceTypes"
               :tm="tm"
               :resolve-source-icon="resolveSourceIcon"
+              :is-monochrome-source-icon="isMonochromeSourceIcon"
               :get-source-display-name="getSourceDisplayName"
               @add-provider-source="addProviderSource"
               @select-provider-source="selectProviderSource"
@@ -159,6 +160,7 @@
                 enabled-field="enable"
                 :loading="isProviderTesting(provider.id)"
                 :bglogo="getProviderIcon(provider.provider)"
+                :bglogo-monochrome="isMonochromeProviderIcon(provider.provider)"
                 :show-copy-button="true"
                 @toggle-enabled="toggleProviderEnable(provider, !provider.enable)"
                 @delete="deleteProvider"
@@ -350,7 +352,7 @@ import ProviderModelsPanel from '@/components/provider/ProviderModelsPanel.vue'
 import ProviderSourcesPanel from '@/components/provider/ProviderSourcesPanel.vue'
 import { useProviderModelConfigDialog } from '@/composables/useProviderModelConfigDialog'
 import { useProviderSources } from '@/composables/useProviderSources'
-import { getProviderIcon } from '@/utils/providerUtils'
+import { getProviderIcon, isMonochromeProviderIcon } from '@/utils/providerUtils'
 
 const props = defineProps({
   defaultTab: {
@@ -394,6 +396,7 @@ const {
   advancedSourceConfig,
   manualProviderId,
   resolveSourceIcon,
+  isMonochromeSourceIcon,
   getSourceDisplayName,
   supportsImageInput,
   supportsAudioInput,


### PR DESCRIPTION
Fixes #9645.

Provider icons rendered as external SVG images cannot inherit the dashboard's
theme color. This made monochrome provider icons hard to see in dark mode.

### Modifications / 改动点

- Added a provider icon classification for icons that require dark-mode inversion.
- Applied the inversion only to classified provider icons in the provider source
  list, add-provider dialog, and provider cards.
- Kept color provider icons unchanged.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

<img width="592" height="1202" alt="image" src="https://github.com/user-attachments/assets/45974529-9d34-4d87-8ff3-f47a06ab1696" />

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Improve dark-mode support for monochrome provider icons across the dashboard.

New Features:
- Classify provider icons that require dark-mode inversion via a dedicated utility helper.

Enhancements:
- Apply conditional inversion styling to monochrome provider icons in add-provider dialogs, provider source lists, and provider cards without affecting colored icons.
- Propagate monochrome icon metadata through provider source composables and shared card components for consistent theming behavior in dark mode.