### PR TITLE
fix: isolate session waiters by sender

### DIFF
--- a/astrbot/core/utils/session_waiter.py
+++ b/astrbot/core/utils/session_waiter.py
@@ -97,8 +97,8 @@ class SessionFilter:
 
 class DefaultSessionFilter(SessionFilter):
     def filter(self, event: AstrMessageEvent) -> str:
-        """默认实现，返回统一消息来源字符串作为会话标识符"""
-        return event.unified_msg_origin
+        """Return a session identifier scoped to the current sender and chat."""
+        return f"{event.unified_msg_origin}:{event.get_sender_id()}"
 
 
 class SessionWaiter:

--- a/tests/unit/test_session_waiter.py
+++ b/tests/unit/test_session_waiter.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock
+
+from astrbot.core.utils.session_waiter import DefaultSessionFilter
+
+
+def _event(umo: str, sender_id: str) -> MagicMock:
+    event = MagicMock()
+    event.unified_msg_origin = umo
+    event.get_sender_id.return_value = sender_id
+    return event
+
+
+def test_default_filter_isolates_group_members() -> None:
+    session_filter = DefaultSessionFilter()
+    umo = "qq:GroupMessage:123"
+
+    first_member = session_filter.filter(_event(umo, "user-1"))
+    second_member = session_filter.filter(_event(umo, "user-2"))
+
+    assert first_member != second_member
+
+
+def test_default_filter_keeps_same_sender_in_same_chat() -> None:
+    session_filter = DefaultSessionFilter()
+    umo = "qq:GroupMessage:123"
+
+    first_message = session_filter.filter(_event(umo, "user-1"))
+    next_message = session_filter.filter(_event(umo, "user-1"))
+
+    assert first_message == next_message
+
+
+def test_default_filter_isolates_same_sender_across_chats() -> None:
+    session_filter = DefaultSessionFilter()
+
+    first_chat = session_filter.filter(_event("qq:GroupMessage:123", "user-1"))
+    second_chat = session_filter.filter(_event("qq:GroupMessage:456", "user-1"))
+
+    assert first_chat != second_chat


### PR DESCRIPTION
## Summary

- scope the default session waiter key to both the current chat and sender
- prevent one group member from triggering another member's active multi-turn handler
- add regression coverage for member and chat isolation

## Problem

`DefaultSessionFilter` returned only `event.unified_msg_origin`. For group messages, that origin identifies the group rather than the sender, so any member's next message could be routed into another member's active session waiter. This also contradicted the documented sender-scoped default behavior.

## Testing

- `uv run pytest tests/unit/test_session_waiter.py tests/unit/test_event_bus.py tests/unit/test_astr_message_event.py -q` (97 passed)
- `uv run ruff check astrbot/core/utils/session_waiter.py tests/unit/test_session_waiter.py`
- `uv run ruff format --check astrbot/core/utils/session_waiter.py tests/unit/test_session_waiter.py`

Full-suite note: `uv run pytest -q` reached 2153 passed and 1 skipped; 39 existing Windows-specific/environment failures remained around symlink privileges, PowerShell quoting, and path expectations. No session waiter tests failed.

## Summary by Sourcery

Scope default session waiter identifiers to the originating chat and sender to prevent cross-user session routing.

Bug Fixes:
- Isolate default session waiters by both chat and sender so group members cannot trigger one another’s active multi-turn sessions.

Tests:
- Add regression tests covering group-member isolation, same-sender continuity within a chat, and isolation across chats.