### PR TITLE
fix: keep proactive agent history in contexts

### DIFF
--- a/astrbot/core/astr_agent_tool_exec.py
+++ b/astrbot/core/astr_agent_tool_exec.py
@@ -565,15 +565,7 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
         req = ProviderRequest()
         conv = await _get_session_conv(event=cron_event, plugin_context=ctx)
         req.conversation = conv
-        context = json.loads(conv.history)
-        if context:
-            req.contexts = context
-            context_dump = req._print_friendly_context()
-            req.contexts = []
-            req.system_prompt += (
-                "\n\nBellow is you and user previous conversation history:\n"
-                f"{context_dump}"
-            )
+        req.contexts = json.loads(conv.history)
 
         bg = json.dumps(extras["background_task_result"], ensure_ascii=False)
         req.system_prompt += BACKGROUND_TASK_RESULT_WOKE_SYSTEM_PROMPT.format(

--- a/astrbot/core/cron/manager.py
+++ b/astrbot/core/cron/manager.py
@@ -458,18 +458,7 @@ class CronJobManager:
         req = ProviderRequest()
         conv = await _get_session_conv(event=cron_event, plugin_context=self.ctx)
         req.conversation = conv
-        # finetine the messages
-        context = json.loads(conv.history)
-        if context:
-            req.contexts = context
-            context_dump = req._print_friendly_context()
-            req.contexts = []
-            req.system_prompt += (
-                "\n\nBellow is you and user previous conversation history:\n"
-                f"---\n"
-                f"{context_dump}\n"
-                f"---\n"
-            )
+        req.contexts = json.loads(conv.history)
         cron_job_str = json.dumps(extras.get("cron_job", {}), ensure_ascii=False)
         req.system_prompt += PROACTIVE_AGENT_CRON_WOKE_SYSTEM_PROMPT.format(
             cron_job=cron_job_str

--- a/tests/unit/test_astr_agent_tool_exec.py
+++ b/tests/unit/test_astr_agent_tool_exec.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -366,18 +367,23 @@ async def test_execute_handoff_passes_tool_call_timeout_to_tool_loop_agent(
 
 
 @pytest.mark.asyncio
-async def test_background_wakeup_passes_provider_settings_to_main_agent(
+async def test_background_wakeup_passes_history_and_provider_settings_to_main_agent(
     monkeypatch: pytest.MonkeyPatch,
 ):
+    """Test background wakeup keeps structured history and provider settings."""
     provider_settings = {
         "fallback_chat_models": ["fallback-provider"],
         "request_max_retries": 3,
         "stream": True,
     }
+    history = [
+        {"role": "user", "content": "old question"},
+        {"role": "assistant", "content": "old answer"},
+    ]
     captured: dict = {}
 
     async def _fake_get_session_conv(**_kwargs):
-        return SimpleNamespace(history="[]")
+        return SimpleNamespace(history=json.dumps(history))
 
     async def _fake_build_main_agent(**kwargs):
         captured.update(kwargs)
@@ -428,6 +434,10 @@ async def test_background_wakeup_passes_provider_settings_to_main_agent(
     assert config.streaming_response == provider_settings["stream"]
     assert config.provider_settings == provider_settings
     assert config.provider_settings["fallback_chat_models"] == ["fallback-provider"]
+    request = captured["req"]
+    assert "old question" not in request.system_prompt
+    assert "old answer" not in request.system_prompt
+    assert request.contexts == history
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_cron_manager.py
+++ b/tests/unit/test_cron_manager.py
@@ -1,5 +1,6 @@
 """Tests for CronJobManager."""
 
+import json
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 from zoneinfo import ZoneInfo
@@ -585,8 +586,10 @@ class TestRunActiveAgentJob:
     """Tests for active agent cron job execution."""
 
     @pytest.mark.asyncio
-    async def test_woke_main_agent_passes_provider_settings(self, cron_manager):
-        """Test active cron agent keeps fallback chat model settings."""
+    async def test_woke_main_agent_passes_history_and_provider_settings(
+        self, cron_manager
+    ):
+        """Test active cron agent keeps structured history and provider settings."""
         provider_settings = {
             "tool_call_timeout": 77,
             "fallback_chat_models": ["fallback-provider"],
@@ -598,8 +601,12 @@ class TestRunActiveAgentJob:
         }
         cron_manager.ctx = ctx
 
+        history = [
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+        ]
         conv = MagicMock()
-        conv.history = "[]"
+        conv.history = json.dumps(history)
 
         class FakeRunner:
             def step_until_done(self, max_step):
@@ -616,6 +623,7 @@ class TestRunActiveAgentJob:
 
         async def fake_build_main_agent(*, event, plugin_context, config, req):
             captured["config"] = config
+            captured["req"] = req
             return MagicMock(agent_runner=FakeRunner())
 
         async def fake_persist_agent_history(*args, **kwargs):
@@ -645,6 +653,10 @@ class TestRunActiveAgentJob:
         assert config.tool_call_timeout == 77
         assert config.provider_settings is provider_settings
         assert config.provider_settings["fallback_chat_models"] == ["fallback-provider"]
+        request = captured["req"]
+        assert "old question" not in request.system_prompt
+        assert "old answer" not in request.system_prompt
+        assert request.contexts == history
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #9763.

Cron and background-task wakeups serialized the complete conversation history
into `system_prompt` and then cleared `req.contexts`. Because system messages
are preserved during context truncation, long histories could not be removed
when the provider reported a context-length error.

### Modifications / 改动点

- Preserve conversation history as structured `req.contexts` for cron-triggered agent wakeups.
- Apply the same behavior to background-task result wakeups.
- Keep the original `user` and `assistant` roles instead of serializing history into `system_prompt`.
- Allow the existing context truncation and compression pipeline to process proactive-agent history normally.
- Add regression tests for both wakeup paths, verifying that history remains in `contexts` and is not duplicated in `system_prompt`.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

The new regression tests failed before the fix because the historical messages were present in `system_prompt`. They pass after preserving the history in `req.contexts`.

```text
$ uv run pytest tests/unit/test_cron_manager.py::TestRunActiveAgentJob::test_woke_main_agent_passes_history_and_provider_settings tests/unit/test_astr_agent_tool_exec.py::test_background_wakeup_passes_history_and_provider_settings_to_main_agent
2 passed, 1 warning

$ uv run pytest tests/unit/test_cron_manager.py tests/unit/test_astr_agent_tool_exec.py
59 passed, 1 warning

$ uv run ruff format .
497 files left unchanged

$ uv run ruff check .
All checks passed!
```

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

  Bug fix only; no new features are introduced.

- [x] 👀 My changes have been well-tested, and verification steps and results have been provided above.
  / 我的更改经过了良好的测试，并已在上方提供验证步骤和测试结果。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者已将新依赖添加到相应文件中。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改不包含恶意代码。

## Summary by Sourcery

Keep proactive-agent history in structured request contexts for cron and background-task wakeups.

Bug Fixes:
- Preserve proactive-agent conversation history as structured contexts during cron and background-task wakeups so context truncation and compression can handle long histories correctly.

Tests:
- Add regression coverage confirming both proactive wakeup paths retain user and assistant history in contexts without duplicating it in the system prompt.