### PR TITLE
feat: log effective Windows local runtime shell

### DIFF
--- a/astrbot/core/computer/computer_client.py
+++ b/astrbot/core/computer/computer_client.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import shutil
+import sys
 import time
 import uuid
 from dataclasses import dataclass
@@ -16,7 +17,7 @@ from astrbot.core.utils.astrbot_path import (
 )
 
 from .booters.base import ComputerBooter
-from .booters.local import LocalBooter
+from .booters.local import LocalBooter, resolve_windows_shell
 
 session_booter: dict[str, ComputerBooter] = {}
 local_booter: ComputerBooter | None = None
@@ -688,6 +689,11 @@ def get_local_booter() -> ComputerBooter:
     global local_booter
     if local_booter is None:
         local_booter = LocalBooter()
+        if sys.platform == "win32":
+            logger.info(
+                "[Computer] Windows local runtime shell: %s",
+                resolve_windows_shell(),
+            )
     return local_booter
 
 

--- a/tests/unit/test_computer.py
+++ b/tests/unit/test_computer.py
@@ -507,6 +507,60 @@ class TestComputerClient:
         # Reset for other tests
         computer_client.local_booter = None
 
+    @pytest.mark.parametrize("shell_executable", ["pwsh.exe", "powershell.exe"])
+    def test_get_local_booter_logs_windows_shell_once(
+        self,
+        monkeypatch,
+        shell_executable,
+    ):
+        """Test Windows effective shell is logged once per local booter."""
+        from astrbot.core.computer import computer_client
+
+        mock_logger = MagicMock()
+        mock_resolver = MagicMock(return_value=shell_executable)
+        monkeypatch.setattr(computer_client, "local_booter", None)
+        monkeypatch.setattr(computer_client.sys, "platform", "win32")
+        monkeypatch.setattr(computer_client, "logger", mock_logger)
+        monkeypatch.setattr(
+            computer_client,
+            "resolve_windows_shell",
+            mock_resolver,
+        )
+
+        booter1 = computer_client.get_local_booter()
+        booter2 = computer_client.get_local_booter()
+
+        assert booter1 is booter2
+        mock_resolver.assert_called_once_with()
+        mock_logger.info.assert_called_once_with(
+            "[Computer] Windows local runtime shell: %s",
+            shell_executable,
+        )
+
+    def test_get_local_booter_skips_windows_shell_log_outside_windows(
+        self,
+        monkeypatch,
+    ):
+        """Test non-Windows local booters skip Windows shell resolution logs."""
+        from astrbot.core.computer import computer_client
+
+        mock_logger = MagicMock()
+        mock_resolver = MagicMock()
+        monkeypatch.setattr(computer_client, "local_booter", None)
+        monkeypatch.setattr(computer_client.sys, "platform", "linux")
+        monkeypatch.setattr(computer_client, "logger", mock_logger)
+        monkeypatch.setattr(
+            computer_client,
+            "resolve_windows_shell",
+            mock_resolver,
+        )
+
+        booter = computer_client.get_local_booter()
+
+        assert isinstance(booter, LocalBooter)
+        mock_resolver.assert_not_called()
+        mock_logger.info.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_shutdown_local_booter_clears_singleton(self):
         """Test local managed resources are released during lifecycle shutdown."""

--- a/tests/unit/test_computer.py
+++ b/tests/unit/test_computer.py
@@ -507,60 +507,6 @@ class TestComputerClient:
         # Reset for other tests
         computer_client.local_booter = None
 
-    @pytest.mark.parametrize("shell_executable", ["pwsh.exe", "powershell.exe"])
-    def test_get_local_booter_logs_windows_shell_once(
-        self,
-        monkeypatch,
-        shell_executable,
-    ):
-        """Test Windows effective shell is logged once per local booter."""
-        from astrbot.core.computer import computer_client
-
-        mock_logger = MagicMock()
-        mock_resolver = MagicMock(return_value=shell_executable)
-        monkeypatch.setattr(computer_client, "local_booter", None)
-        monkeypatch.setattr(computer_client.sys, "platform", "win32")
-        monkeypatch.setattr(computer_client, "logger", mock_logger)
-        monkeypatch.setattr(
-            computer_client,
-            "resolve_windows_shell",
-            mock_resolver,
-        )
-
-        booter1 = computer_client.get_local_booter()
-        booter2 = computer_client.get_local_booter()
-
-        assert booter1 is booter2
-        mock_resolver.assert_called_once_with()
-        mock_logger.info.assert_called_once_with(
-            "[Computer] Windows local runtime shell: %s",
-            shell_executable,
-        )
-
-    def test_get_local_booter_skips_windows_shell_log_outside_windows(
-        self,
-        monkeypatch,
-    ):
-        """Test non-Windows local booters skip Windows shell resolution logs."""
-        from astrbot.core.computer import computer_client
-
-        mock_logger = MagicMock()
-        mock_resolver = MagicMock()
-        monkeypatch.setattr(computer_client, "local_booter", None)
-        monkeypatch.setattr(computer_client.sys, "platform", "linux")
-        monkeypatch.setattr(computer_client, "logger", mock_logger)
-        monkeypatch.setattr(
-            computer_client,
-            "resolve_windows_shell",
-            mock_resolver,
-        )
-
-        booter = computer_client.get_local_booter()
-
-        assert isinstance(booter, LocalBooter)
-        mock_resolver.assert_not_called()
-        mock_logger.info.assert_not_called()
-
     @pytest.mark.asyncio
     async def test_shutdown_local_booter_clears_singleton(self):
         """Test local managed resources are released during lifecycle shutdown."""


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### TL;DR
- Log effective Windows shell once when LocalBooter is created
- No behavior change to pwsh/powershell selection
- Tests + Win E2E for both branches

