### PR TITLE
fix: ensure config directory exists before mkstemp in _write_config_snapshot

### DIFF
--- a/astrbot/core/config/astrbot_config.py
+++ b/astrbot/core/config/astrbot_config.py
@@ -287,6 +287,10 @@ class AstrBotConfig(dict):
             Whether the snapshot replaced the current configuration file.
         """
         directory = os.path.dirname(os.path.abspath(self.config_path)) or "."
+        # The directory may not exist yet when a config profile is created for
+        # the first time (e.g. `create_conf` instantiates AstrBotConfig with a
+        # brand-new path). mkstemp would raise FileNotFoundError otherwise.
+        os.makedirs(directory, exist_ok=True)
         fd, temp_path = tempfile.mkstemp(
             dir=directory,
             prefix=f".{os.path.basename(self.config_path)}.",


### PR DESCRIPTION
## Problem

Three dashboard tests are intermittently failing on `master` (different ones fail on different runs):

- `test_t2i_set_active_template_syncs_all_configs`
- `test_t2i_reset_default_template_syncs_all_configs`
- `test_t2i_update_active_template_reloads_all_schedulers`

```
FileNotFoundError: [Errno 2] No such file or directory:
  '.../data/config/.abconf_<uuid>.json.<random>.tmp'
```

The traceback points to `tempfile.mkstemp()` inside `AstrBotConfig._write_config_snapshot()` (`astrbot/core/config/astrbot_config.py:290`).

## Root Cause

`_write_config_snapshot` creates a temp file in the config file's parent directory, but never ensures that directory exists:

```python
directory = os.path.dirname(os.path.abspath(self.config_path)) or "."
fd, temp_path = tempfile.mkstemp(dir=directory, ...)  # crashes if dir missing
```

When `AstrBotConfig.__init__` (line 64-67) detects the config file doesn't exist yet, it calls `save_config()` → `_write_config_snapshot` → `mkstemp(dir=directory)`. If the directory hasn't been created (fresh profile creation, test fixture race), `mkstemp` raises `FileNotFoundError`.

The `create_conf` path in `astrbot_config_mgr.py:208-210` triggers this — it constructs a new `conf_path` and instantiates `AstrBotConfig(config_path=conf_path, ...)`, which calls `save_config()` during `__init__` before the directory is guaranteed to exist.

## Fix

Add `os.makedirs(directory, exist_ok=True)` before the `mkstemp` call. One line, standard defensive pattern for atomic-write helpers.

## Verification

**Before fix** (current `master` `d2d7e5a`):
```
3 failed, 79 deselected  (different tests fail each run)
```

**After fix** (5 consecutive runs):
```
3 passed, 79 deselected  (×5, stable)
```

**Full suite**: 2201 passed, 0 failed.

`ruff format` / `ruff check` clean.

Closes #9855.

## Summary by Sourcery

Bug Fixes:
- Prevent configuration snapshot writes from failing when the target configuration directory does not yet exist.