### PR TITLE
Refactor: stat service deprecated stats

### DIFF
--- a/astrbot/dashboard/services/stat_service.py
+++ b/astrbot/dashboard/services/stat_service.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import aiohttp
 import psutil
-from sqlmodel import col, select
+from sqlmodel import col, func, select
 
 from astrbot.core import DEMO_MODE, logger
 from astrbot.core.config import VERSION
@@ -23,7 +23,7 @@ from astrbot.core.dashboard_assets import (
     get_dashboard_version,
 )
 from astrbot.core.db import BaseDatabase
-from astrbot.core.db.po import ProviderStat
+from astrbot.core.db.po import PlatformStat, ProviderStat
 from astrbot.core.desktop_runtime import (
     DESKTOP_MANAGED_RESTART_MESSAGE,
     is_desktop_managed_backend,
@@ -210,23 +210,49 @@ class StatService:
 
     async def get_stat(self, offset_sec: int) -> dict:
         try:
-            stat = self.db_helper.get_base_stats(offset_sec)
             now = int(time.time())
             start_time = now - offset_sec
-            message_time_based_stats = []
 
+            async with self.db_helper.get_db() as session:
+                window_start = datetime.now() - timedelta(seconds=offset_sec)
+                result = await session.execute(
+                    select(PlatformStat)
+                    .where(PlatformStat.timestamp >= window_start)
+                    .order_by(col(PlatformStat.timestamp)),
+                )
+                # Convert to (epoch_seconds, count, platform_id) tuples once.
+                rows = [
+                    (int(r.timestamp.timestamp()), r.count, r.platform_id)
+                    for r in result.scalars().all()
+                ]
+                total_messages = (
+                    await session.execute(
+                        select(func.coalesce(func.sum(PlatformStat.count), 0)),
+                    )
+                ).scalar_one()
+
+            # Bucket message counts into hourly slots for the time series chart.
+            message_time_based_stats = []
             idx = 0
             for bucket_end in range(start_time, now, 3600):
                 cnt = 0
-                while (
-                    idx < len(stat.platform)
-                    and stat.platform[idx].timestamp < bucket_end
-                ):
-                    cnt += stat.platform[idx].count
+                while idx < len(rows) and rows[idx][0] < bucket_end:
+                    cnt += rows[idx][1]
                     idx += 1
                 message_time_based_stats.append([bucket_end, cnt])
 
-            stat_dict = stat.__dict__
+            # Aggregate per-platform message counts within the window.
+            per_platform: dict[str, int] = defaultdict(int)
+            for _, count, platform_id in rows:
+                per_platform[platform_id] += count
+            platform_stats = [
+                {
+                    "name": platform_id,
+                    "count": count,
+                    "timestamp": int(window_start.timestamp()),
+                }
+                for platform_id, count in per_platform.items()
+            ]
 
             process_cpu = await asyncio.to_thread(psutil.Process().cpu_percent, 0.5)
             cpu_percent = process_cpu / (psutil.cpu_count() or 1)
@@ -246,29 +272,24 @@ class StatService:
                 int(time.time()) - self.core_lifecycle.start_time,
             )
 
