### PR TITLE
fix: add missing KB parser routes for mdx/mkd/html/htm/csv

### DIFF
--- a/astrbot/core/knowledge_base/parsers/util.py
+++ b/astrbot/core/knowledge_base/parsers/util.py
@@ -2,7 +2,28 @@ from .base import BaseParser
 
 
 async def select_parser(ext: str) -> BaseParser:
-    if ext in {".md", ".txt", ".markdown", ".rst", ".adoc", ".xlsx", ".docx", ".xls"}:
+    # Markdown variants that the MarkdownChunker whitelist in kb_helper
+    # already accepts; parse them as plain text without extra dependencies.
+    if ext in {".mdx", ".mkd"}:
+        from .text_parser import TextParser
+
+        return TextParser()
+    # Formats supported by markitdown-no-magika (verified converters:
+    # HtmlConverter, CsvConverter, PlainTextConverter; note it has no
+    # RTF converter, so .rtf stays unsupported).
+    if ext in {
+        ".csv",
+        ".html",
+        ".htm",
+        ".md",
+        ".txt",
+        ".markdown",
+        ".rst",
+        ".adoc",
+        ".xlsx",
+        ".docx",
+        ".xls",
+    }:
         from .markitdown_parser import MarkitdownParser
 
         return MarkitdownParser()

--- a/tests/test_kb_parser_routing.py
+++ b/tests/test_kb_parser_routing.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+from astrbot.core.knowledge_base.parsers.markitdown_parser import MarkitdownParser
+from astrbot.core.knowledge_base.parsers.text_parser import TextParser
+from astrbot.core.knowledge_base.parsers.util import select_parser
+
+
+@pytest.mark.parametrize("ext", [".mdx", ".mkd"])
+@pytest.mark.asyncio
+async def test_markdown_variants_use_text_parser(ext: str) -> None:
+    # These extensions are accepted by the MarkdownChunker whitelist in
+    # kb_helper but previously had no parser route, so uploads always
+    # failed with "暂时不支持的文件格式".
+    parser = await select_parser(ext)
+
+    assert isinstance(parser, TextParser)
+
+
+@pytest.mark.parametrize("ext", [".html", ".htm", ".csv"])
+@pytest.mark.asyncio
+async def test_html_csv_use_markitdown_parser(ext: str) -> None:
+    parser = await select_parser(ext)
+
+    assert isinstance(parser, MarkitdownParser)
+
+
+@pytest.mark.asyncio
+async def test_markitdown_parses_html_and_csv() -> None:
+    html = b"<html><body><h1>Title</h1><p>Hello <b>world</b></p></body></html>"
+    result = await MarkitdownParser().parse(html, "a.html")
+    assert "Title" in result.text and "Hello **world**" in result.text
+
+    csv = b"name,age\nalice,1\n"
+    result = await MarkitdownParser().parse(csv, "a.csv")
+    assert "alice" in result.text
+
+
+@pytest.mark.asyncio
+async def test_rtf_still_unsupported() -> None:
+    # markitdown-no-magika 0.1.2 has no RTF converter, so .rtf must keep
+    # raising instead of being routed to a parser that cannot handle it.
+    with pytest.raises(ValueError, match="暂时不支持的文件格式"):
+        await select_parser(".rtf")


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

Fixes #9903

`select_parser` and the `MarkdownChunker` whitelist in `kb_helper.py` were inconsistent:

- `.mdx` / `.mkd` are accepted by the chunker whitelist but had no parser route — uploads of these files always failed at the parsing stage with "暂时不支持的文件格式", making that chunker branch dead code.
- `.html` / `.htm` / `.csv` had no route at all, although the bundled `markitdown-no-magika` version registers `HtmlConverter` and `CsvConverter`, so the capability was wasted.

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- `astrbot/core/knowledge_base/parsers/util.py`:
  - Route `.mdx` / `.mkd` to `TextParser` (plain markdown variants, no extra dependency; the chunker whitelist already expects them).
  - Route `.html` / `.htm` / `.csv` to `MarkitdownParser`.
- `tests/test_kb_parser_routing.py`: cover the new routes, a real HTML/CSV parse smoke test, and that `.rtf` stays unsupported.

Note on `.rtf`: the issue suggested routing it to `MarkitdownParser`, but `markitdown-no-magika` 0.1.2 registers **no** RTF converter (verified: `md.convert(...)` raises `UnsupportedFormatException` for `.rtf`), so adding the route would only move the failure to a later stage with a worse error message. It intentionally keeps raising the explicit "unsupported format" error. Content sniffing for extension validation (optional in the issue) is left out to keep this change minimal.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

```
$ uv run pytest tests/test_kb_parser_routing.py tests/test_epub_parser.py tests/test_kb_import.py -q
18 passed, 2 warnings in 2.88s
```

- `uv run ruff format` / `uv run ruff check` pass.
- Verification steps: upload an `.mdx`/`.mkd`/`.html`/`.htm`/`.csv` file to a knowledge base — previously `.mdx/.mkd` failed with "暂时不支持的文件格式" and html/csv were rejected outright; now all of them parse and index.

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Add parser routes for supported Markdown variants, HTML, and CSV knowledge-base uploads while preserving explicit rejection of unsupported RTF files.

New Features:
- Add knowledge-base parser support for `.mdx`, `.mkd`, `.html`, `.htm`, and `.csv` files.

Bug Fixes:
- Fix uploads of `.mdx` and `.mkd` files that previously failed despite being accepted by the Markdown chunker.

Tests:
- Add parser-routing coverage, HTML and CSV parsing smoke tests, and regression coverage confirming `.rtf` remains unsupported.