### PR TITLE
chore: bump version to 4.27.4

### DIFF
--- a/astrbot/__init__.py
+++ b/astrbot/__init__.py
@@ -1,4 +1,4 @@
 import logging
 
-__version__ = "4.27.3"
+__version__ = "4.27.4"
 logger = logging.getLogger("astrbot")

--- a/changelogs/v4.27.4.md
+++ b/changelogs/v4.27.4.md
@@ -1,0 +1,49 @@
+## [4.27.4] - 2026-08-20
+
+### Added
+
+- Displayed plugin update times in marketplace details. (#9690)
+- Logged the effective Windows local runtime shell to simplify environment diagnosis. (#9648)
+
+### Fixed
+
+- Fixed an issue where single preference reads could preload the entire preferences table in some cases, causing excessive memory and database overhead. (#9747)
+- Included JSON cards in group-chat context and added an LLM metadata fallback endpoint. (#9655, #9725)
+- Detected audio formats from file contents and converted Telegram audio files into Record components. (#9612, #9702)
+- Kept the chat sidebar accessible at medium viewport widths and adapted trace colors to the active Dashboard theme. (#9698, #9688)
+- Preserved the Dashboard password while `password_change_required` is set. (#9665)
+- Separated reasoning metadata from provider configuration. (#9699)
+- Removed the 10-file limit for knowledge-base uploads. (#9701)
+- Accepted synced Weixin Kefu messages that omit `open_kfid` instead of failing webhook processing.
+
+### Maintenance
+
+- Migrated statistics and Misskey visibility handling away from deprecated interfaces. (#9658, #9674)
+- Added plugin attribution guidance and corrected the self-hosted text-to-image setup documentation. (#9720)
+- Updated the CodeQL GitHub Action. (#9721)
+
+## 中文
+
+### 新增
+
+- 在插件市场详情中展示插件更新时间。 (#9690)
+- 记录 Windows 本地运行时实际使用的 Shell，便于排查环境问题。 (#9648)
+
+### 修复
+
+- 修复部分情况下读取单个偏好设置时会预加载整张偏好设置表，导致内存与数据库开销过高的问题。 (#9747)
+- 将 JSON 卡片纳入群聊上下文，并为 LLM 元数据增加回退接口。 (#9655, #9725)
+- 根据文件内容识别音频格式，并将 Telegram 音频文件转换为 Record 组件。 (#9612, #9702)
+- 确保中等宽度视口下聊天侧边栏仍可访问，并使 Dashboard 链路追踪颜色适配当前主题。 (#9698, #9688)
+- 在设置 `password_change_required` 时保留 Dashboard 密码，不再意外轮换。 (#9665)
+- 将推理元数据与供应商配置分离。 (#9699)
+- 移除知识库每次最多上传 10 个文件的限制。 (#9701)
+- 微信客服同步消息缺少 `open_kfid` 时不再导致 Webhook 处理失败。
+
+### 维护
+
+- 将统计服务和 Misskey 可见性处理迁移出已弃用接口。 (#9658, #9674)
+- 新增插件署名规范，并修正自部署文生图配置文档。 (#9720)
+- 更新 CodeQL GitHub Action。 (#9721)
+
+[4.27.4]: https://github.com/AstrBotDevs/AstrBot/compare/v4.27.3...v4.27.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AstrBot"
-version = "4.27.3"
+version = "4.27.4"
 description = "Easy-to-use multi-platform LLM chatbot and development framework"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }


### PR DESCRIPTION
## What changed

- bumped the package version from 4.27.3 to 4.27.4
- added polished English and Chinese release notes for changes since v4.27.3

## Why

Prepare the 4.27.4 patch release with the fixes, Dashboard improvements, and maintenance updates already merged into `master`.

## User impact

After merge and tagging, users can install and identify AstrBot 4.27.4 and review a concise bilingual changelog.

## Validation

- `uv run ruff format .`
- `uv run ruff check .`
- `git diff --check`

## Summary by Sourcery

Bump AstrBot to version 4.27.4 and publish bilingual release notes for the patch release.

Enhancements:
- Prepare the 4.27.4 patch release with updated version metadata and a bilingual changelog covering recent fixes and maintenance improvements.

Documentation:
- Add polished English and Chinese release notes for version 4.27.4.