### PR TITLE
fix: reject unsafe repository path components

### DIFF
--- a/astrbot/core/repository.py
+++ b/astrbot/core/repository.py
@@ -87,7 +87,14 @@ class GitHubRepository:
                 raise ValueError("Invalid GitHub repository URL")
             branch = "/".join(parts[3:])
 
-        if not owner or not name or owner in {".", ".."} or name in {".", ".."}:
+        if (
+            not owner
+            or not name
+            or any(
+                part in {".", ".."} or "/" in part or "\\" in part
+                for part in (owner, name)
+            )
+        ):
             raise ValueError("Invalid GitHub repository URL")
         return cls(owner, name, branch)
 
@@ -225,7 +232,11 @@ def parse_repository_url(url: str) -> RepositoryReference:
         raise ValueError("Invalid Git repository URL")
     owner = "/".join(parts[:-1])
     name = parts[-1].removesuffix(".git")
-    if not owner or not name or any(part in {".", ".."} for part in parts):
+    if (
+        not owner
+        or not name
+        or any(part in {".", ".."} or "/" in part or "\\" in part for part in parts)
+    ):
         raise ValueError("Invalid Git repository URL")
     return RepositoryReference(
         provider=host.removeprefix("www."),

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -69,3 +69,18 @@ def test_github_repository_rejects_other_hosts(url: str) -> None:
 def test_repository_parser_rejects_unsafe_or_non_repository_urls(url: str) -> None:
     with pytest.raises(ValueError):
         parse_repository_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/owner/x%2F..%2F..%2F.git",
+        "https://github.com/owner/x%5C..%5C..%5C.git",
+        "https://github.com/owner%2F..%2F../plugin.git",
+        "https://example.com/owner/x%2F..%2F..%2F.git",
+        "https://example.com/owner/x%5C..%5C..%5C.git",
+    ],
+)
+def test_repository_parser_rejects_encoded_path_separators(url: str) -> None:
+    with pytest.raises(ValueError):
+        parse_repository_url(url)


### PR DESCRIPTION
### Motivation
- Prevent path-traversal via percent-decoded path separators in repository owner/name that can escape the plugin store during plugin installation.

### Description
- Reject owner/name components that are empty, equal to `.`/`..`, or contain decoded `/` or `\` in `GitHubRepository.parse` (in `astrbot/core/repository.py`).
- Apply the same validation to the generic HTTP/SSH/SCP repository parser in `parse_repository_url` to block encoded traversal payloads before the name is used as a filesystem path.
- Add regression coverage for encoded forward-slash and backslash traversal payloads in `tests/test_repository.py` to ensure those inputs raise `ValueError`.

### Testing
- Ran a targeted parser validation using `uv run --no-sync python -` to assert the parser rejects the encoded traversal payloads while accepting a valid generic repo URL, and it passed.
- Ran formatting and lint checks with `uv run --no-sync ruff format .` and `uv run --no-sync ruff check .`, and `git diff --check`, all of which passed.
- Attempted `uv run pytest tests/test_repository.py`, but full test execution could not complete because the environment could not fetch `shipyard-python-sdk` from PyPI and `pytest_asyncio` was not available, so the full test suite was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6dcc6909988320bb3925e8170c93db)

## Summary by Sourcery

Prevent unsafe repository paths from escaping the plugin store during installation.

Bug Fixes:
- Reject repository owner and name components containing decoded path separators or traversal components to prevent filesystem path traversal during plugin installation.

Enhancements:
- Apply unsafe path-component validation consistently across GitHub and generic repository URL parsing.

Tests:
- Add regression coverage for encoded forward-slash and backslash traversal payloads in repository URLs.