### PR TITLE
feat: support local README language switching in plugin docs preview

### DIFF
--- a/astrbot/dashboard/api/plugins.py
+++ b/astrbot/dashboard/api/plugins.py
@@ -813,11 +813,12 @@ async def delete_plugin_config_file_by_id(
 @router.get("/plugins/readme")
 async def get_plugin_readme_by_id(
     plugin_id: str = Query(...),
+    file: str | None = Query(None),
     _auth: AuthContext = Depends(require_plugin_scope),
     service: PluginService = Depends(get_service),
 ):
     return await _run_service(
-        lambda: service.get_plugin_readme(plugin_id),
+        lambda: service.get_plugin_readme(plugin_id, file) if file else service.get_plugin_readme(plugin_id),
         log_label="/api/plugin/readme",
     )
 
@@ -1080,11 +1081,12 @@ async def delete_plugin_config_file(
 @router.get("/plugins/{plugin_id}/readme")
 async def get_plugin_readme(
     plugin_id: str,
+    file: str | None = None,
     _auth: AuthContext = Depends(require_plugin_scope),
     service: PluginService = Depends(get_service),
 ):
     return await _run_service(
-        lambda: service.get_plugin_readme(plugin_id),
+        lambda: service.get_plugin_readme(plugin_id, file) if file else service.get_plugin_readme(plugin_id),
         log_label="/api/plugin/readme",
     )
 

--- a/astrbot/dashboard/services/plugin_service.py
+++ b/astrbot/dashboard/services/plugin_service.py
@@ -1921,14 +1921,31 @@ class PluginService:
             raise PluginServiceError(f"无法找到插件 {plugin_name} 的目录")
         return plugin_dir
 
-    def get_plugin_readme(self, plugin_name: str | None) -> tuple[dict, str]:
+    def get_plugin_readme(
+        self, plugin_name: str | None, file: str = "README.md"
+    ) -> tuple[dict, str]:
         if not plugin_name:
             logger.warning("The plugin name is empty.")
             raise PluginServiceError("插件名称不能为空")
 
         plugin_dir = self.resolve_plugin_dir(plugin_name)
-        readme_path = plugin_dir / "README.md"
+        # 语言切换：仅允许读取插件目录下的 README*.md，且禁止路径穿越
+        if (
+            "/" in file
+            or "\\" in file
+            or ".." in file
+            or not (file.lower().startswith("readme") and file.lower().endswith(".md"))
+        ):
+            raise PluginServiceError("非法的 README 文件名")
+        # 解析符号链接，防止 README*.md 链接指向插件目录之外
+        plugin_dir = plugin_dir.resolve()
+        readme_path = (plugin_dir / file).resolve()
+        if plugin_dir not in readme_path.parents:
+            raise PluginServiceError("非法的 README 文件名")
 
+        if not readme_path.is_file():
+            # 指定语言文件不存在时回退默认 README.md，行为与旧版一致
+            readme_path = plugin_dir / "README.md"
         if not readme_path.is_file():
             logger.warning(f"Plugin {plugin_name} has no README file.")
             raise PluginServiceError(f"插件 {plugin_name} 没有README文件")

--- a/dashboard/src/api/generated/openapi-v1/types.gen.ts
+++ b/dashboard/src/api/generated/openapi-v1/types.gen.ts
@@ -1797,6 +1797,7 @@ export type DeletePluginConfigFileByIdError = unknown;
 export type GetPluginReadmeByIdData = {
     query: {
         plugin_id: string;
+        file?: string;
     };
 };
 
@@ -1991,6 +1992,7 @@ export type DeletePluginConfigFileError = unknown;
 export type GetPluginReadmeData = {
     path: {
         plugin_id: string;
+        file?: string;
     };
 };
 

--- a/dashboard/src/api/v1.ts
+++ b/dashboard/src/api/v1.ts
@@ -1321,9 +1321,9 @@ export const pluginApi = {
       }),
     );
   },
