### PR TITLE
fix: support BOM-prefixed encodings in KB TextParser

### DIFF
--- a/astrbot/core/knowledge_base/parsers/text_parser.py
+++ b/astrbot/core/knowledge_base/parsers/text_parser.py
@@ -3,7 +3,11 @@
 支持解析 TXT 和 Markdown 文件。
 """
 
+import codecs
+
 from astrbot.core.knowledge_base.parsers.base import BaseParser, ParseResult
+
+_BOM_UTF16_PAIR = (codecs.BOM_UTF16_LE, codecs.BOM_UTF16_BE)
 
 
 class TextParser(BaseParser):
@@ -15,7 +19,9 @@ class TextParser(BaseParser):
     async def parse(self, file_content: bytes, file_name: str) -> ParseResult:
         """解析文本文件
 
-        尝试使用多种编码解析文件内容。
+        尝试使用多种编码解析文件内容。带 BOM 的文件（如 Windows 记事本
+        「UTF-8 with BOM」/「Unicode」保存的 txt）按 BOM 直接解码，避免被
+        无 BOM 序列误判。
 
         Args:
             file_content: 文件内容
@@ -28,15 +34,20 @@ class TextParser(BaseParser):
             ValueError: 如果无法解码文件
 
         """
-        # 尝试多种编码
-        for encoding in ["utf-8", "gbk", "gb2312", "gb18030"]:
-            try:
-                text = file_content.decode(encoding)
-                break
-            except UnicodeDecodeError:
-                continue
+        if file_content.startswith(codecs.BOM_UTF8):
+            text = file_content.decode("utf-8-sig")
+        elif file_content.startswith(_BOM_UTF16_PAIR):
+            text = file_content.decode("utf-16")
         else:
-            raise ValueError(f"无法解码文件: {file_name}")
+            # 尝试多种编码（无 BOM 文件，utf-8 优先，GBK 系兜底）
+            for encoding in ["utf-8", "gbk", "gb2312", "gb18030"]:
+                try:
+                    text = file_content.decode(encoding)
+                    break
+                except UnicodeDecodeError:
+                    continue
+            else:
+                raise ValueError(f"无法解码文件: {file_name}")
 
         # 文本文件无多媒体资源
         return ParseResult(text=text, media=[])

--- a/tests/test_text_parser.py
+++ b/tests/test_text_parser.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import codecs
+
+import pytest
+
+from astrbot.core.knowledge_base.parsers.text_parser import TextParser
+
+
+@pytest.mark.asyncio
+async def test_parse_utf8() -> None:
+    parser = TextParser()
+
+    result = await parser.parse("你好, world".encode(), "a.txt")
+
+    assert result.text == "你好, world"
+    assert result.media == []
+
+
+@pytest.mark.asyncio
+async def test_parse_utf8_with_bom() -> None:
+    parser = TextParser()
+
+    result = await parser.parse(
+        codecs.BOM_UTF8 + "带 BOM 的内容".encode(),
+        "a.txt",
+    )
+
+    assert result.text == "带 BOM 的内容"
+
+
+@pytest.mark.asyncio
+async def test_parse_utf16_le_with_bom() -> None:
+    # Windows Notepad "Unicode" (UTF-16 LE with BOM) saved txt files.
+    parser = TextParser()
+
+    result = await parser.parse(
+        codecs.BOM_UTF16_LE + "Windows 记事本 Unicode".encode("utf-16-le"),
+        "a.txt",
+    )
+
+    assert result.text == "Windows 记事本 Unicode"
+
+
+@pytest.mark.asyncio
+async def test_parse_utf16_be_with_bom() -> None:
+    parser = TextParser()
+
+    result = await parser.parse(
+        codecs.BOM_UTF16_BE + "big endian".encode("utf-16-be"),
+        "a.txt",
+    )
+
+    assert result.text == "big endian"
+
+
+@pytest.mark.asyncio
+async def test_parse_gbk() -> None:
+    parser = TextParser()
+
+    result = await parser.parse("中文内容".encode("gbk"), "a.txt")
+
+    assert result.text == "中文内容"
+
+
+@pytest.mark.asyncio
+async def test_parse_undecodable_raises_value_error() -> None:
+    parser = TextParser()
+
+    with pytest.raises(ValueError, match="无法解码文件"):
+        await parser.parse(b"\x81\x7f\x81\x7f\xff", "a.txt")


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

Fixes #9904

`TextParser` only tried `["utf-8", "gbk", "gb2312", "gb18030"]`, so txt files saved from Windows Notepad as "UTF-8 with BOM" or "Unicode" (UTF-16 LE) failed to decode and KB upload reported an unclear "无法读取或解析上传文件" error.

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- `astrbot/core/knowledge_base/parsers/text_parser.py`: detect `UTF-8` / `UTF-16 LE|BE` BOMs first and decode accordingly; BOM-less files keep the original `utf-8 → gbk → gb2312 → gb18030` sequence.
- `tests/test_text_parser.py`: add unit tests covering plain UTF-8, UTF-8 BOM, UTF-16 LE/BE BOM, GBK, and undecodable input.

Note: BOM detection (instead of blindly adding `utf-16` to the try sequence) is intentional — `utf-16` decodes almost any byte stream, so trying it before GBK would silently mis-decode BOM-less GBK text into garbage instead of raising `UnicodeDecodeError`.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIF, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

```
$ uv run pytest tests/test_text_parser.py -q
......                                                                   [100%]
6 passed in 0.41s
```

- `uv run ruff format` / `uv run ruff check` pass.
- Verification steps: in Windows Notepad, save a txt via "另存为 → 编码: Unicode" (UTF-16 LE with BOM) and upload it to a knowledge base; it now ingests correctly instead of failing.

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Support BOM-prefixed text encodings in the knowledge-base parser to correctly ingest files saved by Windows Notepad.

Bug Fixes:
- Enable knowledge-base text parsing for UTF-8 and UTF-16 files with byte-order marks while preserving existing fallback decoding for BOM-less files.

Tests:
- Add coverage for UTF-8, BOM-prefixed UTF-8 and UTF-16, GBK, and undecodable text inputs.