### PR TITLE
fix: respect LLM wake prefix for empty mentions

### DIFF
--- a/astrbot/builtin_stars/astrbot/main.py
+++ b/astrbot/builtin_stars/astrbot/main.py
@@ -58,6 +58,13 @@ class Main(star.Star):
             cfg = self.context.get_config(umo=event.unified_msg_origin)
             p_settings = cfg["platform_settings"]
             wake_prefix = cfg.get("wake_prefix", [])
+            provider_wake_prefix = cfg.get("provider_settings", {}).get(
+                "wake_prefix",
+                "",
+            )
+            for bot_wake_prefix in wake_prefix:
+                if provider_wake_prefix.startswith(bot_wake_prefix):
+                    provider_wake_prefix = provider_wake_prefix[len(bot_wake_prefix) :]
             if len(messages) != 1:
                 return
 
@@ -74,7 +81,10 @@ class Main(star.Star):
             if not (is_empty_mention or is_wake_prefix_only):
                 return
 
-            if p_settings.get("empty_mention_waiting_need_reply", True):
+            if (
+                p_settings.get("empty_mention_waiting_need_reply", True)
+                and not provider_wake_prefix
+            ):
                 try:
                     curr_cid = await self.context.conversation_manager.get_curr_conversation_id(
                         event.unified_msg_origin,

--- a/tests/unit/test_empty_mention_wake_prefix.py
+++ b/tests/unit/test_empty_mention_wake_prefix.py
@@ -24,7 +24,14 @@ async def test_empty_mention_reply_respects_provider_wake_prefix(
     messages,
     should_request_llm,
 ):
-    """Only request an immediate LLM reply when no extra prefix is required."""
+    """Verify that empty-mention replies respect the additional LLM wake prefix.
+
+    Args:
+        monkeypatch: Pytest fixture used to replace the 60-second session waiter.
+        provider_wake_prefix: Additional LLM wake prefix configured for the provider.
+        messages: Message components passed to the empty-mention handler.
+        should_request_llm: Whether an immediate LLM request should be produced.
+    """
 
     def skip_waiting(_timeout):
         def decorator(_callback):

--- a/tests/unit/test_empty_mention_wake_prefix.py
+++ b/tests/unit/test_empty_mention_wake_prefix.py
@@ -1,0 +1,72 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import astrbot.builtin_stars.astrbot.main as main_module
+from astrbot.api.message_components import At, Plain
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider_wake_prefix", "messages", "should_request_llm"),
+    [
+        ("chat", [At(qq="bot")], False),
+        ("/chat", [At(qq="bot")], False),
+        ("chat", [Plain(text="/")], False),
+        ("", [At(qq="bot")], True),
+        ("/", [At(qq="bot")], True),
+    ],
+)
+async def test_empty_mention_reply_respects_provider_wake_prefix(
+    monkeypatch,
+    provider_wake_prefix,
+    messages,
+    should_request_llm,
+):
+    """Only request an immediate LLM reply when no extra prefix is required."""
+
+    def skip_waiting(_timeout):
+        def decorator(_callback):
+            async def wait(*_args, **_kwargs):
+                raise TimeoutError
+
+            return wait
+
+        return decorator
+
+    monkeypatch.setattr(main_module, "session_waiter", skip_waiting)
+
+    conversation_manager = SimpleNamespace(
+        get_curr_conversation_id=AsyncMock(return_value="conversation-id"),
+        get_conversation=AsyncMock(return_value=None),
+    )
+    main = main_module.Main.__new__(main_module.Main)
+    main.context = MagicMock()
+    main.context.conversation_manager = conversation_manager
+    main.context.get_config.return_value = {
+        "wake_prefix": ["/"],
+        "provider_settings": {"wake_prefix": provider_wake_prefix},
+        "platform_settings": {
+            "empty_mention_waiting": True,
+            "empty_mention_waiting_need_reply": True,
+        },
+    }
+
+    event = MagicMock()
+    event.unified_msg_origin = "aiocqhttp:GroupMessage:group"
+    event.get_messages.return_value = messages
+    event.get_self_id.return_value = "bot"
+    event.get_platform_id.return_value = "aiocqhttp"
+    llm_request = object()
+    event.request_llm.return_value = llm_request
+
+    results = [item async for item in main.handle_empty_mention(event)]
+
+    assert results == ([llm_request] if should_request_llm else [])
+    if should_request_llm:
+        event.request_llm.assert_called_once()
+        conversation_manager.get_curr_conversation_id.assert_awaited_once()
+    else:
+        event.request_llm.assert_not_called()
+        conversation_manager.get_curr_conversation_id.assert_not_awaited()


### PR DESCRIPTION
Fixes #9884

An empty mention currently causes the built-in handler to yield an explicit `ProviderRequest` for its immediate courtesy reply. Explicit provider requests bypass the normal `provider_settings.wake_prefix` check, so the LLM is invoked even when the user did not supply the configured additional LLM wake prefix.

### Modifications / 改动点

- Normalize `provider_settings.wake_prefix` against the configured bot wake prefixes using the same behavior as the normal agent request path.
- Skip only the immediate LLM-generated empty-mention reply when an additional LLM wake prefix remains required.
- Preserve the existing 60-second empty-mention waiter behavior; this PR does not change session waiter scoping or address #9377.
- Add parameterized regression coverage for empty mentions, wake-prefix-only messages, normalized prefixes, and the existing no-extra-prefix behavior.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Verification steps:

```bash
uv run pytest -q tests/unit/test_empty_mention_wake_prefix.py \
  tests/unit/test_waking_check_api_key_admin.py \
  tests/unit/test_group_chat_context_wiring.py \
  tests/unit/test_astr_main_agent.py::TestBuildMainAgent::test_build_main_agent_with_wake_prefix \
  tests/unit/test_astr_main_agent.py::TestBuildMainAgent::test_build_main_agent_no_wake_prefix
uv run pytest -q tests/unit
uv run ruff format .
uv run ruff check .
```

Results:

```text
20 passed, 1 warning
912 passed, 22 warnings
All checks passed!
```

The new regression test failed in the three prefix-bypass cases before the production change and passes after the fix.

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure empty-mention handling honors the provider’s configured LLM wake prefix before issuing an immediate reply.

Bug Fixes:
- Respect the configured additional LLM wake prefix when handling empty mentions, preventing immediate LLM replies unless the required prefix is satisfied.

Enhancements:
- Normalize provider wake prefixes against bot wake prefixes consistently with the regular agent request path while preserving the existing empty-mention waiting behavior.

Tests:
- Add parameterized regression coverage for empty mentions, wake-prefix-only messages, normalized prefixes, and configurations without an additional prefix.