### PR TITLE
fix: sanitize KB retrieval query before dense embedding

### DIFF
--- a/astrbot/core/knowledge_base/retrieval/manager.py
+++ b/astrbot/core/knowledge_base/retrieval/manager.py
@@ -3,8 +3,8 @@
 协调稠密检索、稀疏检索和 Rerank,提供统一的检索接口
 """
 
-import re
 import time
+import unicodedata
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -35,14 +35,26 @@ class RetrievalResult:
     metadata: dict
 
 
-# Control (Cc, except tab/newline/CR) and format (Cf) characters are
-# invisible payloads that some embedding providers reject with HTTP 400
-# (e.g. SiliconFlow code 20015), typically originating from sticker /
-# image-caption pipelines. They are stripped before retrieval.
-_INVISIBLE_CHARS_PATTERN = re.compile(
-    "[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f"
-    "\u00ad\u061c\u180e\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff\ufff9-\ufffb]"
-)
+def _strip_invisible_chars(text: str) -> str:
+    """Remove control and format characters from a retrieval query.
+
+    Control (Cc, except tab/newline/CR) and format (Cf) characters are
+    invisible payloads that some embedding providers reject with HTTP 400
+    (e.g. SiliconFlow code 20015), typically originating from sticker /
+    image-caption pipelines.
+
+    Args:
+        text: Raw query text.
+
+    Returns:
+        The query with invisible characters removed.
+
+    """
+    return "".join(
+        ch
+        for ch in text
+        if ch not in "\t\n\r" and unicodedata.category(ch) not in ("Cc", "Cf")
+    )
 
 
 class RetrievalManager:
@@ -100,7 +112,7 @@ class RetrievalManager:
         """
         # Remove invisible characters and skip retrieval when nothing
         # remains, so invalid queries never reach the embedding provider.
