### PR TITLE
fix: unregister plugin web APIs on plugin unload

### DIFF
--- a/astrbot/core/star/context.py
+++ b/astrbot/core/star/context.py
@@ -726,6 +726,51 @@ class Context:
                 return
         self.registered_web_apis.append((route, view_handler, methods, desc))
 
+    @classmethod
+    def unregister_web_apis(cls, module_path: str) -> int:
+        """Unregister all web APIs registered by a plugin.
+
+        Args:
+            module_path: Plugin module path prefix, e.g. ``data.plugins.my_plugin``.
+            Handlers whose defining module equals this path or resides under it
+            are removed, so that unloading a plugin releases its handlers and
+            avoids ghost routes.
+
+        Returns:
+            The number of web API registrations removed.
+        """
+        if not module_path:
+            return 0
+        prefix = f"{module_path}."
+        remaining: list[RegisteredWebApi] = []
+        removed = 0
+        for api in cls.registered_web_apis:
+            handler = api[1]
+            handler_modules = set()
+            handler_module = getattr(handler, "__module__", None)
+            if isinstance(handler_module, str):
+                handler_modules.add(handler_module)
+            # Bound methods also expose the owner class module, which may
+            # differ from the function module in edge cases.
+            owner = getattr(handler, "__self__", None)
+            if owner is not None:
+                class_module = type(owner).__module__
+                if isinstance(class_module, str):
+                    handler_modules.add(class_module)
+            if any(
+                module == module_path or module.startswith(prefix)
+                for module in handler_modules
+            ):
+                removed += 1
+                logger.debug(
+                    f"Removed registered web API {api[0]} owned by {module_path}"
+                )
+                continue
+            remaining.append(api)
+        if removed:
+            cls.registered_web_apis[:] = remaining
+        return removed
+
     """
     以下的方法已经不推荐使用。请从 AstrBot 文档查看更好的注册方式。
     """

--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -807,6 +807,13 @@ class PluginManager:
                 llm_tools.func_list.remove(tool)
                 logger.info(f"Removed tool: {tool.name}")
 
+        # 清理插件注册的 Web API
+        removed_web_apis = Context.unregister_web_apis(module_prefix)
+        if removed_web_apis:
+            logger.info(
+                f"Removed {removed_web_apis} registered web API(s) from plugin {dir_name}",
+            )
+
         for adapter_name in unregister_platform_adapters_by_module(module_prefix):
             logger.info(f"Removed platform adapter: {adapter_name}")
 
@@ -1046,6 +1053,9 @@ class PluginManager:
                 star_handlers_registry.clear()
                 star_map.clear()
                 star_registry.clear()
+                # Clear web APIs registered by plugins; every plugin has been
+                # unbound above and will be re-registered by load().
+                Context.registered_web_apis.clear()
             else:
                 # 只重载指定插件
                 smd = star_map.get(specified_module_path)
@@ -1925,6 +1935,15 @@ class PluginManager:
             for adapter_name in unregistered_adapters:
                 logger.info(
                     f"Removed platform adapter {adapter_name} from plugin {plugin_name}",
+                )
+
+            # Unregister web APIs registered by this plugin to avoid ghost
+            # routes and memory leaks after unloading.
+            removed_web_apis = Context.unregister_web_apis(module_prefix)
+            if removed_web_apis:
+                logger.info(
+                    f"Removed {removed_web_apis} registered web API(s) "
+                    f"from plugin {plugin_name}",
                 )
 
         if plugin is None:

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -10,6 +10,7 @@ import pytest
 import yaml
 
 from astrbot.core.star import star_manager as star_manager_module
+from astrbot.core.star.context import Context
 from astrbot.core.star.star_handler import EventType, StarHandlerMetadata
 from astrbot.core.star.star_manager import PluginDependencyInstallError, PluginManager
 from astrbot.core.utils.pip_installer import PipInstallError
