### PR TITLE
fix: register standard SVG MIME type for WebUI static files

### DIFF
--- a/astrbot/dashboard/server.py
+++ b/astrbot/dashboard/server.py
@@ -32,9 +32,7 @@ from .api.app import create_dashboard_asgi_app
 from .plugin_page_auth import PluginPageAuth
 from .services.auth_service import DASHBOARD_JWT_COOKIE_NAME
 
-# Windows 下 Python mimetypes 会按系统注册表将 .svg 映射为 image/svg,
-# 导致 WebUI 静态资源(favicon.svg 等)返回非标准 MIME 类型,Chrome 无法渲染。
-# 显式覆盖为标准类型,使其在任意平台上行为一致。
+# Windows 的 mimetypes 会把 .svg 映射成非标准的 image/svg,这里强制覆盖为标准类型
 mimetypes.add_type("image/svg+xml", ".svg", strict=True)
 
 _RATE_LIMITED_ENDPOINTS: frozenset = frozenset(

--- a/astrbot/dashboard/server.py
+++ b/astrbot/dashboard/server.py
@@ -1,5 +1,6 @@
 import asyncio
 import ipaddress
+import mimetypes
 import os
 import socket
 import time
@@ -30,6 +31,11 @@ from astrbot.dashboard.responses import error
 from .api.app import create_dashboard_asgi_app
 from .plugin_page_auth import PluginPageAuth
 from .services.auth_service import DASHBOARD_JWT_COOKIE_NAME
+
+# Windows 下 Python mimetypes 会按系统注册表将 .svg 映射为 image/svg,
+# 导致 WebUI 静态资源(favicon.svg 等)返回非标准 MIME 类型,Chrome 无法渲染。
+# 显式覆盖为标准类型,使其在任意平台上行为一致。
+mimetypes.add_type("image/svg+xml", ".svg", strict=True)
 
 _RATE_LIMITED_ENDPOINTS: frozenset = frozenset(
     {

--- a/astrbot/dashboard/server.py
+++ b/astrbot/dashboard/server.py
@@ -32,8 +32,9 @@ from .api.app import create_dashboard_asgi_app
 from .plugin_page_auth import PluginPageAuth
 from .services.auth_service import DASHBOARD_JWT_COOKIE_NAME
 
-# Windows 的 mimetypes 会把 .svg 映射成非标准的 image/svg,这里强制覆盖为标准类型
-mimetypes.add_type("image/svg+xml", ".svg", strict=True)
+if os.name == "nt":
+    # Windows 的 mimetypes 会把 .svg 映射成非标准的 image/svg,这里强制覆盖为标准类型
+    mimetypes.add_type("image/svg+xml", ".svg", strict=True)
 
 _RATE_LIMITED_ENDPOINTS: frozenset = frozenset(
     {


### PR DESCRIPTION
### Modifications / 改动点

Fixes #9734

On Windows, Python's `mimetypes` resolves `.svg` from the registry to `image/svg`, a non-standard MIME type. The WebUI static file route serves `favicon.svg` (and any plugin icon fallback) via Starlette `FileResponse`, which infers `Content-Type` from `mimetypes.guess_type`, so Chrome fails to render these resources.

Registered the standard `image/svg+xml` type at module load in `astrbot/dashboard/server.py`. This runs on both entry paths (`python main.py` and the `astrbot run` CLI), so the override applies process-wide regardless of how the dashboard is started.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

The bug is Windows-specific and cannot be reproduced on macOS/Linux (which already map `.svg` to `image/svg+xml`). Simulated the Windows registry mis-mapping and verified the module-level override wins:

```text
after bad mapping: ('image/svg', None)
after fix:        ('image/svg+xml', None)
via server module: ('image/svg+xml', None)
```

A manual `curl -I /favicon.svg` on Windows should now return `Content-Type: image/svg+xml`.

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Ensure WebUI SVG assets are served with the standard `image/svg+xml` MIME type on Windows so browsers render them correctly.

## Summary by Sourcery

Bug Fixes:
- Ensure WebUI SVG assets are served with the standard `image/svg+xml` MIME type on Windows so browsers render them correctly.