### PR TITLE
fix(logging): make console and root logger follow configured log level

### DIFF
--- a/astrbot/core/log.py
+++ b/astrbot/core/log.py
@@ -499,6 +499,32 @@ class LogManager:
             except Exception:
                 logger.setLevel(logging.INFO)
 
+            # Sync the console loguru sink and root logger to the configured
+            try:
+                configured_level = logging.getLevelName(logger.level)
+                if isinstance(configured_level, str):
+                    _loguru.remove(cls._console_sink_id)
+                    cls._console_sink_id = _loguru.add(
+                        sys.stdout,
+                        level=configured_level,
+                        colorize=True,
+                        filter=lambda record: not record["extra"].get(
+                            "is_trace", False
+                        ),
+                        format=(
+                            "<green>[{time:HH:mm:ss.SSS}]</green> {extra[plugin_tag]} "
+                            "<level>[{extra[short_levelname]}]</level>{extra[astrbot_version_tag]} "
+                            "[{extra[source_file]}:{extra[source_line]}]: <level>{message}</level>"
+                        ),
+                    )
+            except Exception:
+                pass
+
+            root_logger = logging.getLogger()
+            root_logger.setLevel(logger.level)
+            for name, level in cls._NOISY_LOGGER_LEVELS.items():
+                logging.getLogger(name).setLevel(level)
+
             # Plugin loggers without an explicit override follow the global level.
             plugin_level = logger.level
             overrides = cls._load_plugin_level_overrides()

--- a/astrbot/core/log.py
+++ b/astrbot/core/log.py
@@ -503,13 +503,12 @@ class LogManager:
             try:
                 configured_level = logging.getLevelName(logger.level)
                 if isinstance(configured_level, str):
-                    _loguru.remove(cls._console_sink_id)
-                    cls._console_sink_id = _loguru.add(
+                    new_sink_id = _loguru.add(
                         sys.stdout,
                         level=configured_level,
                         colorize=True,
-                        filter=lambda record: not record["extra"].get(
-                            "is_trace", False
+                        filter=lambda record: (
+                            not record["extra"].get("is_trace", False)
                         ),
                         format=(
                             "<green>[{time:HH:mm:ss.SSS}]</green> {extra[plugin_tag]} "
@@ -517,6 +516,8 @@ class LogManager:
                             "[{extra[source_file]}:{extra[source_line]}]: <level>{message}</level>"
                         ),
                     )
+                    _loguru.remove(cls._console_sink_id)
+                    cls._console_sink_id = new_sink_id
             except Exception:
                 pass
 


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### 问题描述

从 v4.26 升级到 v4.27 后，终端窗口日志全部刷成 `DEBUG`，即使在 WebUI 配置中把「日志级别」设为 `INFO` 也无效，导致其他关键日志被淹没。WebUI 侧边栏的「平台日志」页面却显示正常。

### 根因分析

v4.27 基于 **loguru + LogBroker** 的新日志架构（`astrbot/core/log.py`），存在两处**硬编码 DEBUG**，绕过了 `log_level` 配置：

1. **console sink 硬编码 `level="DEBUG"`**（`_setup_loguru()`）：终端输出根本不看 `log_level` 配置；
2. **root logger 硬编码 `setLevel(logging.DEBUG)`**（`_setup_root_bridge()`）：所有第三方库（aiohttp、httpx 等）的 DEBUG 日志全部涌入终端。

而 `configure_logger()` 里的 `log_level` 只设置了 `astrbot` logger 自身的级别，**从未同步到 console sink 和 root logger**。所以终端输出永远是 DEBUG，配置形同虚设。

WebUI 平台日志正常，是因为它走的是另一条独立通道（`LogQueueHandler` → `LogBroker` → WebSocket），自带级别过滤。

### 修复方案

在 `configure_logger()` 中，当 `log_level` 生效时：

1. 用配置的级别**重建 loguru console sink**（替换掉硬编码 DEBUG 的那个）；
2. 将 **root logger 的级别同步**为配置级别；
3. 保留原有的 `_NOISY_LOGGER_LEVELS` 第三方库降噪逻辑。

### Modifications / 改动点

改动仅 1 个文件、约 27 行，不影响 WebUI 日志通道、文件日志 sink、插件独立日志级别等既有行为。

### 涉及文件

- `astrbot/core/log.py`

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

- 配置 `log_level: INFO` 后，终端不再输出 DEBUG 日志；
- 配置 `log_level: DEBUG` 时，终端恢复完整 DEBUG 输出；
- WebUI 平台日志功能不受影响。

Before（海量 DEBUG 日志）：
<img width="960" height="510" alt="ea7491b2d8ce11af6a6ec2d91c908026" src="https://github.com/user-attachments/assets/7df8c77e-9710-4d31-a639-dfa3d60b0ada" />

After（不再被 DEBUG 刷屏）：
<img width="960" height="510" alt="image" src="https://github.com/user-attachments/assets/53e853c7-cbcd-4c2f-b868-8a88065d7a2f" />

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Synchronize console and root logging with the configured log level.

Bug Fixes:
- Make console and root logger output honor the configured global log level, preventing DEBUG logs from overwhelming terminals when a higher level is selected.

Enhancements:
- Keep third-party logger noise suppression synchronized while preserving existing WebUI, file, and plugin-specific logging behavior.