### PR TITLE
feat: add Synthorai chat completion provider adapter

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1524,6 +1524,17 @@ CONFIG_METADATA_2 = {
                         "proxy": "",
                         "custom_headers": {},
                     },
+                    "Synthorai": {
+                        "id": "synthorai",
+                        "provider": "synthorai",
+                        "type": "synthorai_chat_completion",
+                        "provider_type": "chat_completion",
+                        "enable": True,
+                        "key": [],
+                        "timeout": 120,
+                        "api_base": "https://synthorai.io/v1",
+                        "proxy": "",
+                    },
                     "SSYCloud(胜算云)": {
                         "id": "ssycloud",
                         "provider": "ssycloud",

--- a/astrbot/core/provider/manager.py
+++ b/astrbot/core/provider/manager.py
@@ -443,6 +443,10 @@ class ProviderManager:
                 from .sources.openrouter_source import (
                     ProviderOpenRouter as ProviderOpenRouter,
                 )
+            case "synthorai_chat_completion":
+                from .sources.synthorai_source import (
+                    ProviderSynthorai as ProviderSynthorai,
+                )
             case "ssycloud_chat_completion":
                 from .sources.ssycloud_source import (
                     ProviderSSYCloud as ProviderSSYCloud,

--- a/astrbot/core/provider/sources/synthorai_source.py
+++ b/astrbot/core/provider/sources/synthorai_source.py
@@ -1,0 +1,25 @@
+from ..register import register_provider_adapter
+from .openai_source import ProviderOpenAIOfficial
+
+
+@register_provider_adapter(
+    "synthorai_chat_completion", "Synthorai Chat Completion Provider Adapter"
+)
+class ProviderSynthorai(ProviderOpenAIOfficial):
+    """Synthorai provider using its OpenAI-compatible Chat Completions API."""
+
+    def __init__(
+        self,
+        provider_config: dict,
+        provider_settings: dict,
+    ) -> None:
+        """Initialize the Synthorai client with provider defaults.
+
+        Args:
+            provider_config: AstrBot provider source configuration.
+            provider_settings: Global provider settings.
+        """
+        if not provider_config.get("api_base"):
+            provider_config["api_base"] = "https://synthorai.io/v1"
+        super().__init__(provider_config, provider_settings)
+        self.client._custom_headers["X-Title"] = "AstrBot"  # type: ignore

--- a/dashboard/src/utils/providerUtils.js
+++ b/dashboard/src/utils/providerUtils.js
@@ -43,6 +43,7 @@ export function getProviderIcon(type) {
     'groq': 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/groq.svg',
     'aihubmix': 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/aihubmix-color.svg',
     'openrouter': 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/openrouter.svg',
+    'synthorai': 'https://synthorai.io/synthorai-mark.svg',
     'ssycloud': 'https://admin.shengsuanyun.com/assets/logo-BoujJhP-.png',
     "tokenpony": "https://tokenpony.cn/tokenpony-web/logo.png",
     "compshare": "https://compshare.cn/favicon.ico",

--- a/tests/test_synthorai_source.py
+++ b/tests/test_synthorai_source.py
@@ -1,0 +1,40 @@
+from astrbot.core.config.default import CONFIG_METADATA_2
+from astrbot.core.provider.sources.synthorai_source import ProviderSynthorai
+
+
+def _make_provider(overrides: dict | None = None) -> ProviderSynthorai:
+    config = {
+        "id": "synthorai-test",
+        "provider": "synthorai",
+        "type": "synthorai_chat_completion",
+        "model": "claude-opus-5",
+        "key": ["test-key"],
+    }
+    if overrides:
+        config.update(overrides)
+    return ProviderSynthorai(config, {})
+
+
+def test_synthorai_template_uses_expected_defaults():
+    templates = CONFIG_METADATA_2["provider_group"]["metadata"]["provider"][
+        "config_template"
+    ]
+
+    template = templates["Synthorai"]
+    assert template["type"] == "synthorai_chat_completion"
+    assert template["api_base"] == "https://synthorai.io/v1"
+    assert template["provider_type"] == "chat_completion"
+
+
+def test_synthorai_provider_sets_endpoint_and_attribution_header():
+    provider = _make_provider()
+
+    assert str(provider.client.base_url) == "https://synthorai.io/v1/"
+    assert provider.client._custom_headers["X-Title"] == "AstrBot"
+
+
+def test_synthorai_provider_respects_explicit_api_base():
+    """A user-supplied endpoint must win over the default."""
+    provider = _make_provider({"api_base": "https://example.test/v1"})
+
+    assert str(provider.client.base_url) == "https://example.test/v1/"


### PR DESCRIPTION
### Modifications / 改动点

新增 Synthorai provider adapter,形状对照 **#9659(SSYCloud 胜算云,2026-08-13 合并)**:

| 文件 | 作用 |
|---|---|
| `astrbot/core/provider/sources/synthorai_source.py` | provider source(25 行) |
| `astrbot/core/config/default.py` | `config_template` 条目,紧随 OpenRouter |
| `astrbot/core/provider/manager.py` | `dynamic_import_provider` 的 match case |
| `dashboard/src/utils/providerUtils.js` | 图标映射(仓里用外链 URL,不往仓内塞图片) |
| `tests/test_synthorai_source.py` | 模板默认值 / endpoint 与 header / 用户自填 base 优先 |

**比 SSYCloud 少一件事**:没有覆写 `get_models`。SSYCloud 需要它是因为要按 `support_apis` 过滤自家目录;纯 OpenAI 兼容网关不需要,直接继承 `ProviderOpenAIOfficial` 即可。

**利益披露:我是 Synthorai 的相关方**,这是厂商自己加自己的 provider,不是转述他人需求。按 PR 模板第一条 Checklist 的要求,新功能已先通过 issue #9807 与作者沟通过。

### Screenshots or Test Results / 截图或测试结果

这里必须如实说明:**我本地没有跑起来这三个测试。** 这台机器上没装 `pytest`,AstrBot 的依赖树也没装齐,所以我无法贴一份真实的绿色输出——与其贴一段编出来的结果,不如直说。

我做到的静态验证:

- `python3 -m py_compile` 通过(`synthorai_source.py`、`default.py`、`manager.py`、测试文件)
- 测试里引用的 `CONFIG_METADATA_2["provider_group"]["metadata"]["provider"]["config_template"]` 路径与 #9659 的测试**逐字一致**,且已确认 `"Synthorai"` 模板确实落在该块内
- 没有 `ruff`,所以格式化也没跑;如果 CI 因格式报红,请告诉我,我照 CI 输出改

CI 上跑出来是什么样,以 CI 为准。若需要我补充别的验证,请直说。

### 另外

我不声称有用户需求——据我所知 issue 区没有其他人提过这个。如果你们的判断是暂不新增此类 provider,直接关掉即可,我不会追问。

## Summary by Sourcery

Add Synthorai chat completion support to AstrBot.

New Features:
- Add Synthorai as an OpenAI-compatible chat completion provider with default endpoint configuration and dashboard branding.

Enhancements:
- Allow users to override the default Synthorai API endpoint while applying the provider’s required attribution header.

Tests:
- Add coverage for Synthorai configuration defaults, endpoint selection, and request headers.