### PR TITLE
fix: skip delay before first segmented reply

### DIFF
--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -273,9 +273,10 @@ class RespondStage(Stage):
                         f"actual_chain: {result.chain}",
                     )
                     return
-                for comp in result.chain:
-                    i = await self._calc_comp_interval(comp)
-                    await asyncio.sleep(i)
+                for index, comp in enumerate(result.chain):
+                    if index > 0:
+                        i = await self._calc_comp_interval(comp)
+                        await asyncio.sleep(i)
                     try:
                         if comp.type in need_separately:
                             await event.send(result.derive([comp]))

--- a/tests/unit/test_segmented_reply_delay.py
+++ b/tests/unit/test_segmented_reply_delay.py
@@ -1,0 +1,125 @@
+"""Tests for segmented reply delay scheduling."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from astrbot.core.message.message_event_result import MessageEventResult
+from astrbot.core.pipeline.respond.stage import RespondStage
+
+
+class DummyRespondEvent:
+    """Provide the event interface required by RespondStage tests."""
+
+    def __init__(self, texts: list[str]) -> None:
+        """Initialize an event containing the provided text segments.
+
+        Args:
+            texts: Text segments to include in the event result.
+        """
+        self._result = MessageEventResult()
+        for text in texts:
+            self._result.message(text)
+        self._extras = {}
+        self.send = AsyncMock()
+        self.plugins_name = []
+
+    def get_result(self) -> MessageEventResult | None:
+        """Return the current event result."""
+        return self._result
+
+    def get_extra(self, key: str, default=None):
+        """Return an event extra value.
+
+        Args:
+            key: Extra value key.
+            default: Value returned when the key is missing.
+
+        Returns:
+            The stored value or the provided default.
+        """
+        return self._extras.get(key, default)
+
+    def get_sender_name(self) -> str:
+        """Return a sender name for logging."""
+        return "tester"
+
+    def get_sender_id(self) -> str:
+        """Return a sender ID for logging."""
+        return "user-1"
+
+    def get_platform_id(self) -> str:
+        """Return a platform ID for logging."""
+        return "test"
+
+    def get_platform_name(self) -> str:
+        """Return a platform name eligible for segmented replies."""
+        return "test"
+
+    def _outline_chain(self, chain) -> str:
+        """Return a readable message-chain outline.
+
+        Args:
+            chain: Message components to describe.
+
+        Returns:
+            Plain text contained in the message chain.
+        """
+        return " ".join(comp.text for comp in chain if hasattr(comp, "text"))
+
+    def is_stopped(self) -> bool:
+        """Return whether event propagation has stopped."""
+        return False
+
+    def clear_result(self) -> None:
+        """Clear the current event result."""
+        self._result = None
+
+
+@pytest.mark.asyncio
+async def test_segmented_reply_delays_only_after_first_segment() -> None:
+    """Send the first segment immediately and delay the next segment."""
+    stage = RespondStage()
+    stage.config = {"provider_settings": {}}
+    stage.platform_settings = {"path_mapping": []}
+    stage.enable_seg = True
+    stage.only_llm_result = False
+    stage._calc_comp_interval = AsyncMock(return_value=2.0)
+    event = DummyRespondEvent(["first", "second"])
+    timeline = []
+    event.send.side_effect = lambda chain: timeline.append(
+        ("send", chain.get_plain_text()),
+    )
+    sleep = AsyncMock(side_effect=lambda delay: timeline.append(("sleep", delay)))
+
+    with patch("astrbot.core.pipeline.respond.stage.asyncio.sleep", new=sleep):
+        await stage.process(event)
+
+    assert timeline == [
+        ("send", "first"),
+        ("sleep", 2.0),
+        ("send", "second"),
+    ]
+    sleep.assert_awaited_once_with(2.0)
+    stage._calc_comp_interval.assert_awaited_once()
+    assert stage._calc_comp_interval.await_args.args[0].text == "second"
+
+
+@pytest.mark.asyncio
+async def test_single_segmented_reply_has_no_delay() -> None:
+    """Send a single segmented reply without applying a delay."""
+    stage = RespondStage()
+    stage.config = {"provider_settings": {}}
+    stage.platform_settings = {"path_mapping": []}
+    stage.enable_seg = True
+    stage.only_llm_result = False
+    stage._calc_comp_interval = AsyncMock(return_value=2.0)
+    event = DummyRespondEvent(["only"])
+    sleep = AsyncMock()
+
+    with patch("astrbot.core.pipeline.respond.stage.asyncio.sleep", new=sleep):
+        await stage.process(event)
+
+    event.send.assert_awaited_once()
+    sleep.assert_not_awaited()
+    stage._calc_comp_interval.assert_not_awaited()


### PR DESCRIPTION
分段回复延迟应用于每个消息组件之前，包括第一个也是唯一的组件。这增加了LLM生成响应后的感知响应延迟。

### Modifications / 改动点

- 立即发送第一个分段回复

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```text
$ uv run pytest tests/unit/test_segmented_reply_delay.py -q
..                                                                       [100%]
2 passed, 1 warning in 4.80s

$ uv run ruff format .
504 files left unchanged

$ uv run ruff check .
All checks passed!
```

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Send the first segmented reply immediately while preserving delays between subsequent segments.

Bug Fixes:
- Skip the segmented-reply delay before the first message component so the initial response is sent immediately.

Tests:
- Add unit tests verifying that delays occur only between segments and are omitted for single-segment replies.