### PR TITLE
fix(context): stop compressed history overwriting persistent conversation (#9936)

### DIFF
--- a/astrbot/core/agent/context/compressor.py
+++ b/astrbot/core/agent/context/compressor.py
@@ -152,7 +152,13 @@ class LLMSummaryCompressor:
             "2. If any tools were used, summarize tool usage (total call count) and extract the most valuable insights from tool outputs.\n"
             "3. If any materials (files, documents, code, references) were read during the conversation that may be helpful for subsequent work, list each one with its scope and path.\n"
             "4. If there was an initial user goal, state it first and describe the current progress/status.\n"
-            "5. Write the summary in the user's language.\n"
+            "5. HARD PRESERVE the following hard facts, do NOT summarize or omit them: "
+            "URLs, links, and file paths; coordinates, IDs, version numbers, ports; "
+            "concrete decision reasons, choices made, and constraints; numeric facts, "
+            "measured values, and exact parameters. For secrets/tokens/API keys/"
+            "credentials, preserve their NAME, location and purpose; keep the exact "
+            "value only when continuing the task genuinely requires it.\n"
+            "6. Write the summary in the user's language.\n"
         )
 
     def should_compress(

--- a/astrbot/core/agent/context/manager.py
+++ b/astrbot/core/agent/context/manager.py
@@ -57,11 +57,36 @@ class ContextManager:
             result = messages
 
             # 1. 基于轮次的截断 (Enforce max turns)
-            if self.config.enforce_max_turns != -1:
+            # Skip hard turn truncation when a smart compressor (LLM/custom) is
+            # active and the token guard is on; it summarizes instead.
+            # If the token guard is off, keep the turn limit as the safety net.
+            token_guard_enabled = self.config.max_context_tokens > 0
+            skip_hard_turn_limit = token_guard_enabled and (
+                self.config.llm_compress_provider is not None
+                or self.config.custom_compressor is not None
+            )
+            if (
+                self.config.enforce_max_turns != -1
+                and not skip_hard_turn_limit
+            ):
+                before_len = len(result)
                 result = self.truncator.truncate_by_turns(
                     result,
                     keep_most_recent_turns=self.config.enforce_max_turns,
                     drop_turns=self.config.truncate_turns,
+                )
+                if len(result) != before_len:
+                    logger.info(
+                        "[context] enforce_max_turns truncation applied: "
+                        f"{before_len} -> {len(result)} messages.",
+                    )
+            elif (
+                self.config.enforce_max_turns != -1
+                and skip_hard_turn_limit
+            ):
+                logger.info(
+                    "[context] enforce_max_turns skipped (LLM/custom compressor "
+                    "will handle context instead of hard turn truncation).",
                 )
 
             # 2. 基于 token 的压缩
@@ -73,6 +98,11 @@ class ContextManager:
                 if self.compressor.should_compress(
                     result, total_tokens, self.config.max_context_tokens
                 ):
+                    logger.info(
+                        "[context] compression triggered: "
+                        f"{total_tokens} / {self.config.max_context_tokens} tokens "
+                        f"(trusted_token_usage={trusted_token_usage}).",
+                    )
                     result = await self._run_compression(result, total_tokens)
 
             return result
@@ -113,9 +143,14 @@ class ContextManager:
             messages, tokens_after_summary, self.config.max_context_tokens
         ):
             logger.info(
-                "Context still exceeds max tokens after compression, applying halving truncation..."
+                "Context still exceeds max tokens after compression, applying "
+                "token-budget truncation instead of blind halving..."
             )
-            # still need compress, truncate by half
-            messages = self.truncator.truncate_by_halving(messages)
+            # still need compress, drop oldest until within the token budget
+            messages = self.truncator.truncate_to_token_budget(
+                messages,
+                self.token_counter,
+                self.config.max_context_tokens,
+            )
 
         return messages

--- a/astrbot/core/agent/context/truncator.py
+++ b/astrbot/core/agent/context/truncator.py
@@ -200,3 +200,75 @@ class ContextTruncator:
             system_messages, truncated_non_system, messages
         )
         return self.fix_messages(result)
