### PR TITLE
fix: expose xAI native web search for Responses API providers

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -2119,10 +2119,9 @@ CONFIG_METADATA_2 = {
                     "xai_native_search": {
                         "description": "启用原生搜索功能",
                         "type": "bool",
-                        "hint": "启用后，将通过 xAI 的 Chat Completions 原生 Live Search 进行联网检索（按需计费）。仅对 xAI 提供商生效。",
+                        "hint": "启用后，将通过 xAI 原生搜索进行联网检索（按需计费）。对使用 Chat Completions 或 Responses API 的 xAI 提供商生效。",
                         "condition": {
                             "provider": "xai",
-                            "type": "xai_chat_completion",
                         },
                     },
                     "rerank_api_base": {

--- a/astrbot/core/provider/sources/openai_responses_source.py
+++ b/astrbot/core/provider/sources/openai_responses_source.py
@@ -294,6 +294,24 @@ class ProviderOpenAIResponses(ProviderOpenAIOfficial):
 
         return payloads, context_query
 
+    def _maybe_inject_xai_native_search(self, payloads: dict) -> None:
+        """Inject xAI's server-side web_search tool into a Responses API payload.
+
+        Only takes effect when ``xai_native_search`` is enabled. The option is
+        shown for xAI providers only (see its ``condition`` in
+        ``CONFIG_METADATA_2``). The Chat Completions adapter injects
+        ``search_parameters`` instead; the Responses API requires the tool to
+        be declared explicitly.
+
+        Args:
+            payloads: Responses API request payload, modified in place.
+        """
+        if not bool(self.provider_config.get("xai_native_search", False)):
+            return
+        tools = payloads.setdefault("tools", [])
+        if not any(self._field(tool, "type") == "web_search" for tool in tools):
+            tools.append({"type": "web_search"})
+
     async def _query(
         self,
         payloads: dict,
@@ -322,6 +340,7 @@ class ProviderOpenAIResponses(ProviderOpenAIOfficial):
             if response_tools:
                 payloads["tools"] = response_tools
                 payloads["tool_choice"] = payloads.get("tool_choice", "auto")
+        self._maybe_inject_xai_native_search(payloads)
 
         extra_body: dict[str, Any] = {}
         custom_extra_body = self.provider_config.get("custom_extra_body", {})
@@ -391,6 +410,7 @@ class ProviderOpenAIResponses(ProviderOpenAIOfficial):
             if response_tools:
                 payloads["tools"] = response_tools
                 payloads["tool_choice"] = payloads.get("tool_choice", "auto")
+        self._maybe_inject_xai_native_search(payloads)
 
         extra_body: dict[str, Any] = {}
         custom_extra_body = self.provider_config.get("custom_extra_body", {})

--- a/dashboard/src/i18n/locales/en-US/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/en-US/features/config-metadata.json
@@ -1333,7 +1333,7 @@
       },
       "xai_native_search": {
         "description": "Enable native search",
-        "hint": "When enabled, uses xAI Chat Completions native Live Search for web queries (billed on demand). Only applies to xAI providers."
+        "hint": "When enabled, uses xAI's native web search for web queries (billed on demand). Applies to xAI providers using either the Chat Completions or Responses API."
       },
       "rerank_api_base": {
         "description": "Rerank Model API Base URL",

--- a/dashboard/src/i18n/locales/ru-RU/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/config-metadata.json
@@ -1486,7 +1486,7 @@
             },
             "xai_native_search": {
                 "description": "Включить нативный поиск",
-                "hint": "Если включено, использует Live Search от xAI для веб-запросов (тарифицируется отдельно). Применимо только к провайдерам xAI."
+                "hint": "Если включено, использует нативный веб-поиск xAI для веб-запросов (тарифицируется отдельно). Применимо к провайдерам xAI с Chat Completions или Responses API."
             },
             "rerank_api_base": {
                 "description": "Base URL API модели Rerank",

--- a/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/config-metadata.json
@@ -1354,7 +1354,7 @@
       },
       "xai_native_search": {
         "description": "启用原生搜索功能",
-        "hint": "启用后，将通过 xAI 的 Chat Completions 原生 Live Search 进行联网检索（按需计费）。仅对 xAI 提供商生效。"
+        "hint": "启用后，将通过 xAI 原生搜索进行联网检索（按需计费）。对使用 Chat Completions 或 Responses API 的 xAI 提供商生效。"
       },
       "rerank_api_base": {
         "description": "重排序模型 API Base URL",

--- a/tests/test_openai_responses_source.py
+++ b/tests/test_openai_responses_source.py
@@ -397,3 +397,65 @@ async def test_parse_failed_response_raises_provider_error():
 
     with pytest.raises(RuntimeError, match="server_error: failed"):
         await provider._parse_response(response, tools=None)
+
+
+def test_xai_web_search_not_injected_by_default():
+    provider = _make_provider({"provider": "xai"})
+    payloads: dict = {}
+
+    provider._maybe_inject_xai_native_search(payloads)
+
+    assert "tools" not in payloads
+
+
+def test_xai_web_search_injected_without_function_tools():
+    provider = _make_provider({"provider": "xai", "xai_native_search": True})
+    payloads: dict = {}
+
+    provider._maybe_inject_xai_native_search(payloads)
+
+    assert payloads["tools"] == [{"type": "web_search"}]
+
+
+def test_xai_web_search_appended_after_function_tools_only_once():
+    provider = _make_provider({"provider": "xai", "xai_native_search": True})
+    payloads = {"tools": [{"type": "function", "name": "weather", "parameters": {}}]}
+
+    provider._maybe_inject_xai_native_search(payloads)
+    provider._maybe_inject_xai_native_search(payloads)
+
+    assert payloads["tools"] == [
+        {"type": "function", "name": "weather", "parameters": {}},
+        {"type": "web_search"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_query_sends_xai_web_search_tool_when_native_search_enabled(
+    monkeypatch,
+):
+    provider = _make_provider({"provider": "xai", "xai_native_search": True})
+    captured: dict = {}
+
+    async def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _make_response(
+            [
+                {
+                    "type": "message",
+                    "id": "msg_1",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "news", "annotations": []},
+                    ],
+                }
+            ]
+        )
+
+    monkeypatch.setattr(provider.client.responses, "create", fake_create)
+
+    result = await provider._query({"model": "grok-4.5", "input": "news"}, None)
+
+    assert captured["tools"] == [{"type": "web_search"}]
+    assert result.completion_text == "news"


### PR DESCRIPTION
The official xAI provider template now creates `openai_responses` type providers, but native search support was left behind on the legacy adapter:

- The `xai_native_search` option is still gated on `type: xai_chat_completion`, so the WebUI hides the toggle for every provider created from the current xAI template.
- Even with the option force-enabled in config, requests to `POST /v1/responses` never declare xAI's server-side `web_search` tool, so native web search silently never runs (the model answers from prior knowledge, without real-time sources or citations).

Fixes #9723.

### Modifications / 改动点

- `astrbot/core/config/default.py`: relax the `xai_native_search` condition to `{"provider": "xai"}` so the toggle shows for xAI providers regardless of API type, and update the hint to cover both Chat Completions and Responses API. (The dashboard evaluates `condition` entries as a strict AND, so an OR over the two types cannot be expressed there.)
- `astrbot/core/provider/sources/openai_responses_source.py`: add `_maybe_inject_xai_native_search()`, called in both `_query` and `_query_stream`. When the option is enabled, it appends `{"type": "web_search"}` to `payloads["tools"]` idempotently, after any function tools (so the existing `tool_choice` handling stays unchanged). This mirrors the Chat Completions adapter, which injects `search_parameters` instead. Response-side parsing already tolerates `web_search_call` output items (unknown item types are skipped by `_parse_response`).
- Dashboard i18n: `xai_native_search` hint updated for zh-CN / en-US / ru-RU.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

**Verification Steps / 验证步骤**

```bash
python -m pytest tests/test_openai_responses_source.py -q
ruff check astrbot/core/config/default.py astrbot/core/provider/sources/openai_responses_source.py tests/test_openai_responses_source.py
ruff format --check astrbot/core/config/default.py astrbot/core/provider/sources/openai_responses_source.py tests/test_openai_responses_source.py
```

**Test Results / 运行结果**

```
12 passed, 1 warning in 6.75s
```

- The 8 existing tests in `tests/test_openai_responses_source.py` still pass; 4 tests were added: no injection by default; injection without function tools (`tools == [{"type": "web_search"}]`); idempotent append after function tools; end-to-end `_query` payload carries `web_search`.
- Ruff version 0.15.22 (same as CI): `ruff check` and `ruff format --check` pass on all changed files.
- Note: I don't have an xAI API key, so this is not verified with a live end-to-end call; the request construction is covered by unit tests and the response tolerance was verified by code reading.

---

### Checklist / 检查清单

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Expose and activate xAI native web search for Responses API providers while preserving existing tool handling.

New Features:
- Enable xAI native web search for providers using the Responses API.

Bug Fixes:
- Restore native xAI web search requests for current Responses API provider configurations so real-time search can run when enabled.

Enhancements:
- Make the xAI native search setting available across both Chat Completions and Responses API providers and update its localized guidance.

Tests:
- Add coverage for disabled, enabled, idempotent, and end-to-end Responses API web-search tool injection.