### PR TITLE
fix(command): keep an argument that equals another alias of the same command

### DIFF
--- a/astrbot/core/star/filter/command.py
+++ b/astrbot/core/star/filter/command.py
@@ -198,10 +198,18 @@ class CommandFilter(HandlerFilter):
         # 检查是否以指令开头
         message_str = re.sub(r"\s+", " ", event.get_message_str().strip())
         ok = False
-        for full_cmd in self.get_complete_command_names():
+        # Try the longest name first so that when several complete command names
+        # share a prefix (e.g. an alias "show" and "show all"), the most specific
+        # one wins and the match is stable. get_complete_command_names() is built
+        # from a set, so its own order is not deterministic; sort here rather than
+        # there because other callers rely on [0] being the primary command name.
+        for full_cmd in sorted(
+            self.get_complete_command_names(), key=lambda name: (-len(name), name)
+        ):
             if message_str.startswith(f"{full_cmd} ") or message_str == full_cmd:
                 ok = True
                 message_str = message_str[len(full_cmd) :].strip()
+                break
         if not ok:
             return False
 

--- a/tests/test_command_filter.py
+++ b/tests/test_command_filter.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from astrbot.core.star.filter.command import CommandFilter
+from astrbot.core.star.filter.command import CommandFilter, GreedyStr
 
 
 async def postponed_annotations_handler(
@@ -37,3 +37,48 @@ def test_command_filter_rejects_missing_postponed_required_param():
 
     with pytest.raises(ValueError, match="必要参数缺失"):
         command_filter.validate_and_convert_params([], command_filter.handler_params)
+
+
+def _run_filter(command_name: str, alias: set, message: str):
+    cmd_filter = CommandFilter(command_name=command_name, alias=set(alias))
+    # A single greedy parameter captures everything after the command name.
+    cmd_filter.handler_params = {"query": GreedyStr}
+    extras: dict = {}
+    event = SimpleNamespace(
+        is_at_or_wake_command=True,
+        get_message_str=lambda: message,
+        set_extra=lambda key, value: extras.__setitem__(key, value),
+    )
+    ok = cmd_filter.filter(event, None)
+    return ok, extras.get("parsed_params")
+
+
+def test_command_filter_keeps_argument_matching_an_alias():
+    # Invoking a command by one name with a first argument that happens to equal
+    # another alias of the same command must not strip that argument a second time.
+    ok, params = _run_filter("search", {"find"}, "search find keyword")
+    assert ok
+    assert params == {"query": "find keyword"}
+
+
+def test_command_filter_keeps_sole_argument_matching_an_alias():
+    ok, params = _run_filter("add", {"new"}, "add new")
+    assert ok
+    assert params == {"query": "new"}
+
+
+def test_command_filter_normal_argument_unaffected():
+    ok, params = _run_filter("search", {"find"}, "search cat photo")
+    assert ok
+    assert params == {"query": "cat photo"}
+
+
+def test_command_filter_prefers_longest_overlapping_command_name():
+    # When a command name and one of its aliases share a prefix ("show" vs
+    # "show all"), the most specific one must win regardless of the set's
+    # iteration order, so only the longer name is stripped and the rest is the
+    # argument. Without the longest-first ordering, "show" would match first and
+    # leak "all" into the argument.
+    ok, params = _run_filter("show", {"show all"}, "show all photos")
+    assert ok
+    assert params == {"query": "photos"}


### PR DESCRIPTION
Fixes a silent argument-parsing bug in `CommandFilter`. When a command has an alias and the user's first argument happens to equal that alias, the argument is silently dropped.

`CommandFilter.filter` loops over `get_complete_command_names()` (the command name plus every alias) and strips the matched prefix from `message_str`, but it never `break`s after the first match. So once the command prefix is stripped, the loop keeps testing the remaining text against the other names, and if the first argument equals one of the command's own aliases it gets stripped a second time. No error, no log, the argument just disappears.

## What changed

- `astrbot/core/star/filter/command.py`: break out of the name loop after the first match, and try the longest name first. The name set is built from a `set`, so its iteration order is not deterministic; sorting longest-first keeps overlapping names (an alias that extends the command name, like `show` vs `show all`) resolving to the most specific one.
- `tests/test_command_filter.py`: regression tests for an argument colliding with an alias (with and without trailing text), a normal argument, and prefix-overlapping names.

## Verification

`pytest tests/test_command_filter.py` on Python 3.12: 6 passed with the fix. Against master the three bug-pinning tests fail (the alias argument is swallowed; the overlapping name leaks `all` into the argument) and the three behavior tests still pass. ruff 0.15.22 check and format clean on both files.

This replaces #9294, same fix and tests; that branch picked up unrelated junk files from a sync artifact and its diff no longer renders on GitHub.

## Summary by Sourcery

Fix command parsing so matched command prefixes are removed only once and arguments are preserved reliably.

Bug Fixes:
- Preserve command arguments that match another alias of the same command during parsing.
- Resolve overlapping command names by selecting the most specific match.

Tests:
- Add regression coverage for alias-colliding arguments, normal arguments, and overlapping command names.