### PR TITLE
fix(dashboard): reset persona folder after deletion

### DIFF
--- a/dashboard/src/stores/personaStore.ts
+++ b/dashboard/src/stores/personaStore.ts
@@ -259,17 +259,23 @@ export const usePersonaStore = defineStore("persona", {
      * 删除文件夹
      */
     async deleteFolder(folderId: string): Promise<void> {
+      const deletedFolder = this.findFolderInTree(folderId);
+      const isCurrentFolderDeleted =
+        this.currentFolderId === folderId ||
+        this.breadcrumbPath.some(folder => folder.folder_id === folderId);
       const response = await personaApi.deleteFolder(folderId);
 
       if (response.data.status !== 'ok') {
         throw new Error(response.data.message || '删除文件夹失败');
       }
 
-      // 刷新当前文件夹内容和文件夹树
-      await Promise.all([
-        this.refreshCurrentFolder(),
-        this.loadFolderTree(),
-      ]);
+      // If the active folder was deleted, return to its parent instead of
+      // keeping a stale folder ID that would hide moved personas and folders.
+      const targetFolderId = isCurrentFolderDeleted
+        ? deletedFolder?.parent_id ?? null
+        : this.currentFolderId;
+      await this.loadFolderTree();
+      await this.navigateToFolder(targetFolderId);
     },
 
     /**


### PR DESCRIPTION
## Summary
- navigate to the parent or root when the active persona folder is deleted
- reload the folder tree before refreshing the destination folder
- preserve the existing empty-root layout without a folder sidebar

## Validation
- `cd dashboard && pnpm typecheck`
- `cd dashboard && pnpm build`
- `uv run ruff format --check .`
- `uv run ruff check .`

## Summary by Sourcery

Reset persona navigation to a valid parent or root folder after deleting the active folder.

Bug Fixes:
- Return to the deleted persona folder’s parent or the root when the active folder is removed, preventing stale folder selections from hiding content.

Enhancements:
- Reload the persona folder tree before refreshing and navigating to the destination folder while preserving the empty-root layout without a folder sidebar.