### PR TITLE
fix(provider): exclude cached tokens from Gemini input usage accounting

### DIFF
--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -451,7 +451,7 @@ class ProviderGoogleGenAI(Provider):
     def _extract_usage(
         self, usage_metadata: types.GenerateContentResponseUsageMetadata
     ) -> TokenUsage:
-        """Extract usage from candidate.
+        """Extract usage from response metadata.
 
         `prompt_token_count` includes tokens served from cache, so subtract
         `cached_content_token_count` to avoid double-counting cached input

--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -451,10 +451,17 @@ class ProviderGoogleGenAI(Provider):
     def _extract_usage(
         self, usage_metadata: types.GenerateContentResponseUsageMetadata
     ) -> TokenUsage:
-        """Extract usage from candidate"""
+        """Extract usage from candidate.
+
+        `prompt_token_count` includes tokens served from cache, so subtract
+        `cached_content_token_count` to avoid double-counting cached input
+        (matching the OpenAI provider's TokenUsage accounting).
+        """
+        prompt_tokens = usage_metadata.prompt_token_count or 0
+        cached = usage_metadata.cached_content_token_count or 0
         return TokenUsage(
-            input_other=usage_metadata.prompt_token_count or 0,
-            input_cached=usage_metadata.cached_content_token_count or 0,
+            input_other=prompt_tokens - cached,
+            input_cached=cached,
             output=usage_metadata.candidates_token_count or 0,
         )
 

--- a/tests/test_gemini_source.py
+++ b/tests/test_gemini_source.py
@@ -131,6 +131,42 @@ def test_gemini_reasoning_only_output_is_allowed():
     )
 
 
+def test_gemini_extract_usage_excludes_cached_tokens_from_input_other():
+    provider = ProviderGoogleGenAI.__new__(ProviderGoogleGenAI)
+
+    usage_metadata = SimpleNamespace(
+        prompt_token_count=100,
+        cached_content_token_count=30,
+        candidates_token_count=50,
+    )
+
+    usage = provider._extract_usage(usage_metadata)
+
+    # prompt_token_count already includes cached tokens; input_other must
+    # exclude them so input (input_other + input_cached) is not inflated.
+    assert usage.input_other == 70
+    assert usage.input_cached == 30
+    assert usage.input == 100
+    assert usage.output == 50
+
+
+def test_gemini_extract_usage_without_cache_keeps_full_prompt_tokens():
+    provider = ProviderGoogleGenAI.__new__(ProviderGoogleGenAI)
+
+    usage_metadata = SimpleNamespace(
+        prompt_token_count=100,
+        cached_content_token_count=0,
+        candidates_token_count=20,
+    )
+
+    usage = provider._extract_usage(usage_metadata)
+
+    assert usage.input_other == 100
+    assert usage.input_cached == 0
+    assert usage.input == 100
+    assert usage.output == 20
+
+
 @pytest.mark.asyncio
 async def test_gemini_get_models_retries_transient_request_error(monkeypatch):
     monkeypatch.setattr(request_retry, "REQUEST_RETRY_WAIT_MIN_S", 0)


### PR DESCRIPTION
## Problem

`ProviderGoogleGenAI._extract_usage` builds `TokenUsage` by passing Gemini's `prompt_token_count` straight into `input_other` while also setting `input_cached` to `cached_content_token_count`.

Per the [Gemini API docs](https://ai.google.dev/api/generate-content#GenerateContentResponseUsageMetadata), `prompt_token_count` **already includes** the tokens served from cache. So `TokenUsage.input` (`input_other + input_cached`) double-counts cached tokens, inflating context-occupancy stats (e.g. `current_context_tokens` in the tool-loop runner).

The OpenAI provider handles this correctly (`input_other = prompt_tokens - cached`, see `openai_source.py`), so the two providers are inconsistent.

## Changes

- `astrbot/core/provider/sources/gemini_source.py`: subtract `cached_content_token_count` from `prompt_token_count` when building `input_other`, matching the OpenAI provider's accounting.
- `tests/test_gemini_source.py`: add two unit tests covering usage with and without cached tokens.

## Verification

```
$ uv run pytest tests/test_gemini_source.py tests/unit/test_provider_stats.py -q
10 passed
```

## Summary by Sourcery

Prevent cached Gemini prompt tokens from inflating reported input usage.

Bug Fixes:
- Correct Gemini input token usage accounting so cached prompt tokens are not double-counted.

Tests:
- Add coverage for Gemini usage accounting with and without cached tokens.