+
+    def truncate_to_token_budget(
+        self,
+        messages: list[Message],
+        token_counter,
+        budget: int,
+    ) -> list[Message]:
+        """Truncate by token budget, keeping the most recent messages.
+
+        Unlike ``truncate_by_halving`` (which blindly halves by message count and
+        can produce crude, disproportionate cuts), this drops the OLDEST messages
+        until the remaining non-system suffix fits within ``budget`` tokens.
+        System messages are always preserved and their cost is excluded from the
+        budget. If a single newest message alone exceeds the budget (e.g. the
+        active request), it is kept whole -- budget overflow is accepted in that
+        case rather than discarding the active request.
+
+        Args:
+            messages: The message list to truncate.
+            token_counter: Token counter used to estimate size.
+            budget: Maximum tokens to keep (the context cap).
+
+        Returns:
+            The truncated message list.
+        """
+        if budget <= 0:
+            return messages
+
+        system_messages, non_system_messages = self._split_system_rest(messages)
+        if not non_system_messages:
+            return messages
+
+        if token_counter.count_tokens(messages) <= budget:
+            return messages
+
+        # Deduct the system messages token cost first, so the budget applies to
+        # the non-system suffix only; system messages are always preserved.
+        system_tokens = token_counter.count_tokens(system_messages)
+        effective_budget = max(1, budget - system_tokens)
+
+        # Walk from the most recent message backwards, accumulating tokens until
+        # the effective budget is exceeded; keep the newest suffix that fits.
+        best_start = 0
+        accum = 0
+        for start in range(len(non_system_messages) - 1, -1, -1):
+            accum += token_counter.count_tokens([non_system_messages[start]])
+            if accum > effective_budget:
+                best_start = start + 1
+                break
+            best_start = start
+
+        truncated_non_system = non_system_messages[best_start:]
+
+        # A single oversized message (active request / huge tool output) can
+        # exceed the budget alone; keep the newest user message whole instead of
+        # answering a stale question. Overflow is accepted by design.
+        if not any(m.role == "user" for m in truncated_non_system):
+            newest_user_idx = next(
+                (
+                    i
+                    for i in range(len(non_system_messages) - 1, -1, -1)
+                    if non_system_messages[i].role == "user"
+                ),
+                None,
+            )
+            if newest_user_idx is not None:
+                truncated_non_system = non_system_messages[newest_user_idx:]
+
+        result = self._ensure_user_message(
+            system_messages, truncated_non_system, messages
+        )
+        return self.fix_messages(result)

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -277,6 +277,8 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
         self.tool_executor = tool_executor
         self.agent_hooks = agent_hooks
         self.run_context = run_context
+        self._request_messages: list[Message] | None = None
+        self._request_messages_base: int | None = None
         self._aborted = False
         self._abort_signal = asyncio.Event()
         self._pending_follow_ups: list[FollowUpTicket] = []
@@ -497,12 +499,33 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 abort_task.cancel()
             await asyncio.gather(abort_task, return_exceptions=True)
 
+    def _effective_request_messages(self) -> list[Message]:
+        """Return the messages to send to the provider.
+
+        Request-time context processing (compression/truncation) result is kept
+        in ``_request_messages`` and only used for the current provider call;
+        ``run_context.messages`` always stays as the full persistent history.
+        """
+        request_messages = getattr(self, "_request_messages", None)
+        return request_messages if request_messages is not None else self.run_context.messages
+
     async def _iter_llm_responses(
         self, *, include_model: bool = True
     ) -> T.AsyncGenerator[LLMResponse, None]:
         """Yields chunks *and* a final LLMResponse."""
+        request_messages = self._effective_request_messages()
+        if not request_messages:
+            logger.warning(
+                "Skipping LLM request because no messages remain after agent/request "
+                "hooks and context processing."
+            )
+            yield LLMResponse(
+                role="err",
+                completion_text="No messages remain for the LLM request.",
+            )
+            return
         payload = {
-            "contexts": self._sanitize_contexts_for_provider(self.run_context.messages),
+            "contexts": self._sanitize_contexts_for_provider(request_messages),
             "func_tool": self._func_tool_for_provider(),
             "session_id": self.req.session_id,
             "extra_user_content_parts": self.req.extra_user_content_parts,  # list[ContentPart]
@@ -534,7 +557,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
         self,
     ) -> T.AsyncGenerator[LLMResponse, None]:
         """Wrap _iter_llm_responses with provider fallback handling."""
