### PR TITLE
fix: ignore stale group context records

### DIFF
--- a/astrbot/builtin_stars/astrbot/group_chat_context.py
+++ b/astrbot/builtin_stars/astrbot/group_chat_context.py
@@ -175,10 +175,12 @@ class GroupChatContext:
 
             raw_list = list(records)
             id_list = list(self._record_ids.get(umo, deque()))
-            if isinstance(record_id, str) and record_id in id_list:
+            if isinstance(record_id, str):
+                if record_id not in id_list:
+                    return
                 prompt_idx = id_list.index(record_id)
 
-            if prompt_idx >= len(raw_list):
+            if prompt_idx < 0 or prompt_idx >= len(raw_list):
                 return
 
             records_to_inject = raw_list[:prompt_idx]

--- a/tests/unit/test_group_chat_context_wiring.py
+++ b/tests/unit/test_group_chat_context_wiring.py
@@ -300,3 +300,23 @@ async def test_format_message_truncates_long_json_card_fields():
     formatted = await context._format_message(event, {})
 
     assert f"Description: {'a' * 200}...]" in formatted
+
+
+@pytest.mark.asyncio
+async def test_on_req_llm_ignores_stale_record_id():
+    context = GroupChatContext(MagicMock(), MagicMock())
+    context.raw_records["umo"].extend(["first", "second"])
+    context._record_ids["umo"].extend(["id-1", "id-2"])
+
+    event = MagicMock()
+    event.unified_msg_origin = "umo"
+    event.get_extra.side_effect = lambda key, default=None: {
+        "_group_context_record_id": "stale-id",
+    }.get(key, default)
+    req = SimpleNamespace(extra_user_content_parts=[])
+
+    await context.on_req_llm(event, req)
+
+    assert req.extra_user_content_parts == []
+    assert list(context.raw_records["umo"]) == ["first", "second"]
+    assert list(context._record_ids["umo"]) == ["id-1", "id-2"]


### PR DESCRIPTION
### Modifications / 改动点

- 修复群聊上下文 LLM hook 处理过期记录 ID 时错误使用 `prompt_idx = -1` 的问题。
- 过期或未知的记录 ID 现在会安全地忽略，不再注入当前群聊历史，也不会修改缓存。
- 为该场景新增回归测试：`tests/unit/test_group_chat_context_wiring.py::test_on_req_llm_ignores_stale_record_id`。
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图、测试结果

Verification steps:

```text
uv run pytest tests/unit/test_group_chat_context_wiring.py -q
11 passed, 1 warning in 3.30s

uv run ruff format --check astrbot/builtin_stars/astrbot/group_chat_context.py tests/unit/test_group_chat_context_wiring.py
2 files already formatted

uv run ruff check astrbot/builtin_stars/astrbot/group_chat_context.py tests/unit/test_group_chat_context_wiring.py
All checks passed!
```

The warning is the existing Python `audioop` deprecation warning from `astrbot/core/utils/tencent_record_helper.py`. No screenshot is applicable because this is a backend correctness fix.

---

### Checklist / 检查清单

- [ ] 新功能讨论确认。不适用，本 PR 是 bug 修复。
- [x] My changes have been well-tested, and Verification Steps and Screenshots have been provided above. / 更改已经过测试，并已提供验证步骤和测试结果。
- [x] My changes do not introduce new dependencies. / 未引入新依赖。
- [x] My changes do not introduce malicious code. / 未引入恶意代码。

## Summary by Sourcery

Prevent stale group-chat context references from affecting LLM requests or cached conversation state.

Bug Fixes:
- Ignore stale or unknown group-chat record IDs instead of injecting incorrect conversation history or altering cached records.

Tests:
- Add regression coverage confirming stale record IDs leave the LLM request and group-chat caches unchanged.