### PR TITLE
fix: avoid premature context compression from persisted usage

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -99,6 +99,16 @@ class FollowUpTicket:
     resolved: asyncio.Event = field(default_factory=asyncio.Event)
 
 
+@dataclass(slots=True)
+class _ContextUsageSnapshot:
+    """Store provider prompt usage bound to one request context."""
+
+    message_ids: tuple[int, ...]
+    prompt_tokens: int
+    provider: Provider
+    func_tool: ToolSet | None
+
+
 class _ToolExecutionInterrupted(Exception):
     """Raised when a running tool call is interrupted by a stop request."""
 
@@ -261,6 +271,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
         )
 
         self.provider = provider
+        self._context_usage_snapshot: _ContextUsageSnapshot | None = None
         self.fallback_providers: list[Provider] = []
         seen_provider_ids: set[str] = {str(provider.provider_config.get("id", ""))}
         for fallback_provider in fallback_providers or []:
@@ -813,18 +824,51 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
         llm_resp_result = None
 
         # Process request-time context before sending it to the provider.
-        # Persisted usage belongs to a previous provider request and may include
-        # provider-specific cache accounting, so it cannot describe these messages.
+        trusted_token_usage = 0
+        snapshot = self._context_usage_snapshot
+        current_func_tool = self._func_tool_for_provider()
+        if (
+            snapshot
+            and self.enforce_max_turns == -1
+            and snapshot.provider is self.provider
+            and snapshot.func_tool is current_func_tool
+            and len(self.run_context.messages) >= len(snapshot.message_ids)
+            and all(
+                id(message) == message_id
+                for message, message_id in zip(
+                    self.run_context.messages,
+                    snapshot.message_ids,
+                )
+            )
+        ):
+            # The previous provider prompt includes overhead such as tool schemas.
+            # Only reuse it while the current request preserves that exact prefix.
+            tail_messages = self.run_context.messages[len(snapshot.message_ids) :]
+            trusted_token_usage = snapshot.prompt_tokens + (
+                self.request_context_manager.token_counter.count_tokens(tail_messages)
+            )
         self._simple_print_message_role("[BefCompact]", self.run_context.messages)
         processed_messages = await self._await_or_stop(
             self.request_context_manager.process(
                 self.run_context.messages,
+                trusted_token_usage=trusted_token_usage,
             )
         )
         if processed_messages is None:
             yield await self._finalize_aborted_step()
             return
         self.run_context.messages = processed_messages
+        if snapshot and (
+            len(processed_messages) < len(snapshot.message_ids)
+            or any(
+                id(message) != message_id
+                for message, message_id in zip(
+                    processed_messages,
+                    snapshot.message_ids,
+                )
+            )
+        ):
+            self._context_usage_snapshot = None
         self._simple_print_message_role("[AftCompact]", self.run_context.messages)
 
         async for llm_response in self._iter_llm_responses_with_fallback():
@@ -868,6 +912,15 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 self.stats.current_context_tokens = llm_response.usage.input
                 if self.req.conversation:
                     self.req.conversation.token_usage = llm_response.usage.total
