### PR TITLE
fix: accumulate all text blocks in Anthropic non-streaming response

### DIFF
--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -540,11 +540,11 @@ class ProviderAnthropic(Provider):
             )
 
         llm_response = LLMResponse(role="assistant")
+        completion_text_parts: list[str] = []
 
         for content_block in completion.content:
             if content_block.type == "text":
-                completion_text = str(content_block.text).strip()
-                llm_response.completion_text = completion_text
+                completion_text_parts.append(str(content_block.text))
 
             if content_block.type == "thinking":
                 reasoning_content = str(content_block.thinking).strip()
@@ -556,6 +556,7 @@ class ProviderAnthropic(Provider):
                 llm_response.tools_call_name.append(content_block.name)
                 llm_response.tools_call_ids.append(content_block.id)
 
+        llm_response.completion_text = "".join(completion_text_parts).strip()
         llm_response.id = completion.id
         llm_response.usage = self._extract_usage(completion.usage)
 

--- a/tests/test_anthropic_kimi_code_provider.py
+++ b/tests/test_anthropic_kimi_code_provider.py
@@ -737,6 +737,40 @@ async def test_query_handles_none_usage_when_content_filtered(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_query_accumulates_multiple_text_blocks(monkeypatch):
+    """A Message with more than one text content block (e.g. Citations API
+    output) must concatenate every block, not keep only the last one."""
+    provider = _setup_provider_with_mock_client(monkeypatch)
+
+    class _FakeMessageBlock:
+        def __init__(self, text: str):
+            self.type = "text"
+            self.text = text
+
+    class _FakeMessage:
+        def __init__(self):
+            self.id = "msg_multi_block"
+            self.content = [
+                _FakeMessageBlock("First block: the important part."),
+                _FakeMessageBlock("Second block: a trailing citation note."),
+            ]
+            self.stop_reason = "end_turn"
+            self.usage = None
+
+    async def fake_create(**kwargs):
+        return _FakeMessage()
+
+    monkeypatch.setattr(anthropic_source, "Message", _FakeMessage)
+    provider.client.messages.create = fake_create
+
+    llm_response = await provider.text_chat(prompt="test")
+
+    assert llm_response.completion_text == (
+        "First block: the important part.Second block: a trailing citation note."
+    )
+
+
+@pytest.mark.asyncio
 async def test_tool_choice_auto_converts_to_dict(monkeypatch):
     """tool_choice='auto' 应转换为 {'type': 'auto'}"""
     provider = _setup_provider_with_mock_client(monkeypatch)


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

`ProviderAnthropic._query` (the non-streaming path in `anthropic_source.py`) sets `llm_response.completion_text` inside a loop over `completion.content`, once per text content block, instead of appending. When a `Message` carries more than one text block, only the last one survives; every earlier text block is silently dropped from the reply and from conversation history. This can happen with the Citations API and with extended-thinking flows, both of which can split a response into multiple text blocks. The streaming sibling, `_query_stream`, already accumulates correctly with `final_text += event.delta.text`.

### Modifications / 改动点

Collect each text block into a list during the loop and join them once after the loop, instead of overwriting `completion_text` per block. `thinking` and `tool_use` handling are unchanged.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Added `test_query_accumulates_multiple_text_blocks`, which feeds `ProviderAnthropic._query` a fake `Message` with two text blocks. It fails on unmodified `master` (`AssertionError`, only the second block's text survives) and passes with this fix. The full `tests/test_anthropic_kimi_code_provider.py` file: 28 passed, 1 pre-existing failure unrelated to this change (`test_create_http_client_uses_anthropic_httpx_module`, an SDK version drift already being fixed in open PR #9769). `ruff format --check` and `ruff check` are clean on both changed files.

Not verified: a live call to the provider's API. This was reproduced and tested against the SDK's `Message`/content-block shape directly, not against a real multi-block response from the API.

---

### Checklist / 检查清单

- [x] If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Accumulate every text block returned by Anthropic’s non-streaming API so complete responses and conversation history are preserved.

Bug Fixes:
- Preserve all text content blocks in Anthropic non-streaming responses instead of returning only the final block.

Tests:
- Add coverage verifying that multiple Anthropic text blocks are concatenated in the response.