### PR TITLE
fix: support anthropic SDK 1.0 httpx2 module

### DIFF
--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -131,7 +131,11 @@ class ProviderAnthropic(Provider):
         try:
             from anthropic import _base_client as anthropic_base_client
 
-            httpx_module = getattr(anthropic_base_client, "httpx", httpx)
+            httpx_module = getattr(
+                anthropic_base_client,
+                "httpx2",
+                getattr(anthropic_base_client, "httpx", httpx),
+            )
         except ImportError:
             pass
         return create_proxy_client(

--- a/tests/test_anthropic_kimi_code_provider.py
+++ b/tests/test_anthropic_kimi_code_provider.py
@@ -137,7 +137,13 @@ def test_create_http_client_uses_anthropic_httpx_module(monkeypatch):
     assert captured["provider_label"] == "Anthropic"
     assert captured["proxy"] == "http://127.0.0.1:7890"
     assert captured["headers"] == {"X-Trace-Id": "trace-1"}
-    assert captured["httpx_module"] is anthropic_base_client.httpx
+    sdk_httpx = getattr(
+        anthropic_base_client,
+        "httpx2",
+        getattr(anthropic_base_client, "httpx", None),
+    )
+    assert sdk_httpx is not None
+    assert captured["httpx_module"] is sdk_httpx
 
 
 def test_create_http_client_falls_back_to_global_httpx_module(monkeypatch):


### PR DESCRIPTION
### Modifications / 改动点

Anthropic SDK 1.0.0 (released 2026-08-20; see [Claude Platform release notes](https://platform.claude.com/docs/en/release-notes/overview#august-20-2026)) renamed its internal transport module from `anthropic._base_client.httpx` to `httpx2`. Since `uv.lock` is gitignored, CI resolves `anthropic>=0.51.0` to the latest PyPI release, so since 2026-08-21 every run installs `anthropic==1.0.0` and the existing unit test `test_create_http_client_uses_anthropic_httpx_module` fails (`module 'anthropic._base_client' has no attribute 'httpx'`).

- `astrbot/core/provider/sources/anthropic_source.py`: resolve the SDK's own httpx module preferring `httpx2` (anthropic 1.x) and falling back to `httpx` (anthropic 0.x), so proxy clients still pass the SDK's `isinstance` check when multiple httpx installations are on `sys.path`.
- `tests/test_anthropic_kimi_code_provider.py`: mirror the same resolution in the test instead of hard-coding the private `httpx` attribute.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Verification Steps / 验证步骤

1. Ran with `anthropic==1.0.0` installed (venv, `httpx2` present, `httpx` absent):
   - `pytest tests/test_anthropic_kimi_code_provider.py` → 27 passed
   - full `pytest tests/` → 2163 passed
   - `ruff format --check` and `ruff check` → clean
2. Fallback path (`httpx` attribute) is covered by the existing `test_create_http_client_falls_back_to_global_httpx_module`.

### Screenshots or Test Results / 运行截图或测试结果

```text
$ pytest tests/test_anthropic_kimi_code_provider.py -q
27 passed, 1 warning in 1.06s

$ pytest tests/ -q
2163 passed, 19 warnings in 74.88s
```

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Maintain Anthropic proxy client compatibility across SDK versions by supporting both the new and legacy internal HTTP transport modules.

Bug Fixes:
- Support Anthropic SDK 1.x by resolving its renamed internal HTTP transport module while retaining compatibility with SDK 0.x.

Tests:
- Update Anthropic provider tests to validate the SDK-compatible transport module across supported SDK versions.

## Summary by Sourcery

Maintain Anthropic provider compatibility across SDK versions by supporting both the new and legacy internal HTTP transport modules.

Bug Fixes:
- Support Anthropic SDK 1.x while retaining compatibility with SDK 0.x by resolving either its renamed or legacy internal HTTP transport module for proxy clients.

Tests:
- Update Anthropic provider tests to validate the SDK-compatible HTTP transport module across supported SDK versions.