### PR TITLE
feat: show plugin update time in marketplace details

### DIFF
--- a/dashboard/src/i18n/locales/en-US/features/extension.json
+++ b/dashboard/src/i18n/locales/en-US/features/extension.json
@@ -132,6 +132,7 @@
       "author": "Author",
       "category": "Category",
       "stars": "Stars",
+      "updatedAt": "Updated At",
       "tags": "Tags",
       "astrbotVersion": "AstrBot Version Requirement",
       "supportPlatforms": "Supported Platforms",

--- a/dashboard/src/i18n/locales/ru-RU/features/extension.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/extension.json
@@ -132,6 +132,7 @@
             "author": "Автор",
             "category": "Категория",
             "stars": "Звезды",
+            "updatedAt": "Обновлено",
             "tags": "Теги",
             "astrbotVersion": "Требуемая версия AstrBot",
             "supportPlatforms": "Поддерживаемые платформы",

--- a/dashboard/src/i18n/locales/zh-CN/features/extension.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/extension.json
@@ -132,6 +132,7 @@
       "author": "作者",
       "category": "类别",
       "stars": "Star数",
+      "updatedAt": "更新时间",
       "tags": "标签",
       "astrbotVersion": "AstrBot 版本要求",
       "supportPlatforms": "支持平台",

--- a/dashboard/src/views/extension/PluginDetailPage.vue
+++ b/dashboard/src/views/extension/PluginDetailPage.vue
@@ -12,6 +12,7 @@ import DOMPurify from "dompurify";
 import MarkdownIt from "markdown-it";
 import defaultPluginIcon from "/favicon.svg";
 import { pluginApi } from "@/api/v1";
+import { useI18n } from "@/i18n/composables";
 import { usePluginI18n } from "@/utils/pluginI18n";
 import PluginPlatformChip from "@/components/shared/PluginPlatformChip.vue";
 
@@ -35,6 +36,7 @@ const props = defineProps({
 });
 
 const { tm, router } = props.state;
+const { locale } = useI18n();
 const {
   pluginName,
   pluginDesc: resolvePluginDesc,
@@ -233,6 +235,29 @@ const supportPlatformsDisplay = computed(() => {
   return platforms.filter((platform) => typeof platform === "string");
 });
 
+const updatedAtDisplay = computed(() => {
+  if (!isMarketDetail.value) return "";
+
+  const value = firstPresentValue(
+    pluginData.value?.updated_at,
+    props.marketPlugin?.updated_at,
+  );
+  if (!value) return "";
+
+  const updatedAt = new Date(value);
+  if (Number.isNaN(updatedAt.getTime())) return "";
+
+  return new Intl.DateTimeFormat(locale.value, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).format(updatedAt);
+});
+
 const infoRows = computed(() => {
   const rows = [
     {
@@ -249,6 +274,11 @@ const infoRows = computed(() => {
     {
       label: tm("detail.info.stars"),
       value: starsDisplay.value,
+      optional: true,
+    },
+    {
+      label: tm("detail.info.updatedAt"),
+      value: updatedAtDisplay.value,
       optional: true,
     },
     {


### PR DESCRIPTION
## Summary

- show the marketplace plugin `updated_at` value in the plugin detail information table
- format the timestamp with the active dashboard locale and hide missing or invalid values
- add localized labels for Simplified Chinese, English, and Russian

## Why

Marketplace entries already include an update timestamp, but the plugin detail page did not expose it. Displaying it helps users understand how recently a plugin was maintained before installing it.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `uv run ruff format --check .`
- `uv run ruff check .`

## Summary by Sourcery

Display marketplace plugin update time in the plugin detail view using localized formatting.

New Features:
- Show the marketplace plugin last updated time in the plugin detail information table.

Enhancements:
- Format the plugin update timestamp according to the active dashboard locale and hide missing or invalid values.
- Add localized labels for the plugin update time in Simplified Chinese, English, and Russian.