### PR TITLE
fix: gray out commands of disabled plugins in behavior manager

### DIFF
--- a/astrbot/core/star/command_management.py
+++ b/astrbot/core/star/command_management.py
@@ -189,6 +189,7 @@ async def list_commands() -> list[dict[str, Any]]:
     descriptors = _collect_descriptors(include_sub_commands=True)
     config_records = await db_helper.get_command_configs()
     _bind_configs_to_descriptors(descriptors, config_records)
+    _apply_plugin_activation_to_descriptors(descriptors)
 
     conflict_groups = _group_conflicts(descriptors)
     conflict_handler_names: set[str] = {
@@ -228,6 +229,7 @@ async def list_command_conflicts() -> list[dict[str, Any]]:
     descriptors = _collect_descriptors(include_sub_commands=False)
     config_records = await db_helper.get_command_configs()
     _bind_configs_to_descriptors(descriptors, config_records)
+    _apply_plugin_activation_to_descriptors(descriptors)
 
     conflict_groups = _group_conflicts(descriptors)
     details = [
@@ -248,6 +250,20 @@ async def list_command_conflicts() -> list[dict[str, Any]]:
 
 
 # Internal helpers ----------------------------------------------------------
+
+
+def _is_plugin_activated(desc: CommandDescriptor) -> bool:
+    plugin_meta = star_map.get(desc.module_path)
+    return bool(plugin_meta.activated) if plugin_meta else True
+
+
+def _apply_plugin_activation_to_descriptors(
+    descriptors: list[CommandDescriptor],
+) -> None:
+    """Keep per-command config, but treat inactive-plugin commands as not live."""
+    for desc in descriptors:
+        if not _is_plugin_activated(desc):
+            desc.enabled = False
 
 
 def _collect_descriptors(include_sub_commands: bool) -> list[CommandDescriptor]:
@@ -531,6 +547,7 @@ def _descriptor_to_dict(desc: CommandDescriptor) -> dict[str, Any]:
         "aliases": desc.aliases,
         "permission": desc.permission,
         "enabled": desc.enabled,
+        "plugin_activated": _is_plugin_activated(desc),
         "is_group": desc.is_group,
         "has_conflict": desc.has_conflict,
         "reserved": desc.reserved,

--- a/astrbot/core/star/command_management.py
+++ b/astrbot/core/star/command_management.py
@@ -189,7 +189,6 @@ async def list_commands() -> list[dict[str, Any]]:
     descriptors = _collect_descriptors(include_sub_commands=True)
     config_records = await db_helper.get_command_configs()
     _bind_configs_to_descriptors(descriptors, config_records)
-    _apply_plugin_activation_to_descriptors(descriptors)
 
     conflict_groups = _group_conflicts(descriptors)
     conflict_handler_names: set[str] = {
@@ -229,7 +228,6 @@ async def list_command_conflicts() -> list[dict[str, Any]]:
     descriptors = _collect_descriptors(include_sub_commands=False)
     config_records = await db_helper.get_command_configs()
     _bind_configs_to_descriptors(descriptors, config_records)
-    _apply_plugin_activation_to_descriptors(descriptors)
 
     conflict_groups = _group_conflicts(descriptors)
     details = [
@@ -255,15 +253,6 @@ async def list_command_conflicts() -> list[dict[str, Any]]:
 def _is_plugin_activated(desc: CommandDescriptor) -> bool:
     plugin_meta = star_map.get(desc.module_path)
     return bool(plugin_meta.activated) if plugin_meta else True
-
-
-def _apply_plugin_activation_to_descriptors(
-    descriptors: list[CommandDescriptor],
-) -> None:
-    """Keep per-command config, but treat inactive-plugin commands as not live."""
-    for desc in descriptors:
-        if not _is_plugin_activated(desc):
-            desc.enabled = False
 
 
 def _collect_descriptors(include_sub_commands: bool) -> list[CommandDescriptor]:
@@ -481,7 +470,7 @@ def _group_conflicts(
 ) -> dict[str, list[CommandDescriptor]]:
     conflicts: dict[str, list[CommandDescriptor]] = defaultdict(list)
     for desc in descriptors:
-        if desc.effective_command and desc.enabled:
+        if desc.effective_command and desc.enabled and _is_plugin_activated(desc):
             conflicts[desc.effective_command].append(desc)
     return {k: v for k, v in conflicts.items() if len(v) > 1}
 

--- a/dashboard/src/components/extension/componentPanel/components/CommandTable.vue
+++ b/dashboard/src/components/extension/componentPanel/components/CommandTable.vue
@@ -202,33 +202,37 @@ const getRowProps = ({ item }: { item: CommandItem }) => {
       <template v-slot:item.actions="{ item }">
         <div class="d-flex align-center">
           <v-btn-group density="default" variant="text" color="primary">
-            <v-btn
-              v-if="!item.enabled"
-              icon
-              size="small"
-              color="success"
-              :disabled="isPluginInactive(item)"
-              @click="emit('toggle-command', item)"
-            >
-              <v-icon size="22">mdi-play</v-icon>
+            <span v-if="!item.enabled" class="command-action-tooltip">
+              <v-btn
+                icon
+                size="small"
+                color="success"
+                :disabled="isPluginInactive(item)"
+                @click="emit('toggle-command', item)"
+              >
+                <v-icon size="22">mdi-play</v-icon>
+              </v-btn>
               <v-tooltip activator="parent" location="top">{{ isPluginInactive(item) ? tm('tooltips.pluginInactive') : tm('tooltips.enable') }}</v-tooltip>
-            </v-btn>
-            <v-btn
-              v-else
-              icon
-              size="small"
-              color="error"
-              :disabled="isPluginInactive(item)"
-              @click="emit('toggle-command', item)"
-            >
-              <v-icon size="22">mdi-pause</v-icon>
+            </span>
+            <span v-else class="command-action-tooltip">
+              <v-btn
+                icon
+                size="small"
+                color="error"
+                :disabled="isPluginInactive(item)"
+                @click="emit('toggle-command', item)"
+              >
+                <v-icon size="22">mdi-pause</v-icon>
+              </v-btn>
               <v-tooltip activator="parent" location="top">{{ isPluginInactive(item) ? tm('tooltips.pluginInactive') : tm('tooltips.disable') }}</v-tooltip>
-            </v-btn>
+            </span>
 
-            <v-btn icon size="small" color="warning" :disabled="isPluginInactive(item)" @click="emit('rename', item)">
-              <v-icon size="22">mdi-pencil</v-icon>
+            <span class="command-action-tooltip">
+              <v-btn icon size="small" color="warning" :disabled="isPluginInactive(item)" @click="emit('rename', item)">
+                <v-icon size="22">mdi-pencil</v-icon>
+              </v-btn>
               <v-tooltip activator="parent" location="top">{{ isPluginInactive(item) ? tm('tooltips.pluginInactive') : tm('tooltips.rename') }}</v-tooltip>
-            </v-btn>
+            </span>
 
             <v-btn icon size="small" @click="emit('view-details', item)">
               <v-icon size="22">mdi-information</v-icon>
@@ -297,6 +301,16 @@ code.sub-command-code {
   cursor: pointer;
 }
 
+.command-action-tooltip {
+  display: inline-flex;
+  height: 100%;
+}
+
+.v-btn-group .command-action-tooltip .v-btn {
+  border-radius: 0;
+  height: 100%;
+}
+
 .v-data-table .plugin-inactive-row,
 .v-data-table .plugin-inactive-row td,
 .v-data-table .plugin-inactive-row .v-data-table__td {
@@ -319,9 +333,8 @@ code.sub-command-code {
   opacity: 1;
 }
 
-.v-data-table .plugin-inactive-row .v-btn-group .v-btn:disabled,
+.v-data-table .plugin-inactive-row .command-action-tooltip,
 .v-data-table .plugin-inactive-row .v-chip.cursor-pointer.v-chip--disabled {
   cursor: not-allowed !important;
 }
 </style>
-

--- a/dashboard/src/components/extension/componentPanel/components/CommandTable.vue
+++ b/dashboard/src/components/extension/componentPanel/components/CommandTable.vue
@@ -65,7 +65,7 @@ const getPermissionLabel = (permission: string): string => {
   }
 };
 
-const isPluginInactive = (cmd: CommandItem) => cmd.plugin_activated === false;
+const isPluginInactive = (cmd: CommandItem) => !cmd.plugin_activated;
 
 // 获取状态信息
 const getStatusInfo = (cmd: CommandItem): StatusInfo => {
@@ -230,9 +230,9 @@ const getRowProps = ({ item }: { item: CommandItem }) => {
               <v-tooltip activator="parent" location="top">{{ isPluginInactive(item) ? tm('tooltips.pluginInactive') : tm('tooltips.rename') }}</v-tooltip>
             </v-btn>
 
-            <v-btn icon size="small" :disabled="isPluginInactive(item)" @click="emit('view-details', item)">
+            <v-btn icon size="small" @click="emit('view-details', item)">
               <v-icon size="22">mdi-information</v-icon>
-              <v-tooltip activator="parent" location="top">{{ isPluginInactive(item) ? tm('tooltips.pluginInactive') : tm('tooltips.viewDetails') }}</v-tooltip>
+              <v-tooltip activator="parent" location="top">{{ tm('tooltips.viewDetails') }}</v-tooltip>
             </v-btn>
           </v-btn-group>
         </div>
@@ -319,10 +319,9 @@ code.sub-command-code {
   opacity: 1;
 }
 
-.v-data-table .plugin-inactive-row .v-btn-group .v-btn,
-.v-data-table .plugin-inactive-row .v-chip.cursor-pointer {
+.v-data-table .plugin-inactive-row .v-btn-group .v-btn:disabled,
+.v-data-table .plugin-inactive-row .v-chip.cursor-pointer.v-chip--disabled {
   cursor: not-allowed !important;
-  pointer-events: none !important;
 }
 </style>
 

--- a/dashboard/src/components/extension/componentPanel/components/CommandTable.vue
+++ b/dashboard/src/components/extension/componentPanel/components/CommandTable.vue
@@ -65,8 +65,13 @@ const getPermissionLabel = (permission: string): string => {
   }
 };
 
+const isPluginInactive = (cmd: CommandItem) => cmd.plugin_activated === false;
+
 // 获取状态信息
 const getStatusInfo = (cmd: CommandItem): StatusInfo => {
+  if (isPluginInactive(cmd)) {
+    return { text: tm('status.pluginDisabled'), color: 'default', variant: 'outlined' };
+  }
   if (cmd.has_conflict) {
     return { text: tm('status.conflict'), color: 'warning', variant: 'flat' };
   }
@@ -87,6 +92,9 @@ const getRowProps = ({ item }: { item: CommandItem }) => {
   }
   if (item.is_group) {
     classes.push('group-row');
+  }
+  if (isPluginInactive(item)) {
+    classes.push('plugin-inactive-row');
   }
   return classes.length > 0 ? { class: classes.join(' ') } : {};
 };
@@ -154,6 +162,7 @@ const getRowProps = ({ item }: { item: CommandItem }) => {
               :color="getPermissionColor(item.permission)"
               size="small"
               class="font-weight-medium cursor-pointer"
+              :disabled="isPluginInactive(item)"
               link
             >
               {{ getPermissionLabel(item.permission) }}
@@ -198,30 +207,32 @@ const getRowProps = ({ item }: { item: CommandItem }) => {
               icon
               size="small"
               color="success"
+              :disabled="isPluginInactive(item)"
               @click="emit('toggle-command', item)"
             >
               <v-icon size="22">mdi-play</v-icon>
-              <v-tooltip activator="parent" location="top">{{ tm('tooltips.enable') }}</v-tooltip>
+              <v-tooltip activator="parent" location="top">{{ isPluginInactive(item) ? tm('tooltips.pluginInactive') : tm('tooltips.enable') }}</v-tooltip>
             </v-btn>
             <v-btn
               v-else
               icon
               size="small"
               color="error"
+              :disabled="isPluginInactive(item)"
               @click="emit('toggle-command', item)"
             >
               <v-icon size="22">mdi-pause</v-icon>
-              <v-tooltip activator="parent" location="top">{{ tm('tooltips.disable') }}</v-tooltip>
+              <v-tooltip activator="parent" location="top">{{ isPluginInactive(item) ? tm('tooltips.pluginInactive') : tm('tooltips.disable') }}</v-tooltip>
             </v-btn>
 
-            <v-btn icon size="small" color="warning" @click="emit('rename', item)">
+            <v-btn icon size="small" color="warning" :disabled="isPluginInactive(item)" @click="emit('rename', item)">
               <v-icon size="22">mdi-pencil</v-icon>
-              <v-tooltip activator="parent" location="top">{{ tm('tooltips.rename') }}</v-tooltip>
+              <v-tooltip activator="parent" location="top">{{ isPluginInactive(item) ? tm('tooltips.pluginInactive') : tm('tooltips.rename') }}</v-tooltip>
             </v-btn>
 
-            <v-btn icon size="small" @click="emit('view-details', item)">
+            <v-btn icon size="small" :disabled="isPluginInactive(item)" @click="emit('view-details', item)">
               <v-icon size="22">mdi-information</v-icon>
-              <v-tooltip activator="parent" location="top">{{ tm('tooltips.viewDetails') }}</v-tooltip>
+              <v-tooltip activator="parent" location="top">{{ isPluginInactive(item) ? tm('tooltips.pluginInactive') : tm('tooltips.viewDetails') }}</v-tooltip>
             </v-btn>
           </v-btn-group>
         </div>
@@ -284,6 +295,34 @@ code.sub-command-code {
 
 .cursor-pointer {
   cursor: pointer;
+}
+
+.v-data-table .plugin-inactive-row,
+.v-data-table .plugin-inactive-row td,
+.v-data-table .plugin-inactive-row .v-data-table__td {
+  background-color: rgba(var(--v-theme-on-surface), 0.06) !important;
+  color: rgba(var(--v-theme-on-surface), 0.72) !important;
+}
+
+.v-data-table .plugin-inactive-row:hover,
+.v-data-table .plugin-inactive-row:hover td,
+.v-data-table .plugin-inactive-row:hover .v-data-table__td {
+  background-color: rgba(var(--v-theme-on-surface), 0.09) !important;
+}
+
+.v-data-table .plugin-inactive-row .v-chip,
+.v-data-table .plugin-inactive-row code,
+.v-data-table .plugin-inactive-row .text-body-2,
+.v-data-table .plugin-inactive-row .text-subtitle-1 {
+  color: rgba(var(--v-theme-on-surface), 0.72) !important;
+  filter: grayscale(1);
+  opacity: 1;
+}
+
+.v-data-table .plugin-inactive-row .v-btn-group .v-btn,
+.v-data-table .plugin-inactive-row .v-chip.cursor-pointer {
+  cursor: not-allowed !important;
+  pointer-events: none !important;
 }
 </style>
 

--- a/dashboard/src/components/extension/componentPanel/types.ts
+++ b/dashboard/src/components/extension/componentPanel/types.ts
@@ -19,6 +19,7 @@ export interface CommandItem {
   aliases: string[];
   permission: PermissionType;
   enabled: boolean;
+  plugin_activated?: boolean;
   is_group: boolean;
   has_conflict: boolean;
   reserved: boolean;

--- a/dashboard/src/components/extension/componentPanel/types.ts
+++ b/dashboard/src/components/extension/componentPanel/types.ts
@@ -19,7 +19,7 @@ export interface CommandItem {
   aliases: string[];
   permission: PermissionType;
   enabled: boolean;
-  plugin_activated?: boolean;
+  plugin_activated: boolean;
   is_group: boolean;
   has_conflict: boolean;
   reserved: boolean;

--- a/dashboard/src/i18n/locales/en-US/features/command.json
+++ b/dashboard/src/i18n/locales/en-US/features/command.json
@@ -29,6 +29,7 @@
   "status": {
     "enabled": "Enabled",
     "disabled": "Disabled",
+    "pluginDisabled": "Plugin off",
     "conflict": "Conflict"
   },
   "permission": {
@@ -39,7 +40,8 @@
     "enable": "Enable command",
     "disable": "Disable command",
     "rename": "Rename command",
-    "viewDetails": "View details"
+    "viewDetails": "View details",
+    "pluginInactive": "Enable the plugin first"
   },
   "dialogs": {
     "rename": {

--- a/dashboard/src/i18n/locales/ru-RU/features/command.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/command.json
@@ -29,6 +29,7 @@
     "status": {
         "enabled": "Активна",
         "disabled": "Отключена",
+        "pluginDisabled": "Плагин отключён",
         "conflict": "Конфликт"
     },
     "permission": {
@@ -39,7 +40,8 @@
         "enable": "Включить",
         "disable": "Выключить",
         "rename": "Переименовать",
-        "viewDetails": "Подробности"
+        "viewDetails": "Подробности",
+        "pluginInactive": "Сначала включите плагин"
     },
     "dialogs": {
         "rename": {

--- a/dashboard/src/i18n/locales/zh-CN/features/command.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/command.json
@@ -29,6 +29,7 @@
   "status": {
     "enabled": "已启用",
     "disabled": "已禁用",
+    "pluginDisabled": "未启用",
     "conflict": "有冲突"
   },
   "permission": {
@@ -39,7 +40,8 @@
     "enable": "启用指令",
     "disable": "禁用指令",
     "rename": "重命名指令",
-    "viewDetails": "查看详情"
+    "viewDetails": "查看详情",
+    "pluginInactive": "请先启用所属插件"
   },
   "dialogs": {
     "rename": {

--- a/tests/unit/test_command_plugin_activation.py
+++ b/tests/unit/test_command_plugin_activation.py
@@ -1,0 +1,33 @@
+"""Commands from disabled plugins should not look enabled in the dashboard."""
+
+from types import SimpleNamespace
+
+
+def test_inactive_plugin_commands_are_not_effectively_enabled():
+    from astrbot.core.star.command_management import (
+        _apply_plugin_activation_to_descriptors,
+        _is_plugin_activated,
+        star_map,
+    )
+
+    original = dict(star_map)
+    try:
+        star_map.clear()
+        star_map["data.plugins.foo.main"] = SimpleNamespace(activated=True)
+        star_map["data.plugins.bar.main"] = SimpleNamespace(activated=False)
+
+        active = SimpleNamespace(module_path="data.plugins.foo.main", enabled=True)
+        inactive = SimpleNamespace(module_path="data.plugins.bar.main", enabled=True)
+        unknown = SimpleNamespace(module_path="data.plugins.missing.main", enabled=True)
+
+        _apply_plugin_activation_to_descriptors([active, inactive, unknown])
+
+        assert _is_plugin_activated(active) is True
+        assert _is_plugin_activated(inactive) is False
+        assert _is_plugin_activated(unknown) is True
+        assert active.enabled is True
+        assert inactive.enabled is False
+        assert unknown.enabled is True
+    finally:
+        star_map.clear()
+        star_map.update(original)

--- a/tests/unit/test_command_plugin_activation.py
+++ b/tests/unit/test_command_plugin_activation.py
@@ -2,32 +2,69 @@
 
 from types import SimpleNamespace
 
+from astrbot.core.star.command_management import (
+    CommandDescriptor,
+    _descriptor_to_dict,
+    _group_conflicts,
+    _is_plugin_activated,
+    star_map,
+)
 
-def test_inactive_plugin_commands_are_not_effectively_enabled():
-    from astrbot.core.star.command_management import (
-        _apply_plugin_activation_to_descriptors,
-        _is_plugin_activated,
-        star_map,
+
+def _descriptor(module_path: str, *, enabled: bool = True) -> CommandDescriptor:
+    return CommandDescriptor(
+        handler=SimpleNamespace(),  # type: ignore[arg-type]
+        module_path=module_path,
+        enabled=enabled,
+        effective_command="demo",
     )
 
+
+def test_plugin_activation_is_serialized_without_mutating_enabled():
     original = dict(star_map)
     try:
         star_map.clear()
         star_map["data.plugins.foo.main"] = SimpleNamespace(activated=True)
         star_map["data.plugins.bar.main"] = SimpleNamespace(activated=False)
 
-        active = SimpleNamespace(module_path="data.plugins.foo.main", enabled=True)
-        inactive = SimpleNamespace(module_path="data.plugins.bar.main", enabled=True)
-        unknown = SimpleNamespace(module_path="data.plugins.missing.main", enabled=True)
-
-        _apply_plugin_activation_to_descriptors([active, inactive, unknown])
+        active = _descriptor("data.plugins.foo.main", enabled=True)
+        inactive = _descriptor("data.plugins.bar.main", enabled=True)
+        unknown = _descriptor("data.plugins.missing.main", enabled=True)
 
         assert _is_plugin_activated(active) is True
         assert _is_plugin_activated(inactive) is False
         assert _is_plugin_activated(unknown) is True
         assert active.enabled is True
-        assert inactive.enabled is False
+        assert inactive.enabled is True
         assert unknown.enabled is True
+
+        active_dict = _descriptor_to_dict(active)
+        inactive_dict = _descriptor_to_dict(inactive)
+        unknown_dict = _descriptor_to_dict(unknown)
+
+        assert active_dict["enabled"] is True
+        assert inactive_dict["enabled"] is True
+        assert unknown_dict["enabled"] is True
+        assert active_dict["plugin_activated"] is True
+        assert inactive_dict["plugin_activated"] is False
+        assert unknown_dict["plugin_activated"] is True
+    finally:
+        star_map.clear()
+        star_map.update(original)
+
+
+def test_inactive_plugin_commands_are_excluded_from_conflicts():
+    original = dict(star_map)
+    try:
+        star_map.clear()
+        star_map["data.plugins.foo.main"] = SimpleNamespace(activated=True)
+        star_map["data.plugins.bar.main"] = SimpleNamespace(activated=False)
+
+        live = _descriptor("data.plugins.foo.main")
+        off = _descriptor("data.plugins.bar.main")
+        conflicts = _group_conflicts([live, off])
+
+        assert conflicts == {}
     finally:
         star_map.clear()
         star_map.update(original)


### PR DESCRIPTION
Fixes #9562

After a plugin is disabled, its commands still show as Enabled on Plugins → Behavior Manager, but they no longer work at runtime.

### Modifications / 改动点

The command list only checked each command's own `enabled` flag and ignored the plugin `activated` state.

- Backend `command_management.py`: add `plugin_activated`. If the plugin is off, treat its commands as inactive without changing stored command toggles.
- Frontend `CommandTable.vue`: keep those commands visible, mark them as 未启用 / Plugin off, dim the whole row, and disable row actions.
- Use theme `on-surface` colors so light and dark mode both stay readable.
- Add zh-CN / en-US / ru-RU copy and a small backend unit test.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果
<img width="1219" height="262" alt="image" src="https://github.com/user-attachments/assets/f377efb1-75d8-46f8-948d-3acede931516" />
<img width="1210" height="216" alt="image" src="https://github.com/user-attachments/assets/f9c2559c-3141-467b-9edd-f2b9f21d1cd0" />

Verification:

1. Install any plugin and confirm its commands show as Enabled and work.
2. Disable the plugin.
3. Open Plugins → Behavior Manager: the commands are still listed, status is 未启用 / Plugin off, the row is dimmed, and actions cannot be clicked.
4. Re-enable the plugin and confirm the row returns to normal.

pytest tests/unit/test_command_plugin_activation.py -q

passed

(Paste a screenshot of the dimmed row here.)

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Show commands from disabled plugins as inactive in the Behavior Manager without changing their saved command settings.

Bug Fixes:
- Reflect plugin activation in Behavior Manager so commands from disabled plugins are shown as inactive instead of appearing enabled.

Enhancements:
- Keep disabled-plugin commands visible while dimming their rows and disabling command-management actions.
- Expose plugin activation separately from each command’s stored enabled setting and exclude inactive plugin commands from conflict detection.
- Use theme-aware inactive-row styling and add localized status and tooltip text.

Tests:
- Add backend unit tests covering plugin activation serialization and conflict filtering.