### PR TITLE
docs: add Parallel Search remote MCP example

### DIFF
--- a/docs/en/use/mcp.md
+++ b/docs/en/use/mcp.md
@@ -96,6 +96,18 @@ Configure it in the AstrBot WebUI:
 
 That's it.
 
+### Remote MCP Server Example
+
+Remote MCP servers that use Streamable HTTP only need a URL. For example, you can add Parallel Search without installing a local package:
+
+```json
+{
+    "url": "https://search.parallel.ai/mcp"
+}
+```
+
+This endpoint does not require an API key. Add the configuration in the AstrBot WebUI, then enable the server to make its search tools available to the agent.
+
 Reference links:
 
 1. Learn how to use MCP here: [Model Context Protocol](https://modelcontextprotocol.io/introduction)

--- a/docs/zh/use/mcp.md
+++ b/docs/zh/use/mcp.md
@@ -95,6 +95,18 @@ npx -v
 
 即可。
 
+### 远程 MCP 服务器示例
+
+使用 Streamable HTTP 的远程 MCP 服务器只需要一个 URL。例如，无需安装本地软件包即可添加 Parallel Search：
+
+```json
+{
+    "url": "https://search.parallel.ai/mcp"
+}
+```
+
+此端点不需要 API Key。在 AstrBot WebUI 中添加配置并启用服务器后，Agent 即可使用其搜索工具。
+
 参考链接：
 
 1. 在这里了解如何使用 MCP: [Model Context Protocol](https://modelcontextprotocol.io/introduction)


### PR DESCRIPTION
### Modifications / 改动点

- Documented the credential-free Parallel Search Streamable HTTP configuration in the English MCP guide.
- Added the equivalent example to the Chinese MCP guide.
- Kept existing MCP providers, defaults, and runtime behavior unchanged.
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

- `git diff --check`
- `git status --short`
- The VitePress build could not be run because Node.js and pnpm are unavailable in the isolated validation environment.

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。
- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。
- [x] 🤓 My changes do not introduce new dependencies.
  / 我的更改没有引入新依赖库。
- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.

## Summary by Sourcery

Documentation:
- Add English and Chinese documentation for configuring the credential-free Parallel Search remote MCP server over Streamable HTTP.