### PR TITLE
fix: bridge unsigned Gemini 3 tool histories

### DIFF
--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -386,6 +386,15 @@ class ProviderGoogleGenAI(Provider):
                             thinking_signature = None
 
                     if (
+                        is_gemini3_model
+                        and tool_calls
+                        and not tool_calls_have_thought_signature
+                    ):
+                        # An unsigned tool step came from another provider, so
+                        # its opaque reasoning signature is not valid for Gemini.
+                        thinking_signature = None
+
+                    if (
                         not text
                         and thinking_signature
                         and tool_calls_have_thought_signature

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -331,6 +331,10 @@ class ProviderGoogleGenAI(Provider):
             else:
                 contents.append(content_cls(parts=part))
 
+        model_name = str(
+            payloads.get("model", getattr(self, "model_name", "")),
+        ).lower()
+        is_gemini3_model = model_name.rsplit("/", 1)[-1].startswith("gemini-3")
         gemini_contents: list[types.Content] = []
         for message in payloads["messages"]:
             role, content = message["role"], message.get("content")
@@ -351,6 +355,14 @@ class ProviderGoogleGenAI(Provider):
 
             elif role == "assistant":
                 parts = []
+                tool_calls = message.get("tool_calls") or []
+                tool_calls_have_thought_signature = any(
+                    isinstance(tool, dict)
+                    and isinstance(tool.get("extra_content"), dict)
+                    and isinstance(tool["extra_content"].get("google"), dict)
+                    and tool["extra_content"]["google"].get("thought_signature")
+                    for tool in tool_calls
+                )
                 if isinstance(content, str):
                     parts.append(types.Part.from_text(text=content))
                 elif isinstance(content, list):
@@ -376,14 +388,7 @@ class ProviderGoogleGenAI(Provider):
                     if (
                         not text
                         and thinking_signature
-                        and "tool_calls" in message
-                        and any(
-                            isinstance(tool, dict)
-                            and isinstance(tool.get("extra_content"), dict)
-                            and isinstance(tool["extra_content"].get("google"), dict)
-                            and tool["extra_content"]["google"].get("thought_signature")
-                            for tool in message["tool_calls"]
-                        )
+                        and tool_calls_have_thought_signature
                     ):
                         # If the main content is empty but tool calls have thought signatures,
                         # skip adding an empty text part to deduplicate the thinking signature in the main content and tool calls.
@@ -396,8 +401,8 @@ class ProviderGoogleGenAI(Provider):
                             )
                         )
 
-                if "tool_calls" in message:
-                    for tool in message["tool_calls"]:
+                if tool_calls:
+                    for index, tool in enumerate(tool_calls):
                         part = types.Part.from_function_call(
                             name=tool["function"]["name"],
                             args=json.loads(tool["function"]["arguments"]),
@@ -405,14 +410,24 @@ class ProviderGoogleGenAI(Provider):
                         # we should set thought_signature back to part if exists
                         # for more info about thought_signature, see:
                         # https://ai.google.dev/gemini-api/docs/thought-signatures
+                        ts_bs64 = None
                         if "extra_content" in tool and tool["extra_content"]:
                             ts_bs64 = (
                                 tool["extra_content"]
                                 .get("google", {})
                                 .get("thought_signature")
                             )
-                            if ts_bs64:
-                                part.thought_signature = base64.b64decode(ts_bs64)
+                        if ts_bs64:
+                            part.thought_signature = base64.b64decode(ts_bs64)
+                        elif (
+                            is_gemini3_model
+                            and not tool_calls_have_thought_signature
+                            and index == 0
+                        ):
+                            # Cross-provider histories do not carry Gemini's opaque
+                            # signature. Gemini 3 accepts this documented sentinel
+                            # on the first function call in the step.
+                            part.thought_signature = b"skip_thought_signature_validator"
                         parts.append(part)
 
                 if not parts:

--- a/tests/test_gemini_source.py
+++ b/tests/test_gemini_source.py
@@ -1,3 +1,4 @@
+import base64
 from types import SimpleNamespace
 
 import httpx
@@ -105,6 +106,111 @@ async def test_gemini_prepare_conversation_resolves_local_history_image(tmp_path
     assert image_part.inline_data is not None
     assert image_part.inline_data.mime_type == "image/webp"
     assert image_part.inline_data.data == image_bytes
+
+
+@pytest.mark.asyncio
+async def test_gemini3_prepare_conversation_adds_signature_to_cross_provider_tool_calls():
+    provider = ProviderGoogleGenAI.__new__(ProviderGoogleGenAI)
+
+    contents = await provider._prepare_conversation(
+        {
+            "model": "gemini-3.1-pro-preview",
+            "messages": [
+                {"role": "user", "content": "find the latest result"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "function": {
+                                "name": "search",
+                                "arguments": '{"query": "result"}',
+                            },
+                            "extra_content": {"openai": {"item_id": "item_1"}},
+                        },
+                        {
+                            "function": {
+                                "name": "read_page",
+                                "arguments": '{"id": "page"}',
+                            }
+                        },
+                    ],
+                },
+            ],
+        }
+    )
+
+    assert contents[-1].parts is not None
+    assert (
+        contents[-1].parts[0].thought_signature == b"skip_thought_signature_validator"
+    )
+    assert contents[-1].parts[1].thought_signature is None
+
+
+@pytest.mark.asyncio
+async def test_gemini3_prepare_conversation_preserves_real_tool_signature():
+    provider = ProviderGoogleGenAI.__new__(ProviderGoogleGenAI)
+    signature = b"real-gemini-signature"
+
+    contents = await provider._prepare_conversation(
+        {
+            "model": "gemini-3-flash-preview",
+            "messages": [
+                {"role": "user", "content": "find the latest result"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "function": {
+                                "name": "search",
+                                "arguments": '{"query": "result"}',
+                            },
+                            "extra_content": {
+                                "google": {
+                                    "thought_signature": base64.b64encode(
+                                        signature
+                                    ).decode("utf-8")
+                                }
+                            },
+                        }
+                    ],
+                },
+            ],
+        }
+    )
+
+    assert contents[-1].parts is not None
+    assert contents[-1].parts[0].thought_signature == signature
+
+
+@pytest.mark.asyncio
+async def test_gemini25_prepare_conversation_keeps_unsigned_tool_calls_unchanged():
+    provider = ProviderGoogleGenAI.__new__(ProviderGoogleGenAI)
+
+    contents = await provider._prepare_conversation(
+        {
+            "model": "gemini-2.5-pro",
+            "messages": [
+                {"role": "user", "content": "find the latest result"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "function": {
+                                "name": "search",
+                                "arguments": '{"query": "result"}',
+                            }
+                        }
+                    ],
+                },
+            ],
+        }
+    )
+
+    assert contents[-1].parts is not None
+    assert contents[-1].parts[0].thought_signature is None
 
 
 def test_gemini_empty_output_raises_empty_model_output_error():

