### PR TITLE
fix: stop requiring a preamble before every tool call in skills-like mode

### DIFF
--- a/astrbot/core/astr_main_agent_resources.py
+++ b/astrbot/core/astr_main_agent_resources.py
@@ -32,7 +32,7 @@ TOOL_CALL_PROMPT = (
 
 TOOL_CALL_PROMPT_SKILLS_LIKE_MODE = (
     "You MUST NOT return an empty response, especially after invoking a tool."
-    " Before calling any tool, provide a brief explanatory message to the user stating the purpose of the tool call."
+    " When using tools, briefly explain the purpose when starting a new type of task, but not before every tool call."
     " Tool schemas are provided in two stages: first only name and description; "
     "if you decide to use a tool, the full parameter schema will be provided in "
     "a follow-up step. Do not guess arguments before you see the schema."


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

Fixes #9929.

In skills-like (two-stage) tool schema mode, `TOOL_CALL_PROMPT_SKILLS_LIKE_MODE` required the model to "provide a brief explanatory message to the user stating the purpose of the tool call" **before calling any tool**, which surfaces as narrator-style preambles ("let me check...") that break role-play immersion. Full schema mode already uses softer wording for the same concern. The "You MUST NOT return an empty response, especially after invoking a tool." guard is kept unchanged, so models still emit text around tool calls.

### Modifications / 改动点

<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- `astrbot/core/astr_main_agent_resources.py`: replaced the "Before calling any tool, provide a brief explanatory message..." sentence in `TOOL_CALL_PROMPT_SKILLS_LIKE_MODE` with the wording already used in `TOOL_CALL_PROMPT`: "briefly explain the purpose when starting a new type of task, but not before every tool call". No other constants or modes are touched.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图，GIF 或测试日志，作为执行"验证步骤"的证据，证明此改动有效。-->

Prompt-copy change only; no logic or control flow is modified, and the repo has no tests asserting these prompt constants (grepped). Verified with the versions pinned in `.pre-commit-config.yaml`:

```
$ uv run ruff check astrbot/core/astr_main_agent_resources.py
All checks passed!

$ uv run ruff format --check astrbot/core/astr_main_agent_resources.py
1 file already formatted

$ uvx pyupgrade --py310-plus astrbot/core/astr_main_agent_resources.py
(no changes)
```

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Stop skills-like tool-call prompts from requiring a preamble before every individual tool invocation, preserving explanatory text for new task types.