### PR TITLE
fix: keep chat sidebar accessible at medium widths

### DIFF
--- a/dashboard/src/layouts/full/vertical-header/VerticalHeader.vue
+++ b/dashboard/src/layouts/full/vertical-header/VerticalHeader.vue
@@ -1105,8 +1105,9 @@ onMounted(async () => {
       <span class="version-text hidden-xs">{{ botCurrVersion }}</span>
     </div>
 
+    <!-- Keep the chat drawer accessible whenever it is not permanent. -->
     <v-btn
-      v-if="isChatPath && $vuetify.display.smAndDown"
+      v-if="isChatPath && !lgAndUp"
       class="chat-mobile-sidebar-toggle"
       icon
       size="small"


### PR DESCRIPTION
## What changed

- Show the ChatUI sidebar toggle whenever the sidebar is using temporary mode.
- Align the header toggle visibility with the drawer's `lgAndUp` breakpoint.

## Root cause

The drawer becomes temporary below the `lg` breakpoint, while its header toggle was only visible at `smAndDown`. At `md` widths, the history sidebar was hidden and there was no control to open it.

## Impact

Users can open the history sidebar at every viewport width where it is not permanently displayed, including Windows desktop scaling scenarios.

## Validation

- `pnpm typecheck`
- `pnpm build`
- `uv run ruff format .`
- `uv run ruff check .`
- `git diff --check`

Closes #9695

## Summary by Sourcery

Enhancements:
- Adjust chat sidebar toggle visibility logic so users can access the chat history at medium viewport widths where the drawer is temporary.