### PR TITLE
fix: preserve text in Lark mixed messages

### DIFF
--- a/astrbot/core/platform/sources/lark/lark_event.py
+++ b/astrbot/core/platform/sources/lark/lark_event.py
@@ -239,9 +239,10 @@ class LarkMessageEvent(AstrMessageEvent):
 
                 image_key = response.data.image_key
                 logger.debug(image_key)
-                ret.append(_stage)
+                if _stage:
+                    ret.append(_stage.copy())
+                    _stage.clear()
                 ret.append([{"tag": "img", "image_key": image_key}])
-                _stage.clear()
             elif isinstance(comp, File):
                 # 文件将通过 _send_file_message 方法单独发送，这里跳过
                 logger.debug("[Lark] 检测到文件组件，将单独发送")


### PR DESCRIPTION
Fixes #9839.

Lark message conversion stored the text buffer by reference and then cleared it when processing an image. This also emptied the buffered text already added to the result, causing mixed messages to display only images.

### Modifications / 改动点

- Copy non-empty buffered text and mention elements before clearing the buffer.
- Avoid emitting empty content blocks when an image appears before any text.
- Preserve the original ordering of text and images.
- No new test files or dependencies were added.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Verified mixed-message conversion without creating a test file:

```bash
uv run python -c '
import asyncio
from types import SimpleNamespace
from unittest.mock import AsyncMock, Mock

from astrbot.api.event import MessageChain
from astrbot.api.message_components import Image, Plain
from astrbot.core.platform.sources.lark.lark_event import LarkMessageEvent

async def main():
    response = Mock()
    response.success.return_value = True
    response.data.image_key = "image-key"

    image_api = SimpleNamespace(
        acreate=AsyncMock(return_value=response),
    )
    client = SimpleNamespace(
        im=SimpleNamespace(
            v1=SimpleNamespace(image=image_api),
        ),
    )

    image = Image.fromBytes(b"image")
    message = MessageChain([
        image,
        Plain("before image"),
        image,
        Plain("after image"),
    ])

    result = await LarkMessageEvent._convert_to_lark(message, client)

    expected = [
        [{"tag": "img", "image_key": "image-key"}],
        [{"tag": "md", "text": "before image"}],
        [{"tag": "img", "image_key": "image-key"}],
        [{"tag": "md", "text": "after image"}],
    ]

    assert result == expected, result
    assert image_api.acreate.await_count == 2
    print("Lark mixed-message conversion passed")

asyncio.run(main())
'
```

Result:

```text
Lark mixed-message conversion passed
```

Additional checks:

```text
$ uv run pytest tests/test_lark_app_registration.py -q
3 passed, 1 warning in 1.07s

$ uv run ruff format .
497 files left unchanged

$ uv run ruff check .
All checks passed!

$ git diff --check
# No output
```

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

  Bug fix only; tracked in #9839.

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改不包含恶意代码。

## Summary by Sourcery

Fix Lark mixed-message conversion so text remains intact alongside images.

Bug Fixes:
- Preserve buffered text and mentions when converting Lark messages containing images, preventing earlier text from being lost.
- Avoid emitting empty content blocks while maintaining the original ordering of text and images.

Tests:
- Verify mixed-message conversion and run the existing Lark registration tests, formatting, lint, and diff checks.