### PR TITLE
fix(agent): run response hooks before yielding llm_result in skills_like fallback (#9788)

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -947,6 +947,10 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                     logger.warning(
                         "skills_like tool re-query returned no tool calls; fallback to assistant response."
                     )
+                    # Complete the assistant response (including hooks) BEFORE
+                    # yielding llm_result so response hooks run before the
+                    # result is sent to the user (#9788).
+                    await self._complete_with_assistant_response(llm_resp)
                     if llm_resp.reasoning_content:
                         yield AgentResponse(
                             type="llm_result",
@@ -969,7 +973,6 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                             ),
                         )
 
-                    await self._complete_with_assistant_response(llm_resp)
                     # Re-query uses text_chat(), so its reply has no stream chunks.
                     # Supply them after hooks without changing llm_result ordering.
                     if self.streaming:


### PR DESCRIPTION
## What Problem This Solves

In the `skills_like` tool requery fallback path, the runner yields `llm_result` (sending the response to the user) **before** calling `_complete_with_assistant_response`, which triggers `on_agent_done` hooks. Plugins doing content safety review, sanitization, or rewriting cannot affect text that has already been sent.

## Why This Change Was Made

When `tool_schema_mode=skills_like` and the model initially selects a tool but the schema requery returns a plain assistant response (no tool calls), the fallback branch at `tool_loop_agent_runner.py:934` yields the response to the user before the response hooks run. The normal no-tool path already has the correct order (complete first, then yield); this fallback branch was missed.

## User Impact

Response hooks (content safety, sanitization, rewriting, audit) now run before the response reaches the user in the `skills_like` fallback path, matching the behavior of the normal no-tool path.

## Evidence

- Issue: https://github.com/AstrBotDevs/AstrBot/issues/9788
- Root cause confirmed at `tool_loop_agent_runner.py:934-962` — yields before `_complete_with_assistant_response`
- `_complete_with_assistant_response` calls `on_agent_done` hook at line 201
- Fix: moved `await self._complete_with_assistant_response(llm_resp)` before the yield statements
- 1 file changed, 4 insertions, 1 deletion

## Summary by Sourcery

Bug Fixes:
- Run response completion hooks before yielding assistant responses in the `skills_like` tool requery fallback path, ensuring safety, sanitization, rewriting, and audit hooks can modify or inspect content before delivery.