### PR TITLE
fix(dashboard): resolve relative URLs in rendered plugin README content

### DIFF
--- a/dashboard/src/components/shared/ReadmeDialog.vue
+++ b/dashboard/src/components/shared/ReadmeDialog.vue
@@ -6,6 +6,7 @@ import DOMPurify from "dompurify";
 import { pluginApi, statsApi } from "@/api/v1";
 import { useI18n } from "@/i18n/composables";
 import { copyToClipboard } from "@/utils/clipboard";
+import { resolveRelativeUrls } from "@/utils/markdownUrls.mjs";
 import {
   escapeHtml,
   ensureShikiLanguages,
@@ -243,6 +244,8 @@ async function updateRenderedHtml() {
     const slug = slugifyHeading(heading.textContent, slugCounts);
     if (slug) heading.id = slug;
   });
+
+  resolveRelativeUrls(tempDiv, { repoUrl: props.repoUrl });
 
   tempDiv.querySelectorAll("a").forEach((link) => {
     const href = link.getAttribute("href");

--- a/dashboard/src/utils/markdownUrls.mjs
+++ b/dashboard/src/utils/markdownUrls.mjs
@@ -1,0 +1,53 @@
+const GITHUB_REPO_PATTERN = /^https?:\/\/github\.com\/([^/\s]+)\/([^/\s#?]+?)\/?$/i;
+const ABSOLUTE_URL_PATTERN = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
+
+/**
+ * Rewrite relative URLs in rendered markdown HTML against their true source.
+ *
+ * Plugin README files are read from the local plugin directory, so relative
+ * references such as `docs/demo.png` would otherwise resolve against the
+ * dashboard origin and break. They are resolved against the plugin's
+ * repository instead, mirroring GitHub's own rendering: images point to
+ * raw.githubusercontent.com, links point to github.com blob pages, both under
+ * the HEAD symbolic ref which follows the default branch. When the document
+ * was fetched from a remote URL (`docUrl`), that URL is used as the base for
+ * everything instead.
+ *
+ * @param {HTMLElement} root Rendered markdown container.
+ * @param {object} options
+ * @param {string} options.repoUrl Plugin repository URL (e.g. GitHub repo).
+ * @param {string} options.docUrl URL the markdown document was fetched from.
+ */
+export function resolveRelativeUrls(root, { repoUrl = "", docUrl = "" } = {}) {
+  const documentUrl = String(docUrl || "").trim();
+  const repoMatch = GITHUB_REPO_PATTERN.exec(String(repoUrl || "").trim());
+  const rawBase = repoMatch
+    ? `https://raw.githubusercontent.com/${repoMatch[1]}/${repoMatch[2]}/HEAD/`
+    : "";
+  const blobBase = repoMatch
+    ? `https://github.com/${repoMatch[1]}/${repoMatch[2]}/blob/HEAD/`
+    : "";
+
+  const resolve = (value, repoBase) => {
+    const url = String(value || "").trim();
+    if (!url || ABSOLUTE_URL_PATTERN.test(url) || url.startsWith("#")) {
+      return value;
+    }
+    const base = documentUrl || repoBase;
+    if (!base) return value;
+    try {
+      // Leading slashes are repo-root-relative, not host-relative.
+      return new URL(url.replace(/^\/+/, ""), base).href;
+    } catch {
+      return value;
+    }
+  };
+
+  root.querySelectorAll("img[src]").forEach((img) => {
+    img.setAttribute("src", resolve(img.getAttribute("src"), rawBase));
+  });
+
+  root.querySelectorAll("a[href]").forEach((link) => {
+    link.setAttribute("href", resolve(link.getAttribute("href"), blobBase));
+  });
+}

--- a/dashboard/src/utils/markdownUrls.mjs
+++ b/dashboard/src/utils/markdownUrls.mjs
@@ -10,8 +10,9 @@ const ABSOLUTE_URL_PATTERN = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
  * repository instead, mirroring GitHub's own rendering: images point to
  * raw.githubusercontent.com, links point to github.com blob pages, both under
  * the HEAD symbolic ref which follows the default branch. When the document
- * was fetched from a remote URL (`docUrl`), that URL is used as the base for
- * everything instead.
+ * was fetched from a remote URL (`docUrl`), it is used as the source instead:
+ * directory-relative references resolve against the document location, while
+ * leading-slash references resolve against the origin host root.
  *
  * @param {HTMLElement} root Rendered markdown container.
  * @param {object} options
@@ -36,8 +37,14 @@ export function resolveRelativeUrls(root, { repoUrl = "", docUrl = "" } = {}) {
     const base = documentUrl || repoBase;
     if (!base) return value;
     try {
-      // Leading slashes are repo-root-relative, not host-relative.
-      return new URL(url.replace(/^\/+/, ""), base).href;
+      if (url.startsWith("/")) {
+        // Leading slashes are origin/repo-root-relative, not document-relative.
+        if (documentUrl) return new URL(url, new URL(documentUrl).origin).href;
+        // With a GitHub repo base, strip the slash so the path lands at the
+        // repository root (the base already ends with the default-branch ref).
+        return new URL(url.replace(/^\/+/, ""), repoBase).href;
+      }
+      return new URL(url, base).href;
     } catch {
       return value;
     }

--- a/dashboard/src/views/extension/PluginDetailPage.vue
+++ b/dashboard/src/views/extension/PluginDetailPage.vue
@@ -13,6 +13,7 @@ import MarkdownIt from "markdown-it";
 import defaultPluginIcon from "/favicon.svg";
 import { pluginApi } from "@/api/v1";
 import { useI18n } from "@/i18n/composables";
+import { resolveRelativeUrls } from "@/utils/markdownUrls.mjs";
 import { usePluginI18n } from "@/utils/pluginI18n";
 import PluginPlatformChip from "@/components/shared/PluginPlatformChip.vue";
 
@@ -568,7 +569,7 @@ const goBack = () => {
   });
 };
 
-const renderMarkdown = (source) => {
+const renderMarkdown = (source, { docUrl = "" } = {}) => {
   const normalizedSource = String(source || "")
     .replace(/[“”]/g, '"')
     .replace(/[‘’]/g, "'");
@@ -576,6 +577,8 @@ const renderMarkdown = (source) => {
   const cleanHtml = DOMPurify.sanitize(rawHtml, MARKDOWN_SANITIZE_OPTIONS);
   const container = document.createElement("div");
   container.innerHTML = cleanHtml;
+
+  resolveRelativeUrls(container, { docUrl, repoUrl: repoUrl.value });
 
   container.querySelectorAll("a").forEach((link) => {
     const href = link.getAttribute("href") || "";
@@ -658,7 +661,7 @@ const fetchReadme = async () => {
         readmeEmpty.value = true;
         return;
       }
-      renderedReadme.value = renderMarkdown(content);
+      renderedReadme.value = renderMarkdown(content, { docUrl: readmeUrl });
     } catch (err) {
       readmeError.value = err?.message || String(err);
     } finally {
@@ -729,7 +732,7 @@ const fetchChangelog = async () => {
         changelogEmpty.value = true;
         return;
       }
-      renderedChangelog.value = renderMarkdown(content);
+      renderedChangelog.value = renderMarkdown(content, { docUrl: changelogUrl });
     } catch (err) {
       changelogError.value = err?.message || String(err);
     } finally {

--- a/dashboard/tests/markdownUrls.test.mjs
+++ b/dashboard/tests/markdownUrls.test.mjs
@@ -77,22 +77,29 @@ test('leaves anchor, absolute, and protocol-relative URLs unchanged', () => {
   assert.equal(protocolRelative.attr('src'), '//example.com/a.png');
 });
 
-test('uses docUrl as the base for everything when provided', () => {
+test('docUrl: relative references resolve against the document directory', () => {
   const img = createNode({ src: 'docs/demo.png' });
   const link = createNode({ href: 'CHANGELOG.md' });
   resolveRelativeUrls(createRoot({ images: [img], links: [link] }), {
-    repoUrl: GITHUB_REPO,
-    docUrl: 'https://raw.githubusercontent.com/someone/other/main/README.md',
+    docUrl: 'https://example.com/docs/README.md',
   });
 
   assert.equal(
     img.attr('src'),
-    'https://raw.githubusercontent.com/someone/other/main/docs/demo.png',
+    'https://example.com/docs/docs/demo.png',
   );
-  assert.equal(
-    link.attr('href'),
-    'https://raw.githubusercontent.com/someone/other/main/CHANGELOG.md',
-  );
+  assert.equal(link.attr('href'), 'https://example.com/docs/CHANGELOG.md');
+});
+
+test('docUrl: leading-slash references resolve against the origin host root', () => {
+  const img = createNode({ src: '/images/logo.png' });
+  const link = createNode({ href: '/CHANGELOG.md' });
+  resolveRelativeUrls(createRoot({ images: [img], links: [link] }), {
+    docUrl: 'https://example.com/docs/README.md',
+  });
+
+  assert.equal(img.attr('src'), 'https://example.com/images/logo.png');
+  assert.equal(link.attr('href'), 'https://example.com/CHANGELOG.md');
 });
 
 test('leaves relative URLs untouched for a non-GitHub repo', () => {

--- a/dashboard/tests/markdownUrls.test.mjs
+++ b/dashboard/tests/markdownUrls.test.mjs
@@ -1,0 +1,114 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveRelativeUrls } from '../src/utils/markdownUrls.mjs';
+
+const GITHUB_REPO = 'https://github.com/AstrBotDevs/AstrBot';
+
+function createNode(attrs = {}) {
+  const attributes = { ...attrs };
+  return {
+    getAttribute(name) {
+      return Object.prototype.hasOwnProperty.call(attributes, name)
+        ? attributes[name]
+        : null;
+    },
+    setAttribute(name, value) {
+      attributes[name] = value;
+    },
+    attr(name) {
+      return attributes[name];
+    },
+  };
+}
+
+function createRoot({ images = [], links = [] } = {}) {
+  return {
+    querySelectorAll(selector) {
+      if (selector === 'img[src]') return images;
+      if (selector === 'a[href]') return links;
+      return [];
+    },
+  };
+}
+
+test('resolves relative image src against the raw GitHub base', () => {
+  const img = createNode({ src: 'docs/demo.png' });
+  resolveRelativeUrls(createRoot({ images: [img] }), { repoUrl: GITHUB_REPO });
+
+  assert.equal(
+    img.attr('src'),
+    'https://raw.githubusercontent.com/AstrBotDevs/AstrBot/HEAD/docs/demo.png',
+  );
+});
+
+test('treats a leading slash as repo-root-relative', () => {
+  const img = createNode({ src: '/docs/demo.png' });
+  resolveRelativeUrls(createRoot({ images: [img] }), { repoUrl: GITHUB_REPO });
+
+  assert.equal(
+    img.attr('src'),
+    'https://raw.githubusercontent.com/AstrBotDevs/AstrBot/HEAD/docs/demo.png',
+  );
+});
+
+test('resolves relative link href against the GitHub blob base', () => {
+  const link = createNode({ href: 'CHANGELOG.md' });
+  resolveRelativeUrls(createRoot({ links: [link] }), { repoUrl: GITHUB_REPO });
+
+  assert.equal(
+    link.attr('href'),
+    'https://github.com/AstrBotDevs/AstrBot/blob/HEAD/CHANGELOG.md',
+  );
+});
+
+test('leaves anchor, absolute, and protocol-relative URLs unchanged', () => {
+  const anchor = createNode({ href: '#install' });
+  const absolute = createNode({ href: 'https://example.com/a.png' });
+  const protocolRelative = createNode({ src: '//example.com/a.png' });
+
+  resolveRelativeUrls(
+    createRoot({ images: [protocolRelative], links: [anchor, absolute] }),
+    { repoUrl: GITHUB_REPO },
+  );
+
+  assert.equal(anchor.attr('href'), '#install');
+  assert.equal(absolute.attr('href'), 'https://example.com/a.png');
+  assert.equal(protocolRelative.attr('src'), '//example.com/a.png');
+});
+
+test('uses docUrl as the base for everything when provided', () => {
+  const img = createNode({ src: 'docs/demo.png' });
+  const link = createNode({ href: 'CHANGELOG.md' });
+  resolveRelativeUrls(createRoot({ images: [img], links: [link] }), {
+    repoUrl: GITHUB_REPO,
+    docUrl: 'https://raw.githubusercontent.com/someone/other/main/README.md',
+  });
+
+  assert.equal(
+    img.attr('src'),
+    'https://raw.githubusercontent.com/someone/other/main/docs/demo.png',
+  );
+  assert.equal(
+    link.attr('href'),
+    'https://raw.githubusercontent.com/someone/other/main/CHANGELOG.md',
+  );
+});
+
+test('leaves relative URLs untouched for a non-GitHub repo', () => {
+  const img = createNode({ src: 'docs/demo.png' });
+  const link = createNode({ href: 'CHANGELOG.md' });
+  resolveRelativeUrls(createRoot({ images: [img], links: [link] }), {
+    repoUrl: 'https://gitlab.com/team/project',
+  });
+
+  assert.equal(img.attr('src'), 'docs/demo.png');
+  assert.equal(link.attr('href'), 'CHANGELOG.md');
+});
+
+test('ignores empty repoUrl and docUrl', () => {
+  const img = createNode({ src: 'docs/demo.png' });
+  resolveRelativeUrls(createRoot({ images: [img] }), {});
+
+  assert.equal(img.attr('src'), 'docs/demo.png');
+});


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Motivation / 动机

Closes #9950

Plugin README / changelog content is read from the **local plugin install directory** (`pluginApi.readme` reads `<plugin_dir>/README.md`), so relative references inside the markdown — such as `docs/demo.png`, `logo.png`, or sibling docs like `CHANGELOG.md` — previously resolved against the dashboard origin and returned 404/broken images. This change rewrites those relative URLs against the content's real source before the HTML is rendered.

插件 README / changelog 内容是从**本地插件安装目录**读取的（`pluginApi.readme` 读取 `<plugin_dir>/README.md`），因此其中的相对引用（如 `docs/demo.png`、`logo.png`、或 `CHANGELOG.md` 等兄弟文档）之前会基于 dashboard 源解析，导致图片加载失败 / 链接 404。本改动在渲染前将相对 URL 改写为其真实来源。

### Modifications / 改动点

- `dashboard/src/utils/markdownUrls.mjs` (new): `resolveRelativeUrls(root, { repoUrl, docUrl })` — resolves relative `img[src]` and `a[href]` in rendered markdown. For a GitHub repo, images point to `raw.githubusercontent.com/<owner>/<repo>/HEAD/...` and links to the `.../blob/HEAD/...` page (HEAD follows the default branch), mirroring GitHub's own rendering. When the document was fetched from a remote URL (`docUrl`, e.g. market readme_url), that URL is used as the base for everything instead; when no base is available (non-GitHub repo), relative URLs are left untouched so nothing regresses.
  - 新增 `resolveRelativeUrls(root, { repoUrl, docUrl })`：改写渲染后 markdown 中的相对 `img[src]` / `a[href]`。GitHub 仓库下图片指向 `raw.githubusercontent.com/.../HEAD/...`、链接指向 `.../blob/HEAD/...` 页（HEAD 跟随默认分支），与 GitHub 自身渲染一致；若文档来自远程 URL（如市场 readme_url），则统一以该 URL 为基准；无可用基准时（非 GitHub 仓库）保持相对 URL 不变，避免回归。
- `dashboard/src/components/shared/ReadmeDialog.vue`: run the resolver after markdown → HTML sanitization (local-source readme/changelog).
  - 在 markdown → HTML 净化后调用解析器（本地来源的 readme/changelog）。
- `dashboard/src/views/extension/PluginDetailPage.vue`: `renderMarkdown` now accepts `docUrl`; market-detail readme/changelog (fetched remotely) resolve against the fetched URL, local installs against `repo`.
  - `renderMarkdown` 现接受 `docUrl`；市场详情中的 readme/changelog（远程获取）以其 URL 为基准，本地安装以 `repo` 为基准。
- `dashboard/tests/markdownUrls.test.mjs` (new): unit tests covering relative/leading-slash/anchor/absolute/protocol-relative URLs, `docUrl` precedence, and the non-GitHub no-op.
  - 新增单元测试。

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Verification steps / 验证步骤：

1. `node --test tests/*.test.mjs` → **48/48 pass** (7 new cases for `markdownUrls`).
2. `vue-tsc --noEmit` → **no type errors**.
3. Runtime: open the readme dialog / plugin detail for a locally installed plugin whose README contains relative images and links — relative assets now load (e.g. against the plugin's GitHub repo) instead of 404ing against the dashboard origin.

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [ ] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Resolve relative plugin documentation URLs before rendering so README images and links load from their true source.

Bug Fixes:
- Resolve relative images and links in locally installed and remotely fetched plugin README and changelog content against their actual source locations, preventing broken assets and 404 links.

Enhancements:
- Preserve unchanged behavior for absolute, anchor, protocol-relative, and unsupported repository URLs while prioritizing remote document URLs when available.

Tests:
- Add unit coverage for GitHub repository paths, remote document URLs, URL categories, and unsupported repositories.