### PR TITLE
fix: keep system reminders out of conversation history

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -1010,7 +1010,9 @@ def _append_system_reminders(
         system_content = (
             "<system_reminder>" + "\n".join(system_parts) + "</system_reminder>"
         )
-        req.extra_user_content_parts.append(TextPart(text=system_content))
+        req.extra_user_content_parts.append(
+            TextPart(text=system_content).mark_as_temp()
+        )
 
 
 async def _decorate_llm_request(

--- a/tests/unit/test_astr_main_agent.py
+++ b/tests/unit/test_astr_main_agent.py
@@ -142,8 +142,9 @@ def _setup_conversation_for_build(conv_mgr, cid: str = "conv-id") -> MagicMock:
     return conversation
 
 
-def test_append_system_reminders_includes_weekday(mock_event):
-    """Test datetime reminder includes weekday information."""
+@pytest.mark.asyncio
+async def test_append_system_reminders_includes_weekday(mock_event):
+    """Test datetime reminder includes weekday and is not persisted."""
     req = ProviderRequest(prompt="Hello")
     fixed_now = datetime.datetime(
         2026,
@@ -172,6 +173,14 @@ def test_append_system_reminders_includes_weekday(mock_event):
     assert [part.text for part in req.extra_user_content_parts] == [
         "<system_reminder>Current datetime: "
         "2026-06-08 12:34 (UTC), Weekday: Monday</system_reminder>"
+    ]
+    assert req.extra_user_content_parts[0]._no_save is True
+
+    message = Message.model_validate(await req.assemble_context())
+    assert isinstance(message.content, list)
+    assert message.content[1].text == req.extra_user_content_parts[0].text
+    assert dump_messages_with_checkpoints([message]) == [
+        {"role": "user", "content": [{"type": "text", "text": "Hello"}]}
     ]
 
 


### PR DESCRIPTION
## Summary

Mark injected system reminders as temporary content. The reminders remain available to the model for the current request but are excluded from persisted conversation history, preventing them from polluting later context and repeatedly consuming tokens.

The existing main-agent test is extended to cover both the current-request and persistence behavior.

## Testing

- `uv run ruff format .`
- `uv run ruff check .`
- `uv run pytest tests/unit/test_astr_main_agent.py`

Fixes #9779

## Summary by Sourcery

Prevent system reminders from polluting future conversation context and consuming tokens repeatedly.

Bug Fixes:
- Exclude injected system reminders from persisted conversation history while keeping them available during the current model request.

Tests:
- Extend main-agent coverage to verify system reminders are included in the current request but omitted from saved messages.