### PR TITLE
fix: skip queued LLM requests after disabling

### DIFF
--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -34,6 +34,7 @@ from astrbot.core.provider.entities import (
     LLMResponse,
     ProviderRequest,
 )
+from astrbot.core.star.session_llm_manager import SessionServiceManager
 from astrbot.core.star.star_handler import EventType
 from astrbot.core.utils.metrics import Metric
 from astrbot.core.utils.session_lock import session_lock_manager
@@ -219,6 +220,18 @@ class InternalAgentSubStage(Stage):
 
             async with session_lock_manager.acquire_lock(event.unified_msg_origin):
                 logger.debug("acquired session lock for llm request")
+                current_config = self.ctx.plugin_manager.context.get_config(
+                    umo=event.unified_msg_origin
+                )
+                if not current_config.get("provider_settings", {}).get(
+                    "enable", True
+                ) or not await SessionServiceManager.should_process_llm_request(event):
+                    logger.debug(
+                        "LLM was disabled while waiting for the session lock; "
+                        "skipping request for %s.",
+                        event.unified_msg_origin,
+                    )
+                    return
                 agent_runner: AgentRunner | None = None
                 runner_registered = False
                 try:

--- a/tests/unit/test_session_lock.py
+++ b/tests/unit/test_session_lock.py
@@ -5,9 +5,16 @@ import threading
 import time
 import weakref
 from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
+from astrbot.core.pipeline.process_stage.method.agent_sub_stages import internal
+from astrbot.core.pipeline.process_stage.method.agent_sub_stages.internal import (
+    InternalAgentSubStage,
+)
+from astrbot.core.star.session_llm_manager import SessionServiceManager
 from astrbot.core.utils.session_lock import SessionLockManager
 
 
@@ -144,6 +151,66 @@ class TestCrossLoopIsolation:
 
 class TestConcurrency:
     """Tests for concurrent access."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("provider_enabled", "session_enabled"),
+        [(False, True), (True, False)],
+    )
+    async def test_waiting_llm_request_rechecks_enabled_status(
+        self,
+        monkeypatch,
+        provider_enabled,
+        session_enabled,
+    ):
+        """A queued request must honor LLM status changes made while waiting."""
+        session_id = "disabled-while-waiting"
+        manager = SessionLockManager()
+        typing_started = asyncio.Event()
+        config = {"provider_settings": {"enable": True}}
+        build_main_agent = AsyncMock()
+
+        async def send_typing():
+            typing_started.set()
+
+        event = SimpleNamespace(
+            unified_msg_origin=session_id,
+            message_str="hello",
+            message_obj=SimpleNamespace(message=[]),
+            get_extra=lambda _key: None,
+            get_sender_id=lambda: "user-1",
+            send_typing=send_typing,
+            stop_typing=AsyncMock(),
+        )
+        stage = InternalAgentSubStage()
+        stage.streaming_response = False
+        stage.ctx = SimpleNamespace(
+            plugin_manager=SimpleNamespace(
+                context=SimpleNamespace(get_config=lambda **_kwargs: config)
+            )
+        )
+
+        monkeypatch.setattr(internal, "session_lock_manager", manager)
+        monkeypatch.setattr(internal, "call_event_hook", AsyncMock(return_value=False))
+        monkeypatch.setattr(internal, "build_main_agent", build_main_agent)
+        monkeypatch.setattr(
+            SessionServiceManager,
+            "should_process_llm_request",
+            AsyncMock(return_value=session_enabled),
+        )
+
+        async def process_request():
+            async for _ in stage.process(event, ""):
+                pass
+
+        async with manager.acquire_lock(session_id):
+            task = asyncio.create_task(process_request())
+            await typing_started.wait()
+            config["provider_settings"]["enable"] = provider_enabled
+
+        await task
+
+        build_main_agent.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_concurrent_acquisitions_same_loop(self):


### PR DESCRIPTION
## Summary

- Recheck the global and session-level LLM status after acquiring the session lock.
- Skip queued requests when LLM access was disabled while they were waiting.
- Add regression coverage for both global provider disabling and session-level LLM disabling.

## Motivation

LLM availability was previously checked before entering the internal agent stage. A request that passed this check could wait for the session lock while an administrator disabled LLM access.

After acquiring the lock, the queued request continued without checking the latest state, which could cause delayed replies after LLM access had already been disabled.

This change performs a second authoritative check immediately before building and dispatching the agent request.

Fixes #9819.

## Testing

- `uv run ruff format .`
- `uv run ruff check .`
- `uv run pytest tests/unit/test_session_lock.py -q`
- `uv run pytest tests/unit/test_session_management_service.py -q`
- `uv run pytest tests/test_conversation_checkpoint.py -q`

## Summary by Sourcery

Recheck LLM availability after queued requests acquire the session lock to prevent processing after access has been disabled.

Bug Fixes:
- Skip queued LLM requests when global provider access or session-level LLM access is disabled while they wait for the session lock.

Tests:
- Add regression coverage for queued requests affected by global and session-level LLM disabling.