### PR TITLE
fix: verify audio magic bytes before extension-based short-circuit in convert_audio_format

### DIFF
--- a/tests/test_media_utils.py
+++ b/tests/test_media_utils.py
@@ -874,7 +874,9 @@ async def test_wav_to_tencent_silk_skips_resample_for_supported_rate(
 
 
 # ---------------------------------------------------------------------------
-# convert_audio_format: extension vs magic-byte mismatch (issue #9594)
+# convert_audio_format: extension vs magic-byte mismatch (#9594, fixed in #9612)
+# These tests guard the magic-byte verification logic that prevents platforms
+# like NapCat from passing AMR content through with a .wav extension.
 # ---------------------------------------------------------------------------
 
 # Minimal AMR header (magic bytes: #!AMR)
@@ -903,6 +905,7 @@ def _patch_ffmpeg_not_called(monkeypatch, reason: str) -> None:
         monkeypatch: pytest monkeypatch fixture.
         reason: scenario description included in the failure message.
     """
+
     async def fake_exec(*args, **kwargs):
         raise AssertionError(f"ffmpeg should not be called {reason}")
 
@@ -965,14 +968,31 @@ async def test_convert_audio_format_real_wav_with_wav_extension_short_circuits(
 
 
 @pytest.mark.asyncio
-async def test_convert_audio_format_unknown_content_with_matching_ext_short_circuits(
+async def test_convert_audio_format_unknown_content_with_matching_ext_converts(
     tmp_path, monkeypatch
 ):
-    """When magic bytes cannot be identified, fall back to extension matching."""
+    """When magic bytes cannot be identified, proceed with conversion (safer)."""
     audio_file = tmp_path / "voice.wav"
     audio_file.write_bytes(b"\x00" * 64)
 
-    _patch_ffmpeg_not_called(monkeypatch, "for unrecognised content")
+    called = _patch_ffmpeg(monkeypatch, tmp_path, output_content=_make_wav_bytes())
+
+    result = await media_utils.convert_audio_format(str(audio_file), "wav")
+
+    assert called[0], (
+        "ffmpeg should be invoked for unrecognised content (safer to convert)"
+    )
+    assert result != str(audio_file)
+
+
+@pytest.mark.asyncio
+async def test_convert_audio_format_missing_file_with_matching_ext_returns_path(
+    tmp_path, monkeypatch
+):
+    """When the file does not exist yet (e.g. NapCat race), return the path as-is."""
+    audio_file = tmp_path / "voice.wav"  # never created
+
+    _patch_ffmpeg_not_called(monkeypatch, "for a missing file")
 
     result = await media_utils.convert_audio_format(str(audio_file), "wav")
     assert result == str(audio_file)

--- a/tests/test_media_utils.py
+++ b/tests/test_media_utils.py
@@ -896,6 +896,19 @@ class _FakeFFmpegProcess:
         return (b"", b"")
 
 
+def _patch_ffmpeg_not_called(monkeypatch, reason: str) -> None:
+    """Monkeypatch ``asyncio.create_subprocess_exec`` to fail if ffmpeg runs.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture.
+        reason: scenario description included in the failure message.
+    """
+    async def fake_exec(*args, **kwargs):
+        raise AssertionError(f"ffmpeg should not be called {reason}")
+
+    monkeypatch.setattr(media_utils.asyncio, "create_subprocess_exec", fake_exec)
+
+
 def _patch_ffmpeg(monkeypatch, tmp_path, *, output_content: bytes = b""):
     """Monkeypatch ``asyncio.create_subprocess_exec`` to simulate ffmpeg.
 
@@ -945,10 +958,7 @@ async def test_convert_audio_format_real_wav_with_wav_extension_short_circuits(
     audio_file = tmp_path / "voice.wav"
     audio_file.write_bytes(_make_wav_bytes())
 
-    async def fake_exec(*args, **kwargs):
-        raise AssertionError("ffmpeg should not be called for a real WAV file")
-
-    monkeypatch.setattr(media_utils.asyncio, "create_subprocess_exec", fake_exec)
+    _patch_ffmpeg_not_called(monkeypatch, "for a real WAV file")
 
     result = await media_utils.convert_audio_format(str(audio_file), "wav")
     assert result == str(audio_file)
@@ -962,10 +972,7 @@ async def test_convert_audio_format_unknown_content_with_matching_ext_short_circ
     audio_file = tmp_path / "voice.wav"
     audio_file.write_bytes(b"\x00" * 64)
 
-    async def fake_exec(*args, **kwargs):
-        raise AssertionError("ffmpeg should not be called for unrecognised content")
-
-    monkeypatch.setattr(media_utils.asyncio, "create_subprocess_exec", fake_exec)
+    _patch_ffmpeg_not_called(monkeypatch, "for unrecognised content")
 
     result = await media_utils.convert_audio_format(str(audio_file), "wav")
     assert result == str(audio_file)
@@ -979,10 +986,7 @@ async def test_convert_audio_format_real_amr_with_amr_extension_short_circuits(
     audio_file = tmp_path / "voice.amr"
     audio_file.write_bytes(_AMR_HEADER + b"\x00" * 50)
 
-    async def fake_exec(*args, **kwargs):
-        raise AssertionError("ffmpeg should not be called for a real AMR file")
-
-    monkeypatch.setattr(media_utils.asyncio, "create_subprocess_exec", fake_exec)
+    _patch_ffmpeg_not_called(monkeypatch, "for a real AMR file")
 
     result = await media_utils.convert_audio_format(str(audio_file), "amr")
     assert result == str(audio_file)

--- a/tests/test_media_utils.py
+++ b/tests/test_media_utils.py
@@ -871,3 +871,136 @@ async def test_wav_to_tencent_silk_skips_resample_for_supported_rate(
 
     assert len(fake.calls) == 1
     assert fake.calls[0]["sample_rate"] == 24000
+
+
+# ---------------------------------------------------------------------------
+# convert_audio_format: extension vs magic-byte mismatch (issue #9594)
+# ---------------------------------------------------------------------------
+
+# Minimal AMR header (magic bytes: #!AMR)
+_AMR_HEADER = b"#!AMR\n"
+
+
+def _make_wav_bytes() -> bytes:
+    """Build a minimal valid WAV header (RIFF/WAVE)."""
+    return b"RIFF\x24\x00\x00\x00WAVEfmt " + b"\x00" * 16
+
+
+class _FakeFFmpegProcess:
+    """Minimal async subprocess mock for ffmpeg."""
+
+    def __init__(self, returncode: int = 0, stderr: bytes = b"") -> None:
+        self.returncode = returncode
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        return (b"", b"")
+
+
+@pytest.mark.asyncio
+async def test_convert_audio_format_amr_with_wav_extension_does_not_short_circuit(
+    tmp_path, monkeypatch
+):
+    """AMR content saved with a .wav extension must still be converted (#9594)."""
+    # NapCat saves AMR-encoded QQ voice with a .wav extension.
+    audio_file = tmp_path / "voice.wav"
+    audio_file.write_bytes(_AMR_HEADER + b"\x00" * 50)
+
+    # Intercept ffmpeg subprocess so the test never depends on a real binary.
+    ffmpeg_called = False
+
+    async def fake_exec(*args, **kwargs):
+        nonlocal ffmpeg_called
+        ffmpeg_called = True
+        # Write a dummy output file so convert_audio_format can return it.
+        output_path = args[-1]
+        Path(output_path).write_bytes(_make_wav_bytes())
+        return _FakeFFmpegProcess()
+
+    monkeypatch.setattr(media_utils.asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(media_utils, "get_astrbot_temp_path", lambda: str(tmp_path))
+
+    result = await media_utils.convert_audio_format(str(audio_file), "wav")
+
+    assert ffmpeg_called, (
+        "ffmpeg should have been invoked because content is AMR, not WAV"
+    )
+    assert result != str(audio_file)
+
+
+@pytest.mark.asyncio
+async def test_convert_audio_format_real_wav_with_wav_extension_short_circuits(
+    tmp_path, monkeypatch
+):
+    """Genuine WAV content with a .wav extension should skip conversion."""
+    audio_file = tmp_path / "voice.wav"
+    audio_file.write_bytes(_make_wav_bytes())
+
+    async def fake_exec(*args, **kwargs):
+        raise AssertionError("ffmpeg should not be called for a real WAV file")
+
+    monkeypatch.setattr(media_utils.asyncio, "create_subprocess_exec", fake_exec)
+
+    result = await media_utils.convert_audio_format(str(audio_file), "wav")
+    assert result == str(audio_file)
+
+
+@pytest.mark.asyncio
+async def test_convert_audio_format_unknown_content_with_matching_ext_short_circuits(
+    tmp_path, monkeypatch
+):
+    """When magic bytes cannot be identified, fall back to extension matching."""
+    audio_file = tmp_path / "voice.wav"
+    audio_file.write_bytes(b"\x00" * 64)
+
+    async def fake_exec(*args, **kwargs):
+        raise AssertionError("ffmpeg should not be called for unrecognised content")
+
+    monkeypatch.setattr(media_utils.asyncio, "create_subprocess_exec", fake_exec)
+
+    result = await media_utils.convert_audio_format(str(audio_file), "wav")
+    assert result == str(audio_file)
+
+
+@pytest.mark.asyncio
+async def test_convert_audio_format_real_amr_with_amr_extension_short_circuits(
+    tmp_path, monkeypatch
+):
+    """AMR content with a matching .amr extension should skip conversion."""
+    audio_file = tmp_path / "voice.amr"
+    audio_file.write_bytes(_AMR_HEADER + b"\x00" * 50)
+
+    async def fake_exec(*args, **kwargs):
+        raise AssertionError("ffmpeg should not be called for a real AMR file")
+
+    monkeypatch.setattr(media_utils.asyncio, "create_subprocess_exec", fake_exec)
+
+    result = await media_utils.convert_audio_format(str(audio_file), "amr")
+    assert result == str(audio_file)
+
+
+@pytest.mark.asyncio
+async def test_convert_audio_format_wav_with_ogg_extension_does_not_short_circuit(
+    tmp_path, monkeypatch
+):
+    """WAV content saved with a .ogg extension must still be converted."""
+    audio_file = tmp_path / "voice.ogg"
+    audio_file.write_bytes(_make_wav_bytes())
+
+    ffmpeg_called = False
+
+    async def fake_exec(*args, **kwargs):
+        nonlocal ffmpeg_called
+        ffmpeg_called = True
+        output_path = args[-1]
+        Path(output_path).write_bytes(b"OggS" + b"\x00" * 60)
+        return _FakeFFmpegProcess()
+
+    monkeypatch.setattr(media_utils.asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(media_utils, "get_astrbot_temp_path", lambda: str(tmp_path))
+
+    result = await media_utils.convert_audio_format(str(audio_file), "ogg")
+
+    assert ffmpeg_called, (
+        "ffmpeg should have been invoked because content is WAV, not OGG"
+    )
+    assert result != str(audio_file)

--- a/tests/test_media_utils.py
+++ b/tests/test_media_utils.py
@@ -889,11 +889,36 @@ def _make_wav_bytes() -> bytes:
 class _FakeFFmpegProcess:
     """Minimal async subprocess mock for ffmpeg."""
 
-    def __init__(self, returncode: int = 0, stderr: bytes = b"") -> None:
+    def __init__(self, returncode: int = 0) -> None:
         self.returncode = returncode
 
     async def communicate(self) -> tuple[bytes, bytes]:
         return (b"", b"")
+
+
+def _patch_ffmpeg(monkeypatch, tmp_path, *, output_content: bytes = b""):
+    """Monkeypatch ``asyncio.create_subprocess_exec`` to simulate ffmpeg.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture.
+        tmp_path: pytest tmp_path fixture (used for temp dir patching).
+        output_content: Bytes written to the output path so
+            ``convert_audio_format`` can return it.
+
+    Returns:
+        A mutable list whose first element tracks whether ffmpeg was called.
+    """
+    called = [False]
+
+    async def fake_exec(*args, **kwargs):
+        called[0] = True
+        output_path = args[-1]
+        Path(output_path).write_bytes(output_content)
+        return _FakeFFmpegProcess()
+
+    monkeypatch.setattr(media_utils.asyncio, "create_subprocess_exec", fake_exec)
+    monkeypatch.setattr(media_utils, "get_astrbot_temp_path", lambda: str(tmp_path))
+    return called
 
 
 @pytest.mark.asyncio
@@ -901,29 +926,14 @@ async def test_convert_audio_format_amr_with_wav_extension_does_not_short_circui
     tmp_path, monkeypatch
 ):
     """AMR content saved with a .wav extension must still be converted (#9594)."""
-    # NapCat saves AMR-encoded QQ voice with a .wav extension.
     audio_file = tmp_path / "voice.wav"
     audio_file.write_bytes(_AMR_HEADER + b"\x00" * 50)
 
-    # Intercept ffmpeg subprocess so the test never depends on a real binary.
-    ffmpeg_called = False
-
-    async def fake_exec(*args, **kwargs):
-        nonlocal ffmpeg_called
-        ffmpeg_called = True
-        # Write a dummy output file so convert_audio_format can return it.
-        output_path = args[-1]
-        Path(output_path).write_bytes(_make_wav_bytes())
-        return _FakeFFmpegProcess()
-
-    monkeypatch.setattr(media_utils.asyncio, "create_subprocess_exec", fake_exec)
-    monkeypatch.setattr(media_utils, "get_astrbot_temp_path", lambda: str(tmp_path))
+    called = _patch_ffmpeg(monkeypatch, tmp_path, output_content=_make_wav_bytes())
 
     result = await media_utils.convert_audio_format(str(audio_file), "wav")
 
-    assert ffmpeg_called, (
-        "ffmpeg should have been invoked because content is AMR, not WAV"
-    )
+    assert called[0], "ffmpeg should have been invoked because content is AMR, not WAV"
     assert result != str(audio_file)
 
 
@@ -986,21 +996,9 @@ async def test_convert_audio_format_wav_with_ogg_extension_does_not_short_circui
     audio_file = tmp_path / "voice.ogg"
     audio_file.write_bytes(_make_wav_bytes())
 
-    ffmpeg_called = False
-
-    async def fake_exec(*args, **kwargs):
-        nonlocal ffmpeg_called
-        ffmpeg_called = True
-        output_path = args[-1]
-        Path(output_path).write_bytes(b"OggS" + b"\x00" * 60)
-        return _FakeFFmpegProcess()
-
-    monkeypatch.setattr(media_utils.asyncio, "create_subprocess_exec", fake_exec)
-    monkeypatch.setattr(media_utils, "get_astrbot_temp_path", lambda: str(tmp_path))
+    called = _patch_ffmpeg(monkeypatch, tmp_path, output_content=b"OggS" + b"\x00" * 60)
 
     result = await media_utils.convert_audio_format(str(audio_file), "ogg")
 
-    assert ffmpeg_called, (
-        "ffmpeg should have been invoked because content is WAV, not OGG"
-    )
+    assert called[0], "ffmpeg should have been invoked because content is WAV, not OGG"
     assert result != str(audio_file)


### PR DESCRIPTION
## Problem

When a platform adapter (e.g. NapCat via aiocqhttp / OneBot v11) saves QQ voice messages, the actual audio encoding is AMR (magic bytes `#!AMR`) but the local file is given a `.wav` extension. The `convert_audio_format()` function short-circuits purely on file extension:

```python
if audio_path.lower().endswith(f".{output_format}"):
    return audio_path   # ← skips ffmpeg, returns raw AMR bytes
```

When `output_format` is `wav`, the extension matches and the raw AMR byte stream is returned unchanged. Downstream STT providers (e.g. Whisper-compatible APIs) receive malformed WAV data and reject it with HTTP 400.

Reported in #9594.

## Fix

Reuse the existing `_get_audio_magic_type()` helper (already used by `ensure_wav()`) to verify the file content actually matches the target format before short-circuiting:

```python
if audio_path.lower().endswith(f".{output_format}"):
    detected = _get_audio_magic_type(audio_path)
    if not detected or detected == output_format:
        return audio_path
    # Extension/content mismatch → proceed with ffmpeg conversion
```

Three cases:
- **Extension matches AND magic bytes confirm the format** → short-circuit (preserves the optimization).
- **Extension matches BUT magic bytes detect a different format** → proceed with ffmpeg conversion (fixes the bug).
- **Extension matches BUT format is unrecognised** → short-circuit (preserves old behaviour for formats we cannot detect, avoids unnecessary ffmpeg overhead).

## Tests

5 new tests added to `tests/test_media_utils.py`, all passing:

| Test | Scenario | Expected |
|---|---|---|
| `amr_with_wav_extension_does_not_short_circuit` | AMR content, `.wav` ext, target `wav` | ffmpeg invoked |
| `real_wav_with_wav_extension_short_circuits` | WAV content, `.wav` ext, target `wav` | no conversion |
| `unknown_content_with_matching_ext_short_circuits` | unrecognised content, `.wav` ext, target `wav` | no conversion |
| `real_amr_with_amr_extension_short_circuits` | AMR content, `.amr` ext, target `amr` | no conversion |
| `wav_with_ogg_extension_does_not_short_circuit` | WAV content, `.ogg` ext, target `ogg` | ffmpeg invoked |

Full suite: **55 passed**. `ruff format` / `ruff check` clean.

Closes #9594.

## Summary by Sourcery

Validate audio content against its detected format before skipping conversion based on the file extension.

Bug Fixes:
- Prevent audio files whose extensions do not match their detected magic-byte format from bypassing conversion and reaching downstream consumers with invalid data.

Enhancements:
- Preserve conversion short-circuiting for matching, detectable formats and missing files while covering extension/content mismatch scenarios with focused tests.

Tests:
- Add coverage for matching formats, mismatched extensions, AMR/WAV detection, unknown content, and missing audio files.