### PR TITLE
fix: heal stale plugin sidebar entries when plugin page errors out

### DIFF
--- a/dashboard/src/views/PluginPagePage.vue
+++ b/dashboard/src/views/PluginPagePage.vue
@@ -552,7 +552,13 @@ const handleIframeLoad = () => {
   sendIframeContext();
 };
 
+let loadSequence = 0;
+
 const loadPluginPage = async () => {
+  // Sequence guard: a stale response from a previous route must never
+  // mutate view state or the shared plugin sidebar state.
+  const requestSequence = ++loadSequence;
+  const requestedPluginName = pluginName.value;
   loading.value = true;
   errorMessage.value = "";
   plugin.value = null;
@@ -562,7 +568,8 @@ const loadPluginPage = async () => {
   cleanupSSEConnections();
 
   try {
-    const detailResponse = await pluginApi.get(pluginName.value);
+    const detailResponse = await pluginApi.get(requestedPluginName);
+    if (requestSequence !== loadSequence) return;
     if (detailResponse.data?.status === "error") {
       throw new Error(
         detailResponse.data.message || tm("messages.pluginPageLoadFailed"),
@@ -572,23 +579,27 @@ const loadPluginPage = async () => {
     const pluginData = detailResponse.data?.data || null;
     if (!pluginData) {
       errorMessage.value = tm("messages.pluginNotFound");
-      // 修正侧边栏共享状态中已卸载插件的陈旧入口
+      // Heal the stale plugin entry in the shared sidebar state.
       pluginSidebarState.plugins = pluginSidebarState.plugins.filter(
-        (p) => p.name !== pluginName.value,
+        (p) => p.name !== requestedPluginName,
       );
       return;
     }
 
     if (!pluginData.activated) {
       errorMessage.value = tm("messages.pluginDisabled");
-      // 修正侧边栏共享状态中已禁用插件的陈旧入口
+      // Heal the stale plugin entry in the shared sidebar state.
       pluginSidebarState.plugins = pluginSidebarState.plugins.map((p) =>
-        p.name === pluginName.value ? { ...p, activated: false } : p,
+        p.name === requestedPluginName ? { ...p, activated: false } : p,
       );
       return;
     }
 
-    const entryResponse = await pluginApi.page(pluginName.value, pageName.value);
+    const entryResponse = await pluginApi.page(
+      requestedPluginName,
+      pageName.value,
+    );
+    if (requestSequence !== loadSequence) return;
     if (entryResponse.data?.status === "error") {
       throw new Error(
         entryResponse.data.message || tm("messages.pluginPageLoadFailed"),
@@ -611,12 +622,15 @@ const loadPluginPage = async () => {
     contentUrl.searchParams.set('theme', themeParam.value);
     iframeSrc.value = contentUrl.pathname + contentUrl.search + contentUrl.hash;
   } catch (error) {
+    if (requestSequence !== loadSequence) return;
     errorMessage.value =
       error?.response?.data?.message ||
       error?.message ||
       tm("messages.pluginPageLoadFailed");
   } finally {
-    loading.value = false;
+    if (requestSequence === loadSequence) {
+      loading.value = false;
+    }
   }
 };
 

--- a/dashboard/src/views/PluginPagePage.vue
+++ b/dashboard/src/views/PluginPagePage.vue
@@ -7,6 +7,7 @@ import { fetchWithAuth } from "@/api/http";
 import { useModuleI18n } from "@/i18n/composables";
 import { usePluginI18n } from "@/utils/pluginI18n";
 import { useCustomizerStore } from "@/stores/customizer";
+import { pluginSidebarState } from "@/composables/usePluginSidebarItems";
 
 const BRIDGE_CHANNEL = "astrbot-plugin-page";
 
@@ -571,11 +572,19 @@ const loadPluginPage = async () => {
     const pluginData = detailResponse.data?.data || null;
     if (!pluginData) {
       errorMessage.value = tm("messages.pluginNotFound");
+      // 修正侧边栏共享状态中已卸载插件的陈旧入口
+      pluginSidebarState.plugins = pluginSidebarState.plugins.filter(
+        (p) => p.name !== pluginName.value,
+      );
       return;
     }
 
     if (!pluginData.activated) {
       errorMessage.value = tm("messages.pluginDisabled");
+      // 修正侧边栏共享状态中已禁用插件的陈旧入口
+      pluginSidebarState.plugins = pluginSidebarState.plugins.map((p) =>
+        p.name === pluginName.value ? { ...p, activated: false } : p,
+      );
       return;
     }
 


### PR DESCRIPTION
### Motivation / 动机

侧边栏的“插件 WebUI”分组由模块级共享状态（`pluginSidebarState`）驱动，仅在首次挂载或扩展页操作时刷新。若插件在当前会话之外被卸载/禁用（其他标签页、CLI、直接调用 API），侧边栏仍会渲染该插件的入口，用户点击后进入错误页，直到访问扩展页才恢复同步。

### Modifications / 改动点

- `dashboard/src/views/PluginPagePage.vue`：`loadPluginPage()` 发现目标插件不存在时，从共享状态中移除该插件的陈旧入口；发现插件被禁用时，将共享状态中对应条目标记为 `activated: false`。侧边栏已有的 `watch` 会立即响应数组引用变化并重建菜单项。
- 采用“发现即修复”策略：无轮询、无定时器，仅在陈旧状态真正暴露（用户点击陈旧入口）时精确修正。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```
$ cd dashboard && pnpm typecheck
vue-tsc --noEmit  # passed, no errors
```

验证步骤：

1. 打开 Dashboard，确认侧边栏出现某插件的 WebUI 入口。
2. 在另一个标签页（或通过 API）卸载/禁用该插件。
3. 回到原标签页点击侧边栏该入口 → 显示“插件不存在/未启用”错误的同时，侧边栏分组中该入口立即消失，无需手动刷新。

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Synchronize plugin sidebar state when plugin pages reveal that plugins were removed or disabled, while guarding against stale route-load responses.

Bug Fixes:
- Remove stale plugin sidebar entries when a plugin is missing and mark entries inactive when a plugin is disabled.
- Prevent outdated asynchronous plugin page responses from overwriting current view or sidebar state.

Tests:
- Verify the dashboard passes the TypeScript typecheck without errors.