### PR TITLE
feat(stt): expose language + prompt config for openai_whisper_api

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1692,6 +1692,8 @@ CONFIG_METADATA_2 = {
                         "api_key": "",
                         "api_base": "",
                         "model": "whisper-1",
+                        "language": "",
+                        "prompt": "",
                         "proxy": "",
                     },
                     "MiMo STT(API)": {
@@ -2841,6 +2843,16 @@ CONFIG_METADATA_2 = {
                         "type": "string",
                         "hint": "Whisper 推理设备。Apple Silicon 可选 mps；其他环境建议使用 cpu。若指定 mps 但当前环境不可用，将自动回退到 cpu。",
                         "options": ["cpu", "mps"],
+                    },
+                    "language": {
+                        "description": "识别语言",
+                        "type": "string",
+                        "hint": "可选的 ISO 语言代码（如 de、en、zh），传给 Whisper 以固定识别语言。留空则由 Whisper 自动检测。",
+                    },
+                    "prompt": {
+                        "description": "转写提示词",
+                        "type": "string",
+                        "hint": "可选的自由文本提示，传给 Whisper 以提升专有名词、缩写和专业术语的识别准确率。留空则不传。",
                     },
                     "id": {
                         "description": "ID",

--- a/astrbot/core/provider/sources/whisper_api_source.py
+++ b/astrbot/core/provider/sources/whisper_api_source.py
@@ -21,6 +21,12 @@ class ProviderOpenAIWhisperAPI(STTProvider):
         super().__init__(provider_config, provider_settings)
         self.chosen_api_key = provider_config.get("api_key", "")
 
+        # Optional transcription hints. Empty values fall back to NOT_GIVEN so
+        # that Whisper keeps auto-detecting the language, matching the previous
+        # behavior for users who do not configure these fields.
+        self.language = str(provider_config.get("language") or "").strip()
+        self.prompt = str(provider_config.get("prompt") or "").strip()
+
         self.client = AsyncOpenAI(
             api_key=self.chosen_api_key,
             base_url=provider_config.get("api_base"),
@@ -40,6 +46,8 @@ class ProviderOpenAIWhisperAPI(STTProvider):
                 result = await self.client.audio.transcriptions.create(
                     model=self.model_name,
                     file=("audio.wav", audio_file),
+                    language=self.language or NOT_GIVEN,
+                    prompt=self.prompt or NOT_GIVEN,
                 )
         return result.text
 

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -1812,6 +1812,14 @@
         "description": "Inference device",
         "hint": "Whisper inference device. Apple Silicon can use mps; other environments should use cpu. If mps is selected but unavailable, AstrBot will fall back to cpu."
       },
+      "language": {
+        "description": "Recognition language",
+        "hint": "Optional ISO language code (e.g., de, en, zh) passed to Whisper to pin the transcription language. Leave empty to let Whisper auto-detect."
+      },
+      "prompt": {
+        "description": "Transcription prompt",
+        "hint": "Optional free-text hint passed to Whisper to improve recognition of proper nouns, acronyms, and domain terms. Leave empty to omit."
+      },
       "id": {
         "description": "ID"
       },

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -1833,6 +1833,14 @@
         "description": "推理设备",
         "hint": "Whisper 推理设备。Apple Silicon 可选 mps；其他环境建议使用 cpu。若指定 mps 但当前环境不可用，将自动回退到 cpu。"
       },
+      "language": {
+        "description": "识别语言",
+        "hint": "可选的 ISO 语言代码（如 de、en、zh），传给 Whisper 以固定识别语言。留空则由 Whisper 自动检测。"
+      },
+      "prompt": {
+        "description": "转写提示词",
+        "hint": "可选的自由文本提示，传给 Whisper 以提升专有名词、缩写和专业术语的识别准确率。留空则不传。"
+      },
       "id": {
         "description": "ID"
       },

--- a/tests/test_whisper_api_source.py
+++ b/tests/test_whisper_api_source.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from openai import NOT_GIVEN
 
 from astrbot.core.provider.sources.whisper_api_source import ProviderOpenAIWhisperAPI
 
@@ -71,5 +72,93 @@ async def test_get_text_converts_opus_files_to_wav_before_transcription(
         assert file_arg[0] == "audio.wav"
         assert file_arg[1].name.endswith(".wav")
         file_arg[1].close()
+    finally:
+        await provider.terminate()
+
+
+def _make_provider_with_config(
+    provider_config: dict,
+) -> ProviderOpenAIWhisperAPI:
+    provider = ProviderOpenAIWhisperAPI(
+        provider_config=provider_config,
+        provider_settings={},
+    )
+    provider.client = SimpleNamespace(
+        audio=SimpleNamespace(
+            transcriptions=SimpleNamespace(
+                create=AsyncMock(return_value=SimpleNamespace(text="transcribed text"))
+            )
+        ),
+        close=AsyncMock(),
+    )
+    return provider
+
+
+def _write_wav(path: Path) -> None:
+    import struct
+
+    data = b"\x00\x00\x00\x00"
+    path.write_bytes(
+        b"RIFF"
+        + struct.pack("<I", 36 + len(data))
+        + b"WAVE"
+        + b"fmt "
+        + struct.pack("<IHHIIHH", 16, 1, 1, 8000, 8000, 1, 8)
+        + b"data"
+        + struct.pack("<I", len(data))
+        + data
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_text_passes_configured_language_and_prompt(tmp_path: Path):
+    provider = _make_provider_with_config(
+        {
+            "id": "test-whisper-api",
+            "type": "openai_whisper_api",
+            "model": "whisper-1",
+            "api_key": "test-key",
+            "language": " de ",
+            "prompt": "Steuer-ID, Aktenschrank",
+        },
+    )
+    wav_path = tmp_path / "voice.wav"
+    _write_wav(wav_path)
+
+    try:
+        result = await provider.get_text(str(wav_path))
+
+        assert result == "transcribed text"
+        create_mock = provider.client.audio.transcriptions.create
+        create_mock.assert_awaited_once()
+        kwargs = create_mock.await_args.kwargs
+        assert kwargs["language"] == "de"
+        assert kwargs["prompt"] == "Steuer-ID, Aktenschrank"
+    finally:
+        await provider.terminate()
+
+
+@pytest.mark.asyncio
+async def test_get_text_omits_language_and_prompt_when_unset(tmp_path: Path):
+    provider = _make_provider_with_config(
+        {
+            "id": "test-whisper-api",
+            "type": "openai_whisper_api",
+            "model": "whisper-1",
+            "api_key": "test-key",
+        },
+    )
+    wav_path = tmp_path / "voice.wav"
+    _write_wav(wav_path)
+
+    try:
+        result = await provider.get_text(str(wav_path))
+
+        assert result == "transcribed text"
+        create_mock = provider.client.audio.transcriptions.create
+        create_mock.assert_awaited_once()
+        kwargs = create_mock.await_args.kwargs
+        assert kwargs["language"] is NOT_GIVEN
+        assert kwargs["prompt"] is NOT_GIVEN
     finally:
         await provider.terminate()


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

## Problem

`ProviderOpenAIWhisperAPI` (`openai_whisper_api` STT provider) does not forward `language` / `prompt` parameters to `client.audio.transcriptions.create()`. Whisper relies solely on auto-detection, which can mis-classify speech in non-English languages (German in my deployment), hurting transcription accuracy. Users have no way to hint the language or provide vocabulary context through the provider config or WebUI.

## Solution

Expose two optional config fields on the **Whisper(API)** provider, both defaulting to `""` (preserves current auto-detect behavior — fully backwards compatible):

- **`language`** — ISO language hint, e.g. `"de"` / `"en"` / `"zh"`
- **`prompt`** — free-text guidance for proper nouns / acronyms / domain terms ([OpenAI prompting guide](https://platform.openai.com/docs/guides/speech-to-text/prompting))

Config values are `strip()`-ped and cast to `str` for robustness against malformed configs. When unset, `NOT_GIVEN` is passed so the OpenAI SDK omits the parameter entirely — identical wire format to the current code.

### Modifications / 改动点

- `astrbot/core/provider/sources/whisper_api_source.py` — read `language`/`prompt` from `provider_config`, forward to `transcriptions.create()` as `NOT_GIVEN` when empty
- `astrbot/core/config/default.py` — add fields to the `Whisper(API)` config template + metadata entries (WebUI visibility)
- `dashboard/src/i18n/locales/{en-US,zh-CN}/features/config-metadata.json` — i18n for both fields (per the file's own comment about syncing i18n resources)
- `tests/test_whisper_api_source.py` — two new regression tests:
  - configured `language`/`prompt` are passed through (with whitespace stripping)
  - unset fields are sent as `NOT_GIVEN` (wire-compat with current behavior)

## Duplicate check

Checked open/closed PRs for `whisper language`, `whisper prompt`, `openai_whisper_api language` — found closed PR #8063 (same idea, provider-only, closed without merge in June 2026) and open PR #8668 (proxy passthrough, unrelated scope). This PR differs from #8063 by also adding the WebUI config fields + i18n + tests.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```text
.venv/bin/python -m pytest tests/test_whisper_api_source.py -q
3 passed in 12.14s

.venv/bin/python -m ruff check astrbot/core/provider/sources/whisper_api_source.py astrbot/core/config/default.py tests/test_whisper_api_source.py
All checks passed!

.venv/bin/python -m ruff format --check astrbot/core/provider/sources/whisper_api_source.py tests/test_whisper_api_source.py
2 files already formatted
```

Verified live in a production deployment (German voice notes via Telegram through Groq `whisper-large-v3-turbo`): with `language: de` pinned, transcription is deterministic German; with the field left empty the provider behaves exactly as before.

---

### Checklist / 检查清单

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**. / 我的更改经过了良好的测试，并已在上方提供了"验证步骤"和"运行截图"。
- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`. / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 My changes do not introduce malicious code. / 我的更改没有引入恶意代码。

## Summary by Sourcery

Enable users to provide language hints and transcription prompts to improve OpenAI Whisper API accuracy while retaining backward-compatible defaults.

New Features:
- Expose optional language and prompt settings for the OpenAI Whisper API speech-to-text provider and its WebUI configuration.

Enhancements:
- Preserve automatic language detection and existing request behavior when the new settings are unset.
- Normalize configured transcription hints before sending them to the Whisper API.

Tests:
- Add regression coverage for configured and unset language and prompt values.