### PR TITLE
fix(config): don't rotate dashboard password on password_change_required

### DIFF
--- a/astrbot/core/config/astrbot_config.py
+++ b/astrbot/core/config/astrbot_config.py
@@ -98,14 +98,6 @@ class AstrBotConfig(dict):
         ):
             self._reset_generated_dashboard_password(conf)
             has_new = True
-        elif (
-            "dashboard" in conf
-            and isinstance(conf["dashboard"], dict)
-            and stored_dashboard_password_change_required
-            and conf["dashboard"].get("pbkdf2_password")
-        ):
-            self._reset_generated_dashboard_password(conf)
-            has_new = True
         self.update(conf)
         if has_new:
             self.save_config()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -280,24 +280,28 @@ class TestAstrBotConfigLoad:
                 default_config=default_config,
             )
 
-    def test_legacy_password_change_required_rotates_and_keeps_config_flag(
+    def test_password_change_required_does_not_rotate_existing_password(
         self, temp_config_path
     ):
-        """Test that the setup flag stays in dashboard config."""
+        """A pending password change must not silently rotate the stored password."""
         default_config = {
             "dashboard": {
                 "username": "astrbot",
                 "password": "",
                 "pbkdf2_password": "",
+                "password_storage_upgraded": False,
+                "password_change_required": False,
             },
         }
+        stored_pbkdf2 = "pbkdf2_sha256$600000$00$00"
         with open(temp_config_path, "w", encoding="utf-8") as f:
             json.dump(
                 {
                     "dashboard": {
                         "username": "astrbot",
                         "password": "",
-                        "pbkdf2_password": "pbkdf2_sha256$600000$00$00",
+                        "pbkdf2_password": stored_pbkdf2,
+                        "password_storage_upgraded": True,
                         "password_change_required": True,
                     }
                 },
@@ -308,20 +312,57 @@ class TestAstrBotConfigLoad:
             config_path=temp_config_path,
             default_config=default_config,
         )
-        generated_password = getattr(config, "_generated_dashboard_password", None)
 
-        assert isinstance(generated_password, str)
+        assert getattr(config, "_generated_dashboard_password", None) is None
+        assert config["dashboard"]["pbkdf2_password"] == stored_pbkdf2
         assert config["dashboard"]["password_change_required"] is True
         assert config["dashboard"]["password_storage_upgraded"] is True
         assert (
             getattr(config, "_dashboard_password_change_required_from_config", False)
             is True
         )
-        assert verify_dashboard_password(
-            config["dashboard"]["pbkdf2_password"], generated_password
+
+    def test_password_change_required_is_stable_across_reloads(
+        self, temp_config_path
+    ):
+        """Repeated constructions must not rotate a pending generated password (issue #9662)."""
+        default_config = {
+            "dashboard": {
+                "username": "astrbot",
+                "password": "",
+                "pbkdf2_password": "",
+                "password_storage_upgraded": False,
+                "password_change_required": False,
+            },
+        }
+        with open(temp_config_path, "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "dashboard": {
+                        "username": "astrbot",
+                        "password": "",
+                        "pbkdf2_password": "pbkdf2_sha256$600000$00$00",
+                        "password_storage_upgraded": True,
+                        "password_change_required": True,
+                    }
+                },
+                f,
+            )
+
+        first = AstrBotConfig(
+            config_path=temp_config_path,
+            default_config=default_config,
         )
-        assert verify_dashboard_password(
-            config["dashboard"]["password"], generated_password
+        second = AstrBotConfig(
+            config_path=temp_config_path,
+            default_config=default_config,
+        )
+
+        assert getattr(first, "_generated_dashboard_password", None) is None
+        assert getattr(second, "_generated_dashboard_password", None) is None
+        assert (
+            first["dashboard"]["pbkdf2_password"]
+            == second["dashboard"]["pbkdf2_password"]
         )
 
     def test_reset_dashboard_password_env_rotates_existing_password(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -322,9 +322,7 @@ class TestAstrBotConfigLoad:
             is True
         )
 
-    def test_password_change_required_is_stable_across_reloads(
-        self, temp_config_path
-    ):
+    def test_password_change_required_is_stable_across_reloads(self, temp_config_path):
         """Repeated constructions must not rotate a pending generated password (issue #9662)."""
         default_config = {
             "dashboard": {


### PR DESCRIPTION
Fixes #9662

Fix #9693

### Modifications / 改动点

- Removed the `elif` branch in `astrbot/core/config/astrbot_config.py` that treated `password_change_required=True` (with an existing `pbkdf2_password`) as a signal to regenerate the dashboard password. The flag only means "prompt the user to change the initial password", so it must never rotate the stored password.
- Updated `tests/unit/test_config.py`: replaced the test that asserted the buggy rotation behavior with two tests that assert the stored password is stable across reloads.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Reproduction from #9662 — the password is no longer rotated across two constructions:

```python
import json, tempfile, os
from astrbot.core.config.astrbot_config import AstrBotConfig

d = {"dashboard": {"username": "astrbot", "password": "", "pbkdf2_password": ""}}
fd, path = tempfile.mkstemp(suffix=".json"); os.close(fd)
json.dump({"dashboard": {"username": "astrbot", "password": "",
    "pbkdf2_password": "pbkdf2_sha256$600000$00$00",
    "password_change_required": True}}, open(path, "w"))

p1 = getattr(AstrBotConfig(config_path=path, default_config=d), "_generated_dashboard_password", None)
p2 = getattr(AstrBotConfig(config_path=path, default_config=d), "_generated_dashboard_password", None)

assert p1 == p2
print("p1 =", p1)
print("p2 =", p2)
```

```
p1 = None
p2 = None
```

Regression tests (these additionally assert the `password_change_required` flag is preserved, which the minimal repro above can't check because its `default_config` strips unknown keys):

```
$ python -m pytest "tests/unit/test_config.py::TestAstrBotConfigLoad::test_password_change_required_does_not_rotate_existing_password" "tests/unit/test_config.py::TestAstrBotConfigLoad::test_password_change_required_is_stable_across_reloads" -v

tests/unit/test_config.py::TestAstrBotConfigLoad::test_password_change_required_does_not_rotate_existing_password PASSED [ 50%]
tests/unit/test_config.py::TestAstrBotConfigLoad::test_password_change_required_is_stable_across_reloads PASSED [100%]

2 passed in 0.31s
```

Full config suite:

```
$ python -m pytest tests/unit/test_config.py -q
47 passed
```

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Prevent dashboard password rotation when a password change is pending and ensure configuration reloads keep the stored password stable.

Bug Fixes:
- Stop treating `password_change_required` with an existing stored password as a trigger to regenerate the dashboard password, avoiding silent password rotation.

Tests:
- Replace the legacy rotation test with new tests that verify no generated password is created and the stored pbkdf2 hash remains unchanged across reloads.

## Summary by Sourcery

Ensure dashboard password is not rotated when a password change is merely pending and keep configuration stable across reloads.

Bug Fixes:
- Stop treating the password_change_required flag with an existing stored dashboard password as a trigger to regenerate the password, preventing unintended password rotation.

Tests:
- Replace the legacy rotation test with new tests that verify the stored dashboard pbkdf2 hash and related flags remain unchanged and no generated password is created across configuration reloads.