### Background

Fixes #9642

PR #9622 introduced automatic Windows shell selection for the Local Runtime, preferring PowerShell 7 (`pwsh.exe`) when available and falling back to Windows PowerShell 5.1 (`powershell.exe`) otherwise.

While this removes the need for an additional configuration option, the selected shell is not directly visible to users. In environments where `PATH` differs between the process launching AstrBot and an interactive terminal—for example, when AstrBot is started by a launcher—the runtime may unexpectedly fall back to Windows PowerShell 5.1 even though `pwsh.exe` is installed and available elsewhere.

Without any indication of the effective shell, this is typically only discovered later when a PowerShell 7-specific command or syntax fails.

This PR addresses that observability gap by logging the shell selected by the Windows Local Runtime.

---

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

This PR adds observability for the effective shell selected by the automatic shell detection introduced for the Windows Local Runtime in PR #9622.

#### When the Local Runtime singleton is first created, it logs the selected PowerShell executable using the existing Windows shell resolution logic:

- When PowerShell 7 is available, `pwsh.exe` is logged;
- When PowerShell 7 is unavailable and the runtime falls back to Windows PowerShell 5.1, `powershell.exe` is logged;
- The log is emitted only once when the Local Runtime singleton is first created and is not repeated on subsequent Shell Tool calls;
- The existing shell resolution logic from #9622 is reused without changing the current PowerShell 7 preference or Windows PowerShell 5.1 fallback behavior.

**Example:**

```text
[Computer] Windows local runtime shell: pwsh.exe
```

**Or:**

```text
[Computer] Windows local runtime shell: powershell.exe
```

Unit tests are also added to cover:

- Logging `pwsh.exe` when the Windows shell resolver returns it;
- Logging `powershell.exe` when the Windows shell resolver returns the fallback;
- Avoiding Windows shell resolution and the corresponding log on non-Windows platforms;
- Ensuring repeated retrieval of the same Local Runtime singleton does not resolve or log the shell again.

- [X] This is NOT a breaking change. / 这不是一个破坏性变更。

<!-- If your changes is a breaking change, please uncheck the checkbox above -->

---

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

This PR does not include any UI changes, so no screenshots are provided. The following sections show the actual runtime logs and automated test results.

#### Test Environment

- Windows 11 Home 64-bit
- DisplayVersion: 25H2
- Build: `26200.9168`
- Python: `3.14.0`
- PowerShell 7: `7.6.4`

---

#### Windows End-to-End Verification: PowerShell 7 Available

When `pwsh.exe` can be resolved from `PATH`, the Local Runtime correctly logs:

```text
[Computer] Windows local runtime shell: pwsh.exe
```

The Agent was then asked in the conversation to execute:

```powershell
$PSVersionTable.PSVersion.ToString()
```

Output:

```text
7.6.4
```

The Agent was subsequently asked to verify PowerShell 7-specific features such as the ternary operator, `??`, and `$IsWindows`, all of which executed successfully.

It was also verified that repeated Shell Tool calls do not emit the effective shell log again, as expected since it is logged only once per singleton lifecycle.

---

#### Windows End-to-End Verification: Fallback When PowerShell 7 Is Unavailable

After temporarily removing PowerShell 7 from the current process's `PATH` and restarting AstrBot, the Local Runtime correctly falls back and logs:

```text
[Computer] Windows local runtime shell: powershell.exe
```

The Agent was then asked in the conversation to execute:

```powershell
$PSVersionTable.PSVersion.ToString()
```

Output:

```text
5.1.26100.8972
```

PowerShell 7-specific syntax was also verified to be unavailable in this environment, confirming that the actual shell being executed was Windows PowerShell 5.1.

A subsequent Shell Tool call likewise did not emit the effective shell log again.

---

#### Automated Tests

New #9642 logging tests:

```text
3 passed
```

Regression tests related to #9642 and #9622:

```text
13 passed
```

Formatting and static checks:

```text
uv run ruff format --check .
500 files already formatted

uv run ruff check .
All checks passed!

git diff --check
No whitespace errors
```

Five pre-existing failures were observed when running a broader set of related tests on Windows. The same five failures were reproduced unchanged in an independent detached worktree using the unmodified baseline commit `5e40eb4b522ea8cbe30ddbc2e3bff8ca18c7b166`, confirming that they are not regressions introduced by this PR.

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->


- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Log the effective Windows shell used by the local runtime when the LocalBooter singleton is first created, and ensure this behavior is covered by unit tests.

New Features:
- Add a one-time informational log indicating the resolved Windows PowerShell executable for the Windows local runtime.

Tests:
- Add unit tests verifying the Windows shell is logged once per LocalBooter singleton on Windows and skipped on non-Windows platforms.

## Summary by Sourcery

Log the effective Windows shell used by the local runtime when the LocalBooter singleton is first created.

New Features:
- Emit a one-time informational log indicating the resolved Windows PowerShell executable for the Windows local runtime on Windows platforms.

Tests:
- Add unit tests ensuring the Windows shell is logged once per LocalBooter singleton on Windows and that shell resolution/logging is skipped on non-Windows platforms.