### PR TITLE
fix: consume injected tool call results in tool loop runner

### DIFF
--- a/astrbot/api/provider/__init__.py
+++ b/astrbot/api/provider/__init__.py
@@ -1,3 +1,7 @@
+from astrbot.core.agent.message import (
+    AssistantMessageSegment,
+    ToolCallMessageSegment,
+)
 from astrbot.core.db.po import Personality
 from astrbot.core.provider import Provider, STTProvider
 from astrbot.core.provider.entities import (
@@ -5,9 +9,11 @@ from astrbot.core.provider.entities import (
     ProviderMetaData,
     ProviderRequest,
     ProviderType,
+    ToolCallsResult,
 )
 
 __all__ = [
+    "AssistantMessageSegment",
     "LLMResponse",
     "Personality",
     "Provider",
@@ -15,4 +21,6 @@ __all__ = [
     "ProviderRequest",
     "ProviderType",
     "STTProvider",
+    "ToolCallMessageSegment",
+    "ToolCallsResult",
 ]

--- a/astrbot/core/agent/message.py
+++ b/astrbot/core/agent/message.py
@@ -14,6 +14,7 @@ from pydantic import (
 from pydantic_core import core_schema
 
 ContentPartT = TypeVar("ContentPartT", bound="ContentPart")
+MessageT = TypeVar("MessageT", bound="Message")
 
 
 class ContentPart(BaseModel):
@@ -215,11 +216,15 @@ class Message(BaseModel):
     _no_save: bool = PrivateAttr(default=False)
     _checkpoint_after: CheckpointData | None = PrivateAttr(default=None)
 
-    def mark_as_temp(self) -> "Message":
+    def mark_as_temp(self: MessageT) -> MessageT:
         """Mark this message as provider-facing only, not persisted.
 
-        临时注入（如伪造工具调用对）应成对标记：assistant 与 tool 消息都调用
-        本方法，避免历史中残留悬空的 tool 消息。
+        Injected pairs (e.g. fake tool-call results) should mark both the
+        assistant and tool messages so no dangling tool message remains in
+        history.
+
+        Returns:
+            Self, for method chaining.
         """
         self._no_save = True
         return self

--- a/astrbot/core/agent/message.py
+++ b/astrbot/core/agent/message.py
@@ -215,6 +215,15 @@ class Message(BaseModel):
     _no_save: bool = PrivateAttr(default=False)
     _checkpoint_after: CheckpointData | None = PrivateAttr(default=None)
 
+    def mark_as_temp(self) -> "Message":
+        """Mark this message as provider-facing only, not persisted.
+
+        临时注入（如伪造工具调用对）应成对标记：assistant 与 tool 消息都调用
+        本方法，避免历史中残留悬空的 tool 消息。
+        """
+        self._no_save = True
+        return self
+
     @model_validator(mode="after")
     def check_content_required(self):
         if self.role == CHECKPOINT_ROLE:

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -315,6 +315,20 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
         ):
             m = await self._assemble_request_context_for_provider(request)
             messages.append(Message.model_validate(m))
+        # Plugin-injected tool call results (on_llm_request → req.append_tool_calls_result)
+        # follow the current user message so the assistant(tool_calls) → tool(result)
+        # block belongs to the current turn. Providers consume the same
+        # ProviderRequest.tool_calls_result in this order (see text_chat payload
+        # assembly), so binding it here keeps the in-run context identical to what
+        # a plain provider call would send.
+        if request.tool_calls_result:
+            tool_call_results = (
+                request.tool_calls_result
+                if isinstance(request.tool_calls_result, list)
+                else [request.tool_calls_result]
+            )
+            for tcr in tool_call_results:
+                messages.extend(tcr.to_openai_messages_model())
         if request.system_prompt:
             messages.insert(
                 0,

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -465,8 +465,9 @@ class InternalAgentSubStage(Stage):
             if message.role == "system" and not skipped_initial_system:
                 skipped_initial_system = True
                 continue
-            # _no_save 语义与角色无关：临时注入的消息（含伪造工具调用对的
-            # tool 消息）一律不落库，避免历史中残留悬空的 tool 消息。
+            # _no_save is role-agnostic: temp-injected messages (including the
+            # tool message of a fake tool-call pair) are never persisted, so no
+            # dangling tool message remains in history.
             if message._no_save:
                 continue
             messages_to_save.append(message)

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -465,7 +465,9 @@ class InternalAgentSubStage(Stage):
             if message.role == "system" and not skipped_initial_system:
                 skipped_initial_system = True
                 continue
-            if message.role in ["assistant", "user"] and message._no_save:
+            # _no_save 语义与角色无关：临时注入的消息（含伪造工具调用对的
+            # tool 消息）一律不落库，避免历史中残留悬空的 tool 消息。
+            if message._no_save:
                 continue
             messages_to_save.append(message)
 

--- a/astrbot/core/provider/entities.py
+++ b/astrbot/core/provider/entities.py
@@ -81,6 +81,16 @@ class ToolCallsResult:
     def to_openai_messages_model(
         self,
     ) -> list[AssistantMessageSegment | ToolCallMessageSegment]:
+        # A tool-call pair must be marked temp together (or not at all): a
+        # partial mark would persist a dangling assistant(tool_calls) that
+        # providers reject on the next round.
+        info_is_temp = self.tool_calls_info._no_save
+        if any(message._no_save != info_is_temp for message in self.tool_calls_result):
+            raise ValueError(
+                "ToolCallsResult pair must be marked temp together: call "
+                "mark_as_temp() on both tool_calls_info and every message in "
+                "tool_calls_result, or on neither."
+            )
         return [
             self.tool_calls_info,
             *self.tool_calls_result,

--- a/docs/zh/dev/star/plugin.md
+++ b/docs/zh/dev/star/plugin.md
@@ -561,6 +561,61 @@ async def my_custom_hook_1(self, event: AstrMessageEvent, req: ProviderRequest):
 
 > 这里不能使用 yield 来发送消息。如需发送，请直接使用 `event.send()` 方法。
 
+###### 注入工具调用结果
+
+> 适用于 AstrBot 版本 > v4.27.3
+
+如果希望 LLM 在回答本轮问题时"看到"一次工具调用及其结果（例如插件自行检索了长期记忆后，将结果包装成一次记忆召回的工具调用），不要直接向 `req.contexts` 追加消息，而应通过 `req.append_tool_calls_result()` 注入。runner 会保证最终消息顺序为：
+
+```
+history → 当前 user → assistant(tool_calls) → tool(result)
+```
+
+```python
+from astrbot.api.event import filter, AstrMessageEvent
+from astrbot.api.provider import (
+    ProviderRequest,
+    ToolCallsResult,
+    AssistantMessageSegment,
+    ToolCallMessageSegment,
+)
+
+@filter.on_llm_request()
+async def inject_memory_recall(self, event: AstrMessageEvent, req: ProviderRequest):
+    tool_call_id = "fake_recall_memory"
+    req.append_tool_calls_result(
+        ToolCallsResult(
+            tool_calls_info=AssistantMessageSegment(
+                tool_calls=[
+                    {
+                        "id": tool_call_id,
+                        "type": "function",
+                        "function": {
+                            "name": "recall_long_term_memory",
+                            "arguments": '{"query": "..."}',
+                        },
+                    }
+                ]
+            ),
+            tool_calls_result=[
+                ToolCallMessageSegment(
+                    tool_call_id=tool_call_id,
+                    content="<memory json>",
+                )
+            ],
+        )
+    )
+```
+
+注入的工具调用结果**默认会随会话历史持久化**。如果只希望参与本轮请求、不落库，请对 assistant 与 tool 消息**成对**调用 `.mark_as_temp()`：
+
+```python
+tool_calls_info=AssistantMessageSegment(...).mark_as_temp(),
+tool_calls_result=[ToolCallMessageSegment(...).mark_as_temp()],
+```
+
+> 这里不能使用 yield 来发送消息。如需发送，请直接使用 `event.send()` 方法。
+
 ##### LLM 请求完成时
 
 在 LLM 请求完成后，会触发 `on_llm_response` 钩子。

--- a/docs/zh/dev/star/plugin.md
+++ b/docs/zh/dev/star/plugin.md
@@ -618,6 +618,20 @@ tool_calls_result=[ToolCallMessageSegment(...).mark_as_temp()],
 > `assistant(tool_calls)` 或 `tool` 消息，下一轮 provider API 会拒绝该请求。
 > 若标记不一致，runner 在组装上下文时会抛出 `ValueError` 提醒。
 
+**多个插件同时注入时，顺序由 `on_llm_request(priority=...)` 控制**：priority 越高的
+handler 越早执行，其 `append_tool_calls_result()` 的结果越靠前。最终顺序为
+`history → 当前 user → 高优先级插件的注入对 → 低优先级插件的注入对 → ...`。
+
+```python
+@filter.on_llm_request(priority=10)
+async def high_priority_inject(self, event: AstrMessageEvent, req: ProviderRequest):
+    req.append_tool_calls_result(...)  # 排在前
+
+@filter.on_llm_request(priority=0)
+async def low_priority_inject(self, event: AstrMessageEvent, req: ProviderRequest):
+    req.append_tool_calls_result(...)  # 排在后
+```
+
 > 这里不能使用 yield 来发送消息。如需发送，请直接使用 `event.send()` 方法。
 
 ##### LLM 请求完成时

--- a/docs/zh/dev/star/plugin.md
+++ b/docs/zh/dev/star/plugin.md
@@ -614,6 +614,10 @@ tool_calls_info=AssistantMessageSegment(...).mark_as_temp(),
 tool_calls_result=[ToolCallMessageSegment(...).mark_as_temp()],
 ```
 
+> **注意**：`.mark_as_temp()` 必须成对使用。只标记其中一方会导致历史中残留悬空的
+> `assistant(tool_calls)` 或 `tool` 消息，下一轮 provider API 会拒绝该请求。
+> 若标记不一致，runner 在组装上下文时会抛出 `ValueError` 提醒。
+
 > 这里不能使用 yield 来发送消息。如需发送，请直接使用 `event.send()` 方法。
 
 ##### LLM 请求完成时

--- a/tests/test_conversation_checkpoint.py
+++ b/tests/test_conversation_checkpoint.py
@@ -332,6 +332,65 @@ async def test_terminal_tool_result_persists_history_without_checkpoint():
 
 
 @pytest.mark.asyncio
+async def test_temp_injected_tool_pair_not_persisted():
+    """临时注入的伪造工具调用对（成对 mark_as_temp）整对不落库，不残留悬空 tool 消息。"""
+    conversation_manager = AsyncMock()
+    stage = InternalAgentSubStage()
+    stage.conv_manager = conversation_manager
+    event = SimpleNamespace(
+        unified_msg_origin="webchat:FriendMessage:test",
+        get_extra=lambda _key: None,
+    )
+    fake_info = AssistantMessageSegment(
+        tool_calls=[
+            {
+                "id": "fake_1",
+                "type": "function",
+                "function": {"name": "recall", "arguments": "{}"},
+            }
+        ]
+    ).mark_as_temp()
+    fake_result = ToolCallMessageSegment(
+        tool_call_id="fake_1",
+        content="mem",
+    ).mark_as_temp()
+    request = ProviderRequest(
+        conversation=Conversation(
+            platform_id="webchat",
+            user_id="webchat:FriendMessage:test",
+            cid="conversation-1",
+        ),
+        tool_calls_result=ToolCallsResult(
+            tool_calls_info=fake_info,
+            tool_calls_result=[fake_result],
+        ),
+    )
+
+    await stage._save_to_history(
+        event,
+        request,
+        LLMResponse(role="assistant", completion_text="ok"),
+        [
+            Message(role="user", content="hello"),
+            fake_info,
+            fake_result,
+            ToolCallMessageSegment(tool_call_id="real_1", content="real result"),
+        ],
+        runner_stats=None,
+    )
+
+    conversation_manager.update_conversation.assert_awaited_once_with(
+        "webchat:FriendMessage:test",
+        "conversation-1",
+        history=[
+            {"role": "user", "content": "hello"},
+            {"role": "tool", "tool_call_id": "real_1", "content": "real result"},
+        ],
+        token_usage=None,
+    )
+
+
+@pytest.mark.asyncio
 async def test_terminal_tool_result_with_checkpoint_uses_none_token_usage():
     conversation_manager = AsyncMock()
     stage = InternalAgentSubStage()

--- a/tests/test_tool_calls_result_cross_provider.py
+++ b/tests/test_tool_calls_result_cross_provider.py
@@ -1,0 +1,164 @@
+"""Cross-provider conversion of injected tool-call result pairs.
+
+An injected pair (assistant with tool_calls + tool result) is structurally
+identical to a real tool-call pair, so each provider must convert it through
+the same native-format path. These tests lock in the conversion for the three
+providers that do not speak the OpenAI chat format natively.
+
+Anthropic:  tool_calls -> tool_use blocks, tool role -> tool_result block.
+Gemini:     tool_calls -> functionCall part, tool role -> functionResponse part.
+Responses:  tool_calls -> function_call item, tool role -> function_call_output.
+"""
+
+import pytest
+
+from astrbot.core.provider.sources.anthropic_source import ProviderAnthropic
+from astrbot.core.provider.sources.gemini_source import ProviderGoogleGenAI
+from astrbot.core.provider.sources.openai_responses_source import (
+    ProviderOpenAIResponses,
+)
+
+INJECTED_PAIR_CONTEXT = [
+    {"role": "system", "content": "system"},
+    {"role": "user", "content": "history user"},
+    {"role": "assistant", "content": "history bot"},
+    {"role": "user", "content": "current question"},
+    {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "fake_1",
+                "type": "function",
+                "function": {"name": "recall", "arguments": "{}"},
+            }
+        ],
+    },
+    {"role": "tool", "tool_call_id": "fake_1", "content": "memory json"},
+]
+
+
+@pytest.mark.asyncio
+async def test_anthropic_payload_converts_injected_tool_calls_pair():
+    provider = ProviderAnthropic(
+        provider_config={
+            "id": "test-anthropic",
+            "type": "anthropic_chat_completion",
+            "model": "claude-test",
+            "key": ["test-key"],
+            "api_base": "https://api.anthropic.com",
+        },
+        provider_settings={},
+    )
+    try:
+        system_prompt, new_messages = provider._prepare_payload(INJECTED_PAIR_CONTEXT)
+    finally:
+        await provider.terminate()
+
+    assert system_prompt == "system"
+    assert new_messages == [
+        {"role": "user", "content": "history user"},
+        {"role": "assistant", "content": [{"type": "text", "text": "history bot"}]},
+        {"role": "user", "content": "current question"},
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "recall",
+                    "input": {},
+                    "id": "fake_1",
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "fake_1",
+                    "content": "memory json",
+                }
+            ],
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gemini_conversation_converts_injected_tool_calls_pair():
+    provider = ProviderGoogleGenAI(
+        provider_config={
+            "id": "test-gemini",
+            "type": "google_gemini",
+            "model": "gemini-test",
+            "key": ["test-key"],
+            "api_base": "https://generativelanguage.googleapis.com",
+        },
+        provider_settings={},
+    )
+    try:
+        contents = provider._prepare_conversation({"messages": INJECTED_PAIR_CONTEXT})
+    finally:
+        await provider.terminate()
+
+    assert [c.role for c in contents] == ["user", "model", "user", "model", "user"]
+
+    function_call_part = next(
+        part
+        for content in contents
+        for part in content.parts
+        if part.function_call is not None
+    )
+    assert function_call_part.function_call.name == "recall"
+    assert function_call_part.function_call.args == {}
+
+    function_response_part = next(
+        part
+        for content in contents
+        for part in content.parts
+        if part.function_response is not None
+    )
+    assert function_response_part.function_response.name == "fake_1"
+    assert function_response_part.function_response.response == {
+        "name": "fake_1",
+        "content": "memory json",
+    }
+
+
+@pytest.mark.asyncio
+async def test_responses_payload_converts_injected_tool_calls_pair():
+    provider = ProviderOpenAIResponses(
+        provider_config={
+            "id": "test-responses",
+            "provider": "openai",
+            "type": "openai_responses",
+            "model": "gpt-test",
+            "key": ["test-key"],
+            "api_base": "https://api.openai.com/v1",
+        },
+        provider_settings={},
+    )
+    try:
+        response_input = provider._convert_chat_messages_to_response_input(
+            INJECTED_PAIR_CONTEXT
+        )
+    finally:
+        await provider.terminate()
+
+    assert response_input == [
+        {"type": "message", "role": "system", "content": "system"},
+        {"type": "message", "role": "user", "content": "history user"},
+        {"type": "message", "role": "assistant", "content": "history bot"},
+        {"type": "message", "role": "user", "content": "current question"},
+        {
+            "type": "function_call",
+            "call_id": "fake_1",
+            "name": "recall",
+            "arguments": "{}",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "fake_1",
+            "output": "memory json",
+        },
+    ]

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -14,13 +14,24 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from astrbot.core.agent.agent import Agent
 from astrbot.core.agent.handoff import HandoffTool
 from astrbot.core.agent.hooks import BaseAgentRunHooks
-from astrbot.core.agent.message import ImageURLPart, Message, TextPart
+from astrbot.core.agent.message import (
+    AssistantMessageSegment,
+    ImageURLPart,
+    Message,
+    TextPart,
+    ToolCallMessageSegment,
+)
 from astrbot.core.agent.run_context import ContextWrapper
 from astrbot.core.agent.runners.tool_loop_agent_runner import ToolLoopAgentRunner
 from astrbot.core.agent.tool import FunctionTool, ToolSet
 from astrbot.core.astr_agent_tool_exec import FunctionToolExecutor
 from astrbot.core.exceptions import EmptyModelOutputError
-from astrbot.core.provider.entities import LLMResponse, ProviderRequest, TokenUsage
+from astrbot.core.provider.entities import (
+    LLMResponse,
+    ProviderRequest,
+    TokenUsage,
+    ToolCallsResult,
+)
 from astrbot.core.provider.provider import Provider
 
 
@@ -1557,6 +1568,156 @@ async def test_tool_result_injects_follow_up_notice(
     assert ticket2.resolved.is_set() is True
     assert ticket1.consumed is True
     assert ticket2.consumed is True
+
+
+@pytest.mark.asyncio
+async def test_reset_appends_injected_tool_calls_result_after_user(
+    runner, mock_provider, mock_tool_executor, mock_hooks
+):
+    """reset() 把 on_llm_request 注入的 tool_calls_result 追加在当前 user 消息之后。
+
+    最终顺序：history → 当前 user → assistant(tool_calls) → tool(result)。
+    """
+    request = ProviderRequest(
+        prompt="当前问题",
+        contexts=[
+            {"role": "user", "content": "历史消息"},
+            {"role": "assistant", "content": "历史回答"},
+        ],
+        tool_calls_result=ToolCallsResult(
+            tool_calls_info=AssistantMessageSegment(
+                tool_calls=[
+                    {
+                        "id": "fake_1",
+                        "type": "function",
+                        "function": {
+                            "name": "recall_long_term_memory",
+                            "arguments": "{}",
+                        },
+                    }
+                ]
+            ),
+            tool_calls_result=[
+                ToolCallMessageSegment(
+                    tool_call_id="fake_1",
+                    content="memory json",
+                )
+            ],
+        ),
+    )
+
+    await runner.reset(
+        provider=mock_provider,
+        request=request,
+        run_context=ContextWrapper(context=None),
+        tool_executor=mock_tool_executor,
+        agent_hooks=mock_hooks,
+        streaming=False,
+    )
+
+    roles = [m.role for m in runner.run_context.messages]
+    assert roles == ["user", "assistant", "user", "assistant", "tool"]
+    assert runner.run_context.messages[-2].tool_calls[0].id == "fake_1"
+    assert runner.run_context.messages[-1].tool_call_id == "fake_1"
+
+
+@pytest.mark.asyncio
+async def test_runner_with_openai_provider_preserves_injected_tool_calls_order(
+    mock_tool_executor, mock_hooks
+):
+    """端到端：runner 消费注入的 tool_calls_result 后，OpenAI payload 顺序保持正确。
+
+    覆盖 ToolLoopAgentRunner → ProviderOpenAIOfficial.text_chat → _query 的完整
+    payload 组装路径（真实 provider，仅对 SDK create 的入口 _query 打桩捕获）。
+    顺序：history → 当前 user → assistant(tool_calls) → tool(result)。
+    """
+    from astrbot.core.agent.tool import FunctionTool, ToolSet
+    from astrbot.core.provider.entities import ToolCallsResult
+    from astrbot.core.provider.sources.openai_source import ProviderOpenAIOfficial
+
+    provider = ProviderOpenAIOfficial(
+        provider_config={
+            "id": "test-openai",
+            "type": "openai_chat_completion",
+            "model": "gpt-4o-mini",
+            "key": ["test-key"],
+        },
+        provider_settings={},
+    )
+    captured: dict[str, list[dict[str, Any]]] = {}
+
+    async def fake_query(payloads, func_tool, *, request_max_retries=None):
+        captured["messages"] = [dict(m) for m in payloads["messages"]]
+        return LLMResponse(role="assistant", completion_text="ok")
+
+    provider._query = fake_query  # type: ignore[method-assign]
+
+    tool_set = ToolSet(
+        tools=[
+            FunctionTool(
+                name="test_tool",
+                description="测试工具",
+                parameters={
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                },
+                handler=AsyncMock(),
+            )
+        ]
+    )
+    request = ProviderRequest(
+        prompt="当前问题",
+        func_tool=tool_set,
+        contexts=[
+            {"role": "user", "content": "历史消息"},
+            {"role": "assistant", "content": "历史回答"},
+        ],
+        tool_calls_result=ToolCallsResult(
+            tool_calls_info=AssistantMessageSegment(
+                tool_calls=[
+                    {
+                        "id": "fake_1",
+                        "type": "function",
+                        "function": {
+                            "name": "recall_long_term_memory",
+                            "arguments": "{}",
+                        },
+                    }
+                ]
+            ),
+            tool_calls_result=[
+                ToolCallMessageSegment(
+                    tool_call_id="fake_1",
+                    content="memory json",
+                )
+            ],
+        ),
+    )
+
+    runner = ToolLoopAgentRunner()
+    try:
+        await runner.reset(
+            provider=provider,
+            request=request,
+            run_context=ContextWrapper(context=None),
+            tool_executor=mock_tool_executor,
+            agent_hooks=mock_hooks,
+            streaming=False,
+        )
+        async for _ in runner.step():
+            pass
+    finally:
+        await provider.terminate()
+
+    assert [m["role"] for m in captured["messages"]] == [
+        "user",
+        "assistant",
+        "user",
+        "assistant",
+        "tool",
+    ]
+    assert captured["messages"][-2]["tool_calls"][0]["id"] == "fake_1"
+    assert captured["messages"][-1]["tool_call_id"] == "fake_1"
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -1738,6 +1738,129 @@ def test_injected_tool_calls_result_partial_temp_mark_raises():
 
 
 @pytest.mark.asyncio
+async def test_on_llm_request_priority_determines_injected_tool_calls_order(
+    runner, mock_provider, mock_tool_executor, mock_hooks
+):
+    """高 priority 的 on_llm_request 先执行，其注入对在最终上下文中排在前面。"""
+    from astrbot.core.pipeline.context_utils import call_event_hook
+    from astrbot.core.star.register.star_handler import get_handler_or_create
+    from astrbot.core.star.star import StarMetadata, star_map
+    from astrbot.core.star.star_handler import EventType, star_handlers_registry
+
+    async def high_priority_inject(_event, req):
+        req.append_tool_calls_result(
+            ToolCallsResult(
+                tool_calls_info=AssistantMessageSegment(
+                    tool_calls=[
+                        {
+                            "id": "high_1",
+                            "type": "function",
+                            "function": {
+                                "name": "high_priority_recall",
+                                "arguments": "{}",
+                            },
+                        }
+                    ]
+                ),
+                tool_calls_result=[
+                    ToolCallMessageSegment(
+                        tool_call_id="high_1",
+                        content="high priority memory",
+                    )
+                ],
+            )
+        )
+
+    async def low_priority_inject(_event, req):
+        req.append_tool_calls_result(
+            ToolCallsResult(
+                tool_calls_info=AssistantMessageSegment(
+                    tool_calls=[
+                        {
+                            "id": "low_1",
+                            "type": "function",
+                            "function": {
+                                "name": "low_priority_recall",
+                                "arguments": "{}",
+                            },
+                        }
+                    ]
+                ),
+                tool_calls_result=[
+                    ToolCallMessageSegment(
+                        tool_call_id="low_1",
+                        content="low priority memory",
+                    )
+                ],
+            )
+        )
+
+    class HookEvent:
+        plugins_name = None
+
+        def is_stopped(self):
+            return False
+
+    original_handlers = list(star_handlers_registry)
+    original_star_map = dict(star_map)
+    handler_module = high_priority_inject.__module__
+    try:
+        star_handlers_registry.clear()
+        star_map[handler_module] = StarMetadata(
+            name="test-inject-priority",
+            module_path=handler_module,
+            activated=True,
+        )
+        get_handler_or_create(
+            high_priority_inject, EventType.OnLLMRequestEvent, priority=10
+        )
+        get_handler_or_create(
+            low_priority_inject, EventType.OnLLMRequestEvent, priority=0
+        )
+
+        req = ProviderRequest(
+            prompt="current question",
+            contexts=[
+                {"role": "user", "content": "history user"},
+                {"role": "assistant", "content": "history bot"},
+            ],
+        )
+        await call_event_hook(HookEvent(), EventType.OnLLMRequestEvent, req)
+
+        injected_ids = [
+            tcr.tool_calls_info.tool_calls[0].id for tcr in req.tool_calls_result
+        ]
+        assert injected_ids == ["high_1", "low_1"]
+
+        await runner.reset(
+            provider=mock_provider,
+            request=req,
+            run_context=ContextWrapper(context=None),
+            tool_executor=mock_tool_executor,
+            agent_hooks=mock_hooks,
+            streaming=False,
+        )
+        roles = [m.role for m in runner.run_context.messages]
+        assert roles == [
+            "user",
+            "assistant",
+            "user",
+            "assistant",
+            "tool",
+            "assistant",
+            "tool",
+        ]
+        assert runner.run_context.messages[-4].tool_calls[0].id == "high_1"
+        assert runner.run_context.messages[-2].tool_calls[0].id == "low_1"
+    finally:
+        star_handlers_registry.clear()
+        star_map.clear()
+        star_map.update(original_star_map)
+        for handler in original_handlers:
+            star_handlers_registry.append(handler)
+
+
+@pytest.mark.asyncio
 async def test_runner_with_openai_provider_preserves_injected_tool_calls_order(
     mock_tool_executor, mock_hooks
 ):

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -1596,12 +1596,12 @@ async def test_reset_appends_injected_tool_calls_result_after_user(
                         },
                     }
                 ]
-            ),
+            ).mark_as_temp(),
             tool_calls_result=[
                 ToolCallMessageSegment(
                     tool_call_id="fake_1",
                     content="memory json",
-                )
+                ).mark_as_temp()
             ],
         ),
     )
@@ -1619,6 +1619,122 @@ async def test_reset_appends_injected_tool_calls_result_after_user(
     assert roles == ["user", "assistant", "user", "assistant", "tool"]
     assert runner.run_context.messages[-2].tool_calls[0].id == "fake_1"
     assert runner.run_context.messages[-1].tool_call_id == "fake_1"
+    # _no_save 标记经 reset() 追加后保留，持久化时才会被过滤。
+    assert runner.run_context.messages[-2]._no_save is True
+    assert runner.run_context.messages[-1]._no_save is True
+
+
+@pytest.mark.asyncio
+async def test_reset_appends_multiple_injected_tool_calls_results_in_order(
+    runner, mock_provider, mock_tool_executor, mock_hooks
+):
+    """list 形式的多个 ToolCallsResult 按列表顺序追加在 user 消息之后。"""
+    request = ProviderRequest(
+        prompt="当前问题",
+        contexts=[
+            {"role": "user", "content": "历史消息"},
+            {"role": "assistant", "content": "历史回答"},
+        ],
+        tool_calls_result=[
+            ToolCallsResult(
+                tool_calls_info=AssistantMessageSegment(
+                    tool_calls=[
+                        {
+                            "id": "fake_1",
+                            "type": "function",
+                            "function": {
+                                "name": "recall_long_term_memory",
+                                "arguments": "{}",
+                            },
+                        }
+                    ]
+                ),
+                tool_calls_result=[
+                    ToolCallMessageSegment(
+                        tool_call_id="fake_1",
+                        content="memory json 1",
+                    )
+                ],
+            ),
+            ToolCallsResult(
+                tool_calls_info=AssistantMessageSegment(
+                    tool_calls=[
+                        {
+                            "id": "fake_2",
+                            "type": "function",
+                            "function": {
+                                "name": "recall_short_term_memory",
+                                "arguments": "{}",
+                            },
+                        }
+                    ]
+                ),
+                tool_calls_result=[
+                    ToolCallMessageSegment(
+                        tool_call_id="fake_2",
+                        content="memory json 2",
+                    )
+                ],
+            ),
+        ],
+    )
+
+    await runner.reset(
+        provider=mock_provider,
+        request=request,
+        run_context=ContextWrapper(context=None),
+        tool_executor=mock_tool_executor,
+        agent_hooks=mock_hooks,
+        streaming=False,
+    )
+
+    roles = [m.role for m in runner.run_context.messages]
+    assert roles == [
+        "user",
+        "assistant",
+        "user",
+        "assistant",
+        "tool",
+        "assistant",
+        "tool",
+    ]
+    tool_calls = [
+        m.tool_calls[0].id
+        for m in runner.run_context.messages
+        if m.role == "assistant" and m.tool_calls
+    ]
+    assert tool_calls == ["fake_1", "fake_2"]
+    tool_results = [
+        m.tool_call_id for m in runner.run_context.messages if m.role == "tool"
+    ]
+    assert tool_results == ["fake_1", "fake_2"]
+
+
+def test_injected_tool_calls_result_partial_temp_mark_raises():
+    """只标记对中一方时抛 ValueError，防止悬空 assistant(tool_calls) 落库。"""
+    partial = ToolCallsResult(
+        tool_calls_info=AssistantMessageSegment(
+            tool_calls=[
+                {
+                    "id": "fake_1",
+                    "type": "function",
+                    "function": {
+                        "name": "recall",
+                        "arguments": "{}",
+                    },
+                }
+            ]
+        ).mark_as_temp(),
+        tool_calls_result=[
+            ToolCallMessageSegment(
+                tool_call_id="fake_1",
+                content="memory json",
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match="marked temp together"):
+        partial.to_openai_messages_model()
 
 
 @pytest.mark.asyncio
@@ -1631,8 +1747,6 @@ async def test_runner_with_openai_provider_preserves_injected_tool_calls_order(
     payload 组装路径（真实 provider，仅对 SDK create 的入口 _query 打桩捕获）。
     顺序：history → 当前 user → assistant(tool_calls) → tool(result)。
     """
-    from astrbot.core.agent.tool import FunctionTool, ToolSet
-    from astrbot.core.provider.entities import ToolCallsResult
     from astrbot.core.provider.sources.openai_source import ProviderOpenAIOfficial
 
     provider = ProviderOpenAIOfficial(


### PR DESCRIPTION
### Motivation / 动机

  通过复用现有的 `ProviderRequest.tool_calls_result` ，允许插件注入伪造的 `assistant(tool_calls) → tool(result)`
  消息对，**强制** LLM 认为自己已经调用了某个工具并拿到了结果，从而：

  - 跳过 LLM 自身的工具调用决策，**节省 token**
  - **降低延迟**（不需要等 LLM 生成工具调用）
  - **增加确定性**（固定或规则触发，不受模型输出波动影响）

  这是一种通用手法，已在 LivingMemory 插件中长期记忆注入中使用，未来可能被更多插件用于各种确定性工具调用场景。

  初版方案在 `OpenAI_Provider` 内做启发式重排（从尾部弹出 user 消息，再收集 assistant(tool_calls)+tool
  对重排），存在两个问题：

  1. **平台特判**：只覆盖 `OpenAI_Provider`，Anthropic / Gemini / OpenAI Responses 等其他 provider
  不重排，注入顺序依然错误
  2. **启发式猜测**：按消息模式判断哪些是伪造对，真实工具调用场景存在误判/误杀风险

  本 PR 使用@whatevertogo 审查建议的机制方案：`tool_calls_result` 通道本就存在，且所有 provider 在组装 text_chat 载荷时都按 `history →
   user → assistant(tool_calls) → tool(result)` 顺序消费它。让 `ToolLoopAgentRunner.reset()`
  以相同顺序把注入对绑定到会话上下文，保证：

  - **顺序天然正确**（紧跟当前用户消息之后）
  - **跨 provider 一致**（四条 provider 路径行为相同）
  - **无需启发式检测**，不会误杀真实工具调用

  Refs: #9451

  ### Modifications / 改动点

  **`astrbot/core/agent/runners/tool_loop_agent_runner.py`**

  `ToolLoopAgentRunner.reset()` 在拼接 `[history, 当前用户消息]` 之后，消费 `request.tool_calls_result`（单个
  `ToolCallsResult` 或列表），经 `to_openai_messages_model()` 追加伪造的 `assistant(tool_calls) → tool(result)`
  消息，使该块属于当前轮次，与 provider 载荷组装顺序完全一致。

  **`astrbot/api/provider/__init__.py`**

  公开导出 `AssistantMessageSegment`、`ToolCallMessageSegment`、`ToolCallsResult`，插件可通过公共 API
  路径构造并注入伪造对。

  **`astrbot/core/agent/message.py`**

  新增 `Message.mark_as_temp()`：标记消息为仅 provider 可见、不落库。伪造的 assistant(tool_calls) 与 tool(result)
  应**成对**调用，避免历史中残留悬空 tool 消息。

  **`astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py`**

  `_save_to_history` 持久化过滤由按角色（仅 assistant/user）改为按 `_no_save` 标记，临时注入的消息（含 tool
  角色）一律不落库。

  **`docs/zh/dev/star/plugin.md`**

  新增"注入工具调用结果"小节，说明 `req.append_tool_calls_result()` 用法、顺序保证与成对 `.mark_as_temp()` 语义。

  - 不依赖具体插件实现，通用机制
  - 不改动 `req.contexts`，不破坏其他 `on_llm_request` handler
  - 覆盖全部 provider 路径
  - 真实工具调用场景不受影响

  - [x] This is NOT a breaking change. / 这不是一个破坏性变更。

  ### Test Results / 测试结果

  新增 3 个测试：
  - `test_reset_appends_injected_tool_calls_result_after_user` — 顺序断言 `[user, assistant, user, assistant(tc), tool]`
  - `test_runner_with_openai_provider_preserves_injected_tool_calls_order` — 走真实 `ProviderOpenAIOfficial`
  端到端验证（mock `_query`，无网络）
  - `test_temp_injected_tool_pair_not_persisted` — 伪造对整对不落库，真实 tool 消息正常落库

  验证结果：
  - `tests/test_tool_loop_agent_runner.py` + `tests/test_conversation_checkpoint.py`：**59 passed**
  - `tests/unit/test_astr_main_agent.py`：**102 passed**
  - ruff check / format：全部通过

  ---

  ### Checklist / 检查清单

  - [ ] 😊 新功能已通过 Issue 与作者讨论
  - [x] 👀 我的更改经过了充分测试，测试结果已在上方提供
  - [x] 🤓 无新依赖引入
  - [x] 😮 无恶意代码

## Summary by Sourcery

Handle plugin-injected tool call results via ProviderRequest.tool_calls_result so they are bound to the current user turn and consumed consistently across providers without affecting real tool usage or other handlers.

New Features:
- Expose AssistantMessageSegment, ToolCallMessageSegment, and ToolCallsResult in the public provider API for plugins to construct and inject synthetic tool call/result pairs.
- Add Message.mark_as_temp() to flag provider-only, non-persisted messages for temporary injected tool call pairs.

Enhancements:
- Update ToolLoopAgentRunner.reset() to append injected tool_calls_result messages after the current user message, aligning in-run context with provider payload assembly order.
- Change history persistence in InternalAgentSubStage._save_to_history to honor the _no_save flag on any message role, preventing temporary injected tool messages from being stored.

Documentation:
- Document the recommended plugin pattern for injecting tool call results using req.append_tool_calls_result(), including order guarantees and mark_as_temp() semantics in the Chinese dev plugin guide.

Tests:
- Add tests to verify injected tool_calls_result are appended after the current user message, preserved in OpenAI provider payloads, and that temp-marked injected tool pairs are not persisted to conversation history.