### PR TITLE
fix(provider): make OpenAI-compatible reasoning field name configurable per channel (#9783)

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -2235,6 +2235,11 @@ CONFIG_METADATA_2 = {
                         "type": "bool",
                         "hint": "关闭 Ollama 思考模式。",
                     },
+                    "reasoning_key": {
+                        "description": "思考内容字段名",
+                        "type": "string",
+                        "hint": "从响应中提取思考内容的字段名。默认 reasoning_content（DeepSeek/Moonshot/阿里百炼等）；OpenRouter 及其兼容中转渠道使用 reasoning。",
+                    },
                     "custom_extra_body": {
                         "description": "自定义请求体参数",
                         "type": "dict",

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -396,7 +396,13 @@ class ProviderOpenAIOfficial(Provider):
         model = provider_config.get("model", "unknown")
         self.set_model(model)
 
-        self.reasoning_key = "reasoning_content"
+        # Different upstream/relay channels name the thinking field
+        # differently (e.g. reasoning_content for DeepSeek/Moonshot,
+        # reasoning for OpenRouter-style relays), so allow overriding it
+        # via the provider config. See issue #9783.
+        self.reasoning_key = (
+            provider_config.get("reasoning_key") or "reasoning_content"
+        )
 
     def _ollama_disable_thinking_enabled(self) -> bool:
         value = self.provider_config.get("ollama_disable_thinking", False)
@@ -1036,7 +1042,9 @@ class ProviderOpenAIOfficial(Provider):
                 # When all parts were think blocks, fall back to None.
                 message["content"] = new_content or None
                 if reasoning_content_present:
-                    message["reasoning_content"] = reasoning_content
+                    # Emit the thinking history under the configured key so
+                    # channels that expect `reasoning` (issue #9783) accept it.
+                    message[self.reasoning_key] = reasoning_content
 
             if (
                 message.get("role") == "assistant"

--- a/astrbot/core/provider/sources/openai_source.py
+++ b/astrbot/core/provider/sources/openai_source.py
@@ -455,13 +455,18 @@ class ProviderOpenAIOfficial(Provider):
             raise Exception(f"获取模型列表失败：{e}")
 
     @staticmethod
-    def _sanitize_assistant_messages(payloads: dict) -> None:
+    def _sanitize_assistant_messages(
+        payloads: dict, reasoning_key: str = "reasoning_content"
+    ) -> None:
         """在请求发送前过滤/规范化空的 assistant 消息。
 
         严格 API（Moonshot、DeepSeek Reasoner 等）会在 assistant 消息同时缺少
         ``content`` 和 ``tool_calls`` 时返回 400。把 ``""`` / ``None`` / ``[]``
         都视作空内容：无 tool_calls 时整条过滤掉；有 tool_calls 时将 content
         设为 ``None`` 以符合 OpenAI 规范。就地修改 ``payloads["messages"]``。
+
+        ``reasoning_key`` 是思考历史的字段名（可经 provider 配置 ``reasoning_key``
+        覆盖，issue #9783）；同时兼容默认 ``reasoning_content`` 的历史存量消息。
         """
         messages = payloads.get("messages")
         if not isinstance(messages, list):
@@ -478,7 +483,11 @@ class ProviderOpenAIOfficial(Provider):
 
             content = msg.get("content")
             tool_calls = msg.get("tool_calls")
-            reasoning_content = msg.get("reasoning_content")
+            # Follow the configured reasoning key (#9783); fall back to the
+            # default key so history saved by older versions is not dropped.
+            reasoning_content = msg.get(reasoning_key) or msg.get(
+                "reasoning_content"
+            )
 
             if _is_empty(content) and not tool_calls:
                 if not reasoning_content:
@@ -569,7 +578,7 @@ class ProviderOpenAIOfficial(Provider):
 
         model = payloads.get("model", "").lower()
 
-        self._sanitize_assistant_messages(payloads)
+        self._sanitize_assistant_messages(payloads, self.reasoning_key)
 
         completion = await retry_provider_request(
             "OpenAI",
@@ -627,7 +636,7 @@ class ProviderOpenAIOfficial(Provider):
             del payloads[key]
         self._apply_provider_specific_request_overrides(payloads, extra_body)
 
-        self._sanitize_assistant_messages(payloads)
+        self._sanitize_assistant_messages(payloads, self.reasoning_key)
 
         stream = await retry_provider_request(
             "OpenAI",

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -5,7 +5,11 @@ from types import SimpleNamespace
 
 import httpx
 import pytest
-from openai.types.chat.chat_completion import ChatCompletion
+from openai.types.chat.chat_completion import (
+    ChatCompletion,
+    ChatCompletionMessage,
+    Choice,
+)
 from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
 from PIL import Image as PILImage
 
@@ -396,6 +400,71 @@ async def test_groq_payload_drops_reasoning_content_from_assistant_history():
         ]
         assert "reasoning_content" not in assistant_message
         assert "reasoning" not in assistant_message
+    finally:
+        await provider.terminate()
+
+
+def _make_reasoning_completion(
+    thinking_field: str,
+) -> ChatCompletion:
+    kwargs = {thinking_field: "thoughts"}
+    message = ChatCompletionMessage(role="assistant", content="answer", **kwargs)
+    return ChatCompletion(
+        id="chatcmpl-reasoning-test",
+        choices=[Choice(index=0, finish_reason="stop", message=message)],
+        created=1,
+        model="test-model",
+        object="chat.completion",
+    )
+
+
+@pytest.mark.asyncio
+async def test_reasoning_key_configurable_extracts_alias_field():
+    """reasoning_key 可配置：按配置字段名提取思考内容 (#9783)"""
+    provider = _make_provider({"reasoning_key": "reasoning"})
+    try:
+        completion = _make_reasoning_completion("reasoning")
+        assert provider._extract_reasoning_content(completion) == "thoughts"
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_reasoning_key_default_keeps_reasoning_content_behavior():
+    """默认 key 仍为 reasoning_content，不取 reasoning 别名（行为不回归）"""
+    provider = _make_provider()
+    try:
+        aliased = _make_reasoning_completion("reasoning")
+        assert provider._extract_reasoning_content(aliased) is None
+        standard = _make_reasoning_completion("reasoning_content")
+        assert provider._extract_reasoning_content(standard) == "thoughts"
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_reasoning_key_applied_to_assistant_history_payload():
+    """配置 reasoning_key 后，历史 think 内容写入配置的字段名 (#9783)"""
+    provider = _make_provider({"reasoning_key": "reasoning"})
+    try:
+        payloads = {
+            "model": "test-model",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "think", "think": "step 1"},
+                        {"type": "text", "text": "final answer"},
+                    ],
+                }
+            ],
+        }
+
+        provider._finally_convert_payload(payloads)
+
+        assistant_message = payloads["messages"][0]
+        assert assistant_message["reasoning"] == "step 1"
+        assert "reasoning_content" not in assistant_message
     finally:
         await provider.terminate()
 