-        query = _INVISIBLE_CHARS_PATTERN.sub("", query).strip()
+        query = _strip_invisible_chars(query).strip()
         if not query:
             logger.debug(
                 "Knowledge base retrieval skipped: query is empty after "

--- a/astrbot/core/knowledge_base/retrieval/manager.py
+++ b/astrbot/core/knowledge_base/retrieval/manager.py
@@ -3,6 +3,7 @@
 协调稠密检索、稀疏检索和 Rerank,提供统一的检索接口
 """
 
+import re
 import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -32,6 +33,16 @@ class RetrievalResult:
     content: str
     score: float
     metadata: dict
+
+
+# Control (Cc, except tab/newline/CR) and format (Cf) characters are
+# invisible payloads that some embedding providers reject with HTTP 400
+# (e.g. SiliconFlow code 20015), typically originating from sticker /
+# image-caption pipelines. They are stripped before retrieval.
+_INVISIBLE_CHARS_PATTERN = re.compile(
+    "[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f"
+    "\u00ad\u061c\u180e\u200b-\u200f\u202a-\u202e\u2060-\u206f\ufeff\ufff9-\ufffb]"
+)
 
 
 class RetrievalManager:
@@ -87,6 +98,16 @@ class RetrievalManager:
             List[RetrievalResult]: 检索结果列表
 
         """
+        # Remove invisible characters and skip retrieval when nothing
+        # remains, so invalid queries never reach the embedding provider.
+        query = _INVISIBLE_CHARS_PATTERN.sub("", query).strip()
+        if not query:
+            logger.debug(
+                "Knowledge base retrieval skipped: query is empty after "
+                "removing invisible characters.",
+            )
+            return []
+
         if not kb_ids:
             return []
 
@@ -229,7 +250,8 @@ class RetrievalManager:
                 all_results.extend(vec_results)
             except Exception as e:
                 logger.error(
-                    f"知识库 {kb_id} 稠密检索失败: {type(e).__name__}: {e}",
+                    f"知识库 {kb_id} 稠密检索失败: {type(e).__name__}: {e} "
+                    f"(query={query!r}, query_length={len(query)})",
                     exc_info=True,
                 )
                 # skip the faulty KB and continue

--- a/tests/test_retrieval_query_sanitize.py
+++ b/tests/test_retrieval_query_sanitize.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Import astrbot.api first: the kb retrieval import chain
+# (manager -> kb_helper -> provider.manager -> persona_mgr -> astrbot.api)
+# only resolves when astrbot.api is fully initialized beforehand.
+import astrbot.api  # noqa: F401
+from astrbot.core.knowledge_base.retrieval.manager import RetrievalManager
+
+
+def _make_manager() -> RetrievalManager:
+    manager = RetrievalManager(
+        sparse_retriever=MagicMock(),
+        rank_fusion=MagicMock(),
+        kb_db=MagicMock(),
+    )
+    manager.rank_fusion.fuse = AsyncMock(return_value=[])
+    manager.kb_db.get_documents_with_metadata_batch = AsyncMock(return_value={})
+    return manager
+
+
+@pytest.mark.asyncio
+async def test_invisible_only_query_skips_retrieval() -> None:
+    manager = _make_manager()
+    manager._dense_retrieve = AsyncMock(return_value=[])
+    manager.sparse_retriever.retrieve = AsyncMock(return_value=[])
+
+    results = await manager.retrieve(
+        query="\u200b\ufeff\x00",
+        kb_ids=["kb-1"],
+        kb_id_helper_map={},
+    )
+
+    assert results == []
+    manager._dense_retrieve.assert_not_awaited()
+    manager.sparse_retriever.retrieve.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_invisible_chars_are_stripped_before_retrieval() -> None:
+    manager = _make_manager()
+    manager._dense_retrieve = AsyncMock(return_value=[])
+    manager.sparse_retriever.retrieve = AsyncMock(return_value=[])
+    manager.rank_fusion.fuse = AsyncMock(return_value=[])
+
+    kb_helper = MagicMock()
+    kb_helper.kb.top_k_dense = 50
+    kb_helper.kb.top_k_sparse = 50
+    kb_helper.kb.top_m_final = 5
+    kb_helper.vec_db.rerank_provider = None
+
+    results = await manager.retrieve(
+        query="\u200bOni\u200f 恶鬼 ",
+        kb_ids=["kb-1"],
+        kb_id_helper_map={"kb-1": kb_helper},
+    )
+
+    assert results == []
+    sent_query = manager._dense_retrieve.await_args.kwargs["query"]
+    assert sent_query == "Oni 恶鬼"


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

Fixes #8135

Dense KB retrieval passed the raw query straight into the embedding provider. Some sticker/image-caption messages leave invisible control/format characters (zero-width chars, bidi controls, BOM, stray control bytes) in the query text, which certain embedding providers reject with `HTTP 400` (e.g. SiliconFlow `code 20015 "The parameter is invalid"`), producing recurring "稠密检索失败" errors for those messages.

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->

- `astrbot/core/knowledge_base/retrieval/manager.py`:
  - Strip control (`Cc`, except tab/newline/CR) and format (`Cf`) characters at the `RetrievalManager.retrieve()` entry, and skip retrieval entirely when nothing remains, so invalid queries never reach the embedding provider (as suggested in the issue).
  - When dense retrieval fails, the error log now includes `repr(query)` and its length to make such cases diagnosable.
- `tests/test_retrieval_query_sanitize.py`: cover the invisible-only query skip and the stripping of embedded invisible characters before `_dense_retrieve` is called.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

```
$ uv run pytest tests/test_retrieval_query_sanitize.py -q
2 passed in 1.05s
$ uv run pytest tests/unit/test_kb_manager_resilience.py -q
4 passed in 1.25s
```

- `uv run ruff format` / `uv run ruff check` pass.
- Verification steps: send a sticker/image that previously logged `知识库 ... 稠密检索失败: ... 400` — the error no longer occurs (retrieval is skipped or the sanitized query embeds successfully); a failing embedding call now logs `repr(query)` and its length for diagnosis.

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Prevent dense knowledge-base retrieval failures by sanitizing invisible characters from queries before embedding.

Bug Fixes:
- Sanitize knowledge-base retrieval queries to remove invisible control and formatting characters before they reach embedding providers, preventing invalid-query failures.
- Skip retrieval for queries that become empty after sanitization.

Enhancements:
- Include the sanitized query representation and length in dense-retrieval failure logs to improve diagnosis.

Tests:
- Add coverage for skipping invisible-only queries and sanitizing queries before dense retrieval.