### PR TITLE
fix: keep Gemini functionResponse name/id paired

### DIFF
--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -322,6 +322,19 @@ class ProviderGoogleGenAI(Provider):
                 contents.append(content_cls(parts=part))
 
         gemini_contents: list[types.Content] = []
+        # Tool result messages only carry tool_call_id, not the function name.
+        # Index first so functionResponse.name still matches even if a tool
+        # message appears before its assistant tool_calls in this payload.
+        tool_call_names: dict[str, str] = {}
+        for message in payloads["messages"]:
+            if message.get("role") != "assistant":
+                continue
+            for tool in message.get("tool_calls") or []:
+                tool_id = tool.get("id")
+                func_name = (tool.get("function") or {}).get("name")
+                if tool_id and func_name:
+                    tool_call_names[tool_id] = func_name
+
         for message in payloads["messages"]:
             role, content = message["role"], message.get("content")
 
@@ -392,10 +405,20 @@ class ProviderGoogleGenAI(Provider):
 
                 if "tool_calls" in message:
                     for tool in message["tool_calls"]:
+                        func_name = tool["function"]["name"]
+                        tool_id = tool.get("id")
                         part = types.Part.from_function_call(
-                            name=tool["function"]["name"],
+                            name=func_name,
                             args=json.loads(tool["function"]["arguments"]),
                         )
+                        # Official Gemini often omits id (and we fall back to name).
+                        # Only emit a distinct id so strict proxies can pair history.
+                        if (
+                            tool_id
+                            and tool_id != func_name
+                            and part.function_call is not None
+                        ):
+                            part.function_call.id = tool_id
                         # we should set thought_signature back to part if exists
                         # for more info about thought_signature, see:
                         # https://ai.google.dev/gemini-api/docs/thought-signatures
@@ -415,7 +438,12 @@ class ProviderGoogleGenAI(Provider):
                 append_or_extend(gemini_contents, parts, types.ModelContent)
 
             elif role == "tool":
-                func_name = message.get("name", message["tool_call_id"])
+                tool_call_id = message.get("tool_call_id")
+                func_name = (
+                    message.get("name")
+                    or tool_call_names.get(tool_call_id)
+                    or tool_call_id
+                )
                 part = types.Part.from_function_response(
                     name=func_name,
                     response={
@@ -423,6 +451,12 @@ class ProviderGoogleGenAI(Provider):
                         "content": message["content"],
                     },
                 )
+                if (
+                    tool_call_id
+                    and tool_call_id != func_name
+                    and part.function_response is not None
+                ):
+                    part.function_response.id = tool_call_id
 
                 parts = [part]
                 append_or_extend(gemini_contents, parts, types.UserContent)

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -359,7 +359,8 @@ class ProviderGoogleGenAI(Provider):
             elif role == "assistant":
                 parts = []
                 if isinstance(content, str):
-                    parts.append(types.Part.from_text(text=content))
+                    if content:
+                        parts.append(types.Part.from_text(text=content))
                 elif isinstance(content, list):
                     thinking_signature = None
                     text = ""


### PR DESCRIPTION
Fixes #9760.

Gemini tool-result messages only carry `tool_call_id`, so `_prepare_conversation` was using that id as `functionResponse.name`. Strict Gemini backends then reject the follow-up request (`functionResponse.name "call_176130" does not match functionCall.name "gemini_search"`), and they also require `functionResponse.id` when the matching `functionCall` has a distinct id.

A second failure showed up on the same follow-up path: an empty assistant `content` was serialized as an empty `text` part (`contents[n].parts[0].data: required oneof field 'data' must have one initialized field`). Tool-only first turns hit this often.

### Modifications / 改动点

- Index assistant `tool_calls` before building Gemini contents so `functionResponse.name` is the original function name, even if a tool message appears before its call in the payload.
- Round-trip `functionCall.id` / `functionResponse.id` only when the id is distinct from the function name, so official Gemini (which often omits id, or uses the function name as a fallback) does not receive the field that previously caused #7357 / #7386.
- Skip empty assistant `text` parts so a tool-only model turn does not produce an invalid `Part`.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Verification Steps / 验证步骤

1. Ran `ruff format --check` and `ruff check` on `astrbot/core/provider/sources/gemini_source.py`.
2. Ran `pytest tests/test_gemini_source.py` (3 passed).
3. Exercised `_prepare_conversation` locally for:
   - the reported `call_176130` / `gemini_search` pairing
   - a tool message appearing before its assistant `tool_calls`
   - official Gemini `id == name`, which still omits `id`
4. Live two-round tool call with `gemini-3.7-flash` on a backend that strictly validates function-call history:
   - Round 1: model called `get_weather` with a distinct id (`call_1517`).
   - Prepared contents paired `functionCall` / `functionResponse` as `name=get_weather`, `id=call_1517`, with no empty `text` part.
   - Round 2 `text_chat` with the tool result succeeded and used the tool output (`30°C`, sunny).
   - A no-tool prompt also succeeded.

### Screenshots or Test Results / 运行截图或测试结果

```text
tests/test_gemini_source.py ... 3 passed
```

Prepared Gemini contents for the reported shape:

```text
function_call:     {id: call_176130, name: gemini_search, ...}
function_response: {id: call_176130, name: gemini_search, response: {name: gemini_search, content: ok}}
```

When `tool_call_id` equals the function name (`get_weather`), both parts omit `id`.

Live `gemini-3.7-flash` tool round-trip:

```text
ROUND1  role=tool  name=get_weather  id=call_1517  args={city: Beijing}
PREPARED
  ModelContent  function_call:     {id: call_1517, name: get_weather, ...}
  UserContent   function_response: {id: call_1517, name: get_weather, response: {name: get_weather, content: "temperature=30C, condition=Sunny"}}
ROUND2  "The current weather in Beijing is sunny with a temperature of 30°C."
```

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Fix Gemini tool-result conversation serialization so strict backends accept function-call history and tool-only turns.

Bug Fixes:
- Preserve matching Gemini function names and distinct call IDs when converting tool-call history into function-call and function-response messages.
- Avoid serializing empty assistant text parts that produce invalid Gemini requests.

Tests:
- Validate Gemini conversation preparation and tool round-trips with focused tests and live verification.