### PR TITLE
fix(agent): run response hooks before send in skills_like no-tool fallback

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -936,6 +936,9 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                     logger.warning(
                         "skills_like tool re-query returned no tool calls; fallback to assistant response."
                     )
+                    # Finalize before yielding so response hooks can review or rewrite
+                    # the fallback text before downstream stages send it.
+                    await self._complete_with_assistant_response(llm_resp)
                     if llm_resp.reasoning_content:
                         yield AgentResponse(
                             type="llm_result",
@@ -958,7 +961,6 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                             ),
                         )
 
-                    await self._complete_with_assistant_response(llm_resp)
                     return
                 else:
                     llm_resp.tools_call_name = requery_resp.tools_call_name

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -936,6 +936,25 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                     logger.warning(
                         "skills_like tool re-query returned no tool calls; fallback to assistant response."
                     )
+                    if llm_resp.role == "err":
+                        # The re-query returned a provider error instead of a normal
+                        # assistant response; route it through error handling instead
+                        # of finalizing it as assistant content.
+                        self.final_llm_resp = llm_resp
+                        self.stats.end_time = time.time()
+                        self._transition_state(AgentState.ERROR)
+                        self._resolve_unconsumed_follow_ups()
+                        custom_error_message = self._get_persona_custom_error_message()
+                        error_text = custom_error_message or (
+                            f"LLM 响应错误: {llm_resp.completion_text or '未知错误'}"
+                        )
+                        yield AgentResponse(
+                            type="err",
+                            data=AgentResponseData(
+                                chain=MessageChain().message(error_text),
+                            ),
+                        )
+                        return
                     # Finalize before yielding so response hooks can review or rewrite
                     # the fallback text before downstream stages send it.
                     await self._complete_with_assistant_response(llm_resp)

