### PR TITLE
fix: convert telegram audio files into a Record component

### DIFF
--- a/astrbot/core/platform/sources/telegram/tg_adapter.py
+++ b/astrbot/core/platform/sources/telegram/tg_adapter.py
@@ -588,6 +588,25 @@ class TelegramPlatformAdapter(Platform):
             record.path = path_wav
             message.message = [record]
 
+        elif update.message.audio:
+            # Audio files use their own Bot API field and do not fall back to document.
+            file = await update.message.audio.get_file()
+
+            file_basename = os.path.basename(cast(str, file.file_path))
+            temp_dir = get_astrbot_temp_path()
+            temp_path = os.path.join(temp_dir, file_basename)
+            await download_file(cast(str, file.file_path), path=temp_path)
+            path_wav = await MediaResolver(
+                temp_path,
+                media_type="audio",
+                default_suffix=".wav",
+            ).to_path(target_format="wav")
+
+            record = Comp.Record(file=path_wav, url=path_wav)
+            record.path = path_wav
+            message.message.append(record)
+            _apply_caption()
+
         elif update.message.photo:
             photo = update.message.photo[-1]  # get the largest photo
             file = await photo.get_file()

--- a/tests/fixtures/helpers.py
+++ b/tests/fixtures/helpers.py
@@ -98,6 +98,7 @@ def create_mock_update(
     video: MagicMock | None = None,
     document: MagicMock | None = None,
     voice: MagicMock | None = None,
+    audio: MagicMock | None = None,
     sticker: MagicMock | None = None,
     video_note: MagicMock | None = None,
     reply_to_message: MagicMock | None = None,
@@ -122,6 +123,7 @@ def create_mock_update(
         video: 视频对象
         document: 文档对象
         voice: 语音对象
+        audio: 音频文件对象
         sticker: 贴纸对象
         video_note: 圆形视频消息对象
         reply_to_message: 回复的消息
@@ -160,6 +162,7 @@ def create_mock_update(
     message.video = video
     message.document = document
     message.voice = voice
+    message.audio = audio
     message.sticker = sticker
     message.video_note = video_note
     message.reply_to_message = reply_to_message

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -350,6 +350,49 @@ async def test_telegram_voice_message_creates_record_component(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_telegram_audio_caption_populates_message_text_and_plain(tmp_path):
+    TelegramPlatformAdapter = _load_telegram_adapter()
+    adapter = TelegramPlatformAdapter(
+        make_platform_config("telegram"),
+        {},
+        asyncio.Queue(),
+    )
+    audio = create_mock_file("https://api.telegram.org/file/test/song.mp3")
+    update = create_mock_update(
+        message_text=None,
+        audio=audio,
+        caption="这首歌是什么",
+    )
+    wav_path = tmp_path / "song.mp3.wav"
+    convert_message_globals = adapter.convert_message.__func__.__globals__
+
+    with (
+        patch.dict(
+            convert_message_globals,
+            {
+                "get_astrbot_temp_path": MagicMock(return_value=str(tmp_path)),
+                "download_file": AsyncMock(),
+            },
+        ),
+        patch(
+            "astrbot.core.utils.media_utils.ensure_wav",
+            AsyncMock(return_value=str(wav_path)),
+        ),
+    ):
+        result = await adapter.convert_message(update, _build_context())
+
+    assert result is not None
+    assert result.message_str == "这首歌是什么"
+    assert len(result.message) == 2
+    assert isinstance(result.message[0], Comp.Record)
+    assert result.message[0].file == str(wav_path)
+    assert result.message[0].path == str(wav_path)
+    assert result.message[0].url == str(wav_path)
+    assert isinstance(result.message[1], Comp.Plain)
+    assert result.message[1].text == "这首歌是什么"
+
+
+@pytest.mark.asyncio
 async def test_telegram_final_segment_splits_long_markdown_messages():
     TelegramPlatformEvent = _load_telegram_platform_event()
     client = MagicMock()


### PR DESCRIPTION
When a music or audio file, that is `audio`, is sent to the Bot on Telegram, the message is silently dropped and the Bot gives no response. The cause is that `convert_message()` in `tg_adapter.py` only handles types such as `text` in turn, and `audio` is not among them. As a result the message chain and `message_str` are both empty, and the flow stops at `skip llm request` in `agent_sub_stages/internal.py`. The Bot does not react; if the audio content is then asked about, the model gives an unrelated answer.


### Modifications / 改动点

`astrbot/core/platform/sources/telegram/tg_adapter.py`:
 - Add an `audio` branch in `convert_message()` that produces a `Comp.Record` and calls `_apply_caption()`.

`tests/fixtures/helpers.py`:
 - Add an `audio` parameter to `create_mock_update()`.

`tests/test_telegram_adapter.py`:
 - Add a test case covering the creation of the `Record` component and the handling of the caption.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果


| Observation point | Before | After |
| --- | --- | --- |
| `tg_adapter.py` message dump | `audio=Audio(...)` | `audio=Audio(...)` |
| `event_bus.py` message outline | empty | `[ComponentType.Record]` |
| `agent_sub_stages/internal.py` | `skip llm request` | `ready to request llm provider` |
| `MediaModality.AUDIO` on the provider side | absent | `token_count=2000` |

The message dump on the Telegram side contains the complete `audio=Audio(...)` both before and after the change, which shows that the audio data itself arrives intact and is dropped inside the adapter. After the change an `AUDIO` modality appears in the usage statistics returned by the provider, confirming that the audio entered the model through the multimodal channel.

<img width="1172" height="1919" alt="修复前截图" src="https://github.com/user-attachments/assets/c9ed716e-6f59-4405-9daf-dd36c3b20b92" />

<details>

<summary>Log before</summary>

The audio message is dropped after it arrives, and no request is produced:

```
[15:32:21.722] [Core] [DBUG] [telegram.tg_adapter:427]: Telegram message: Message(audio=Audio(_duration=datetime.timedelta(seconds=80), api_kwargs={'thumb': {'file_id': 'AAMCBAADGQEAA3JqgAd7XPnA7G9LhiWk13GsceHScAACkyEAAq_KAVAAAR_elEBjKlYBAAdtAAM9BA', 'file_unique_id': 'AQADkyEAAq_KAVBy', 'file_size': 4289, 'width': 132, 'height': 132}}, file_id='CQACAgQAAxkBAANyaoAHe1z5wOxvS4YlpNdxrHHh0nAAApMhAAKvygFQAAEf3pRAYypWPQQ', file_name='Ennio Morricone - Toto and Alfredo.mp3', file_size=3235600, file_unique_id='AgADkyEAAq_KAVA', mime_type='audio/mpeg', performer='Ennio Morricone', thumbnail=PhotoSize(file_id='AAMCBAADGQEAA3JqgAd7XPnA7G9LhiWk13GsceHScAACkyEAAq_KAVAAAR_elEBjKlYBAAdtAAM9BA', file_size=4289, file_unique_id='AQADkyEAAq_KAVBy', height=132, width=132), title='Toto and Alfredo'), channel_chat_created=False, chat=Chat(first_name='testuser', id=100000000, type=<ChatType.PRIVATE>), date=datetime.datetime(2026, 8, 15, 6, 32, 20, tzinfo=datetime.timezone.utc), delete_chat_photo=False, from_user=User(first_name='testuser', id=100000000, is_bot=False, language_code='zh-hans'), group_chat_created=False, message_id=121, supergroup_chat_created=False)
[15:32:21.723] [Core] [INFO] [core.event_bus:74]: [default] [telegram(telegram)] Unknown/100000000:
[15:32:21.723] [Core] [DBUG] [waking_check.stage:165]: enabled_plugins_name: ['*']
[15:32:21.723] [Core] [DBUG] [method.star_request:46]: plugin -> astrbot - handle_session_control_agent
[15:32:21.723] [Core] [DBUG] [method.star_request:46]: plugin -> astrbot - handle_empty_mention
[15:32:21.723] [Core] [DBUG] [method.star_request:46]: plugin -> astrbot - persist_group_message
[15:32:21.723] [Core] [DBUG] [method.star_request:46]: plugin -> astrbot - on_message
[15:32:21.723] [Core] [DBUG] [agent_sub_stages.internal:190]: skip llm request: empty message and no provider_request
[15:32:21.723] [Core] [DBUG] [pipeline.scheduler:97]: pipeline execution completed.
```

The audio content is then asked about, and that request is sent normally:

```
[15:32:27.843] [Core] [DBUG] [telegram.tg_adapter:427]: Telegram message: Message(channel_chat_created=False, chat=Chat(first_name='testuser', id=100000000, type=<ChatType.PRIVATE>), date=datetime.datetime(2026, 8, 15, 6, 32, 26, tzinfo=datetime.timezone.utc), delete_chat_photo=False, from_user=User(first_name='testuser', id=100000000, is_bot=False, language_code='zh-hans'), group_chat_created=False, message_id=122, supergroup_chat_created=False, text='描述音频内容')
[15:32:27.844] [Core] [INFO] [core.event_bus:74]: [default] [telegram(telegram)] Unknown/100000000: 描述音频内容
[15:32:27.844] [Core] [DBUG] [waking_check.stage:165]: enabled_plugins_name: ['*']
[15:32:27.844] [Core] [DBUG] [method.star_request:46]: plugin -> astrbot - handle_session_control_agent
[15:32:27.844] [Core] [DBUG] [method.star_request:46]: plugin -> astrbot - handle_empty_mention
[15:32:27.845] [Core] [DBUG] [method.star_request:46]: plugin -> astrbot - persist_group_message
[15:32:27.845] [Core] [DBUG] [method.star_request:46]: plugin -> astrbot - on_message
[15:32:27.845] [Core] [DBUG] [agent_sub_stages.internal:193]: ready to request llm provider
[15:32:29.170] [Core] [DBUG] [agent_sub_stages.internal:221]: acquired session lock for llm request
```

Request construction and response body are omitted here; below are the usage statistics of that response

```
)] create_time=None model_version='gemini-3.6-flash' prompt_feedback=None response_id='_QeAasqwD6K12roPyqm6iQ4' usage_metadata=GenerateContentResponseUsageMetadata(
  candidates_token_count=36,
  prompt_token_count=3286,
  prompt_tokens_details=[
    ModalityTokenCount(
      modality=<MediaModality.TEXT: 'TEXT'>,
      token_count=3286
    ),
  ],
  thoughts_token_count=142,
  total_token_count=3464
) model_status=None automatic_function_calling_history=None parsed=None
```

`prompt_tokens_details` contains only `TEXT`, so the audio is not in the context of that request.

</details>

<img width="1172" height="2134" alt="修复后截图" src="https://github.com/user-attachments/assets/1826ee54-a03c-447d-8b80-14a743d3218c" />

<details>
<summary>Log after</summary>

The same audio file is converted into a `Comp.Record` and triggers the request directly:

```
[15:38:49.831] [Core] [DBUG] [telegram.tg_adapter:427]: Telegram message: Message(audio=Audio(_duration=datetime.timedelta(seconds=80), api_kwargs={'thumb': {'file_id': 'AAMCBAADGQEAA3JqgAd7XPnA7G9LhiWk13GsceHScAACkyEAAq_KAVAAAR_elEBjKlYBAAdtAAM9BA', 'file_unique_id': 'AQADkyEAAq_KAVBy', 'file_size': 4289, 'width': 132, 'height': 132}}, file_id='CQACAgQAAxkBAANyaoAHe1z5wOxvS4YlpNdxrHHh0nAAApMhAAKvygFQAAEf3pRAYypWPQQ', file_name='Ennio Morricone - Toto and Alfredo.mp3', file_size=3235600, file_unique_id='AgADkyEAAq_KAVA', mime_type='audio/mpeg', performer='Ennio Morricone', thumbnail=PhotoSize(file_id='AAMCBAADGQEAA3JqgAd7XPnA7G9LhiWk13GsceHScAACkyEAAq_KAVAAAR_elEBjKlYBAAdtAAM9BA', file_size=4289, file_unique_id='AQADkyEAAq_KAVBy', height=132, width=132), title='Toto and Alfredo'), channel_chat_created=False, chat=Chat(first_name='testuser', id=100000000, type=<ChatType.PRIVATE>), date=datetime.datetime(2026, 8, 15, 6, 38, 48, tzinfo=datetime.timezone.utc), delete_chat_photo=False, from_user=User(first_name='testuser', id=100000000, is_bot=False, language_code='zh-hans'), group_chat_created=False, message_id=126, supergroup_chat_created=False)
[15:38:57.451] [Core] [DBUG] [utils.media_utils:1187]: Audio converted successfully: C:\Users\user\Desktop\AstrBot-repro\data\temp\file_17.mp3 -> C:\Users\user\Desktop\AstrBot-repro\data\temp\media_audio_20260815153856913_bc9a.wav
[15:38:57.452] [Core] [INFO] [core.event_bus:74]: [default] [telegram(telegram)] Unknown/100000000: [ComponentType.Record]
[15:38:57.453] [Core] [DBUG] [waking_check.stage:165]: enabled_plugins_name: ['*']
[15:38:57.464] [Core] [DBUG] [method.star_request:46]: plugin -> astrbot - handle_session_control_agent
[15:38:57.465] [Core] [DBUG] [method.star_request:46]: plugin -> astrbot - handle_empty_mention
[15:38:57.465] [Core] [DBUG] [method.star_request:46]: plugin -> astrbot - persist_group_message
[15:38:57.465] [Core] [DBUG] [method.star_request:46]: plugin -> astrbot - on_message
[15:38:57.465] [Core] [DBUG] [agent_sub_stages.internal:193]: ready to request llm provider
[15:38:58.801] [Core] [DBUG] [agent_sub_stages.internal:221]: acquired session lock for llm request
```

Request construction and response body are omitted here; below are the usage statistics of that response

```
)] create_time=None model_version='gemini-3.6-flash' prompt_feedback=None response_id='iAmAav6YLsP_2roPvZ2xiQI' usage_metadata=GenerateContentResponseUsageMetadata(
  candidates_token_count=203,
  prompt_token_count=5341,
  prompt_tokens_details=[
    ModalityTokenCount(
      modality=<MediaModality.TEXT: 'TEXT'>,
      token_count=3341
    ),
    ModalityTokenCount(
      modality=<MediaModality.AUDIO: 'AUDIO'>,
      token_count=2000
    ),
  ],
  thoughts_token_count=387,
  total_token_count=5931
) model_status=None automatic_function_calling_history=None parsed=None
```

An `AUDIO` modality appears in `prompt_tokens_details`, so the audio has entered the context of that request.

</details>

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Handle Telegram Bot audio messages by converting them into Record components so they participate in LLM requests.

New Features:
- Support Telegram audio messages as Record components in the platform adapter so audio can be sent to the LLM along with captions.

Bug Fixes:
- Fix dropped Telegram audio messages where no provider request was previously created.
- Ensure captions on Telegram audio messages populate both the aggregated message string and a Plain text component.

Tests:
- Add helper fixture support for Telegram audio messages.
- Add tests verifying conversion of Telegram audio messages into Record components and proper handling of captions.