### PR TITLE
fix: stabilize OpenAI tool schema order

### DIFF
--- a/astrbot/core/agent/tool.py
+++ b/astrbot/core/agent/tool.py
@@ -203,7 +203,8 @@ class ToolSet:
     def openai_schema(self, omit_empty_parameter_field: bool = False) -> list[dict]:
         """Convert tools to OpenAI API function calling schema format."""
         result = []
-        for tool in self.tools:
+        # Stable ordering preserves prompt-cache prefixes for compatible providers.
+        for tool in sorted(self.tools, key=lambda tool: tool.name):
             func_def = {"type": "function", "function": {"name": tool.name}}
             if tool.description:
                 func_def["function"]["description"] = tool.description

--- a/tests/unit/test_tool_google_schema.py
+++ b/tests/unit/test_tool_google_schema.py
@@ -75,3 +75,38 @@ def test_google_schema_fills_missing_array_items_with_string_schema():
 
     assert source_uuids["type"] == "array"
     assert source_uuids["items"] == {"type": "string"}
+
+
+def test_openai_schema_sorts_tools_by_name_without_mutating_toolset_order():
+    tool_module = load_tool_module()
+    FunctionTool = tool_module.FunctionTool
+    ToolSet = tool_module.ToolSet
+
+    toolset = ToolSet(
+        [
+            FunctionTool(
+                name="zebra",
+                description="Zebra tool.",
+                parameters={"type": "object", "properties": {}},
+            ),
+            FunctionTool(
+                name="alpha",
+                description="Alpha tool.",
+                parameters={"type": "object", "properties": {}},
+            ),
+            FunctionTool(
+                name="middle",
+                description="Middle tool.",
+                parameters={"type": "object", "properties": {}},
+            ),
+        ]
+    )
+
+    schema = toolset.openai_schema()
+
+    assert [tool["function"]["name"] for tool in schema] == [
+        "alpha",
+        "middle",
+        "zebra",
+    ]
+    assert [tool.name for tool in toolset.tools] == ["zebra", "alpha", "middle"]


### PR DESCRIPTION
## 修改说明
- 在序列化 OpenAI 兼容的函数声明前，按工具名称进行稳定排序。
- 保持 `ToolSet.tools` 原有的注册顺序不变。
- 补充工具 Schema 稳定序列化的单元测试。

当工具注册顺序在不同运行中发生变化时，稳定的声明顺序可以避免兼容上游的提示词前缀产生不必要变化，也有利于上游的 Prompt Cache 复用。

## 验证
- `python -m ruff format --check astrbot/core/agent/tool.py tests/unit/test_tool_google_schema.py`
- `python -m ruff check astrbot/core/agent/tool.py tests/unit/test_tool_google_schema.py`
- `python -m pytest tests/unit/test_tool_google_schema.py -q`