### PR TITLE
fix(dashboard): harden config selector paths

### DIFF
--- a/dashboard/src/components/shared/AstrBotConfigV4.vue
+++ b/dashboard/src/components/shared/AstrBotConfigV4.vue
@@ -87,8 +87,16 @@ let currentEditingKeyIterable = null
 function getValueBySelector(obj, selector) {
   const keys = selector.split('.')
   let current = obj
+
   for (const key of keys) {
-    if (current && typeof current === 'object' && key in current) {
+    if (['__proto__', 'prototype', 'constructor'].includes(key)) {
+      return undefined
+    }
+    if (
+      current &&
+      typeof current === 'object' &&
+      Object.prototype.hasOwnProperty.call(current, key)
+    ) {
       current = current[key]
     } else {
       return undefined
@@ -104,6 +112,9 @@ function setValueBySelector(obj, selector, value) {
   // 创建嵌套对象路径
   for (let i = 0; i < keys.length - 1; i++) {
     const key = keys[i]
+    if (['__proto__', 'prototype', 'constructor'].includes(key)) {
+      return
+    }
     if (!current[key] || typeof current[key] !== 'object') {
       current[key] = {}
     }
@@ -111,7 +122,11 @@ function setValueBySelector(obj, selector, value) {
   }
 
   // 设置最终值
-  current[keys[keys.length - 1]] = value
+  const lastKey = keys[keys.length - 1]
+  if (['__proto__', 'prototype', 'constructor'].includes(lastKey)) {
+    return
+  }
+  current[lastKey] = value
 }
 
 // 创建一个计算属性来处理 JSON selector 的获取和设置


### PR DESCRIPTION
## Summary

- reject `__proto__`, `prototype`, and `constructor` segments in dashboard config selectors
- read only own properties while traversing selector paths
- port the focused hardening from `dev` commit `99f57c9`

## Why

The selector setter accepted arbitrary path segments and could write through JavaScript prototype-related keys. The getter also traversed inherited properties. This keeps selector access limited to the intended configuration object.

## Impact

This is a one-file defensive change with no API, dependency, or configuration changes. Normal selector paths keep the existing behavior.

Extracted as a small, reviewable part of the broader draft PR #6325.

## Validation

- `pnpm run typecheck`
- `pnpm run build`
- `git diff --check`

The production build completed successfully. Its existing Google Fonts download step logged a DNS warning in the restricted build environment but did not fail the build.

## Summary by Sourcery

Harden dashboard configuration selector handling to avoid unsafe prototype path access while preserving existing behavior for normal selectors.

Bug Fixes:
- Prevent selector getters from traversing non-own properties on configuration objects.
- Block use of JavaScript prototype-related segments (such as __proto__, prototype, constructor) in selector paths for reads and writes.