### PR TITLE
fix: stop preloading entire preferences table into memory

### DIFF
--- a/astrbot/core/db/sqlite.py
+++ b/astrbot/core/db/sqlite.py
@@ -1379,6 +1379,34 @@ class SQLiteDatabase(BaseDatabase):
             result = await session.execute(query)
             return result.scalar_one_or_none()
 
+    def get_preference_sync(self, scope, scope_id, key) -> dict | None:
+        """Synchronous point query for a single preference value.
+
+        Uses a dedicated stdlib sqlite3 connection instead of the async
+        SQLAlchemy pool, so deprecated synchronous SharedPreferences APIs never
+        wait on (or deadlock against) the event-loop-owned pool. The database
+        runs in WAL mode, so this short index lookup can read concurrently with
+        the async writer.
+
+        Returns:
+            The stored value dict (e.g. ``{"val": ...}``), or None if missing.
+        """
+        import sqlite3
+
+        conn = sqlite3.connect(self.db_path, timeout=30)
+        try:
+            row = conn.execute(
+                "SELECT value FROM preferences "
+                "WHERE scope = ? AND scope_id = ? AND key = ?",
+                (scope, scope_id, key),
+            ).fetchone()
+            if row is None:
+                return None
+            value = row[0]
+            return json.loads(value) if isinstance(value, str) else value
+        finally:
+            conn.close()
+
     async def get_preferences(self, scope=None, scope_id=None, key=None):
         """Get preferences, optionally filtered by scope, scope ID, or key."""
         async with self.get_db() as session:

--- a/astrbot/core/db/sqlite.py
+++ b/astrbot/core/db/sqlite.py
@@ -1,9 +1,11 @@
 import asyncio
 import json
+import sqlite3
 import threading
 import typing as T
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 from deprecated import deprecated
 from sqlalchemy import CursorResult, Row, not_
@@ -1379,7 +1381,12 @@ class SQLiteDatabase(BaseDatabase):
             result = await session.execute(query)
             return result.scalar_one_or_none()
 
-    def get_preference_sync(self, scope, scope_id, key) -> dict | None:
+    def get_preference_sync(
+        self,
+        scope: str,
+        scope_id: str,
+        key: str,
+    ) -> dict | None:
         """Synchronous point query for a single preference value.
 
         Uses a dedicated stdlib sqlite3 connection instead of the async
@@ -1388,12 +1395,15 @@ class SQLiteDatabase(BaseDatabase):
         runs in WAL mode, so this short index lookup can read concurrently with
         the async writer.
 
+        Args:
+            scope: Preference scope.
+            scope_id: Identifier within the preference scope.
+            key: Preference key.
+
         Returns:
             The stored value dict (e.g. ``{"val": ...}``), or None if missing.
         """
