### PR TITLE
fix: route txt/md KB uploads to TextParser and clarify missing markitdown

### DIFF
--- a/astrbot/core/knowledge_base/parsers/util.py
+++ b/astrbot/core/knowledge_base/parsers/util.py
@@ -1,10 +1,32 @@
+from astrbot.core.exceptions import KnowledgeBaseUploadError
+
 from .base import BaseParser
+
+# Formats that are plain text by nature and need no external dependency.
+_TEXT_PARSER_EXTS = {".md", ".txt", ".markdown"}
+# Formats handled by markitdown-no-magika (an optional heavy dependency).
+_MARKITDOWN_EXTS = {".rst", ".adoc", ".xlsx", ".docx", ".xls"}
+
+_MARKITDOWN_MISSING_HINT = (
+    "文档解析失败：处理该格式需要 markitdown-no-magika 依赖，"
+    "请先安装：pip install 'markitdown-no-magika[docx,xls,xlsx]'"
+)
 
 
 async def select_parser(ext: str) -> BaseParser:
-    if ext in {".md", ".txt", ".markdown", ".rst", ".adoc", ".xlsx", ".docx", ".xls"}:
-        from .markitdown_parser import MarkitdownParser
+    if ext in _TEXT_PARSER_EXTS:
+        from .text_parser import TextParser
 
+        return TextParser()
+    if ext in _MARKITDOWN_EXTS:
+        try:
+            from .markitdown_parser import MarkitdownParser
+        except ImportError as exc:
+            raise KnowledgeBaseUploadError(
+                stage="parsing",
+                user_message=_MARKITDOWN_MISSING_HINT,
+                details={"file_ext": ext},
+            ) from exc
         return MarkitdownParser()
     if ext == ".epub":
         from .epub_parser import EpubParser

--- a/tests/test_kb_select_parser.py
+++ b/tests/test_kb_select_parser.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from astrbot.core.exceptions import KnowledgeBaseUploadError
+from astrbot.core.knowledge_base.parsers.markitdown_parser import MarkitdownParser
+from astrbot.core.knowledge_base.parsers.text_parser import TextParser
+from astrbot.core.knowledge_base.parsers.util import select_parser
+
+
+@pytest.mark.parametrize("ext", [".txt", ".md", ".markdown"])
+@pytest.mark.asyncio
+@pytest.mark.asyncio
+async def test_text_formats_use_text_parser(ext: str) -> None:
+    parser = await select_parser(ext)
+
+    assert isinstance(parser, TextParser)
+
+
+@pytest.mark.parametrize("ext", [".rst", ".adoc", ".xlsx", ".docx", ".xls"])
+@pytest.mark.asyncio
+@pytest.mark.asyncio
+async def test_office_formats_use_markitdown_parser(ext: str) -> None:
+    parser = await select_parser(ext)
+
+    assert isinstance(parser, MarkitdownParser)
+
+
+@pytest.mark.asyncio
+async def test_epub_and_pdf_routing() -> None:
+    from astrbot.core.knowledge_base.parsers.epub_parser import EpubParser
+    from astrbot.core.knowledge_base.parsers.pdf_parser import PDFParser
+
+    assert isinstance(await select_parser(".epub"), EpubParser)
+    assert isinstance(await select_parser(".pdf"), PDFParser)
+
+
+@pytest.mark.asyncio
+async def test_unsupported_ext_raises() -> None:
+    with pytest.raises(ValueError, match="暂时不支持的文件格式"):
+        await select_parser(".exe")
+
+
+@pytest.mark.asyncio
+async def test_missing_markitdown_dependency_raises_clear_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Drop cached modules so the lazy import runs again, then make
+    # `import markitdown_no_magika` fail as if the package were absent.
+    for name in list(sys.modules):
+        if name == "markitdown_no_magika" or name.endswith("markitdown_parser"):
+            monkeypatch.delitem(sys.modules, name)
+    monkeypatch.setitem(sys.modules, "markitdown_no_magika", None)
+
+    with pytest.raises(KnowledgeBaseUploadError, match="markitdown-no-magika"):
+        await select_parser(".docx")


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

Fixes #9598

`.txt` / `.md` / `.markdown` uploads were routed to `MarkitdownParser`, which imports `markitdown-no-magika` at module level. On environments where that package is absent, uploading a txt file failed with a generic "文档解析失败：无法读取或解析上传文件" error that never mentioned the actual cause (`ModuleNotFoundError`). Meanwhile `TextParser` — a dependency-free plain-text parser explicitly written for TXT/MD — existed but was never used by `select_parser`.

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- `astrbot/core/knowledge_base/parsers/util.py`:
  - Route `.txt` / `.md` / `.markdown` to `TextParser` (no external dependency needed; behavior is unchanged since markitdown just passed these through).
  - Keep `.rst/.adoc/.xlsx/.docx/.xls` on `MarkitdownParser`, but catch `ImportError` at selection time and raise `KnowledgeBaseUploadError` with an explicit install hint (`pip install 'markitdown-no-magika[docx,xls,xlsx]'`). `kb_helper` re-raises `KnowledgeBaseUploadError` untouched, so users now see the real cause instead of the misleading "file corrupted" message.
- `tests/test_kb_select_parser.py`: cover routing for all extensions, unsupported extension error, and the missing-dependency error path (simulated via `sys.modules`).

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

```
$ uv run pytest tests/test_kb_select_parser.py tests/test_epub_parser.py tests/test_kb_import.py -q
22 passed, 2 warnings in 2.97s
```

- `uv run ruff format` / `uv run ruff check` pass.
- Verification steps: in an environment without `markitdown-no-magika`, upload a `.txt` file to a knowledge base — it now parses and indexes successfully; uploading a `.docx` in the same environment reports the missing-dependency hint instead of a generic parse failure.

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Fix knowledge-base parser selection and clarify missing optional dependency errors for supported upload formats.

Bug Fixes:
- Route plain-text knowledge-base uploads through the dependency-free text parser so TXT and Markdown files work without Markitdown installed.
- Report a clear Markitdown installation hint when optional document-format dependencies are missing instead of returning a generic parsing failure.

Tests:
- Add parser-selection coverage for text, office, EPUB, PDF, unsupported formats, and missing Markitdown dependencies.