### PR TITLE
fix(plugin): respect type annotations when parsing command parameters

### DIFF
--- a/astrbot/core/star/filter/command.py
+++ b/astrbot/core/star/filter/command.py
@@ -44,6 +44,8 @@ class CommandFilter(HandlerFilter):
         self.parent_command_names = (
             parent_command_names if parent_command_names is not None else [""]
         )
+        # Default values of handler parameters, used when the user omits them
+        self.handler_param_defaults: dict[str, Any] = {}
         if handler_md:
             self.init_handler_md(handler_md)
         self.custom_filter_list: list[CustomFilter] = []
@@ -52,31 +54,48 @@ class CommandFilter(HandlerFilter):
         self._cmpl_cmd_names: list | None = None
 
     def print_types(self):
+        """Render the handler parameter list in a human-readable form for error hints."""
         parts = []
         for k, v in self.handler_params.items():
+            default = self.handler_param_defaults.get(k, inspect.Parameter.empty)
             if isinstance(v, type):
-                parts.append(f"{k}({v.__name__}),")
+                label = v.__name__
             elif isinstance(v, types.UnionType) or typing.get_origin(v) is typing.Union:
-                parts.append(f"{k}({v}),")
+                label = str(v)
+            elif v is inspect.Parameter.empty:
+                label = "any"
             else:
-                parts.append(f"{k}({type(v).__name__})={v},")
-        result = "".join(parts).rstrip(",")
-        return result
+                label = type(v).__name__
+            if default is inspect.Parameter.empty:
+                parts.append(f"{k}({label}),")
+            else:
+                parts.append(f"{k}({label})={default},")
+        return "".join(parts).rstrip(",")
 
     def init_handler_md(self, handle_md: StarHandlerMetadata) -> None:
         self.handler_md = handle_md
         signature = inspect.signature(self.handler_md.handler, eval_str=True)
-        self.handler_params = {}  # 参数名 -> 参数类型，如果有默认值则为默认值
+        # 参数名 -> 类型注解（无注解时回退为默认值或空标记）
+        self.handler_params = {}
+        # 参数名 -> 默认值（仅当参数有默认值时）
+        self.handler_param_defaults = {}
         idx = 0
         for k, v in signature.parameters.items():
             if idx < 2:
                 # 忽略前两个参数，即 self 和 event
                 idx += 1
                 continue
-            if v.default == inspect.Parameter.empty:
+            if v.annotation is not inspect.Parameter.empty:
+                # 优先使用类型注解作为参数转换的目标类型
                 self.handler_params[k] = v.annotation
-            else:
+            elif v.default is not inspect.Parameter.empty and v.default is not None:
+                # 无注解时，用默认值的运行时类型推断转换目标，保持旧行为
                 self.handler_params[k] = v.default
+            else:
+                # 无注解且无默认值（或默认值为 None）：运行时按启发式处理
+                self.handler_params[k] = inspect.Parameter.empty
+            if v.default is not inspect.Parameter.empty:
+                self.handler_param_defaults[k] = v.default
 
     def get_handler_md(self) -> StarHandlerMetadata:
         return self.handler_md
@@ -90,12 +109,83 @@ class CommandFilter(HandlerFilter):
                 return False
         return True
 
+    def _convert_param(self, param_name: str, raw_value: str, target: Any) -> Any:
+        """Convert a single raw string parameter according to its target type.
+
+        The target type is normally the declared annotation. When there is no
+        annotation, the target falls back to the runtime type of the default
+        value, or to an empty marker that keeps the legacy heuristic.
+
+        Args:
+            param_name: Parameter name, used in error hints.
+            raw_value: Raw string value provided by the user.
+            target: Type annotation, or a default value / empty marker when
+                the parameter has no annotation.
+
+        Returns:
+            The converted parameter value.
+
+        Raises:
+            ValueError: When the raw value cannot be converted to the target.
+        """
+        try:
+            if (
+                target is None
+                or target is inspect.Parameter.empty
+                or target is typing.Any
+            ):
+                # No type constraint: keep the legacy heuristic that parses
+                # digit strings as int.
+                return int(raw_value) if raw_value.isdigit() else raw_value
+            origin = typing.get_origin(target)
+            if origin in (typing.Union, types.UnionType):
+                # Union annotation: when only one non-None type remains after
+                # unwrapping Optional, convert to it; otherwise keep the raw
+                # value (no type validation for multi-type unions yet).
+                non_none_types = unwrap_optional(target)
+                if len(non_none_types) == 1:
+                    return self._convert_param(param_name, raw_value, non_none_types[0])
+                return raw_value
+            if target is str:
+                # str is the raw value itself, no conversion needed
+                return raw_value
+            if target is bool:
+                # Accept true/false, yes/no, 1/0
+                lower_value = str(raw_value).lower()
+                if lower_value in ("true", "yes", "1"):
+                    return True
+                if lower_value in ("false", "no", "0"):
+                    return False
+                raise ValueError(
+                    f"参数 {param_name} 必须是布尔值（true/false, yes/no, 1/0）。",
+                )
+            if isinstance(target, type):
+                # Plain type: convert via its constructor (int/float/custom)
+                return target(raw_value)
+            # No annotation: infer the target from the default value type
+            if isinstance(target, bool):
+                # bool first since it is a subclass of int
+                return self._convert_param(param_name, raw_value, bool)
+            if isinstance(target, str):
+                return raw_value
+            if isinstance(target, int):
+                return int(raw_value)
+            if isinstance(target, float):
+                return float(raw_value)
+            if callable(target):
+                return target(raw_value)
+            return raw_value
+        except ValueError:
+            raise ValueError(
+                f"参数 {param_name} 类型错误。完整参数: {self.print_types()}",
+            )
+
     def validate_and_convert_params(
         self,
         params: list[Any],
         param_type: dict[str, type],
     ) -> dict[str, Any]:
