### PR TITLE
fix: drop invalid 'All' page size option in knowledge base documents list

### DIFF
--- a/dashboard/src/views/knowledge-base/components/DocumentsTab.vue
+++ b/dashboard/src/views/knowledge-base/components/DocumentsTab.vue
@@ -12,6 +12,7 @@
     <!-- 文档列表 -->
     <v-card variant="outlined">
       <v-data-table-server :headers="headers" :items="documents" :loading="loading"
+        :items-per-page-options="[10, 25, 50, 100]"
         :items-per-page="pageSize" :page="page" :items-length="total"
         @update:page="onPageChange" @update:items-per-page="onItemsPerPageChange">
         <template #item.doc_name="{ item }">


### PR DESCRIPTION
### Motivation / 变更动机

Fixes #9907.

The `v-data-table-server` in `DocumentsTab.vue` did not set `:items-per-page-options`, so it inherited Vuetify's default `[10, 25, 50, 100, -1]` where `-1` renders as "All". Selecting "All" sends `page_size=-1` to `GET /api/v1/knowledge-bases/<kb_id>/documents`, and the backend clamps it to `1` (`page_size = max(page_size, 1)` in `KnowledgeBaseService.list_documents`), so only 1 document is shown instead of all.

This is a regression introduced by #9055, which switched the list to server-side pagination but never handled the "All" semantics.

### Modifications / 改动点

- `dashboard/src/views/knowledge-base/components/DocumentsTab.vue`: explicitly set `:items-per-page-options="[10, 25, 50, 100]"` on `v-data-table-server`, removing the invalid "All" option — consistent with existing pages such as `ConversationPage.vue`.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Verification Steps / 验证步骤

1. `cd dashboard && npx vue-tsc --noEmit` — type check passes (no output, no errors).
2. `cd dashboard && npx eslint src/views/knowledge-base/components/DocumentsTab.vue` — the file has no lint errors (the repo-wide `npm run lint` failures are pre-existing parsing errors in unrelated `.mjs`/`.ts` files).
3. Manual check: the pagination selector on the documents tab now only offers `10 / 25 / 50 / 100`, and the "All" option no longer appears.

### Screenshots or Test Results / 运行截图或测试结果

<img width="1595" height="1137" alt="image" src="https://github.com/user-attachments/assets/d3947f08-5896-4dd6-85d0-ade3d9d2ee91" />

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Remove the invalid “All” page-size option from the knowledge base documents list to prevent requests that display only one document.