### PR TITLE
fix: scope the default session waiter identity to the sender

### DIFF
--- a/astrbot/core/utils/session_waiter.py
+++ b/astrbot/core/utils/session_waiter.py
@@ -97,8 +97,20 @@ class SessionFilter:
 
 class DefaultSessionFilter(SessionFilter):
     def filter(self, event: AstrMessageEvent) -> str:
-        """默认实现，返回统一消息来源字符串作为会话标识符"""
-        return event.unified_msg_origin
+        """默认实现，返回「消息来源 + 发送人」作为会话标识符。
+
+        两部分都是必需的: 只用 ``unified_msg_origin`` 会让群内任意成员的下一条
+        消息命中别人注册的等待器(等待器会截获并重新投递该消息); 只用
+        ``sender_id`` 又会让同一用户在其他群聊/私聊中的消息命中此等待器。
+        需要整群共享一个会话时，请自定义 :class:`SessionFilter`。
+
+        Args:
+            event: 待判定的消息事件。
+
+        Returns:
+            会话标识符，格式为 ``{unified_msg_origin}!{sender_id}``。
+        """
+        return f"{event.unified_msg_origin}!{event.get_sender_id()}"
 
 
 class SessionWaiter:

--- a/tests/unit/test_session_waiter.py
+++ b/tests/unit/test_session_waiter.py
@@ -1,0 +1,135 @@
+"""Tests for the session waiter's default session identity.
+
+Regression coverage for the group-chat interception bug: a waiter registered by
+one group member must not be triggered by a different member of the same group,
+while the same member must still be isolated across different sessions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from astrbot.core.message.components import Plain
+from astrbot.core.platform.astr_message_event import AstrMessageEvent
+from astrbot.core.platform.astrbot_message import AstrBotMessage, MessageMember
+from astrbot.core.platform.message_type import MessageType
+from astrbot.core.platform.platform_metadata import PlatformMetadata
+from astrbot.core.utils.session_waiter import (
+    USER_SESSIONS,
+    DefaultSessionFilter,
+    SessionController,
+    SessionWaiter,
+    session_waiter,
+)
+
+PLATFORM_META = PlatformMetadata(
+    name="aiocqhttp",
+    description="test platform",
+    id="aiocqhttp",
+)
+
+
+def make_event(
+    sender_id: str,
+    session_id: str,
+    message_type: MessageType = MessageType.GROUP_MESSAGE,
+    text: str = "hello",
+) -> AstrMessageEvent:
+    """Build a minimal group/private message event.
+
+    Args:
+        sender_id: ID of the member that sent the message.
+        session_id: Platform session ID (group ID for group messages).
+        message_type: Message type of the event.
+        text: Plain text payload of the message.
+
+    Returns:
+        A usable ``AstrMessageEvent`` for session-identity assertions.
+    """
+    message_obj = AstrBotMessage()
+    message_obj.type = message_type
+    message_obj.self_id = "bot"
+    message_obj.session_id = session_id
+    message_obj.message_id = "1"
+    message_obj.sender = MessageMember(user_id=sender_id, nickname=sender_id)
+    message_obj.message = [Plain(text=text)]
+    message_obj.message_str = text
+    message_obj.raw_message = None
+    if message_type == MessageType.GROUP_MESSAGE:
+        message_obj.group_id = session_id
+    return AstrMessageEvent(
+        message_str=text,
+        message_obj=message_obj,
+        platform_meta=PLATFORM_META,
+        session_id=session_id,
+    )
+
+
+def test_default_filter_separates_members_of_the_same_group():
+    """Two members of one group must map to different session identities."""
+    session_filter = DefaultSessionFilter()
+    event_a = make_event("member_a", "group_1")
+    event_b = make_event("member_b", "group_1")
+
+    assert session_filter.filter(event_a) != session_filter.filter(event_b)
+
+
+def test_default_filter_is_stable_for_the_same_member():
+    """The same member in the same group must map to one session identity."""
+    session_filter = DefaultSessionFilter()
+    first = make_event("member_a", "group_1", text="one")
+    second = make_event("member_a", "group_1", text="two")
+
+    assert session_filter.filter(first) == session_filter.filter(second)
+
+
+def test_default_filter_separates_sessions_of_the_same_member():
+    """One member must not share a waiter across groups or private chats."""
+    session_filter = DefaultSessionFilter()
+    in_group_1 = make_event("member_a", "group_1")
+    in_group_2 = make_event("member_a", "group_2")
+    in_private = make_event(
+        "member_a",
+        "member_a",
+        message_type=MessageType.FRIEND_MESSAGE,
+    )
+
+    identities = {
+        session_filter.filter(in_group_1),
+        session_filter.filter(in_group_2),
+        session_filter.filter(in_private),
+    }
+    assert len(identities) == 3
+
+
+@pytest.mark.asyncio
+async def test_waiter_ignores_other_members_and_accepts_the_owner():
+    """A registered waiter only fires for the member that created it."""
+    USER_SESSIONS.clear()
+    session_filter = DefaultSessionFilter()
+    owner_event = make_event("member_a", "group_1", text="@bot")
+    other_event = make_event("member_b", "group_1", text="unrelated chatter")
+
+    triggered: list[str] = []
+
+    @session_waiter(timeout=5)
+    async def waiter(controller: SessionController, event: AstrMessageEvent) -> None:
+        triggered.append(event.get_sender_id())
+        controller.stop()
+
+    waiting = asyncio.create_task(waiter(owner_event, session_filter))
+    await asyncio.sleep(0)
+
+    # A different member of the same group must not reach the waiter.
+    await SessionWaiter.trigger(session_filter.filter(other_event), other_event)
+    assert triggered == []
+
+    # The owner's own follow-up message must reach the waiter.
+    follow_up = make_event("member_a", "group_1", text="the real question")
+    await SessionWaiter.trigger(session_filter.filter(follow_up), follow_up)
+    await asyncio.wait_for(waiting, timeout=5)
+
+    assert triggered == ["member_a"]
+    assert USER_SESSIONS == {}


### PR DESCRIPTION
Fixes #9377.

In a group chat, `DefaultSessionFilter` keyed a session waiter on `event.unified_msg_origin` alone. That value is identical for every member of the group, so a waiter registered by member A was matched by **any** other member's next message. `handle_session_control_agent` then stopped that message (other plugins never saw it), inserted a synthetic `At` component pointing at the bot, and re-dispatched it through the pipeline — the bot answered an unrelated message from member B as if it were A's follow-up input.

This is reachable in the default configuration: `platform_settings.empty_mention_waiting` defaults to `True` and `platform_settings.unique_session` defaults to `False`. The empty-mention waiter in `astrbot/builtin_stars/astrbot/main.py` registers a 60 s waiter without passing a `session_filter`, so it inherited the group-wide key.

It also contradicts the documented contract. `docs/zh/dev/star/guides/session-control.md` states that the default identity is based on `sender_id` and that a custom filter is required to treat a whole group as one session — the opposite of the actual behaviour.

Note that reverting to a `sender_id`-only key would bring back the defect #1326 fixed, where a waiter registered by one user captured that same user's messages in other groups and private chats. The key needs both parts, which is what this PR does.

### Modifications / 改动点

- `astrbot/core/utils/session_waiter.py`: `DefaultSessionFilter.filter()` now returns `f"{event.unified_msg_origin}!{event.get_sender_id()}"` instead of `event.unified_msg_origin`. Session waiters are isolated per sender *and* per session, so neither cross-member interception nor cross-session interception is possible. Callers that genuinely want a group-wide session keep doing what the guide already describes: pass a custom `SessionFilter`.
- `tests/unit/test_session_waiter.py` (new): regression coverage for the default session identity.

Two lines of behaviour change, no public API change, no new dependency.

Scope note: this PR fixes the cross-member interception the issue reports, and deliberately leaves the two "连带问题" items listed at the end of #9377 alone, since they are separate defects in different code paths. Their blast radius does shrink a lot once the key includes the sender: the unconditional `event.stop_event()` in `handle_session_control_agent` can now only swallow a message from the member who registered the waiter (previously any member's image message), and the `SessionWaiter._cleanup()` pop can now only affect two waiters registered by the same member in the same session. I am happy to send follow-up PRs for either if you would like them handled separately.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

The default waiter becomes strictly more selective, and it moves toward the behaviour the developer guide already documents. Plugins that intentionally rely on a group-wide waiter should already be passing their own `SessionFilter`, as shown in the "自定义会话 ID 算子" section of the guide.

### Screenshots or Test Results / 运行截图或测试结果

**Verification steps**

1. `uv sync`
2. `uv run pytest tests/unit/test_session_waiter.py -v`
3. `uv run ruff format --check .` and `uv run ruff check .`
4. `uv run pytest tests -q` to check for regressions

**New tests, before the fix** (`DefaultSessionFilter` still returning `unified_msg_origin`) — the group-chat interception is reproduced:

```
FAILED tests/unit/test_session_waiter.py::test_default_filter_separates_members_of_the_same_group
FAILED tests/unit/test_session_waiter.py::test_waiter_ignores_other_members_and_accepts_the_owner
2 failed, 2 passed

>       assert triggered == []
E       AssertionError: assert ['member_b'] == []
E         Left contains one more item: 'member_b'
```

`member_b` reaching a waiter that `member_a` registered is exactly the reported bug.

**New tests, after the fix:**

```
tests/unit/test_session_waiter.py::test_default_filter_separates_members_of_the_same_group PASSED [ 25%]
tests/unit/test_session_waiter.py::test_default_filter_is_stable_for_the_same_member PASSED      [ 50%]
tests/unit/test_session_waiter.py::test_default_filter_separates_sessions_of_the_same_member PASSED [ 75%]
tests/unit/test_session_waiter.py::test_waiter_ignores_other_members_and_accepts_the_owner PASSED [100%]
======================== 4 passed, 1 warning in 2.63s =========================
```

The four cases cover: two members of one group get distinct identities; the same member in the same group is stable across messages; one member across two groups and a private chat gets three distinct identities (the #1326 guard); and an end-to-end waiter run where another member's message does not trigger the waiter while the owner's follow-up does, with `USER_SESSIONS` cleaned up afterwards.

**Lint:**

```
$ uv run ruff format --check astrbot/core/utils/session_waiter.py
1 file already formatted
$ uv run ruff check astrbot/core/utils/session_waiter.py
All checks passed!
```

**Full suite:** `2132 passed, 34 failed, 1 skipped`. The 34 failures are pre-existing and environment-specific to my Windows development machine (`file://` URI drive-letter parsing, symlink creation, POSIX shell/`python3` invocation). I confirmed they are unrelated by stashing this change and re-running the same selection — the failure set is byte-for-byte identical:

```
$ git stash push astrbot/core/utils/session_waiter.py
$ uv run pytest tests/test_media_utils.py tests/test_openai_source.py \
    tests/unit/test_computer.py tests/test_preprocess_stage.py \
    tests/unit/test_message_tools.py -q
FAILED tests/test_media_utils.py::test_file_uri_to_path_supports_localhost_and_encoded_paths
FAILED tests/test_openai_source.py::test_file_uri_to_path_preserves_windows_drive_letter
FAILED tests/test_openai_source.py::test_file_uri_to_path_preserves_windows_netloc_drive_letter
FAILED tests/test_openai_source.py::test_file_uri_to_path_preserves_remote_netloc_as_unc_path
FAILED tests/unit/test_computer.py::TestLocalShellComponent::test_exec_with_cwd
FAILED tests/unit/test_computer.py::TestLocalShellComponent::test_exec_with_env
FAILED tests/unit/test_computer.py::TestLocalPythonComponent::test_exec_simple_code
FAILED tests/test_preprocess_stage.py::test_preprocess_path_mapping_accepts_file_uri
FAILED tests/unit/test_message_tools.py::test_send_message_downloads_windows_sandbox_file_with_original_name
9 failed, 166 passed
```

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

  No new feature — this is a bug fix for #9377, which contains the maintainer-facing root-cause analysis.

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Prevent default session waiters from intercepting unrelated messages by isolating them per sender and message session.

Bug Fixes:
- Scope default session waiters to both the message origin and sender, preventing messages from other group members or sessions from triggering a waiter.

Tests:
- Add regression tests covering sender isolation within groups, session isolation across chats, stable identities, and end-to-end waiter behavior.