### PR TITLE
fix(tts): repair placeholder RIFF/data sizes in streamed MiniMax WAV output

### DIFF
--- a/astrbot/core/provider/sources/minimax_tts_api_source.py
+++ b/astrbot/core/provider/sources/minimax_tts_api_source.py
@@ -12,6 +12,51 @@ from ..entities import ProviderType
 from ..provider import TTSProvider
 from ..register import register_provider_adapter
 
+# Streamed WAV containers cannot know their total length up front, so the
+# producing encoder writes 0xFFFFFFFF placeholders into the RIFF size and the
+# ``data`` chunk size fields (see issue #9860).
+WAV_SIZE_PLACEHOLDER = 0xFFFFFFFF
+
+
+def _patch_streamed_wav_header(audio: bytes) -> bytes:
+    """Repair placeholder RIFF/data chunk sizes in a streamed WAV file.
+
+    MiniMax streams WAV produced by server-side ffmpeg with placeholder
+    chunk sizes. Browsers tolerate such headers, but strict decoders
+    (e.g. Android WebView) reject the file. Once the whole stream has been
+    assembled, the real sizes are known and can be written back. Files
+    whose sizes are already valid are returned unchanged.
+    """
+    if len(audio) < 12 or audio[0:4] != b"RIFF" or audio[8:12] != b"WAVE":
+        return audio
+
+    patched = bytearray(audio)
+    riff_size = int.from_bytes(patched[4:8], "little")
+    data_patched = False
+
+    # Walk the chunk list to locate the ``data`` chunk. Chunk payloads are
+    # padded to even lengths, which the walk accounts for.
+    pos = 12
+    while pos + 8 <= len(patched):
+        chunk_id = bytes(patched[pos : pos + 4])
+        declared = int.from_bytes(patched[pos + 4 : pos + 8], "little")
+        payload_start = pos + 8
+        if chunk_id == b"data":
+            if declared == WAV_SIZE_PLACEHOLDER:
+                actual = len(patched) - payload_start
+                patched[pos + 4 : pos + 8] = actual.to_bytes(4, "little")
+                data_patched = True
+            break
+        if declared == WAV_SIZE_PLACEHOLDER:
+            # A placeholder size before ``data`` makes the walk unsafe;
+            # leave the file untouched rather than guess.
+            return audio
+        pos = payload_start + declared + (declared & 1)
+
+    if data_patched and riff_size == WAV_SIZE_PLACEHOLDER:
+        patched[4:8] = (len(patched) - 8).to_bytes(4, "little")
+    return bytes(patched)
+
 
 @register_provider_adapter(
     "minimax_tts_api",
@@ -170,6 +215,9 @@ class ProviderMiniMaxTTSAPI(TTSProvider):
                     "Please verify your configuration, especially the 'group_id' parameter. "
                     "You can find your group_id in Account Management -> Basic Information on the MiniMax platform."
                 )
+
+            # 流式 WAV 的头部长度是占位值，落盘前按实际长度修复
+            audio = _patch_streamed_wav_header(audio)
 
             # 结果保存至文件
             with open(path, "wb") as file:

--- a/astrbot/core/provider/sources/minimax_tts_api_source.py
+++ b/astrbot/core/provider/sources/minimax_tts_api_source.py
@@ -32,7 +32,7 @@ def _patch_streamed_wav_header(audio: bytes) -> bytes:
 
     patched = bytearray(audio)
     riff_size = int.from_bytes(patched[4:8], "little")
-    data_patched = False
+    data_found = False
 
     # Walk the chunk list to locate the ``data`` chunk. Chunk payloads are
     # padded to even lengths, which the walk accounts for.
@@ -42,10 +42,10 @@ def _patch_streamed_wav_header(audio: bytes) -> bytes:
         declared = int.from_bytes(patched[pos + 4 : pos + 8], "little")
         payload_start = pos + 8
         if chunk_id == b"data":
+            data_found = True
             if declared == WAV_SIZE_PLACEHOLDER:
                 actual = len(patched) - payload_start
                 patched[pos + 4 : pos + 8] = actual.to_bytes(4, "little")
-                data_patched = True
             break
         if declared == WAV_SIZE_PLACEHOLDER:
             # A placeholder size before ``data`` makes the walk unsafe;
@@ -53,7 +53,7 @@ def _patch_streamed_wav_header(audio: bytes) -> bytes:
             return audio
         pos = payload_start + declared + (declared & 1)
 
-    if data_patched and riff_size == WAV_SIZE_PLACEHOLDER:
+    if data_found and riff_size == WAV_SIZE_PLACEHOLDER:
         patched[4:8] = (len(patched) - 8).to_bytes(4, "little")
     return bytes(patched)
 

