### PR TITLE
fix(stt): honor Whisper provider proxy

### DIFF
--- a/astrbot/core/provider/sources/whisper_api_source.py
+++ b/astrbot/core/provider/sources/whisper_api_source.py
@@ -1,6 +1,10 @@
+from typing import Any
+
+import httpx
 from openai import NOT_GIVEN, AsyncOpenAI
 
 from astrbot.core.utils.media_utils import MediaResolver
+from astrbot.core.utils.network_utils import create_proxy_client
 
 from ..entities import ProviderType
 from ..provider import STTProvider
@@ -25,9 +29,26 @@ class ProviderOpenAIWhisperAPI(STTProvider):
             api_key=self.chosen_api_key,
             base_url=provider_config.get("api_base"),
             timeout=provider_config.get("timeout", NOT_GIVEN),
+            http_client=self._create_http_client(provider_config),
         )
 
         self.set_model(provider_config["model"])
+
+    @staticmethod
+    def _create_http_client(provider_config: dict) -> httpx.AsyncClient:
+        """Create an HTTP client that honors the provider proxy setting."""
+        proxy = provider_config.get("proxy", "")
+        httpx_module: Any = httpx
+        try:
+            # The OpenAI SDK can bundle its own compatible httpx module.
+            from openai import _base_client as openai_base_client
+
+            httpx_module = getattr(openai_base_client, "httpx", httpx)
+        except ImportError:
+            pass
+        return create_proxy_client(
+            "OpenAI Whisper", proxy, httpx_module=httpx_module
+        )
 
     async def get_text(self, audio_url: str) -> str:
         """Only supports mp3, mp4, mpeg, m4a, wav, webm"""

--- a/tests/test_whisper_api_source.py
+++ b/tests/test_whisper_api_source.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -26,6 +26,36 @@ def _make_provider() -> ProviderOpenAIWhisperAPI:
         close=AsyncMock(),
     )
     return provider
+
+
+def test_init_passes_the_provider_proxy_to_the_http_client():
+    proxy = "http://127.0.0.1:7890"
+    http_client = MagicMock()
+
+    with (
+        patch(
+            "astrbot.core.provider.sources.whisper_api_source.create_proxy_client",
+            return_value=http_client,
+        ) as create_proxy_client,
+        patch(
+            "astrbot.core.provider.sources.whisper_api_source.AsyncOpenAI"
+        ) as async_openai,
+    ):
+        ProviderOpenAIWhisperAPI(
+            provider_config={
+                "id": "test-whisper-api",
+                "type": "openai_whisper_api",
+                "model": "whisper-1",
+                "api_key": "test-key",
+                "proxy": proxy,
+            },
+            provider_settings={},
+        )
+
+    create_proxy_client.assert_called_once_with(
+        "OpenAI Whisper", proxy, httpx_module=ANY
+    )
+    assert async_openai.call_args.kwargs["http_client"] is http_client
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- pass the configured provider proxy to the Whisper STT OpenAI client
- add regression coverage for proxy client construction

## Testing
- `python -m pytest -q /tmp/test_whisper_api_source.py`

## Summary by Sourcery

Route Whisper STT requests through the configured provider proxy.

Bug Fixes:
- Honor the configured provider proxy when constructing the Whisper STT OpenAI client.

Tests:
- Add regression coverage verifying the provider proxy is passed to the Whisper HTTP client.