+                if llm_response.usage.input > 0:
+                    self._context_usage_snapshot = _ContextUsageSnapshot(
+                        message_ids=tuple(
+                            id(message) for message in self.run_context.messages
+                        ),
+                        prompt_tokens=llm_response.usage.input,
+                        provider=self.provider,
+                        func_tool=self._func_tool_for_provider(),
+                    )
             # end_time must be set before the yield serializes to_dict().
             self.stats.end_time = time.time()
             yield AgentResponse(

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -1,5 +1,7 @@
 import asyncio
 import copy
+import hashlib
+import json
 import sys
 import time
 import traceback
@@ -103,10 +105,10 @@ class FollowUpTicket:
 class _ContextUsageSnapshot:
     """Store provider prompt usage bound to one request context."""
 
-    message_ids: tuple[int, ...]
+    message_fingerprints: tuple[str, ...]
     prompt_tokens: int
     provider: Provider
-    func_tool: ToolSet | None
+    tool_schema_fingerprint: str | None
 
 
 class _ToolExecutionInterrupted(Exception):
@@ -688,6 +690,50 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             return None
         return self.req.func_tool
 
+    def _context_usage_fingerprints(
+        self,
+        messages: list[Message],
+        func_tool: ToolSet | None,
+    ) -> tuple[tuple[str, ...], str | None]:
+        """Build immutable fingerprints for a context-usage snapshot.
+
+        Args:
+            messages: Messages that form the provider request context.
+            func_tool: Tools exposed to the provider for that request.
+
+        Returns:
+            Immutable fingerprints for the messages and tool schema.
+        """
+        json_dump_kwargs = {
+            "default": str,
+            "ensure_ascii": False,
+            "separators": (",", ":"),
+            "sort_keys": True,
+        }
+        message_fingerprints = tuple(
+            hashlib.sha256(
+                json.dumps(message.model_dump(), **json_dump_kwargs).encode()
+            ).hexdigest()
+            for message in messages
+        )
+        tool_schema_fingerprint = None
+        if func_tool is not None:
+            tool_schema_fingerprint = hashlib.sha256(
+                json.dumps(
+                    [
+                        {
+                            "active": getattr(tool, "active", True),
+                            "description": tool.description,
+                            "name": tool.name,
+                            "parameters": tool.parameters,
+                        }
+                        for tool in func_tool.tools
+                    ],
+                    **json_dump_kwargs,
+                ).encode()
+            ).hexdigest()
+        return message_fingerprints, tool_schema_fingerprint
+
     def _simple_print_message_role(self, tag: str, messages: list):
         roles = [m.role for m in messages]
         n = len(roles)
@@ -827,26 +873,31 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
         trusted_token_usage = 0
         snapshot = self._context_usage_snapshot
         current_func_tool = self._func_tool_for_provider()
-        if (
-            snapshot
-            and self.enforce_max_turns == -1
-            and snapshot.provider is self.provider
-            and snapshot.func_tool is current_func_tool
-            and len(self.run_context.messages) >= len(snapshot.message_ids)
-            and all(
-                id(message) == message_id
-                for message, message_id in zip(
+        if snapshot:
+            message_fingerprints, tool_schema_fingerprint = (
+                self._context_usage_fingerprints(
                     self.run_context.messages,
-                    snapshot.message_ids,
+                    current_func_tool,
                 )
             )
-        ):
-            # The previous provider prompt includes overhead such as tool schemas.
-            # Only reuse it while the current request preserves that exact prefix.
-            tail_messages = self.run_context.messages[len(snapshot.message_ids) :]
-            trusted_token_usage = snapshot.prompt_tokens + (
-                self.request_context_manager.token_counter.count_tokens(tail_messages)
-            )
+            if (
+                self.enforce_max_turns == -1
+                and snapshot.provider is self.provider
+                and snapshot.tool_schema_fingerprint == tool_schema_fingerprint
+                and len(self.run_context.messages) >= len(snapshot.message_fingerprints)
+                and snapshot.message_fingerprints
+                == message_fingerprints[: len(snapshot.message_fingerprints)]
+            ):
+                # The previous provider prompt includes overhead such as tool schemas.
+                # Only reuse it while the current request preserves that exact prefix.
+                tail_messages = self.run_context.messages[
+                    len(snapshot.message_fingerprints) :
+                ]
+                trusted_token_usage = snapshot.prompt_tokens + (
+                    self.request_context_manager.token_counter.count_tokens(
+                        tail_messages
+                    )
+                )
         self._simple_print_message_role("[BefCompact]", self.run_context.messages)
         processed_messages = await self._await_or_stop(
             self.request_context_manager.process(
@@ -858,17 +909,20 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
             yield await self._finalize_aborted_step()
             return
         self.run_context.messages = processed_messages
-        if snapshot and (
-            len(processed_messages) < len(snapshot.message_ids)
-            or any(
-                id(message) != message_id
-                for message, message_id in zip(
+        if snapshot:
+            processed_message_fingerprints, processed_tool_schema_fingerprint = (
+                self._context_usage_fingerprints(
                     processed_messages,
-                    snapshot.message_ids,
+                    self._func_tool_for_provider(),
                 )
             )
-        ):
-            self._context_usage_snapshot = None
+            if (
+                len(processed_messages) < len(snapshot.message_fingerprints)
+                or snapshot.tool_schema_fingerprint != processed_tool_schema_fingerprint
+                or snapshot.message_fingerprints
+                != processed_message_fingerprints[: len(snapshot.message_fingerprints)]
+            ):
+                self._context_usage_snapshot = None
         self._simple_print_message_role("[AftCompact]", self.run_context.messages)
 
         async for llm_response in self._iter_llm_responses_with_fallback():
@@ -913,13 +967,17 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 if self.req.conversation:
                     self.req.conversation.token_usage = llm_response.usage.total
                 if llm_response.usage.input > 0:
+                    message_fingerprints, tool_schema_fingerprint = (
+                        self._context_usage_fingerprints(
+                            self.run_context.messages,
+                            self._func_tool_for_provider(),
+                        )
+                    )
                     self._context_usage_snapshot = _ContextUsageSnapshot(
-                        message_ids=tuple(
-                            id(message) for message in self.run_context.messages
-                        ),
+                        message_fingerprints=message_fingerprints,
                         prompt_tokens=llm_response.usage.input,
                         provider=self.provider,
-                        func_tool=self._func_tool_for_provider(),
+                        tool_schema_fingerprint=tool_schema_fingerprint,
                     )
             # end_time must be set before the yield serializes to_dict().
             self.stats.end_time = time.time()

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -813,12 +813,12 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
         llm_resp_result = None
 
         # Process request-time context before sending it to the provider.
-        token_usage = self.req.conversation.token_usage if self.req.conversation else 0
+        # Persisted usage belongs to a previous provider request and may include
+        # provider-specific cache accounting, so it cannot describe these messages.
         self._simple_print_message_role("[BefCompact]", self.run_context.messages)
         processed_messages = await self._await_or_stop(
             self.request_context_manager.process(
                 self.run_context.messages,
-                trusted_token_usage=token_usage,
             )
         )
         if processed_messages is None:

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -19,6 +19,7 @@ from astrbot.core.agent.run_context import ContextWrapper
 from astrbot.core.agent.runners.tool_loop_agent_runner import ToolLoopAgentRunner
 from astrbot.core.agent.tool import FunctionTool, ToolSet
 from astrbot.core.astr_agent_tool_exec import FunctionToolExecutor
+from astrbot.core.db.po import Conversation
 from astrbot.core.exceptions import EmptyModelOutputError
 from astrbot.core.provider.entities import LLMResponse, ProviderRequest, TokenUsage
 from astrbot.core.provider.provider import Provider
@@ -615,6 +616,62 @@ async def test_tool_loop_next_request_includes_tool_result(
     assert len(tool_messages) == 1
     assert tool_messages[0].tool_call_id == "call_context_refresh"
     assert "工具执行结果" in tool_messages[0].content
+
+
+@pytest.mark.asyncio
+async def test_context_compression_ignores_persisted_conversation_token_usage(
+    runner, mock_provider, provider_request, mock_tool_executor, mock_hooks
+):
+    """A previous request's usage must not compress a small current context."""
+    mock_provider.provider_config["max_context_tokens"] = 1_000_000
+    mock_provider.should_call_tools = False
+    provider_request.contexts = [
+        {"role": "user", "content": "x" * 320_000},
+        {"role": "assistant", "content": "important historical answer"},
+    ]
+    provider_request.prompt = "current question"
+    provider_request.conversation = Conversation(
+        platform_id="webchat",
+        user_id="user",
+        cid="conversation-id",
+        token_usage=3_879_963,
+    )
+
+    await runner.reset(
+        provider=mock_provider,
+        request=provider_request,
+        run_context=ContextWrapper(context=None),
+        tool_executor=mock_tool_executor,
+        agent_hooks=mock_hooks,
+        streaming=False,
+    )
+
+    original_messages = list(runner.run_context.messages)
+    estimated_tokens = runner.request_context_manager.token_counter.count_tokens(
+        original_messages
+    )
+    assert estimated_tokens < 820_000
+
+    legacy_messages = await runner.request_context_manager.process(
+        original_messages,
+        trusted_token_usage=provider_request.conversation.token_usage,
+    )
+    assert "current question" not in [
+        message.content
+        for message in legacy_messages
+        if isinstance(message.content, str)
+    ]
+
+    async for _ in runner.step_until_done(1):
+        pass
+
+    contents = [
+        message.content
+        for message in runner.run_context.messages
+        if isinstance(message.content, str)
+    ]
+    assert "important historical answer" in contents
+    assert "current question" in contents
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -328,6 +328,7 @@ class CapturingToolLoopProvider(MockProvider):
         super().__init__()
         self.tool_name = tool_name
         self.received_contexts = []
+        self.first_response_usage = TokenUsage(input_other=10, output=5)
 
     async def text_chat(self, **kwargs) -> LLMResponse:
         self.call_count += 1
@@ -346,7 +347,7 @@ class CapturingToolLoopProvider(MockProvider):
             tools_call_name=[self.tool_name],
             tools_call_args=[{"query": "test"}],
             tools_call_ids=["call_context_refresh"],
-            usage=TokenUsage(input_other=10, output=5),
+            usage=self.first_response_usage,
         )
 
 
@@ -611,6 +612,12 @@ async def test_tool_loop_next_request_includes_tool_result(
         pass
 
     assert provider.call_count == 2
+    assert (
+        runner.request_context_manager.token_counter.count_tokens(
+            provider.received_contexts[0]
+        )
+        < 820
+    )
     second_contexts = provider.received_contexts[1]
     tool_messages = [msg for msg in second_contexts if msg.role == "tool"]
     assert len(tool_messages) == 1
@@ -672,6 +679,43 @@ async def test_context_compression_ignores_persisted_conversation_token_usage(
     ]
     assert "important historical answer" in contents
     assert "current question" in contents
+
+
+@pytest.mark.asyncio
+async def test_tool_loop_uses_current_run_context_usage_snapshot(
+    runner, provider_request, mock_tool_executor, mock_hooks
+):
+    """Use the last matching provider prompt to guard the next tool-loop request."""
+    provider = CapturingToolLoopProvider("test_tool")
+    provider.provider_config["max_context_tokens"] = 1_000
+    provider.first_response_usage = TokenUsage(input_other=900, output=10)
+    provider_request.contexts = [
+        {"role": "user", "content": "previous question"},
+        {"role": "assistant", "content": "important historical answer"},
+    ]
+    provider_request.prompt = "current question"
+
+    await runner.reset(
+        provider=provider,
+        request=provider_request,
+        run_context=ContextWrapper(context=None),
+        tool_executor=mock_tool_executor,
+        agent_hooks=mock_hooks,
+        streaming=False,
+    )
+
+    async for _ in runner.step_until_done(3):
+        pass
+
+    assert provider.call_count == 2
+    second_contexts = provider.received_contexts[1]
+    second_contents = [
+        message.content
+        for message in second_contexts
+        if isinstance(message.content, str)
+    ]
+    assert "important historical answer" not in second_contents
+    assert "current question" in second_contents
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -719,6 +719,49 @@ async def test_tool_loop_uses_current_run_context_usage_snapshot(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("mutation", ["message", "tool_schema"])
+async def test_tool_loop_reestimates_after_in_place_request_mutation(
+    runner, provider_request, mock_tool_executor, mutation
+):
+    """Do not reuse prompt usage after a hook mutates the request in place."""
+
+    class MutatingHooks(MockHooks):
+        async def on_tool_end(self, run_context, tool, tool_args, tool_result):
+            await super().on_tool_end(run_context, tool, tool_args, tool_result)
+            if mutation == "message":
+                run_context.messages[0].content = "changed historical question"
+            else:
+                tool.parameters["properties"]["extra"] = {"type": "string"}
+
+    provider = CapturingToolLoopProvider("test_tool")
+    provider.first_response_usage = TokenUsage(input_other=900, output=10)
+    mutating_hooks = MutatingHooks()
+
+    await runner.reset(
+        provider=provider,
+        request=provider_request,
+        run_context=ContextWrapper(context=None),
+        tool_executor=mock_tool_executor,
+        agent_hooks=mutating_hooks,
+        streaming=False,
+    )
+
+    trusted_token_usages = []
+
+    async def capture_context_processing(messages, trusted_token_usage=0):
+        trusted_token_usages.append(trusted_token_usage)
+        return list(messages)
+
+    runner.request_context_manager.process = capture_context_processing
+
+    async for _ in runner.step_until_done(3):
+        pass
+
+    assert provider.call_count == 2
+    assert trusted_token_usages == [0, 0]
+
+
+@pytest.mark.asyncio
 async def test_normal_completion_without_max_step(
     runner, mock_provider, provider_request, mock_tool_executor, mock_hooks
 ):


### PR DESCRIPTION
Fixes #9864.

### Modifications / 改动点

- Stop using persisted `conversation.token_usage` as the token count for a new request context.
- Retain a runner-local provider prompt snapshot for the next tool-loop request only while the provider remains the same and the message-prefix and exposed-tool-schema fingerprints still match. The snapshot keeps provider-only overhead such as tool schemas while newly appended messages are estimated.
- Fall back to full message estimation after a change to the snapshotted prefix or tool schema, or when no matching runtime snapshot exists.
- Add regressions for stale persisted usage, a high provider prompt usage with a low messages-only estimate, and in-place mutations of an existing message or `FunctionTool.parameters`.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Verification steps:

- `uv run pytest tests/test_tool_loop_agent_runner.py tests/agent/test_context_manager.py tests/agent/test_token_counter.py -q` — passed: 107 tests.
- `make pr-test-neo` — passed: Ruff format and lint checks, 13 tests, and the startup smoke test.
- The stale-usage regression proves that a 3,879,963 persisted value does not compact a roughly 96,000-token context. The tool-loop regression proves that a matching 900/1,000 provider prompt snapshot still triggers compression when messages-only estimation remains below 82%. The mutation regression proves that changing an existing message or tool schema invalidates the snapshot and re-estimates the request.

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Correct context compression accounting so requests use current message estimates and only reuse validated provider prompt usage from the active tool loop.

Bug Fixes:
- Prevent persisted conversation token usage from prematurely triggering context compression for new requests.
- Preserve provider prompt usage across matching tool-loop requests while invalidating it when messages or tool schemas change.

Enhancements:
- Add runtime context fingerprints to safely reuse provider-specific prompt overhead alongside newly appended messages.

Tests:
- Add regressions covering stale persisted usage, provider prompt overhead during tool loops, and in-place message or tool-schema mutations.