### PR TITLE
fix: prevent RecursiveCharacterChunker overlap from exceeding chunk_size

### DIFF
--- a/astrbot/core/knowledge_base/chunking/recursive.py
+++ b/astrbot/core/knowledge_base/chunking/recursive.py
@@ -56,6 +56,14 @@ class RecursiveCharacterChunker(BaseChunker):
 
         overlap = kwargs.get("chunk_overlap", self.chunk_overlap)
         chunk_size = kwargs.get("chunk_size", self.chunk_size)
+        # 与 _split_by_character 保持一致的参数防护，保证任何输出块都不超过
+        # chunk_size 上限。
+        if chunk_size <= 0:
+            raise ValueError("chunk_size must be greater than 0")
+        if overlap < 0:
+            raise ValueError("chunk_overlap must be non-negative")
+        if overlap >= chunk_size:
+            raise ValueError("chunk_overlap must be less than chunk_size")
 
         text_length = self.length_function(text)
         if text_length <= chunk_size:
@@ -114,10 +122,16 @@ class RecursiveCharacterChunker(BaseChunker):
                         overlap_start = max(0, len(combined_text) - overlap)
                         if overlap_start > 0:
                             overlap_text = combined_text[overlap_start:]
-                            current_chunk = [overlap_text, split]
-                            current_chunk_length = (
-                                self.length_function(overlap_text) + split_length
-                            )
+                            overlap_length = self.length_function(overlap_text)
+                            if overlap_length + split_length > chunk_size:
+                                # 携带 overlap 会超出 chunk_size，改为将
+                                # overlap 独立成块，避免输出块超限。
+                                final_chunks.append(overlap_text)
+                                current_chunk = [split]
+                                current_chunk_length = split_length
+                            else:
+                                current_chunk = [overlap_text, split]
+                                current_chunk_length = overlap_length + split_length
                         else:
                             current_chunk = [split]
                             current_chunk_length = split_length

--- a/tests/test_recursive_chunker.py
+++ b/tests/test_recursive_chunker.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import pytest
+
+from astrbot.core.knowledge_base.chunking.recursive import RecursiveCharacterChunker
+
+
+def _make_split(chars: int, separator: str = "\n\n") -> str:
+    return "a" * chars + separator
+
+
+@pytest.mark.asyncio
+async def test_overlap_never_pushes_chunks_over_chunk_size() -> None:
+    # Regression test for #9901: with chunk_size=100 / overlap=30 and 80-char
+    # splits, the old code built "overlap + split" chunks of 110 chars.
+    chunker = RecursiveCharacterChunker(
+        chunk_size=100,
+        chunk_overlap=30,
+        separators=["\n\n"],
+    )
+    text = "".join(_make_split(78) for _ in range(3))
+
+    chunks = await chunker.chunk(text, chunk_size=100, chunk_overlap=30)
+
+    assert chunks
+    assert all(len(chunk) <= 100 for chunk in chunks), chunks
+    assert all(chunk for chunk in chunks)
+
+
+@pytest.mark.asyncio
+async def test_small_text_returned_as_single_chunk() -> None:
+    chunker = RecursiveCharacterChunker()
+
+    assert await chunker.chunk("hello", chunk_size=100, chunk_overlap=10) == ["hello"]
+    assert await chunker.chunk("", chunk_size=100, chunk_overlap=10) == []
+
+
+@pytest.mark.asyncio
+async def test_normal_text_chunks_within_limit() -> None:
+    chunker = RecursiveCharacterChunker(
+        chunk_size=50,
+        chunk_overlap=10,
+        separators=["\n\n"],
+    )
+    text = "\n\n".join(f"段落{i}" + "字" * 20 for i in range(6))
+
+    chunks = await chunker.chunk(text, chunk_size=50, chunk_overlap=10)
+
+    assert all(0 < len(chunk) <= 50 for chunk in chunks), chunks
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "a" * 30 + "\n\n" + "b" * 200,  # separator-driven path
+        "a" * 200,  # falls through to _split_by_character
+    ],
+)
+async def test_invalid_overlap_raises(text: str) -> None:
+    chunker = RecursiveCharacterChunker()
+
+    with pytest.raises(ValueError, match="chunk_overlap must be less than chunk_size"):
+        await chunker.chunk(text, chunk_size=100, chunk_overlap=100)


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

Fixes #9901

In `RecursiveCharacterChunker.chunk()`, when a split triggered a flush, the next chunk was unconditionally built as `overlap_text + split` without re-checking the combined length against `chunk_size`. Every flushed chunk could therefore be up to `chunk_size + overlap` long (about 562 chars with the default 512/50 config), and a larger configured `overlap` made the repeated overlap portion dominate the chunks, distorting embedding counts and retrieval quality.

Meanwhile `_split_by_character()` already rejects `overlap >= chunk_size`, so the two code paths disagreed on the same invariant.

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- `astrbot/core/knowledge_base/chunking/recursive.py`:
  - After prepending the overlap to the next chunk, re-check the combined length; when `overlap + split` would exceed `chunk_size`, emit the overlap as a standalone chunk (bounded by `overlap < chunk_size`) and start the new chunk with the split only.
  - Add the same parameter validation as `_split_by_character` at `chunk()` entry (`chunk_size > 0`, `0 <= overlap < chunk_size`) so both paths enforce the same invariant.
- `tests/test_recursive_chunker.py`: regression test proving no output chunk exceeds `chunk_size` (fails on the old code with 110-char chunks), plus small-text, normal-text, and invalid-overlap cases.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

```
$ uv run pytest tests/test_recursive_chunker.py -q
5 passed in 0.40s

# on the unfixed code the regression test fails as expected:
# FAILED test_overlap_never_pushes_chunks_over_chunk_size (110 > 100)
```

- `uv run ruff format` / `uv run ruff check` pass.
- Verification steps: upload a long document with the default chunker config and inspect the stored chunks — max chunk length is now within the configured `chunk_size` instead of `chunk_size + overlap`.

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Prevent recursive chunk overlap from exceeding chunk size while enforcing consistent parameter validation.

Bug Fixes:
- Ensure recursive chunking never emits chunks larger than the configured chunk size when overlap is applied.
- Reject invalid chunk size and overlap configurations consistently across recursive chunking paths.

Tests:
- Add regression and validation coverage for chunk size limits, small and normal inputs, and invalid overlap settings.