-            stat_dict.update(
-                {
-                    "platform": self.db_helper.get_grouped_base_stats(
-                        offset_sec,
-                    ).platform,
-                    "message_count": self.db_helper.get_total_message_count() or 0,
-                    "platform_count": len(
-                        self.core_lifecycle.platform_manager.get_insts(),
-                    ),
-                    "plugin_count": len(plugins),
-                    "plugins": plugin_info,
-                    "message_time_series": message_time_based_stats,
-                    "running": running_time,
-                    "memory": {
-                        "process": psutil.Process().memory_info().rss >> 20,
-                        "system": psutil.virtual_memory().total >> 20,
-                    },
-                    "cpu_percent": round(cpu_percent, 1),
-                    "thread_count": thread_count,
-                    "start_time": self.core_lifecycle.start_time,
+            return {
+                "platform": platform_stats,
+                "message_count": total_messages,
+                "platform_count": len(
+                    self.core_lifecycle.platform_manager.get_insts(),
+                ),
+                "plugin_count": len(plugins),
+                "plugins": plugin_info,
+                "message_time_series": message_time_based_stats,
+                "running": running_time,
+                "memory": {
+                    "process": psutil.Process().memory_info().rss >> 20,
+                    "system": psutil.virtual_memory().total >> 20,
                 },
-            )
-            return stat_dict
+                "cpu_percent": round(cpu_percent, 1),
+                "thread_count": thread_count,
+                "start_time": self.core_lifecycle.start_time,
+            }
         except Exception as exc:
             logger.error(traceback.format_exc())
             raise StatServiceError(str(exc)) from exc

--- a/tests/unit/test_stat_service.py
+++ b/tests/unit/test_stat_service.py
@@ -1,0 +1,80 @@
+import time
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from astrbot.dashboard.services.stat_service import StatService
+
+
+def _make_service(db) -> StatService:
+    """Build a StatService with a real DB and a mocked core lifecycle."""
+    core_lifecycle = MagicMock()
+    core_lifecycle.star_context.get_all_stars.return_value = []
+    core_lifecycle.platform_manager.get_insts.return_value = []
+    core_lifecycle.start_time = int(time.time()) - 100
+    return StatService(db_helper=db, core_lifecycle=core_lifecycle, config={})
+
+
+@pytest.mark.asyncio
+async def test_get_stat_aggregates_platform_stats(temp_db):
+    """Seeded rows must aggregate into windowed platform sums and a global total."""
+    now = datetime.now()
+    seed = [
+        ("aiocqhttp", 3, now - timedelta(hours=1)),
+        ("aiocqhttp", 5, now - timedelta(hours=1, minutes=30)),
+        ("qqofficial", 2, now - timedelta(hours=2)),
+        ("webchat", 7, now - timedelta(minutes=10)),
+        # Outside the 24h window: counted in the total but not in window stats.
+        ("aiocqhttp", 4, now - timedelta(hours=26)),
+    ]
+    for platform_id, count, ts in seed:
+        await temp_db.insert_platform_stats(platform_id, platform_id, count, ts)
+
+    result = await _make_service(temp_db).get_stat(86400)
+
+    # Global total counts every row, including the one outside the window.
+    assert result["message_count"] == 21
+
+    # Windowed per-platform sums, serialized with the legacy response keys.
+    platform = {entry["name"]: entry["count"] for entry in result["platform"]}
+    assert platform == {"aiocqhttp": 8, "qqofficial": 2, "webchat": 7}
+    for entry in result["platform"]:
+        assert set(entry) == {"name", "count", "timestamp"}
+
+    # Hourly buckets cover [now - offset, now) in ascending order.
+    series = result["message_time_series"]
+    assert len(series) == 24
+    bucket_ends = [bucket_end for bucket_end, _ in series]
+    assert bucket_ends == sorted(bucket_ends)
+    assert all(count >= 0 for _, count in series)
+    # Rows within the current partial hour are not bucketed yet, so the
+    # series sum never exceeds the windowed total of 17.
+    assert sum(count for _, count in series) <= 17
+
+    assert set(result) == {
+        "platform",
+        "message_count",
+        "platform_count",
+        "plugin_count",
+        "plugins",
+        "message_time_series",
+        "running",
+        "memory",
+        "cpu_percent",
+        "thread_count",
+        "start_time",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_stat_empty_window(temp_db):
+    """A window with no rows yields empty platform stats but keeps the total."""
+    old_ts = datetime.now() - timedelta(hours=2)
+    await temp_db.insert_platform_stats("aiocqhttp", "aiocqhttp", 4, old_ts)
+
+    result = await _make_service(temp_db).get_stat(1)
+
+    assert result["platform"] == []
+    assert result["message_count"] == 4
+    assert all(count == 0 for _, count in result["message_time_series"])


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

- `StatService.get_stat` (the endpoint behind the dashboard stats page) still relied on three methods that were deprecated in v4.0.0: `get_base_stats`, `get_grouped_base_stats`, and `get_total_message_count`. Every stats page load emitted a burst of `DeprecationWarning`s — one per method call plus one per row from instantiating the deprecated `po.Platform`/`Stats` dataclasses — and each call spawned a throwaway thread running `asyncio.run` to bridge sync to async. 

- This PR migrates `get_stat` to query `PlatformStat` directly while keeping the response shape byte-identical.                                

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Refactor dashboard stat retrieval to use PlatformStat directly while preserving the existing response schema for the stats endpoint.

Enhancements:
- Simplify StatService.get_stat to compute per-platform aggregates, global totals, and hourly time-series directly from PlatformStat rows instead of deprecated helper methods.

Tests:
- Add unit tests for StatService.get_stat to verify aggregation logic, window behavior, and response structure for non-empty and empty stat windows.