### PR TITLE
fix(provider): serialize Gemini thinking levels correctly

### DIFF
--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -251,17 +251,22 @@ class ProviderGoogleGenAI(Provider):
             )
             if thinking_level and isinstance(thinking_level, str):
                 thinking_level = thinking_level.upper()
-                if thinking_level not in ["MINIMAL", "LOW", "MEDIUM", "HIGH"]:
+                allowed_levels = {"MINIMAL", "LOW", "MEDIUM", "HIGH"}
+                fallback_level = "HIGH"
+                if model_name.startswith("gemini-3.7"):
+                    allowed_levels = {"LOW", "MEDIUM", "HIGH"}
+                    fallback_level = "MEDIUM"
+                if thinking_level not in allowed_levels:
                     logger.warning(
-                        f"Invalid thinking level: {thinking_level}, using HIGH"
+                        "Invalid thinking level %s for %s, using %s",
+                        thinking_level,
+                        model_name,
+                        fallback_level,
                     )
-                    thinking_level = "HIGH"
-                level = types.ThinkingLevel(thinking_level)
-                thinking_config = types.ThinkingConfig()
-                if not hasattr(types.ThinkingConfig, "thinking_level"):
-                    setattr(types.ThinkingConfig, "thinking_level", level)
-                else:
-                    thinking_config.thinking_level = level
+                    thinking_level = fallback_level
+                thinking_config = types.ThinkingConfig(
+                    thinking_level=types.ThinkingLevel(thinking_level)
+                )
 
         return types.GenerateContentConfig(
             system_instruction=system_instruction,

--- a/tests/test_gemini_source.py
+++ b/tests/test_gemini_source.py
@@ -11,6 +11,45 @@ from astrbot.core.provider.sources.gemini_source import ProviderGoogleGenAI
 
 
 @pytest.mark.asyncio
+async def test_gemini_thinking_level_is_serialized_on_every_request():
+    model = "gemini-3.7-flash"
+    provider = ProviderGoogleGenAI.__new__(ProviderGoogleGenAI)
+    provider.provider_config = {"gm_thinking_config": {"level": "HIGH"}}
+    provider.provider_settings = {}
+    provider.model_name = model
+    provider.safety_settings = []
+
+    first_config = await provider._prepare_query_config({"model": model})
+    second_config = await provider._prepare_query_config({"model": model})
+
+    assert first_config.thinking_config is not None
+    assert second_config.thinking_config is not None
+    assert first_config.thinking_config.model_dump(exclude_none=True) == {
+        "thinking_level": types.ThinkingLevel.HIGH,
+    }
+    assert second_config.thinking_config.model_dump(exclude_none=True) == {
+        "thinking_level": types.ThinkingLevel.HIGH,
+    }
+
+
+@pytest.mark.asyncio
+async def test_gemini_37_minimal_thinking_level_falls_back_to_medium():
+    model = "gemini-3.7-flash"
+    provider = ProviderGoogleGenAI.__new__(ProviderGoogleGenAI)
+    provider.provider_config = {"gm_thinking_config": {"level": "MINIMAL"}}
+    provider.provider_settings = {}
+    provider.model_name = model
+    provider.safety_settings = []
+
+    config = await provider._prepare_query_config({"model": model})
+
+    assert config.thinking_config is not None
+    assert config.thinking_config.model_dump(exclude_none=True) == {
+        "thinking_level": types.ThinkingLevel.MEDIUM,
+    }
+
+
+@pytest.mark.asyncio
 async def test_gemini_prepare_conversation_removes_leading_model_content():
     provider = ProviderGoogleGenAI.__new__(ProviderGoogleGenAI)
 


### PR DESCRIPTION
Gemini 3 thinking levels are currently assigned through a class-level fallback on `types.ThinkingConfig`. On the first request this can leave the Pydantic instance without a serialized `thinking_level`, while also mutating SDK class state for later requests. In addition, Gemini 3.7 Flash does not accept `MINIMAL` and should use its supported `MEDIUM` fallback.

### Modifications / 改动点

- Pass `types.ThinkingLevel` directly to the `ThinkingConfig` constructor so every request serializes its own value.
- Keep case-insensitive validation for Gemini 3 models.
- Use `MEDIUM` when Gemini 3.7 receives `MINIMAL` or another unsupported value; retain the existing `HIGH` fallback for other Gemini 3 variants.
- Add regressions proving two consecutive requests both serialize `HIGH` and Gemini 3.7 maps `MINIMAL` to `MEDIUM`.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```text
# Locked project SDK: google-genai 2.20.0
pytest tests/test_gemini_source.py
9 passed

# Declared minimum SDK compatibility: google-genai 1.56.0
uv run --with google-genai==1.56.0 --no-sync \
  python -m pytest tests/test_gemini_source.py
9 passed

ruff format --check .
502 files already formatted

ruff check .
All checks passed!
```

No dependency or API-schema change is introduced. This PR intentionally does not add a Gemini-local retry for empty `STOP` responses: #7104 already handles empty model output in the shared runner, and another provider-local retry would multiply retry attempts.

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. / Not applicable: this is a bug fix and adds no user-facing feature.
- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
- [x] 😮 My changes do not introduce malicious code.

## Summary by Sourcery

Fix Gemini thinking-level serialization and validation across supported Gemini 3 models.

Bug Fixes:
- Serialize Gemini thinking levels independently for every request and apply model-specific fallbacks, including mapping unsupported Gemini 3.7 Flash values to MEDIUM.

Tests:
- Add regression coverage for repeated HIGH-level serialization and Gemini 3.7 MINIMAL fallback behavior.