-        if not self.run_context.messages:
+        if not self._effective_request_messages():
             logger.warning(
                 "Skipping LLM request because no messages remain after agent/request "
                 "hooks and context processing."
@@ -815,17 +838,29 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
         # Process request-time context before sending it to the provider.
         token_usage = self.req.conversation.token_usage if self.req.conversation else 0
         self._simple_print_message_role("[BefCompact]", self.run_context.messages)
+        # Keep run_context.messages as the full persistent history; compressed
+        # results are only for the current provider request, never persisted.
+        # Build the request source incrementally (snapshot + new delta) so we
+        # do not re-compress the whole history on every step.
+        if self._request_messages is None or self._request_messages_base is None:
+            source = list(self.run_context.messages)
+        else:
+            source = [
+                *self._request_messages,
+                *self.run_context.messages[self._request_messages_base:],
+            ]
         processed_messages = await self._await_or_stop(
             self.request_context_manager.process(
-                self.run_context.messages,
+                source,
                 trusted_token_usage=token_usage,
             )
         )
         if processed_messages is None:
             yield await self._finalize_aborted_step()
             return
-        self.run_context.messages = processed_messages
-        self._simple_print_message_role("[AftCompact]", self.run_context.messages)
+        self._request_messages = processed_messages
+        self._request_messages_base = len(self.run_context.messages)
+        self._simple_print_message_role("[AftCompact]", self._request_messages)
 
         async for llm_response in self._iter_llm_responses_with_fallback():
             if llm_response.is_chunk:
@@ -1372,7 +1407,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
     ) -> list[dict[str, T.Any]]:
         """Build contexts for re-querying LLM with param-only tool schemas."""
         contexts: list[dict[str, T.Any]] = []
-        for msg in self.run_context.messages:
+        for msg in self._effective_request_messages():
             if hasattr(msg, "model_dump"):
                 contexts.append(msg.model_dump())  # type: ignore[call-arg]
             elif isinstance(msg, dict):

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -480,6 +480,11 @@ class InternalAgentSubStage(Stage):
         checkpoint_id = event.get_extra("llm_checkpoint_id")
         has_checkpoint = isinstance(checkpoint_id, str) and bool(checkpoint_id)
         message_to_save = dump_messages_with_checkpoints(messages_to_save)
+        logger.info(
+            "[conversation] saving history for cid=%s: %d messages.",
+            req.conversation.cid,
+            len(message_to_save),
+        )
         if not user_aborted and (
             llm_response is None or llm_response.role != "assistant"
         ):

--- a/tests/agent/test_context_manager.py
+++ b/tests/agent/test_context_manager.py
@@ -582,7 +582,7 @@ class TestContextManager:
 
     @pytest.mark.asyncio
     async def test_double_check_after_compression(self):
-        """Test that halving is applied if still over threshold after compression."""
+        """Test that token-budget truncation is applied if still over threshold after compression."""
         config = ContextConfig(max_context_tokens=100)
         manager = ContextManager(config)
 
@@ -598,13 +598,32 @@ class TestContextManager:
             with patch.object(manager.compressor, "__call__", new=mock_compress):
                 with patch.object(
                     manager.truncator,
-                    "truncate_by_halving",
+                    "truncate_to_token_budget",
                     return_value=long_messages[:5],
-                ) as mock_halving:
+                ) as mock_token_budget:
                     _ = await manager.process(long_messages)
 
-                    # Halving should be called
-                    mock_halving.assert_called_once()
+                    # Token-budget truncation should be called
+                    mock_token_budget.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_enforce_turns_skipped_when_llm_compress(self):
+        """When LLM compression is configured, enforce_max_turns must not
+        unconditionally hard-truncate."""
+        config = ContextConfig(
+            enforce_max_turns=2,
+            max_context_tokens=10_000,
+            llm_compress_provider=MockProvider(),  # type: ignore
+            llm_compress_keep_recent_ratio=0.15,
+        )
+        manager = ContextManager(config)
+        messages = self.create_messages(20)
+
+        result = await manager.process(messages)
+
+        # Hard turn limit should be skipped; no turn-based truncation applied.
+        assert len(result) == 20
+
 
     # ==================== Combined Truncation and Compression Tests ====================
 