@@ -623,6 +624,90 @@ async def test_reload_all_unbinds_every_registered_plugin(
 
     assert terminated == plugin_names
     assert unbound == plugin_names
+
+
+def _make_bound_web_api_handler(module_name: str):
+    """Creates a bound method handler whose owner class lives in ``module_name``."""
+
+    class Owner:
+        pass
+
+    Owner.__module__ = module_name
+
+    async def handler(self):
+        return {}
+
+    Owner.handler = handler
+    return Owner().handler
+
+
+def _make_web_api_function(module_name: str):
+    async def handler():
+        return {}
+
+    handler.__module__ = module_name
+    return handler
+
+
+def test_unregister_web_apis_removes_only_owner_plugin_apis():
+    plugin_handler = _make_bound_web_api_handler("data.plugins.demo_plugin.main")
+    child_handler = _make_web_api_function("data.plugins.demo_plugin.tools.utils")
+    other_handler = _make_bound_web_api_handler("data.plugins.other_plugin.main")
+    core_handler = _make_web_api_function("astrbot.dashboard.api.plugins")
+
+    original_apis = list(Context.registered_web_apis)
+    try:
+        Context.registered_web_apis[:] = [
+            ("/demo/test", plugin_handler, ["GET"], "demo"),
+            ("/demo/tools", child_handler, ["POST"], "demo tools"),
+            ("/other/test", other_handler, ["GET"], "other"),
+            ("/core/test", core_handler, ["GET"], "core"),
+        ]
+
+        assert Context.unregister_web_apis("data.plugins.demo_plugin") == 2
+        assert [api[0] for api in Context.registered_web_apis] == [
+            "/other/test",
+            "/core/test",
+        ]
+        assert Context.unregister_web_apis("") == 0
+    finally:
+        Context.registered_web_apis[:] = original_apis
+
+
+@pytest.mark.asyncio
+async def test_unbind_plugin_removes_registered_web_apis(
+    plugin_manager_pm: PluginManager,
+):
+    _clear_star_runtime_state()
+    module_path = "data.plugins.demo_plugin.main"
+    metadata = star_manager_module.StarMetadata(
+        name="demo_plugin",
+        root_dir_name="demo_plugin",
+        module_path=module_path,
+    )
+    star_manager_module.star_map[module_path] = metadata
+    star_manager_module.star_registry.append(metadata)
+
+    plugin_handler = _make_bound_web_api_handler(module_path)
+    child_handler = _make_web_api_function("data.plugins.demo_plugin.tools")
+    other_handler = _make_bound_web_api_handler("data.plugins.other_plugin.main")
+
+    original_apis = list(Context.registered_web_apis)
+    try:
+        Context.registered_web_apis[:] = [
+            ("/demo/api", plugin_handler, ["GET"], "demo"),
+            ("/demo/tools/api", child_handler, ["POST"], "demo tools"),
+            ("/other/api", other_handler, ["GET"], "other"),
+        ]
+
+        await plugin_manager_pm._unbind_plugin("demo_plugin", module_path)
+
+        assert [(api[0], api[1]) for api in Context.registered_web_apis] == [
+            ("/other/api", other_handler)
+        ]
+    finally:
+        Context.registered_web_apis[:] = original_apis
+        _clear_star_runtime_state()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation / 动机

`Context.registered_web_apis` never released entries registered by plugins. After a plugin was uninstalled, disabled or reloaded, its registered web API handlers stayed in the list forever:

- **Memory leak**: the list holds bound methods of plugin instances, so purged modules cannot be garbage collected. Repeated install/uninstall cycles keep growing the list.
- **Ghost routes**: requests to `/api/v1/plugins/extensions/<uninstalled-plugin>/...` still match the stale handler and execute it, instead of returning 404.
- **Reload residue**: `register_web_api` only replaces entries with the exact same route and methods; routes removed or changed in a new plugin version stay forever.

`PluginManager._unbind_plugin()` already cleans up event handlers, LLM tools, platform adapters and `sys.modules` — this PR closes the gap by also releasing registered web APIs.

### Modifications / 改动点

- `astrbot/core/star/context.py`: add `Context.unregister_web_apis(module_path)` classmethod that removes all web APIs whose handler is owned by the given plugin module path prefix (checked via the handler function module and, for bound methods, the owner class module).
- `astrbot/core/star/star_manager.py`:
  - `_unbind_plugin()`: unregister web APIs owned by the plugin (shared cleanup path for uninstall, disable and single-plugin reload).
  - `_cleanup_plugin_state()`: unregister web APIs for plugins that failed to load.
  - `reload(all)`: clear all registered web APIs alongside the existing registry clears, since every plugin is re-loaded afterwards.
- `tests/test_plugin_manager.py`: unit tests for ownership-prefixed removal (other plugins and core routes are preserved) and an integration test for `_unbind_plugin()`.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```
$ uv run pytest tests/test_plugin_manager.py tests/test_dashboard.py tests/test_fastapi_v1_dashboard.py -q
64 passed (plugin manager, includes 2 new tests)
172 passed (dashboard regression)
```

Verification steps:

1. Install a plugin that calls `context.register_web_api(...)`.
2. Uninstall it, then request its extension endpoint — it now returns 未找到该路由 instead of executing the stale handler.
3. Check logs for `Removed N registered web API(s) from plugin ...`.

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Ensure plugin web APIs are fully removed whenever plugin state is cleaned up so unloaded plugins no longer retain memory or serve ghost routes.

Bug Fixes:
- Remove plugin-owned web API registrations when plugins are unloaded, disabled, reloaded, or fail to load, preventing stale routes, memory leaks, and handlers from removed plugin versions from persisting.

Enhancements:
- Preserve web APIs belonging to other plugins and core components while identifying ownership across plugin submodules and bound methods.

Tests:
- Add unit and integration coverage for selective web API cleanup during plugin unbinding.