### PR TITLE
fix: honor Whisper provider proxy

### DIFF
--- a/astrbot/core/provider/sources/whisper_api_source.py
+++ b/astrbot/core/provider/sources/whisper_api_source.py
@@ -1,6 +1,8 @@
+import httpx
 from openai import NOT_GIVEN, AsyncOpenAI
 
 from astrbot.core.utils.media_utils import MediaResolver
+from astrbot.core.utils.network_utils import create_proxy_client
 
 from ..entities import ProviderType
 from ..provider import STTProvider
@@ -20,11 +22,24 @@ class ProviderOpenAIWhisperAPI(STTProvider):
     ) -> None:
         super().__init__(provider_config, provider_settings)
         self.chosen_api_key = provider_config.get("api_key", "")
+        proxy = provider_config.get("proxy", "")
+        httpx_module = httpx
+        try:
+            # The OpenAI SDK can bundle its own compatible httpx module.
+            from openai import _base_client as openai_base_client
+
+            httpx_module = getattr(openai_base_client, "httpx", httpx)
+        except ImportError:
+            pass
+        http_client = create_proxy_client(
+            "OpenAI Whisper", proxy, httpx_module=httpx_module
+        )
 
         self.client = AsyncOpenAI(
             api_key=self.chosen_api_key,
             base_url=provider_config.get("api_base"),
             timeout=provider_config.get("timeout", NOT_GIVEN),
+            http_client=http_client,
         )
 
         self.set_model(provider_config["model"])

--- a/tests/test_whisper_api_source.py
+++ b/tests/test_whisper_api_source.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -26,6 +26,36 @@ def _make_provider() -> ProviderOpenAIWhisperAPI:
         close=AsyncMock(),
     )
     return provider
+
+
+def test_init_passes_the_provider_proxy_to_the_http_client():
+    proxy = "http://127.0.0.1:7890"
+    http_client = MagicMock()
+
+    with (
+        patch(
+            "astrbot.core.provider.sources.whisper_api_source.create_proxy_client",
+            return_value=http_client,
+        ) as create_proxy_client,
+        patch(
+            "astrbot.core.provider.sources.whisper_api_source.AsyncOpenAI"
+        ) as async_openai,
+    ):
+        ProviderOpenAIWhisperAPI(
+            provider_config={
+                "id": "test-whisper-api",
+                "type": "openai_whisper_api",
+                "model": "whisper-1",
+                "api_key": "test-key",
+                "proxy": proxy,
+            },
+            provider_settings={},
+        )
+
+    create_proxy_client.assert_called_once_with(
+        "OpenAI Whisper", proxy, httpx_module=ANY
+    )
+    assert async_openai.call_args.kwargs["http_client"] is http_client
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Modifications / 改动点

- Pass the configured provider proxy to the Whisper STT OpenAI client.
- Add regression coverage for proxy-aware client construction.
- [x] This is NOT a breaking change.

### Screenshots or Test Results / 运行截图或测试结果

- `python -m pytest -q /tmp/test_whisper_api_source.py`: 2 passed.
- `python -m ruff check ...`: All checks passed.

---

### Checklist / 检查清单

- [ ] No new feature is introduced.
- [x] The change was tested and verification results are provided above.
- [x] No new dependencies are introduced.
- [x] The change does not introduce malicious code.

## Summary by Sourcery

Honor provider proxy settings for OpenAI Whisper transcription requests.

Bug Fixes:
- Honor the configured provider proxy when constructing the OpenAI Whisper STT client.

Tests:
- Add regression coverage verifying proxy-aware HTTP client construction for Whisper providers.