--- a/tests/test_skills_like_hook_order.py
+++ b/tests/test_skills_like_hook_order.py
@@ -1,0 +1,447 @@
+"""Lifecycle contracts for the skills-like no-tool re-query fallback."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from mcp.types import CallToolResult, TextContent
+
+from astrbot.core import astr_agent_hooks as agent_hooks_module
+from astrbot.core.agent.message import TextPart
+from astrbot.core.agent.run_context import ContextWrapper
+from astrbot.core.agent.runners.tool_loop_agent_runner import ToolLoopAgentRunner
+from astrbot.core.agent.tool import FunctionTool, ToolSet
+from astrbot.core.astr_agent_hooks import MainAgentHooks
+from astrbot.core.astr_agent_run_util import run_agent
+from astrbot.core.message.message_event_result import MessageEventResult
+from astrbot.core.pipeline.process_stage.method.agent_sub_stages.internal import (
+    InternalAgentSubStage,
+)
+from astrbot.core.pipeline.respond import stage as respond_stage_module
+from astrbot.core.pipeline.respond.stage import RespondStage
+from astrbot.core.pipeline.scheduler import PipelineScheduler
+from astrbot.core.provider.entities import LLMResponse, ProviderRequest
+from astrbot.core.provider.provider import Provider
+from astrbot.core.star.star_handler import EventType
+
+
+class _SequenceProvider(Provider):
+    """Return a deterministic sequence of model responses."""
+
+    def __init__(
+        self,
+        responses: Iterable[LLMResponse] = (),
+        error: Exception | None = None,
+    ) -> None:
+        super().__init__({"id": "contract-provider", "model": "contract-model"}, {})
+        self._responses = iter(responses)
+        self._error = error
+        self.call_count = 0
+
+    def get_current_key(self) -> str:
+        """Return a placeholder key required by the provider interface."""
+        return "contract-key"
+
+    def set_key(self, key: str) -> None:
+        """Accept provider key updates without external state."""
+        del key
+
+    async def get_models(self) -> list[str]:
+        """Return the single fake model exposed by this provider."""
+        return ["contract-model"]
+
+    async def text_chat(self, **kwargs: Any) -> LLMResponse:
+        """Return the next configured response or raise the configured error."""
+        del kwargs
+        self.call_count += 1
+        if self._error is not None:
+            raise self._error
+        return next(self._responses)
+
+    async def text_chat_stream(self, **kwargs: Any):
+        """Expose the non-streaming response through the streaming interface."""
+        yield await self.text_chat(**kwargs)
+
+
+class _ToolExecutor:
+    """Return a stable tool result without touching external systems."""
+
+    @classmethod
+    def execute(cls, tool, run_context, **tool_args):
+        """Yield one text result for a tool invocation."""
+        del cls, tool, run_context, tool_args
+
+        async def _result():
+            yield CallToolResult(
+                content=[TextContent(type="text", text="contract tool result")]
+            )
+
+        return _result()
+
+
+class _ContractEvent:
+    """Provide the event surface used by run_agent and RespondStage."""
+
+    def __init__(self, lifecycle: list[str]) -> None:
+        self.unified_msg_origin = "contract:FriendMessage:session"
+        self.plugins_name: list[str] = []
+        self.trace = SimpleNamespace(record=lambda *args, **kwargs: None)
+        self._extras: dict[str, Any] = {}
+        self._result: MessageEventResult | None = None
+        self._stopped = False
+        self.lifecycle = lifecycle
+        self.sent_texts: list[str] = []
+
+    def get_extra(self, key: str, default=None):
+        """Return an event extra value."""
+        return self._extras.get(key, default)
+
+    def set_extra(self, key: str, value: Any) -> None:
+        """Store an event extra value."""
+        self._extras[key] = value
+
+    def set_result(self, result: MessageEventResult) -> None:
+        """Set the current pipeline result."""
+        self._result = result
+
+    def get_result(self) -> MessageEventResult | None:
+        """Return the current pipeline result."""
+        return self._result
+
+    def clear_result(self) -> None:
+        """Clear the current pipeline result."""
+        self._result = None
+
+    def stop_event(self) -> None:
+        """Stop event propagation."""
+        self._stopped = True
+
+    def is_stopped(self) -> bool:
+        """Return whether event propagation has stopped."""
+        return self._stopped
+
+    def get_platform_name(self) -> str:
+        """Return a platform name used by the runner and respond stage."""
+        return "contract"
+
+    def get_platform_id(self) -> str:
+        """Return a platform identifier used by the runner and respond stage."""
+        return "contract"
+
+    def get_sender_name(self) -> str:
+        """Return a sender name for respond-stage logging."""
+        return "contract-user"
+
+    def get_sender_id(self) -> str:
+        """Return a sender identifier for respond-stage logging."""
+        return "contract-user-id"
+
+    def _outline_chain(self, chain) -> str:
+        """Render the text portion of a message chain for logging."""
+        return "".join(str(getattr(component, "text", "")) for component in chain)
+
+    async def send(self, payload) -> None:
+        """Capture the text that the real RespondStage attempted to send."""
+        chain = getattr(payload, "chain", []) or []
+        text = "".join(str(getattr(component, "text", "")) for component in chain)
+        self.lifecycle.append("send")
+        self.sent_texts.append(text)
+
+
+class _ConversationManager:
+    """Capture history persisted by the real internal-agent save method."""
+
+    def __init__(self, lifecycle: list[str]) -> None:
+        self.lifecycle = lifecycle
+        self.saved_history: list[dict[str, Any]] | None = None
+
+    async def update_conversation(
+        self,
+        unified_msg_origin: str,
+        conversation_id: str,
+        *,
+        history: list[dict[str, Any]],
+        token_usage: int | None,
+    ) -> None:
+        """Capture one framework history write without external persistence."""
+        del unified_msg_origin, conversation_id, token_usage
+        self.saved_history = history
+        self.lifecycle.append("history_save")
+
+    async def update_conversation_merged(
+        self,
+        unified_msg_origin: str,
+        conversation_id: str,
+        *,
+        history: list[dict[str, Any]],
+        token_usage: int | None,
+    ) -> None:
+        """Capture one framework history write without external persistence."""
+        del unified_msg_origin, conversation_id, token_usage
+        self.saved_history = history
+        self.lifecycle.append("history_save")
+
+
+class _RunnerStage:
+    """Expose the real runner as an onion-style pipeline stage."""
+
+    def __init__(
+        self,
+        runner: ToolLoopAgentRunner,
+        request: ProviderRequest,
+        lifecycle: list[str],
+    ) -> None:
+        self.runner = runner
+        self.request = request
+        self.lifecycle = lifecycle
+        self.conversation_manager = _ConversationManager(lifecycle)
+
+    @property
+    def saved_tail_text(self) -> str | None:
+        """Return the final text written through the real history-save path."""
+        history = self.conversation_manager.saved_history
+        if not history:
+            return None
+        content = history[-1]["content"]
+        if not isinstance(content, list) or not content:
+            return None
+        return content[-1].get("text")
+
+    async def process(self, event: _ContractEvent):
+        """Run the agent and persist history after downstream stages return."""
+        async for _ in run_agent(
+            self.runner,
+            max_step=8,
+            show_tool_use=False,
+            show_tool_call_result=False,
+            buffer_intermediate_messages=False,
+        ):
+            yield
+
+        final_response = self.runner.get_final_llm_resp()
+        history_owner = SimpleNamespace(conv_manager=self.conversation_manager)
+        await InternalAgentSubStage._save_to_history(
+            history_owner,
+            event,
+            self.request,
+            final_response,
+            self.runner.run_context.messages,
+            self.runner.stats,
+        )
+
+
+def _tool_call(name: str, call_id: str) -> LLMResponse:
+    """Build a model response that requests one tool call."""
+    return LLMResponse(
+        role="assistant",
+        completion_text="",
+        tools_call_name=[name],
+        tools_call_args=[{"query": call_id}],
+        tools_call_ids=[call_id],
+    )
+
+
+def _final(text: str) -> LLMResponse:
+    """Build a plain final assistant response."""
+    return LLMResponse(role="assistant", completion_text=text)
+
+
+async def _run_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+    responses: Iterable[LLMResponse] = (),
+    *,
+    tool_schema_mode: str = "full",
+    error: Exception | None = None,
+) -> tuple[_ContractEvent, _RunnerStage, _SequenceProvider, list[str], list[str]]:
+    """Run a real runner/scheduler/respond lifecycle with isolated fake I/O."""
+    lifecycle: list[str] = []
+    after_hook_texts: list[str] = []
+    event = _ContractEvent(lifecycle)
+    provider = _SequenceProvider(responses, error=error)
+
+    tool = FunctionTool(
+        name="contract_tool",
+        description="Contract test tool",
+        parameters={"type": "object", "properties": {"query": {"type": "string"}}},
+        handler=AsyncMock(),
+    )
+    request = ProviderRequest(
+        prompt="Run the contract scenario",
+        func_tool=ToolSet(tools=[tool]),
+        contexts=[],
+        conversation=SimpleNamespace(cid="contract-conversation", token_usage=0),
+    )
+    runner = ToolLoopAgentRunner()
+
+    async def _agent_hook(event_arg, hook_type, *args, **kwargs):
+        del event_arg, kwargs
+        if hook_type == EventType.OnLLMResponseEvent:
+            response = args[0]
+            lifecycle.append("response_hook")
+            if response.role == "assistant" and response.completion_text:
+                response.completion_text = f"reviewed::{response.completion_text}"
+        elif hook_type == EventType.OnAgentDoneEvent:
+            run_context, response = args
+            lifecycle.append("agent_done_hook")
+            if response.role == "assistant" and response.completion_text:
+                last_part = run_context.messages[-1].content[-1]
+                assert isinstance(last_part, TextPart)
+                last_part.text = response.completion_text
+        return False
+
+    async def _after_hook(event_arg, hook_type, *args, **kwargs):
+        del args, kwargs
+        assert hook_type == EventType.OnAfterMessageSentEvent
+        result = event_arg.get_result()
+        assert result is not None
+        text = "".join(
+            str(getattr(component, "text", "")) for component in result.chain
+        )
+        lifecycle.append("after_hook")
+        after_hook_texts.append(text)
+        return False
+
+    monkeypatch.setattr(agent_hooks_module, "call_event_hook", _agent_hook)
+    monkeypatch.setattr(respond_stage_module, "call_event_hook", _after_hook)
+
+    await runner.reset(
+        provider=provider,
+        request=request,
+        run_context=ContextWrapper(context=SimpleNamespace(event=event)),
+        tool_executor=_ToolExecutor(),
+        agent_hooks=MainAgentHooks(),
+        streaming=False,
+        tool_schema_mode=tool_schema_mode,
+        request_max_retries=0,
+    )
+
+    runner_stage = _RunnerStage(runner, request, lifecycle)
+    respond_stage = RespondStage()
+    respond_stage.config = {"provider_settings": {}}
+    respond_stage.platform_settings = {"path_mapping": []}
+    respond_stage.enable_seg = False
+
+    scheduler = PipelineScheduler(SimpleNamespace())
+    scheduler.stages = [runner_stage, respond_stage]
+    await scheduler._process_stages(event)
+
+    return event, runner_stage, provider, lifecycle, after_hook_texts
+
+
+@pytest.mark.asyncio
+async def test_skills_like_no_tool_requery_runs_hooks_before_send_and_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Send only the post-hook fallback text and persist the same text."""
+    event, runner_stage, provider, lifecycle, after_texts = await _run_lifecycle(
+        monkeypatch,
+        [_tool_call("contract_tool", "select-1"), _final("fallback draft")],
+        tool_schema_mode="skills_like",
+    )
+
+    assert provider.call_count == 2
+    assert event.sent_texts == ["reviewed::fallback draft"]
+    assert after_texts == event.sent_texts
+    assert runner_stage.saved_tail_text == event.sent_texts[-1]
+    assert lifecycle == [
+        "response_hook",
+        "agent_done_hook",
+        "send",
+        "after_hook",
+        "history_save",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_plain_final_response_keeps_existing_hook_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep the existing hook-before-send order for an ordinary final response."""
+    event, runner_stage, provider, lifecycle, after_texts = await _run_lifecycle(
+        monkeypatch,
+        [_final("plain draft")],
+    )
+
+    assert provider.call_count == 1
+    assert event.sent_texts == ["reviewed::plain draft"]
+    assert after_texts == event.sent_texts
+    assert runner_stage.saved_tail_text == event.sent_texts[-1]
+    assert lifecycle == [
+        "response_hook",
+        "agent_done_hook",
+        "send",
+        "after_hook",
+        "history_save",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_full_schema_tool_call_keeps_final_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep one normal tool call followed by one audited final response."""
+    event, runner_stage, provider, lifecycle, after_texts = await _run_lifecycle(
+        monkeypatch,
+        [_tool_call("contract_tool", "full-1"), _final("tool final draft")],
+    )
+
+    assert provider.call_count == 2
+    assert event.sent_texts == ["reviewed::tool final draft"]
+    assert after_texts == event.sent_texts
+    assert runner_stage.saved_tail_text == event.sent_texts[-1]
+    assert lifecycle[-5:] == [
+        "response_hook",
+        "agent_done_hook",
+        "send",
+        "after_hook",
+        "history_save",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_multiple_tool_calls_keep_final_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep a multi-step tool loop and audit only its final assistant response."""
+    event, runner_stage, provider, lifecycle, after_texts = await _run_lifecycle(
+        monkeypatch,
+        [
+            _tool_call("contract_tool", "multi-1"),
+            _tool_call("contract_tool", "multi-2"),
+            _final("multi final draft"),
+        ],
+    )
+
+    assert provider.call_count == 3
+    assert event.sent_texts == ["reviewed::multi final draft"]
+    assert after_texts == event.sent_texts
+    assert runner_stage.saved_tail_text == event.sent_texts[-1]
+    assert lifecycle[-5:] == [
+        "response_hook",
+        "agent_done_hook",
+        "send",
+        "after_hook",
+        "history_save",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_provider_error_does_not_create_assistant_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep provider failures out of assistant history while returning an error."""
+    event, runner_stage, provider, lifecycle, after_texts = await _run_lifecycle(
+        monkeypatch,
+        error=RuntimeError("contract provider failure"),
+    )
+
+    assert provider.call_count == 1
+    assert runner_stage.saved_tail_text is None
+    assert len(event.sent_texts) == 1
+    assert "contract provider failure" in event.sent_texts[0]
+    assert after_texts == event.sent_texts
+    assert "history_save" not in lifecycle

--- a/tests/test_skills_like_hook_order.py
+++ b/tests/test_skills_like_hook_order.py
@@ -445,3 +445,26 @@ async def test_provider_error_does_not_create_assistant_history(
     assert "contract provider failure" in event.sent_texts[0]
     assert after_texts == event.sent_texts
     assert "history_save" not in lifecycle
+
+
+@pytest.mark.asyncio
+async def test_skills_like_error_requery_uses_error_handling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Route an err-role re-query response through error handling, not fallback."""
+    event, runner_stage, provider, lifecycle, after_texts = await _run_lifecycle(
+        monkeypatch,
+        [
+            _tool_call("contract_tool", "select-1"),
+            LLMResponse(role="err", completion_text="requery provider failure"),
+        ],
+        tool_schema_mode="skills_like",
+    )
+
+    assert provider.call_count == 2
+    assert runner_stage.saved_tail_text is None
+    assert len(event.sent_texts) == 1
+    assert "requery provider failure" in event.sent_texts[0]
+    assert after_texts == event.sent_texts
+    assert "agent_done_hook" not in lifecycle
+    assert "history_save" not in lifecycle


### PR DESCRIPTION
Fixes #9788

## Modifications / 改动点

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
- 修复非流式 `skills_like` 工具重查询无工具时的 hook/发送顺序。
- 在 fallback 发送链构造前调用 `_complete_with_assistant_response()`，确保 `OnLLMResponseEvent` 与 `OnAgentDoneEvent` 能先审查或改写最终响应。
- 发送链直接读取 hook 后的 `LLMResponse`，不复用 hook 前构造的消息组件。
- 保持正常工具调用、普通无工具终局、异常路径和 streaming/live 路径不变。
- 新增端到端契约测试 `tests/test_skills_like_hook_order.py`（fake provider 驱动真实 runner、scheduler 与 respond stage）。
- 没有新增依赖。

## Why / 原因

旧顺序是 `yield -> downstream send -> response hooks`。这使所有依赖 response hook 做内容安全、脱敏、改写或审计的插件在该 fallback 分支失去发送前保障，也可能造成已发送文本与最终 history 不一致。

新顺序是 `response hooks -> build chain from finalized response -> yield -> downstream send -> after-message hook -> history save`。与正常无工具终局路径（先 `_complete_with_assistant_response` 再 yield）保持一致。

## Verification Steps / 验证步骤

新增端到端契约测试以 fake provider 驱动真实 runner、scheduler 和 respond stage，验证：

1. `skills_like` 无工具重查询时，response hook 改写后的文本才被发送；
2. after-message hook 观察到的文本与发送文本一致；
3. history 尾项与发送文本逐字相等；
4. 普通无工具终局、正常工具终局、多轮工具和 provider 异常路径不回归。

验证基于最新 master（`19d00fb`）：

- 未打补丁：核心用例失败，复现 issue（`1 failed, 4 passed`）；
- 打补丁后：`5 passed`；
- 相关回归 `tests/test_astr_agent_run_util.py` + `tests/agent/`：`99 passed`。

### Screenshots or Test Results / 运行截图或测试结果

```text
tests/test_skills_like_hook_order.py: 5 passed, 1 warning in 3.70s
tests/test_astr_agent_run_util.py + tests/agent/: 99 passed, 1 warning in 3.53s
```

warning 为既有 `audioop` 弃用提示，与本次修改无关。

## Non-goals / 不在本 PR 范围

本 PR 不调整 streaming/live 发送语义。流式响应的逐块发送与终局 hook 改写之间需要单独的 API/生命周期设计。

## Related / 相关链接

- Fixes #9788
- 相关前史：#8238 / #8240（re-query 主路径的文本-history 分裂修复，未覆盖 fallback 分支）、#7101（skills_like re-query 机制引入）。
- 代码邻近：与 open PR #9220 修改同一函数相邻区块，改动不冲突，但合并顺序靠后时可能需要 rebase。

### Checklist / 检查清单

- [x] 👀 更改已通过端到端契约和相关回归测试，并提供了验证步骤及结果。
- [x] 🤓 未引入新的依赖库。
- [x] 😮 更改不包含恶意代码。
- [x] 本 PR 不添加新功能，因此“新增功能已先讨论”项不适用（对应 bug 已先在 issue 中报告）。

## Summary by Sourcery

Run response hooks before finalizing and sending skills-like fallback responses while preserving correct error handling and history consistency.

Bug Fixes:
- Ensure response hooks run before sending the non-streaming skills-like no-tool fallback response, keeping sent content consistent with after-send processing and persisted history.
- Route error responses from skills-like re-queries through error handling instead of treating them as assistant content.

Tests:
- Add end-to-end lifecycle contract tests covering hook ordering, response consistency, normal tool flows, multi-step tool flows, and provider errors.