### PR TITLE
fix(plugin): detect updates for plugins without persisted install sources

### DIFF
--- a/astrbot/dashboard/services/plugin_service.py
+++ b/astrbot/dashboard/services/plugin_service.py
@@ -643,7 +643,7 @@ class PluginService:
             "version": plugin.version,
             "reserved": plugin.reserved,
             "activated": plugin.activated,
-            "online_vesion": "",
+            "online_version": "",
             "display_name": plugin.display_name,
             "logo": logo_url,
             "support_platforms": plugin.support_platforms,

--- a/dashboard/src/views/extension/useExtensionPage.js
+++ b/dashboard/src/views/extension/useExtensionPage.js
@@ -711,7 +711,10 @@ export const useExtensionPage = (initialTab = "installed") => {
   const findMarketPluginForExtension = (extension) => {
     if (!extension) return null;
     const source = extension.install_source || {};
-    if (source.implicit === true || source.install_method !== "market") {
+    // Implicit records (legacy plugins installed before source persistence)
+    // still carry the plugin repo, so resolve them against the default market
+    // instead of treating them as unmatchable.
+    if (source.install_method !== "market") {
       return null;
     }
     if (extension.update_market_plugin) {
@@ -765,10 +768,12 @@ export const useExtensionPage = (initialTab = "installed") => {
       extension.update_market_plugin = null;
 
       const source = extension.install_source;
+      // Implicit records (legacy plugins with no persisted install source)
+      // resolve to the default registry, so keep them in the update check
+      // instead of skipping them entirely.
       if (
         !extension.updates_enabled ||
         !source ||
-        source.implicit === true ||
         source.install_method !== "market"
       ) {
         return;


### PR DESCRIPTION
Fixes #9668

## Problem

For plugins installed before the install-source persistence feature (PR #9037, v4.26.2), there is no persisted `plugin_install_sources` record. The backend falls back to an **implicit** source record (`implicit: true`) as a display-only placeholder.

The frontend update check (`checkUpdate`) skipped any extension whose `install_source.implicit === true`, so these legacy plugins never surfaced an available update — the user had to manually reinstall or re-bind the plugin source before the "update available" badge appeared.

## Root cause

- `checkUpdate` bails out early on `source.implicit === true`.
- `findMarketPluginForExtension` also returns `null` for implicit sources, so even the update download URL could not be resolved.

## Fix

Include implicit sources in the update check instead of skipping them:

- Implicit records already carry `install_method: "market"` with a null `registry_url`, which resolves to the **default registry**. The existing matching logic then looks the plugin up in the default market by `market_plugin_id` → `repo` → name. Only a real match surfaces an update, so no false positives are introduced for unmatched plugins.
- The update action still routes implicit plugins through the existing "bind source" dialog (via `buildUpdateContext`), so updating remains safe and the persisted record is created on confirm — matching the previously working "reinstall/change source" path.

Also fixes the misspelled `online_vesion` → `online_version` field in `serialize_plugin_base` so the backend payload matches what the frontend reads.

## Testing

- `node --check dashboard/src/views/extension/useExtensionPage.js` passes.
- Backend change is a field rename only; no test references the old name.

## Summary by Sourcery

Restore update detection for legacy market plugins while correcting the plugin version payload field.

Bug Fixes:
- Detect available updates for legacy plugins without persisted install-source records.
- Correct the serialized plugin version field name so frontend update data is populated correctly.