--- a/astrbot/core/provider/sources/minimax_tts_api_source.py
+++ b/astrbot/core/provider/sources/minimax_tts_api_source.py
@@ -18,6 +18,45 @@ from ..register import register_provider_adapter
 WAV_SIZE_PLACEHOLDER = 0xFFFFFFFF
 
 
+def _is_well_formed_chunk_chain(audio: bytes, start: int) -> bool:
+    """Return whether ``audio[start:]`` is a complete RIFF chunk chain.
+
+    A streamed ``data`` chunk has no usable size until the stream is
+    assembled.  Before treating all remaining bytes as audio, use this
+    conservative check to detect a valid trailing chunk (for example a
+    ``LIST`` metadata chunk).  False positives only skip the repair, which is
+    preferable to writing a header that claims metadata is audio data.
+    """
+    if start < 12 or start >= len(audio):
+        return False
+
+    pos = start
+    while pos + 8 <= len(audio):
+        chunk_id = audio[pos : pos + 4]
+        if not all(32 <= byte <= 126 for byte in chunk_id):
+            return False
+
+        declared = int.from_bytes(audio[pos + 4 : pos + 8], "little")
+        end = pos + 8 + declared + (declared & 1)
+        if end > len(audio):
+            return False
+        pos = end
+
+    return pos == len(audio)
+
+
+def _has_trailing_chunk(audio: bytes, payload_start: int) -> bool:
+    """Detect a conservatively parseable chunk after an unknown data payload."""
+    # RIFF chunks are aligned to even offsets.  The scan is intentionally
+    # conservative: a coincidental valid-looking suffix merely leaves the
+    # placeholder untouched rather than risking an incorrect data length.
+    first = payload_start + (payload_start & 1)
+    for candidate in range(first, len(audio) - 7, 2):
+        if _is_well_formed_chunk_chain(audio, candidate):
+            return True
+    return False
+
+
 def _patch_streamed_wav_header(audio: bytes) -> bytes:
     """Repair placeholder RIFF/data chunk sizes in a streamed WAV file.
 
@@ -44,7 +83,13 @@ def _patch_streamed_wav_header(audio: bytes) -> bytes:
         if chunk_id == b"data":
             data_found = True
             if declared == WAV_SIZE_PLACEHOLDER:
+                # The placeholder does not tell us where the payload ends.
+                # Do not absorb a later RIFF chunk into the audio data.
+                # MiniMax emits 16-bit PCM, so an odd number of remaining
+                # bytes cannot be a complete payload.
                 actual = len(patched) - payload_start
+                if actual & 1 or _has_trailing_chunk(patched, payload_start):
+                    return audio
                 patched[pos + 4 : pos + 8] = actual.to_bytes(4, "little")
             break
         if declared == WAV_SIZE_PLACEHOLDER:

--- a/tests/unit/test_minimax_tts_wav_header.py
+++ b/tests/unit/test_minimax_tts_wav_header.py
@@ -1,0 +1,127 @@
+import struct
+
+import pytest
+
+from astrbot.core.provider.sources.minimax_tts_api_source import (
+    WAV_SIZE_PLACEHOLDER,
+    ProviderMiniMaxTTSAPI,
+    _patch_streamed_wav_header,
+)
+
+FMT_CHUNK_SIZE = 24  # 8-byte chunk header + 16-byte PCM fmt body
+
+
+def _make_wav(
+    payload: bytes = b"\x00\x01",
+    riff_size: int = WAV_SIZE_PLACEHOLDER,
+    data_size: int = WAV_SIZE_PLACEHOLDER,
+    extra_chunks: bytes = b"",
+) -> bytes:
+    """Build a minimal PCM WAV file, optionally with placeholder sizes."""
+    fmt = struct.pack("<HHIIHH", 1, 1, 32000, 64000, 2, 16)
+    chunks = (
+        b"WAVE"
+        + extra_chunks
+        + b"fmt "
+        + struct.pack("<I", len(fmt))
+        + fmt
+        + b"data"
+        + struct.pack("<I", data_size)
+        + payload
+    )
+    return b"RIFF" + struct.pack("<I", riff_size) + chunks
+
+
+def _data_size_offset(extra_chunks_len: int) -> int:
+    # RIFF(4) + size(4) + WAVE(4) + extra chunks + fmt chunk + data id(4)
+    return 12 + extra_chunks_len + FMT_CHUNK_SIZE + 4
+
+
+class TestPatchStreamedWavHeader:
+    def test_placeholder_sizes_repaired(self):
+        payload = b"\x00\x01" * 1000
+        fixed = _patch_streamed_wav_header(_make_wav(payload=payload))
+
+        off = _data_size_offset(0)
+        assert int.from_bytes(fixed[4:8], "little") == len(fixed) - 8
+        assert int.from_bytes(fixed[off : off + 4], "little") == len(payload)
+        assert fixed != _make_wav(payload=payload)
+
+    def test_valid_wav_unchanged(self):
+        payload = b"\x00\x01" * 1000
+        wav = _make_wav(
+            payload=payload,
+            riff_size=44 + len(payload) - 8,
+            data_size=len(payload),
+        )
+        assert _patch_streamed_wav_header(wav) == wav
+
+    def test_non_wav_input_unchanged(self):
+        for blob in (
+            b"",
+            b"\x00" * 64,
+            b"RIFF\x00\x00\x00\x00",
+            b"RIFF\x00\x00\x00\x00WAVE",
+            b"NOTWAV" + b"\x00" * 32,
+        ):
+            assert _patch_streamed_wav_header(blob) == blob
+
+    def test_extra_chunks_before_data_still_patched(self):
+        payload = b"\x00\x01" * 100
+        info = b"INFOabcd"  # even length: no pad byte
+        list_chunk = b"LIST" + struct.pack("<I", len(info)) + info
+        fixed = _patch_streamed_wav_header(
+            _make_wav(payload=payload, extra_chunks=list_chunk)
+        )
+
+        off = _data_size_offset(len(list_chunk))
+        assert int.from_bytes(fixed[4:8], "little") == len(fixed) - 8
+        assert int.from_bytes(fixed[off : off + 4], "little") == len(payload)
+
+    def test_placeholder_size_before_data_left_untouched(self):
+        # An un-walkable chunk before ``data`` must not be guessed around.
+        junk = b"junk" + struct.pack("<I", WAV_SIZE_PLACEHOLDER) + b"abcd"
+        wav = _make_wav(payload=b"xy", extra_chunks=junk)
+        assert _patch_streamed_wav_header(wav) == wav
+
+    def test_truncation_cases(self):
+        # Truncated before the data chunk header: nothing to patch.
+        wav = _make_wav(payload=b"abc")[:30]
+        assert _patch_streamed_wav_header(wav) == wav
+        # Truncated inside the data payload: the placeholder is still
+        # replaced with whatever data actually arrived.
+        wav = _make_wav(payload=b"abcdefgh")[:50]
+        fixed = _patch_streamed_wav_header(wav)
+        assert int.from_bytes(fixed[40:44], "little") == 6
+
+
+def _hex_stream(data: bytes, chunk_size: int = 7):
+    for i in range(0, len(data), chunk_size):
+        yield data[i : i + chunk_size].hex()
+
+
+class TestGetAudioEndToEnd:
+    @pytest.mark.asyncio
+    async def test_get_audio_writes_valid_wav(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "astrbot.core.provider.sources.minimax_tts_api_source.get_astrbot_temp_path",
+            lambda: str(tmp_path),
+        )
+        provider = ProviderMiniMaxTTSAPI(
+            {"api_key": "test-key", "model": "speech-01"},
+            {},
+        )
+        wav = _make_wav(payload=b"\x00\x01" * 1000)
+
+        async def fake_stream(_text):
+            for chunk in _hex_stream(wav):
+                yield chunk
+
+        provider._call_tts_stream = fake_stream
+
+        path = await provider.get_audio("你好")
+
+        with open(path, "rb") as f:
+            data = f.read()
+        assert int.from_bytes(data[4:8], "little") == len(data) - 8
+        assert int.from_bytes(data[40:44], "little") == 2000

--- a/tests/unit/test_minimax_tts_wav_header.py
+++ b/tests/unit/test_minimax_tts_wav_header.py
@@ -66,6 +66,20 @@ class TestPatchStreamedWavHeader:
         ):
             assert _patch_streamed_wav_header(blob) == blob
 
+    def test_riff_placeholder_with_valid_data_size_patched(self):
+        # Mixed placeholder state: data size is already real but the RIFF
+        # size is still the placeholder -- only RIFF gets rewritten.
+        payload = b"\x00\x01" * 1000
+        fixed = _patch_streamed_wav_header(
+            _make_wav(
+                payload=payload, riff_size=WAV_SIZE_PLACEHOLDER, data_size=len(payload)
+            )
+        )
+
+        off = _data_size_offset(0)
+        assert int.from_bytes(fixed[4:8], "little") == len(fixed) - 8
+        assert int.from_bytes(fixed[off : off + 4], "little") == len(payload)
+
     def test_extra_chunks_before_data_still_patched(self):
         payload = b"\x00\x01" * 100
         info = b"INFOabcd"  # even length: no pad byte

--- a/tests/unit/test_minimax_tts_wav_header.py
+++ b/tests/unit/test_minimax_tts_wav_header.py
@@ -16,6 +16,7 @@ def _make_wav(
     riff_size: int = WAV_SIZE_PLACEHOLDER,
     data_size: int = WAV_SIZE_PLACEHOLDER,
     extra_chunks: bytes = b"",
+    trailing_chunks: bytes = b"",
 ) -> bytes:
     """Build a minimal PCM WAV file, optionally with placeholder sizes."""
     fmt = struct.pack("<HHIIHH", 1, 1, 32000, 64000, 2, 16)
@@ -28,6 +29,7 @@ def _make_wav(
         + b"data"
         + struct.pack("<I", data_size)
         + payload
+        + trailing_chunks
     )
     return b"RIFF" + struct.pack("<I", riff_size) + chunks
 
@@ -96,6 +98,20 @@ class TestPatchStreamedWavHeader:
         # An un-walkable chunk before ``data`` must not be guessed around.
         junk = b"junk" + struct.pack("<I", WAV_SIZE_PLACEHOLDER) + b"abcd"
         wav = _make_wav(payload=b"xy", extra_chunks=junk)
+        assert _patch_streamed_wav_header(wav) == wav
+
+    def test_placeholder_data_with_trailing_chunk_left_untouched(self):
+        payload = b"\x00\x01" * 100
+        info = b"INFOabcd"
+        list_chunk = b"LIST" + struct.pack("<I", len(info)) + info
+        wav = _make_wav(payload=payload, trailing_chunks=list_chunk)
+
+        # The placeholder makes the boundary unknowable; metadata must not be
+        # counted as audio data.
+        assert _patch_streamed_wav_header(wav) == wav
+
+    def test_odd_placeholder_payload_left_untouched(self):
+        wav = _make_wav(payload=b"abc")
         assert _patch_streamed_wav_header(wav) == wav
 
     def test_truncation_cases(self):


### PR DESCRIPTION
## Problem

`minimax_tts_api` hardcodes `stream: true` and `format: "wav"`, so the WAV bytes come from MiniMax's server-side ffmpeg. A streamed WAV cannot know its total length up front, so ffmpeg writes `0xFFFFFFFF` placeholders into both the RIFF size field and the `data` chunk size field. `_audio_play()` only concatenates the hex-decoded SSE chunks and `get_audio()` writes the bytes to disk untouched, so every saved `minimax_tts_api_*.wav` carries an invalid header.

Browsers tolerate the placeholder sizes, which is why playback looks fine in the WebUI, but strict decoders (Android WebView / system players) reject the file — and nothing appears in AstrBot's logs. Hex dump from the issue:

```text
00000000  52 49 46 46 FF FF FF FF 57 41 56 45 66 6D 74 20   RIFFÿÿÿÿWAVEfmt
```

Closes #9860

## Fix

Add a module-level `_patch_streamed_wav_header()` and call it in `get_audio()` on the assembled bytes right before they are written to disk:

- walks the RIFF chunk list (respecting even-length chunk padding) to locate the `data` chunk;
- rewrites the `data` chunk size and the RIFF size **only** when the field holds the `0xFFFFFFFF` placeholder, so already-valid files are returned byte-for-byte unchanged;
- bails out conservatively (input returned unchanged) for non-`WAVE` input, truncated input, or an un-walkable placeholder-sized chunk before `data`.

## Tests

`tests/unit/test_minimax_tts_wav_header.py` (pytest, no network):

- placeholder sizes are repaired to the real `len(file) - 8` / payload sizes;
- a fully valid WAV passes through byte-for-byte unchanged;
- non-WAV / short / truncated input is unchanged;
- a placeholder-sized chunk before `data` is not guessed around (conservative bail-out);
- standard chunks before `data` (e.g. `LIST`) are walked correctly;
- end-to-end: `get_audio()` with a mocked hex SSE stream writes a file whose repaired header decodes cleanly.

`ruff format` / `ruff check` pass; the repository's neo profile suite (`scripts/pr_test_env.sh --profile neo`) passes except for two pre-existing failures in `tests/test_computer_skill_sync.py`, which fail identically on a clean `master` checkout.

## Historical context

#7144 / #7795 / #7565 reported the earlier `file does not start with RIFF id` failures (MP3 payload under a `.wav` name), fixed by #7797 switching the default output format to WAV. That left the streamed path producing a correctly-named but header-invalid file; this PR closes that remaining gap.

## Summary by Sourcery

Repair streamed MiniMax WAV headers before writing audio files so strict decoders can read the generated output.

Bug Fixes:
- Repair invalid RIFF and data chunk size placeholders in streamed MiniMax WAV files before saving them, improving compatibility with strict audio decoders while preserving already-valid files.

Enhancements:
- Add conservative RIFF chunk parsing that handles padded metadata chunks and avoids modifying malformed, truncated, or ambiguous inputs.

Tests:
- Add unit and end-to-end coverage for WAV header repair, valid and invalid inputs, metadata chunks, truncation, and saved audio output.