### PR TITLE
feat(tools): add image caption fallback for FileReadTool when provider lacks image modality

### DIFF
--- a/astrbot/core/tools/computer_tools/fs.py
+++ b/astrbot/core/tools/computer_tools/fs.py
@@ -40,6 +40,8 @@ import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import mcp.types
+
 from astrbot.api import FunctionTool, logger
 from astrbot.api.event import MessageChain
 from astrbot.core.agent.run_context import ContextWrapper
@@ -303,6 +305,124 @@ def _decode_escaped_text(value: str) -> str:
     )
 
 
+async def _provider_supports_image(
+    context: ContextWrapper[AstrAgentContext],
+) -> bool:
+    """Check whether the current chat provider supports image modality.
+
+    Returns True when the provider supports image or when the check cannot
+    be determined (fail-open). Empty/missing modalities is treated as
+    supporting all modalities for backward compatibility.
+    """
+    try:
+        from astrbot.core.provider.entities import ProviderType
+
+        umo = context.context.event.unified_msg_origin
+        pm = context.context.context.provider_manager
+        provider = None
+        # Prefer async resolution to respect session-specific overrides.
+        if hasattr(pm, "get_using_provider_async"):
+            try:
+                provider = await pm.get_using_provider_async(
+                    ProviderType.CHAT_COMPLETION, umo=umo
+                )
+            except Exception:
+                provider = None
+        if provider is None:
+            try:
+                provider = pm.get_using_provider(ProviderType.CHAT_COMPLETION, umo=umo)
+            except Exception:
+                provider = None
+        if provider is None:
+            return True
+        modalities = provider.provider_config.get("modalities")
+        if not modalities:
+            return True
+        if not isinstance(modalities, list):
+            return True
+        return "image" in modalities
+    except Exception:
+        return True
+
+
+async def _caption_image_fallback(
+    context: ContextWrapper[AstrAgentContext],
+    image_ref: str,
+) -> ToolExecResult:
+    """Try to caption an image using the configured image caption provider.
+
+    When the current chat provider lacks image support and a caption
+    provider is configured, the image is described via that provider and
+    returned as text.
+
+    Args:
+        image_ref: Image reference passed to the caption provider. It may be
+            a local file path or a data URI (``data:image/...;base64,``).
+    """
+    try:
+        from astrbot.core.provider.provider import Provider
+    except Exception:  # pragma: no cover - import guard
+        from astrbot.core.provider.provider import Provider  # type: ignore
+
+    umo = context.context.event.unified_msg_origin
+    try:
+        cfg = context.context.context.get_config(umo=umo)
+    except Exception as exc:
+        logger.warning(f"[ImageFallback] Failed to load config for umo={umo}: {exc}")
+        return (
+            "Error: your provider does not support image modality, "
+            "and the caption configuration is unavailable. Unable to read image file."
+        )
+    provider_settings = (
+        cfg.get("provider_settings", {}) if isinstance(cfg, dict) else {}
+    )
+    caption_provider_id = str(
+        provider_settings.get("default_image_caption_provider_id", "") or ""
+    ).strip()
+
+    if not caption_provider_id:
+        return (
+            "Error: your provider does not support image modality, "
+            "and no image caption provider is configured. "
+            "Please set provider_settings.default_image_caption_provider_id."
+        )
+
+    pm = context.context.context.provider_manager
+    caption_provider = None
+    try:
+        caption_provider = await pm.get_provider_by_id(caption_provider_id)
+    except Exception as exc:
+        logger.warning(
+            f"[ImageFallback] Failed to get caption provider {caption_provider_id}: {exc}"
+        )
+        caption_provider = None
+
+    if caption_provider is None or not isinstance(caption_provider, Provider):
+        return (
+            "Error: your provider does not support image modality, "
+            f"and the configured image caption provider `{caption_provider_id}` is not available. "
+            "Unable to read image file."
+        )
+
+    caption_prompt = str(
+        provider_settings.get("image_caption_prompt", "Please describe the image.")
+        or "Please describe the image."
+    ).strip()
+
+    try:
+        llm_resp = await caption_provider.text_chat(
+            prompt=caption_prompt,
+            image_urls=[image_ref],
+        )
+        caption = (getattr(llm_resp, "completion_text", None) or "").strip()
+        if not caption:
+            return "Error: image caption provider returned an empty description."
+        return f"[Image description]: {caption}"
+    except Exception as exc:
+        logger.error(f"[ImageFallback] Image captioning failed for {image_ref}: {exc}")
+        return f"Error: failed to generate image description: {exc}"
+
+
 @builtin_tool(config=_COMPUTER_RUNTIME_TOOL_CONFIG)
 @dataclass
 class FileReadTool(FunctionTool):
@@ -378,7 +498,7 @@ class FileReadTool(FunctionTool):
                 context.context.context,
                 context.context.event.unified_msg_origin,
             )
-            return await read_file_tool_result(
+            result = await read_file_tool_result(
                 sb,
                 local_mode=local_env,
                 path=normalized_path,
@@ -393,6 +513,42 @@ class FileReadTool(FunctionTool):
                     else None
                 ),
             )
