### PR TITLE
fix: isolate rate limits by unified message origin

### DIFF
--- a/astrbot/core/pipeline/rate_limit_check/stage.py
+++ b/astrbot/core/pipeline/rate_limit_check/stage.py
@@ -54,7 +54,7 @@ class RateLimitStage(Stage):
             MessageEventResult: 继续或停止事件处理的结果。
 
         """
-        session_id = event.session_id
+        session_id = event.unified_msg_origin
 
         async with self.locks[session_id]:  # 确保同一会话不会并发修改队列
             now = datetime.now()

--- a/astrbot/core/pipeline/rate_limit_check/stage.py
+++ b/astrbot/core/pipeline/rate_limit_check/stage.py
@@ -54,13 +54,13 @@ class RateLimitStage(Stage):
             MessageEventResult: 继续或停止事件处理的结果。
 
         """
-        session_id = event.unified_msg_origin
+        umo = event.unified_msg_origin
 
-        async with self.locks[session_id]:  # 确保同一会话不会并发修改队列
+        async with self.locks[umo]:  # 确保同一会话不会并发修改队列
             now = datetime.now()
             # 检查并处理限流，可能需要多次检查直到满足条件
             while True:
-                timestamps = self.event_timestamps[session_id]
+                timestamps = self.event_timestamps[umo]
                 self._remove_expired_timestamps(timestamps, now)
 
                 if self.rate_limit_count <= 0:
@@ -74,7 +74,7 @@ class RateLimitStage(Stage):
                 match self.rl_strategy:
                     case RateLimitStrategy.STALL.value:
                         logger.info(
-                            f"Session {session_id} was rate-limited. Processing will "
+                            f"Session {umo} was rate-limited. Processing will "
                             f"pause for {stall_duration:.2f} seconds according to the "
                             "rate-limit policy.",
                         )
@@ -82,7 +82,7 @@ class RateLimitStage(Stage):
                         now = datetime.now()
                     case RateLimitStrategy.DISCARD.value:
                         logger.info(
-                            f"Session {session_id} was rate-limited. This request was "
+                            f"Session {umo} was rate-limited. This request was "
                             "discarded according to the rate-limit policy; the limit "
                             f"resets in {stall_duration:.2f} seconds.",
                         )

--- a/tests/test_rate_limit_stage.py
+++ b/tests/test_rate_limit_stage.py
@@ -109,5 +109,5 @@ async def test_stalled_concurrent_events_use_current_time_after_lock(monkeypatch
     margin = 0.3
     expected_stall = limiter.rate_limit_time.total_seconds() + margin
     assert sleep_durations == pytest.approx([expected_stall, expected_stall])
-    timestamps = list(limiter.event_timestamps[FakeEvent.session_id])
+    timestamps = list(limiter.event_timestamps[FakeEvent.unified_msg_origin])
     assert timestamps == sorted(timestamps)

--- a/tests/test_rate_limit_stage.py
+++ b/tests/test_rate_limit_stage.py
@@ -11,9 +11,56 @@ class FakeEvent:
     """Minimal message event used by the rate-limit stage tests."""
 
     session_id = "test-session"
+    unified_msg_origin = "test-platform:GroupMessage:test-session"
+
+    def __init__(
+        self,
+        session_id: str = session_id,
+        unified_msg_origin: str = unified_msg_origin,
+    ) -> None:
+        """Initialize a fake event with scoped and unscoped session IDs.
+
+        Args:
+            session_id: Platform-local session identifier.
+            unified_msg_origin: Platform-scoped message origin.
+        """
+        self.session_id = session_id
+        self.unified_msg_origin = unified_msg_origin
+        self.stopped = False
 
     def stop_event(self) -> None:
         """Stop event propagation for discard-strategy compatibility."""
+        self.stopped = True
+
+
+@pytest.mark.asyncio
+async def test_different_platforms_do_not_share_rate_limit_state():
+    """Ensure identical session IDs remain isolated across platform instances."""
+    limiter = rate_limit_stage.RateLimitStage()
+    limiter.rate_limit_count = 1
+    limiter.rate_limit_time = timedelta(seconds=60)
+    limiter.rl_strategy = "discard"
+
+    first_event = FakeEvent(
+        session_id="same-session",
+        unified_msg_origin="platform-a:GroupMessage:same-session",
+    )
+    second_event = FakeEvent(
+        session_id="same-session",
+        unified_msg_origin="platform-b:GroupMessage:same-session",
+    )
+
+    await limiter.process(first_event)
+    await limiter.process(second_event)
+
+    expected_keys = {
+        first_event.unified_msg_origin,
+        second_event.unified_msg_origin,
+    }
+    assert not first_event.stopped
+    assert not second_event.stopped
+    assert set(limiter.event_timestamps) == expected_keys
+    assert set(limiter.locks) == expected_keys
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #9796.

`RateLimitStage` previously used the platform-local `event.session_id` as
the key for both rate-limit timestamp queues and locks.

Different adapter instances can produce identical session IDs. For example,
two aiocqhttp bot instances in the same group can produce the same local
session ID for messages from the same user. When those instances use the
same configuration profile, traffic handled by one bot can incorrectly
consume another bot's rate-limit quota or block it on the same lock.

### Modifications / 改动点

- Use `event.unified_msg_origin` as the key for rate-limit timestamp queues
  and locks.
- Preserve the configured session isolation behavior while additionally
  scoping rate-limit state by adapter instance and message type.
- Add a regression test with two events that have:
  - the same platform-local `session_id`;
  - different `unified_msg_origin` values.
- Verify that both events are accepted and use separate timestamp queues
  and locks.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

#### Regression verification

Before the production code change, the new regression test failed because
the second adapter event was incorrectly discarded:

```text
FAILED test_different_platforms_do_not_share_rate_limit_state

assert not second_event.stopped
E       assert not True
```

The rate limiter also logged:

```text
Session same-session was rate-limited.
This request was discarded according to the rate-limit policy.
```

After changing the key to `event.unified_msg_origin`, the regression test
passes and the two events use separate timestamp queues and locks.

#### Verification steps

```bash
uv run pytest tests/test_rate_limit_stage.py -q
```

```text
2 passed, 1 warning
```

```bash
uv run pytest tests/test_smoke.py -q
```

```text
6 passed, 2 warnings
```

```bash
uv run ruff format .
```

```text
497 files left unchanged
```

```bash
uv run ruff check .
```

```text
All checks passed!
```

```bash
git diff --check
```

```text
Passed with no output.
```

The reported warnings are existing third-party deprecation warnings and are
unrelated to this change.

---

### Checklist / 检查清单

- [x] 😊 Not applicable; this PR fixes an existing bug discussed in #9796.
- [x] 👀 My changes have been well-tested, and verification steps and test
  results have been provided above.
- [x] 🤓 No new dependencies are introduced.
- [x] 😮 My changes do not introduce malicious code.

## Summary by Sourcery

Isolate rate-limit tracking and locking by unified message origin to prevent cross-adapter interference.

Bug Fixes:
- Prevent rate-limit quotas and locks from being incorrectly shared by adapter instances with identical platform-local session IDs.

Enhancements:
- Scope rate-limit state and concurrency control by unified message origin while preserving configured session isolation behavior.

Tests:
- Add regression coverage confirming events with identical local session IDs but distinct unified origins use independent rate-limit state.