-        """将参数列表 params 根据 param_type 转换为参数字典。"""
+        """将参数列表 params 根据参数类型注解转换为参数字典。"""
         result = {}
         param_items = list(param_type.items())
         for i, (param_name, param_type_or_default_val) in enumerate(param_items):
@@ -112,64 +202,22 @@ class CommandFilter(HandlerFilter):
                 remaining_params = params[i:]
                 result[param_name] = " ".join(remaining_params)
                 break
-            # 没有 GreedyStr 的情况
             if i >= len(params):
-                if (
-                    isinstance(param_type_or_default_val, type | types.UnionType)
-                    or typing.get_origin(param_type_or_default_val) is typing.Union
-                    or param_type_or_default_val is inspect.Parameter.empty
-                ):
-                    # 是类型
+                if param_name in self.handler_param_defaults:
+                    # 参数缺失时使用默认值
+                    result[param_name] = self.handler_param_defaults[param_name]
+                else:
+                    # 无默认值，是必填参数
                     raise ValueError(
                         f"必要参数缺失。该指令完整参数: {self.print_types()}",
                     )
-                # 是默认值
-                result[param_name] = param_type_or_default_val
             else:
-                # 尝试强制转换
-                try:
-                    if param_type_or_default_val is None:
-                        if params[i].isdigit():
-                            result[param_name] = int(params[i])
-                        else:
-                            result[param_name] = params[i]
-                    elif isinstance(param_type_or_default_val, str):
-                        # 如果 param_type_or_default_val 是字符串，直接赋值
-                        result[param_name] = params[i]
-                    elif isinstance(param_type_or_default_val, bool):
-                        # 处理布尔类型
-                        lower_param = str(params[i]).lower()
-                        if lower_param in ["true", "yes", "1"]:
-                            result[param_name] = True
-                        elif lower_param in ["false", "no", "0"]:
-                            result[param_name] = False
-                        else:
-                            raise ValueError(
-                                f"参数 {param_name} 必须是布尔值（true/false, yes/no, 1/0）。",
-                            )
-                    elif isinstance(param_type_or_default_val, int):
-                        result[param_name] = int(params[i])
-                    elif isinstance(param_type_or_default_val, float):
-                        result[param_name] = float(params[i])
-                    else:
-                        origin = typing.get_origin(param_type_or_default_val)
-                        if origin in (typing.Union, types.UnionType):
-                            # 注解是联合类型
-                            # NOTE: 目前没有处理联合类型嵌套相关的注解写法
-                            nn_types = unwrap_optional(param_type_or_default_val)
-                            if len(nn_types) == 1:
-                                # 只有一个非 NoneType 类型
-                                result[param_name] = nn_types[0](params[i])
-                            else:
-                                # 没有或者有多个非 NoneType 类型，这里我们暂时直接赋值为原始值。
-                                # NOTE: 目前还没有做类型校验
-                                result[param_name] = params[i]
-                        else:
-                            result[param_name] = param_type_or_default_val(params[i])
-                except ValueError:
-                    raise ValueError(
-                        f"参数 {param_name} 类型错误。完整参数: {self.print_types()}",
-                    )
+                # 参数存在，按照目标类型转换
+                result[param_name] = self._convert_param(
+                    param_name,
+                    params[i],
+                    param_type_or_default_val,
+                )
         return result
 
     def get_complete_command_names(self):

--- a/astrbot/core/star/filter/command.py
+++ b/astrbot/core/star/filter/command.py
@@ -175,7 +175,7 @@ class CommandFilter(HandlerFilter):
             if callable(target):
                 return target(raw_value)
             return raw_value
-        except ValueError:
+        except (ValueError, TypeError):
             raise ValueError(
                 f"参数 {param_name} 类型错误。完整参数: {self.print_types()}",
             )

--- a/tests/test_command_filter.py
+++ b/tests/test_command_filter.py
@@ -22,7 +22,8 @@ def test_command_filter_resolves_postponed_annotations():
         handler_md=SimpleNamespace(handler=postponed_annotations_handler),
     )
 
