### PR TITLE
fix: preserve user content in dict-type config items

### DIFF
--- a/astrbot/core/config/astrbot_config.py
+++ b/astrbot/core/config/astrbot_config.py
@@ -90,7 +90,7 @@ class AstrBotConfig(dict):
         if default_config is DEFAULT_CONFIG:
             config_migrated = migrate_config_on_load(conf, Path(config_path))
         # 检查配置完整性，并插入
-        has_new = self.check_config_integrity(default_config, conf)
+        has_new = self.check_config_integrity(default_config, conf, schema=schema)
         has_new |= config_migrated
         reset_dashboard_password = self._consume_reset_dashboard_password_flag()
         if reset_dashboard_password and "dashboard" in conf:
@@ -169,8 +169,22 @@ class AstrBotConfig(dict):
 
         return conf
 
-    def check_config_integrity(self, refer_conf: dict, conf: dict, path=""):
-        """检查配置完整性，如果有新的配置项或顺序不一致则返回 True"""
+    def check_config_integrity(
+        self, refer_conf: dict, conf: dict, path="", schema: dict | None = None
+    ):
+        """Check the integrity of a user config against its reference defaults.
+
+        Args:
+            refer_conf: Reference configuration holding default values.
+            conf: User configuration, checked and normalized in place.
+            path: Dot-separated path of the current level, used for logging.
+            schema: Schema nodes parallel to ``refer_conf`` at this level. Entries
+                declared as ``"type": "dict"`` are free-form mappings, so their
+                user-added keys are preserved instead of being treated as stale.
+
+        Returns:
+            True if any items were added or the key order was fixed.
+        """
         has_new = False
 
         # 创建一个新的有序字典以保持参考配置的顺序
@@ -178,6 +192,7 @@ class AstrBotConfig(dict):
 
         # 先按照参考配置的顺序添加配置项
         for key, value in refer_conf.items():
+            child_schema = schema.get(key) if schema else None
             if key not in conf:
                 # 配置项不存在，插入默认值
                 path_ = path + "." + key if path else key
@@ -194,15 +209,28 @@ class AstrBotConfig(dict):
                     # 类型不匹配，使用默认值
                     new_conf[key] = value
                     has_new = True
+                elif (
+                    isinstance(child_schema, dict)
+                    and child_schema.get("type") == "dict"
+                ):
+                    # Free-form mapping declared as "type": "dict": user-added
+                    # keys are data instead of stale entries, keep them as-is.
+                    new_conf[key] = conf[key]
                 elif (path + "." + key if path else key) == "agent_runner.config":
                     # Runner config is normalized according to runner_type when saved.
                     new_conf[key] = conf[key]
                 else:
                     # 递归检查并同步顺序
+                    child_items = (
+                        child_schema.get("items")
+                        if isinstance(child_schema, dict)
+                        else None
+                    )
                     child_has_new = self.check_config_integrity(
                         value,
                         conf[key],
                         path + "." + key if path else key,
+                        schema=child_items if isinstance(child_items, dict) else None,
                     )
                     new_conf[key] = conf[key]
                     has_new |= child_has_new

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1101,3 +1101,113 @@ class TestConfigMetadataI18n:
             result["group"]["metadata"]["section"]["items"]["field"]["name"]
             == "group.section.field.name"
         )
