### PR TITLE
feat: add permission check for /new command

### DIFF
--- a/astrbot/builtin_stars/builtin_commands/commands/conversation.py
+++ b/astrbot/builtin_stars/builtin_commands/commands/conversation.py
@@ -221,13 +221,37 @@ class ConversationCommands:
 
     async def new_conv(self, message: AstrMessageEvent) -> None:
         """创建新对话"""
-        cfg = self.context.get_config(umo=message.unified_msg_origin)
+        umo = message.unified_msg_origin
+        cfg = self.context.get_config(umo=umo)
+        is_unique_session = cfg["platform_settings"]["unique_session"]
+        is_group = bool(message.get_group_id())
+
+        scene = RstScene.get_scene(is_group, is_unique_session)
+
+        alter_cmd_cfg = await sp.get_async("global", "global", "alter_cmd", {})
+        plugin_config = alter_cmd_cfg.get("astrbot", {})
+        new_cfg = plugin_config.get("new", {})
+
+        required_perm = new_cfg.get(
+            scene.key,
+            "admin" if is_group and not is_unique_session else "member",
+        )
+
+        if required_perm == "admin" and message.role != "admin":
+            message.set_result(
+                MessageEventResult().message(
+                    f"New conversation command requires admin permission in {scene.name} scenario, "
+                    f"you (ID {message.get_sender_id()}) are not admin, cannot perform this action.",
+                ),
+            )
+            return
+
         agent_runner_type = cfg["provider_settings"]["agent_runner_type"]
         if agent_runner_type in THIRD_PARTY_AGENT_RUNNER_KEY:
-            active_event_registry.stop_all(message.unified_msg_origin, exclude=message)
+            active_event_registry.stop_all(umo, exclude=message)
             await _clear_third_party_agent_runner_state(
                 self.context,
-                message.unified_msg_origin,
+                umo,
                 agent_runner_type,
             )
             message.set_result(
@@ -235,10 +259,10 @@ class ConversationCommands:
             )
             return
 
-        active_event_registry.stop_all(message.unified_msg_origin, exclude=message)
-        cpersona = await self._get_current_persona_id(message.unified_msg_origin)
+        active_event_registry.stop_all(umo, exclude=message)
+        cpersona = await self._get_current_persona_id(umo)
         cid = await self.context.conversation_manager.new_conversation(
-            message.unified_msg_origin,
+            umo,
             message.get_platform_id(),
             persona_id=cpersona,
         )


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->
`/new` 命令缺少权限控制，在群聊且会话隔离关闭的场景下（共享会话），任意成员都可以创建新会话并切换，影响其他用户的对话上下文。而 `/reset` 已有对应的权限检查，`/new` 与之不一致。

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->
- `astrbot/builtin_stars/builtin_commands/commands/conversation.py`：为 `new_conv` 方法新增场景化权限检查，逻辑与 `reset` 一致——群聊+会话隔离关闭时默认要求 `admin`，其余场景 `member` 即可。权限可通过 Dashboard 的指令管理覆盖。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [ ] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Enforce context-aware permissions for creating new conversations.

Bug Fixes:
- Restrict the `/new` command in shared group conversations to administrators, preventing members from changing the shared conversation context.

Enhancements:
- Align `/new` permission behavior with `/reset` while preserving configurable per-scenario permission overrides.