+
+            # If the result is an image and the current chat provider does not
+            # support image input, automatically fall back to the configured
+            # vision/caption provider to describe the image as text.
+            if (
+                isinstance(result, mcp.types.CallToolResult)
+                and result.content
+                and any(
+                    isinstance(item, mcp.types.ImageContent) for item in result.content
+                )
+            ):
+                try:
+                    supports_image = await _provider_supports_image(context)
+                except Exception:
+                    supports_image = True
+                if not supports_image:
+                    # Build a data URI from the already-compressed image when
+                    # available so that sandbox runtimes (where the file lives
+                    # inside the container) can still be captioned without
+                    # host filesystem access. Fall back to the normalized path
+                    # for the local runtime.
+                    image_ref = normalized_path
+                    try:
+                        for item in result.content:
+                            if isinstance(item, mcp.types.ImageContent) and getattr(
+                                item, "data", None
+                            ):
+                                mime = getattr(item, "mimeType", None) or "image/jpeg"
+                                # Avoid huge log spam; data URI is passed directly.
+                                image_ref = f"data:{mime};base64,{item.data}"
+                                break
+                    except Exception:
+                        image_ref = normalized_path
+                    return await _caption_image_fallback(context, image_ref)
+
+            return result
         except PermissionError as exc:
             return f"Error: {exc}"
         except Exception as exc:


### PR DESCRIPTION
### Motivation / 动机

**EN:** When the current chat provider does not support image input (`modalities` lacks `image`) and a vision/caption provider is configured via `provider_settings.default_image_caption_provider_id`, `astrbot_file_read_tool` previously returned a raw `ImageContent` that the chat model cannot consume. The intention is to automatically describe the image as text (image-to-text fallback) when a multimodal model is available.

**中文：** 当主对话模型不支持图片输入（`modalities` 未包含 `image`）且已在 `provider_settings.default_image_caption_provider_id` 配置了多模态/图转文模型时，`astrbot_file_read_tool` 原先会直接返回 `ImageContent`，导致主模型无法消费。期望行为是：自动调用已配置的多模态模型将图片转述为文本（图转文兜底），仅在同时满足“主模型不支持图片 + 已配置图转文模型”时触发。

### Modifications / 改动点

**EN:**
- `astrbot/core/tools/computer_tools/fs.py`
  - Import `mcp.types` for `CallToolResult` / `ImageContent` detection.
  - Add `_provider_supports_image(context)` — resolves the active chat provider via `ProviderManager.get_using_provider_async` (fallback to `get_using_provider`), treats `None` / empty / non-list `modalities` as supporting image (backward-compatible, consistent with `tool_loop_agent_runner`).
  - Add `_caption_image_fallback(context, image_ref)` — reads `provider_settings.default_image_caption_provider_id` and `image_caption_prompt`, resolves the caption provider via `get_provider_by_id`, calls `text_chat(prompt, image_urls=[image_ref])`, returns `[Image description]: {caption}` or a clear error when not configured / unavailable / empty.
  - Update `FileReadTool.call` — after `read_file_tool_result`, if the result is an `ImageContent` and the active provider lacks `image`, builds a `data:image/jpeg;base64,...` URI from the already-compressed payload (so sandbox runtimes work without host file access) and delegates to the caption fallback; otherwise returns the original result. Text/PDF/docx paths are unaffected.

**中文：**
- `astrbot/core/tools/computer_tools/fs.py`
  - 引入 `mcp.types` 用于识别 `CallToolResult` / `ImageContent`。
  - 新增 `_provider_supports_image(context)` —— 通过 `ProviderManager.get_using_provider_async`（回退到 `get_using_provider`）解析当前会话的主对话模型，将 `modalities` 为 `None` / 空数组 / 非列表视为支持图片（向后兼容，与 `tool_loop_agent_runner` 一致）。
  - 新增 `_caption_image_fallback(context, image_ref)` —— 读取 `provider_settings.default_image_caption_provider_id` 和 `image_caption_prompt`，通过 `get_provider_by_id` 获取图转文模型，调用 `text_chat(prompt, image_urls=[image_ref])`，成功返回 `[Image description]: {caption}`，未配置/不可用/空返回时给出明确错误提示。
  - 修改 `FileReadTool.call` —— 在 `read_file_tool_result` 之后，若结果为 `ImageContent` 且主模型不支持 `image`，则从已压缩的图片数据构造 `data:image/jpeg;base64,...` URI（兼容 sandbox 容器内文件无法通过宿主机路径访问的场景）并走图转文兜底，否则原样返回；文本/PDF/docx 流程不受影响。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```
uv run ruff check astrbot/core/tools/computer_tools/fs.py  -> All checks passed
uv run ruff format --check                                  -> 1 file would be reformatted (fixed)
python -m py_compile astrbot/core/tools/computer_tools/fs.py -> OK
```

**EN - Manual verification (7 cases, all passed):**
- provider `modalities=[text,image,tool_use]` → returns `ImageContent` directly
- provider `modalities=[text]` + caption provider `vision-1` configured → `text_chat` called with `data:image/jpeg;base64,...` + prompt, returns `[Image description]: ...`
- `default_image_caption_provider_id=""` → `Error: ... no image caption provider is configured. Please set provider_settings.default_image_caption_provider_id.`
- configured id not found → `Error: ... is not available. Unable to read image file.`
- `modalities=[]` or missing → treated as supporting image, returns `ImageContent`
- text file (`hello.txt`) → unaffected, returns plain text

**中文 - 手动验证（7 项均通过）：**
- `modalities=[text,image,tool_use]` → 直接返回 `ImageContent`
- `modalities=[text]` 且已配置 `vision-1` → 以 `data:image/jpeg;base64,...` + 提示词调用 `text_chat`，返回 `[Image description]: ...`
- `default_image_caption_provider_id=""` → 提示未配置图转文模型
- 配置的 ID 不存在 → 提示模型不可用
- `modalities=[]` 或缺失 → 视为支持图片，直接返回 `ImageContent`
- 文本文件（`hello.txt`）→ 不受影响，原样返回文本

Existing suite against `master` (`tests/test_computer_fs_tools.py -k "not test_sandbox_file_download_handles_windows_remote_filename"`): 15 passed / 5 pre-existing Windows failures unchanged.

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。