--- a/tests/agent/test_truncator.py
+++ b/tests/agent/test_truncator.py
@@ -432,3 +432,94 @@ class TestContextTruncator:
         # 多 user 场景下截断后仍有 user
         roles = [m.role for m in result_before]
         assert "user" in roles
+
+    def test_truncate_to_token_budget_keeps_recent_within_budget(self):
+        """Test token-budget truncation keeps the newest messages within budget."""
+        truncator = ContextTruncator()
+        messages = self.create_messages(20)
+
+        class Counter:
+            def count_tokens(self, msgs):
+                return len(msgs)
+
+        # budget of 5 tokens should keep the newest ~5 messages (+1 anchor user)
+        result = truncator.truncate_to_token_budget(messages, Counter(), 5)
+        assert len(result) <= 6
+        assert result[0].role == "user"
+        assert result[-1].content == "Message 19"  # newest kept
+
+    def test_truncate_to_token_budget_under_budget_unchanged(self):
+        """Messages already under budget are returned unchanged."""
+        truncator = ContextTruncator()
+        messages = self.create_messages(4)
+
+        class Counter:
+            def count_tokens(self, msgs):
+                return len(msgs)
+
+        result = truncator.truncate_to_token_budget(messages, Counter(), 100)
+        assert len(result) == 4
+
+    def test_truncate_to_token_budget_preserves_system(self):
+        """System messages are preserved during token-budget truncation."""
+        truncator = ContextTruncator()
+        messages = self.create_messages(20, include_system=True)
+
+        class Counter:
+            def count_tokens(self, msgs):
+                return len(msgs)
+
+        result = truncator.truncate_to_token_budget(messages, Counter(), 5)
+        assert result[0].role == "system"
+
+    def test_truncate_to_token_budget_single_oversized_keeps_latest_user(self):
+        """A single oversized latest user request must be kept whole, so the
+        active request is never dropped in favor of an older question."""
+        truncator = ContextTruncator()
+        messages = self.create_messages(6)
+        messages[5] = self.create_message("user", "x" * 5000)  # huge latest request
+
+        class Counter:
+            def count_tokens(self, msgs):
+                return sum(len(getattr(m, "content", "") or "") for m in msgs)
+
+        result = truncator.truncate_to_token_budget(messages, Counter(), 10)
+        assert any(
+            m.role == "user" and len(m.content) == 5000 for m in result
+        ), "active request must not be dropped"
+
+    def test_truncate_to_token_budget_system_excluded_from_budget(self):
+        """Huge system messages are preserved and don't consume the budget."""
+        truncator = ContextTruncator()
+        messages = [self.create_message("system", "s" * 5000)]
+        for i in range(10):
+            role = "user" if i % 2 == 0 else "assistant"
+            messages.append(self.create_message(role, f"M{i}"))
+
+        class Counter:
+            def count_tokens(self, msgs):
+                return sum(len(getattr(m, "content", "") or "") for m in msgs)
+
+        result = truncator.truncate_to_token_budget(messages, Counter(), 5)
+        # system preserved; budget (after excluding the huge system) keeps the
+        # newest non-system round only
+        assert result[0].role == "system"
+        assert result[-1].content == "M9"
+        assert len(result) <= 3
+
+    def test_truncate_to_token_budget_uneven_keeps_recent(self):
+        """A huge middle message is dropped; recent messages are kept."""
+        truncator = ContextTruncator()
+        messages = [
+            self.create_message("user", "a"),
+            self.create_message("assistant", "b"),
+            self.create_message("user", "x" * 100),
+            self.create_message("assistant", "c"),
+        ]
+
+        class Counter:
+            def count_tokens(self, msgs):
+                return sum(len(getattr(m, "content", "") or "") for m in msgs)
+
+        result = truncator.truncate_to_token_budget(messages, Counter(), 5)
+        assert result[-1].content == "c"

