### PR TITLE
fix(dashboard): make skill editor dialog responsive on small screens

### DIFF
--- a/dashboard/src/components/extension/SkillsSection.vue
+++ b/dashboard/src/components/extension/SkillsSection.vue
@@ -643,6 +643,7 @@
     <v-dialog
       v-model="editorDialog.show"
       max-width="1180px"
+      :fullscreen="$vuetify.display.mdAndDown"
       :persistent="editorDialog.saving"
     >
       <v-card class="skill-editor-dialog">
@@ -2404,6 +2405,20 @@ export default {
 @media (max-width: 860px) {
   .skills-list {
     grid-template-columns: minmax(0, 1fr);
+  }
+  
+  .skill-editor {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto minmax(0, 1fr);
+    min-height: 0;
+  }
+
+  .skill-editor__files {
+    max-height: 20vh;
+  }
+
+  .skill-editor__monaco {
+    min-height: 40vh;
   }
 
   .skill-list-item :deep(.outlined-action-list-item__actions) {

--- a/dashboard/src/components/extension/SkillsSection.vue
+++ b/dashboard/src/components/extension/SkillsSection.vue
@@ -2403,6 +2403,11 @@ export default {
 }
 
 @media (max-width: 860px) {
+  .skill-editor-dialog {
+    max-height: none;
+    overflow-y: auto;
+  }
+
   .skills-list {
     grid-template-columns: minmax(0, 1fr);
   }


### PR DESCRIPTION
> [!IMPORTANT]
> 此 **Pull Request** 为临时解决方案
> 如果短期内有重置 **Skill 编辑器** 的计划，可关闭此 **PR**
> 如果不需要中等窗口以下的窗口全屏，可追加 commit 移除 646行 的 `:fullscreen="$vuetify.display.mdAndDown"`
> 有什么改进方案均可在此 **PR** 追加新 **commit** 或 **comment** 。或者关闭此 **PR** 时，可以说明一下不方便改动的原因

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点

Fixes #9871 

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

本 **Pull Request** 仅修改了 `SkillsSection.vue` 并添加了两处内容 (`窗口全屏条件` `CSS`): 
- 在 `646行` 添加了 `:fullscreen="$vuetify.display.mdAndDown"` ，避免和固定在右下角的两个按钮出现元素重叠
- 在约 `2405-2441行` 添加了3个选择器
 
#### 关于3个选择器做了什么
- `.skill-editor`  编辑器弹窗内文件树/编辑器在窄屏下改成单列布局
- `.skill-editor__files` 固定为 `20vh` 
- `.skill-editor__monaco` 固定为 `40vh`

如果你认为这个固定数值不合理，可以说明一下原因和相对应的解决方法，或者追加 `commit` 也可以。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

#### Before / 改动前

由于双列布局的原因，在移动端下，文件夹树占比较大，编辑器几乎不可见。

<img width="144" height="320" alt="Screenshot_2026-08-30-10-24-20-657_mark via" src="https://github.com/user-attachments/assets/e6563f51-a8bf-4a01-bc0a-4803f4affced" />

#### After / 改动后

在移动端下，改为**单列布局**，现在用户可以看见**编辑器**且**查看和编辑内容**了。并且由于**窗口全屏**，现在不会和固定在右下角的按钮产生**元素重叠**。

<img width="144" height="320" alt="Screenshot_2026-08-30-11-12-07-331_mark via" src="https://github.com/user-attachments/assets/3d254165-2174-4eac-aef6-8cd5bf95ada0" />

对于桌面端，小窗口和中等窗口也有效果，但影响不大。

<img width="1312" height="1442" alt="Snipaste_2026-08-30_12-11-58" src="https://github.com/user-attachments/assets/cc425028-cd23-4ad1-a402-e729a507c93a" />

<div align="center">桌面端小窗口</div>

<img width="1760" height="1442" alt="Snipaste_2026-08-30_12-12-13" src="https://github.com/user-attachments/assets/a9269814-c14b-4d40-9d60-13c57193eb9e" />

<div align="center">桌面端中等窗口</div>

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Improve the skill editor’s responsive behavior so users can view and edit files reliably on small screens.

Bug Fixes:
- Make the skill editor usable on small screens by switching its file tree and editor to a single-column layout with dedicated vertical space.
- Prevent the responsive skill editor dialog from overlapping fixed bottom-right controls by using fullscreen mode on medium and smaller displays.

Enhancements:
- Improve skill editor dialog scrolling and sizing for narrow viewports.