### PR TITLE
fix: resolve plugin market detail mix-up for same-named plugins

### DIFF
--- a/dashboard/src/views/ExtensionPage.vue
+++ b/dashboard/src/views/ExtensionPage.vue
@@ -103,6 +103,7 @@ const {
   filteredExtensions,
   filteredPlugins,
   filteredMarketPlugins,
+  getMarketPluginKey,
   sortedPlugins,
   RANDOM_PLUGINS_COUNT,
   randomPlugins,
@@ -217,11 +218,18 @@ const selectedMarketPlugin = computed(() => {
     ? pluginMarketData.value
     : [];
   const installedPlugin = selectedInstalledPlugin.value;
+  // Resolve by the unique market plugin key first; the `name` match is a
+  // fallback for legacy deep links, since multiple market entries can share
+  // the same metadata name.
+  const marketKeyMatch =
+    market.find((item) => getMarketPluginKey(item) === selectedPluginId.value) ||
+      null;
   const marketNameMatch =
     market.find((item) => item.name === selectedPluginId.value) || null;
+  const marketMatch = marketKeyMatch || marketNameMatch;
 
   if (selectedDetailTab.value === "market" || !installedPlugin) {
-    return marketNameMatch;
+    return marketMatch;
   }
 
   const repo = normalizeRepoUrl(installedPlugin.repo);

--- a/dashboard/src/views/extension/MarketPluginsTab.vue
+++ b/dashboard/src/views/extension/MarketPluginsTab.vue
@@ -80,6 +80,7 @@ const {
   randomPluginNames,
   marketCategoryFilter,
   marketCategoryItems,
+  getMarketPluginKey,
   normalizeStr,
   toPinyinText,
   toInitials,
@@ -174,11 +175,14 @@ const marketCategorySelectItems = computed(() =>
   })),
 );
 
+// Navigate with the unique market plugin key instead of the metadata name —
+// two market entries can share the same `name`.
 const openMarketPluginDetail = (plugin) => {
-  if (!plugin?.name) return;
+  const pluginKey = getMarketPluginKey(plugin);
+  if (!pluginKey) return;
   router.push({
     name: "ExtensionMarketDetails",
-    params: { pluginId: plugin.name },
+    params: { pluginId: pluginKey },
   });
 };
 </script>
@@ -339,7 +343,7 @@ const openMarketPluginDetail = (plugin) => {
       <v-row style="min-height: 26rem" dense>
         <v-col
           v-for="plugin in paginatedPlugins"
-          :key="plugin.name"
+          :key="getMarketPluginKey(plugin)"
           cols="12"
           md="6"
           lg="4"
@@ -387,7 +391,7 @@ const openMarketPluginDetail = (plugin) => {
           <v-row class="mb-6" dense>
             <v-col
               v-for="plugin in randomPlugins"
-              :key="`random-${plugin.name}`"
+              :key="getMarketPluginKey(plugin)"
               cols="12"
               md="6"
               lg="4"

--- a/dashboard/src/views/extension/useExtensionPage.js
+++ b/dashboard/src/views/extension/useExtensionPage.js
@@ -432,11 +432,13 @@ export const useExtensionPage = (initialTab = "installed") => {
     const allPlugins = pluginMarketData.value;
     if (allPlugins.length === 0) return [];
 
-    const pluginsByName = new Map(
-      allPlugins.map((plugin) => [plugin.name, plugin]),
+    // Key by the unique market plugin key: metadata `name` is not unique and
+    // would collapse same-named plugins into one entry.
+    const pluginsByKey = new Map(
+      allPlugins.map((plugin) => [getMarketPluginKey(plugin), plugin]),
     );
     const selected = randomPluginNames.value
-      .map((name) => pluginsByName.get(name))
+      .map((key) => pluginsByKey.get(key))
       .filter(Boolean);
 
     if (selected.length > 0) {
@@ -462,7 +464,7 @@ export const useExtensionPage = (initialTab = "installed") => {
     const shuffled = shufflePlugins(pluginMarketData.value);
     randomPluginNames.value = shuffled
       .slice(0, Math.min(RANDOM_PLUGINS_COUNT, shuffled.length))
-      .map((plugin) => plugin.name);
+      .map((plugin) => getMarketPluginKey(plugin));
   };
 
   // 分页计算属性
@@ -684,6 +686,17 @@ export const useExtensionPage = (initialTab = "installed") => {
 
   const getMarketPluginId = (plugin) => {
     return String(plugin?.market_plugin_id || "").trim();
+  };
+
+  // Unique identity for a market entry. Metadata `name` alone is not unique —
+  // different authors can publish plugins with the same name — so fall back to
+  // repo and finally name for legacy registry entries without an explicit id.
+  const getMarketPluginKey = (plugin) => {
+    return (
+      getMarketPluginId(plugin) ||
+      String(plugin?.repo || "").trim() ||
+      String(plugin?.name || "").trim()
+    );
   };
 
   const getMarketInstallSourcePayload = () => {
@@ -2574,6 +2587,8 @@ export const useExtensionPage = (initialTab = "installed") => {
     randomPluginNames,
     normalizeStr,
     toPinyinText,
+    getMarketPluginId,
+    getMarketPluginKey,
     toInitials,
     filteredExtensions,
     filteredPlugins,


### PR DESCRIPTION
### Motivation

Fixes #9924.

In the plugin market (WebUI), two entries can share the same metadata `name` (typically plugins published by different authors). The detail flow, however, used `name` as the unique key, so both entries resolved to the same detail page showing the first entry's info (version / author / repo / README / changelog), and duplicate `v-for` keys made the market list render incorrectly as well. Related but distinct from #9026 (installed-vs-market name collision) — this issue is market-entry vs market-entry.

### Modifications

- `dashboard/src/views/extension/useExtensionPage.js`
  - Add `getMarketPluginKey(plugin)` = `market_plugin_id || repo || name` as the unique identity of a market entry (three-level fallback so legacy registry entries without an explicit id still get a stable key), and expose it via the page state.
  - The random-plugins section now keys its sampling `Map` by the unique key instead of `name`, so same-named entries no longer collapse into one.
- `dashboard/src/views/extension/MarketPluginsTab.vue`
  - `openMarketPluginDetail()` navigates with the unique key as `pluginId` instead of `plugin.name`.
  - Both `v-for` `:key`s (paginated list and random list) use the unique key, eliminating duplicate Vue keys.
- `dashboard/src/views/ExtensionPage.vue`
  - `selectedMarketPlugin` now resolves the detail entry by the unique key first; the `name` match is kept only as a fallback for legacy deep links (`/extension/<name>#market`). The installed-tab branch still resolves strictly by repo URL, so the #9026 behavior is unchanged.

Notes:

- Route params containing `/` (e.g. `author/name`) are safe: vue-router 4.2.4 encodes `/` as `%2F` when building the path and decodes it back on parse (verified against the installed version at runtime).
- No backend API/schema changes, so no API client regeneration is needed.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

- `vite build` passes (exit 0).
- `node --test tests/*.test.mjs` → 39/39 pass.
- Runtime round-trip test against vue-router 4.2.4: `router.push({ params: { pluginId: "authorA/astrbot_plugin_foo" } })` → URL `/extension/plugins/market/authorA%2Fastrbot_plugin_foo` → `route.params.pluginId === "authorA/astrbot_plugin_foo"` (also for a second author `authorB/...` → distinct routes).

Verification steps for reviewers:

1. Open the plugin market with a registry containing two entries with the same `name` but different `author`;
2. Click each card → each detail page now shows its own entry's version/author/repo/README;
3. Detail URLs are distinct (`.../market/<authorA>%2F<name>` vs `.../market/<authorB>%2F<name>`);
4. Legacy deep link `/extension/<name>#market` still resolves to a same-named entry (name fallback).

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Fix market plugin identity handling so entries with the same name remain distinct throughout listing, navigation, and detail views.

Bug Fixes:
- Resolve market plugin details using a unique market-entry identity so same-named plugins from different authors display the correct information.
- Preserve legacy name-based market deep links while keeping installed-plugin resolution behavior unchanged.

Enhancements:
- Use unique market-entry identities for random plugin selection and Vue list keys to prevent same-named entries from collapsing or rendering with duplicate keys.

Tests:
- Verify the dashboard build, automated tests, and route parameter round trips for distinct same-named market plugins.