### PR TITLE
fix: remove All option from KB documents pagination to avoid page_size=-1

### DIFF
--- a/dashboard/src/views/knowledge-base/components/DocumentsTab.vue
+++ b/dashboard/src/views/knowledge-base/components/DocumentsTab.vue
@@ -13,6 +13,7 @@
     <v-card variant="outlined">
       <v-data-table-server :headers="headers" :items="documents" :loading="loading"
         :items-per-page="pageSize" :page="page" :items-length="total"
+        :items-per-page-options="[10, 25, 50, 100]"
         @update:page="onPageChange" @update:items-per-page="onItemsPerPageChange">
         <template #item.doc_name="{ item }">
           <div class="d-flex align-center gap-2">


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

Fixes #9907

In the WebUI knowledge base detail page, switching the documents table pagination to "All" sent `page_size=-1` to the backend, where `list_documents` clamps it with `page_size = max(page_size, 1)`. The response therefore contained only 1 document while `total` was correct.

The `v-data-table-server` in `DocumentsTab.vue` did not set `:items-per-page-options`, so it inherited Vuetify's default `[10, 25, 50, 100, -1]`, where `-1` renders as "All".

This PR follows option A suggested in the issue: explicitly provide `[10, 25, 50, 100]` (no "All" entry), consistent with other pages such as `ConversationPage.vue`. The backend clamp is kept as a safety net.

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- `dashboard/src/views/knowledge-base/components/DocumentsTab.vue`: add `:items-per-page-options="[10, 25, 50, 100]"` to the documents `v-data-table-server`, removing the "All" option.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

- `npx vue-tsc --noEmit` in `dashboard/` passes (exit 0).
- Verification steps: open WebUI → Knowledge Base → a KB with ≥ 2 documents → Documents tab → the per-page selector now offers 10 / 25 / 50 / 100 only (no "All"), and every selection returns the expected number of items (`page_size` echoed correctly).

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Remove the unlimited documents pagination option to ensure knowledge base document listings return the expected results.

Bug Fixes:
- Prevent the knowledge base documents table from requesting an unsupported unlimited page size that returns only one document.

Enhancements:
- Align documents pagination options with other pages by limiting the selector to 10, 25, 50, and 100 items per page.

Tests:
- Verify the dashboard type-checks successfully and that each available page-size selection returns the expected number of documents.