-        import sqlite3
-
-        conn = sqlite3.connect(self.db_path, timeout=30)
+        conn = sqlite3.connect(Path(self.db_path), timeout=30)
         try:
             row = conn.execute(
                 "SELECT value FROM preferences "
@@ -1403,7 +1413,62 @@ class SQLiteDatabase(BaseDatabase):
             if row is None:
                 return None
             value = row[0]
-            return json.loads(value) if isinstance(value, str) else value
+            return (
+                json.loads(value)
+                if isinstance(value, (str, bytes, bytearray))
+                else value
+            )
+        finally:
+            conn.close()
+
+    def get_preferences_sync(
+        self,
+        scope: str,
+        scope_id: str | None = None,
+        key: str | None = None,
+    ) -> list[Preference]:
+        """Synchronously query preferences within a scope.
+
+        This compatibility path uses a dedicated sqlite3 connection instead of
+        the async SQLAlchemy pool. It only loads the range explicitly requested
+        by the deprecated synchronous API and is never called during startup.
+
+        Args:
+            scope: Preference scope to query.
+            scope_id: Optional identifier within the scope.
+            key: Optional preference key.
+
+        Returns:
+            Preferences matching the supplied filters.
+        """
+        query = "SELECT scope, scope_id, key, value FROM preferences WHERE scope = ?"
+        params: list[str] = [scope]
+        if scope_id is not None:
+            query += " AND scope_id = ?"
+            params.append(scope_id)
+        if key is not None:
+            query += " AND key = ?"
+            params.append(key)
+
+        conn = sqlite3.connect(Path(self.db_path), timeout=30)
+        try:
+            rows = conn.execute(query, params).fetchall()
+            preferences = []
+            for row_scope, row_scope_id, row_key, row_value in rows:
+                value = (
+                    json.loads(row_value)
+                    if isinstance(row_value, (str, bytes, bytearray))
+                    else row_value
+                )
+                preferences.append(
+                    Preference(
+                        scope=row_scope,
+                        scope_id=row_scope_id,
+                        key=row_key,
+                        value=value,
+                    )
+                )
+            return preferences
         finally:
             conn.close()
 

--- a/astrbot/core/utils/shared_preferences.py
+++ b/astrbot/core/utils/shared_preferences.py
@@ -38,13 +38,18 @@ class SharedPreferences:
         self.temporary_cache: dict[str, dict[str, Any]] = defaultdict(dict)
         """automatically clear per 24 hours. Might be helpful in some cases XD"""
 
-        # In-memory mirror of persistent preferences. It lets synchronous APIs
-        # read and update values without blocking on the async database, provides
-        # immediate read-after-write visibility, and also serves async point reads.
-        # Unlike temporary_cache, it is preloaded at startup, persisted to the
-        # database, and never periodically cleared by the scheduler.
-        # See https://github.com/AstrBotDevs/AstrBot/pull/9649 for the deadlock
-        # scenario and design rationale.
+        # In-memory overlay of preferences written through this process. It gives
+        # read-after-write visibility for both sync and async APIs while writes
+        # are asynchronously persisted through the FIFO write queue.
+        #
+        # This is intentionally NOT a full mirror of the preferences table: the
+        # table can hold gigabytes of plugin KV data, so preloading it at startup
+        # (as PR #9649 did) can OOM the process. Reads that miss the overlay fall
+        # back to point queries against the database: async reads await the async
+        # engine, while deprecated synchronous reads use a dedicated sync SQLite
+        # connection so they never block on (or deadlock against) the async pool.
+        # See https://github.com/AstrBotDevs/AstrBot/pull/9649 for the original
+        # deadlock scenario and design rationale.
         self._cache: dict[tuple[str, str, str], Any] = {}
         self._cache_lock = threading.RLock()
         self._cache_initialized = False
@@ -54,6 +59,7 @@ class SharedPreferences:
         self._write_queue: asyncio.Queue[_WriteOperation] | None = None
         self._writer_task: asyncio.Task[None] | None = None
         self._pending_writes: list[_WriteOperation] = []
+        self._warned_sync_read_unsupported = False
 
         self._scheduler = BackgroundScheduler()
         self._scheduler.add_job(
@@ -173,7 +179,10 @@ class SharedPreferences:
                 queue.task_done()
 
     async def initialize(self) -> None:
-        """Load persisted preferences and bind writes to the current event loop.
+        """Bind writes to the current event loop and replay pending writes.
+
+        The preferences table is intentionally NOT preloaded here: it can be
+        arbitrarily large, and reads fall back to point queries instead.
 
         Raises:
             RuntimeError: If another running event loop already owns the store.
@@ -205,23 +214,13 @@ class SharedPreferences:
                 self._loop = loop
                 self._write_queue = asyncio.Queue()
                 self._writer_task = None
-                if not self._cache_initialized:
-                    preferences = await self.db_helper.get_preferences()
-                    loaded_cache = {
-                        (item.scope, item.scope_id, item.key): deepcopy(
-                            item.value["val"]
-                        )
-                        for item in preferences
-                    }
 
                 with self._cache_lock:
                     pending_writes = list(self._pending_writes)
                     self._pending_writes.clear()
-                    if not self._cache_initialized:
-                        self._cache = loaded_cache
-                        for operation in pending_writes:
-                            self._apply_cache_operation(operation)
-                        self._cache_initialized = True
+                    for operation in pending_writes:
+                        self._apply_cache_operation(operation)
+                    self._cache_initialized = True
                     self._initializing = False
             except BaseException:
                 with self._cache_lock:
@@ -277,7 +276,12 @@ class SharedPreferences:
             return default
         with self._cache_lock:
             value = self._cache.get((scope, scope_id, key), _MISSING)
-            return default if value is _MISSING else deepcopy(value)
+            if value is not _MISSING:
+                return deepcopy(value)
+        preference = await self.db_helper.get_preference(scope, scope_id, key)
+        if preference is None:
+            return default
+        return deepcopy(preference.value["val"])
 
     async def range_get_async(
         self,
@@ -439,12 +443,41 @@ class SharedPreferences:
             raise ValueError(
                 "scope_id and key cannot be None when getting a specific preference.",
             )
+        resolved_scope = scope or "unknown"
+        resolved_scope_id = scope_id or "unknown"
         with self._cache_lock:
-            value = self._cache.get(
-                (scope or "unknown", scope_id or "unknown", key),
-                _MISSING,
+            value = self._cache.get((resolved_scope, resolved_scope_id, key), _MISSING)
+            if value is not _MISSING:
+                return default if value is None else deepcopy(value)
+        # Overlay miss: fall back to a point query through a dedicated
+        # synchronous database connection. This briefly blocks the calling
+        # thread (unavoidable for a synchronous API), but never touches the
+        # async connection pool, so it cannot deadlock the event loop.
+        get_sync = getattr(self.db_helper, "get_preference_sync", None)
+        if get_sync is None:
+            if not self._warned_sync_read_unsupported:
+                self._warned_sync_read_unsupported = True
+                logger.warning(
+                    "SharedPreferences sync get() is not supported by database "
+                    "backend %s; returning the default. Use get_async() instead.",
+                    type(self.db_helper).__name__,
+                )
+            return default
+        try:
+            stored = get_sync(resolved_scope, resolved_scope_id, key)
+        except Exception as exc:
+            logger.warning(
+                "SharedPreferences sync get() failed for %s/%s/%s: %s",
+                resolved_scope,
+                resolved_scope_id,
+                key,
+                exc,
             )
-            return default if value is _MISSING or value is None else deepcopy(value)
+            return default
+        if stored is None:
+            return default
+        value = stored.get("val")
+        return default if value is None else deepcopy(value)
 
     @deprecated(version="4.0.0", reason="Use range_get_async() instead.")
     def range_get(
@@ -453,7 +486,12 @@ class SharedPreferences:
         scope_id: str | None = None,
         key: str | None = None,
     ) -> list[Preference]:
-        """获取指定范围的偏好设置（已弃用）"""
+        """获取指定范围的偏好设置（已弃用）
+
+        Note: 为避免启动时全量加载 preferences 表导致内存溢出，此方法现在只能
+        返回本进程写入过且仍在内存中的值，不再保证覆盖数据库中的全部历史数据。
+        需要完整范围查询时请使用 range_get_async()。
+        """
         with self._cache_lock:
             values = [
                 (cache_scope, cache_scope_id, cache_key, deepcopy(value))

--- a/astrbot/core/utils/shared_preferences.py
+++ b/astrbot/core/utils/shared_preferences.py
@@ -60,6 +60,7 @@ class SharedPreferences:
         self._writer_task: asyncio.Task[None] | None = None
         self._pending_writes: list[_WriteOperation] = []
         self._warned_sync_read_unsupported = False
+        self._warned_sync_range_read_unsupported = False
 
         self._scheduler = BackgroundScheduler()
         self._scheduler.add_job(
@@ -486,33 +487,62 @@ class SharedPreferences:
         scope_id: str | None = None,
         key: str | None = None,
     ) -> list[Preference]:
-        """获取指定范围的偏好设置（已弃用）
+        """Synchronously get preferences matching the supplied range.
 
-        Note: 为避免启动时全量加载 preferences 表导致内存溢出，此方法现在只能
-        返回本进程写入过且仍在内存中的值，不再保证覆盖数据库中的全部历史数据。
-        需要完整范围查询时请使用 range_get_async()。
+        Historical values are loaded on demand through a dedicated synchronous
+        database connection, then values written by this process are overlaid to
+        preserve immediate read-after-write visibility without startup preload.
+
+        Args:
+            scope: Preference scope to query.
+            scope_id: Optional identifier within the scope.
+            key: Optional preference key.
+
+        Returns:
+            Preferences matching the supplied filters.
         """
+        get_sync = getattr(self.db_helper, "get_preferences_sync", None)
+        if get_sync is None:
+            if not self._warned_sync_range_read_unsupported:
+                self._warned_sync_range_read_unsupported = True
+                logger.warning(
+                    "SharedPreferences sync range_get() is not supported by "
+                    "database backend %s; returning process-local values only. "
+                    "Use range_get_async() instead.",
+                    type(self.db_helper).__name__,
+                )
+            persisted: list[Preference] = []
+        else:
+            try:
+                persisted = get_sync(scope, scope_id, key)
+            except Exception as exc:
+                logger.warning(
+                    "SharedPreferences sync range_get() failed for %s/%s/%s: %s",
+                    scope,
+                    scope_id,
+                    key,
+                    exc,
+                )
+                persisted = []
+
+        values = {
+            (preference.scope, preference.scope_id, preference.key): preference
+            for preference in persisted
+        }
         with self._cache_lock:
-            values = [
-                (cache_scope, cache_scope_id, cache_key, deepcopy(value))
-                for (
-                    cache_scope,
-                    cache_scope_id,
-                    cache_key,
-                ), value in self._cache.items()
-                if cache_scope == scope
-                and (scope_id is None or cache_scope_id == scope_id)
-                and (key is None or cache_key == key)
-            ]
-        return [
-            Preference(
-                scope=cache_scope,
-                scope_id=cache_scope_id,
-                key=cache_key,
-                value={"val": value},
-            )
-            for cache_scope, cache_scope_id, cache_key, value in values
-        ]
+            for (cache_scope, cache_scope_id, cache_key), value in self._cache.items():
+                if (
+                    cache_scope == scope
+                    and (scope_id is None or cache_scope_id == scope_id)
+                    and (key is None or cache_key == key)
+                ):
+                    values[(cache_scope, cache_scope_id, cache_key)] = Preference(
+                        scope=cache_scope,
+                        scope_id=cache_scope_id,
+                        key=cache_key,
+                        value={"val": deepcopy(value)},
+                    )
+        return list(values.values())
 
     @deprecated(
         version="4.0.0",

--- a/tests/unit/test_shared_preferences.py
+++ b/tests/unit/test_shared_preferences.py
@@ -194,6 +194,40 @@ async def test_sync_reads_fall_back_to_database_without_preload(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_sync_range_reads_historical_and_process_local_values(tmp_path):
+    """Deprecated range_get() must combine persisted and pending values."""
+    database = SQLiteDatabase(str(tmp_path / "range-fallback.db"))
+    await database.initialize()
+    await database.insert_preference_or_update(
+        "plugin",
+        "example",
+        "historical",
+        {"val": "from-database"},
+    )
+    store = SharedPreferences(database, tmp_path / "preferences.json")
+    try:
+        await store.initialize()
+        store.put(
+            "pending",
+            "from-overlay",
+            scope="plugin",
+            scope_id="example",
+        )
+
+        preferences = store.range_get("plugin", "example")
+        values = {item.key: item.value["val"] for item in preferences}
+
+        assert values == {
+            "historical": "from-database",
+            "pending": "from-overlay",
+        }
+        assert "historical" not in {cache_key for _, _, cache_key in store._cache}
+    finally:
+        await store.close()
+        await database.engine.dispose()
+
+
+@pytest.mark.asyncio
 async def test_get_async_falls_back_to_database_without_caching(preferences):
     store, database = preferences
     await database.insert_preference_or_update(

--- a/tests/unit/test_shared_preferences.py
+++ b/tests/unit/test_shared_preferences.py
@@ -148,8 +148,32 @@ async def test_concurrent_sync_writes_keep_submission_order(
 
 
 @pytest.mark.asyncio
-async def test_initialize_preloads_values_for_sync_reads(tmp_path):
+async def test_initialize_does_not_load_all_preferences(tmp_path, monkeypatch):
+    """Startup must not materialize the whole preferences table in memory."""
     database = SQLiteDatabase(str(tmp_path / "preload.db"))
+    await database.initialize()
+
+    def fail_on_unfiltered_load(scope=None, scope_id=None, key=None):
+        if scope is None and scope_id is None and key is None:
+            raise AssertionError("initialize() must not load all preferences")
+        return original_get_preferences(scope, scope_id, key)
+
+    original_get_preferences = database.get_preferences
+    monkeypatch.setattr(database, "get_preferences", fail_on_unfiltered_load)
+
+    store = SharedPreferences(database, tmp_path / "preferences.json")
+    try:
+        await store.initialize()
+        assert store._cache == {}
+    finally:
+        await store.close()
+        await database.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_sync_reads_fall_back_to_database_without_preload(tmp_path):
+    """Deprecated sync get() must read historical values written before startup."""
+    database = SQLiteDatabase(str(tmp_path / "fallback.db"))
     await database.initialize()
     await database.insert_preference_or_update(
         "umo",
@@ -160,7 +184,51 @@ async def test_initialize_preloads_values_for_sync_reads(tmp_path):
     store = SharedPreferences(database, tmp_path / "preferences.json")
     try:
         await store.initialize()
+        assert store._cache == {}
         assert store.get("provider", scope="umo", scope_id="session") == "provider-1"
+        # Sync fallback reads must not backfill the in-memory overlay.
+        assert store._cache == {}
     finally:
         await store.close()
         await database.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_get_async_falls_back_to_database_without_caching(preferences):
+    store, database = preferences
+    await database.insert_preference_or_update(
+        "plugin",
+        "heavy_plugin",
+        "blob",
+        {"val": {"payload": [1, 2, 3]}},
+    )
+
+    assert store._cache == {}
+    value = await store.get_async("plugin", "heavy_plugin", "blob")
+    assert value == {"payload": [1, 2, 3]}
+    assert await store.get_async("plugin", "heavy_plugin", "missing", "d") == "d"
+    # Reads must not grow the in-memory overlay.
+    assert store._cache == {}
+
+
+@pytest.mark.asyncio
+async def test_sync_get_reads_persisted_value_with_exhausted_pool(preferences):
+    """Sync reads must not depend on the async connection pool."""
+    store, database = preferences
+    await database.insert_preference_or_update(
+        "global",
+        "global",
+        "inactivated_llm_tools",
+        {"val": ["tool-a"]},
+    )
+
+    pool = database.engine.pool
+    capacity = pool.size() + pool._max_overflow
+    connections = [await database.engine.connect() for _ in range(capacity)]
+    try:
+        assert store.get(
+            "inactivated_llm_tools", scope="global", scope_id="global"
+        ) == ["tool-a"]
+    finally:
+        for connection in connections:
+            await connection.close()


### PR DESCRIPTION
#9649 为修复同步 SharedPreferences API 跨事件循环 `.result()` 导致的死锁，在启动时无过滤调用 `get_preferences()` 将 preferences 全表物化进内存并常驻缓存。但 preferences 表可能存储数 GB 级插件 KV 数据（`scope="plugin"`），全量预加载 + deepcopy 会让进程在启动时直接 OOM，峰值内存可达表大小的数倍。

PR #9649 preloaded the entire preferences table into memory at startup to fix an event-loop deadlock. Since the table can hold gigabytes of plugin KV data, this can OOM the process on startup.

### Modifications / 改动点

- `astrbot/core/utils/shared_preferences.py`
  - `initialize()` 不再全表预加载，仅绑定事件循环并重放 pending writes；`_cache` 从"全量镜像"降级为"本进程写入 overlay"，只保证 read-after-write。
  - `get_async()`：overlay 未命中时 `await get_preference(...)` 单点查库，**不回填缓存**，内存占用有界。
  - deprecated 同步 `get()`：overlay 未命中时通过**独立同步 SQLite 连接**点查回源，不经过 async pool，因此不会阻塞/死锁事件循环；后端不支持或查询失败时告警并返回 default，不抛异常，兼容存量插件。
  - deprecated 同步 `range_get()`：注明现在仅覆盖本进程写入的值（全仓已无内部调用方）；完整范围查询仍可用 `range_get_async()`。
  - 写入路径（FIFO 写队列、`flush()`、提交顺序）完全未改动。
- `astrbot/core/db/sqlite.py`
  - 新增 `SQLiteDatabase.get_preference_sync()`：基于 stdlib `sqlite3` 独立连接的唯一索引点查（WAL 模式下可与异步写入并发读取）。
- `tests/unit/test_shared_preferences.py`
  - 新增：初始化不触发无过滤全表查询；同步/异步读在缓存未命中时回源数据库且不回填 overlay；连接池耗尽时同步读仍能读到历史值。

同步、不阻塞、能读取任意历史值三者不可兼得；本 PR 选择让 deprecated 同步读退化为短暂 SQLite 点查（微秒~毫秒级），换取无死锁 + 无全量加载。核心链路与插件 API（`PluginKVStoreMixin`）本就已全部走 async，不受影响。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```
tests/unit/test_shared_preferences.py .........  9 passed
tests/unit/test_astrbot_config_manager.py ....   4 passed
ruff check: All checks passed!
```

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Replace full preferences-table caching with bounded process-local overlays and on-demand database reads to prevent startup memory exhaustion without reintroducing synchronous API deadlocks.

Bug Fixes:
- Prevent startup out-of-memory failures by eliminating full-table preferences preloading and limiting reads to on-demand database lookups.

Enhancements:
- Retain process-local read-after-write behavior while allowing asynchronous and deprecated synchronous APIs to retrieve persisted values without relying on a complete in-memory mirror.
- Add synchronous SQLite preference queries that operate independently of the asynchronous connection pool, avoiding event-loop blocking and deadlocks.

Tests:
- Add coverage for avoiding unfiltered startup loads, database fallback reads, range merging, non-caching behavior, and synchronous reads with an exhausted connection pool.