### PR TITLE
fix(qqofficial): restore @ mentions in group messages

### DIFF
--- a/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
@@ -27,7 +27,7 @@ from tenacity import (
 
 from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent, MessageChain
-from astrbot.api.message_components import File, Image, Plain, Record, Video
+from astrbot.api.message_components import At, File, Image, Plain, Record, Video
 from astrbot.api.platform import AstrBotMessage, PlatformMetadata
 from astrbot.core.platform.sources.qqofficial.qqofficial_chunked_upload import (
     QQOFFICIAL_CHUNKED_UPLOAD_THRESHOLD,
@@ -217,6 +217,29 @@ class QQOfficialMessageEvent(AstrMessageEvent):
         return str(ret_id) if ret_id is not None else None
 
     @staticmethod
+    def _get_mention_id(component: At) -> str | None:
+        qq = getattr(component, "qq", None)
+        if not qq:
+            return None
+        qq_id = str(qq)
+        # QQ Official group bots cannot send @all mentions through this path.
+        return qq_id if qq_id != "all" else None
+
+    @classmethod
+    def _has_mention(cls, message: MessageChain) -> bool:
+        return any(
+            isinstance(component, At) and cls._get_mention_id(component) is not None
+            for component in message.chain
+        )
+
+    @staticmethod
+    def _set_media_payload(payload: dict, media: Media, plain_text: str) -> None:
+        payload["media"] = media
+        payload["msg_type"] = 7
+        payload.pop("markdown", None)
+        payload["content"] = plain_text or None
+
+    @staticmethod
     def _split_message_chain_by_media(message: MessageChain) -> list[MessageChain]:
         chunks: list[MessageChain] = []
         current_chain = []
@@ -322,9 +345,10 @@ class QQOfficialMessageEvent(AstrMessageEvent):
         ):
             plain_text = plain_text + "\n"
 
-        # 根据消息链的 use_markdown_ 标记决定发送模式
+        # QQ only resolves <@openid> mentions in Markdown messages.
+        has_mention = self._has_mention(message_to_send)
         use_md = getattr(self.send_buffer, "use_markdown_", None)
-        if use_md is False:
+        if use_md is False and not has_mention:
             payload: dict = {
                 "content": plain_text,
                 "msg_type": 0,
@@ -354,10 +378,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                         self.IMAGE_FILE_TYPE,
                         group_openid=source.group_openid,
                     )
-                    payload["media"] = media
-                    payload["msg_type"] = 7
-                    payload.pop("markdown", None)
-                    payload["content"] = plain_text or None
+                    self._set_media_payload(payload, media, plain_text)
                 if record_file_path:  # group record msg
                     media = await self.upload_group_and_c2c_media(
                         record_file_path,
@@ -365,10 +386,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                         group_openid=source.group_openid,
                     )
                     if media:
-                        payload["media"] = media
-                        payload["msg_type"] = 7
-                        payload.pop("markdown", None)
-                        payload["content"] = plain_text or None
+                        self._set_media_payload(payload, media, plain_text)
                 if video_file_source:
                     media = await self.upload_group_and_c2c_media(
                         video_file_source,
@@ -376,10 +394,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                         group_openid=source.group_openid,
                     )
                     if media:
-                        payload["media"] = media
-                        payload["msg_type"] = 7
-                        payload.pop("markdown", None)
-                        payload["content"] = plain_text or None
+                        self._set_media_payload(payload, media, plain_text)
                 if file_source:
                     media = await self.upload_group_and_c2c_media(
                         file_source,
@@ -388,10 +403,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                         group_openid=source.group_openid,
                     )
                     if media:
-                        payload["media"] = media
-                        payload["msg_type"] = 7
-                        payload.pop("markdown", None)
-                        payload["content"] = plain_text or None
+                        self._set_media_payload(payload, media, plain_text)
                 ret = await self._send_with_markdown_fallback(
                     send_func=lambda retry_payload: self.bot.api.post_group_message(
                         group_openid=source.group_openid,  # type: ignore
@@ -409,10 +421,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                         self.IMAGE_FILE_TYPE,
                         openid=source.author.user_openid,
                     )
-                    payload["media"] = media
-                    payload["msg_type"] = 7
-                    payload.pop("markdown", None)
-                    payload["content"] = plain_text or None
+                    self._set_media_payload(payload, media, plain_text)
                 if record_file_path:  # c2c record
                     media = await self.upload_group_and_c2c_media(
                         record_file_path,
@@ -420,10 +429,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                         openid=source.author.user_openid,
                     )
                     if media:
-                        payload["media"] = media
-                        payload["msg_type"] = 7
-                        payload.pop("markdown", None)
-                        payload["content"] = plain_text or None
+                        self._set_media_payload(payload, media, plain_text)
                 if video_file_source:
                     media = await self.upload_group_and_c2c_media(
                         video_file_source,
@@ -431,10 +437,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                         openid=source.author.user_openid,
                     )
                     if media:
-                        payload["media"] = media
-                        payload["msg_type"] = 7
-                        payload.pop("markdown", None)
-                        payload["content"] = plain_text or None
+                        self._set_media_payload(payload, media, plain_text)
                 if file_source:
                     media = await self.upload_group_and_c2c_media(
                         file_source,
@@ -443,10 +446,7 @@ class QQOfficialMessageEvent(AstrMessageEvent):
                         openid=source.author.user_openid,
                     )
                     if media:
-                        payload["media"] = media
-                        payload["msg_type"] = 7
-                        payload.pop("markdown", None)
-                        payload["content"] = plain_text or None
+                        self._set_media_payload(payload, media, plain_text)
                 if stream:
                     ret = await self._send_with_markdown_fallback(
                         send_func=lambda retry_payload: self.post_c2c_message(
@@ -804,6 +804,10 @@ class QQOfficialMessageEvent(AstrMessageEvent):
         for i in message.chain:
             if isinstance(i, Plain):
                 plain_text += i.text
+            elif isinstance(i, At):
+                qq_id = QQOfficialMessageEvent._get_mention_id(i)
+                if qq_id:
+                    plain_text += f"<@{qq_id}>"
             elif isinstance(i, Image) and not image_base64:
                 if not i.file:
                     raise ValueError("Unsupported image file format")

--- a/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
+++ b/astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import os
 import random
+import re
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -379,7 +380,17 @@ class QQOfficialPlatformAdapter(Platform):
             )
             return
 
-        payload: dict[str, Any] = {"content": plain_text}
+        has_mention = QQOfficialMessageEvent._has_mention(message_chain)
+        use_markdown = (
+            has_mention or getattr(message_chain, "use_markdown_", None) is True
+        )
+        if use_markdown and plain_text:
+            payload: dict[str, Any] = {
+                "markdown": botpy.types.message.MarkdownPayload(content=plain_text),
+                "msg_type": 2,
+            }
+        else:
+            payload = {"content": plain_text, "msg_type": 0}
         if msg_id and not allow_group_proactive_send:
             payload["msg_id"] = msg_id
         ret: Any = None
@@ -395,8 +406,9 @@ class QQOfficialPlatformAdapter(Platform):
                         QQOfficialMessageEvent.IMAGE_FILE_TYPE,
                         group_openid=session.session_id,
                     )
-                    payload["media"] = media
-                    payload["msg_type"] = 7
+                    QQOfficialMessageEvent._set_media_payload(
+                        payload, media, plain_text
+                    )
                 if record_file_path:
                     media = await QQOfficialMessageEvent.upload_group_and_c2c_media(
                         send_helper,  # type: ignore
@@ -405,8 +417,9 @@ class QQOfficialPlatformAdapter(Platform):
                         group_openid=session.session_id,
                     )
                     if media:
-                        payload["media"] = media
-                        payload["msg_type"] = 7
+                        QQOfficialMessageEvent._set_media_payload(
+                            payload, media, plain_text
+                        )
                 if video_file_source:
                     media = await QQOfficialMessageEvent.upload_group_and_c2c_media(
                         send_helper,  # type: ignore
@@ -415,8 +428,9 @@ class QQOfficialPlatformAdapter(Platform):
                         group_openid=session.session_id,
                     )
                     if media:
-                        payload["media"] = media
-                        payload["msg_type"] = 7
+                        QQOfficialMessageEvent._set_media_payload(
+                            payload, media, plain_text
+                        )
                         payload.pop("msg_id", None)
                 if file_source:
                     media = await QQOfficialMessageEvent.upload_group_and_c2c_media(
@@ -427,8 +441,9 @@ class QQOfficialPlatformAdapter(Platform):
                         group_openid=session.session_id,
                     )
                     if media:
-                        payload["media"] = media
-                        payload["msg_type"] = 7
+                        QQOfficialMessageEvent._set_media_payload(
+                            payload, media, plain_text
+                        )
                         payload.pop("msg_id", None)
                 ret = await self.client.api.post_group_message(
                     group_openid=session.session_id,
@@ -437,6 +452,7 @@ class QQOfficialPlatformAdapter(Platform):
             else:
                 if image_path:
                     payload["file_image"] = image_path
+                payload.pop("msg_type", None)
                 ret = await self.client.api.post_message(
                     channel_id=session.session_id,
                     **payload,
@@ -454,8 +470,7 @@ class QQOfficialPlatformAdapter(Platform):
                     QQOfficialMessageEvent.IMAGE_FILE_TYPE,
                     openid=session.session_id,
                 )
-                payload["media"] = media
-                payload["msg_type"] = 7
+                QQOfficialMessageEvent._set_media_payload(payload, media, plain_text)
             if record_file_path:
                 media = await QQOfficialMessageEvent.upload_group_and_c2c_media(
                     send_helper,  # type: ignore
@@ -464,8 +479,9 @@ class QQOfficialPlatformAdapter(Platform):
                     openid=session.session_id,
                 )
                 if media:
-                    payload["media"] = media
-                    payload["msg_type"] = 7
+                    QQOfficialMessageEvent._set_media_payload(
+                        payload, media, plain_text
+                    )
             if video_file_source:
                 media = await QQOfficialMessageEvent.upload_group_and_c2c_media(
                     send_helper,  # type: ignore
@@ -474,8 +490,9 @@ class QQOfficialPlatformAdapter(Platform):
                     openid=session.session_id,
                 )
                 if media:
-                    payload["media"] = media
-                    payload["msg_type"] = 7
+                    QQOfficialMessageEvent._set_media_payload(
+                        payload, media, plain_text
+                    )
             if file_source:
                 media = await QQOfficialMessageEvent.upload_group_and_c2c_media(
                     send_helper,  # type: ignore
@@ -485,8 +502,9 @@ class QQOfficialPlatformAdapter(Platform):
                     openid=session.session_id,
                 )
                 if media:
-                    payload["media"] = media
-                    payload["msg_type"] = 7
+                    QQOfficialMessageEvent._set_media_payload(
+                        payload, media, plain_text
+                    )
 
             ret = await QQOfficialMessageEvent.post_c2c_message(
                 send_helper,  # type: ignore
@@ -674,7 +692,6 @@ class QQOfficialPlatformAdapter(Platform):
         """
         import base64
         import json
-        import re
 
         def replace_face(match):
             face_tag = match.group(0)
@@ -696,6 +713,15 @@ class QQOfficialPlatformAdapter(Platform):
 
         # Match face tags: <faceType=...>
         return re.sub(r"<faceType=\d+[^>]*>", replace_face, content)
+
+    @staticmethod
+    def _strip_bot_mention_markup(content: str | None, mention_id: str) -> str:
+        normalized = content or ""
+        escaped_id = re.escape(mention_id)
+        markup_pattern = (
+            rf'(?:<qqbot-at-user\s+id="{escaped_id}"\s*/>|<@!?{escaped_id}>)'
+        )
+        return re.sub(rf"(?:[ \t]*{markup_pattern}[ \t]*)+", " ", normalized)
 
     @staticmethod
     async def _parse_from_qqofficial(
@@ -781,12 +807,11 @@ class QQOfficialPlatformAdapter(Platform):
                 group_mentioned = bool(bot_mention_ids) or force_group_mention
                 plain_content_raw = message.content or ""
                 for mention_id in bot_mention_ids:
-                    plain_content_raw = plain_content_raw.replace(
-                        f"<@{mention_id}>",
-                        "",
-                    ).replace(
-                        f"<@!{mention_id}>",
-                        "",
+                    plain_content_raw = (
+                        QQOfficialPlatformAdapter._strip_bot_mention_markup(
+                            plain_content_raw,
+                            mention_id,
+                        )
                     )
                 abm.message_str = QQOfficialPlatformAdapter._parse_face_message(
                     plain_content_raw.strip()
@@ -823,9 +848,9 @@ class QQOfficialPlatformAdapter(Platform):
                 abm.self_id = ""
 
             plain_content = QQOfficialPlatformAdapter._parse_face_message(
-                message.content.replace(
-                    "<@!" + str(abm.self_id) + ">",
-                    "",
+                QQOfficialPlatformAdapter._strip_bot_mention_markup(
+                    message.content,
+                    str(abm.self_id),
                 ).strip()
             )
 

--- a/tests/test_qqofficial_group_message_create.py
+++ b/tests/test_qqofficial_group_message_create.py
@@ -164,11 +164,17 @@ async def test_parse_group_message_create_quoted_context():
     ][-1] == "answer"
 
 
+@pytest.mark.parametrize(
+    "mention_markup",
+    ["<@bot-123>", "<@!bot-123>", '<qqbot-at-user id="bot-123" />'],
+)
 @pytest.mark.asyncio
-async def test_parse_group_message_create_bot_mention_cleans_plain_text():
+async def test_parse_group_message_create_bot_mention_cleans_plain_text(
+    mention_markup: str,
+):
     _, message = _dispatch_group_message(
         _make_group_payload(
-            content="<@!bot-123> hello there",
+            content=f"{mention_markup} hello there",
             mentions=[{"id": "bot-123", "is_you": True}],
         )
     )
@@ -186,6 +192,55 @@ async def test_parse_group_message_create_bot_mention_cleans_plain_text():
     assert abm.message_str == "hello there"
     assert abm.sender.user_id == "member-1"
     assert abm.group_id == "group-1"
+
+
+@pytest.mark.parametrize(
+    ("content", "mention_id", "expected"),
+    [
+        ("before<@bot-123>after", "bot-123", "before after"),
+        ("before <@bot-123><@!bot-123> after", "bot-123", "before after"),
+        (
+            'before<qqbot-at-user id="bot-123" />after',
+            "bot-123",
+            "before after",
+        ),
+        ("before<@other-user>after", "bot-123", "before<@other-user>after"),
+        ("before<@bot.123>after", "bot.123", "before after"),
+    ],
+)
+def test_strip_bot_mention_markup_preserves_word_boundaries(
+    content: str,
+    mention_id: str,
+    expected: str,
+):
+    normalized = QQOfficialPlatformAdapter._strip_bot_mention_markup(
+        content,
+        mention_id,
+    )
+
+    assert normalized.strip() == expected
+
+
+@pytest.mark.asyncio
+async def test_parse_to_qqofficial_preserves_at_component_order():
+    parsed = await QQOfficialMessageEvent._parse_to_qqofficial(
+        MessageChain(chain=[At(qq="member-1"), Plain(" hello"), At(qq="all")])
+    )
+
+    assert parsed[0] == "<@member-1> hello"
+
+
+@pytest.mark.parametrize("qq", [None, ""])
+@pytest.mark.asyncio
+async def test_parse_to_qqofficial_ignores_empty_at_component(qq: str | None):
+    mention = At(qq="placeholder")
+    mention.qq = cast(Any, qq)
+    chain = MessageChain(chain=[mention, Plain("hello")])
+
+    parsed = await QQOfficialMessageEvent._parse_to_qqofficial(chain)
+
+    assert parsed[0] == "hello"
+    assert QQOfficialMessageEvent._has_mention(chain) is False
 
 
 @pytest.mark.asyncio
@@ -311,15 +366,45 @@ async def test_ws_group_send_by_session_with_cached_msg_id_still_omits_msg_id():
 
 
 @pytest.mark.asyncio
+async def test_ws_group_send_by_session_with_at_uses_markdown():
+    adapter = QQOfficialPlatformAdapter(
+        {
+            "id": "qq-official-test",
+            "appid": "123",
+            "secret": "secret",
+            "enable_group_c2c": True,
+            "enable_guild_direct_message": False,
+        },
+        {},
+        asyncio.Queue(),
+    )
+    adapter.client.api = SimpleNamespace(
+        post_group_message=AsyncMock(return_value={"id": "sent-at"}),
+        post_message=AsyncMock(),
+    )
+    adapter._session_scene["group-1"] = "group"
+    chain = MessageChain(chain=[At(qq="member-1"), Plain(" hello")])
+    chain.use_markdown(False)
+
+    await adapter.send_by_session(
+        MessageSession("qq_official", MessageType.GROUP_MESSAGE, "group-1"),
+        chain,
+    )
+
+    kwargs = adapter.client.api.post_group_message.await_args.kwargs
+    assert kwargs["msg_type"] == 2
+    assert kwargs["markdown"]["content"] == "<@member-1> hello"
+    assert "content" not in kwargs
+
+
+@pytest.mark.asyncio
 async def test_media_upload_propagates_qq_api_error(monkeypatch):
     """QQ upload errors propagate so callers cannot report a false success."""
     request = AsyncMock(
         side_effect=botpy.errors.ServerError("413 Request Entity Too Large")
     )
     send_helper = SimpleNamespace(
-        bot=SimpleNamespace(
-            api=SimpleNamespace(_http=SimpleNamespace(request=request))
-        )
+        bot=SimpleNamespace(api=SimpleNamespace(_http=SimpleNamespace(request=request)))
     )
     monkeypatch.setattr(
         "astrbot.core.platform.sources.qqofficial.qqofficial_message_event._qqofficial_retry",


### PR DESCRIPTION
## Summary

- serialize valid `At` components as `<@openid>` markup
- send mention-bearing replies and proactive messages as Markdown
- preserve payload compatibility for media and guild channel messages
- support legacy and current incoming mention formats
- restore regression tests for QQ Official @ mentions

This PR is a follow-up to #9285 and its subsequent revert in #9310.

#9285 originally fixed an issue where QQ Official outgoing messages discarded `At` components in `_parse_to_qqofficial`, causing user mentions to disappear from replies.

Messages sent through `send_by_session`, including proactive and scheduled group messages, were also sent through the plain `content` field. QQ does not resolve `<@openid>` mentions through that path, so the mention could appear as plain text instead of an actual user mention.

#9285 was later reverted by #9310 because it was reported that QQ Official did not support real mentions.

However, the QQ Bot official text-chain documentation explicitly lists mentioning users as available in group chats and text subchannels:

<img width="1003" height="408" alt="PixPin_2026-08-16_07-39-35" src="https://github.com/user-attachments/assets/569d9664-6f01-4cf4-855c-f3adbe4d776d" />

Official documentation:

https://bot.q.qq.com/wiki/develop/api-v2/server-inter/message/trans/text-chain.html

I reapplied the implementation to the current `dev` branch and tested it in a QQ Official group-message environment. In the tested scenario, the target user was rendered as an actual mention rather than displaying the raw `<@openid>` markup.

This PR therefore restores the behavior from #9285 while adapting it to the current codebase and preserving subsequent upstream changes.

<p align="center">
  <img
    width="945"
    alt="Native mention rendering on QQ for Windows"
    src="https://github.com/user-attachments/assets/e12e5204-6ef4-481b-80b3-36f2f148d85c"
  />
</p>

<table>
  <tr>
    <td align="center" width="40%">
      <img
        width="312"
        alt="In-client mention notification on QQ for Windows"
        src="https://github.com/user-attachments/assets/6f85ddd5-d211-4b67-9fa4-9203c71982c9"
      />
    </td>
    <td align="center" width="60%">
      <img
        width="560"
        alt="Native mention rendering on QQ for Android"
        src="https://github.com/user-attachments/assets/6dc8f4c8-c8af-4948-bce3-9a82d77e0932"
      />
    </td>
  </tr>
</table>

### Modifications / 改动点

- Updated `qqofficial_message_event.py` to serialize valid `At` components as `<@openid>`.
- Ignored empty mention IDs.
- Skipped `At(qq="all")`, because QQ Official group bots do not support bot-generated `@all` through this path.
- Ensured event replies containing `At` use Markdown even when Markdown was explicitly disabled on the message chain.
- Updated `send_by_session` so proactive, scheduled, and directly sent group messages containing `At` use `msg_type=2` with a Markdown payload.
- Kept ordinary messages without mentions on the existing plain-text sending path to avoid changing unrelated behavior.
- Preserved compatibility with media messages by removing the Markdown payload, restoring plain `content`, and switching to `msg_type=7`.
- Removed the incompatible `msg_type` field when sending messages to guild text channels.
- Added support for cleaning legacy and current incoming mention formats:
  - `<@bot_id>`
  - `<@!bot_id>`
  - `<qqbot-at-user id="bot_id" />`
- Preserved current `dev` changes. 
- Restored regression tests for outgoing mention serialization, incoming mention cleanup, and proactive group messages containing `At`.

### Compatibility / 兼容性

The mention-specific behavior is only activated when a message chain contains a valid `At` component, or when Markdown is explicitly requested.

Ordinary messages without mentions continue to use the existing plain-text sending path.

Media messages continue to use `msg_type=7`, and guild text-channel messages do not include the incompatible `msg_type` field.

### Environment / 测试环境

- AstrBot base branch: `dev`
- AstrBot base commit: `eede34c18360d12100f27fc2f24c8718777d237b`
- QQ clients tested:
  - QQ for Windows: `9.9.33-52230 (64-bit)`
  - QQ for Android: `9.3.35.39800`
- Bot environment: `Production`
- Message scene: `QQ Official group message`

#### QQ Official regression tests

Test command:

```text
pytest tests/test_qqofficial_group_message_create.py -q
```

Test result:

```text
24 passed, 2 warnings
```

The warnings are unrelated to the mention changes:

- Python 3.12 reports that `audioop` is deprecated and scheduled for removal
  in Python 3.13.
- An `aiosqlite` worker thread may report that the pytest event loop was
  already closed during test teardown.

#### Code-quality test

Test command:

```text
pytest tests/test_code_quality_typing.py -q
```

Test result:

```text
1 passed, 1 warning
```

#### Ruff check

Command:

```text
ruff check \
  astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py \
  astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
```

Result:

```text
All checks passed!
```

#### Ruff format

Command:

```text
ruff format --check \
  astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py \
  astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py \
  tests/test_qqofficial_group_message_create.py
```

Result:

```text
3 files already formatted
```

#### Diff check

```text
git diff --check upstream/dev..HEAD
```

Result:

```text
No whitespace errors.
```

### Changed Files / 修改文件

```text
astrbot/core/platform/sources/qqofficial/qqofficial_message_event.py
astrbot/core/platform/sources/qqofficial/qqofficial_platform_adapter.py
tests/test_qqofficial_group_message_create.py
```

```text
3 files changed, 188 insertions(+), 77 deletions(-)
```

### Related / 相关 PR

- Original implementation: #9285
- Revert: #9310
- Revert commit: `45f4e666e99fa0aa95af448b7642ec84879df683`

## Summary by Sourcery

Restore proper QQ Official group @ mention handling while keeping existing behaviors for non-mention and media/guild messages intact.

New Features:
- Support outgoing QQ Official group messages with At components rendered as <@openid> mentions via Markdown payloads.
- Handle proactive and session-based group messages with mentions using the Markdown msg_type path instead of plain-text content.

Bug Fixes:
- Ensure At components in QQ Official outgoing messages are serialized into content instead of being silently dropped.
- Normalize incoming QQ Official bot mentions by stripping legacy and current mention markup variants from plain text content.

Enhancements:
- Centralize media payload construction to consistently use msg_type=7 and remove markdown when media is present.
- Avoid sending incompatible msg_type values for guild text-channel messages to preserve compatibility with QQ APIs.

Tests:
- Expand QQ Official group message tests to cover mention serialization ordering, empty At components, multiple mention markup formats, and Markdown usage in send_by_session.

## Summary by Sourcery

Restore QQ Official @ mentions across outgoing and incoming group message flows while preserving existing media, guild, and plain-text compatibility.

New Features:
- Restore native QQ Official group-user mentions for outgoing replies and session-based messages, including proactive and scheduled sends.
- Support recognition and cleanup of current and legacy QQ Official bot-mention markup in incoming messages.

Bug Fixes:
- Preserve valid At components during QQ Official message serialization instead of dropping them.
- Ensure mention-bearing messages use the QQ Markdown delivery path while retaining compatible handling for media and guild messages.

Enhancements:
- Centralize media payload handling while keeping ordinary non-mention messages on the existing plain-text path.

Tests:
- Restore regression coverage for outgoing mention serialization, incoming mention normalization, and Markdown-based session sends.