### PR TITLE
fix: hide internal personal WeChat settings

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -19,11 +19,13 @@ PERSONAL_WECHAT_CONFIG_METADATA = {
         "description": "扫码参数 bot_type",
         "type": "string",
         "hint": "默认值: 3",
+        "invisible": True,
     },
     "weixin_oc_qr_poll_interval": {
         "description": "二维码状态轮询间隔（秒）",
         "type": "int",
         "hint": "每隔多少秒轮询一次二维码状态。",
+        "invisible": True,
     },
     "weixin_oc_long_poll_timeout_ms": {
         "description": "getUpdates 长轮询超时时间（毫秒）",
@@ -40,7 +42,11 @@ PERSONAL_WECHAT_CONFIG_METADATA = {
         "type": "string",
         "hint": "扫码登录成功后会自动写入；高级场景可手动填写。",
         "secret": True,
+        "invisible": True,
     },
+    "weixin_oc_account_id": {"invisible": True},
+    "weixin_oc_sync_buf": {"invisible": True},
+    "weixin_oc_context_tokens": {"invisible": True},
 }
 
 WEBHOOK_SUPPORTED_PLATFORMS = [

--- a/tests/test_weixin_oc_config_metadata.py
+++ b/tests/test_weixin_oc_config_metadata.py
@@ -1,0 +1,28 @@
+"""Tests for personal WeChat configuration metadata."""
+
+from astrbot.core.config.default import PERSONAL_WECHAT_CONFIG_METADATA
+
+
+def test_personal_wechat_only_exposes_user_adjustable_fields():
+    """Show only the personal WeChat fields intended for user adjustment."""
+    visible_fields = {
+        key
+        for key, metadata in PERSONAL_WECHAT_CONFIG_METADATA.items()
+        if not metadata.get("invisible", False)
+    }
+
+    assert visible_fields == {
+        "weixin_oc_base_url",
+        "weixin_oc_long_poll_timeout_ms",
+        "weixin_oc_api_timeout_ms",
+    }
+
+
+def test_personal_wechat_runtime_state_fields_are_hidden():
+    """Hide login state persisted outside the personal WeChat template."""
+    for key in (
+        "weixin_oc_account_id",
+        "weixin_oc_sync_buf",
+        "weixin_oc_context_tokens",
+    ):
+        assert PERSONAL_WECHAT_CONFIG_METADATA[key]["invisible"] is True


### PR DESCRIPTION
## Summary
- show only the Base URL and timeout settings for personal WeChat
- hide login parameters and persisted runtime state from the dashboard
- add regression coverage for visible personal WeChat fields

## Testing
- uv run pytest tests/test_weixin_oc_config_metadata.py tests/test_weixin_oc_login_registration.py tests/test_weixin_oc_state_persistence.py
- uv run ruff format .
- uv run ruff check .

## Summary by Sourcery

Hide internal personal WeChat configuration and expose only user-adjustable connection settings.

Bug Fixes:
- Hide personal WeChat login parameters and persisted runtime state from the configuration dashboard.

Enhancements:
- Limit visible personal WeChat settings to the Base URL and timeout options.

Tests:
- Add regression coverage verifying the personal WeChat dashboard fields and runtime state visibility.