### PR TITLE
fix(webui): show WebChat conversations in history lists

### DIFF
--- a/astrbot/dashboard/services/conversation_service.py
+++ b/astrbot/dashboard/services/conversation_service.py
@@ -119,16 +119,24 @@ class ConversationService:
         """
         history_platform_ids = set(await self.db_helper.get_conversation_platform_ids())
         configured_platforms = self.core_lifecycle.astrbot_config.get("platform", [])
-        return {
-            "bots": [
-                {
-                    "id": str(platform.get("id", "")),
-                    "type": str(platform.get("type", "")),
-                }
-                for platform in configured_platforms
-                if platform.get("id") in history_platform_ids
-            ]
-        }
+        bots = [
+            {
+                "id": str(platform.get("id", "")),
+                "type": str(platform.get("type", "")),
+            }
+            for platform in configured_platforms
+            if platform.get("id") in history_platform_ids
+        ]
+
+        # WebChat is a built-in platform that the platform manager always
+        # starts regardless of config, so expose it as a filterable bot ID even
+        # when it is missing from the configured platform list.
+        if "webchat" in history_platform_ids and not any(
+            bot["id"] == "webchat" for bot in bots
+        ):
+            bots.append({"id": "webchat", "type": "webchat"})
+
+        return {"bots": bots}
 
     async def get_conversation_detail(self, data: object) -> dict:
         payload = self._payload(data)

--- a/dashboard/src/views/ConversationPage.vue
+++ b/dashboard/src/views/ConversationPage.vue
@@ -803,7 +803,6 @@ export default {
                 }
 
                 params.exclude_ids = 'astrbot';
-                params.exclude_platforms = 'webchat';
                 params.include_history = false;
 
                 const response = await conversationApi.list(params, {

--- a/dashboard/src/views/conversation/ConversationWorkspacePage.vue
+++ b/dashboard/src/views/conversation/ConversationWorkspacePage.vue
@@ -419,7 +419,6 @@ async function fetchConversations() {
     params.umo = umoQuery.value.trim();
   } else {
     params.exclude_ids = "astrbot";
-    params.exclude_platforms = "webchat";
   }
   if (selectedBotIds.value.length) {
     params.platforms = selectedBotIds.value.join(",");


### PR DESCRIPTION
Closes #9474 

### Modifications / 改动点

- Removed the hard-coded `exclude_platforms='webchat'` from both conversation history pages, so WebChat conversations now appear in history lists like any other platform:
  - `dashboard/src/views/conversation/ConversationWorkspacePage.vue` (new workspace): removed the WebChat filter toggle together with its state, watcher and `hasFilters` / `resetFilters` wiring; the `exclude_platforms` parameter is no longer sent with the conversation list request.
  - `dashboard/src/views/ConversationPage.vue` (legacy): removed the toggle from the filter row (columns restored to `md="4"`), the `showWebchat` data property and its watcher; `exclude_platforms` is no longer sent.
- Exposed WebChat as a regular "机器人 ID" filter option: `get_filter_options()` in `astrbot/dashboard/services/conversation_service.py` now includes the built-in WebChat platform (always started by the platform manager) even when it is absent from the configured platform list, so it can be selected like any other bot ID.
- Reverted the added `filters.includeWebchat` / `workspace.filters.includeWebchat` translations in zh-CN, en-US and ru-RU (`dashboard/src/i18n/locales/*/features/conversation.json`).

**Motivation**: the history pages previously hard-coded `exclude_platforms='webchat'` on every request, so WebChat conversations never appeared in the history list even though all messages are fully stored in `platform_message_history` (see #9474). Per the maintainer's review, the opt-in toggle was redundant: WebChat is a built-in always-on platform, so it is now exposed as a regular bot ID in the filter, giving it the same filtering capability as other platforms.

This change is NOT a breaking change. The practical behavior change is intentional: WebChat conversations are now visible in history lists by default (they were completely hidden before), and can be restricted to WebChat-only via the 机器人 ID filter.

### Screenshots or Test Results / 运行截图或测试结果

Screenshots are in the comments.

Local verification (Node v25 / pnpm v11):

- `pnpm exec vue-tsc --noEmit` — passed (0 errors)
- `pnpm run build` (subset-mdi-font + vue-tsc + vite build) — passed, exit 0

Verified against a full local instance (core + WebUI) seeded with 12 mock conversations (7 WebChat):

- New workspace page and legacy page both list WebChat conversations (e.g. "WebChat 测试对话 - 美食推荐").
- The 机器人 ID filter exposes `webchat` as a selectable option; selecting it shows WebChat-only results.
- Screenshots: new UI list, legacy list, filter panel with webchat option are attached below.

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。Soulter discussed in #9474 

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。
## Summary by Sourcery

Allow WebChat conversations to appear in conversation history listings, with the same filtering capability as other bot IDs.

New Features:
- Expose WebChat as a built-in filterable bot ID in the conversation filter options.

Bug Fixes:
- Remove the hard-coded exclusion of WebChat conversations from both history pages.
- Drop the now-redundant opt-in toggle in favor of the regular bot ID filter.