### PR TITLE
fix(dashboard): show create folder button on mobile in persona manager

### DIFF
--- a/dashboard/src/views/persona/PersonaManager.vue
+++ b/dashboard/src/views/persona/PersonaManager.vue
@@ -36,7 +36,7 @@
                 </v-list-item-title>
               </v-list-item>
               <v-list-item
-                v-if="!hasFolders"
+                v-if="!hasFolders || $vuetify.display.smAndDown"
                 prepend-icon="mdi-folder-plus"
                 @click="showCreateFolderDialog = true"
               >


### PR DESCRIPTION
### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

Fixes #9741 

本次 PR 修改了以下内容: 
- 为 "创建文件夹" 按钮添加了额外的条件 `$vuetify.display.smAndDown`

#### 关于 `$vuetify.display.smAndDown`
如果用户的显示设备为小尺寸，返回 `true`

#### 为什么要添加这个条件？
在移动端下，由于人格设定的侧边栏被隐藏，用户如果需要创建文件夹以存放人格，唯一的方法就是点击创建人格右侧的下拉按钮，找到 “创建文件夹” 。而现版本只添加了 `!hasFolders` 这个条件，也就是说，如果用户在移动端创建了文件夹后，因为 `!hasFolders` 变为了 `false` ，无法再次通过下拉菜单来进行 “创建文件夹” 的操作了。
而添加了 `$vuetify.display.smAndDown` 这个条件后，现在，如果检测到用户的显示设备为小尺寸 (`≥960px`) ，则在下拉菜单继续保留 “创建文件夹” 这个操作。

#### 会影响原来的桌面端操作吗
**不会**。因为 `$vuetify.display.smAndDown`  只对小窗口生效；在中等窗口和大窗口中，由于存在侧边栏，而侧边栏已经有 “创建文件夹” 的按钮了。因此，如果人格设定中，存在文件夹，那么桌面端继续保持从侧边栏的 “创建文件夹” 按钮进行交互。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

#### Before / 改动前
由于用户已经新建了文件夹，且没有侧边栏，用户无法再进行 “创建文件夹” 的操作了。

<img width="144" height="320" alt="Screenshot_2026-08-26-10-38-55-720_mark via" src="https://github.com/user-attachments/assets/71400002-568b-40ff-a183-bc9248e732c4" />

#### After / 改动后
添加了条件 `$vuetify.display.smAndDown` ，现在用户即使创建了文件夹，仍然可以再创建文件夹。

<img width="144" height="320" alt="Screenshot_2026-08-26-10-38-35-669_mark via" src="https://github.com/user-attachments/assets/a57d5de5-ab97-4c01-afc3-19d847d03a16" />

并且，原来桌面端的操作逻辑保持不变，仍然是通过侧边栏新建文件夹。

<img width="3184" height="1736" alt="Snipaste_2026-08-26_10-58-30" src="https://github.com/user-attachments/assets/40de6dd7-5bf7-4688-9874-52f27d55a3ed" />

<div align="center">大窗口尺寸</div>

<img width="2352" height="1436" alt="Snipaste_2026-08-26_10-58-42" src="https://github.com/user-attachments/assets/7bb62bdb-38ef-414b-967f-c38b781fc272" />

<div align="center">中等窗口尺寸</div>

<img width="1830" height="1436" alt="Snipaste_2026-08-26_10-58-50" src="https://github.com/user-attachments/assets/4f2df6ad-1f77-4338-a3c2-872e9a7dcb86" />

<div align="center">小窗口尺寸</div>

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Keep the create-folder action available in the persona manager on small screens, including after folders already exist.