### PR TITLE
fix: align Anthropic API base URL logic with OpenAI API

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1212,7 +1212,7 @@ CONFIG_METADATA_2 = {
                         "provider_type": "chat_completion",
                         "enable": True,
                         "key": [],
-                        "api_base": "https://api.anthropic.com/v1",
+                        "api_base": "https://api.anthropic.com",
                         "timeout": 120,
                         "proxy": "",
                         "custom_headers": {},

--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -90,7 +90,9 @@ class ProviderAnthropic(Provider):
             provider_settings,
         )
 
-        self.base_url = provider_config.get("api_base", "https://api.anthropic.com")
+        api_base = str(provider_config.get("api_base", "") or "").strip()
+        self.base_url = (api_base or "https://api.anthropic.com").rstrip("/")
+        self.base_url = self.base_url.removesuffix("/v1")
         self.timeout = provider_config.get("timeout", 120)
         if isinstance(self.timeout, str):
             self.timeout = int(self.timeout)

--- a/tests/test_anthropic_kimi_code_provider.py
+++ b/tests/test_anthropic_kimi_code_provider.py
@@ -19,6 +19,38 @@ class _FakeAsyncAnthropic:
         return None
 
 
+@pytest.mark.parametrize(
+    ("api_base", "expected_base_url"),
+    [
+        ("https://api.anthropic.com", "https://api.anthropic.com"),
+        ("https://api.anthropic.com/", "https://api.anthropic.com"),
+        ("https://api.anthropic.com/v1", "https://api.anthropic.com"),
+        ("https://api.anthropic.com/v1/", "https://api.anthropic.com"),
+        ("https://gateway.example.com/anthropic", "https://gateway.example.com/anthropic"),
+    ],
+)
+def test_anthropic_provider_normalizes_api_base(
+    monkeypatch,
+    api_base,
+    expected_base_url,
+):
+    monkeypatch.setattr(anthropic_source, "AsyncAnthropic", _FakeAsyncAnthropic)
+
+    provider = anthropic_source.ProviderAnthropic(
+        provider_config={
+            "id": "anthropic-test",
+            "type": "anthropic_chat_completion",
+            "model": "claude-test",
+            "key": ["test-key"],
+            "api_base": api_base,
+        },
+        provider_settings={},
+    )
+
+    assert provider.base_url == expected_base_url
+    assert provider.client.kwargs["base_url"] == expected_base_url
+
+
 def test_anthropic_provider_passes_custom_headers_via_default_headers(monkeypatch):
     monkeypatch.setattr(anthropic_source, "AsyncAnthropic", _FakeAsyncAnthropic)
 


### PR DESCRIPTION
## Summary

- strip a trailing /v1 from Anthropic-compatible API base URLs before passing them to the Anthropic SDK
- update the default Anthropic API base URL to omit /v1
- add regression coverage for versioned, unversioned, and gateway-prefixed base URLs

## Testing

- uv run pytest tests/test_anthropic_kimi_code_provider.py -q
- uv run ruff format .
- uv run ruff check .

## Summary by Sourcery

Normalize Anthropic API base URLs to ensure compatible endpoint configuration across standard and gateway deployments.

Bug Fixes:
- Normalize Anthropic-compatible API base URLs before passing them to the Anthropic SDK, including removing trailing `/v1` segments.

Enhancements:
- Update the default Anthropic API base URL to omit the version suffix.

Tests:
- Add regression coverage for versioned, unversioned, trailing-slash, and gateway-prefixed Anthropic API base URLs.