### PR TITLE
fix: upload loopback image URLs as Discord attachments

### DIFF
--- a/astrbot/core/platform/sources/discord/discord_platform_event.py
+++ b/astrbot/core/platform/sources/discord/discord_platform_event.py
@@ -1,8 +1,10 @@
 import asyncio
 from collections.abc import AsyncGenerator
 from io import BytesIO
+from ipaddress import ip_address
 from pathlib import Path
 from typing import cast
+from urllib.parse import urlparse
 
 import discord
 from discord.types.interactions import ComponentInteractionData
@@ -163,13 +165,30 @@ class DiscordPlatformEvent(AstrMessageEvent):
                         continue
 
                     if file_content.startswith("http"):
-                        logger.debug(
-                            "[Discord] 处理 URL 图片: %s",
-                            describe_media_ref(file_content),
-                        )
-                        embed = discord.Embed().set_image(url=file_content)
-                        embeds.append(embed)
-                        continue
+                        host = None
+                        try:
+                            host = urlparse(file_content).hostname
+                        except ValueError:
+                            pass
+                        is_unreachable = False
+                        if host:
+                            if host == "localhost":
+                                is_unreachable = True
+                            else:
+                                try:
+                                    is_unreachable = ip_address(
+                                        host.strip("[]")
+                                    ).is_loopback
+                                except ValueError:
+                                    pass
+                        if not is_unreachable:
+                            logger.debug(
+                                "[Discord] 处理 URL 图片: %s",
+                                describe_media_ref(file_content),
+                            )
+                            embed = discord.Embed().set_image(url=file_content)
+                            embeds.append(embed)
+                            continue
 
                     image_data = await MediaResolver(
                         file_content,


### PR DESCRIPTION
Fixes #9756.

`text_to_image()` defaults to loopback URLs such as `http://127.0.0.1:<port>/...`. Discord's `_parse_to_discord` treated any `http*` image as a public URL and put it in `discord.Embed.set_image()`. Discord's servers cannot fetch loopback hosts, so the image rendered as a blank bar.

Loopback hosts (`127.0.0.0/8`, `localhost`, `::1`, IPv4-mapped `::ffff:127.0.0.1`) now fall through to the existing `MediaResolver` path and are uploaded as `discord.File` attachments. Public HTTP(S) URLs are unchanged.

### Modifications / 改动点

- `astrbot/core/platform/sources/discord/discord_platform_event.py`: parse the image URL host and skip the Embed path when `ipaddress.ip_address(...).is_loopback` (or `localhost`) is true.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

**Before:** Discord rendered the local T2I URL as a blank white bar (embed whose image Discord cannot fetch).

**After:** Discord now receives the image as an attachment instead of a blank embed. The sparse layout is from the local PIL renderer used only for this repro, not from the adapter change.

<img width="1087" height="347" alt="Screenshot 2026-08-21 at 20 38 09" src="https://github.com/user-attachments/assets/cf27074e-e4f1-4719-8b25-01b7f3740a28" />

Verified locally against Discord (`Astrbot#1126`) with local T2I + file service (`callback_api_base=http://127.0.0.1:6185`). Existing `tests/test_discord_adapter.py` still pass.

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure Discord renders locally hosted image URLs by sending them as attachments while retaining embed handling for public URLs.

Bug Fixes:
- Upload loopback image URLs as Discord file attachments so locally hosted images render correctly instead of appearing as blank embeds.

Enhancements:
- Preserve embed handling for publicly accessible HTTP(S) image URLs while recognizing localhost and loopback IPv4/IPv6 addresses.