### PR TITLE
fix: apply max_agent_step config to cron and background task agents

### DIFF
--- a/astrbot/core/astr_agent_tool_exec.py
+++ b/astrbot/core/astr_agent_tool_exec.py
@@ -553,6 +553,7 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
         agent_max_step = coerce_int_config(
             provider_settings.get("max_agent_step", 30),
             default=30,
+            min_value=1,
             field_name="provider_settings.max_agent_step",
         )
         config = MainAgentBuildConfig(

--- a/astrbot/core/astr_agent_tool_exec.py
+++ b/astrbot/core/astr_agent_tool_exec.py
@@ -48,6 +48,7 @@ from astrbot.core.tools.computer_tools import (
 )
 from astrbot.core.tools.message_tools import SendMessageToUserTool
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
+from astrbot.core.utils.config_number import coerce_int_config
 from astrbot.core.utils.history_saver import persist_agent_history
 from astrbot.core.utils.image_ref_utils import is_supported_image_ref
 from astrbot.core.utils.string_utils import normalize_and_dedupe_strings
@@ -549,6 +550,11 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
         cron_event.role = event.role
         cfg = ctx.get_config(umo=event.unified_msg_origin) or {}
         provider_settings = cfg.get("provider_settings") or {}
+        agent_max_step = coerce_int_config(
+            provider_settings.get("max_agent_step", 30),
+            default=30,
+            field_name="provider_settings.max_agent_step",
+        )
         config = MainAgentBuildConfig(
             tool_call_timeout=run_context.tool_call_timeout,
             streaming_response=provider_settings.get("stream", False),
@@ -594,7 +600,7 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
             return
 
         runner = result.agent_runner
-        async for _ in runner.step_until_done(30):
+        async for _ in runner.step_until_done(agent_max_step):
             # agent will send message to user via using tools
             pass
         llm_resp = runner.get_final_llm_resp()

--- a/astrbot/core/cron/manager.py
+++ b/astrbot/core/cron/manager.py
@@ -446,6 +446,7 @@ class CronJobManager:
         agent_max_step = coerce_int_config(
             provider_settings.get("max_agent_step", 30),
             default=30,
+            min_value=1,
             field_name="provider_settings.max_agent_step",
         )
         config = MainAgentBuildConfig(

--- a/astrbot/core/cron/manager.py
+++ b/astrbot/core/cron/manager.py
@@ -18,6 +18,7 @@ from astrbot.core.db.po import CronJob
 from astrbot.core.platform.message_session import MessageSession
 from astrbot.core.platform.message_type import MessageType
 from astrbot.core.provider.entites import ProviderRequest
+from astrbot.core.utils.config_number import coerce_int_config
 from astrbot.core.utils.history_saver import persist_agent_history
 
 if TYPE_CHECKING:
@@ -442,6 +443,11 @@ class CronJobManager:
 
         provider_settings = cfg.get("provider_settings", {}) or {}
         tool_call_timeout = provider_settings.get("tool_call_timeout", 120)
+        agent_max_step = coerce_int_config(
+            provider_settings.get("max_agent_step", 30),
+            default=30,
+            field_name="provider_settings.max_agent_step",
+        )
         config = MainAgentBuildConfig(
             tool_call_timeout=tool_call_timeout,
             llm_safety_mode=False,
@@ -488,7 +494,7 @@ class CronJobManager:
             return
 
         runner = result.agent_runner
-        async for _ in runner.step_until_done(30):
+        async for _ in runner.step_until_done(agent_max_step):
             # agent will send message to user via using tools
             pass
         llm_resp = runner.get_final_llm_resp()

--- a/tests/unit/test_astr_agent_tool_exec.py
+++ b/tests/unit/test_astr_agent_tool_exec.py
@@ -431,6 +431,84 @@ async def test_background_wakeup_passes_provider_settings_to_main_agent(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider_settings", "expected_max_step"),
+    [
+        pytest.param({"max_agent_step": 50}, 50, id="configured"),
+        pytest.param({}, 30, id="missing_falls_back_to_default"),
+        pytest.param({"max_agent_step": True}, 30, id="boolean_falls_back_to_default"),
+        pytest.param({"max_agent_step": "50"}, 50, id="numeric_string_coerced"),
+    ],
+)
+async def test_background_wakeup_applies_max_agent_step(
+    monkeypatch: pytest.MonkeyPatch,
+    provider_settings: dict,
+    expected_max_step: int,
+):
+    class _StepCapturingRunner:
+        def __init__(self):
+            self.captured_max_step = None
+
+        async def step_until_done(self, max_step):
+            self.captured_max_step = max_step
+            if False:
+                yield
+
+        def get_final_llm_resp(self):
+            return SimpleNamespace(role="assistant", completion_text="done")
+
+    runner = _StepCapturingRunner()
+
+    async def _fake_get_session_conv(**_kwargs):
+        return SimpleNamespace(history="[]")
+
+    async def _fake_build_main_agent(**_kwargs):
+        return SimpleNamespace(agent_runner=runner)
+
+    monkeypatch.setattr(
+        "astrbot.core.astr_main_agent._get_session_conv",
+        _fake_get_session_conv,
+    )
+    monkeypatch.setattr(
+        "astrbot.core.astr_main_agent.build_main_agent",
+        _fake_build_main_agent,
+    )
+    monkeypatch.setattr(
+        "astrbot.core.astr_agent_tool_exec.persist_agent_history",
+        AsyncMock(),
+    )
+
+    send_tool = FunctionTool(
+        name="send_message_to_user",
+        description="send",
+        parameters={"type": "object", "properties": {}},
+    )
+    context = SimpleNamespace(
+        get_config=lambda **_kwargs: {"provider_settings": dict(provider_settings)},
+        get_llm_tool_manager=lambda: SimpleNamespace(
+            get_builtin_tool=lambda _tool_cls: send_tool
+        ),
+        conversation_manager=SimpleNamespace(),
+    )
+    run_context = ContextWrapper(
+        context=SimpleNamespace(event=_DummyEvent([]), context=context),
+        tool_call_timeout=120,
+    )
+
+    await FunctionToolExecutor._wake_main_agent_for_background_result(
+        run_context,
+        task_id="task-id",
+        tool_name="long_tool",
+        result_text="ok",
+        tool_args={},
+        note="task finished",
+        summary_name="BackgroundTask",
+    )
+
+    assert runner.captured_max_step == expected_max_step
+
+
+@pytest.mark.asyncio
 async def test_collect_handoff_image_urls_filters_extensionless_file_outside_temp_root(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/unit/test_astr_agent_tool_exec.py
+++ b/tests/unit/test_astr_agent_tool_exec.py
@@ -438,6 +438,7 @@ async def test_background_wakeup_passes_provider_settings_to_main_agent(
         pytest.param({}, 30, id="missing_falls_back_to_default"),
         pytest.param({"max_agent_step": True}, 30, id="boolean_falls_back_to_default"),
         pytest.param({"max_agent_step": "50"}, 50, id="numeric_string_coerced"),
+        pytest.param({"max_agent_step": 0}, 1, id="zero_clamped_to_min"),
     ],
 )
 async def test_background_wakeup_applies_max_agent_step(

--- a/tests/unit/test_cron_manager.py
+++ b/tests/unit/test_cron_manager.py
@@ -656,6 +656,7 @@ class TestRunActiveAgentJob:
                 {"max_agent_step": True}, 30, id="boolean_falls_back_to_default"
             ),
             pytest.param({"max_agent_step": "50"}, 50, id="numeric_string_coerced"),
+            pytest.param({"max_agent_step": 0}, 1, id="zero_clamped_to_min"),
         ],
     )
     async def test_woke_main_agent_applies_max_agent_step(

--- a/tests/unit/test_cron_manager.py
+++ b/tests/unit/test_cron_manager.py
@@ -646,6 +646,75 @@ class TestRunActiveAgentJob:
         assert config.provider_settings is provider_settings
         assert config.provider_settings["fallback_chat_models"] == ["fallback-provider"]
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("provider_settings", "expected_max_step"),
+        [
+            pytest.param({"max_agent_step": 50}, 50, id="configured"),
+            pytest.param({}, 30, id="missing_falls_back_to_default"),
+            pytest.param(
+                {"max_agent_step": True}, 30, id="boolean_falls_back_to_default"
+            ),
+            pytest.param({"max_agent_step": "50"}, 50, id="numeric_string_coerced"),
+        ],
+    )
+    async def test_woke_main_agent_applies_max_agent_step(
+        self, cron_manager, provider_settings, expected_max_step
+    ):
+        """Test the cron agent runner receives max_agent_step from provider settings."""
+
+        class _StepCapturingRunner:
+            def __init__(self):
+                self.captured_max_step = None
+
+            def step_until_done(self, max_step):
+                self.captured_max_step = max_step
+
+                async def gen():
+                    if False:
+                        yield None
+
+                return gen()
+
+            def get_final_llm_resp(self):
+                return None
+
+        ctx = MagicMock()
+        ctx.get_config.return_value = {
+            "admins_id": [],
+            "provider_settings": dict(provider_settings),
+        }
+        cron_manager.ctx = ctx
+
+        conv = MagicMock()
+        conv.history = "[]"
+        runner = _StepCapturingRunner()
+
+        async def fake_build_main_agent(*, event, plugin_context, config, req):
+            return MagicMock(agent_runner=runner)
+
+        with (
+            patch(
+                "astrbot.core.astr_main_agent._get_session_conv",
+                AsyncMock(return_value=conv),
+            ),
+            patch(
+                "astrbot.core.astr_main_agent.build_main_agent",
+                side_effect=fake_build_main_agent,
+            ),
+            patch(
+                "astrbot.core.cron.manager.persist_agent_history",
+                AsyncMock(),
+            ),
+        ):
+            await cron_manager._woke_main_agent(
+                message="run scheduled task",
+                session_str="test:FriendMessage:user123",
+                extras={"cron_job": {"id": "job-1"}, "cron_payload": {}},
+            )
+
+        assert runner.captured_max_step == expected_max_step
+
 
 class TestGetNextRunTime:
     """Tests for _get_next_run_time method."""


### PR DESCRIPTION
Fixes #9800
修复了 #9800

### Modifications / 改动点

- Read `provider_settings.max_agent_step` in the cron (future task) wake-up path (`astrbot/core/cron/manager.py`) and the background task result wake-up path (`astrbot/core/astr_agent_tool_exec.py`), and pass it to `runner.step_until_done()` instead of the hardcoded `30`.
  在 Cron 未来任务唤醒路径（`astrbot/core/cron/manager.py`）与后台任务结果唤醒路径（`astrbot/core/astr_agent_tool_exec.py`）中读取 `provider_settings.max_agent_step`，传入 `runner.step_until_done()`，替换写死的 `30`。
- Parse the value with the existing `coerce_int_config` utility: bool / non-numeric string / `None` falls back to the default `30` with a warning. This is consistent with the main pipeline's #2622 bool workaround and the existing usage in the deerflow runner / request retry logic. Behavior is unchanged for users who have not customized this setting.
  使用既有的 `coerce_int_config` 工具解析取值：布尔 / 非数字字符串 / `None` 回退到默认值 `30` 并输出警告。与主管线的 #2622 布尔 workaround 及 deerflow runner / 请求重试逻辑的既有用法保持一致。未自定义该项配置的用户行为不变。
- Add 8 parametrized unit tests (4 cases × 2 paths) covering: configured value propagation, missing-key fallback, boolean pollution fallback, and numeric string coercion.
  新增 8 个参数化单元测试（4 种用例 × 2 条路径），覆盖：配置值传播、缺省回退、布尔污染回退、数字字符串转换。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Lint and unit tests (all executed locally on the PR branch) / 代码检查与单元测试（均在 PR 分支本地执行）：

```text
$ ruff check .
All checks passed!

$ ruff format --check astrbot/core/cron/manager.py astrbot/core/astr_agent_tool_exec.py tests/unit/test_cron_manager.py tests/unit/test_astr_agent_tool_exec.py
4 files already formatted

$ pytest tests/unit/test_cron_manager.py tests/unit/test_astr_agent_tool_exec.py -q
57 passed in 6.66s
```

Regression guard verification: with the fix reverted (`git checkout master -- astrbot/core/cron/manager.py astrbot/core/astr_agent_tool_exec.py`), the new value-propagation test cases fail as expected (`4 failed, 4 passed`), proving the tests actually protect against the regression.
回归防护验证：将修复还原后（`git checkout master -- astrbot/core/cron/manager.py astrbot/core/astr_agent_tool_exec.py`），新增的取值传播测试用例如预期失败（`4 failed, 4 passed`），证明测试确实能防护该回归。

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。
  *(Bug fix only, no new features — the fix targets the behavior reported in #9800. / 仅为缺陷修复，无新增功能，修复对象即 #9800 所报告的行为。)*
- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。
- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Honor `max_agent_step` configuration for cron and background-task agent execution while retaining safe fallback behavior.

Bug Fixes:
- Apply the configured `provider_settings.max_agent_step` limit to cron-triggered and background-task agent wake-ups instead of always using the default limit.

Enhancements:
- Normalize invalid or missing step-limit configuration through the existing integer configuration handling, preserving the default and minimum safeguards.

Tests:
- Add parameterized unit coverage for configured values, defaults, boolean and numeric-string inputs, and minimum-value clamping across both wake-up paths.