### PR TITLE
fix(wecom): prevent Weixin Kefu webhook processing from failing when synced messages omit the open_kfid field.

### DIFF
--- a/astrbot/core/platform/sources/wecom/wecom_adapter.py
+++ b/astrbot/core/platform/sources/wecom/wecom_adapter.py
@@ -430,7 +430,7 @@ class WecomPlatformAdapter(Platform):
         abm = AstrBotMessage()
         abm.raw_message = msg
         abm.raw_message["_wechat_kf_flag"] = None  # 方便处理
-        abm.self_id = msg["open_kfid"]
+        abm.self_id = msg.get("open_kfid") or msg.get("OpenKfId") or ""
         abm.sender = MessageMember(external_userid, external_userid)
         abm.session_id = external_userid
         abm.type = MessageType.FRIEND_MESSAGE


### PR DESCRIPTION
## 问题 / Problem

企业微信（微信客服）接入时，`WecomPlatformAdapter.convert_wechat_kf_message` 直接对 `msg["open_kfid"]` 做下标取值：

```python
abm.self_id = msg["open_kfid"]
```

微信客服 `sync_msg` 拉取到的消息列表中，**部分条目（如事件 / 控制类消息）并不携带 `open_kfid` 字段**，此时会抛出 `KeyError: 'open_kfid'`。该异常在 webhook 回调中未被捕获，会导致**这一条微信客服消息被直接丢弃、对话流程中断**——用户体感为“发消息机器人没反应”。

相关社区报告：#4908、#3160（均指向同一处直接索引）。

## 复现 / Reproduction

1. 配置企业微信 → 微信客服接入（统一 Webhook 模式）。
2. 收到某些 `sync_msg` 返回的不含 `open_kfid` 的消息条目时，日志出现：
   `[ERRO] 处理 webhook 回调时发生错误: 'open_kfid'`
3. 对应消息未被处理。

## 修复 / Fix

改为安全取值并兜底：

```python
abm.self_id = msg.get("open_kfid") or msg.get("OpenKfId") or ""
```

- 正常消息仍取到正确的 `open_kfid`（`self_id` 不变）。
- 缺失字段时不再崩溃；缺失字段的消息（如事件类）本就由方法末尾的 `else` 分支以 `logger.warning` 忽略并返回 `None`，不影响主流程。

## 影响范围 / Scope

单行修改，对正常微信客服消息的行为无任何变化。

---
English:
When a synced WeCom Customer Service message lacks the `open_kfid` field (e.g. event/control messages), the direct indexing `msg["open_kfid"]` raises an uncaught `KeyError` that aborts the webhook callback and silently drops the message. This changes it to a safe `.get()` with a fallback, so messages are no longer lost. Normal messages are unaffected. See #4908, #3160.

## Summary by Sourcery

Bug Fixes:
- Prevent WeCom customer-service webhook processing from failing when synced messages omit the customer-service ID field.