### PR TITLE
fix: enable xAI Responses native web search

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -924,6 +924,17 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 ),
             )
 
+        if llm_resp.web_search_sources:
+            yield AgentResponse(
+                type="web_search_sources",
+                data=AgentResponseData(
+                    chain=MessageChain(
+                        type="web_search_sources",
+                        chain=[Json(data={"sources": llm_resp.web_search_sources})],
+                    )
+                ),
+            )
+
         # 如果有工具调用，还需处理工具调用
         if llm_resp.tools_call_name:
             if self.tool_schema_mode == "skills_like":

--- a/astrbot/core/astr_agent_run_util.py
+++ b/astrbot/core/astr_agent_run_util.py
@@ -187,6 +187,11 @@ async def run_agent(
                         await astr_event.send(resp.data["chain"])
                     continue
 
+                if resp.type == "web_search_sources":
+                    if astr_event.get_platform_name() == "webchat":
+                        await astr_event.send(resp.data["chain"])
+                    continue
+
                 if resp.type == "tool_call_result":
                     msg_chain = resp.data["chain"]
 

--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1304,6 +1304,7 @@ CONFIG_METADATA_2 = {
                         "timeout": 120,
                         "proxy": "",
                         "custom_headers": {},
+                        "xai_native_search": False,
                     },
                     "DeepSeek": {
                         "id": "deepseek",
@@ -2032,10 +2033,9 @@ CONFIG_METADATA_2 = {
                     "xai_native_search": {
                         "description": "启用原生搜索功能",
                         "type": "bool",
-                        "hint": "启用后，将通过 xAI 的 Chat Completions 原生 Live Search 进行联网检索（按需计费）。仅对 xAI 提供商生效。",
+                        "hint": "启用后，将通过 xAI 原生 Web Search 进行联网检索（按需计费）。仅对 xAI 提供商生效。",
                         "condition": {
                             "provider": "xai",
-                            "type": "xai_chat_completion",
                         },
                     },
                     "rerank_api_base": {

--- a/astrbot/core/provider/entities.py
+++ b/astrbot/core/provider/entities.py
@@ -312,6 +312,9 @@ class LLMResponse:
     reasoning_signature: str | None = None
     """The signature of the reasoning content, if any."""
 
+    web_search_sources: list[dict[str, Any]] = field(default_factory=list)
+    """Structured web search sources (e.g. xAI url_citation), each with index/url/title."""
+
     raw_completion: (
         ChatCompletion | Response | GenerateContentResponse | AnthropicMessage | None
     ) = None
@@ -339,6 +342,7 @@ class LLMResponse:
         tools_call_extra_content: dict[str, dict[str, Any]] | None = None,
         reasoning_content: str | None = None,
         reasoning_signature: str | None = None,
+        web_search_sources: list[dict[str, Any]] | None = None,
         raw_completion: ChatCompletion
         | Response
         | GenerateContentResponse
@@ -377,6 +381,7 @@ class LLMResponse:
         self.tools_call_extra_content = tools_call_extra_content
         self.reasoning_content = reasoning_content
         self.reasoning_signature = reasoning_signature
+        self.web_search_sources = web_search_sources or []
         self.raw_completion = raw_completion
         self.is_chunk = is_chunk
 

--- a/astrbot/core/provider/sources/openai_responses_source.py
+++ b/astrbot/core/provider/sources/openai_responses_source.py
@@ -294,6 +294,20 @@ class ProviderOpenAIResponses(ProviderOpenAIOfficial):
 
         return payloads, context_query
 
+    def _build_response_tools(self, tools: ToolSet | None) -> list[dict]:
+        response_tools: list[dict] = []
+        if tools:
+            for tool in tools.openai_schema():
+                function = tool.get("function", {})
+                response_tools.append({"type": "function", **function})
+
+        if self.provider_config.get("provider") == "xai" and bool(
+            self.provider_config.get("xai_native_search", False)
+        ):
+            response_tools.append({"type": "web_search"})
+
+        return response_tools
+
     async def _query(
         self,
         payloads: dict,
@@ -314,14 +328,10 @@ class ProviderOpenAIResponses(ProviderOpenAIOfficial):
         Raises:
             TypeError: If the SDK returns an unexpected response type.
         """
-        if tools:
-            response_tools = []
-            for tool in tools.openai_schema():
-                function = tool.get("function", {})
-                response_tools.append({"type": "function", **function})
-            if response_tools:
-                payloads["tools"] = response_tools
-                payloads["tool_choice"] = payloads.get("tool_choice", "auto")
+        response_tools = self._build_response_tools(tools)
+        if response_tools:
+            payloads["tools"] = response_tools
+            payloads["tool_choice"] = payloads.get("tool_choice", "auto")
 
         extra_body: dict[str, Any] = {}
         custom_extra_body = self.provider_config.get("custom_extra_body", {})
@@ -383,14 +393,10 @@ class ProviderOpenAIResponses(ProviderOpenAIOfficial):
         Raises:
             EmptyModelOutputError: If the stream ends without a terminal event.
         """
-        if tools:
-            response_tools = []
-            for tool in tools.openai_schema():
-                function = tool.get("function", {})
-                response_tools.append({"type": "function", **function})
-            if response_tools:
-                payloads["tools"] = response_tools
-                payloads["tool_choice"] = payloads.get("tool_choice", "auto")
+        response_tools = self._build_response_tools(tools)
+        if response_tools:
+            payloads["tools"] = response_tools
+            payloads["tool_choice"] = payloads.get("tool_choice", "auto")
 
         extra_body: dict[str, Any] = {}
         custom_extra_body = self.provider_config.get("custom_extra_body", {})

--- a/astrbot/core/provider/sources/openai_responses_source.py
+++ b/astrbot/core/provider/sources/openai_responses_source.py
@@ -295,6 +295,7 @@ class ProviderOpenAIResponses(ProviderOpenAIOfficial):
         return payloads, context_query
 
     def _build_response_tools(self, tools: ToolSet | None) -> list[dict]:
+        """Build the Responses tools list, appending xAI's native web_search when enabled."""
         response_tools: list[dict] = []
         if tools:
             for tool in tools.openai_schema():
@@ -331,7 +332,8 @@ class ProviderOpenAIResponses(ProviderOpenAIOfficial):
         response_tools = self._build_response_tools(tools)
         if response_tools:
             payloads["tools"] = response_tools
-            payloads["tool_choice"] = payloads.get("tool_choice", "auto")
+            if tools:
+                payloads["tool_choice"] = payloads.get("tool_choice", "auto")
 
         extra_body: dict[str, Any] = {}
         custom_extra_body = self.provider_config.get("custom_extra_body", {})
@@ -396,7 +398,8 @@ class ProviderOpenAIResponses(ProviderOpenAIOfficial):
         response_tools = self._build_response_tools(tools)
         if response_tools:
             payloads["tools"] = response_tools
-            payloads["tool_choice"] = payloads.get("tool_choice", "auto")
+            if tools:
+                payloads["tool_choice"] = payloads.get("tool_choice", "auto")
 
         extra_body: dict[str, Any] = {}
         custom_extra_body = self.provider_config.get("custom_extra_body", {})
@@ -546,7 +549,11 @@ class ProviderOpenAIResponses(ProviderOpenAIOfficial):
                                 continue
                             title = self._field(annotation, "title")
                             web_search_sources.append(
-                                {"index": title, "url": url, "title": title}
+                                {
+                                    "index": str(len(web_search_sources) + 1),
+                                    "url": url,
+                                    "title": title,
+                                }
                             )
                     elif content_type == "refusal":
                         text_parts.append(str(self._field(content, "refusal", "")))

--- a/astrbot/core/provider/sources/openai_responses_source.py
+++ b/astrbot/core/provider/sources/openai_responses_source.py
@@ -529,6 +529,7 @@ class ProviderOpenAIResponses(ProviderOpenAIOfficial):
         text_parts: list[str] = []
         reasoning_parts: list[str] = []
         serialized_reasoning_items: list[dict] = []
+        web_search_sources: list[dict[str, Any]] = []
 
         for item in self._field(response, "output", []) or []:
             item_type = self._field(item, "type")
@@ -537,6 +538,16 @@ class ProviderOpenAIResponses(ProviderOpenAIOfficial):
                     content_type = self._field(content, "type")
                     if content_type == "output_text":
                         text_parts.append(str(self._field(content, "text", "")))
+                        for annotation in self._field(content, "annotations", []) or []:
+                            if self._field(annotation, "type") != "url_citation":
+                                continue
+                            url = self._field(annotation, "url")
+                            if not url:
+                                continue
+                            title = self._field(annotation, "title")
+                            web_search_sources.append(
+                                {"index": title, "url": url, "title": title}
+                            )
                     elif content_type == "refusal":
                         text_parts.append(str(self._field(content, "refusal", "")))
                 continue
@@ -596,6 +607,8 @@ class ProviderOpenAIResponses(ProviderOpenAIOfficial):
             )
         if llm_response.tools_call_args:
             llm_response.role = "tool"
+
+        llm_response.web_search_sources = web_search_sources
 
         usage = self._field(response, "usage")
         if usage is not None:

--- a/astrbot/core/provider/sources/openai_responses_source.py
+++ b/astrbot/core/provider/sources/openai_responses_source.py
@@ -332,8 +332,7 @@ class ProviderOpenAIResponses(ProviderOpenAIOfficial):
         response_tools = self._build_response_tools(tools)
         if response_tools:
             payloads["tools"] = response_tools
-            if tools:
-                payloads["tool_choice"] = payloads.get("tool_choice", "auto")
+            payloads["tool_choice"] = payloads.get("tool_choice", "auto")
 
         extra_body: dict[str, Any] = {}
         custom_extra_body = self.provider_config.get("custom_extra_body", {})
@@ -398,8 +397,7 @@ class ProviderOpenAIResponses(ProviderOpenAIOfficial):
         response_tools = self._build_response_tools(tools)
         if response_tools:
             payloads["tools"] = response_tools
-            if tools:
-                payloads["tool_choice"] = payloads.get("tool_choice", "auto")
+            payloads["tool_choice"] = payloads.get("tool_choice", "auto")
 
         extra_body: dict[str, Any] = {}
         custom_extra_body = self.provider_config.get("custom_extra_body", {})

--- a/astrbot/dashboard/services/chat_service.py
+++ b/astrbot/dashboard/services/chat_service.py
@@ -921,6 +921,8 @@ class ChatService:
                     plain_text,
                     message_parts_to_save,
                 )
+                if not extracted_refs and pending_refs:
+                    extracted_refs = pending_refs
             except Exception as exc:
                 logger.exception(
                     f"Failed to extract web search refs: {exc}",
@@ -967,6 +969,22 @@ class ChatService:
                         run,
                         {"type": "agent_stats", "data": run.agent_stats},
                     )
+                    continue
+
+                if chain_type == "web_search_sources":
+                    try:
+                        parsed = json.loads(result_text)
+                        sources = (
+                            parsed.get("sources", [])
+                            if isinstance(parsed, dict)
+                            else []
+                        )
+                        pending_refs = (
+                            {"used": sources} if isinstance(sources, list) else {}
+                        )
+                    except (TypeError, json.JSONDecodeError):
+                        pending_refs = {}
+                    run.refs = pending_refs
                     continue
 
                 attachment_saved_payload = None
@@ -1036,6 +1054,7 @@ class ChatService:
                                         saved_record.created_at
                                     ),
                                     "llm_checkpoint_id": run.llm_checkpoint_id,
+                                    "refs": run.refs,
                                 },
                             },
                         )
