### PR TITLE
chore: bump version to 4.27.3

### DIFF
--- a/astrbot/__init__.py
+++ b/astrbot/__init__.py
@@ -1,4 +1,4 @@
 import logging
 
-__version__ = "4.27.2"
+__version__ = "4.27.3"
 logger = logging.getLogger("astrbot")

--- a/changelogs/v4.27.3.md
+++ b/changelogs/v4.27.3.md
@@ -1,6 +1,8 @@
 ## [4.27.3] - 2026-08-13
 
-**E quindi uscimmo a riveder le stelle. 我们从那儿走出去，重新见到了群星。**
+E quindi uscimmo a riveder le stelle. 
+
+我们从那儿走出去，重新见到了群星。
 
 ### Added
 
@@ -28,10 +30,6 @@
 - Used static thumbnails for animated Telegram stickers and converted Telegram video notes into video components. (#9610, #9627)
 - Propagated QQ media upload failures instead of silently continuing. (#9644)
 
-### Documentation
-
-- Completed the RainYun deployment guide and refreshed the README.
-
 ### Maintenance
 
 - Updated grouped GitHub Actions dependencies, improved pipeline scheduler typing, and stabilized OpenAI HTTP client tests. (#9620, #9621)
@@ -41,20 +39,15 @@
 ### 新增
 
 - AstrBot 桌面端实行免登录机制，无需登录即可直接进入 WebUI。 (#9585)
-- 在设置中展示 AstrBot 的实际生效时间，并使定时任务继承已配置的时区。 (#9579, #9581)
+- Windows 本地 Shell 新增 PowerShell 7 支持。 (#9622)
+- QQ 官方机器人新增分片文件上传，修复大文件无法正常发送的问题。 (#9646)
 - 将 WebChat 拖放上传区域扩展至整个聊天区域。 (#9564)
 - 新增一键恢复插件配置默认值的功能。 (#9599)
-- Windows 本地 Shell 新增 PowerShell 7 支持。 (#9622)
+- 在设置中展示 AstrBot 的实际生效时间，并使定时任务继承已配置的时区。 (#9579, #9581)
 - 插件市场新增按下载量排序。 (#9570)
-- QQ 官方机器人新增分片文件上传，更可靠地支持大文件。 (#9646)
-
-### 变更
-
-- 将 SharedPreferences 与配置偏好访问迁移到异步、非阻塞路径，提升相关流程的部分性能，并减少潜在假死和死锁情况。 (#9582, #9584, #9649)
 - 使用 favicon 作为插件默认图标，并改善深色主题的文字对比度。 (#9547, #9643)
 
-### 修复
-
+- **提升了一部分性能，减少潜在假死和死锁情况**（将 SharedPreferences 与配置偏好访问迁移到异步、非阻塞路径）。 (#9582, #9584, #9649)
 - 稳定知识库文档搜索，区分加载失败与空结果，恢复完整检索结果，并在按名称查找知识库时支持 UUID 回退。 (#9577, #9578, #9618, #9636)
 - 删除提供商配置后刷新内存状态，并同步 Dashboard 中的插件 Skill 状态。 (#9568, #9596)
 - 防止临时项目会话出现在 ChatUI 会话列表中，并恢复缺失的 WebChat 会话。 (#9587, #9607)
@@ -63,10 +56,6 @@
 - 在发布统计前记录 Agent 结束时间，并立即取消已停止的 Agent 运行。 (#9597, #9602)
 - Telegram 动态贴纸改用静态缩略图，并将 Telegram 视频留言转换为视频组件。 (#9610, #9627)
 - QQ 媒体上传失败时正确向上传递错误，不再静默继续。 (#9644)
-
-### 文档
-
-- 完善雨云部署指南并更新 README。
 
 ### 维护
 

--- a/changelogs/v4.27.3.md
+++ b/changelogs/v4.27.3.md
@@ -1,0 +1,75 @@
+## [4.27.3] - 2026-08-13
+
+**E quindi uscimmo a riveder le stelle. 我们从那儿走出去，重新见到了群星。**
+
+### Added
+
+- AstrBot Desktop now uses passwordless sessions and opens the WebUI directly without requiring a login. (#9585)
+- Added the effective AstrBot time to settings and made cron jobs inherit the configured timezone. (#9579, #9581)
+- Expanded WebChat drag-and-drop uploads to the whole chat area. (#9564)
+- Added a one-click option to restore plugin configuration defaults. (#9599)
+- Added PowerShell 7 support for the Windows local shell. (#9622)
+- Added download-count sorting to the plugin marketplace. (#9570)
+- Added chunked file uploads for QQ Official to support large files more reliably. (#9646)
+
+### Changed
+
+- Migrated SharedPreferences and configuration preference access to asynchronous, non-blocking paths, improving performance in affected flows and reducing the risk of apparent freezes and deadlocks. (#9582, #9584, #9649)
+- Used favicons as the default plugin icon and improved dark-theme text contrast. (#9547, #9643)
+
+### Fixed
+
+- Stabilized knowledge base document search, distinguished loading failures from empty results, restored complete retrieval results, and supported UUID fallback when resolving knowledge bases by name. (#9577, #9578, #9618, #9636)
+- Refreshed in-memory provider configuration after deletion and synchronized plugin Skill state across the Dashboard. (#9568, #9596)
+- Prevented transient project sessions from appearing in ChatUI and restored missing WebChat sessions. (#9587, #9607)
+- Sanitized MCP tool names for LLM APIs and treated empty configuration schemas as having no configurable items. (#9534, #9619)
+- Warned when an explicitly configured WebUI distribution is stale. (#9518)
+- Recorded agent end times before publishing statistics and cancelled stopped agent runs immediately. (#9597, #9602)
+- Used static thumbnails for animated Telegram stickers and converted Telegram video notes into video components. (#9610, #9627)
+- Propagated QQ media upload failures instead of silently continuing. (#9644)
+
+### Documentation
+
+- Completed the RainYun deployment guide and refreshed the README.
+
+### Maintenance
+
+- Updated grouped GitHub Actions dependencies, improved pipeline scheduler typing, and stabilized OpenAI HTTP client tests. (#9620, #9621)
+
+## 中文
+
+### 新增
+
+- AstrBot 桌面端实行免登录机制，无需登录即可直接进入 WebUI。 (#9585)
+- 在设置中展示 AstrBot 的实际生效时间，并使定时任务继承已配置的时区。 (#9579, #9581)
+- 将 WebChat 拖放上传区域扩展至整个聊天区域。 (#9564)
+- 新增一键恢复插件配置默认值的功能。 (#9599)
+- Windows 本地 Shell 新增 PowerShell 7 支持。 (#9622)
+- 插件市场新增按下载量排序。 (#9570)
+- QQ 官方机器人新增分片文件上传，更可靠地支持大文件。 (#9646)
+
+### 变更
+
+- 将 SharedPreferences 与配置偏好访问迁移到异步、非阻塞路径，提升相关流程的部分性能，并减少潜在假死和死锁情况。 (#9582, #9584, #9649)
+- 使用 favicon 作为插件默认图标，并改善深色主题的文字对比度。 (#9547, #9643)
+
+### 修复
+
+- 稳定知识库文档搜索，区分加载失败与空结果，恢复完整检索结果，并在按名称查找知识库时支持 UUID 回退。 (#9577, #9578, #9618, #9636)
+- 删除提供商配置后刷新内存状态，并同步 Dashboard 中的插件 Skill 状态。 (#9568, #9596)
+- 防止临时项目会话出现在 ChatUI 会话列表中，并恢复缺失的 WebChat 会话。 (#9587, #9607)
+- 清理发送给 LLM API 的 MCP 工具名称，并将空配置 Schema 正确视为无配置项。 (#9534, #9619)
+- 显式配置的 WebUI 发行文件过期时给出警告。 (#9518)
+- 在发布统计前记录 Agent 结束时间，并立即取消已停止的 Agent 运行。 (#9597, #9602)
+- Telegram 动态贴纸改用静态缩略图，并将 Telegram 视频留言转换为视频组件。 (#9610, #9627)
+- QQ 媒体上传失败时正确向上传递错误，不再静默继续。 (#9644)
+
+### 文档
+
+- 完善雨云部署指南并更新 README。
+
+### 维护
+
+- 更新 GitHub Actions 依赖组，完善流水线调度器类型标注，并稳定 OpenAI HTTP 客户端测试。 (#9620, #9621)
+
+[4.27.3]: https://github.com/AstrBotDevs/AstrBot/compare/v4.27.2...v4.27.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AstrBot"
-version = "4.27.2"
+version = "4.27.3"
 description = "Easy-to-use multi-platform LLM chatbot and development framework"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }


### PR DESCRIPTION
## Summary

- bump the project and package versions to 4.27.3
- add curated bilingual release notes for changes since v4.27.2
- highlight passwordless AstrBot Desktop WebUI access and the SharedPreferences performance/deadlock improvements
- include the new release quote

## User impact

AstrBot Desktop users can enter the WebUI directly without logging in. SharedPreferences access now uses asynchronous, non-blocking paths to improve performance in affected flows and reduce the risk of apparent freezes and deadlocks.

## Validation

- `uv run ruff format --check .`
- `uv run ruff check .`
- `git diff --check`

## Summary by Sourcery

Bump the AstrBot project version to 4.27.3 and add bilingual release notes describing the changes since 4.27.2.

New Features:
- Document passwordless AstrBot Desktop WebUI access and other newly introduced user-facing capabilities in the 4.27.3 changelog.

Bug Fixes:
- Record recent stability and correctness fixes across knowledge base search, session handling, MCP tools, agents, Telegram/QQ integrations, and related flows in the 4.27.3 changelog.

Enhancements:
- Capture performance and UX improvements, including asynchronous SharedPreferences access and visual tweaks, in the 4.27.3 changelog.

CI:
- Note maintenance work on GitHub Actions dependencies, pipeline scheduler typing, and OpenAI HTTP client tests in the 4.27.3 changelog.

Documentation:
- Add curated bilingual (English and Chinese) release notes for 4.27.3, including a new release quote and updated deployment/README documentation.

Chores:
- Update internal version metadata to 4.27.3 in the package and project configuration.