### PR TITLE
fix(aiocqhttp): evict stale reverse websocket connections

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -362,6 +362,7 @@ CONFIG_METADATA_2 = {
                         "ws_reverse_host": "0.0.0.0",
                         "ws_reverse_port": 6199,
                         "ws_reverse_token": "",
+                        "ws_reverse_idle_timeout": 60,
                     },
                     "个人微信": {
                         "id": "weixin_personal",
@@ -824,6 +825,11 @@ CONFIG_METADATA_2 = {
                         "description": "反向 Websocket Token",
                         "type": "string",
                         "hint": "反向 Websocket Token。未设置则不启用 Token 验证。",
+                    },
+                    "ws_reverse_idle_timeout": {
+                        "description": "反向 Websocket 入站帧超时",
+                        "type": "int",
+                        "hint": "超过该秒数未收到任何帧时关闭连接并等待协议端重连；设为 0 可禁用。",
                     },
                     "wecom_ai_bot_name": {
                         "description": "企业微信智能机器人的名字",

--- a/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
+++ b/astrbot/core/platform/sources/aiocqhttp/aiocqhttp_platform_adapter.py
@@ -25,6 +25,7 @@ from astrbot.core.platform.astr_message_event import MessageSesion
 from ...register import register_platform_adapter
 from .aiocqhttp_message_event import *
 from .aiocqhttp_message_event import AiocqhttpMessageEvent
+from .guarded_cqhttp import GuardedCQHttp
 
 
 @register_platform_adapter(
@@ -52,10 +53,15 @@ class AiocqhttpAdapter(Platform):
             support_streaming_message=False,
         )
 
-        self.bot = CQHttp(
+        self.bot = GuardedCQHttp(
             use_ws_reverse=True,
             import_name="aiocqhttp",
             api_timeout_sec=180,
+            ws_receive_timeout_sec=platform_config.get(
+                "ws_reverse_idle_timeout",
+                60,
+            ),
+            connection_label=self.metadata.id,
             access_token=platform_config.get(
                 "ws_reverse_token",
             ),  # 以防旧版本配置不存在

--- a/astrbot/core/platform/sources/aiocqhttp/guarded_cqhttp.py
+++ b/astrbot/core/platform/sources/aiocqhttp/guarded_cqhttp.py
@@ -1,0 +1,177 @@
+import asyncio
+import inspect
+import json
+from typing import Any
+
+from aiocqhttp import CQHttp
+from aiocqhttp.api_impl import ResultStore
+from quart import websocket
+
+from astrbot.api import logger
+
+
+class GuardedCQHttp(CQHttp):
+    """CQHttp server with stale reverse-WebSocket eviction."""
+
+    def __init__(
+        self,
+        *args: Any,
+        ws_receive_timeout_sec: float = 60.0,
+        connection_label: str = "aiocqhttp",
+        **kwargs: Any,
+    ) -> None:
+        self.ws_receive_timeout_sec = max(float(ws_receive_timeout_sec), 0.0)
+        self.connection_label = connection_label
+        super().__init__(*args, **kwargs)
+
+    async def _receive_payload(self, ws: Any) -> tuple[bool, dict | None]:
+        """Receive and decode one reverse-WebSocket payload.
+
+        Args:
+            ws: Active Quart-compatible WebSocket connection.
+
+        Returns:
+            A tuple containing the connection state and a decoded JSON object.
+        """
+        try:
+            receive = ws.receive()
+            if self.ws_receive_timeout_sec > 0:
+                raw_payload = await asyncio.wait_for(
+                    receive,
+                    timeout=self.ws_receive_timeout_sec,
+                )
+            else:
+                raw_payload = await receive
+        except TimeoutError:
+            logger.warning(
+                "aiocqhttp reverse WebSocket timed out after %.0f seconds "
+                "without an inbound frame; closing stale connection for adapter %s.",
+                self.ws_receive_timeout_sec,
+                self.connection_label,
+            )
+            await self._close_ws(ws, code=1011, reason="Inbound frame timeout")
+            return False, None
+
+        try:
+            payload = json.loads(raw_payload)
+        except (TypeError, ValueError):
+            payload = None
+        return True, payload if isinstance(payload, dict) else None
+
+    async def _close_ws(self, ws: Any, *, code: int, reason: str) -> None:
+        """Close a WebSocket without assuming a specific close signature.
+
+        Args:
+            ws: WebSocket connection to close.
+            code: WebSocket close code.
+            reason: Human-readable close reason.
+        """
+        close = getattr(ws, "close", None)
+        if not callable(close):
+            return
+        try:
+            close_result = close(code=code, reason=reason)
+        except TypeError:
+            try:
+                close_result = close()
+            except Exception:
+                logger.debug(
+                    "Failed to close aiocqhttp reverse WebSocket for adapter %s.",
+                    self.connection_label,
+                    exc_info=True,
+                )
+                return
+        except Exception:
+            logger.debug(
+                "Failed to close aiocqhttp reverse WebSocket for adapter %s.",
+                self.connection_label,
+                exc_info=True,
+            )
+            return
+
+        if not inspect.isawaitable(close_result):
+            return
+        try:
+            await asyncio.wait_for(close_result, timeout=5.0)
+        except Exception:
+            logger.debug(
+                "Failed to close aiocqhttp reverse WebSocket for adapter %s.",
+                self.connection_label,
+                exc_info=True,
+            )
+
+    async def _register_api_client(self, self_id: str, ws: Any) -> None:
+        """Register an API client and evict an older same-account connection.
+
+        Args:
+            self_id: OneBot self identifier supplied by the connection.
+            ws: Newly connected WebSocket.
+        """
+        previous = self._wsr_api_clients.get(self_id)
+        self._wsr_api_clients[self_id] = ws
+        if previous is None or previous is ws:
+            return
+
+        logger.warning(
+            "Replacing an existing aiocqhttp reverse WebSocket connection for "
+            "adapter %s.",
+            self.connection_label,
+        )
+        await self._close_ws(previous, code=1000, reason="Replaced by new connection")
+
+    def _remove_api_client(self, self_id: str, ws: Any) -> None:
+        """Remove a client only when it still owns the account mapping.
+
+        Args:
+            self_id: OneBot self identifier supplied by the connection.
+            ws: WebSocket completing its cleanup path.
+        """
+        if self._wsr_api_clients.get(self_id) is ws:
+            del self._wsr_api_clients[self_id]
+
+    async def _handle_wsr_event(self) -> None:
+        ws = websocket._get_current_object()
+        self._wsr_event_clients.add(ws)
+        try:
+            while True:
+                connected, payload = await self._receive_payload(ws)
+                if not connected:
+                    return
+                if payload is not None:
+                    asyncio.create_task(self._handle_event_with_response(payload))
+        finally:
+            self._wsr_event_clients.discard(ws)
+
+    async def _handle_wsr_api(self) -> None:
+        ws = websocket._get_current_object()
+        self_id = ws.headers["X-Self-ID"]
+        await self._register_api_client(self_id, ws)
+        try:
+            while True:
+                connected, payload = await self._receive_payload(ws)
+                if not connected:
+                    return
+                if payload is not None:
+                    ResultStore.add(payload)
+        finally:
+            self._remove_api_client(self_id, ws)
+
+    async def _handle_wsr_universal(self) -> None:
+        ws = websocket._get_current_object()
+        self_id = ws.headers["X-Self-ID"]
+        await self._register_api_client(self_id, ws)
+        self._wsr_event_clients.add(ws)
+        try:
+            while True:
+                connected, payload = await self._receive_payload(ws)
+                if not connected:
+                    return
+                if payload is None:
+                    continue
+                if "post_type" in payload:
+                    asyncio.create_task(self._handle_event_with_response(payload))
+                else:
+                    ResultStore.add(payload)
+        finally:
+            self._wsr_event_clients.discard(ws)
+            self._remove_api_client(self_id, ws)

--- a/tests/unit/test_aiocqhttp_websocket_guard.py
+++ b/tests/unit/test_aiocqhttp_websocket_guard.py
@@ -1,0 +1,130 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from astrbot.core.platform.sources.aiocqhttp.guarded_cqhttp import GuardedCQHttp
+
+
+def make_guard(timeout: float = 60.0) -> GuardedCQHttp:
+    guard = object.__new__(GuardedCQHttp)
+    guard.ws_receive_timeout_sec = timeout
+    guard.connection_label = "test-adapter"
+    guard._wsr_api_clients = {}
+    guard._wsr_event_clients = set()
+    return guard
+
+
+@pytest.mark.asyncio
+async def test_receive_payload_accepts_valid_json_object():
+    guard = make_guard()
+    ws = AsyncMock()
+    ws.receive.return_value = '{"post_type":"meta_event"}'
+
+    connected, payload = await guard._receive_payload(ws)
+
+    assert connected is True
+    assert payload == {"post_type": "meta_event"}
+    ws.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_receive_payload_ignores_non_object_json():
+    guard = make_guard()
+    ws = AsyncMock()
+    ws.receive.return_value = "[]"
+
+    connected, payload = await guard._receive_payload(ws)
+
+    assert connected is True
+    assert payload is None
+
+
+@pytest.mark.asyncio
+async def test_receive_payload_can_disable_idle_timeout():
+    guard = make_guard(timeout=0)
+    ws = AsyncMock()
+
+    async def delayed_payload():
+        await asyncio.sleep(0.01)
+        return '{"post_type":"meta_event"}'
+
+    ws.receive.side_effect = delayed_payload
+
+    connected, payload = await guard._receive_payload(ws)
+
+    assert connected is True
+    assert payload == {"post_type": "meta_event"}
+    ws.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_receive_payload_closes_connection_after_timeout():
+    guard = make_guard(timeout=0.01)
+    ws = AsyncMock()
+
+    async def wait_forever():
+        await asyncio.Event().wait()
+
+    ws.receive.side_effect = wait_forever
+
+    connected, payload = await guard._receive_payload(ws)
+
+    assert connected is False
+    assert payload is None
+    ws.close.assert_awaited_once_with(code=1011, reason="Inbound frame timeout")
+
+
+@pytest.mark.asyncio
+async def test_close_ws_accepts_synchronous_close_implementation():
+    guard = make_guard()
+
+    class SyncCloseWebSocket:
+        def __init__(self):
+            self.closed_with = None
+
+        def close(self, *, code, reason):
+            self.closed_with = (code, reason)
+
+    ws = SyncCloseWebSocket()
+
+    await guard._close_ws(ws, code=1000, reason="test close")
+
+    assert ws.closed_with == (1000, "test close")
+
+
+@pytest.mark.asyncio
+async def test_new_api_connection_replaces_and_closes_previous_connection():
+    guard = make_guard()
+    previous = AsyncMock()
+    current = AsyncMock()
+    guard._wsr_api_clients["self-id"] = previous
+
+    await guard._register_api_client("self-id", current)
+
+    assert guard._wsr_api_clients["self-id"] is current
+    previous.close.assert_awaited_once_with(
+        code=1000,
+        reason="Replaced by new connection",
+    )
+
+
+def test_old_connection_cleanup_does_not_remove_new_mapping():
+    guard = make_guard()
+    previous = object()
+    current = object()
+    guard._wsr_api_clients["self-id"] = current
+
+    guard._remove_api_client("self-id", previous)
+
+    assert guard._wsr_api_clients["self-id"] is current
+
+
+def test_current_connection_cleanup_removes_its_mapping():
+    guard = make_guard()
+    current = object()
+    guard._wsr_api_clients["self-id"] = current
+
+    guard._remove_api_client("self-id", current)
+
+    assert "self-id" not in guard._wsr_api_clients


### PR DESCRIPTION
## Summary

- add a configurable inbound-frame timeout for aiocqhttp reverse WebSocket connections
- close stale connections so the OneBot client can reconnect after a half-open network failure
- replace older same-account connections without allowing their cleanup path to remove the new API mapping
- add focused tests for timeout, disabled timeout, close compatibility, replacement, and cleanup races

## Motivation

After a transient network or NAT interruption, a reverse WebSocket can remain TCP-established while no longer delivering application frames. aiocqhttp 1.4.4 waits indefinitely in `websocket.receive()`, so the adapter cannot distinguish this state from a healthy idle connection. Restarting the adapter recovers the connection because it closes the stale socket, but there is no automatic recovery path.

The new `ws_reverse_idle_timeout` setting defaults to 60 seconds and can be set to `0` to disable the guard. In the validated NapCat setup, heartbeat and reconnect intervals are both 5 seconds, so the default requires roughly 12 consecutive missed heartbeat frames before eviction.

## Verification

Validated against AstrBot master commit `c6a14e0600485293bd88cf78c04ecec967b21b50`:

```text
python -m ruff check <changed files>                         passed
python -m ruff format --check <changed files>                passed
python -m compileall -q <changed files>                      passed
python -m pytest -q tests/unit/test_aiocqhttp_websocket_guard.py
8 passed
```

No new dependencies are introduced.

## Checklist

- [x] This is not a breaking API change.
- [x] The change has focused automated tests.
- [x] No new dependency is introduced.
- [x] Logs contain the adapter label and no message contents or account identifiers.

## Summary by Sourcery

Prevent stale aiocqhttp reverse WebSocket connections from blocking automatic client recovery.

New Features:
- Add a configurable idle timeout for inbound reverse WebSocket frames, with a default of 60 seconds and an option to disable it.

Bug Fixes:
- Automatically evict stale reverse WebSocket connections after prolonged inactivity so clients can reconnect after half-open network failures.
- Safely replace older same-account connections without allowing their cleanup to remove the active connection mapping.

Enhancements:
- Improve WebSocket closing compatibility across asynchronous and synchronous close implementations.

Tests:
- Add focused unit coverage for idle timeout behavior, disabled timeouts, close compatibility, connection replacement, and cleanup races.