--- a/tests/test_openai_source.py
+++ b/tests/test_openai_source.py
@@ -470,6 +470,62 @@ async def test_reasoning_key_applied_to_assistant_history_payload():
 
 
 @pytest.mark.asyncio
+async def test_sanitize_assistant_messages_uses_configured_reasoning_key():
+    """reasoning_key='reasoning' 时，think-only 历史不被误删为空消息 (#9783, PR #9829 review)"""
+    provider = _make_provider({"reasoning_key": "reasoning"})
+    try:
+        payloads = {
+            "model": "test-model",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [{"type": "think", "think": "step 1"}],
+                }
+            ],
+        }
+
+        provider._finally_convert_payload(payloads)
+        provider._sanitize_assistant_messages(payloads, provider.reasoning_key)
+
+        assert len(payloads["messages"]) == 1
+        assistant_message = payloads["messages"][0]
+        assert assistant_message["reasoning"] == "step 1"
+        assert assistant_message["content"] == ""
+    finally:
+        await provider.terminate()
+
+
+def test_sanitize_assistant_messages_keeps_custom_key_only_history():
+    """自定义 reasoning_key 下：该字段或默认字段的思考历史都保留，真空消息仍丢弃"""
+    payloads = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": None,
+                "reasoning": "thinking under custom key",
+            },
+            {
+                "role": "assistant",
+                "content": None,
+                "reasoning_content": "legacy thinking under default key",
+            },
+            {"role": "assistant", "content": None},
+        ]
+    }
+
+    ProviderOpenAIOfficial._sanitize_assistant_messages(payloads, "reasoning")
+
+    assert len(payloads["messages"]) == 2
+    assert payloads["messages"][0]["reasoning"] == "thinking under custom key"
+    assert payloads["messages"][0]["content"] == ""
+    assert (
+        payloads["messages"][1]["reasoning_content"]
+        == "legacy thinking under default key"
+    )
+    assert payloads["messages"][1]["content"] == ""
+
+
+@pytest.mark.asyncio
 async def test_handle_api_error_content_moderated_without_images_raises():
     provider = _make_provider(
         {"image_moderation_error_patterns": ["file:content-moderated"]}


### PR DESCRIPTION
> Note: PR #9828 was closed automatically when its head branch was recreated (an accidental line-ending noise made the first diff enormous). This is the clean version: **3 files, +85/-3, rebased onto the latest master**.

Fixes #9783

## Problem / 问题

The generic OpenAI-compatible provider hard-codes the thinking field name in `astrbot/core/provider/sources/openai_source.py`:

    self.reasoning_key = "reasoning_content"

Different upstreams name this field differently: DeepSeek / Moonshot and most OpenAI-compatible providers use `reasoning_content`, while OpenRouter and OpenRouter-style relay channels (e.g. cline-pass) use `reasoning`. As a result, when such a relay serves kimi-k3, thinking content is silently dropped in AstrBot even though the same API key works fine in other frontends. The repo already adapts specific sources by subclass overrides (`groq_source.py` / `openrouter_source.py` set `reasoning_key = "reasoning"`), but the generic `openai_chat_completion` channel has no way to benefit.

问题：openai_source.py 将思考内容字段名硬编码为 reasoning_content，而 OpenRouter 系中转渠道使用 reasoning 字段，导致思考内容完全丢失。

## Solution / 修复方案

Implements Option 1 from the issue (per-channel config item, minimal change and most flexible):

- `self.reasoning_key = provider_config.get("reasoning_key") or "reasoning_content"` — reads the field name from provider config; the default is unchanged, so existing users see zero behavior change
- New `reasoning_key` entry in the WebUI config schema (`default.py`, CONFIG_METADATA_2) with description / type / hint
- Multi-turn history round-trip also respects the configured key (see below)

方案：按 issue 方案 1 新增渠道配置项 reasoning_key，默认值不变（存量用户零回归），WebUI 配置档可见可填。

## Notable detail (hidden fix) / 隐藏点修复

`_finally_convert_payload` re-emitted assistant think history as `message["reasoning_content"]` — also hard-coded. With only the extraction side fixed, a relay expecting `reasoning` would still receive the next-turn history under the wrong key. This PR emits history under the same configured `self.reasoning_key`.

隐藏点：多轮对话历史回传同样硬编码了 reasoning_content——只修提取侧时，第二轮起上游仍收到错误字段名的思考历史。本 PR 让历史回传使用同一配置字段名。

## Scope notes / 范围说明

- Auto-detection (Option 2, candidate-key list) intentionally not implemented: the project already adapts via explicit subclass overrides, a config key covers all remaining cases, and Option 1 is what the issue author prefers.
- The model-specific `reasoning_content` handling in the DeepSeek-v4 / MiMo branches is intentionally untouched — that is the official DeepSeek API protocol (missing the field causes HTTP 400), unrelated to relay field dialects.

## Testing / 测试

3 new tests in `tests/test_openai_source.py`:

- `test_reasoning_key_configurable_extracts_alias_field` — with `reasoning_key: reasoning`, thinking content is extracted from the alias field
- `test_reasoning_key_default_keeps_reasoning_content_behavior` — without the config, behavior is unchanged (alias ignored, `reasoning_content` still works)
- `test_reasoning_key_applied_to_assistant_history_payload` — assistant think history is emitted under the configured key (and `reasoning_content` is not)

pytest results:

    $ python -m pytest tests/test_openai_source.py -k reasoning -q
    6 passed, 60 deselected in 4.38s   (3 new + 3 existing reasoning tests)

    $ python -m pytest tests/test_openai_source.py -q
    3 failed, 63 passed in 5.60s

The 3 failures are the pre-existing `test_file_uri_to_path_*` Windows-only path tests — verified identical on the unmodified baseline via `git stash`; project CI runs on Linux.

## Changes / 改动文件

- `astrbot/core/provider/sources/openai_source.py` — configurable reasoning_key for extraction + history round-trip
- `astrbot/core/config/default.py` — reasoning_key config schema
- `tests/test_openai_source.py` — 3 new tests

3 files, +85 / -3.

## Summary by Sourcery

Make the OpenAI-compatible provider’s reasoning field configurable per channel while retaining the existing default behavior.

New Features:
- Add a per-channel configuration option for selecting the reasoning field name used by OpenAI-compatible providers.

Bug Fixes:
- Preserve reasoning content for providers and relays that use `reasoning` instead of `reasoning_content`, including across multi-turn assistant history.

Tests:
- Add coverage for configurable reasoning extraction, default behavior, and assistant history serialization.