@@ -1063,6 +1082,7 @@ class ChatService:
                                 "id": saved_record.id,
                                 "created_at": to_utc_isoformat(saved_record.created_at),
                                 "llm_checkpoint_id": run.llm_checkpoint_id,
+                                "refs": run.refs,
                             },
                         },
                     )

--- a/astrbot/dashboard/services/chat_service.py
+++ b/astrbot/dashboard/services/chat_service.py
@@ -272,6 +272,21 @@ def extract_web_search_refs(accumulated_text: str, accumulated_parts: list) -> d
     return {"used": used_refs} if used_refs else {}
 
 
+def parse_web_search_sources(result_text: str) -> dict:
+    """Parse a web_search_sources back-queue payload into a refs dict.
+
+    The payload is ``{"sources": [...]}``; the refs shape mirrors
+    ``extract_web_search_refs`` so the frontend renders native search
+    sources as the same clickable cards.
+    """
+    try:
+        parsed = json.loads(result_text)
+        sources = parsed.get("sources", []) if isinstance(parsed, dict) else []
+        return {"used": sources} if isinstance(sources, list) else {}
+    except (TypeError, json.JSONDecodeError):
+        return {}
+
+
 def sanitize_message_content(content: dict) -> dict:
     if not isinstance(content, dict):
         raise ValueError("Missing key: content")
