### PR TITLE
fix: handle DingTalk app creation status

### DIFF
--- a/astrbot/core/platform/sources/dingtalk/app_registration.py
+++ b/astrbot/core/platform/sources/dingtalk/app_registration.py
@@ -121,7 +121,7 @@ async def poll_dingtalk_app_registration_once(device_code: str) -> dict[str, Any
 
 def dingtalk_registration_poll_result(raw: dict[str, Any]) -> dict[str, Any]:
     status_raw = _string_field(raw, "status").upper()
-    if status_raw == "WAITING":
+    if status_raw in {"WAITING", "CREATING"}:
         return {"status": "pending"}
     if status_raw == "SUCCESS":
         client_id = _string_field(raw, "client_id")

--- a/tests/test_dingtalk_app_registration.py
+++ b/tests/test_dingtalk_app_registration.py
@@ -15,8 +15,11 @@ def test_dingtalk_registration_defaults(monkeypatch):
     assert dingtalk_registration_source() == DEFAULT_DINGTALK_REGISTRATION_SOURCE
 
 
-def test_dingtalk_registration_poll_result_maps_waiting_and_success():
+def test_dingtalk_registration_poll_result_maps_pending_states_and_success():
     assert dingtalk_registration_poll_result({"status": "WAITING"}) == {
+        "status": "pending"
+    }
+    assert dingtalk_registration_poll_result({"status": "CREATING"}) == {
         "status": "pending"
     }
 


### PR DESCRIPTION
## Summary

- treat DingTalk app registration status CREATING as an in-progress state
- keep polling instead of reporting an unknown creation status
- add regression coverage for the pending response

## Testing

- `uv run pytest -q tests/test_dingtalk_app_registration.py tests/test_lark_app_registration.py`
- `uv run ruff check astrbot/core/platform/sources/dingtalk/app_registration.py tests/test_dingtalk_app_registration.py`

## Summary by Sourcery

Keep polling DingTalk app registrations while app creation is still in progress.

Bug Fixes:
- Treat DingTalk app registration status CREATING as pending so registration polling continues instead of reporting an unknown status.

Tests:
- Add regression coverage confirming CREATING maps to the pending registration state.