### PR TITLE
fix: reject extension API calls for disabled plugins

### DIFF
--- a/astrbot/dashboard/api/plugins.py
+++ b/astrbot/dashboard/api/plugins.py
@@ -205,6 +205,37 @@ async def _call_plugin_extension(
 
     view_handler, path_values = matched_api
     plugin_name = plugin_path.strip("/").split("/", 1)[0].strip() or None
+
+    # Gate calls on the owning plugin's activation state, mirroring the
+    # static plugin pages behavior. Ownership is resolved from the handler
+    # module so legacy routes without a plugin name prefix keep working.
+    handler_modules = set()
+    handler_module = getattr(view_handler, "__module__", None)
+    if isinstance(handler_module, str):
+        handler_modules.add(handler_module)
+    handler_owner = getattr(view_handler, "__self__", None)
+    if handler_owner is not None:
+        handler_modules.add(type(handler_owner).__module__)
+
+    plugin = None
+    if handler_modules:
+        for (
+            star
+        ) in request.app.state.core_lifecycle.plugin_manager.context.get_all_stars():
+            if not star.root_dir_name:
+                continue
+            prefix = (
+                "astrbot.builtin_stars" if star.reserved else "data.plugins"
+            ) + f".{star.root_dir_name}"
+            if any(
+                module == prefix or module.startswith(f"{prefix}.")
+                for module in handler_modules
+            ):
+                plugin = star
+                break
+
+    if plugin is not None and not plugin.activated:
+        return {"status": "error", "message": "插件未启用", "data": {}}
     plugin_request = PluginRequest(
         request,
         path_params=path_values,

--- a/tests/test_fastapi_v1_dashboard.py
+++ b/tests/test_fastapi_v1_dashboard.py
@@ -3005,6 +3005,76 @@ def test_astrbot_web_request_requires_plugin_context():
         _ = plugin_request.method
 
 
+@pytest.mark.asyncio
+async def test_v1_plugin_extension_rejects_disabled_plugin(
+    asgi_client: httpx.AsyncClient,
+    fake_core_lifecycle,
+):
+    from astrbot.api.web import json_response
+
+    async def plugin_owned_extension():
+        return json_response({"ok": True})
+
+    plugin_owned_extension.__module__ = "data.plugins.demo_plugin.main"
+
+    disabled_plugin = SimpleNamespace(
+        name="astrbot_plugin_demo",
+        root_dir_name="demo_plugin",
+        reserved=False,
+        activated=False,
+    )
+    fake_core_lifecycle.plugin_manager.context.get_all_stars = lambda: [disabled_plugin]
+    fake_core_lifecycle.star_context.registered_web_apis = [
+        ("/demo_plugin/status", plugin_owned_extension, ["GET"], "demo")
+    ]
+
+    response = await asgi_client.get(
+        "/api/v1/plugins/extensions/demo_plugin/status",
+        headers=_jwt_headers(),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "error",
+        "message": "插件未启用",
+        "data": {},
+    }
+
+
+@pytest.mark.asyncio
+async def test_v1_plugin_extension_allows_activated_plugin(
+    asgi_client: httpx.AsyncClient,
+    fake_core_lifecycle,
+):
+    from astrbot.api.web import json_response
+
+    async def plugin_owned_extension():
+        return json_response({"ok": True})
+
+    plugin_owned_extension.__module__ = "data.plugins.demo_plugin.main"
+
+    activated_plugin = SimpleNamespace(
+        name="astrbot_plugin_demo",
+        root_dir_name="demo_plugin",
+        reserved=False,
+        activated=True,
+    )
+    fake_core_lifecycle.plugin_manager.context.get_all_stars = lambda: [
+        activated_plugin
+    ]
+    fake_core_lifecycle.star_context.registered_web_apis = [
+        ("/demo_plugin/status", plugin_owned_extension, ["GET"], "demo")
+    ]
+
+    response = await asgi_client.get(
+        "/api/v1/plugins/extensions/demo_plugin/status",
+        headers=_jwt_headers(),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
 def test_astrbot_web_request_proxy_exposes_typed_methods():
     from typing import get_type_hints
 


### PR DESCRIPTION
### Motivation / 动机

插件动态 Web API（`context.register_web_api()` 注册、经 `/api/v1/plugins/extensions/...` 分发）在插件被**禁用**后仍然可以调用，而静态 Plugin Pages 在同一状态下返回 403（`PluginPageService` 的 `activated` 检查）。两个入口行为不一致，禁用插件的后端接口没有真正下线。

### Modifications / 改动点

- `astrbot/dashboard/api/plugins.py`：`_call_plugin_extension()` 在路由匹配成功后，通过 handler 的归属模块（函数 `__module__` 或绑定方法的所属类 `__module__`）解析所属插件，插件处于禁用状态时返回 `{"status": "error", "message": "插件未启用"}`。
- 归属解析基于插件模块命名空间（`data.plugins.<root_dir_name>` / `astrbot.builtin_stars.<root_dir_name>`），因此**不带插件前缀的 legacy 路由不受影响**（现有 `/web/<item_id>`、`/upload` 等行为保持不变）。
- `tests/test_fastapi_v1_dashboard.py`：新增禁用插件被拒、启用插件正常放行两个用例。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```
$ uv run pytest tests/test_fastapi_v1_dashboard.py tests/test_dashboard.py -q
174 passed
```

验证步骤：

1. 安装一个注册了 `register_web_api` 的插件并确认可正常调用其接口。
2. 在 WebUI 中禁用该插件，再次请求其扩展 API → 返回 `插件未启用` 错误，与插件 Page 的 403 行为对齐。
3. 重新启用插件后接口恢复可用。

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Prevent disabled plugins from serving their registered extension APIs while keeping enabled plugin and legacy API behavior unchanged.

Bug Fixes:
- Reject extension API requests owned by disabled plugins while preserving access for activated plugins and legacy routes.

Enhancements:
- Align dynamic plugin extension API behavior with static plugin pages by enforcing plugin activation state.

Tests:
- Add coverage for rejecting disabled-plugin extension requests and allowing activated-plugin requests.