+
+
+class TestDictTypeConfigIntegrity:
+    """Tests for preserving user content in dict-type ("type": "dict") config items.
+
+    See https://github.com/AstrBotDevs/AstrBot/issues/9512.
+    """
+
+    def test_dict_type_config_preserved_on_reload(self, temp_config_path):
+        """Test that user key-value pairs survive a plugin reload."""
+        schema = {
+            "user_map": {
+                "type": "dict",
+                "default": {},
+                "description": "free-form key-value pairs",
+            },
+        }
+
+        config = AstrBotConfig(config_path=temp_config_path, schema=schema)
+        config["user_map"] = {"group_a": "123", "group_b": "456"}
+        config.save_config()
+
+        reloaded = AstrBotConfig(config_path=temp_config_path, schema=schema)
+
+        assert reloaded["user_map"] == {"group_a": "123", "group_b": "456"}
+
+        with open(temp_config_path, encoding="utf-8-sig") as f:
+            assert json.load(f)["user_map"] == {
+                "group_a": "123",
+                "group_b": "456",
+            }
+
+    def test_nested_dict_type_config_preserved_on_reload(self, temp_config_path):
+        """Test that dict items nested inside objects are preserved."""
+        schema = {
+            "section": {
+                "type": "object",
+                "items": {
+                    "enabled": {"type": "bool"},
+                    "mapping": {"type": "dict"},
+                },
+            },
+        }
+
+        config = AstrBotConfig(config_path=temp_config_path, schema=schema)
+        config["section"]["mapping"] = {"key1": "value1"}
+        config.save_config()
+
+        reloaded = AstrBotConfig(config_path=temp_config_path, schema=schema)
+
+        assert reloaded["section"]["enabled"] is False
+        assert reloaded["section"]["mapping"] == {"key1": "value1"}
+
+    def test_dict_type_config_with_non_empty_default_preserved_on_reload(
+        self, temp_config_path
+    ):
+        """Test that user keys survive reload when the dict default is non-empty."""
+        schema = {
+            "user_map": {
+                "type": "dict",
+                "default": {"preset_a": "1"},
+            },
+        }
+
+        config = AstrBotConfig(config_path=temp_config_path, schema=schema)
+        config["user_map"] = {"preset_a": "2", "user_added": "3"}
+        config.save_config()
+
+        reloaded = AstrBotConfig(config_path=temp_config_path, schema=schema)
+
+        assert reloaded["user_map"] == {"preset_a": "2", "user_added": "3"}
+
+    def test_object_with_empty_items_still_removes_stale_keys(self, temp_config_path):
+        """Test that object entries with empty items still drop unknown keys."""
+        schema = {
+            "section": {"type": "object", "items": {}},
+        }
+
+        config = AstrBotConfig(config_path=temp_config_path, schema=schema)
+        config["section"] = {"user_key": "value"}
+        config.save_config()
+
+        reloaded = AstrBotConfig(config_path=temp_config_path, schema=schema)
+
+        assert reloaded["section"] == {}
+
+    def test_stale_keys_in_structured_dict_still_removed(self):
+        """Test that non-empty reference dicts still drop unknown keys."""
+        refer_conf = {"structured": {"keep": 1}}
+        conf = {"structured": {"keep": 2, "stale": 3}}
+
+        config = AstrBotConfig.__new__(AstrBotConfig)
+        has_new = config.check_config_integrity(refer_conf, conf)
+
+        assert has_new is True
+        assert conf["structured"] == {"keep": 2}
+
+    def test_dict_type_config_non_dict_value_reset_to_default(self, temp_config_path):
+        """Test that a non-dict value stored in a dict item is reset to default."""
+        schema = {
+            "user_map": {"type": "dict"},
+        }
+
+        existing_config = {"user_map": "corrupted"}
+        with open(temp_config_path, "w", encoding="utf-8-sig") as f:
+            json.dump(existing_config, f)
+
+        config = AstrBotConfig(config_path=temp_config_path, schema=schema)
+
+        assert config["user_map"] == {}


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

Fixes #9512.

Plugin schema items declared as `"type": "dict"` are free-form mappings edited from the WebUI. `check_config_integrity()` recursed into them like structured dicts, so user-added keys were treated as stale entries and removed on plugin reload/restart, and the wiped value was written back to disk.

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- `astrbot/core/config/astrbot_config.py`: `check_config_integrity()` now receives the schema of the current level (the `items` mapping for `object` nodes). Entries declared as `"type": "dict"` keep the user's mapping as-is instead of being recursed and cleaned; `"type": "object"` entries — including empty `items` — and the schema-less global config keep the existing stale-key cleanup.
- `tests/unit/test_config.py`: add regression tests covering dict items with empty and non-empty defaults on reload, dict items nested in objects, object entries with empty `items` still dropping unknown keys, stale-key cleanup for structured dicts, and non-dict values resetting to default.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

Regression tests for the fix are in `tests/unit/test_config.py::TestDictTypeConfigIntegrity`. Full test logs (pre-existing third-party `DeprecationWarning`s filtered via `-W ignore::DeprecationWarning`):

```
$ uv run pytest tests/unit/test_config.py -q -W ignore::DeprecationWarning
.....................................................                    [100%]
53 passed in 3.10s

$ uv run pytest tests/unit/test_astrbot_config_manager.py tests/test_plugin_manager.py -q -W ignore::DeprecationWarning
..................................................................       [100%]
66 passed in 8.58s

$ uv run pytest tests/unit/test_agent_runner_config.py tests/test_fastapi_v1_dashboard.py -q -W ignore::DeprecationWarning
........................................................................ [ 63%]
..........................................                               [100%]
114 passed in 28.34s

$ uv run ruff check astrbot/core/config/astrbot_config.py tests/unit/test_config.py
All checks passed!

$ uv run ruff format --check astrbot/core/config/astrbot_config.py tests/unit/test_config.py
2 files already formatted
```

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Preserve user content in free-form dictionary configuration items without weakening structured configuration cleanup.

Bug Fixes:
- Preserve user-defined entries in plugin schema items declared as free-form dictionaries across reloads and restarts.
- Reset invalid non-dictionary values to the configured default while retaining existing cleanup for structured objects and dictionaries.

Enhancements:
- Propagate schema context during configuration integrity checks so free-form and structured mappings are handled according to their declared types.

Tests:
- Add regression coverage for top-level and nested free-form dictionaries, non-empty defaults, invalid values, and continued stale-key cleanup for structured objects.