### PR TITLE
fix(provider): count Anthropic cache_creation tokens in input usage

### DIFF
--- a/astrbot/core/provider/sources/anthropic_source.py
+++ b/astrbot/core/provider/sources/anthropic_source.py
@@ -445,15 +445,21 @@ class ProviderAnthropic(Provider):
         if usage is None:
             return TokenUsage()
         # https://docs.claude.com/en/docs/build-with-claude/prompt-caching#tracking-cache-performance
+        # Anthropic's input_tokens excludes cache served reads AND writes, so
+        # cache_creation_input_tokens must be added back into input_other to
+        # keep total input (and context-occupancy stats) accurate.
         return TokenUsage(
-            input_other=usage.input_tokens or 0,
+            input_other=(usage.input_tokens or 0)
+            + (usage.cache_creation_input_tokens or 0),
             input_cached=usage.cache_read_input_tokens or 0,
             output=usage.output_tokens or 0,
         )
 
     def _update_usage(self, token_usage: TokenUsage, usage: MessageDeltaUsage) -> None:
         if usage.input_tokens is not None:
-            token_usage.input_other = usage.input_tokens
+            token_usage.input_other = usage.input_tokens + (
+                usage.cache_creation_input_tokens or 0
+            )
         if usage.cache_read_input_tokens is not None:
             token_usage.input_cached = usage.cache_read_input_tokens
         if usage.output_tokens is not None:

--- a/tests/test_anthropic_source.py
+++ b/tests/test_anthropic_source.py
@@ -1,0 +1,77 @@
+from anthropic.types import MessageDeltaUsage, Usage
+
+from astrbot.core.provider.entities import TokenUsage
+from astrbot.core.provider.sources.anthropic_source import ProviderAnthropic
+
+
+def _provider() -> ProviderAnthropic:
+    return ProviderAnthropic.__new__(ProviderAnthropic)
+
+
+def test_anthropic_extract_usage_counts_cache_creation_input():
+    provider = _provider()
+
+    usage = provider._extract_usage(
+        Usage(
+            input_tokens=10,
+            cache_read_input_tokens=100,
+            cache_creation_input_tokens=50,
+            output_tokens=20,
+        )
+    )
+
+    # Anthropic's input_tokens excludes cache writes, so cache_creation
+    # must be folded into input_other to keep total input accurate.
+    assert usage.input_other == 60
+    assert usage.input_cached == 100
+    assert usage.input == 160
+    assert usage.output == 20
+
+
+def test_anthropic_extract_usage_without_cache_breakpoints():
+    provider = _provider()
+
+    usage = provider._extract_usage(Usage(input_tokens=30, output_tokens=10))
+
+    assert usage.input_other == 30
+    assert usage.input_cached == 0
+    assert usage.input == 30
+    assert usage.output == 10
+
+
+def test_anthropic_extract_usage_none_returns_empty():
+    provider = _provider()
+
+    assert provider._extract_usage(None) == TokenUsage()
+
+
+def test_anthropic_update_usage_counts_cache_creation_input():
+    provider = _provider()
+    token_usage = TokenUsage(input_other=5, input_cached=0, output=0)
+
+    provider._update_usage(
+        token_usage,
+        MessageDeltaUsage(
+            input_tokens=10,
+            cache_read_input_tokens=100,
+            cache_creation_input_tokens=50,
+            output_tokens=20,
+        ),
+    )
+
+    assert token_usage.input_other == 60
+    assert token_usage.input_cached == 100
+    assert token_usage.input == 160
+    assert token_usage.output == 20
+
+
+def test_anthropic_update_usage_omitted_fields_are_preserved():
+    provider = _provider()
+    token_usage = TokenUsage(input_other=5, input_cached=0, output=0)
+
+    # message_delta usage only carries output tokens in practice.
+    provider._update_usage(token_usage, MessageDeltaUsage(output_tokens=7))
+
+    assert token_usage.input_other == 5
+    assert token_usage.input_cached == 0
+    assert token_usage.output == 7


### PR DESCRIPTION
## Problem

Anthropic's `Usage.input_tokens` only counts tokens **after the last cache breakpoint** — it excludes both cache reads and cache writes. `ProviderAnthropic._extract_usage` maps `input_tokens` into `TokenUsage.input_other` and `cache_read_input_tokens` into `input_cached`, which is correct for reads — but **`cache_creation_input_tokens` (tokens written into a freshly created cache entry) are dropped entirely**.

Per Anthropic's official docs (linked in the code comment):

> `total_input_tokens = cache_read_input_tokens + cache_creation_input_tokens + input_tokens`

So on any request that creates a new cache entry (e.g. first turn after a cache `ephemeral_1h` breakpoint on a long system prompt), `usage.input` and `usage.total` undercount the real input — which feeds context-occupancy stats (`current_context_tokens` in the tool-loop runner).

The OpenAI provider handles this category correctly: `input_other = prompt_tokens - cached`, so `input_other` includes cache-write tokens. Anthropic was the only provider dropping them.

## Changes

- `astrbot/core/provider/sources/anthropic_source.py`: fold `cache_creation_input_tokens` into `input_other` in both `_extract_usage` (non-streaming / message_start) and `_update_usage` (streaming message_delta), mirroring OpenAI's accounting where `input_other` holds all non-cache-read input including cache writes.
- `tests/test_anthropic_source.py` (new): 5 unit tests covering extract/update with and without cache fields, and omitted-field preservation in streaming deltas.

## Verification

```
$ uv run pytest tests/test_anthropic_source.py tests/test_anthropic_kimi_code_provider.py tests/unit/test_provider_stats.py -q
38 passed
```

## Summary by Sourcery

Ensure Anthropic cache writes are included in input token accounting so context and usage statistics remain accurate.

Bug Fixes:
- Correct Anthropic input and total token usage by including cache-creation tokens in non-cached input accounting.

Tests:
- Add unit coverage for Anthropic usage extraction and streaming updates with cache fields and omitted usage fields.