### PR TITLE
fix(provider): preserve current user turn in Gemini history

### DIFF
--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -428,7 +428,7 @@ class ProviderGoogleGenAI(Provider):
                 append_or_extend(gemini_contents, parts, types.UserContent)
 
         if gemini_contents and isinstance(gemini_contents[0], types.ModelContent):
-            gemini_contents.pop()
+            gemini_contents.pop(0)
 
         return gemini_contents
 

--- a/tests/test_gemini_source.py
+++ b/tests/test_gemini_source.py
@@ -10,12 +10,8 @@ from astrbot.core.provider.entities import LLMResponse
 from astrbot.core.provider.sources.gemini_source import ProviderGoogleGenAI
 
 
-def _make_gemini_provider() -> ProviderGoogleGenAI:
-    return ProviderGoogleGenAI.__new__(ProviderGoogleGenAI)
-
-
 def test_gemini_prepare_conversation_removes_leading_model_content():
-    provider = _make_gemini_provider()
+    provider = ProviderGoogleGenAI.__new__(ProviderGoogleGenAI)
 
     contents = provider._prepare_conversation(
         {
@@ -33,7 +29,7 @@ def test_gemini_prepare_conversation_removes_leading_model_content():
 
 
 def test_gemini_prepare_conversation_keeps_normal_user_first_history():
-    provider = _make_gemini_provider()
+    provider = ProviderGoogleGenAI.__new__(ProviderGoogleGenAI)
 
     contents = provider._prepare_conversation(
         {
@@ -52,6 +48,26 @@ def test_gemini_prepare_conversation_keeps_normal_user_first_history():
     ]
     assert contents[-1].parts is not None
     assert contents[-1].parts[-1].text == "current user turn"
+
+
+def test_gemini_prepare_conversation_preserves_user_model_history():
+    provider = ProviderGoogleGenAI.__new__(ProviderGoogleGenAI)
+
+    contents = provider._prepare_conversation(
+        {
+            "messages": [
+                {"role": "user", "content": "user turn"},
+                {"role": "assistant", "content": "assistant turn"},
+            ]
+        }
+    )
+
+    assert [type(content) for content in contents] == [
+        types.UserContent,
+        types.ModelContent,
+    ]
+    assert contents[-1].parts is not None
+    assert contents[-1].parts[-1].text == "assistant turn"
 
 
 def test_gemini_empty_output_raises_empty_model_output_error():

--- a/tests/test_gemini_source.py
+++ b/tests/test_gemini_source.py
@@ -2,11 +2,56 @@ from types import SimpleNamespace
 
 import httpx
 import pytest
+from google.genai import types
 
-from astrbot.core.exceptions import EmptyModelOutputError
 import astrbot.core.provider.sources.request_retry as request_retry
+from astrbot.core.exceptions import EmptyModelOutputError
 from astrbot.core.provider.entities import LLMResponse
 from astrbot.core.provider.sources.gemini_source import ProviderGoogleGenAI
+
+
+def _make_gemini_provider() -> ProviderGoogleGenAI:
+    return ProviderGoogleGenAI.__new__(ProviderGoogleGenAI)
+
+
+def test_gemini_prepare_conversation_removes_leading_model_content():
+    provider = _make_gemini_provider()
+
+    contents = provider._prepare_conversation(
+        {
+            "messages": [
+                {"role": "assistant", "content": "stale assistant turn"},
+                {"role": "user", "content": "current user turn"},
+            ]
+        }
+    )
+
+    assert len(contents) == 1
+    assert isinstance(contents[0], types.UserContent)
+    assert contents[0].parts is not None
+    assert contents[0].parts[-1].text == "current user turn"
+
+
+def test_gemini_prepare_conversation_keeps_normal_user_first_history():
+    provider = _make_gemini_provider()
+
+    contents = provider._prepare_conversation(
+        {
+            "messages": [
+                {"role": "user", "content": "first user turn"},
+                {"role": "assistant", "content": "assistant turn"},
+                {"role": "user", "content": "current user turn"},
+            ]
+        }
+    )
+
+    assert [type(content) for content in contents] == [
+        types.UserContent,
+        types.ModelContent,
+        types.UserContent,
+    ]
+    assert contents[-1].parts is not None
+    assert contents[-1].parts[-1].text == "current user turn"
 
 
 def test_gemini_empty_output_raises_empty_model_output_error():


### PR DESCRIPTION
## Summary
- remove the leading converted Gemini model block instead of the final current user block
- add regression coverage for assistant-first and normal user-first histories

## Problem
When persisted history begins with an assistant turn, the Gemini adapter currently removes the final converted content. That can leave a request ending in a model turn, which Gemini rejects and which may also make a fallback provider receive stale history.

## Tests
- `pytest -q tests/test_gemini_source.py`: 5 passed
- `ruff check astrbot/core/provider/sources/gemini_source.py tests/test_gemini_source.py`: passed
- full Windows suite: 2152 passed, 1 skipped, 34 failed
- unchanged `upstream/master` baseline on the same 34 failed nodes: the same 34 failed (plus 19 passing parametrized/class cases); failures are existing Windows path/newline/symlink/shell fixture issues and do not touch the changed files

## Summary by Sourcery

Preserve valid conversation ordering when converting persisted histories for Gemini requests.

Bug Fixes:
- Preserve the current user turn when preparing Gemini conversation history that begins with an assistant turn, preventing invalid requests and stale fallback history.

Tests:
- Add regression coverage for assistant-first, normal user-first, and user-model Gemini histories.