@@ -972,18 +987,7 @@ class ChatService:
                     continue
 
                 if chain_type == "web_search_sources":
-                    try:
-                        parsed = json.loads(result_text)
-                        sources = (
-                            parsed.get("sources", [])
-                            if isinstance(parsed, dict)
-                            else []
-                        )
-                        pending_refs = (
-                            {"used": sources} if isinstance(sources, list) else {}
-                        )
-                    except (TypeError, json.JSONDecodeError):
-                        pending_refs = {}
+                    pending_refs = parse_web_search_sources(result_text)
                     run.refs = pending_refs
                     continue
 

--- a/astrbot/dashboard/services/live_chat_service.py
+++ b/astrbot/dashboard/services/live_chat_service.py
@@ -33,6 +33,7 @@ from astrbot.dashboard.services.chat_service import (
     BotMessageAccumulator,
     build_bot_history_content,
     collect_plain_text_from_message_parts,
+    parse_web_search_sources,
 )
 
 SendJson = Callable[[dict], Awaitable[None]]
@@ -704,16 +705,7 @@ class LiveChatService:
                     continue
 
                 if chain_type == "web_search_sources":
-                    try:
-                        parsed = json.loads(result_text)
-                        sources = (
-                            parsed.get("sources", [])
-                            if isinstance(parsed, dict)
-                            else []
-                        )
-                        refs = {"used": sources} if isinstance(sources, list) else {}
-                    except Exception:
-                        refs = {}
+                    refs = parse_web_search_sources(result_text)
                     continue
 
                 outgoing = {"ct": "chat", **result}