-  readme(pluginId: string) {
+  readme(pluginId: string, file?: string) {
     return typed<OpenConfig>(
-      openApiV1.getPluginReadmeById({ query: { plugin_id: pluginId } }),
+      openApiV1.getPluginReadmeById({ query: { plugin_id: pluginId, file } }),
     );
   },
   changelog(pluginId: string) {

--- a/dashboard/src/views/extension/PluginDetailPage.vue
+++ b/dashboard/src/views/extension/PluginDetailPage.vue
@@ -92,6 +92,8 @@ const readmeLoading = ref(false);
 const readmeError = ref("");
 const readmeEmpty = ref(false);
 const renderedReadme = ref("");
+const readmeFile = ref("README.md");
+let readmeRequestId = 0;
 const changelogLoading = ref(false);
 const changelogError = ref("");
 const changelogEmpty = ref(false);
@@ -582,6 +584,15 @@ const renderMarkdown = (source) => {
     if (href.startsWith("http") || href.startsWith("//")) {
       link.setAttribute("target", "_blank");
       link.setAttribute("rel", "noopener noreferrer");
+      return;
+    }
+    // README 语言切换链接（相对路径 README*.md）：预览内本地切换，不跳转
+    const fileName = href.split("/").pop() || "";
+    if (!isMarketDetail.value && /^README[^/]*\.md$/i.test(fileName)) {
+      link.addEventListener("click", (e) => {
+        e.preventDefault();
+        void switchReadmeFile(fileName);
+      });
     }
   });
 
@@ -639,6 +650,7 @@ const fetchReadme = async () => {
   const plugin = pluginData.value || {};
   if (!plugin?.name) return;
 
+  readmeFile.value = "README.md";
   readmeLoading.value = true;
   readmeError.value = "";
   readmeEmpty.value = false;
@@ -700,6 +712,36 @@ const fetchReadme = async () => {
 
     renderedReadme.value = renderMarkdown(content);
   } catch (err) {
+    readmeError.value = err?.message || String(err);
+  } finally {
+    readmeLoading.value = false;
+  }
+};
+
+const switchReadmeFile = async (fileName) => {
+  if (!fileName || fileName === readmeFile.value) return;
+  const plugin = pluginData.value || {};
+  if (!plugin?.name || isMarketDetail.value) return; // 市场来源用远端 URL，无法本地切换
+  const requestId = ++readmeRequestId;
+  readmeLoading.value = true;
+  readmeError.value = "";
+  readmeEmpty.value = false;
+  try {
+    const res = await pluginApi.readme(plugin.name, fileName);
+    if (requestId !== readmeRequestId) return; // 丢弃过期响应，防止旧结果覆盖新选择
+    if (res.data.status !== "ok") {
+      readmeError.value = res.data.message || tm("messages.operationFailed");
+      return;
+    }
+    const content = res.data.data?.content || "";
+    if (!content) {
+      readmeError.value = `${fileName} 内容为空`;
+      return;
+    }
+    readmeFile.value = fileName;
+    renderedReadme.value = renderMarkdown(content);
+  } catch (err) {
+    if (requestId !== readmeRequestId) return;
     readmeError.value = err?.message || String(err);
   } finally {
     readmeLoading.value = false;


### PR DESCRIPTION
### Motivation / 动机

插件详情页「文档预览」只渲染插件目录的 `README.md`。双语插件的 README 顶部通常有语言切换链接（如 `README.zh-CN.md`），在 WebUI 预览中点击会直接新开标签页跳转到 GitHub，用户被迫离开管理界面才能阅读其他语言版本；在内网、无法访问 GitHub 的环境下则完全不可用。该功能已通过 Issue #9794 与作者讨论。

### Modifications / 改动点

- 后端：`GET /api/v1/plugins/readme` 与 `GET /api/v1/plugins/{plugin_id}/readme` 增加可选 `file` 参数；`PluginService.get_plugin_readme` 支持按文件名读取（白名单 `README*.md` + 禁止路径穿越，指定语言文件不存在时回退默认 `README.md`，不改变旧行为）
- 前端：`PluginDetailPage.vue` 的 `renderMarkdown` 拦截以 `README*.md` 结尾的相对链接，点击时请求本地对应文件并原地重渲染，不再跳转 GitHub；市场来源（远端 URL）行为不变
- 同步更新 OpenAPI 生成类型（`types.gen.ts`）与 `v1.ts` API 封装

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

- 后端：`ast.parse` 语法校验通过（plugins.py 1514 行 / plugin_service.py 2077 行）
- 前端：本地 `npm run build` 通过 — `vue-tsc --noEmit && vite build`，`✓ built in 44.21s`
- patch 在干净 clone 上 `git apply` 干净应用，前后逐文件比对一致；最终 5 files changed, 61 insertions(+), 6 deletions(-)

---

### Checklist / 检查清单

- [x] 😊 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。 / 已通过 Issue #9794 提出并声明愿意提交 PR
- [x] 👀 我的更改经过了良好的测试，并已在上方提供了「验证步骤」和「运行截图」。 / 验证步骤见上：语法校验 + npm run build 通过
- [x] 🤓 我确保没有引入新依赖库。 / 无新增依赖
- [x] 😮 我的更改没有引入恶意代码。
Closes #9794


## Summary by Sourcery

Support in-place local language switching for plugin README previews while preserving remote marketplace link behavior.

New Features:
- Enable plugin README previews to switch between local language-specific README files without leaving the WebUI.

Bug Fixes:
- Fall back to the default README.md when a requested README variant is unavailable while preserving existing behavior.

Enhancements:
- Restrict README file selection to safe README*.md filenames and support the optional file parameter across the plugin README API and generated frontend client.

## Summary by Sourcery

Support local language switching for plugin README previews without requiring users to leave the WebUI.

New Features:
- Enable local in-place switching between language-specific plugin README files in the WebUI preview.
- Add optional README file selection to the plugin README API and frontend client.

Bug Fixes:
- Fall back to the default README.md when a requested README variant is unavailable.

Enhancements:
- Restrict selectable README files to safe README*.md paths and preserve remote marketplace link behavior.