### PR TITLE
fix: dispatch OnAfterMessageSentEvent after streaming delivery

### DIFF
--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -127,6 +127,12 @@ class RespondStage(Stage):
         # 如果所有组件都为空
         return True
 
+    async def _after_sent_cleanup(self, event: AstrMessageEvent) -> bool:
+        if await call_event_hook(event, EventType.OnAfterMessageSentEvent):
+            return True
+        event.clear_result()
+        return False
+
     def is_seg_reply_required(self, event: AstrMessageEvent) -> bool:
         """检查是否需要分段回复"""
         if not self.enable_seg:
@@ -222,9 +228,8 @@ class RespondStage(Stage):
             )
             logger.info(f"Applying streaming output ({event.get_platform_id()}).")
             await event.send_streaming(result.async_stream, realtime_segmenting)
-            if await call_event_hook(event, EventType.OnAfterMessageSentEvent):
+            if await self._after_sent_cleanup(event):
                 return
-            event.clear_result()
             return
         if len(result.chain) > 0:
             # 检查路径映射
@@ -322,7 +327,5 @@ class RespondStage(Stage):
                             exc_info=True,
                         )
 
-        if await call_event_hook(event, EventType.OnAfterMessageSentEvent):
+        if await self._after_sent_cleanup(event):
             return
-
-        event.clear_result()

--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -222,6 +222,9 @@ class RespondStage(Stage):
             )
             logger.info(f"Applying streaming output ({event.get_platform_id()}).")
             await event.send_streaming(result.async_stream, realtime_segmenting)
+            if await call_event_hook(event, EventType.OnAfterMessageSentEvent):
+                return
+            event.clear_result()
             return
         if len(result.chain) > 0:
             # 检查路径映射


### PR DESCRIPTION
The streaming output path in RespondStage early-returns after send_streaming(), skipping the OnAfterMessageSentEvent dispatch that the non-streaming path performs.

This means plugins hooking after_message_sent (e.g. simple_memory _capture) never fire for streaming platforms such as webchat.

## Change

Add the same OnAfterMessageSentEvent dispatch after send_streaming() completes, matching the non-streaming path:

```diff
             await event.send_streaming(result.async_stream, realtime_segmenting)
+            if await call_event_hook(event, EventType.OnAfterMessageSentEvent):
+                return
+            event.clear_result()
             return
```

## Test plan

- Webchat: send a message, verify after_message_sent hook fires
- Non-streaming (QQ): verify behavior unchanged

## Summary by Sourcery

Bug Fixes:
- Dispatch the after-message-sent event after streaming delivery so post-send hooks also run for streaming platforms.

Fixes #9740