--- a/tests/test_gemini_source.py
+++ b/tests/test_gemini_source.py
@@ -148,6 +148,47 @@ async def test_gemini3_prepare_conversation_adds_signature_to_cross_provider_too
 
 
 @pytest.mark.asyncio
+async def test_gemini3_prepare_conversation_drops_foreign_tool_step_signature():
+    provider = ProviderGoogleGenAI.__new__(ProviderGoogleGenAI)
+    foreign_signature = base64.b64encode(b"foreign-provider-signature").decode("utf-8")
+
+    contents = await provider._prepare_conversation(
+        {
+            "model": "gemini-3.1-pro-preview",
+            "messages": [
+                {"role": "user", "content": "find the latest result"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "think",
+                            "text": "provider-specific reasoning",
+                            "encrypted": foreign_signature,
+                        },
+                        {"type": "text", "text": "I will check."},
+                    ],
+                    "tool_calls": [
+                        {
+                            "function": {
+                                "name": "search",
+                                "arguments": '{"query": "result"}',
+                            }
+                        }
+                    ],
+                },
+            ],
+        }
+    )
+
+    assert contents[-1].parts is not None
+    assert contents[-1].parts[0].text == "I will check."
+    assert contents[-1].parts[0].thought_signature is None
+    assert (
+        contents[-1].parts[1].thought_signature == b"skip_thought_signature_validator"
+    )
+
+
+@pytest.mark.asyncio
 async def test_gemini3_prepare_conversation_preserves_real_tool_signature():
     provider = ProviderGoogleGenAI.__new__(ProviderGoogleGenAI)
     signature = b"real-gemini-signature"


### PR DESCRIPTION
Gemini 3 requires a thought signature when function-call history is replayed. AstrBot preserves genuine Gemini signatures, but a tool call produced by another provider has no Google-specific metadata, so switching or falling back to Gemini 3 can fail with a 4xx validation error.

Google documents `skip_thought_signature_validator` for the unavoidable cross-model-history case: https://ai.google.dev/gemini-api/docs/generate-content/thought-signatures

### Modifications / 改动点

- Detect Gemini 3 requests while converting AstrBot conversation history.
- Preserve genuine Google thought signatures exactly as received.
- When a function-call step has no genuine signature, add the documented sentinel only to the first call in that step (including parallel calls).
- Leave Gemini 2.5 and unsigned non-Gemini histories unchanged.
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Verification Steps / 验证步骤

```powershell
python -m pytest tests/test_gemini_source.py -q
python -m ruff check astrbot/core/provider/sources/gemini_source.py tests/test_gemini_source.py
python -m ruff format --check astrbot/core/provider/sources/gemini_source.py tests/test_gemini_source.py
```

### Test Results / 运行结果

- `9 passed`
- Ruff check passed.
- Ruff format check passed.

---

### Checklist / 检查清单

- [x] 👀 My changes have been well-tested, and verification steps/results are provided above.
- [x] 🤓 No new dependencies are introduced.
- [x] 😮 My changes do not introduce malicious code.

## Summary by Sourcery

Support reliable Gemini 3 fallback and model switching when replayed tool histories lack Google thought signatures.

Bug Fixes:
- Allow Gemini 3 to replay unsigned cross-provider function-call histories without triggering thought-signature validation errors.

Enhancements:
- Preserve genuine Google thought signatures while applying the documented fallback sentinel only to the first unsigned function call in a tool step.
- Keep Gemini 2.5 and non-Gemini conversation histories unchanged.

Tests:
- Add coverage for unsigned cross-provider tool calls, foreign signatures, genuine Gemini signatures, and unchanged Gemini 2.5 behavior.