### PR TITLE
feat: improve default and local t2i rendering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \
     ffmpeg \
     libavcodec-extra \
+    fonts-noto-cjk \
     curl \
     gnupg \
     git \

--- a/astrbot/core/utils/t2i/local_strategy.py
+++ b/astrbot/core/utils/t2i/local_strategy.py
@@ -1,932 +1,1571 @@
-import os
+import asyncio
+import html
+import logging
+import math
 import re
-import ssl
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from io import BytesIO
+from pathlib import Path
 
 import aiohttp
-import certifi
 from PIL import Image, ImageDraw, ImageFont
 
 from astrbot.core.config import VERSION
 from astrbot.core.utils.astrbot_path import get_astrbot_data_path
+from astrbot.core.utils.http_ssl import build_tls_connector
 from astrbot.core.utils.io import save_temp_img
 
 from . import RenderStrategy
 
+logger = logging.getLogger("astrbot")
+
+PAPER = (251, 251, 250)
+INK = (32, 34, 36)
+MUTED = (102, 107, 112)
+LINE = (212, 216, 219)
+STRONG_LINE = (188, 194, 198)
+SOFT_FILL = (242, 243, 243)
+CODE_FILL = (244, 245, 245)
+ACCENT = (47, 134, 189)
+CONTENT_MARGIN = 32
+
 
 class FontManager:
-    """字体管理类，负责加载和缓存字体"""
+    """Load and cache cross-platform fonts with CJK coverage."""
 
-    _font_cache = {}
+    _font_cache: dict[
+        tuple[int, bool, bool], ImageFont.FreeTypeFont | ImageFont.ImageFont
+    ] = {}
 
     @classmethod
