### PR TITLE
fix: stop misclassifying plugin skills as sandbox-only via stale cache

### DIFF
--- a/astrbot/core/skills/skill_manager.py
+++ b/astrbot/core/skills/skill_manager.py
@@ -681,6 +681,8 @@ class SkillManager:
         return [skills_by_name[name] for name in sorted(skills_by_name)]
 
     def is_sandbox_only_skill(self, name: str) -> bool:
+        if self._get_plugin_skill_dir(name) is not None:
+            return False
         skill_dir = Path(self.skills_root) / name
         skill_md_exists = _normalize_skill_markdown_path(skill_dir) is not None
         if skill_md_exists:

--- a/tests/test_skill_manager_sandbox_cache.py
+++ b/tests/test_skill_manager_sandbox_cache.py
@@ -170,3 +170,42 @@ def test_sandbox_and_local_path_resolution_with_show_sandbox_path_false(
     assert local_skill_path.is_relative_to(skills_root)
     assert local_skill_path == skills_root / "custom-local" / "SKILL.md"
     assert by_name["python-sandbox"].path == "/app/skills/python-sandbox/SKILL.md"
+
+
+def test_plugin_skill_with_stale_sandbox_cache_is_not_sandbox_only(
+    monkeypatch,
+    tmp_path: Path,
+):
+    data_dir = tmp_path / "data"
+    temp_dir = tmp_path / "temp"
+    skills_root = tmp_path / "skills"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    skills_root.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(
+        "astrbot.core.skills.skill_manager.get_astrbot_data_path",
+        lambda: str(data_dir),
+    )
+    monkeypatch.setattr(
+        "astrbot.core.skills.skill_manager.get_astrbot_temp_path",
+        lambda: str(temp_dir),
+    )
+
+    from astrbot.core.skills import skill_manager as skill_manager_module
+
+    plugin_skills_root = Path(skill_manager_module.get_astrbot_plugin_path())
+    _write_skill(plugin_skills_root / "astrbot" / "skills", "pdf", "builtin pdf")
+
+    mgr = SkillManager(skills_root=str(skills_root))
+    mgr.set_sandbox_skills_cache(
+        [
+            {
+                "name": "pdf",
+                "description": "stale sandbox cache entry",
+                "path": "/app/skills/pdf/SKILL.md",
+            }
+        ]
+    )
+
+    assert mgr.is_sandbox_only_skill("pdf") is False


### PR DESCRIPTION
Fixes #9754

### Modifications / 改动点

- `SkillManager.is_sandbox_only_skill()` now returns `False` when the name resolves to a plugin-provided skill directory, before consulting the sandbox skills cache.
- Previously, the method only checked the local `skills_root` and `data/sandbox_skills_cache.json`. That cache is persistent and never cleaned up when switching back to the `local` runtime, so a leftover entry with the same name as a builtin-star skill (e.g. the `pdf` skill shipped by the builtin `astrbot` star) made `SkillsService.resolve_local_skill_dir()` reject the skill with `PermissionError: Sandbox preset skill cannot be opened from local skill files.` even though the skill has real local files under `astrbot/builtin_stars/astrbot/skills/` and should be viewable read-only in the Dashboard.
- Added a regression test `test_plugin_skill_with_stale_sandbox_cache_is_not_sandbox_only`.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```shell
$ uv run pytest tests/test_skill_manager_sandbox_cache.py -q
4 passed, 1 warning in 9.41s
```

The new test fails on `master` (assertion at tests/test_skill_manager_sandbox_cache.py:211) and passes with the fix. Other skill-related suites show no new failures (9 pre-existing Windows path-related failures in `tests/test_skill_metadata_enrichment.py` etc. are identical with and without this change).

`uv run ruff format` and `uv run ruff check` pass on the touched files.

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Correct sandbox classification so plugin-provided skills take precedence over stale sandbox cache entries.

Bug Fixes:
- Prevent plugin-provided skills from being misclassified as sandbox-only when a stale sandbox cache entry has the same name.
- Allow local resolution and read-only dashboard access to plugin skills despite obsolete sandbox cache data.

Tests:
- Add a regression test covering plugin skills that conflict with stale sandbox cache entries.