### PR TITLE
fix: apply session-level plugin disable rules to event hooks, tools and skills 

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -48,6 +48,7 @@ from astrbot.core.skills.skill_manager import (
     build_skills_prompt,
 )
 from astrbot.core.star.context import Context
+from astrbot.core.star.session_plugin_manager import SessionPluginManager
 from astrbot.core.star.star import star_registry
 from astrbot.core.star.star_handler import star_map
 from astrbot.core.tools.computer_tools import (
@@ -494,6 +495,7 @@ def _build_local_mode_prompt() -> str:
 def _filter_skills_for_current_config(
     skills: list[SkillInfo],
     cfg: dict,
+    session_disabled_plugins: set[str] | None = None,
 ) -> list[SkillInfo]:
     plugin_set = cfg.get("plugin_set", ["*"])
     allowed_plugins = (
@@ -501,6 +503,7 @@ def _filter_skills_for_current_config(
         if not isinstance(plugin_set, list) or "*" in plugin_set
         else {str(name) for name in plugin_set}
     )
+    session_disabled_plugins = session_disabled_plugins or set()
     plugin_by_root_dir = {
         metadata.root_dir_name: metadata
         for metadata in star_registry
@@ -515,7 +518,12 @@ def _filter_skills_for_current_config(
         plugin = plugin_by_root_dir.get(skill.plugin_name)
         if not plugin or not plugin.activated:
             continue
-        if plugin.reserved or allowed_plugins is None:
+        if plugin.reserved:
+            filtered.append(skill)
+            continue
+        if plugin.name is not None and plugin.name in session_disabled_plugins:
+            continue
+        if allowed_plugins is None:
             filtered.append(skill)
             continue
         if plugin.name is not None and plugin.name in allowed_plugins:
@@ -571,7 +579,11 @@ async def _ensure_persona_and_skills(
     runtime = cfg.get("computer_use_runtime", "local")
     skill_manager = SkillManager()
     skills = skill_manager.list_skills(active_only=True, runtime=runtime)
-    skills = _filter_skills_for_current_config(skills, cfg)
+    skills = _filter_skills_for_current_config(
+        skills,
+        cfg,
+        await SessionPluginManager.get_disabled_plugins(event),
+    )
     workspace_skills: list[SkillInfo] = []
     if runtime == "local":
         workspace_root = await _get_workspace_path_for_umo(
@@ -1068,33 +1080,52 @@ async def _decorate_llm_request(
     await _apply_workspace_extra_prompt(event, req, plugin_context)
 
 
-def _plugin_tool_fix(event: AstrMessageEvent, req: ProviderRequest) -> None:
-    """根据事件中的插件设置，过滤请求中的工具列表。
+async def _plugin_tool_fix(
+    event: AstrMessageEvent,
+    req: ProviderRequest,
+    session_disabled_plugins: set[str] | None = None,
+) -> None:
+    """根据事件中的插件设置与当前会话的禁用插件，过滤请求中的工具列表。
 
     注意：没有 handler_module_path 的工具（如 MCP 工具）会被保留，
     因为它们不属于任何插件，不应被插件过滤逻辑影响。
+
+    当 event.plugins_name 为 None 时（全局所有插件启用），仍然会过滤掉
+    当前会话中通过会话级规则禁用的插件所注册的工具。
     """
-    if event.plugins_name is not None and req.func_tool:
-        new_tool_set = ToolSet()
-        for tool in req.func_tool.tools:
-            if isinstance(tool, MCPTool):
-                # 保留 MCP 工具
-                new_tool_set.add_tool(tool)
-                continue
-            mp = tool.handler_module_path
-            if not mp:
-                # 没有 plugin 归属信息的工具（如 subagent transfer_to_*）
-                # 不应受到会话插件过滤影响。
-                new_tool_set.add_tool(tool)
-                continue
-            plugin = star_map.get(mp)
-            if not plugin:
-                # 无法解析插件归属时，保守保留工具，避免误过滤。
-                new_tool_set.add_tool(tool)
-                continue
-            if plugin.name in event.plugins_name or plugin.reserved:
-                new_tool_set.add_tool(tool)
-        req.func_tool = new_tool_set
+    if not req.func_tool:
+        return
+    session_disabled_plugins = session_disabled_plugins or set()
+
+    new_tool_set = ToolSet()
+    for tool in req.func_tool.tools:
+        if isinstance(tool, MCPTool):
+            # 保留 MCP 工具
+            new_tool_set.add_tool(tool)
+            continue
+        mp = tool.handler_module_path
+        if not mp:
+            # 没有 plugin 归属信息的工具（如 subagent transfer_to_*）
+            # 不应受到会话插件过滤影响。
+            new_tool_set.add_tool(tool)
+            continue
+        plugin = star_map.get(mp)
+        if not plugin:
+            # 无法解析插件归属时，保守保留工具，避免误过滤。
+            new_tool_set.add_tool(tool)
+            continue
+        if plugin.reserved:
+            # 保留插件（系统插件）不参与会话级禁用。
+            new_tool_set.add_tool(tool)
+            continue
+        if plugin.name in session_disabled_plugins:
+            continue
+        if event.plugins_name is not None and (
+            plugin.name is None or plugin.name not in event.plugins_name
+        ):
+            continue
+        new_tool_set.add_tool(tool)
+    req.func_tool = new_tool_set
 
 
 async def _handle_webchat(
@@ -1617,7 +1648,11 @@ async def build_main_agent(
     if not req.session_id:
         req.session_id = event.unified_msg_origin
 
-    _plugin_tool_fix(event, req)
+    await _plugin_tool_fix(
+        event,
+        req,
+        await SessionPluginManager.get_disabled_plugins(event),
+    )
     await _apply_web_search_tools(event, req, plugin_context)
 
     if config.llm_safety_mode:

--- a/astrbot/core/pipeline/context_utils.py
+++ b/astrbot/core/pipeline/context_utils.py
@@ -5,6 +5,7 @@ import typing as T
 from astrbot import logger
 from astrbot.core.message.message_event_result import CommandResult, MessageEventResult
 from astrbot.core.platform.astr_message_event import AstrMessageEvent
+from astrbot.core.star.session_plugin_manager import SessionPluginManager
 from astrbot.core.star.star import star_map
 from astrbot.core.star.star_handler import EventType, star_handlers_registry
 
@@ -92,6 +93,8 @@ async def call_event_hook(
         hook_type,
         plugins_name=event.plugins_name,
     )
+    # 过滤当前会话中通过会话级规则禁用的插件
+    handlers = await SessionPluginManager.filter_handlers_by_session(event, handlers)
     for handler in handlers:
         try:
             assert inspect.iscoroutinefunction(handler.handler)

--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -11,6 +11,7 @@ from astrbot.core.pipeline.content_safety_check.stage import ContentSafetyCheckS
 from astrbot.core.platform.astr_message_event import AstrMessageEvent
 from astrbot.core.platform.message_type import MessageType
 from astrbot.core.star.session_llm_manager import SessionServiceManager
+from astrbot.core.star.session_plugin_manager import SessionPluginManager
 from astrbot.core.star.star import star_map
 from astrbot.core.star.star_handler import EventType, star_handlers_registry
 
@@ -159,6 +160,10 @@ class ResultDecorateStage(Stage):
         handlers = star_handlers_registry.get_handlers_by_event_type(
             EventType.OnDecoratingResultEvent,
             plugins_name=event.plugins_name,
+        )
+        handlers = await SessionPluginManager.filter_handlers_by_session(
+            event,
+            handlers,
         )
         for handler in handlers:
             try:

--- a/astrbot/core/star/session_plugin_manager.py
+++ b/astrbot/core/star/session_plugin_manager.py
@@ -14,6 +14,7 @@ class SessionPluginManager:
         """返回事件所属会话通过会话级规则禁用的插件名称集合。
 
         结果会缓存在事件 extras 上，同一事件内不会重复查询数据库。
+        事件对象可能不实现 set_extra（例如测试中的轻量事件），此时不做缓存。
 
         Args:
             event: 消息事件。
@@ -21,13 +22,15 @@ class SessionPluginManager:
         Returns:
             会话禁用的插件名称集合，可能为空集合。
         """
+        set_extra = getattr(event, "set_extra", None)
         cached = event.get_extra(_SESSION_DISABLED_PLUGINS_EXTRA_KEY)
         if cached is not None:
             return cached
 
         session_id = getattr(event, "unified_msg_origin", None)
         if not session_id:
-            event.set_extra(_SESSION_DISABLED_PLUGINS_EXTRA_KEY, set())
+            if set_extra is not None:
+                set_extra(_SESSION_DISABLED_PLUGINS_EXTRA_KEY, set())
             return set()
 
         session_plugin_config = await sp.get_async(
@@ -38,7 +41,8 @@ class SessionPluginManager:
         )
         session_config = session_plugin_config.get(session_id, {})
         disabled_plugins = set(session_config.get("disabled_plugins", []))
-        event.set_extra(_SESSION_DISABLED_PLUGINS_EXTRA_KEY, disabled_plugins)
+        if set_extra is not None:
+            set_extra(_SESSION_DISABLED_PLUGINS_EXTRA_KEY, disabled_plugins)
         return disabled_plugins
 
     @staticmethod

--- a/astrbot/core/star/session_plugin_manager.py
+++ b/astrbot/core/star/session_plugin_manager.py
@@ -3,9 +3,43 @@
 from astrbot.core import logger, sp
 from astrbot.core.platform.astr_message_event import AstrMessageEvent
 
+_SESSION_DISABLED_PLUGINS_EXTRA_KEY = "session_disabled_plugins"
+
 
 class SessionPluginManager:
     """管理会话级别的插件启停状态"""
+
+    @staticmethod
+    async def get_disabled_plugins(event: AstrMessageEvent) -> set[str]:
+        """返回事件所属会话通过会话级规则禁用的插件名称集合。
+
+        结果会缓存在事件 extras 上，同一事件内不会重复查询数据库。
+
+        Args:
+            event: 消息事件。
+
+        Returns:
+            会话禁用的插件名称集合，可能为空集合。
+        """
+        cached = event.get_extra(_SESSION_DISABLED_PLUGINS_EXTRA_KEY)
+        if cached is not None:
+            return cached
+
+        session_id = getattr(event, "unified_msg_origin", None)
+        if not session_id:
+            event.set_extra(_SESSION_DISABLED_PLUGINS_EXTRA_KEY, set())
+            return set()
+
+        session_plugin_config = await sp.get_async(
+            scope="umo",
+            scope_id=session_id,
+            key="session_plugin_config",
+            default={},
+        )
+        session_config = session_plugin_config.get(session_id, {})
+        disabled_plugins = set(session_config.get("disabled_plugins", []))
+        event.set_extra(_SESSION_DISABLED_PLUGINS_EXTRA_KEY, disabled_plugins)
+        return disabled_plugins
 
     @staticmethod
     async def is_plugin_enabled_for_session(
@@ -62,17 +96,10 @@ class SessionPluginManager:
         """
         from astrbot.core.star.star import star_map
 
-        session_id = event.unified_msg_origin
+        session_id = getattr(event, "unified_msg_origin", None)
         filtered_handlers = []
 
-        session_plugin_config = await sp.get_async(
-            scope="umo",
-            scope_id=session_id,
-            key="session_plugin_config",
-            default={},
-        )
-        session_config = session_plugin_config.get(session_id, {})
-        disabled_plugins = session_config.get("disabled_plugins", [])
+        disabled_plugins = await SessionPluginManager.get_disabled_plugins(event)
 
         for handler in handlers:
             # 获取处理器对应的插件

--- a/tests/unit/test_astr_main_agent.py
+++ b/tests/unit/test_astr_main_agent.py
@@ -176,9 +176,12 @@ def test_append_system_reminders_includes_weekday(mock_event):
 
 
 def test_local_mode_prompt_uses_windows_powershell_51():
-    with patch("astrbot.core.astr_main_agent.platform.system", return_value="Windows"), patch(
-        "astrbot.core.astr_main_agent.resolve_windows_shell",
-        return_value="powershell.exe",
+    with (
+        patch("astrbot.core.astr_main_agent.platform.system", return_value="Windows"),
+        patch(
+            "astrbot.core.astr_main_agent.resolve_windows_shell",
+            return_value="powershell.exe",
+        ),
     ):
         prompt = ama._build_local_mode_prompt()
 
@@ -188,9 +191,12 @@ def test_local_mode_prompt_uses_windows_powershell_51():
 
 
 def test_local_mode_prompt_hints_pwsh_when_resolved():
-    with patch("astrbot.core.astr_main_agent.platform.system", return_value="Windows"), patch(
-        "astrbot.core.astr_main_agent.resolve_windows_shell",
-        return_value="pwsh.exe",
+    with (
+        patch("astrbot.core.astr_main_agent.platform.system", return_value="Windows"),
+        patch(
+            "astrbot.core.astr_main_agent.resolve_windows_shell",
+            return_value="pwsh.exe",
+        ),
     ):
         prompt = ama._build_local_mode_prompt()
 
@@ -200,9 +206,12 @@ def test_local_mode_prompt_hints_pwsh_when_resolved():
 
 
 def test_local_mode_prompt_ignores_pwsh_on_non_windows():
-    with patch("astrbot.core.astr_main_agent.platform.system", return_value="Linux"), patch(
-        "astrbot.core.astr_main_agent.resolve_windows_shell",
-        return_value="pwsh.exe",
+    with (
+        patch("astrbot.core.astr_main_agent.platform.system", return_value="Linux"),
+        patch(
+            "astrbot.core.astr_main_agent.resolve_windows_shell",
+            return_value="pwsh.exe",
+        ),
     ):
         prompt = ama._build_local_mode_prompt()
 
@@ -1383,17 +1392,19 @@ class TestDecorateLlmRequest:
 class TestPluginToolFix:
     """Tests for _plugin_tool_fix function."""
 
-    def test_plugin_tool_fix_none_plugins(self, mock_event):
+    @pytest.mark.asyncio
+    async def test_plugin_tool_fix_none_plugins(self, mock_event):
         """Test plugin tool fix when no plugins specified."""
         module = ama
         req = ProviderRequest(func_tool=ToolSet())
         mock_event.plugins_name = None
 
-        module._plugin_tool_fix(mock_event, req)
+        await module._plugin_tool_fix(mock_event, req)
 
         assert req.func_tool is not None
 
-    def test_plugin_tool_fix_filters_by_plugin(self, mock_event):
+    @pytest.mark.asyncio
+    async def test_plugin_tool_fix_filters_by_plugin(self, mock_event):
         """Test plugin tool fix filters tools by enabled plugins."""
         module = ama
         mcp_tool = MagicMock(spec=MCPTool)
@@ -1417,12 +1428,13 @@ class TestPluginToolFix:
             mock_plugin.reserved = False
             mock_star_map.get.return_value = mock_plugin
 
-            module._plugin_tool_fix(mock_event, req)
+            await module._plugin_tool_fix(mock_event, req)
 
         assert "mcp_tool" in req.func_tool.names()
         assert "plugin_tool" in req.func_tool.names()
 
-    def test_plugin_tool_fix_mcp_preserved(self, mock_event):
+    @pytest.mark.asyncio
+    async def test_plugin_tool_fix_mcp_preserved(self, mock_event):
         """Test that MCP tools are always preserved."""
         module = ama
         mcp_tool = MagicMock(spec=MCPTool)
@@ -1436,11 +1448,14 @@ class TestPluginToolFix:
         mock_event.plugins_name = ["other_plugin"]
 
         with patch("astrbot.core.astr_main_agent.star_map"):
-            module._plugin_tool_fix(mock_event, req)
+            await module._plugin_tool_fix(mock_event, req)
 
         assert "mcp_tool" in req.func_tool.names()
 
-    def test_plugin_tool_fix_preserves_tools_without_plugin_origin(self, mock_event):
+    @pytest.mark.asyncio
+    async def test_plugin_tool_fix_preserves_tools_without_plugin_origin(
+        self, mock_event
+    ):
         """Tools without handler_module_path should not be filtered out."""
         module = ama
         handoff_tool = FunctionTool(
@@ -1458,9 +1473,66 @@ class TestPluginToolFix:
         mock_event.plugins_name = ["other_plugin"]
 
         with patch("astrbot.core.astr_main_agent.star_map"):
-            module._plugin_tool_fix(mock_event, req)
+            await module._plugin_tool_fix(mock_event, req)
 
         assert "transfer_to_demo_agent" in req.func_tool.names()
+
+    @pytest.mark.asyncio
+    async def test_plugin_tool_fix_filters_session_disabled_plugin(self, mock_event):
+        """Session-disabled plugin tools are removed even if globally enabled."""
+        module = ama
+        plugin_tool = MagicMock()
+        plugin_tool.name = "plugin_tool"
+        plugin_tool.handler_module_path = "test_plugin"
+        plugin_tool.active = True
+
+        tool_set = ToolSet()
+        tool_set.add_tool(plugin_tool)
+
+        req = ProviderRequest(func_tool=tool_set)
+        mock_event.plugins_name = None
+
+        with patch("astrbot.core.astr_main_agent.star_map") as mock_star_map:
+            mock_plugin = MagicMock()
+            mock_plugin.name = "test_plugin"
+            mock_plugin.reserved = False
+            mock_star_map.get.return_value = mock_plugin
+
+            await module._plugin_tool_fix(
+                mock_event, req, session_disabled_plugins={"test_plugin"}
+            )
+
+        assert req.func_tool is None or "plugin_tool" not in req.func_tool.names()
+
+    @pytest.mark.asyncio
+    async def test_plugin_tool_fix_preserves_reserved_when_session_disabled(
+        self,
+        mock_event,
+    ):
+        """Reserved (system) plugin tools are kept even when session-disabled."""
+        module = ama
+        plugin_tool = MagicMock()
+        plugin_tool.name = "plugin_tool"
+        plugin_tool.handler_module_path = "test_plugin"
+        plugin_tool.active = True
+
+        tool_set = ToolSet()
+        tool_set.add_tool(plugin_tool)
+
+        req = ProviderRequest(func_tool=tool_set)
+        mock_event.plugins_name = None
+
+        with patch("astrbot.core.astr_main_agent.star_map") as mock_star_map:
+            mock_plugin = MagicMock()
+            mock_plugin.name = "test_plugin"
+            mock_plugin.reserved = True
+            mock_star_map.get.return_value = mock_plugin
+
+            await module._plugin_tool_fix(
+                mock_event, req, session_disabled_plugins={"test_plugin"}
+            )
+
+        assert "plugin_tool" in req.func_tool.names()
 
 
 class TestBuildMainAgent:

--- a/tests/unit/test_session_plugin_manager.py
+++ b/tests/unit/test_session_plugin_manager.py
@@ -112,6 +112,29 @@ async def test_filter_handlers_by_session_skips_disabled_plugin(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_get_disabled_plugins_tolerates_event_without_set_extra(monkeypatch):
+    """Lightweight events without set_extra (used in some pipeline tests) must not raise."""
+    from types import SimpleNamespace
+
+    event = SimpleNamespace(
+        unified_msg_origin=UMO,
+        get_extra=lambda *_args, **_kwargs: None,
+    )
+    mock_sp = MagicMock()
+    mock_sp.get_async = AsyncMock(
+        return_value={UMO: {"disabled_plugins": ["astrbot_meme_plugin"]}}
+    )
+    monkeypatch.setattr(
+        "astrbot.core.star.session_plugin_manager.sp",
+        mock_sp,
+    )
+
+    assert await SessionPluginManager.get_disabled_plugins(event) == {
+        "astrbot_meme_plugin"
+    }
+
+
+@pytest.mark.asyncio
 async def test_call_event_hook_skips_disabled_plugin_hook(monkeypatch):
     """call_event_hook does not invoke hooks of session-disabled plugins."""
     event = make_event()

--- a/tests/unit/test_session_plugin_manager.py
+++ b/tests/unit/test_session_plugin_manager.py
@@ -1,0 +1,170 @@
+"""Tests for SessionPluginManager session-level plugin disable rules."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from astrbot.core.pipeline.context_utils import call_event_hook
+from astrbot.core.star.session_plugin_manager import SessionPluginManager
+from astrbot.core.star.star_handler import EventType
+
+UMO = "test-platform:GroupMessage:12345"
+
+
+def make_event() -> MagicMock:
+    """Create a mock message event bound to a fixed session."""
+    event = MagicMock()
+    event.unified_msg_origin = UMO
+    event._extras = {}
+    event.get_extra.side_effect = lambda key=None, default=None: event._extras.get(
+        key,
+        default,
+    )
+    event.set_extra.side_effect = lambda key, value: event._extras.__setitem__(
+        key,
+        value,
+    )
+    event.plugins_name = None
+    event.is_stopped.return_value = False
+    return event
+
+
+def make_handler(name: str, plugin_module: str) -> tuple[MagicMock, list[str]]:
+    """Create a mock event handler metadata belonging to a plugin module.
+
+    handler.handler is a real coroutine function so that
+    inspect.iscoroutinefunction() accepts it inside call_event_hook.
+    Returns the handler and a call log list shared by the coroutine.
+    """
+    handler = MagicMock()
+    handler.handler_name = name
+    handler.handler_module_path = plugin_module
+    log: list[str] = []
+
+    async def _invoke(event, *args, **kwargs):
+        log.append(name)
+
+    handler.handler = _invoke
+    return handler, log
+
+
+@pytest.mark.asyncio
+async def test_get_disabled_plugins_reads_and_caches(monkeypatch):
+    """Disabled plugin list is read from preferences and cached on the event."""
+    event = make_event()
+    mock_sp = MagicMock()
+    mock_sp.get_async = AsyncMock(
+        return_value={UMO: {"disabled_plugins": ["astrbot_meme_plugin"]}}
+    )
+    monkeypatch.setattr(
+        "astrbot.core.star.session_plugin_manager.sp",
+        mock_sp,
+    )
+
+    first = await SessionPluginManager.get_disabled_plugins(event)
+    second = await SessionPluginManager.get_disabled_plugins(event)
+
+    assert first == {"astrbot_meme_plugin"}
+    assert second == {"astrbot_meme_plugin"}
+    mock_sp.get_async.assert_awaited_once()
+
+    assert event._extras["session_disabled_plugins"] == {"astrbot_meme_plugin"}
+
+
+@pytest.mark.asyncio
+async def test_get_disabled_plugins_returns_empty_when_no_config(monkeypatch):
+    """No session config means no disabled plugins."""
+    event = make_event()
+    mock_sp = MagicMock()
+    mock_sp.get_async = AsyncMock(return_value={})
+    monkeypatch.setattr(
+        "astrbot.core.star.session_plugin_manager.sp",
+        mock_sp,
+    )
+
+    assert await SessionPluginManager.get_disabled_plugins(event) == set()
+
+
+@pytest.mark.asyncio
+async def test_filter_handlers_by_session_skips_disabled_plugin(monkeypatch):
+    """Handlers of plugins disabled in the session are filtered out."""
+    event = make_event()
+    handler, _ = make_handler("on_llm_request", "astrbot_meme_plugin")
+    mock_sp = MagicMock()
+    mock_sp.get_async = AsyncMock(
+        return_value={UMO: {"disabled_plugins": ["astrbot_meme_plugin"]}}
+    )
+    monkeypatch.setattr(
+        "astrbot.core.star.session_plugin_manager.sp",
+        mock_sp,
+    )
+    mock_plugin = MagicMock()
+    mock_plugin.name = "astrbot_meme_plugin"
+    mock_plugin.reserved = False
+    monkeypatch.setattr(
+        "astrbot.core.star.star.star_map",
+        {"astrbot_meme_plugin": mock_plugin},
+    )
+
+    filtered = await SessionPluginManager.filter_handlers_by_session(event, [handler])
+
+    assert filtered == []
+
+
+@pytest.mark.asyncio
+async def test_call_event_hook_skips_disabled_plugin_hook(monkeypatch):
+    """call_event_hook does not invoke hooks of session-disabled plugins."""
+    event = make_event()
+    disabled_handler, disabled_log = make_handler(
+        "on_llm_request",
+        "astrbot_meme_plugin",
+    )
+    enabled_handler, enabled_log = make_handler(
+        "on_llm_request",
+        "astrbot_other_plugin",
+    )
+
+    mock_registry = MagicMock()
+    mock_registry.get_handlers_by_event_type.return_value = [
+        disabled_handler,
+        enabled_handler,
+    ]
+    monkeypatch.setattr(
+        "astrbot.core.pipeline.context_utils.star_handlers_registry",
+        mock_registry,
+    )
+
+    mock_plugin_disabled = MagicMock()
+    mock_plugin_disabled.name = "astrbot_meme_plugin"
+    mock_plugin_disabled.reserved = False
+    mock_plugin_enabled = MagicMock()
+    mock_plugin_enabled.name = "astrbot_other_plugin"
+    mock_plugin_enabled.reserved = False
+    monkeypatch.setattr(
+        "astrbot.core.star.star.star_map",
+        {
+            "astrbot_meme_plugin": mock_plugin_disabled,
+            "astrbot_other_plugin": mock_plugin_enabled,
+        },
+    )
+    monkeypatch.setattr(
+        "astrbot.core.pipeline.context_utils.star_map",
+        {
+            "astrbot_meme_plugin": mock_plugin_disabled,
+            "astrbot_other_plugin": mock_plugin_enabled,
+        },
+    )
+
+    mock_sp = MagicMock()
+    mock_sp.get_async = AsyncMock(
+        return_value={UMO: {"disabled_plugins": ["astrbot_meme_plugin"]}}
+    )
+    monkeypatch.setattr(
+        "astrbot.core.star.session_plugin_manager.sp",
+        mock_sp,
+    )
+
+    await call_event_hook(event, EventType.OnLLMRequestEvent, None)
+
+    assert disabled_log == []
+    assert enabled_log == ["on_llm_request"]


### PR DESCRIPTION
fix #7949 
Session-level plugin disable rules (custom rules per UMO) were only applied to AdapterMessageEvent handlers. Event hooks (OnLLMRequestEvent, OnDecoratingResultEvent, etc.), function call tools and plugin skills from session-disabled plugins were still executed, which made the disable rule ineffective.

- session_plugin_manager: add get_disabled_plugins() with per-event cache
- context_utils: filter hook handlers by session in call_event_hook
- result_decorate: filter OnDecoratingResultEvent handlers by session
- astr_main_agent: filter function tools and plugin skills by session even when the global plugin_set is '*'

Adds unit tests for hook/tool/skill session-level filtering.

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Enforce session-level plugin disable rules across all plugin-provided event, tool, and skill execution paths.

Bug Fixes:
- Apply session-level plugin disable rules consistently to event hooks, result decoration handlers, function tools, and plugin skills.
- Preserve reserved system plugins and non-plugin tools while filtering session-disabled plugin integrations.

Enhancements:
- Cache session-disabled plugin lookups per event to avoid repeated configuration reads.

Tests:
- Add unit coverage for cached session plugin configuration and filtering of hooks, tools, and skills, including reserved-plugin and lightweight-event cases.