-    def get_font(cls, size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
-        """获取指定大小的字体，优先从缓存获取"""
-        if size in cls._font_cache:
-            return cls._font_cache[size]
+    def get_font(
+        cls,
+        size: int,
+        *,
+        bold: bool = False,
+        monospace: bool = False,
+    ) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+        """Return a font suitable for local T2I rendering.
 
-        # 首先尝试加载自定义字体
-        try:
-            font_path = os.path.join(get_astrbot_data_path(), "font.ttf")
-            font = ImageFont.truetype(font_path, size)
-            cls._font_cache[size] = font
-            return font
-        except Exception:
-            pass
+        Args:
+            size: Font size in pixels.
+            bold: Whether a bold face should be preferred.
+            monospace: Whether a monospace face should be preferred.
 
-        # 跨平台常见字体列表
-        fonts = [
-            "msyh.ttc",  # Windows
-            "NotoSansCJK-Regular.ttc",  # Linux
-            "msyhbd.ttc",  # Windows
-            "PingFang.ttc",  # macOS
-            "Heiti.ttc",  # macOS
-            "Arial.ttf",  # 通用
-            "DejaVuSans.ttf",  # Linux
-        ]
+        Returns:
+            A loaded Pillow font. System CJK fonts are preferred over Latin-only
+            fallbacks so Chinese text does not render as missing-glyph boxes.
+        """
+        cache_key = (size, bold, monospace)
+        if cache_key in cls._font_cache:
+            return cls._font_cache[cache_key]
 
-        for font_name in fonts:
+        data_dir = Path(get_astrbot_data_path())
+        if monospace:
+            candidates: list[tuple[str | Path, int]] = [
+                (data_dir / "font-mono.ttf", 0),
+                ("/usr/share/fonts/opentype/noto/NotoSansMonoCJK-Regular.ttc", 0),
+                ("C:/Windows/Fonts/msyh.ttc", 0),
+                ("/System/Library/Fonts/Hiragino Sans GB.ttc", 0),
+                ("/Library/Fonts/Arial Unicode.ttf", 0),
+                ("/System/Library/Fonts/SFNSMono.ttf", 0),
+                ("DejaVuSansMono.ttf", 0),
+            ]
+        elif bold:
+            candidates = [
+                (data_dir / "font-bold.ttf", 0),
+                ("C:/Windows/Fonts/msyhbd.ttc", 0),
+                ("/System/Library/Fonts/Hiragino Sans GB.ttc", 2),
+                ("/System/Library/Fonts/PingFang.ttc", 1),
+                ("/usr/share/fonts/opentype/noto/NotoSansCJK-Bold.ttc", 0),
+                ("/usr/share/fonts/opentype/noto/NotoSansCJK-Bold.otf", 0),
+                ("NotoSansCJK-Bold.ttc", 0),
+                (data_dir / "font.ttf", 0),
+                ("/Library/Fonts/Arial Unicode.ttf", 0),
+                ("DejaVuSans-Bold.ttf", 0),
+            ]
+        else:
+            candidates = [
+                (data_dir / "font.ttf", 0),
+                ("C:/Windows/Fonts/msyh.ttc", 0),
+                ("/System/Library/Fonts/Hiragino Sans GB.ttc", 0),
+                ("/System/Library/Fonts/PingFang.ttc", 0),
+                ("/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc", 0),
+                ("/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.otf", 0),
+                ("NotoSansCJK-Regular.ttc", 0),
+                ("/Library/Fonts/Arial Unicode.ttf", 0),
+                ("DejaVuSans.ttf", 0),
+            ]
+
+        for font_path, index in candidates:
             try:
-                font = ImageFont.truetype(font_name, size)
-                cls._font_cache[size] = font
-                return font
-            except Exception:
+                font = ImageFont.truetype(str(font_path), size, index=index)
+            except (OSError, TypeError):
                 continue
+            cls._font_cache[cache_key] = font
+            return font
 
-        # 如果所有字体都失败，使用默认字体
-        try:
-            default_font = ImageFont.load_default()
-            # PIL默认字体大小固定，这里不缓存
-            return default_font
-        except Exception:
-            raise RuntimeError("无法加载任何字体")
+        font = ImageFont.load_default(size=size)
+        cls._font_cache[cache_key] = font
+        return font
 
 
 class TextMeasurer:
-    """测量文本尺寸的工具类"""
+    """Measure and wrap text using the actual selected font."""
 
     @staticmethod
     def get_text_size(
-        text: str, font: ImageFont.FreeTypeFont | ImageFont.ImageFont
+        text: str,
+        font: ImageFont.FreeTypeFont | ImageFont.ImageFont,
     ) -> tuple[int, int]:
-        """获取文本的尺寸"""
+        """Measure the supplied text.
 
-        # 依赖库Pillow>=11.2.1，不再需要考虑<9.0.0
-        left, top, right, bottom = font.getbbox("Hello world")
-        return int(right - left), int(bottom - top)
+        Args:
+            text: Text to measure.
+            font: Pillow font used for measurement.
+
+        Returns:
+            Width and line height in pixels.
+        """
+        width = math.ceil(font.getlength(text)) if text else 0
+        try:
+            ascent, descent = font.getmetrics()
+            height = math.ceil(ascent + descent)
+        except AttributeError:
+            left, top, right, bottom = font.getbbox(text or "Ag")
+            height = math.ceil(bottom - top)
+        return width, max(1, height)
 
     @staticmethod
     def split_text_to_fit_width(
-        text: str, font: ImageFont.FreeTypeFont | ImageFont.ImageFont, max_width: int
+        text: str,
+        font: ImageFont.FreeTypeFont | ImageFont.ImageFont,
+        max_width: int,
+        *,
+        preserve_whitespace: bool = False,
     ) -> list[str]:
-        """将文本拆分为多行，确保每行不超过指定宽度"""
-        lines = []
-        if not text:
-            return lines
+        """Wrap text so every returned line fits the requested width.
 
-        remaining_text = text
-        while remaining_text:
-            # 如果文本宽度小于最大宽度，直接添加
-            text_width = TextMeasurer.get_text_size(remaining_text, font)[0]
-            if text_width <= max_width:
-                lines.append(remaining_text)
+        Args:
+            text: A single logical line of text.
+            font: Pillow font used for measurement.
+            max_width: Maximum line width in pixels.
+            preserve_whitespace: Preserve leading and trailing spaces for code.
+
+        Returns:
+            Wrapped lines. An empty input produces one empty line.
+        """
+        if not text:
+            return [""]
+        if max_width <= 0:
+            return list(text)
+
+        lines: list[str] = []
+        remaining = text
+        while remaining:
+            if TextMeasurer.get_text_size(remaining, font)[0] <= max_width:
+                lines.append(remaining if preserve_whitespace else remaining.rstrip())
                 break
 
-            # 尝试逐字计算能放入当前行的最多字符
-            for i in range(len(remaining_text), 0, -1):
-                width = TextMeasurer.get_text_size(remaining_text[:i], font)[0]
-                if width <= max_width:
-                    lines.append(remaining_text[:i])
-                    remaining_text = remaining_text[i:]
-                    break
+            low = 1
+            high = len(remaining)
+            while low <= high:
+                middle = (low + high) // 2
+                if TextMeasurer.get_text_size(remaining[:middle], font)[0] <= max_width:
+                    low = middle + 1
+                else:
+                    high = middle - 1
+
+            split_at = max(1, high)
+            if not preserve_whitespace and split_at < len(remaining):
+                prefix = remaining[:split_at]
+                word_break = max(prefix.rfind(" "), prefix.rfind("\t"))
+                if word_break >= max(1, split_at // 2):
+                    split_at = word_break + 1
+
+            line = remaining[:split_at]
+            remaining = remaining[split_at:]
+            if preserve_whitespace:
+                lines.append(line)
             else:
-                # 如果单个字符都放不下，强制放一个字符
-                lines.append(remaining_text[0])
-                remaining_text = remaining_text[1:]
+                lines.append(line.rstrip())
+                remaining = remaining.lstrip(" \t")
 
         return lines
 
 
-class MarkdownElement(ABC):
-    """Markdown元素的基类"""
+@dataclass(frozen=True)
+class InlineSpan:
+    """A styled span inside a paragraph."""
 
-    def __init__(self, content: str):
+    text: str
+    bold: bool = False
+    code: bool = False
+    strike: bool = False
+    link: bool = False
+
+
+@dataclass
+class InlineRun:
+    """A measured inline span fragment placed on one visual line."""
+
+    span: InlineSpan
+    text: str
+    font: ImageFont.FreeTypeFont | ImageFont.ImageFont
+    width: int
+
+
+_INLINE_PATTERN = re.compile(
+    r"(`[^`]+`|\*\*.+?\*\*|__.+?__|~~.+?~~|\[[^\]]+\]\([^)]+\)|(?<!\*)\*[^*]+\*(?!\*))"
+)
+_CJK_RANGE = "\u2e80-\u9fff\uf900-\ufaff"
+
+
+def _parse_inline_spans(text: str) -> list[InlineSpan]:
+    """Parse common inline Markdown without creating separate block rows.
+
+    Args:
+        text: Markdown paragraph text.
+
+    Returns:
+        Styled inline spans in source order.
+    """
+    spans: list[InlineSpan] = []
+    position = 0
+    for match in _INLINE_PATTERN.finditer(text):
+        if match.start() > position:
+            spans.append(InlineSpan(html.unescape(text[position : match.start()])))
+
+        token = match.group(0)
+        if token.startswith("`"):
+            spans.append(InlineSpan(token[1:-1], code=True))
+        elif token.startswith(("**", "__")):
+            spans.append(InlineSpan(token[2:-2], bold=True))
+        elif token.startswith("~~"):
+            spans.append(InlineSpan(token[2:-2], strike=True))
+        elif token.startswith("["):
+            spans.append(InlineSpan(token[1 : token.index("]")], link=True))
+        else:
+            spans.append(InlineSpan(token[1:-1]))
+        position = match.end()
+
+    if position < len(text):
+        spans.append(InlineSpan(html.unescape(text[position:])))
+    return spans or [InlineSpan("")]
+
+
+def _tokenize_inline_text(text: str) -> list[str]:
+    """Split inline text into wrap-friendly Latin words and CJK characters.
+
+    Args:
+        text: Plain inline text.
+
+    Returns:
+        Tokens that may be placed independently during wrapping.
+    """
+    return re.findall(
+        rf"\s+|[{_CJK_RANGE}]|[A-Za-z0-9_]+(?:['’-][A-Za-z0-9_]+)*|[^\s]",
+        text,
+    )
+
+
+def _clean_inline_markdown(text: str) -> str:
+    """Remove inline Markdown delimiters while preserving visible content.
+
+    Args:
+        text: Markdown text.
+
+    Returns:
+        Human-readable plain text.
+    """
+    cleaned = re.sub(r"!\[([^\]]*)\]\([^)]+\)", r"\1", text)
+    cleaned = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", cleaned)
+    cleaned = re.sub(r"`([^`]+)`", r"\1", cleaned)
+    cleaned = re.sub(
+        r"\*\*(.+?)\*\*|__(.+?)__", lambda m: m.group(1) or m.group(2), cleaned
+    )
+    cleaned = re.sub(r"~~(.+?)~~", r"\1", cleaned)
+    cleaned = re.sub(r"(?<!\*)\*([^*]+)\*(?!\*)", r"\1", cleaned)
+    cleaned = re.sub(r"(?<!\w)_([^_]+)_(?!\w)", r"\1", cleaned)
+    cleaned = re.sub(r"(?<!\$)\$([^$]+)\$(?!\$)", r"\1", cleaned)
+    cleaned = re.sub(r"<[^>]+>", "", cleaned)
+    return html.unescape(cleaned)
+
+
+class MarkdownBlock(ABC):
+    """Base class for measured Markdown blocks."""
+
+    height: int = 0
+
+    @abstractmethod
+    def measure(self, width: int, font_size: int) -> int:
+        """Measure the block and cache its layout."""
+
+    @abstractmethod
+    def render(
+        self,
+        image: Image.Image,
+        draw: ImageDraw.ImageDraw,
+        x: int,
+        y: int,
+        width: int,
+        font_size: int,
+    ) -> int:
+        """Draw the cached layout and return the next y coordinate."""
+
+
+class ParagraphBlock(MarkdownBlock):
+    """A paragraph with mixed inline styles and automatic wrapping."""
+
+    def __init__(self, content: str) -> None:
         self.content = content
+        self.lines: list[list[InlineRun]] = []
+        self.line_height = 0
 
-    @abstractmethod
-    def calculate_height(self, image_width: int, font_size: int) -> int:
-        """计算元素的高度"""
-        pass
+    def measure(self, width: int, font_size: int) -> int:
+        """Lay out inline spans across visual lines.
 
-    @abstractmethod
-    def render(
-        self,
-        image: Image.Image,
-        draw: ImageDraw.ImageDraw,
-        x: int,
-        y: int,
-        image_width: int,
-        font_size: int,
-    ) -> int:
-        """渲染元素到图像，返回新的y坐标"""
-        pass
+        Args:
+            width: Available content width.
+            font_size: Base body font size.
 
+        Returns:
+            Measured block height.
+        """
+        regular_font = FontManager.get_font(font_size)
+        _, font_height = TextMeasurer.get_text_size("Ag", regular_font)
+        self.line_height = font_height + 8
+        self.lines = []
 
-class TextElement(MarkdownElement):
-    """普通文本元素"""
-
-    def calculate_height(self, image_width: int, font_size: int) -> int:
-        if not self.content.strip():
-            return 10  # 空行高度
-
-        font = FontManager.get_font(font_size)
-        lines = TextMeasurer.split_text_to_fit_width(
-            self.content, font, image_width - 20
-        )
-        return len(lines) * (font_size + 8)
-
-    def render(
-        self,
-        image: Image.Image,
-        draw: ImageDraw.ImageDraw,
-        x: int,
-        y: int,
-        image_width: int,
-        font_size: int,
-    ) -> int:
-        if not self.content.strip():
-            return y + 10  # 空行
-
-        font = FontManager.get_font(font_size)
-        lines = TextMeasurer.split_text_to_fit_width(
-            self.content, font, image_width - 20
-        )
-
-        for line in lines:
-            draw.text((x, y), line, font=font, fill=(0, 0, 0))
-            y += font_size + 8
-
-        return y
-
-
-class BoldTextElement(MarkdownElement):
-    """粗体文本元素"""
-
-    def calculate_height(self, image_width: int, font_size: int) -> int:
-        font = FontManager.get_font(font_size)
-        lines = TextMeasurer.split_text_to_fit_width(
-            self.content, font, image_width - 20
-        )
-        return len(lines) * (font_size + 8)
-
-    def render(
-        self,
-        image: Image.Image,
-        draw: ImageDraw.ImageDraw,
-        x: int,
-        y: int,
-        image_width: int,
-        font_size: int,
-    ) -> int:
-        # 尝试使用粗体字体，如果没有则绘制两次模拟粗体效果
-        try:
-            bold_fonts = [
-                "msyhbd.ttc",  # 微软雅黑粗体 (Windows)
-                "Arial-Bold.ttf",  # Arial粗体
-                "DejaVuSans-Bold.ttf",  # Linux粗体
-            ]
-
-            bold_font = None
-            for font_name in bold_fonts:
-                try:
-                    bold_font = ImageFont.truetype(font_name, font_size)
-                    break
-                except Exception:
-                    continue
-
-            if bold_font:
-                lines = TextMeasurer.split_text_to_fit_width(
-                    self.content, bold_font, image_width - 20
+        for source_line in self.content.split("\n"):
+            current_line: list[InlineRun] = []
+            current_width = 0
+            for span in _parse_inline_spans(source_line):
+                font = FontManager.get_font(
+                    font_size if not span.code else max(16, font_size - 2),
+                    bold=span.bold,
+                    monospace=span.code,
                 )
-                for line in lines:
-                    draw.text((x, y), line, font=bold_font, fill=(0, 0, 0))
-                    y += font_size + 8
-            else:
-                # 如果没有粗体字体，则绘制两次文本轻微偏移以模拟粗体
-                font = FontManager.get_font(font_size)
-                lines = TextMeasurer.split_text_to_fit_width(
-                    self.content, font, image_width - 20
-                )
-                for line in lines:
-                    draw.text((x, y), line, font=font, fill=(0, 0, 0))
-                    draw.text((x + 1, y), line, font=font, fill=(0, 0, 0))
-                    y += font_size + 8
-        except Exception:
-            # 兜底方案：使用普通字体
-            font = FontManager.get_font(font_size)
-            lines = TextMeasurer.split_text_to_fit_width(
-                self.content, font, image_width - 20
-            )
-            for line in lines:
-                draw.text((x, y), line, font=font, fill=(0, 0, 0))
-                y += font_size + 8
-
-        return y
-
-
-class ItalicTextElement(MarkdownElement):
-    """斜体文本元素"""
-
-    def calculate_height(self, image_width: int, font_size: int) -> int:
-        font = FontManager.get_font(font_size)
-        lines = TextMeasurer.split_text_to_fit_width(
-            self.content, font, image_width - 20
-        )
-        return len(lines) * (font_size + 8)
-
-    def render(
-        self,
-        image: Image.Image,
-        draw: ImageDraw.ImageDraw,
-        x: int,
-        y: int,
-        image_width: int,
-        font_size: int,
-    ) -> int:
-        # 尝试使用斜体字体，如果没有则使用倾斜变换模拟斜体效果
-        try:
-            italic_fonts = [
-                "msyhi.ttc",  # 微软雅黑斜体 (Windows)
-                "Arial-Italic.ttf",  # Arial斜体
-                "DejaVuSans-Oblique.ttf",  # Linux斜体
-            ]
-
-            italic_font = None
-            for font_name in italic_fonts:
-                try:
-                    italic_font = ImageFont.truetype(font_name, font_size)
-                    break
-                except Exception:
-                    continue
-
-            if italic_font:
-                lines = TextMeasurer.split_text_to_fit_width(
-                    self.content, italic_font, image_width - 20
-                )
-                for line in lines:
-                    draw.text((x, y), line, font=italic_font, fill=(0, 0, 0))
-                    y += font_size + 8
-            else:
-                # 如果没有斜体字体，使用变换
-                font = FontManager.get_font(font_size)
-                lines = TextMeasurer.split_text_to_fit_width(
-                    self.content, font, image_width - 20
-                )
-
-                for line in lines:
-                    # 先创建一个临时图像用于倾斜处理
-                    text_width, text_height = TextMeasurer.get_text_size(line, font)
-                    text_img = Image.new(
-                        "RGBA", (text_width + 20, text_height + 10), (0, 0, 0, 0)
-                    )
-                    text_draw = ImageDraw.Draw(text_img)
-                    text_draw.text((0, 0), line, font=font, fill=(0, 0, 0, 255))
-
-                    # 倾斜变换，使用仿射变换实现斜体效果
-                    # 变换矩阵: [1, 0.2, 0, 0, 1, 0]
-                    italic_img = text_img.transform(
-                        text_img.size,
-                        Image.Transform.AFFINE,
-                        (1, 0.2, 0, 0, 1, 0),
-                        Image.Resampling.BICUBIC,
-                    )
-
-                    # 粘贴到原图像
-                    image.paste(italic_img, (x, y), italic_img)
-                    y += font_size + 8
-        except Exception:
-            # 兜底方案：使用普通字体
-            font = FontManager.get_font(font_size)
-            lines = TextMeasurer.split_text_to_fit_width(
-                self.content, font, image_width - 20
-            )
-            for line in lines:
-                draw.text((x, y), line, font=font, fill=(0, 0, 0))
-                y += font_size + 8
-
-        return y
-
-
-class UnderlineTextElement(MarkdownElement):
-    """下划线文本元素"""
-
-    def calculate_height(self, image_width: int, font_size: int) -> int:
-        font = FontManager.get_font(font_size)
-        lines = TextMeasurer.split_text_to_fit_width(
-            self.content, font, image_width - 20
-        )
-        return len(lines) * (font_size + 8)
-
-    def render(
-        self,
-        image: Image.Image,
-        draw: ImageDraw.ImageDraw,
-        x: int,
-        y: int,
-        image_width: int,
-        font_size: int,
-    ) -> int:
-        font = FontManager.get_font(font_size)
-        lines = TextMeasurer.split_text_to_fit_width(
-            self.content, font, image_width - 20
-        )
-
-        for line in lines:
-            # 绘制文本
-            draw.text((x, y), line, font=font, fill=(0, 0, 0))
-
-            # 绘制下划线
-            text_width, _ = TextMeasurer.get_text_size(line, font)
-            underline_y = y + font_size + 2
-            draw.line(
-                (x, underline_y, x + text_width, underline_y), fill=(0, 0, 0), width=1
-            )
-
-            y += font_size + 8
-
-        return y
-
-
-class StrikethroughTextElement(MarkdownElement):
-    """删除线文本元素"""
-
-    def calculate_height(self, image_width: int, font_size: int) -> int:
-        font = FontManager.get_font(font_size)
-        lines = TextMeasurer.split_text_to_fit_width(
-            self.content, font, image_width - 20
-        )
-        return len(lines) * (font_size + 8)
-
-    def render(
-        self,
-        image: Image.Image,
-        draw: ImageDraw.ImageDraw,
-        x: int,
-        y: int,
-        image_width: int,
-        font_size: int,
-    ) -> int:
-        font = FontManager.get_font(font_size)
-        lines = TextMeasurer.split_text_to_fit_width(
-            self.content, font, image_width - 20
-        )
-
-        for line in lines:
-            # 绘制文本
-            draw.text((x, y), line, font=font, fill=(0, 0, 0))
-
-            # 绘制删除线
-            text_width, _ = TextMeasurer.get_text_size(line, font)
-            strike_y = y + font_size // 2
-            draw.line((x, strike_y, x + text_width, strike_y), fill=(0, 0, 0), width=1)
-
-            y += font_size + 8
-
-        return y
-
-
-class HeaderElement(MarkdownElement):
-    """标题元素"""
-
-    def __init__(self, content: str):
-        # 去除开头的 # 并计算级别
-        level = 0
-        for char in content:
-            if char == "#":
-                level += 1
-            else:
-                break
-
-        super().__init__(content[level:].strip())
-        self.level = min(level, 6)  # h1-h6
-
-    def calculate_height(self, image_width: int, font_size: int) -> int:
-        header_font_size = 42 - (self.level - 1) * 4
-        font = FontManager.get_font(header_font_size)
-        lines = TextMeasurer.split_text_to_fit_width(
-            self.content, font, image_width - 20
-        )
-        return len(lines) * header_font_size + 30  # 包含上下间距和分隔线
-
-    def render(
-        self,
-        image: Image.Image,
-        draw: ImageDraw.ImageDraw,
-        x: int,
-        y: int,
-        image_width: int,
-        font_size: int,
-    ) -> int:
-        header_font_size = 42 - (self.level - 1) * 4
-        font = FontManager.get_font(header_font_size)
-
-        y += 10  # 上间距
-        draw.text((x, y), self.content, font=font, fill=(0, 0, 0))
-
-        # 添加分隔线
-        y += header_font_size + 8
-        draw.line((x, y, image_width - 10, y), fill=(230, 230, 230), width=3)
-
-        return y + 10  # 返回包含下间距的新y坐标
-
-
-class QuoteElement(MarkdownElement):
-    """引用元素"""
-
-    def __init__(self, content: str):
-        # 去除开头的 >
-        super().__init__(content[1:].strip())
-
-    def calculate_height(self, image_width: int, font_size: int) -> int:
-        font = FontManager.get_font(font_size)
-        lines = TextMeasurer.split_text_to_fit_width(
-            self.content, font, image_width - 30
-        )  # 左边留出引用线的空间
-        return len(lines) * (font_size + 6) + 12  # 包含上下间距
-
-    def render(
-        self,
-        image: Image.Image,
-        draw: ImageDraw.ImageDraw,
-        x: int,
-        y: int,
-        image_width: int,
-        font_size: int,
-    ) -> int:
-        font = FontManager.get_font(font_size)
-        lines = TextMeasurer.split_text_to_fit_width(
-            self.content, font, image_width - 30
-        )
-
-        total_height = len(lines) * (font_size + 6)
-
-        # 绘制引用线
-        quote_line_x = x + 3
-        draw.line(
-            (quote_line_x, y + 6, quote_line_x, y + total_height + 6),
-            fill=(180, 180, 180),
-            width=5,
-        )
-
-        # 绘制文本
-        text_x = x + 15
-        text_y = y + 6
-        for line in lines:
-            draw.text((text_x, text_y), line, font=font, fill=(180, 180, 180))
-            text_y += font_size + 6
-
-        return y + total_height + 12
-
-
-class ListItemElement(MarkdownElement):
-    """列表项元素"""
-
-    def calculate_height(self, image_width: int, font_size: int) -> int:
-        font = FontManager.get_font(font_size)
-        lines = TextMeasurer.split_text_to_fit_width(
-            self.content, font, image_width - 30
-        )  # 左边留出项目符号的空间
-        return len(lines) * (font_size + 6) + 16  # 包含上下间距
-
-    def render(
-        self,
-        image: Image.Image,
-        draw: ImageDraw.ImageDraw,
-        x: int,
-        y: int,
-        image_width: int,
-        font_size: int,
-    ) -> int:
-        font = FontManager.get_font(font_size)
-        lines = TextMeasurer.split_text_to_fit_width(
-            self.content, font, image_width - 30
-        )
-
-        y += 8  # 上间距
-
-        # 绘制项目符号
-        bullet_x = x + 5
-        draw.text((bullet_x, y), "•", font=font, fill=(0, 0, 0))
-
-        # 绘制文本
-        text_x = x + 25
-        text_y = y
-        for line in lines:
-            draw.text((text_x, text_y), line, font=font, fill=(0, 0, 0))
-            text_y += font_size + 6
-
-        return text_y + 8  # 包含下间距
-
-
-class CodeBlockElement(MarkdownElement):
-    """代码块元素"""
-
-    def __init__(self, content: list[str]):
-        super().__init__("\n".join(content))
-
-    def calculate_height(self, image_width: int, font_size: int) -> int:
-        if not self.content:
-            return 40  # 空代码块的最小高度
-
-        font = FontManager.get_font(font_size)
-        lines = self.content.split("\n")
-        wrapped_lines = []
-
-        for line in lines:
-            wrapped = TextMeasurer.split_text_to_fit_width(line, font, image_width - 40)
-            wrapped_lines.extend(wrapped)
-
-        return len(wrapped_lines) * (font_size + 4) + 40  # 包含内边距和上下间距
-
-    def render(
-        self,
-        image: Image.Image,
-        draw: ImageDraw.ImageDraw,
-        x: int,
-        y: int,
-        image_width: int,
-        font_size: int,
-    ) -> int:
-        font = FontManager.get_font(font_size)
-        lines = self.content.split("\n")
-        wrapped_lines = []
-
-        for line in lines:
-            wrapped = TextMeasurer.split_text_to_fit_width(line, font, image_width - 40)
-            wrapped_lines.extend(wrapped)
-
-        content_height = len(wrapped_lines) * (font_size + 4)
-        total_height = content_height + 30  # 包含内边距
-
-        # 绘制背景
-        draw.rounded_rectangle(
-            (x, y + 5, image_width - 10, y + total_height),
-            radius=5,
-            fill=(240, 240, 240),
-            width=1,
-        )
-
-        # 绘制代码
-        text_y = y + 15
-        for line in wrapped_lines:
-            draw.text((x + 15, text_y), line, font=font, fill=(0, 0, 0))
-            text_y += font_size + 4
-
-        return y + total_height + 10
-
-
-class InlineCodeElement(MarkdownElement):
-    """行内代码元素"""
-
-    def calculate_height(self, image_width: int, font_size: int) -> int:
-        return font_size + 16  # 包含内边距和上下间距
-
-    def render(
-        self,
-        image: Image.Image,
-        draw: ImageDraw.ImageDraw,
-        x: int,
-        y: int,
-        image_width: int,
-        font_size: int,
-    ) -> int:
-        font = FontManager.get_font(font_size)
-
-        # 计算文本大小
-        text_width, _ = TextMeasurer.get_text_size(self.content, font)
-        text_height = font_size
-
-        # 绘制背景
-        padding = 4
-        draw.rounded_rectangle(
-            (x, y + 4, x + text_width + padding * 2, y + text_height + padding * 2 + 4),
-            radius=5,
-            fill=(230, 230, 230),
-            width=1,
-        )
-
-        # 绘制文本
-        draw.text(
-            (x + padding, y + padding + 4), self.content, font=font, fill=(0, 0, 0)
-        )
-
-        return y + text_height + 16  # 返回新的y坐标
-
-
-class ImageElement(MarkdownElement):
-    """图片元素"""
-
-    def __init__(self, content: str, image_url: str):
-        super().__init__(content)
-        self.image_url = image_url
-        self.image = None
-
-    async def load_image(self):
-        """加载图片"""
-        try:
-            ssl_context = ssl.create_default_context(cafile=certifi.where())
-            connector = aiohttp.TCPConnector(ssl=ssl_context)
-
-            async with aiohttp.ClientSession(
-                trust_env=True, connector=connector
-            ) as session:
-                async with session.get(self.image_url) as resp:
-                    if resp.status == 200:
-                        image_data = await resp.read()
-                        self.image = Image.open(BytesIO(image_data))
-                    else:
-                        print(f"Failed to load image: HTTP {resp.status}")
-        except Exception as e:
-            print(f"Failed to load image: {e}")
-
-    def calculate_height(self, image_width: int, font_size: int) -> int:
-        if self.image is None:
-            return font_size + 20  # 图片加载失败的默认高度
-
-        # 计算调整大小后的图片高度
-        max_width = image_width * 0.8
-        if self.image.width > max_width:
-            ratio = max_width / self.image.width
-            height = int(self.image.height * ratio)
-        else:
-            height = self.image.height
-
-        return height + 30  # 包含上下间距
-
-    def render(
-        self,
-        image: Image.Image,
-        draw: ImageDraw.ImageDraw,
-        x: int,
-        y: int,
-        image_width: int,
-        font_size: int,
-    ) -> int:
-        if self.image is None:
-            # 图片加载失败
-            font = FontManager.get_font(font_size)
-            draw.text((x, y + 10), "[图片加载失败]", font=font, fill=(255, 0, 0))
-            return y + font_size + 20
-
-        # 调整图片大小
-        max_width = image_width * 0.8
-        pasted_image = self.image
-
-        if pasted_image.width > max_width:
-            ratio = max_width / pasted_image.width
-            new_size = (int(max_width), int(pasted_image.height * ratio))
-            pasted_image = pasted_image.resize(new_size, Image.Resampling.LANCZOS)
-
-        # 计算居中位置
-        paste_x = x + (image_width - pasted_image.width) // 2 - 10
-
-        # 粘贴图片
-        if pasted_image.mode == "RGBA":
-            # 处理透明图片
-            image.paste(pasted_image, (paste_x, y + 15), pasted_image)
-        else:
-            image.paste(pasted_image, (paste_x, y + 15))
-
-        return y + pasted_image.height + 30
-
-
-class MarkdownParser:
-    """Markdown解析器，将文本解析为元素"""
-
-    @staticmethod
-    async def parse(text: str) -> list[MarkdownElement]:
-        elements = []
-        lines = text.split("\n")
-
-        i = 0
-        while i < len(lines):
-            line = lines[i].rstrip()
-
-            # 图片检测
-            image_match = re.search(r"!\s*\[(.*?)\]\s*\((.*?)\)", line)
-            if image_match:
-                image_url = image_match.group(2)
-                element = ImageElement(line, image_url)
-                await element.load_image()
-                elements.append(element)
-                i += 1
-                continue
-
-            # 标题
-            if line.startswith("#"):
-                elements.append(HeaderElement(line))
-                i += 1
-                continue
-
-            # 引用
-            if line.startswith(">"):
-                elements.append(QuoteElement(line))
-                i += 1
-                continue
-
-            # 列表项
-            if line.startswith("-") or line.startswith("*"):
-                elements.append(ListItemElement(line[1:].strip()))
-                i += 1
-                continue
-
-            # 代码块
-            if line.startswith("```"):
-                code_lines = []
-                i += 1  # 跳过开始标记行
-
-                while i < len(lines) and not lines[i].startswith("```"):
-                    code_lines.append(lines[i])
-                    i += 1
-
-                i += 1  # 跳过结束标记行
-                elements.append(CodeBlockElement(code_lines))
-                continue
-
-            # 检查行内样式（粗体、斜体、下划线、删除线、行内代码）
-            if re.search(
-                r"(\*\*.*?\*\*)|(\*.*?\*)|(__.*?__)|(_.*?_)|(~~.*?~~)|(`.*?`)", line
-            ):
-                # 分析行内样式:
-                # - 粗体: **text** 或 __text__
-                # - 斜体: *text* 或 _text_
-                # - 删除线: ~~text~~
-                # - 行内代码: `text`
-
-                # 定义正则模式和对应的元素类型
-                patterns = [
-                    (r"\*\*(.*?)\*\*", BoldTextElement),  # **粗体**
-                    (r"__(.*?)__", BoldTextElement),  # __粗体__
-                    (
-                        r"\*((?!\*\*).*?)\*",
-                        ItalicTextElement,
-                    ),  # *斜体* (但不匹配 ** 开头)
-                    (r"_((?!__).*?)_", ItalicTextElement),  # _斜体_ (但不匹配 __ 开头)
-                    (r"~~(.*?)~~", StrikethroughTextElement),  # ~~删除线~~
-                    (r"__(.*?)__", UnderlineTextElement),  # __下划线__
-                    (r"`(.*?)`", InlineCodeElement),  # `行内代码`
-                ]
-
-                # 创建标记位置列表
-                markers = []
-                for pattern, element_class in patterns:
-                    for match in re.finditer(pattern, line):
-                        markers.append(
-                            {
-                                "start": match.start(),
-                                "end": match.end(),
-                                "text": match.group(1),  # 提取内容部分
-                                "element_class": element_class,
-                            }
+                for token in _tokenize_inline_text(span.text):
+                    if token.isspace() and not current_line:
+                        continue
+
+                    token_width = TextMeasurer.get_text_size(token, font)[0]
+                    if current_line and current_width + token_width > width:
+                        self.lines.append(current_line)
+                        current_line = []
+                        current_width = 0
+                        if token.isspace():
+                            continue
+
+                    if token_width > width:
+                        fragments = TextMeasurer.split_text_to_fit_width(
+                            token,
+                            font,
+                            width,
                         )
+                    else:
+                        fragments = [token]
 
-                # 按开始位置排序
-                markers.sort(key=lambda x: x["start"])
+                    for fragment_index, fragment in enumerate(fragments):
+                        fragment_width = TextMeasurer.get_text_size(fragment, font)[0]
+                        if current_line and current_width + fragment_width > width:
+                            self.lines.append(current_line)
+                            current_line = []
+                            current_width = 0
 
-                # 如果没有找到任何匹配，直接添加为普通文本
-                if not markers:
-                    elements.append(TextElement(line))
-                    i += 1
-                    continue
+                        if (
+                            current_line
+                            and current_line[-1].span == span
+                            and fragment_index == 0
+                        ):
+                            previous = current_line[-1]
+                            previous.text += fragment
+                            previous.width = TextMeasurer.get_text_size(
+                                previous.text,
+                                previous.font,
+                            )[0]
+                            current_width = sum(run.width for run in current_line)
+                        else:
+                            current_line.append(
+                                InlineRun(span, fragment, font, fragment_width)
+                            )
+                            current_width += fragment_width
 
-                # 处理每个文本片段
-                current_pos = 0
-                for marker in markers:
-                    # 添加前面的普通文本
-                    if marker["start"] > current_pos:
-                        normal_text = line[current_pos : marker["start"]]
-                        if normal_text:
-                            elements.append(TextElement(normal_text))
+                        if fragment_index < len(fragments) - 1:
+                            self.lines.append(current_line)
+                            current_line = []
+                            current_width = 0
 
-                    # 添加特殊样式的文本
-                    elements.append(marker["element_class"](marker["text"]))
-                    current_pos = marker["end"]
+            self.lines.append(current_line)
 
-                # 添加最后一段普通文本
-                if current_pos < len(line):
-                    elements.append(TextElement(line[current_pos:]))
+        self.height = max(1, len(self.lines)) * self.line_height + 7
+        return self.height
 
-                i += 1
-                continue
+    def render(
+        self,
+        image: Image.Image,
+        draw: ImageDraw.ImageDraw,
+        x: int,
+        y: int,
+        width: int,
+        font_size: int,
+    ) -> int:
+        """Render the paragraph.
 
-            # 行内代码 (如果之前没匹配到混合样式)
-            inline_code_matches = re.findall(r"`([^`]+)`", line)
-            if inline_code_matches:
-                parts = re.split(r"`([^`]+)`", line)
-                for j, part in enumerate(parts):
-                    if j % 2 == 0:  # 普通文本
-                        if part:
-                            elements.append(TextElement(part))
-                    else:  # 行内代码
-                        elements.append(InlineCodeElement(part))
-                i += 1
-                continue
+        Args:
+            image: Destination image.
+            draw: Pillow drawing context.
+            x: Left content coordinate.
+            y: Top block coordinate.
+            width: Available content width.
+            font_size: Base body font size.
 
-            # 普通文本
-            elements.append(TextElement(line))
-            i += 1
+        Returns:
+            The next y coordinate.
+        """
+        del image, width, font_size
+        text_y = y
+        for line in self.lines:
+            text_x = x
+            for run in line:
+                if run.span.code:
+                    draw.rounded_rectangle(
+                        (
+                            text_x - 3,
+                            text_y + 1,
+                            text_x + run.width + 3,
+                            text_y + self.line_height - 4,
+                        ),
+                        radius=3,
+                        fill=CODE_FILL,
+                        outline=LINE,
+                        width=1,
+                    )
+                color = ACCENT if run.span.link else INK
+                draw.text((text_x, text_y), run.text, font=run.font, fill=color)
+                if run.span.strike:
+                    strike_y = text_y + self.line_height // 2
+                    draw.line(
+                        (text_x, strike_y, text_x + run.width, strike_y),
+                        fill=MUTED,
+                        width=1,
+                    )
+                text_x += run.width
+            text_y += self.line_height
+        return y + self.height
 
-        return elements
+
+class HeadingBlock(MarkdownBlock):
+    """A Markdown heading with balanced spacing and wrapping."""
+
+    def __init__(self, content: str, level: int, *, show_rule: bool = True) -> None:
+        self.content = _clean_inline_markdown(content)
+        self.level = max(1, min(level, 6))
+        self.show_rule = show_rule
+        self.lines: list[str] = []
+        self.font: ImageFont.FreeTypeFont | ImageFont.ImageFont | None = None
+        self.line_height = 0
+        self.top_gap = 0
+        self.bottom_gap = 0
+
+    def measure(self, width: int, font_size: int) -> int:
+        """Measure the heading.
+
+        Args:
+            width: Available content width.
+            font_size: Base body font size.
+
+        Returns:
+            Measured heading height.
+        """
+        factors = (1.84, 1.48, 1.28, 1.12, 1.0, 0.92)
+        heading_size = max(18, round(font_size * factors[self.level - 1]))
+        self.font = FontManager.get_font(heading_size, bold=True)
+        _, measured_height = TextMeasurer.get_text_size("Ag", self.font)
+        self.line_height = measured_height + 6
+        self.lines = TextMeasurer.split_text_to_fit_width(
+            self.content,
+            self.font,
+            width,
+        )
+        self.top_gap = (0, 28, 22, 18, 15, 13)[self.level - 1]
+        self.bottom_gap = (14, 12, 10, 8, 7, 6)[self.level - 1]
+        self.height = (
+            self.top_gap + len(self.lines) * self.line_height + self.bottom_gap
+        )
+        return self.height
+
+    def render(
+        self,
+        image: Image.Image,
+        draw: ImageDraw.ImageDraw,
+        x: int,
+        y: int,
+        width: int,
+        font_size: int,
+    ) -> int:
+        """Render the heading.
+
+        Args:
+            image: Destination image.
+            draw: Pillow drawing context.
+            x: Left content coordinate.
+            y: Top block coordinate.
+            width: Available content width.
+            font_size: Base body font size.
+
+        Returns:
+            The next y coordinate.
+        """
+        del image, font_size
+        text_y = y + self.top_gap
+        if self.level == 2 and self.show_rule:
+            draw.line(
+                (
+                    x,
+                    y + max(8, self.top_gap - 10),
+                    x + width,
+                    y + max(8, self.top_gap - 10),
+                ),
+                fill=LINE,
+                width=1,
+            )
+        for line in self.lines:
+            draw.text((x, text_y), line, font=self.font, fill=INK)
+            text_y += self.line_height
+        return y + self.height
 
 
-class MarkdownRenderer:
-    """Markdown渲染器，将元素渲染为图像"""
+class RuleBlock(MarkdownBlock):
+    """A horizontal Markdown rule."""
+
+    def measure(self, width: int, font_size: int) -> int:
+        """Measure the rule.
+
+        Args:
+            width: Available content width.
+            font_size: Base body font size.
+
+        Returns:
+            Fixed rule height.
+        """
+        del width, font_size
+        self.height = 30
+        return self.height
+
+    def render(
+        self,
+        image: Image.Image,
+        draw: ImageDraw.ImageDraw,
+        x: int,
+        y: int,
+        width: int,
+        font_size: int,
+    ) -> int:
+        """Render the horizontal rule.
+
+        Args:
+            image: Destination image.
+            draw: Pillow drawing context.
+            x: Left content coordinate.
+            y: Top block coordinate.
+            width: Available content width.
+            font_size: Base body font size.
+
+        Returns:
+            The next y coordinate.
+        """
+        del image, font_size
+        draw.line((x, y + 15, x + width, y + 15), fill=LINE, width=1)
+        return y + self.height
+
+
+class QuoteBlock(MarkdownBlock):
+    """A grouped block quote."""
+
+    def __init__(self, content: str) -> None:
+        self.content = _clean_inline_markdown(content)
+        self.lines: list[str] = []
+        self.font: ImageFont.FreeTypeFont | ImageFont.ImageFont | None = None
+        self.line_height = 0
+
+    def measure(self, width: int, font_size: int) -> int:
+        """Measure quote text inside its inset panel.
+
+        Args:
+            width: Available content width.
+            font_size: Base body font size.
+
+        Returns:
+            Measured quote height.
+        """
+        self.font = FontManager.get_font(max(16, font_size - 1))
+        _, measured_height = TextMeasurer.get_text_size("Ag", self.font)
+        self.line_height = measured_height + 7
+        self.lines = []
+        for source_line in self.content.split("\n"):
+            self.lines.extend(
+                TextMeasurer.split_text_to_fit_width(
+                    source_line,
+                    self.font,
+                    width - 32,
+                )
+            )
+        self.height = len(self.lines) * self.line_height + 28
+        return self.height
+
+    def render(
+        self,
+        image: Image.Image,
+        draw: ImageDraw.ImageDraw,
+        x: int,
+        y: int,
+        width: int,
+        font_size: int,
+    ) -> int:
+        """Render the quote panel.
+
+        Args:
+            image: Destination image.
+            draw: Pillow drawing context.
+            x: Left content coordinate.
+            y: Top block coordinate.
+            width: Available content width.
+            font_size: Base body font size.
+
+        Returns:
+            The next y coordinate.
+        """
+        del image, font_size
+        draw.rectangle((x, y + 4, x + width, y + self.height - 4), fill=SOFT_FILL)
+        draw.line((x, y + 4, x + width, y + 4), fill=LINE, width=1)
+        draw.line(
+            (x, y + self.height - 4, x + width, y + self.height - 4),
+            fill=LINE,
+            width=1,
+        )
+        text_y = y + 13
+        for line in self.lines:
+            draw.text((x + 16, text_y), line, font=self.font, fill=MUTED)
+            text_y += self.line_height
+        return y + self.height
+
+
+@dataclass
+class ListEntry:
+    """A parsed ordered, unordered, or task-list item."""
+
+    marker: str
+    content: str
+    depth: int = 0
+    checked: bool | None = None
+
+
+class ListBlock(MarkdownBlock):
+    """A consecutive Markdown list."""
+
+    def __init__(self, entries: list[ListEntry]) -> None:
+        self.entries = entries
+        self.layouts: list[tuple[ListEntry, list[str]]] = []
+        self.font: ImageFont.FreeTypeFont | ImageFont.ImageFont | None = None
+        self.line_height = 0
+
+    def measure(self, width: int, font_size: int) -> int:
+        """Measure all list items with hanging indentation.
+
+        Args:
+            width: Available content width.
+            font_size: Base body font size.
+
+        Returns:
+            Measured list height.
+        """
+        self.font = FontManager.get_font(font_size)
+        _, measured_height = TextMeasurer.get_text_size("Ag", self.font)
+        self.line_height = measured_height + 7
+        self.layouts = []
+        total_height = 6
+        for entry in self.entries:
+            indent = min(entry.depth, 3) * 22
+            lines = TextMeasurer.split_text_to_fit_width(
+                _clean_inline_markdown(entry.content),
+                self.font,
+                max(40, width - 34 - indent),
+            )
+            self.layouts.append((entry, lines))
+            total_height += len(lines) * self.line_height + 5
+        self.height = total_height + 3
+        return self.height
+
+    def render(
+        self,
+        image: Image.Image,
+        draw: ImageDraw.ImageDraw,
+        x: int,
+        y: int,
+        width: int,
+        font_size: int,
+    ) -> int:
+        """Render list markers and wrapped item text.
+
+        Args:
+            image: Destination image.
+            draw: Pillow drawing context.
+            x: Left content coordinate.
+            y: Top block coordinate.
+            width: Available content width.
+            font_size: Base body font size.
+
+        Returns:
+            The next y coordinate.
+        """
+        del image, width, font_size
+        text_y = y + 6
+        for entry, lines in self.layouts:
+            indent = min(entry.depth, 3) * 22
+            marker_x = x + indent
+            text_x = marker_x + 30
+            if entry.checked is None:
+                draw.text(
+                    (marker_x, text_y),
+                    entry.marker,
+                    font=self.font,
+                    fill=ACCENT,
+                )
+            else:
+                box_top = text_y + 6
+                draw.rectangle(
+                    (marker_x + 2, box_top, marker_x + 16, box_top + 14),
+                    outline=ACCENT,
+                    width=2,
+                )
+                if entry.checked:
+                    draw.line(
+                        (
+                            marker_x + 5,
+                            box_top + 7,
+                            marker_x + 9,
+                            box_top + 11,
+                            marker_x + 15,
+                            box_top + 3,
+                        ),
+                        fill=ACCENT,
+                        width=2,
+                        joint="curve",
+                    )
+            for line in lines:
+                draw.text((text_x, text_y), line, font=self.font, fill=INK)
+                text_y += self.line_height
+            text_y += 5
+        return y + self.height
+
+
+class CodeBlock(MarkdownBlock):
+    """A fenced code block with preserved indentation and wrapping."""
+
+    def __init__(self, content: list[str], language: str = "") -> None:
+        self.content = content or [""]
+        self.language = language
+        self.lines: list[str] = []
+        self.font: ImageFont.FreeTypeFont | ImageFont.ImageFont | None = None
+        self.label_font: ImageFont.FreeTypeFont | ImageFont.ImageFont | None = None
+        self.line_height = 0
+        self.label_height = 0
+
+    def measure(self, width: int, font_size: int) -> int:
+        """Measure wrapped code lines.
+
+        Args:
+            width: Available content width.
+            font_size: Base body font size.
+
+        Returns:
+            Measured code-block height.
+        """
+        code_size = max(16, font_size - 5)
+        self.font = FontManager.get_font(code_size, monospace=True)
+        self.label_font = FontManager.get_font(max(13, code_size - 5), bold=True)
+        _, measured_height = TextMeasurer.get_text_size("Ag", self.font)
+        self.line_height = measured_height + 6
+        self.label_height = 22 if self.language else 0
+        self.lines = []
+        for source_line in self.content:
+            self.lines.extend(
+                TextMeasurer.split_text_to_fit_width(
+                    source_line,
+                    self.font,
+                    width - 30,
+                    preserve_whitespace=True,
+                )
+            )
+        self.height = 24 + self.label_height + len(self.lines) * self.line_height
+        return self.height
+
+    def render(
+        self,
+        image: Image.Image,
+        draw: ImageDraw.ImageDraw,
+        x: int,
+        y: int,
+        width: int,
+        font_size: int,
+    ) -> int:
+        """Render the code panel.
+
+        Args:
+            image: Destination image.
+            draw: Pillow drawing context.
+            x: Left content coordinate.
+            y: Top block coordinate.
+            width: Available content width.
+            font_size: Base body font size.
+
+        Returns:
+            The next y coordinate.
+        """
+        del image, font_size
+        draw.rounded_rectangle(
+            (x, y + 4, x + width, y + self.height - 4),
+            radius=4,
+            fill=CODE_FILL,
+            outline=LINE,
+            width=1,
+        )
+        text_y = y + 13
+        if self.language:
+            label = self.language.upper()
+            label_width = TextMeasurer.get_text_size(label, self.label_font)[0]
+            draw.text(
+                (x + width - label_width - 14, text_y),
+                label,
+                font=self.label_font,
+                fill=MUTED,
+            )
+            text_y += self.label_height
+        for line in self.lines:
+            draw.text((x + 15, text_y), line, font=self.font, fill=INK)
+            text_y += self.line_height
+        return y + self.height
+
+
+class MathBlock(MarkdownBlock):
+    """A display-math fallback that keeps TeX source readable and wrapped."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content.strip()
+        self.lines: list[str] = []
+        self.font: ImageFont.FreeTypeFont | ImageFont.ImageFont | None = None
+        self.line_height = 0
+
+    def measure(self, width: int, font_size: int) -> int:
+        """Measure display-math source.
+
+        Args:
+            width: Available content width.
+            font_size: Base body font size.
+
+        Returns:
+            Measured block height.
+        """
+        self.font = FontManager.get_font(max(16, font_size - 2), monospace=True)
+        _, measured_height = TextMeasurer.get_text_size("Ag", self.font)
+        self.line_height = measured_height + 7
+        self.lines = []
+        for source_line in self.content.split("\n"):
+            self.lines.extend(
+                TextMeasurer.split_text_to_fit_width(
+                    source_line.strip(),
+                    self.font,
+                    width - 28,
+                )
+            )
+        self.height = len(self.lines) * self.line_height + 24
+        return self.height
+
+    def render(
+        self,
+        image: Image.Image,
+        draw: ImageDraw.ImageDraw,
+        x: int,
+        y: int,
+        width: int,
+        font_size: int,
+    ) -> int:
+        """Render display-math source as a centered local fallback.
+
+        Args:
+            image: Destination image.
+            draw: Pillow drawing context.
+            x: Left content coordinate.
+            y: Top block coordinate.
+            width: Available content width.
+            font_size: Base body font size.
+
+        Returns:
+            The next y coordinate.
+        """
+        del image, font_size
+        text_y = y + 10
+        for line in self.lines:
+            line_width = TextMeasurer.get_text_size(line, self.font)[0]
+            draw.text(
+                (x + max(0, (width - line_width) // 2), text_y),
+                line,
+                font=self.font,
+                fill=INK,
+            )
+            text_y += self.line_height
+        return y + self.height
+
+
+class TableBlock(MarkdownBlock):
+    """A compact GFM table with alignment and content-aware columns."""
 
     def __init__(
         self,
-        font_size: int = 26,
+        headers: list[str],
+        rows: list[list[str]],
+        alignments: list[str],
+    ) -> None:
+        self.headers = headers
+        self.rows = rows
+        self.alignments = alignments
+        self.column_widths: list[int] = []
+        self.row_layouts: list[list[list[str]]] = []
+        self.row_heights: list[int] = []
+        self.body_font: ImageFont.FreeTypeFont | ImageFont.ImageFont | None = None
+        self.header_font: ImageFont.FreeTypeFont | ImageFont.ImageFont | None = None
+        self.line_height = 0
+
+    def measure(self, width: int, font_size: int) -> int:
+        """Measure cells and allocate content-aware column widths.
+
+        Args:
+            width: Available content width.
+            font_size: Base body font size.
+
+        Returns:
+            Measured table height including outer spacing.
+        """
+        table_size = max(16, font_size - 4)
+        self.body_font = FontManager.get_font(table_size)
+        self.header_font = FontManager.get_font(table_size, bold=True)
+        _, measured_height = TextMeasurer.get_text_size("Ag", self.body_font)
+        self.line_height = measured_height + 6
+
+        column_count = len(self.headers)
+        all_rows = [self.headers, *self.rows]
+        natural_widths: list[int] = []
+        for column_index in range(column_count):
+            measured = max(
+                TextMeasurer.get_text_size(
+                    _clean_inline_markdown(
+                        row[column_index] if column_index < len(row) else ""
+                    ),
+                    self.header_font if row is self.headers else self.body_font,
+                )[0]
+                for row in all_rows
+            )
+            natural_widths.append(min(measured + 24, int(width * 0.55)))
+
+        minimum_width = min(78, max(42, width // max(1, column_count * 2)))
+        remaining_width = max(0, width - minimum_width * column_count)
+        total_natural = max(1, sum(natural_widths))
+        self.column_widths = [
+            minimum_width + int(remaining_width * natural / total_natural)
+            for natural in natural_widths
+        ]
+        self.column_widths[-1] += width - sum(self.column_widths)
+
+        self.row_layouts = []
+        self.row_heights = []
+        for row_index, row in enumerate(all_rows):
+            font = self.header_font if row_index == 0 else self.body_font
+            cell_layouts: list[list[str]] = []
+            for column_index, column_width in enumerate(self.column_widths):
+                content = _clean_inline_markdown(
+                    row[column_index] if column_index < len(row) else ""
+                )
+                cell_layouts.append(
+                    TextMeasurer.split_text_to_fit_width(
+                        content,
+                        font,
+                        max(20, column_width - 24),
+                    )
+                )
+            self.row_layouts.append(cell_layouts)
+            self.row_heights.append(
+                max(len(lines) for lines in cell_layouts) * self.line_height + 20
+            )
+
+        self.height = sum(self.row_heights) + 16
+        return self.height
+
+    def render(
+        self,
+        image: Image.Image,
+        draw: ImageDraw.ImageDraw,
+        x: int,
+        y: int,
+        width: int,
+        font_size: int,
+    ) -> int:
+        """Render the table grid and cell contents.
+
+        Args:
+            image: Destination image.
+            draw: Pillow drawing context.
+            x: Left content coordinate.
+            y: Top block coordinate.
+            width: Available content width.
+            font_size: Base body font size.
+
+        Returns:
+            The next y coordinate.
+        """
+        del image, font_size
+        table_y = y + 8
+        table_height = sum(self.row_heights)
+        row_y = table_y
+        for row_index, row_height in enumerate(self.row_heights):
+            if row_index == 0:
+                fill = (238, 241, 242)
+            elif row_index % 2 == 0:
+                fill = (247, 248, 248)
+            else:
+                fill = (253, 253, 252)
+            draw.rectangle((x, row_y, x + width, row_y + row_height), fill=fill)
+
+            column_x = x
+            font = self.header_font if row_index == 0 else self.body_font
+            for column_index, column_width in enumerate(self.column_widths):
+                text_y = row_y + 10
+                alignment = (
+                    self.alignments[column_index]
+                    if column_index < len(self.alignments)
+                    else "left"
+                )
+                for line in self.row_layouts[row_index][column_index]:
+                    line_width = TextMeasurer.get_text_size(line, font)[0]
+                    if alignment == "center":
+                        text_x = column_x + max(12, (column_width - line_width) // 2)
+                    elif alignment == "right":
+                        text_x = column_x + column_width - line_width - 12
+                    else:
+                        text_x = column_x + 12
+                    draw.text((text_x, text_y), line, font=font, fill=INK)
+                    text_y += self.line_height
+                column_x += column_width
+            row_y += row_height
+
+        draw.rectangle(
+            (x, table_y, x + width, table_y + table_height),
+            outline=STRONG_LINE,
+            width=1,
+        )
+        row_y = table_y
+        for row_height in self.row_heights[:-1]:
+            row_y += row_height
+            draw.line((x, row_y, x + width, row_y), fill=LINE, width=1)
+        column_x = x
+        for column_width in self.column_widths[:-1]:
+            column_x += column_width
+            draw.line(
+                (column_x, table_y, column_x, table_y + table_height),
+                fill=LINE,
+                width=1,
+            )
+        return y + self.height
+
+
+class ImageBlock(MarkdownBlock):
+    """A remotely loaded Markdown image with a readable failure fallback."""
+
+    def __init__(self, alt_text: str, image_url: str) -> None:
+        self.alt_text = alt_text
+        self.image_url = image_url
+        self.image: Image.Image | None = None
+        self.display_image: Image.Image | None = None
+        self.fallback_lines: list[str] = []
+        self.font: ImageFont.FreeTypeFont | ImageFont.ImageFont | None = None
+
+    async def load(self) -> None:
+        """Load the image over HTTP with a bounded timeout."""
+        timeout = aiohttp.ClientTimeout(total=12)
+        try:
+            async with (
+                aiohttp.ClientSession(
+                    trust_env=True,
+                    connector=build_tls_connector(),
+                    timeout=timeout,
+                ) as session,
+                session.get(self.image_url) as response,
+            ):
+                if response.status != 200:
+                    logger.warning(
+                        "Failed to load local T2I image %s: HTTP %s",
+                        self.image_url,
+                        response.status,
+                    )
+                    return
+                image_data = await response.read()
+            with Image.open(BytesIO(image_data)) as loaded:
+                self.image = loaded.convert("RGBA").copy()
+        except Exception as err:
+            logger.warning(
+                "Failed to load local T2I image %s: %s",
+                self.image_url,
+                err,
+            )
+
+    def measure(self, width: int, font_size: int) -> int:
+        """Measure the resized image or its failure message.
+
+        Args:
+            width: Available content width.
+            font_size: Base body font size.
+
+        Returns:
+            Measured image-block height.
+        """
+        if self.image is None:
+            self.font = FontManager.get_font(max(16, font_size - 2))
+            self.fallback_lines = TextMeasurer.split_text_to_fit_width(
+                f"[Image unavailable: {self.alt_text or self.image_url}]",
+                self.font,
+                width,
+            )
+            _, line_height = TextMeasurer.get_text_size("Ag", self.font)
+            self.height = len(self.fallback_lines) * (line_height + 6) + 16
+            return self.height
+
+        display = self.image.copy()
+        display.thumbnail((width, 900), Image.Resampling.LANCZOS)
+        self.display_image = display
+        self.height = display.height + 20
+        return self.height
+
+    def render(
+        self,
+        image: Image.Image,
+        draw: ImageDraw.ImageDraw,
+        x: int,
+        y: int,
+        width: int,
+        font_size: int,
+    ) -> int:
+        """Render the image or failure text.
+
+        Args:
+            image: Destination image.
+            draw: Pillow drawing context.
+            x: Left content coordinate.
+            y: Top block coordinate.
+            width: Available content width.
+            font_size: Base body font size.
+
+        Returns:
+            The next y coordinate.
+        """
+        del font_size
+        if self.display_image is None:
+            text_y = y + 7
+            _, line_height = TextMeasurer.get_text_size("Ag", self.font)
+            for line in self.fallback_lines:
+                draw.text((x, text_y), line, font=self.font, fill=MUTED)
+                text_y += line_height + 6
+            return y + self.height
+
+        paste_x = x + (width - self.display_image.width) // 2
+        paste_y = y + 10
+        image.paste(self.display_image, (paste_x, paste_y), self.display_image)
+        draw.rectangle(
+            (
+                paste_x,
+                paste_y,
+                paste_x + self.display_image.width,
+                paste_y + self.display_image.height,
+            ),
+            outline=LINE,
+            width=1,
+        )
+        return y + self.height
+
+
+class MarkdownParser:
+    """Parse a practical subset of Markdown into local-render blocks."""
+
+    _heading_pattern = re.compile(r"^\s*(#{1,6})\s+(.+?)\s*$")
+    _list_pattern = re.compile(r"^(\s*)([-+*]|\d+[.)])\s+(.+)$")
+    _rule_pattern = re.compile(r"^\s{0,3}((\*\s*){3,}|(-\s*){3,}|(_\s*){3,})$")
+    _image_pattern = re.compile(
+        r"^\s*!\[([^\]]*)\]\((\S+?)(?:\s+[\"'][^\"']*[\"'])?\)\s*$"
+    )
+    _table_separator_pattern = re.compile(
+        r"^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$"
+    )
+
+    @classmethod
+    def _is_table_start(cls, lines: list[str], index: int) -> bool:
+        """Return whether the current and following lines start a GFM table.
+
+        Args:
+            lines: Source Markdown lines.
+            index: Current source-line index.
+
+        Returns:
+            True when a header and separator row are present.
+        """
+        return (
+            index + 1 < len(lines)
+            and "|" in lines[index]
+            and bool(cls._table_separator_pattern.match(lines[index + 1]))
+        )
+
+    @staticmethod
+    def _split_table_row(line: str) -> list[str]:
+        """Split a simple GFM table row.
+
+        Args:
+            line: Raw table row.
+
+        Returns:
+            Trimmed cell contents.
+        """
+        return [cell.strip() for cell in line.strip().strip("|").split("|")]
+
+    @classmethod
+    def _starts_block(cls, lines: list[str], index: int) -> bool:
+        """Return whether a source line begins a non-paragraph block.
+
+        Args:
+            lines: Source Markdown lines.
+            index: Current source-line index.
+
+        Returns:
+            True when parsing should end the active paragraph.
+        """
+        stripped = lines[index].strip()
+        return bool(
+            not stripped
+            or stripped.startswith(("```", "$$", ">"))
+            or cls._heading_pattern.match(lines[index])
+            or cls._rule_pattern.match(lines[index])
+            or cls._list_pattern.match(lines[index])
+            or cls._image_pattern.match(lines[index])
+            or cls._is_table_start(lines, index)
+        )
+
+    @classmethod
+    async def parse(cls, text: str) -> list[MarkdownBlock]:
+        """Parse Markdown and load referenced images.
+
+        Args:
+            text: Markdown source.
+
+        Returns:
+            Parsed and image-ready block objects.
+        """
+        normalized = text.replace("\r\n", "\n").replace("\r", "\n").expandtabs(4)
+        lines = normalized.split("\n")
+        blocks: list[MarkdownBlock] = []
+        image_blocks: list[ImageBlock] = []
+        index = 0
+
+        while index < len(lines):
+            line = lines[index]
+            stripped = line.strip()
+            if not stripped:
+                index += 1
+                continue
+
+            fence_match = re.match(r"^\s*```([^\s`]*)", line)
+            if fence_match:
+                language = fence_match.group(1)
+                code_lines: list[str] = []
+                index += 1
+                while index < len(lines) and not re.match(r"^\s*```", lines[index]):
+                    code_lines.append(lines[index])
+                    index += 1
+                if index < len(lines):
+                    index += 1
+                blocks.append(CodeBlock(code_lines, language))
+                continue
+
+            if stripped.startswith("$$"):
+                if stripped.endswith("$$") and len(stripped) > 4:
+                    math_content = stripped[2:-2].strip()
+                    index += 1
+                else:
+                    math_lines: list[str] = []
+                    opening_remainder = stripped[2:].strip()
+                    if opening_remainder:
+                        math_lines.append(opening_remainder)
+                    index += 1
+                    while index < len(lines) and not lines[index].strip().endswith(
+                        "$$"
+                    ):
+                        math_lines.append(lines[index])
+                        index += 1
+                    if index < len(lines):
+                        closing = lines[index].strip()
+                        if closing != "$$":
+                            math_lines.append(closing[:-2].rstrip())
+                        index += 1
+                    math_content = "\n".join(math_lines)
+                blocks.append(MathBlock(math_content))
+                continue
+
+            image_match = cls._image_pattern.match(line)
+            if image_match:
+                image_block = ImageBlock(image_match.group(1), image_match.group(2))
+                image_blocks.append(image_block)
+                blocks.append(image_block)
+                index += 1
+                continue
+
+            heading_match = cls._heading_pattern.match(line)
+            if heading_match:
+                level = len(heading_match.group(1))
+                blocks.append(
+                    HeadingBlock(
+                        heading_match.group(2),
+                        level,
+                        show_rule=level != 2
+                        or not blocks
+                        or not isinstance(blocks[-1], RuleBlock),
+                    )
+                )
+                index += 1
+                continue
+
+            if cls._rule_pattern.match(line):
+                blocks.append(RuleBlock())
+                index += 1
+                continue
+
+            if cls._is_table_start(lines, index):
+                headers = cls._split_table_row(lines[index])
+                separator = cls._split_table_row(lines[index + 1])
+                alignments = []
+                for cell in separator:
+                    stripped_cell = cell.strip()
+                    if stripped_cell.startswith(":") and stripped_cell.endswith(":"):
+                        alignments.append("center")
+                    elif stripped_cell.endswith(":"):
+                        alignments.append("right")
+                    else:
+                        alignments.append("left")
+                index += 2
+                rows: list[list[str]] = []
+                while (
+                    index < len(lines) and "|" in lines[index] and lines[index].strip()
+                ):
+                    rows.append(cls._split_table_row(lines[index]))
+                    index += 1
+                blocks.append(TableBlock(headers, rows, alignments))
+                continue
+
+            if stripped.startswith(">"):
+                quote_lines: list[str] = []
+                while index < len(lines) and lines[index].strip().startswith(">"):
+                    quote_lines.append(re.sub(r"^\s*>\s?", "", lines[index]))
+                    index += 1
+                blocks.append(QuoteBlock("\n".join(quote_lines)))
+                continue
+
+            list_match = cls._list_pattern.match(line)
+            if list_match:
+                entries: list[ListEntry] = []
+                while index < len(lines):
+                    item_match = cls._list_pattern.match(lines[index])
+                    if item_match:
+                        indent, marker, content = item_match.groups()
+                        checked: bool | None = None
+                        task_match = re.match(r"^\[([ xX])\]\s+(.*)$", content)
+                        if task_match:
+                            checked = task_match.group(1).lower() == "x"
+                            content = task_match.group(2)
+                        visible_marker = "•" if not marker[0].isdigit() else marker
+                        entries.append(
+                            ListEntry(
+                                visible_marker,
+                                content,
+                                min(3, len(indent) // 2),
+                                checked,
+                            )
+                        )
+                        index += 1
+                        continue
+                    if (
+                        entries
+                        and index < len(lines)
+                        and lines[index].startswith("  ")
+                        and lines[index].strip()
+                    ):
+                        entries[-1].content += " " + lines[index].strip()
+                        index += 1
+                        continue
+                    break
+                blocks.append(ListBlock(entries))
+                continue
+
+            paragraph_lines = [line.strip()]
+            index += 1
+            while index < len(lines) and not cls._starts_block(lines, index):
+                paragraph_lines.append(lines[index].strip())
+                index += 1
+            blocks.append(ParagraphBlock("\n".join(paragraph_lines)))
+
+        if image_blocks:
+            await asyncio.gather(*(block.load() for block in image_blocks))
+        return blocks
+
+
+class MarkdownRenderer:
+    """Render parsed Markdown blocks into a compact branded image."""
+
+    def __init__(
+        self,
+        font_size: int = 25,
         width: int = 800,
-        bg_color: tuple[int, int, int] = (255, 255, 255),
-    ):
+        bg_color: tuple[int, int, int] = PAPER,
+    ) -> None:
+        """Initialize the local renderer.
+
+        Args:
+            font_size: Base body font size.
+            width: Output image width.
+            bg_color: RGB background color.
+        """
         self.font_size = font_size
-        self.width = width
+        self.width = max(320, width)
         self.bg_color = bg_color
 
+    def _draw_masthead(self, draw: ImageDraw.ImageDraw) -> None:
+        """Draw the AstrBot mark, wordmark, and version.
+
+        Args:
+            draw: Pillow drawing context.
+        """
+        center_x = CONTENT_MARGIN + 14
+        center_y = 43
+        outer = 13
+        inner = 4
+        draw.polygon(
+            [
+                (center_x, center_y - outer),
+                (center_x + inner, center_y - inner),
+                (center_x + outer, center_y),
+                (center_x + inner, center_y + inner),
+                (center_x, center_y + outer),
+                (center_x - inner, center_y + inner),
+                (center_x - outer, center_y),
+                (center_x - inner, center_y - inner),
+            ],
+            fill=ACCENT,
+        )
+        small_x = center_x + 16
+        small_y = center_y - 14
+        draw.polygon(
+            [
+                (small_x, small_y - 5),
+                (small_x + 2, small_y - 2),
+                (small_x + 5, small_y),
+                (small_x + 2, small_y + 2),
+                (small_x, small_y + 5),
+                (small_x - 2, small_y + 2),
+                (small_x - 5, small_y),
+                (small_x - 2, small_y - 2),
+            ],
+            fill=ACCENT,
+        )
+
+        brand_font = FontManager.get_font(28, bold=True)
+        version_font = FontManager.get_font(18)
+        draw.text((CONTENT_MARGIN + 42, 27), "AstrBot", font=brand_font, fill=INK)
+        version_text = f"v{VERSION}"
+        version_width = TextMeasurer.get_text_size(version_text, version_font)[0]
+        draw.text(
+            (self.width - CONTENT_MARGIN - version_width, 31),
+            version_text,
+            font=version_font,
+            fill=MUTED,
+        )
+
     async def render(self, markdown_text: str) -> Image.Image:
-        # 解析Markdown文本
-        elements = await MarkdownParser.parse(markdown_text)
+        """Render Markdown into a Pillow image.
 
-        # 计算总高度
-        total_height = 20  # 初始边距
-        for element in elements:
-            total_height += element.calculate_height(self.width, self.font_size)
+        Args:
+            markdown_text: Markdown source.
 
-        # 为页脚添加额外空间
-        footer_height = 40
-        total_height += 20 + footer_height  # 结束边距 + 页脚高度
+        Returns:
+            Rendered RGB image.
+        """
+        blocks = await MarkdownParser.parse(markdown_text)
+        content_width = self.width - CONTENT_MARGIN * 2
+        masthead_height = 91
+        bottom_padding = 34
+        total_height = masthead_height + bottom_padding
+        for block in blocks:
+            total_height += block.measure(content_width, self.font_size)
 
-        # 创建图像
-        image = Image.new("RGB", (self.width, max(100, total_height)), self.bg_color)
+        image = Image.new(
+            "RGB",
+            (self.width, max(140, total_height)),
+            self.bg_color,
+        )
         draw = ImageDraw.Draw(image)
+        self._draw_masthead(draw)
 
-        # 渲染元素
-        y = 10
-        for element in elements:
-            y = element.render(image, draw, 10, y, self.width, self.font_size)
-
-        # 添加页脚
-        # 克莱因蓝色，近似RGB为(0, 47, 167)
-        klein_blue = (0, 47, 167)
-        # 灰色
-        grey_color = (130, 130, 130)
-
-        # 绘制"Powered by AstrBot"文本
-        footer_font_size = 20
-        footer_font = FontManager.get_font(footer_font_size)
-
-        # 获取"Powered by "和"AstrBot"的宽度以便居中
-        powered_by_text = "Powered by "
-        astrbot_text = f"AstrBot v{VERSION}"
-
-        powered_by_width, _ = TextMeasurer.get_text_size(powered_by_text, footer_font)
-        astrbot_width, _ = TextMeasurer.get_text_size(astrbot_text, footer_font)
-
-        total_width = powered_by_width + astrbot_width
-        x_start = (self.width - total_width) // 2
-
-        footer_y = total_height - footer_height
-
-        # 绘制"Powered by "（灰色）
-        draw.text(
-            (x_start, footer_y), powered_by_text, font=footer_font, fill=grey_color
-        )
-
-        # 绘制"AstrBot"（克莱因蓝）
-        draw.text(
-            (x_start + powered_by_width, footer_y),
-            astrbot_text,
-            font=footer_font,
-            fill=klein_blue,
-        )
-
+        y = masthead_height
+        for block in blocks:
+            y = block.render(
+                image,
+                draw,
+                CONTENT_MARGIN,
+                y,
+                content_width,
+                self.font_size,
+            )
         return image
 
 
 class LocalRenderStrategy(RenderStrategy):
-    """本地渲染策略实现"""
+    """Render Markdown locally with Pillow when remote T2I is unavailable."""
 
     async def render_custom_template(
-        self, tmpl_str: str, tmpl_data: dict, return_url: bool = True
+        self,
+        tmpl_str: str,
+        tmpl_data: dict,
+        return_url: bool = True,
     ) -> str:
+        """Reject HTML templates because the local backend is Markdown-only.
+
+        Args:
+            tmpl_str: HTML template source.
+            tmpl_data: Template variables.
+            return_url: Whether the caller requested a URL.
+
+        Raises:
+            NotImplementedError: Always, because Pillow cannot render HTML templates.
+        """
+        del tmpl_str, tmpl_data, return_url
         raise NotImplementedError
 
     async def render(self, text: str, return_url: bool = False) -> str:
-        # 创建渲染器
-        renderer = MarkdownRenderer(font_size=26, width=800)
+        """Render Markdown locally and save it as a temporary image.
 
-        # 渲染Markdown文本
+        Args:
+            text: Markdown source.
+            return_url: Retained for strategy compatibility; local output is a path.
+
+        Returns:
+            Path to the saved temporary image.
+        """
+        del return_url
+        renderer = MarkdownRenderer(font_size=25, width=800)
         image = await renderer.render(text)
-
-        # 保存图像并返回路径/URL
         return save_temp_img(image)

--- a/astrbot/core/utils/t2i/template/base.html
+++ b/astrbot/core/utils/t2i/template/base.html
@@ -1,246 +1,443 @@
 <!doctype html>
-<html>
+<html lang="zh-CN">
 <head>
-  <meta charset="utf-8"/>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>AstrBot {{ version }}</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Outfit:wght@400..700&display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/misans@4.1.0/lib/Normal/MiSans-Regular.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/misans@4.1.0/lib/Normal/MiSans-Bold.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css" integrity="sha384-wcIxkf4k558AjM3Yz3BBFQUbk/zgIYC2R0QpeeYb+TwlBVMrlgLqwRjRtGZiK7ww" crossorigin="anonymous">
   <style>
-      #content {
-          min-width: 200px;
-          max-width: 85%;
-          margin: 0 auto;
-          padding: 2rem 1em 1em;
+    :root {
+      --paper: #fbfbfa;
+      --ink: #202224;
+      --muted: #666b70;
+      --line: #d9dcde;
+      --soft-line: #d4d8db;
+      --strong-line: #bcc2c6;
+      --soft-fill: #f2f3f3;
+      --accent: #2f86bd;
+      --code-fill: #f4f5f5;
+    }
+
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+
+    html {
+      background: var(--paper);
+    }
+
+    body {
+      min-width: 320px;
+      margin: 0;
+      padding: 0 32px;
+      overflow-x: hidden;
+      color: var(--ink);
+      background: var(--paper);
+      font-family: "MiSans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans CJK SC", "Noto Sans SC", "Microsoft YaHei", Arial, sans-serif;
+      font-size: 25px;
+      font-weight: 400;
+      line-height: 1.72;
+      text-rendering: optimizeLegibility;
+      overflow-wrap: break-word;
+    }
+
+    .masthead {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      width: min(100%, 920px);
+      margin: 0 auto;
+      padding: 30px 0 0;
+      font-family: "Outfit", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 11px;
+    }
+
+    .brand-icon {
+      width: 34px;
+      height: 34px;
+      flex: 0 0 auto;
+    }
+
+    .wordmark {
+      font-size: 28px;
+      font-weight: 650;
+      letter-spacing: -0.02em;
+    }
+
+    .version {
+      color: var(--muted);
+      font-size: 18px;
+      font-weight: 500;
+      letter-spacing: 0.02em;
+    }
+
+    main {
+      width: min(100%, 920px);
+      margin: 0 auto;
+      padding: 42px 0 60px;
+    }
+
+    #content > :first-child {
+      margin-top: 0;
+    }
+
+    #content > :last-child {
+      margin-bottom: 0;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      color: var(--ink);
+      font-weight: 720;
+      line-height: 1.28;
+      text-wrap: balance;
+    }
+
+    h1 {
+      margin: 0 0 0.62em;
+      font-size: 2em;
+      letter-spacing: -0.035em;
+    }
+
+    h2 {
+      margin: 1.65em 0 0.62em;
+      padding-top: 0.45em;
+      border-top: 1px solid var(--soft-line);
+      font-size: 1.5em;
+      letter-spacing: -0.025em;
+    }
+
+    h3 {
+      margin: 1.4em 0 0.52em;
+      font-size: 1.24em;
+      letter-spacing: -0.015em;
+    }
+
+    h4 {
+      margin: 1.25em 0 0.45em;
+      font-size: 1.06em;
+    }
+
+    h5,
+    h6 {
+      margin: 1.15em 0 0.4em;
+      font-size: 0.92em;
+    }
+
+    h6 {
+      color: var(--muted);
+    }
+
+    p {
+      margin: 0.78em 0;
+      white-space: pre-line;
+    }
+
+    strong {
+      font-weight: 720;
+    }
+
+    em {
+      font-style: italic;
+    }
+
+    a {
+      color: var(--accent);
+      text-decoration-color: color-mix(in srgb, var(--accent) 55%, transparent);
+      text-decoration-line: underline;
+      text-decoration-thickness: 0.06em;
+      text-underline-offset: 0.16em;
+    }
+
+    hr {
+      height: 1px;
+      margin: 1.55em 0;
+      border: 0;
+      background: var(--soft-line);
+    }
+
+    hr + h2 {
+      margin-top: 1em;
+      padding-top: 0;
+      border-top: 0;
+    }
+
+    ul,
+    ol {
+      margin: 0.75em 0;
+      padding-left: 1.45em;
+    }
+
+    li {
+      padding-left: 0.15em;
+    }
+
+    li + li {
+      margin-top: 0.28em;
+    }
+
+    li::marker {
+      color: var(--accent);
+      font-weight: 650;
+    }
+
+    li > p {
+      margin: 0.35em 0;
+    }
+
+    li.task-list-item {
+      margin-left: -1.35em;
+      padding-left: 0;
+      list-style: none;
+    }
+
+    .task-list-item input[type="checkbox"] {
+      width: 0.9em;
+      height: 0.9em;
+      margin: 0 0.5em 0 0;
+      vertical-align: -0.05em;
+      accent-color: var(--accent);
+    }
+
+    blockquote {
+      margin: 1.15em 0;
+      padding: 0.75em 1em;
+      border-top: 1px solid var(--line);
+      border-bottom: 1px solid var(--line);
+      color: #4d5256;
+      background: var(--soft-fill);
+    }
+
+    blockquote > :first-child {
+      margin-top: 0;
+    }
+
+    blockquote > :last-child {
+      margin-bottom: 0;
+    }
+
+    code,
+    kbd,
+    samp {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    }
+
+    :not(pre) > code {
+      padding: 0.12em 0.35em;
+      border: 1px solid var(--soft-line);
+      border-radius: 3px;
+      color: #273a33;
+      background: var(--code-fill);
+      font-size: 0.84em;
+      overflow-wrap: anywhere;
+    }
+
+    pre {
+      max-width: 100%;
+      margin: 1.15em 0;
+      padding: 1em 1.1em;
+      overflow: visible;
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      background: var(--code-fill);
+      font-size: 0.76em;
+      line-height: 1.58;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      tab-size: 2;
+    }
+
+    pre > code {
+      display: block;
+      padding: 0;
+      border: 0;
+      color: inherit;
+      background: transparent;
+      font-size: inherit;
+      line-height: inherit;
+      white-space: inherit;
+    }
+
+    pre.shiki {
+      padding: 1em 1.1em;
+      background: var(--code-fill) !important;
+      white-space: pre-wrap;
+    }
+
+    pre.shiki > code {
+      white-space: inherit;
+    }
+
+    img {
+      display: block;
+      max-width: 100%;
+      height: auto;
+      margin: 1.2em auto;
+      border: 1px solid var(--line);
+    }
+
+    table {
+      width: 100%;
+      margin: 1.2em 0;
+      overflow: hidden;
+      border: 1px solid var(--strong-line);
+      border-collapse: separate;
+      border-spacing: 0;
+      border-radius: 4px;
+      background: #fdfdfc;
+      font-size: 0.82em;
+      line-height: 1.5;
+    }
+
+    th,
+    td {
+      padding: 0.65em 0.75em;
+      border-bottom: 1px solid var(--line);
+      text-align: left;
+      vertical-align: top;
+      overflow-wrap: break-word;
+      word-break: normal;
+    }
+
+    th + th,
+    td + td {
+      border-left: 1px solid var(--line);
+    }
+
+    th {
+      color: var(--ink);
+      border-bottom-color: var(--strong-line);
+      background: #eef1f2;
+      font-weight: 700;
+      letter-spacing: 0.01em;
+      white-space: nowrap;
+    }
+
+    tbody tr:nth-child(even) {
+      background: #f7f8f8;
+    }
+
+    tbody tr:last-child td {
+      border-bottom: 0;
+    }
+
+    th[align="center"],
+    td[align="center"] {
+      text-align: center;
+      white-space: nowrap;
+    }
+
+    th[align="right"],
+    td[align="right"] {
+      text-align: right;
+      white-space: nowrap;
+    }
+
+    caption {
+      padding: 0 0 0.55em;
+      color: var(--muted);
+      font-size: 0.9em;
+      text-align: left;
+    }
+
+    details {
+      margin: 1.05em 0;
+      padding: 0.65em 0;
+      border-top: 1px solid var(--line);
+      border-bottom: 1px solid var(--line);
+    }
+
+    summary {
+      cursor: pointer;
+      font-weight: 680;
+    }
+
+    summary::marker {
+      color: var(--accent);
+    }
+
+    details[open] summary {
+      margin-bottom: 0.65em;
+    }
+
+    mark {
+      padding: 0.05em 0.2em;
+      color: inherit;
+      background: #e9e0aa;
+    }
+
+    del {
+      color: var(--muted);
+    }
+
+    .katex-display {
+      max-width: 100%;
+      margin: 1.1em 0;
+      overflow: visible;
+      font-size: 0.95em;
+    }
+
+    @media (max-width: 700px) {
+      body {
+        padding: 0 14px;
+        font-size: 21px;
       }
 
-      body {
-          word-break: break-word;
-          line-height: 1.75;
-          font-weight: 400;
-          font-size: 32px;
-          margin: 0;
-          padding: 0;
-          overflow-x: hidden;
-          color: #333;
-          font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
+      .masthead {
+        padding-top: 18px;
       }
-      h1, h2, h3, h4, h5, h6 {
-          line-height: 1.5;
-          margin-top: 35px;
-          margin-bottom: 10px;
-          padding-bottom: 5px;
+
+      main {
+        padding: 34px 0 46px;
       }
-      h1:first-child, h2:first-child, h3:first-child, h4:first-child, h5:first-child, h6:first-child {
-          margin-top: -1.5rem;
-          margin-bottom: 1rem;
-      }
-      h1::before, h2::before, h3::before, h4::before, h5::before, h6::before {
-          content: "#";
-          display: inline-block;
-          color: #3eaf7c;
-          padding-right: 0.23em;
-      }
+
       h1 {
-          position: relative;
-          font-size: 2.5rem;
-          margin-bottom: 5px;
+        font-size: 1.72em;
       }
-      h1::before {
-          font-size: 2.5rem;
-      }
+
       h2 {
-          padding-bottom: 0.5rem;
-          font-size: 2.2rem;
-          border-bottom: 1px solid #ececec;
+        font-size: 1.38em;
       }
-      h3 {
-          font-size: 1.5rem;
-          padding-bottom: 0;
-      }
-      h4 {
-          font-size: 1.25rem;
-      }
-      h5 {
-          font-size: 1rem;
-      }
-      h6 {
-          margin-top: 5px;
-      }
-      p {
-          line-height: inherit;
-          margin-top: 22px;
-          margin-bottom: 22px;
-      }
-      strong {
-          color: #3eaf7c;
-      }
-      img {
-          max-width: 100%;
-          border-radius: 2px;
-          display: block;
-          margin: auto;
-          border: 3px solid rgba(62, 175, 124, 0.2);
-      }
-      hr {
-          border-top: 1px solid #3eaf7c;
-          border-bottom: none;
-          border-left: none;
-          border-right: none;
-          margin-top: 32px;
-          margin-bottom: 32px;
-      }
-      code {
-          font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
-          word-break: break-word;
-          overflow-x: auto;
-          padding: 0.2rem 0.5rem;
-          margin: 0;
-          color: #3eaf7c;
-          font-size: 0.85em;
-          background-color: rgba(27, 31, 35, 0.05);
-          border-radius: 3px;
-      }
-      pre {
-          font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
-          overflow: auto;
-          position: relative;
-          line-height: 1.75;
-          border-radius: 6px;
-          border: 2px solid #3eaf7c;
-      }
-      pre > code {
-          font-size: 12px;
-          padding: 15px 12px;
-          margin: 0;
-          word-break: normal;
-          display: block;
-          overflow-x: auto;
-          color: #333;
-          background: #f8f8f8;
-      }
-      pre.shiki {
-          padding: 15px 12px;
-      }
-      pre.shiki > code {
-          padding: 0;
-          background: transparent !important;
-          color: inherit;
-          font-size: 12px;
-      }
-      a {
-          font-weight: 500;
-          text-decoration: none;
-          color: #3eaf7c;
-      }
-      a:hover, a:active {
-          border-bottom: 1.5px solid #3eaf7c;
-      }
-      a:before {
-          content: "⇲";
-      }
+
       table {
-          display: inline-block !important;
-          font-size: 12px;
-          width: auto;
-          max-width: 100%;
-          overflow: auto;
-          border: solid 1px #3eaf7c;
+        font-size: 0.75em;
       }
-      thead {
-          background: #3eaf7c;
-          color: #fff;
-          text-align: left;
-      }
-      tr:nth-child(2n) {
-          background-color: rgba(62, 175, 124, 0.2);
-      }
-      th, td {
-          padding: 12px 7px;
-          line-height: 24px;
-      }
-      td {
-          min-width: 120px;
-      }
-      blockquote {
-          color: #666;
-          padding: 1px 23px;
-          margin: 22px 0;
-          border-left: 0.5rem solid rgba(62, 175, 124, 0.6);
-          border-color: #42b983;
-          background-color: #f8f8f8;
-      }
-      blockquote::after {
-          display: block;
-          content: "";
-      }
-      blockquote > p {
-          margin: 10px 0;
-      }
-      details {
-          border: none;
-          outline: none;
-          border-left: 4px solid #3eaf7c;
-          padding-left: 10px;
-          margin-left: 4px;
-      }
-      details summary {
-          cursor: pointer;
-          border: none;
-          outline: none;
-          background: white;
-          margin: 0 -17px;
-      }
-      details summary::-webkit-details-marker {
-          color: #3eaf7c;
-      }
-      ol, ul {
-          padding-left: 28px;
-      }
-      ol li, ul li {
-          margin-bottom: 0;
-          list-style: inherit;
-      }
-      ol li .task-list-item, ul li .task-list-item {
-          list-style: none;
-      }
-      ol li .task-list-item ul, ul li .task-list-item ul, ol li .task-list-item ol, ul li .task-list-item ol {
-          margin-top: 0;
-      }
-      ol ul, ul ul, ol ol, ul ol {
-          margin-top: 3px;
-      }
-      ol li {
-          padding-left: 6px;
-      }
-      ol li::marker {
-          color: #3eaf7c;
-      }
-      ul li {
-          list-style: none;
-      }
-      ul li:before {
-          content: "•";
-          margin-right: 4px;
-          color: #3eaf7c;
-      }
-      @media (max-width: 720px) {
-          h1 {
-              font-size: 24px;
-          }
-          h2 {
-              font-size: 20px;
-          }
-          h3 {
-              font-size: 18px;
-          }
-      }
+    }
   </style>
 </head>
 <body>
-  <div style="background-color: #3276dc; color: #fff; font-size: 64px;">
-    <span style="font-weight: bold; margin-left: 16px"># AstrBot</span>
-    <span>{{ version }}</span>
-  </div>
-  <article style="margin-top: 32px" id="content"></article>
+  <header class="masthead">
+    <span class="brand">
+      <svg class="brand-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" preserveAspectRatio="xMidYMid meet" aria-hidden="true">
+        <g transform="translate(0.8 0.9)">
+          <g transform="translate(0 32)">
+            <path d="m246.3 328.1-17.8 41.2c-6.4 14.8-26.9 14.8-33.3 0l-17.8-41.2c-14.9-34.2-41.8-61.4-75.3-76.3l-48.8-21.6c-14.7-6.5-14.7-27.9 0-34.4l47.2-21c34.4-15.3 61.7-43.5 76.4-78.8l18-43.7c6.3-15.2 27.3-15.2 33.6 0l18 43.7c14.7 35.3 42 63.6 76.4 78.8l47.2 21c14.7 6.5 14.7 27.9 0 34.4l-48.8 21.6c-33.5 14.8-60.4 42.1-75.3 76.2z" fill="#2f86bd" transform="translate(0 35)" />
+            <path d="m402.2 449.3-5.3 12.2c-3.5 7.9-14.4 7.9-17.9 0l-5.3-12.2c-8.4-19.3-23.6-34.6-42.4-43l-15.4-6.9c-7.9-3.5-7.9-14.9 0-18.4l14.5-6.5c19.4-8.6 34.8-24.5 43.1-44.5l5.4-13.1c3.4-8.1 14.6-8.1 18 0l5.4 13.1c8.3 19.9 23.7 35.8 43.1 44.5l14.5 6.5c7.9 3.5 7.9 14.9 0 18.4l-15.4 6.9c-19 8.3-34.1 23.7-42.5 43z" fill="#2f86bd" transform="matrix(0.95 0 0 0.95 22 -278)" />
+          </g>
+        </g>
+      </svg>
+      <span class="wordmark">AstrBot</span>
+    </span>
+    <span class="version">{{ version }}</span>
+  </header>
+
+  <main>
+    <article id="content"></article>
+  </main>
 
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js" integrity="sha384-hIoBPJpTUs74ddyc4bFZSM1TVlQDA60VBbJS0oA934VSz82sBx1X7kSx2ATBDIyd" crossorigin="anonymous"></script>
@@ -251,6 +448,10 @@
       const contentElement = document.getElementById("content");
       const source = document.getElementById("markdown-source").value;
 
+      marked.use({
+        gfm: true,
+        breaks: false
+      });
       contentElement.innerHTML = marked.parse(source);
 
       if (window.AstrBotT2IShiki) {
@@ -265,7 +466,6 @@
           ]
         });
       }
-
     })();
   </script>
 </body>

--- a/astrbot/core/utils/t2i/template/base.html
+++ b/astrbot/core/utils/t2i/template/base.html
@@ -144,7 +144,7 @@
 
     p {
       margin: 0.78em 0;
-      white-space: pre-line;
+      white-space: normal;
     }
 
     strong {
@@ -387,7 +387,8 @@
     .katex-display {
       max-width: 100%;
       margin: 1.1em 0;
-      overflow: visible;
+      overflow-x: auto;
+      overflow-y: hidden;
       font-size: 0.95em;
     }
 
@@ -465,6 +466,27 @@
             { left: "$", right: "$", display: false }
           ]
         });
+
+        window.addEventListener(
+          "load",
+          function () {
+            contentElement
+              .querySelectorAll(".katex-display")
+              .forEach(function (displayElement) {
+                const availableWidth = displayElement.clientWidth;
+                const renderedWidth = displayElement.scrollWidth;
+                if (availableWidth > 0 && renderedWidth > availableWidth) {
+                  const fontSize = parseFloat(
+                    window.getComputedStyle(displayElement).fontSize
+                  );
+                  const fittedFontSize =
+                    fontSize * (availableWidth / renderedWidth) * 0.98;
+                  displayElement.style.fontSize = `${fittedFontSize}px`;
+                }
+              });
+          },
+          { once: true }
+        );
       }
     })();
   </script>

--- a/astrbot/core/utils/t2i/template_manager.py
+++ b/astrbot/core/utils/t2i/template_manager.py
@@ -1,15 +1,29 @@
 # astrbot/core/utils/t2i/template_manager.py
 
+import hashlib
 import logging
 import os
 import re
 import shutil
+from pathlib import Path
 
 from astrbot.core.utils.astrbot_path import get_astrbot_data_path, get_astrbot_path
 
 logger = logging.getLogger("astrbot")
 
 _ALLOWED_VARS = frozenset({"text", "version", "shiki_runtime"})
+
+# Built-in base templates copied by releases that support user template overrides.
+# Matching copies are safe to upgrade because their content was never customized.
+_LEGACY_CORE_TEMPLATE_HASHES = {
+    "base.html": frozenset(
+        {
+            "23714149d06b3abdcee3a5ac1aed3a95785efd75a49a3a3f4a8d26e0f84253e1",
+            "380ccf1824c877635bd2e97df3df0f1960166dfa582aebce768b583c4d6c480a",
+            "7d0beae08e25ae51f6b3f8f00338fada559e0b883cef15ec609309d17ba708f0",
+        }
+    )
+}
 
 _SSTI_BLACKLIST: list[tuple[str, re.Pattern]] = [
     (
@@ -83,8 +97,30 @@ class TemplateManager:
                 shutil.copyfile(src, dst)
 
     def _initialize_user_templates(self) -> None:
-        """如果用户目录下缺少核心模板，则进行复制。"""
+        """复制缺失的核心模板，并升级未被用户修改的旧版模板。"""
         self._copy_core_templates(overwrite=False)
+
+        for filename, legacy_hashes in _LEGACY_CORE_TEMPLATE_HASHES.items():
+            src = Path(self.builtin_template_dir) / filename
+            dst = Path(self.user_template_dir) / filename
+            if not src.exists() or not dst.exists():
+                continue
+
+            try:
+                # Text mode normalizes CRLF so unmodified Windows copies also migrate.
+                content = dst.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError) as err:
+                logger.warning(
+                    "Failed to inspect core T2I template %s for migration: %s",
+                    filename,
+                    err,
+                )
+                continue
+
+            content_hash = hashlib.sha256(content.encode()).hexdigest()
+            if content_hash in legacy_hashes:
+                shutil.copyfile(src, dst)
+                logger.info("Updated unmodified core T2I template: %s", filename)
 
     def _get_user_template_path(self, name: str) -> str:
         """获取用户模板的完整路径，防止路径遍历漏洞。"""

--- a/tests/test_t2i_local_strategy.py
+++ b/tests/test_t2i_local_strategy.py
@@ -1,0 +1,83 @@
+import pytest
+
+from astrbot.core.utils.t2i.local_strategy import (
+    CodeBlock,
+    FontManager,
+    HeadingBlock,
+    MarkdownParser,
+    MarkdownRenderer,
+    MathBlock,
+    TableBlock,
+    TextMeasurer,
+)
+
+
+def test_text_measurer_uses_content_and_wraps_to_requested_width() -> None:
+    """Verify measurement uses real text and wrapping never exceeds the limit."""
+    font = FontManager.get_font(24)
+
+    assert (
+        TextMeasurer.get_text_size("WWWW", font)[0]
+        > TextMeasurer.get_text_size("iiii", font)[0]
+    )
+
+    max_width = 180
+    lines = TextMeasurer.split_text_to_fit_width(
+        "这是一段需要自动换行的中文 mixed-with-a-very-long-English-token 内容。",
+        font,
+        max_width,
+    )
+
+    assert len(lines) > 1
+    assert all(TextMeasurer.get_text_size(line, font)[0] <= max_width for line in lines)
+
+
+@pytest.mark.asyncio
+async def test_markdown_parser_recognizes_common_rich_blocks() -> None:
+    """Verify headings, tables, code, and display math receive native blocks."""
+    markdown = """# Heading
+
+| Name | Value |
+| :--- | ---: |
+| Wrap | A long table value |
+
+```python
+print("hello")
+```
+
+$$
+E = mc^2
+$$
+"""
+
+    blocks = await MarkdownParser.parse(markdown)
+
+    assert any(isinstance(block, HeadingBlock) for block in blocks)
+    assert any(isinstance(block, TableBlock) for block in blocks)
+    assert any(isinstance(block, CodeBlock) for block in blocks)
+    assert any(isinstance(block, MathBlock) for block in blocks)
+
+
+@pytest.mark.asyncio
+async def test_markdown_renderer_produces_requested_width_with_wrapped_content() -> (
+    None
+):
+    """Verify a narrow render completes without allowing long content to expand it."""
+    renderer = MarkdownRenderer(font_size=22, width=420)
+    markdown = """## 自动换行
+
+正文包含 **粗体**、`inline_code()` 和一个不会自然断开的超长字符串：abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz。
+
+```python
+result = "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz"
+```
+
+| 项目 | 说明 |
+| --- | --- |
+| 表格 | 这一格也需要在固定宽度里自动换行 |
+"""
+
+    image = await renderer.render(markdown)
+
+    assert image.width == 420
+    assert image.height > 400

--- a/tests/test_t2i_template_manager.py
+++ b/tests/test_t2i_template_manager.py
@@ -1,4 +1,5 @@
 import hashlib
+import re
 from pathlib import Path
 
 import pytest
@@ -8,6 +9,29 @@ from astrbot.core.utils.t2i import template_manager
 LEGACY_TEMPLATE = "<html>\n<body>legacy default</body>\n</html>\n"
 CURRENT_TEMPLATE = "<html>\n<body>current default</body>\n</html>\n"
 CUSTOM_TEMPLATE = "<html>\n<body>customized by user</body>\n</html>\n"
+
+
+def test_default_template_preserves_soft_breaks_and_fits_display_math() -> None:
+    """Verify the default template keeps Markdown and wide-math layout safe."""
+    template_path = (
+        Path(__file__).parents[1]
+        / "astrbot/core/utils/t2i/template/base.html"
+    )
+    template = template_path.read_text(encoding="utf-8")
+
+    paragraph_rule = re.search(r"\n    p \{(?P<body>.*?)\n    \}", template, re.DOTALL)
+    math_rule = re.search(
+        r"\n    \.katex-display \{(?P<body>.*?)\n    \}",
+        template,
+        re.DOTALL,
+    )
+
+    assert paragraph_rule is not None
+    assert "white-space: normal;" in paragraph_rule.group("body")
+    assert math_rule is not None
+    assert "overflow-x: auto;" in math_rule.group("body")
+    assert 'querySelectorAll(".katex-display")' in template
+    assert "renderedWidth > availableWidth" in template
 
 
 @pytest.mark.parametrize(

--- a/tests/test_t2i_template_manager.py
+++ b/tests/test_t2i_template_manager.py
@@ -1,0 +1,70 @@
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from astrbot.core.utils.t2i import template_manager
+
+LEGACY_TEMPLATE = "<html>\n<body>legacy default</body>\n</html>\n"
+CURRENT_TEMPLATE = "<html>\n<body>current default</body>\n</html>\n"
+CUSTOM_TEMPLATE = "<html>\n<body>customized by user</body>\n</html>\n"
+
+
+@pytest.mark.parametrize(
+    ("user_content", "expected_content"),
+    [
+        pytest.param(None, CURRENT_TEMPLATE, id="missing-template"),
+        pytest.param(LEGACY_TEMPLATE, CURRENT_TEMPLATE, id="legacy-template"),
+        pytest.param(
+            LEGACY_TEMPLATE.replace("\n", "\r\n"),
+            CURRENT_TEMPLATE,
+            id="legacy-template-crlf",
+        ),
+        pytest.param(CUSTOM_TEMPLATE, CUSTOM_TEMPLATE, id="custom-template"),
+    ],
+)
+def test_initialize_user_templates_migrates_only_unmodified_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    user_content: str | None,
+    expected_content: str,
+) -> None:
+    """Verify automatic migration preserves customized user templates.
+
+    Args:
+        monkeypatch: Pytest fixture used to isolate AstrBot paths and legacy hashes.
+        tmp_path: Temporary directory used for built-in and user templates.
+        user_content: Existing user template content, or None when it is missing.
+        expected_content: Template content expected after manager initialization.
+    """
+    builtin_root = tmp_path / "astrbot-root"
+    builtin_dir = builtin_root / "astrbot/core/utils/t2i/template"
+    builtin_dir.mkdir(parents=True)
+    (builtin_dir / "base.html").write_text(CURRENT_TEMPLATE, encoding="utf-8")
+
+    data_root = tmp_path / "data"
+    user_dir = data_root / "t2i_templates"
+    if user_content is not None:
+        user_dir.mkdir(parents=True)
+        (user_dir / "base.html").write_text(user_content, encoding="utf-8")
+
+    legacy_hash = hashlib.sha256(LEGACY_TEMPLATE.encode()).hexdigest()
+    monkeypatch.setattr(
+        template_manager,
+        "_LEGACY_CORE_TEMPLATE_HASHES",
+        {"base.html": frozenset({legacy_hash})},
+    )
+    monkeypatch.setattr(
+        template_manager,
+        "get_astrbot_path",
+        lambda: str(builtin_root),
+    )
+    monkeypatch.setattr(
+        template_manager,
+        "get_astrbot_data_path",
+        lambda: str(data_root),
+    )
+
+    template_manager.TemplateManager()
+
+    assert (user_dir / "base.html").read_text(encoding="utf-8") == expected_content


### PR DESCRIPTION
## Summary

- replace the legacy default T2I layout with a restrained editorial design
- use MiSans for body copy and Outfit for the masthead, with the AstrBot favicon embedded inline
- improve Markdown headings, rules, lists, quotes, code blocks, tables, images, and responsive spacing
- retain Shiki highlighting and KaTeX rendering while preventing long content from clipping
- automatically migrate unmodified legacy `base.html` copies while preserving customized user templates
- rewrite the Pillow local renderer with cross-platform CJK font fallback and correct text measurement
- install Noto Sans CJK in the official Docker image so local rendering has Chinese glyph coverage in containers
- add wrapping and native layout for paragraphs, headings, quotes, ordered/task lists, code, tables, images, and readable TeX fallback

## Validation

- `uv run ruff format .`
- `uv run ruff check .`
- `uv run pytest tests/test_t2i_local_strategy.py tests/test_t2i_template_manager.py -q` (7 passed)
- `uv run pytest tests/test_dashboard.py -k 't2i_' -q` (3 passed)
- rendered representative Markdown through AstrBot's built-in remote T2I service, including code, tables, images, and inline/display math
- rendered and visually inspected the same common Markdown cases with the local Pillow strategy

Docker package installation could not be exercised locally because the Docker daemon was unavailable; CI validates the image build.

## Summary by Sourcery

Improve default and local T2I rendering with a refined responsive template and robust rich-Markdown Pillow output.

New Features:
- Introduce a refreshed editorial-style default HTML template with branded typography, inline AstrBot iconography, responsive layout, and improved Markdown presentation.
- Add a native Pillow renderer for rich Markdown content, including styled text, headings, lists, quotes, code, tables, images, and readable TeX fallback.
- Provide cross-platform CJK-aware font selection and accurate text measurement for local rendering.

Bug Fixes:
- Prevent long Markdown, code, tables, and mathematical content from clipping or exceeding the rendered width.
- Preserve customized user templates while automatically upgrading unmodified legacy default templates.
- Ensure local container rendering has Chinese glyph coverage through bundled CJK fonts.

Enhancements:
- Retain Shiki syntax highlighting and KaTeX rendering while improving responsive spacing and display-math fitting.

Build:
- Install Noto Sans CJK fonts in the official Docker image.

Tests:
- Add coverage for local text measurement, Markdown block parsing, fixed-width rendering, default-template layout safeguards, and selective template migration.