--- a/astrbot/dashboard/services/live_chat_service.py
+++ b/astrbot/dashboard/services/live_chat_service.py
@@ -630,6 +630,8 @@ class LiveChatService:
                         exc_info=True,
                     )
                     extracted_refs = refs
+                if not extracted_refs and refs:
+                    extracted_refs = refs
 
                 saved_record = await self.save_bot_message(
                     session_id,
@@ -699,6 +701,19 @@ class LiveChatService:
                         )
                     except Exception:
                         pass
+                    continue
+
+                if chain_type == "web_search_sources":
+                    try:
+                        parsed = json.loads(result_text)
+                        sources = (
+                            parsed.get("sources", [])
+                            if isinstance(parsed, dict)
+                            else []
+                        )
+                        refs = {"used": sources} if isinstance(sources, list) else {}
+                    except Exception:
+                        refs = {}
                     continue
 
                 outgoing = {"ct": "chat", **result}

--- a/astrbot/dashboard/services/open_api_service.py
+++ b/astrbot/dashboard/services/open_api_service.py
@@ -29,6 +29,7 @@ from astrbot.dashboard.services.auth_service import (
 from astrbot.dashboard.services.chat_service import (
     BotMessageAccumulator,
     collect_plain_text_from_message_parts,
+    parse_web_search_sources,
 )
 
 SendJson = Callable[[dict], Awaitable[None]]
@@ -486,16 +487,7 @@ class OpenApiService:
                     continue
 
                 if chain_type == "web_search_sources":
-                    try:
-                        parsed = json.loads(result_text)
-                        sources = (
-                            parsed.get("sources", [])
-                            if isinstance(parsed, dict)
-                            else []
-                        )
-                        refs = {"used": sources} if isinstance(sources, list) else {}
-                    except Exception:
-                        refs = {}
+                    refs = parse_web_search_sources(result_text)
                     continue
 
                 await send_json(result)
@@ -530,7 +522,7 @@ class OpenApiService:
                     plain_text = collect_plain_text_from_message_parts(
                         message_parts_to_save
                     )
-                    pending_xai_refs = refs
+                    fallback_refs = refs
                     try:
                         refs = chat_bridge.extract_web_search_refs(
                             plain_text,
@@ -541,8 +533,8 @@ class OpenApiService:
                             f"Open API WS failed to extract web search refs: {exc}",
                             exc_info=True,
                         )
-                    if not refs and pending_xai_refs:
-                        refs = pending_xai_refs
+                    if not refs and fallback_refs:
+                        refs = fallback_refs
 
                     saved_record = await chat_bridge.save_bot_message(
                         session_id,

--- a/astrbot/dashboard/services/open_api_service.py
+++ b/astrbot/dashboard/services/open_api_service.py
@@ -485,6 +485,19 @@ class OpenApiService:
                         pass
                     continue
 
+                if chain_type == "web_search_sources":
+                    try:
+                        parsed = json.loads(result_text)
+                        sources = (
+                            parsed.get("sources", [])
+                            if isinstance(parsed, dict)
+                            else []
+                        )
+                        refs = {"used": sources} if isinstance(sources, list) else {}
+                    except Exception:
+                        refs = {}
+                    continue
+
                 await send_json(result)
 
                 if msg_type == "plain":
@@ -517,6 +530,7 @@ class OpenApiService:
                     plain_text = collect_plain_text_from_message_parts(
                         message_parts_to_save
                     )
+                    pending_xai_refs = refs
                     try:
                         refs = chat_bridge.extract_web_search_refs(
                             plain_text,
@@ -527,6 +541,8 @@ class OpenApiService:
                             f"Open API WS failed to extract web search refs: {exc}",
                             exc_info=True,
                         )
+                    if not refs and pending_xai_refs:
+                        refs = pending_xai_refs
 
                     saved_record = await chat_bridge.save_bot_message(
                         session_id,

--- a/dashboard/src/composables/useProviderSources.ts
+++ b/dashboard/src/composables/useProviderSources.ts
@@ -393,6 +393,10 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
       source.ollama_disable_thinking = false
     }
 
+    if (source.provider === 'xai' && source.xai_native_search === undefined) {
+      source.xai_native_search = false
+    }
+
     return source
   }
 

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -1206,7 +1206,7 @@
       },
       "xai_native_search": {
         "description": "Enable native search",
-        "hint": "When enabled, uses xAI Chat Completions native Live Search for web queries (billed on demand). Only applies to xAI providers."
+        "hint": "When enabled, uses xAI native Web Search for web queries (billed on demand). Only applies to xAI providers."
       },
       "rerank_api_base": {
         "description": "Rerank Model API Base URL",

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -1208,7 +1208,7 @@
       },
       "xai_native_search": {
         "description": "启用原生搜索功能",
-        "hint": "启用后，将通过 xAI 的 Chat Completions 原生 Live Search 进行联网检索（按需计费）。仅对 xAI 提供商生效。"
+        "hint": "启用后，将通过 xAI 原生 Web Search 进行联网检索（按需计费）。仅对 xAI 提供商生效。"
       },
       "rerank_api_base": {
         "description": "重排序模型 API Base URL",

--- a/tests/test_openai_responses_source.py
+++ b/tests/test_openai_responses_source.py
@@ -61,7 +61,7 @@ def test_responses_provider_templates_are_independent_and_stateless():
     assert templates["DeepSeek Responses"]["api_base"] == "https://api.deepseek.com/v1"
     assert templates["xAI"]["type"] == "openai_responses"
     assert templates["xAI"]["api_base"] == "https://api.x.ai/v1"
-    assert "xai_native_search" not in templates["xAI"]
+    assert templates["xAI"]["xai_native_search"] is False
 
 
 def test_convert_chat_history_preserves_response_items_and_function_calls():


### PR DESCRIPTION
Fixes #9723.

This PR restores the xAI native-search toggle for `openai_responses` provider sources, injects the `web_search` tool into Responses API requests, and surfaces xAI `url_citation` sources as WebChat source cards.

### Modifications / 改动点

- Expose the xAI native-search toggle for `openai_responses` provider sources and keep it disabled by default.
- Backfill the disabled toggle in the Dashboard when editing existing xAI provider sources that predate the setting.
- Add xAI's `web_search` tool to both streaming and non-streaming Responses API requests when the toggle is enabled, while preserving AstrBot function tools.
- Extract xAI `url_citation` annotations into `LLMResponse.web_search_sources` and carry them through the agent runner into the WebChat refs pipeline (chat / live-chat / OpenAPI consumers), rendering them as the existing clickable source cards.
- Update the English and Chinese configuration hints to describe xAI native Web Search rather than the legacy Chat Completions-only behavior.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Verification Steps / 验证步骤

1. Ran Ruff lint and format checks for the changed Python files.
2. Built the Dashboard successfully, including `vue-tsc --noEmit`.
3. Started an isolated AstrBot instance and opened the real Dashboard in a browser.
4. Verified that an existing xAI provider source without `xai_native_search` displays the toggle as disabled by default; enabled it, saved it, reloaded the page, and confirmed the setting persisted.
5. Validated both streaming and non-streaming requests through OpenCode Go's Responses-compatible endpoint using `grok-4.5`, without an official xAI API key. The outgoing payload included `{"type":"web_search"}`, and the model returned current news with a source URL.
6. Repeated the final end-to-end Dashboard chat flow using the configured `grok-4.5` model and received a current international-news result with a source URL.
7. Validated citation rendering against a local mock of the official xAI Responses web-search shape (`web_search_call` + `url_citation`): the sources were parsed and shown as WebChat source cards in both streaming and non-streaming paths.

### Screenshots or Test Results / 运行截图或测试结果

#### 1. Dashboard configuration

<img width="857" height="342" alt="Screenshot 2026-08-18 at 16 09 18" src="https://github.com/user-attachments/assets/a80bc5da-6184-4002-8225-890cfda3696e" />

#### 2. End-to-end WebChat result

<img width="1184" height="713" alt="Screenshot 2026-08-18 at 15 56 26" src="https://github.com/user-attachments/assets/fd9817cb-e108-4c3f-8818-e0bb79c279fe" />

This request uses Grok's native `web_search` tool through the Responses API. No AstrBot web-search plugin, function tool, or external search provider was configured.

#### 3. Citation card via a local mock of the official xAI Responses shape

<img width="1190" height="716" alt="Screenshot 2026-08-18 at 22 40 43" src="https://github.com/user-attachments/assets/c6ab2473-35c1-40bf-85a9-e3dbf5a8a146" />

The mock returns the official xAI `web_search_call` + `url_citation` shape. Because OpenCode Go strips citation metadata, the source-card rendering is validated against the mock rather than a live provider; an official xAI API re-check is recommended.

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Enable optional xAI native Web Search in Responses API requests and surface its citations throughout WebChat.

New Features:
- Enable optional native xAI Web Search for Responses API provider sources.
- Expose xAI citation URLs as clickable WebChat source cards across chat, live-chat, and OpenAPI consumers.

Bug Fixes:
- Restore the xAI native-search setting for Responses API sources and default it safely for existing configurations.

Enhancements:
- Preserve existing AstrBot function tools alongside the native xAI search tool and propagate structured search references through agent responses.

Documentation:
- Update English and Chinese configuration guidance to describe xAI native Web Search.

Tests:
- Update provider template coverage for the default xAI native-search setting.