### PR TITLE
fix: preserve context prefix during tool requery

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -1382,11 +1382,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
         )
         if extra_instruction:
             instruction = f"{instruction}\n{extra_instruction}"
-        if contexts and contexts[0].get("role") == "system":
-            content = contexts[0].get("content") or ""
-            contexts[0]["content"] = f"{content}\n{instruction}"
-        else:
-            contexts.insert(0, {"role": "system", "content": instruction})
+        contexts.append({"role": "user", "content": instruction})
         return contexts
 
     @staticmethod

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -1733,6 +1733,25 @@ async def test_skills_like_requery_passes_extra_user_content_parts():
     assert parts[0].text == "<image_caption>一张猫的照片</image_caption>"
 
 
+def test_skills_like_requery_preserves_existing_context_prefix():
+    messages = [
+        Message(role="system", content="stable system prompt"),
+        Message(role="user", content="earlier user message"),
+        Message(role="assistant", content="earlier assistant message"),
+        Message(role="user", content="current request"),
+    ]
+    runner = ToolLoopAgentRunner()
+    runner.run_context = ContextWrapper(context=None, messages=messages)
+    original_contexts = [message.model_dump() for message in messages]
+
+    contexts = runner._build_tool_requery_context(["test_tool"])
+
+    assert contexts[:-1] == original_contexts
+    assert contexts[-1]["role"] == "user"
+    assert "test_tool" in contexts[-1]["content"]
+    assert [message.model_dump() for message in messages] == original_contexts
+
+
 @pytest.mark.asyncio
 async def test_follow_up_accepted_when_active_and_not_stopping(
     runner, mock_provider, provider_request, mock_tool_executor, mock_hooks


### PR DESCRIPTION
## Summary
- append the skills-like requery instruction after the existing conversation messages
- preserve the system prompt and long conversation history as a stable prefix
- add a regression test that verifies existing contexts and source messages remain unchanged

## Testing
- `pytest -q tests/test_tool_loop_agent_runner.py` (43 passed)
- `ruff format --check astrbot/core/agent/runners/tool_loop_agent_runner.py tests/test_tool_loop_agent_runner.py`
- `ruff check astrbot/core/agent/runners/tool_loop_agent_runner.py tests/test_tool_loop_agent_runner.py`

Fixes #9935

## Summary by Sourcery

Preserve conversation context during tool requeries by appending instructions without modifying existing messages.

Bug Fixes:
- Preserve the existing system prompt and conversation history when building tool requery contexts by appending the requery instruction as a new user message.
- Add regression coverage confirming existing context and source messages remain unchanged during skills-like tool requery.

Tests:
- Add a regression test for stable context prefixes and non-mutating tool requery behavior.