### PR TITLE
docs: fix self-hosted t2i setup instructions

### DIFF
--- a/docs/en/others/self-host-t2i.md
+++ b/docs/en/others/self-host-t2i.md
@@ -18,11 +18,8 @@ You can choose to self-host the text-to-image service to improve response speed.
 docker run -itd -p 8999:8999 soulter/astrbot-t2i-service:latest
 ```
 
-After deployment, go to AstrBot Dashboard -> Config -> System, and change `Text-to-Image Service API Endpoint` to the URL you deployed (as shown below).
+After deployment, go to AstrBot Dashboard -> Settings -> Appearance. Under "Text-to-Image," set `Text-to-Image Strategy` to `remote`. The `Text-to-Image Service API Endpoint` field will then appear; set it to the URL of your deployed service.
 
 > If you deployed AstrBot using the Docker tutorial in this documentation, the URL should be `http://<t2i-service-container-name>:8999`.
 
 > If you deployed on the same machine as AstrBot, the URL should be `http://localhost:8999`.
-
-<img width="589" height="255" alt="image" src="https://github.com/user-attachments/assets/5ef09db2-1a33-440c-9986-c7b544325e34" />
-

--- a/docs/zh/others/self-host-t2i.md
+++ b/docs/zh/others/self-host-t2i.md
@@ -18,10 +18,8 @@ https://t2i.rcfortress.site/text2img
 docker run -itd -p 8999:8999 soulter/astrbot-t2i-service:latest
 ```
 
-在部署完成后，前往 AstrBot 仪表盘 -> 配置文件 -> 系统，修改 `文本转图像服务 API 地址` 为你部署好的 url（如下图所示）
+部署完成后，前往 AstrBot 仪表盘 -> 设置 -> 外观。在“文本转图像”中，将 `文本转图像策略` 设为 `remote`；随后会显示 `文本转图像服务 API 地址`，将其修改为你部署好的 URL。
 
->如果你是使用本文档的 Docker教程 部署的 AstrBot ，url应为  `http://文转图服务容器名:8999`。
+> 如果你是使用本文档的 Docker 教程部署的 AstrBot，URL 应为 `http://文转图服务容器名:8999`。
 
->如果部署在与 AstrBot 相同的机器上，url 应为 `http://localhost:8999`。
-
-<img width="591" height="228" alt="image" src="https://github.com/user-attachments/assets/f3564b46-11a4-402a-85e3-5f44a82713fe" />
+> 如果部署在与 AstrBot 相同的机器上，URL 应为 `http://localhost:8999`。


### PR DESCRIPTION
## Summary

- update the English and Chinese self-hosted T2I guides to use the current **Settings → Appearance** navigation
- explain that `Text-to-Image Strategy` must be set to `remote` before the endpoint field appears
- remove outdated dashboard screenshots and clean up URL wording in the Chinese guide

## Root cause

The guides still referenced the removed **Config → System** path and did not document the conditional visibility of the endpoint field. Users following the current dashboard could therefore not find the setting while `local` rendering was selected.

## User impact

Users can now locate and configure a self-hosted T2I endpoint in the current dashboard without relying on obsolete screenshots.

## Checks

- `cd docs && pnpm docs:build`
- `uv run ruff format .`
- `uv run ruff check .`
- `git diff --check`

## Summary by Sourcery

Update self-hosted text-to-image setup docs to match the current dashboard UI and configuration behavior.

Documentation:
- Refresh English and Chinese self-hosted text-to-image guides to use the current Settings → Appearance navigation and terminology.
- Document that the text-to-image service endpoint field only appears when the strategy is set to remote and remove outdated dashboard screenshots.