--- a/tests/test_request_context_isolation.py
+++ b/tests/test_request_context_isolation.py
@@ -1,0 +1,53 @@
+"""Regression tests: request-time context processing must never mutate the
+persistent conversation history (``run_context.messages``).
+"""
+from types import SimpleNamespace
+
+from astrbot.core.agent.runners.tool_loop_agent_runner import ToolLoopAgentRunner
+
+
+def test_request_messages_separated_from_persistent_history():
+    """Request messages used for the provider must not replace run_context."""
+    runner = ToolLoopAgentRunner()
+    runner.run_context = SimpleNamespace(messages=["full-a", "full-b"])
+
+    # Simulate request-time context processing producing a compressed list.
+    runner._request_messages = ["compressed"]
+
+    assert runner._effective_request_messages() == ["compressed"]
+    # Persistent history must stay untouched.
+    assert runner.run_context.messages == ["full-a", "full-b"]
+
+
+def test_request_messages_fallback_to_run_context():
+    """When no request-time result is set, fall back to the full history."""
+    runner = ToolLoopAgentRunner()
+    runner.run_context = SimpleNamespace(messages=["full-a", "full-b"])
+    runner._request_messages = None
+
+    assert runner._effective_request_messages() == ["full-a", "full-b"]
+
+
+def test_empty_request_messages_do_not_fall_back_to_full():
+    """An empty request result must NOT silently fall back to the full history.
+
+    Otherwise a (wrongly) empty compressed result would bypass the empty-message
+    error guard and send the whole, over-window history to the provider.
+    """
+    runner = ToolLoopAgentRunner()
+    runner.run_context = SimpleNamespace(messages=["full-a", "full-b"])
+    runner._request_messages = []
+
+    assert runner._effective_request_messages() == []
+
+
+def test_run_context_not_mutated_after_processing():
+    """Queueing a request result must not write back into the persistent list."""
+    runner = ToolLoopAgentRunner()
+    runner.run_context = SimpleNamespace(messages=["full-a", "full-b"])
+    runner._request_messages = ["compressed"]
+
+    # Even if later re-fetched, run_context must remain the source of truth.
+    assert runner.run_context.messages == ["full-a", "full-b"]
+    runner._request_messages = None
+    assert runner._effective_request_messages() == ["full-a", "full-b"]


### PR DESCRIPTION
修复 #9936 的上下文丢失问题。

问题根因是 request_context_manager.process() 对 run_context.messages 做压缩/裁剪后，把结果直接写回，随后 _save_to_history 又用这个已裁剪的临时结果整体覆盖持久化历史，造成不可逆的数据丢失和长对话"失忆"。

本次改动把"请求用的上下文"与"持久化历史"分开：压缩结果只用于发给模型的本次请求，持久化历史始终保持完整；请求上下文按增量演进，避免每步重复压缩全量历史。同时让 skills_like 的 requery 复用一致的请求消息，配置了 LLM 压缩且 token 守护开启时不再无条件硬截断，兜底改用按 token 预算保留最新的算法，并强化压缩摘要对硬信息的保留。相关流程也补了日志。

新增并调整了若干测试用例，相关套件 155 passed。

阶段二（token 口径统一、阈值可配置、压缩冷却）和存储层优化（增量写、大正文旁路、摘要独立列+归档）建议后续单独跟进。

Closes #9936

## Summary by Sourcery

Separate request-time context processing from persistent conversation history to prevent compressed context from causing irreversible message loss.

Bug Fixes:
- Prevent request-time context compression and truncation from overwriting the complete persistent conversation history, avoiding irreversible context loss in long conversations.

Enhancements:
- Reuse incrementally processed request context across agent steps and tool re-queries while keeping persistent history separate.
- Replace blind post-compression halving with token-budget truncation that preserves system messages and the latest active request.
- Avoid hard turn truncation when configured intelligent compression and token protection can handle context limits.
- Strengthen compression summaries to retain URLs, paths, identifiers, parameters, decisions, constraints, and other hard facts.
- Add logging around context processing and conversation-history persistence.

Tests:
- Add regression coverage for persistent/request context isolation and empty request handling.
- Expand context manager and truncator tests for intelligent compression behavior and token-budget retention.