-    assert command_filter.handler_params == {"machine": str, "retries": 1}
+    assert command_filter.handler_params == {"machine": str, "retries": int}
+    assert command_filter.handler_param_defaults == {"retries": 1}
     assert command_filter.validate_and_convert_params(
         ["server-1", "2"],
         command_filter.handler_params,
@@ -37,3 +38,78 @@ def test_command_filter_rejects_missing_postponed_required_param():
 
     with pytest.raises(ValueError, match="必要参数缺失"):
         command_filter.validate_and_convert_params([], command_filter.handler_params)
+
+
+async def optional_str_handler(self, event, text: str = None) -> None:
+    pass
+
+
+async def optional_union_handler(self, event, text: str | None = None) -> None:
+    pass
+
+
+async def required_bool_handler(self, event, flag: bool) -> None:
+    pass
+
+
+async def defaulted_str_handler(self, event, text: str = "fallback") -> None:
+    pass
+
+
+async def untyped_handler(self, event, arg) -> None:
+    pass
+
+
+@pytest.mark.parametrize(
+    "handler",
+    [optional_str_handler, optional_union_handler],
+)
+def test_command_filter_keeps_digit_string_for_annotated_str(handler):
+    """A digit string must stay str when the parameter is annotated as str."""
+    command_filter = CommandFilter("echo", handler_md=SimpleNamespace(handler=handler))
+
+    result = command_filter.validate_and_convert_params(
+        ["123"],
+        command_filter.handler_params,
+    )
+
+    assert result == {"text": "123"}
+    assert isinstance(result["text"], str)
+
+
+def test_command_filter_parses_annotation_only_bool():
+    """Annotation-only bool must parse true/false instead of bool() truthiness."""
+    command_filter = CommandFilter(
+        "flag",
+        handler_md=SimpleNamespace(handler=required_bool_handler),
+    )
+
+    assert command_filter.validate_and_convert_params(
+        ["false"],
+        command_filter.handler_params,
+    ) == {"flag": False}
+
+
+def test_command_filter_uses_default_when_param_missing():
+    command_filter = CommandFilter(
+        "echo",
+        handler_md=SimpleNamespace(handler=defaulted_str_handler),
+    )
+
+    assert command_filter.validate_and_convert_params(
+        [],
+        command_filter.handler_params,
+    ) == {"text": "fallback"}
+
+
+def test_command_filter_keeps_untyped_digit_heuristic():
+    """Untyped parameters keep the legacy digit-to-int heuristic."""
+    command_filter = CommandFilter(
+        "t",
+        handler_md=SimpleNamespace(handler=untyped_handler),
+    )
+
+    assert command_filter.validate_and_convert_params(
+        ["123"],
+        command_filter.handler_params,
+    ) == {"arg": 123}


### PR DESCRIPTION
Parameter conversion was driven by the runtime type of the default value instead of the declared annotation, so digit input like 123 was passed as int to parameters annotated as str (e.g. Optional[str] = None). Conversion now follows the annotation; defaults are only used as fallbacks when the argument is omitted. Annotation-only bool parameters also parse true/false/yes/no/1/0 correctly now.

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

`astrbot/core/star/filter/command.py`
- init_handler_md()：类型注解作为转换目标，默认值单独存入 handler_param_defaults（仅用于参数缺省时填充）
- 新增 _convert_param()：str 注解原样传字符串、bool 注解正确解析 true/false/yes/no/1/0、Optional[T]/T | None 解包后按 T 转换、int/float/自定义类型调用构造函数
- 无注解的参数保留旧的 isdigit → int 启发式，向后兼容。

`tests/test_command_filter.py`
- 更新原断言
- 增加4个回归测试

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

插件中定义指令：
```python
    @filter.command("helloworld")
    async def helloworld(self, event: AstrMessageEvent, msg: str | None = None):
        logger.info(type(msg).__name__)
```
输入`/helloworld 101`
日志输出：
```text
[2026-08-29 14:21:22.683] [helloworld]
[INFO]
[helloworld.main:16]: str
```
在之前版本的输出：
```text
[2026-08-29 14:23:47.682] [helloworld]
[INFO]
[helloworld.main:16]: int
```
说明目前版本能够正确识别插件自身的类型注解

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Fix command parameter parsing to prioritize declared type annotations while retaining backward-compatible behavior for untyped parameters.

Bug Fixes:
- Respect declared command-parameter annotations during conversion so annotated strings remain strings and annotated booleans parse accepted textual values correctly.

Enhancements:
- Separate parameter defaults from conversion targets, using defaults only when arguments are omitted while preserving legacy heuristics for untyped parameters.
- Support conversion of optional annotations and constructor-based annotated types with clearer parameter type reporting.

Tests:
- Add regression coverage for annotated string, optional string, boolean, default-value, and untyped parameter handling.