### PR TITLE
fix: refresh subagent personas after dashboard updates

### DIFF
--- a/astrbot/dashboard/services/persona_service.py
+++ b/astrbot/dashboard/services/persona_service.py
@@ -10,6 +10,7 @@ class PersonaServiceError(Exception):
 
 class PersonaService:
     def __init__(self, core_lifecycle: AstrBotCoreLifecycle) -> None:
+        self.core_lifecycle = core_lifecycle
         self.persona_mgr = core_lifecycle.persona_mgr
 
     async def list_personas(
@@ -114,6 +115,12 @@ class PersonaService:
             update_kwargs["custom_error_message"] = custom_error_message
 
         await self.persona_mgr.update_persona(**update_kwargs)
+        orchestrator = getattr(self.core_lifecycle, "subagent_orchestrator", None)
+        if orchestrator is not None:
+            # Handoffs snapshot persona prompts, dialogs and tools when loaded.
+            await orchestrator.reload_from_config(
+                self.core_lifecycle.astrbot_config.get("subagent_orchestrator", {})
+            )
         return {"message": "人格更新成功"}
 
     async def delete_persona(self, data: object) -> dict:

--- a/astrbot/dashboard/services/persona_service.py
+++ b/astrbot/dashboard/services/persona_service.py
@@ -118,9 +118,12 @@ class PersonaService:
         orchestrator = getattr(self.core_lifecycle, "subagent_orchestrator", None)
         if orchestrator is not None:
             # Handoffs snapshot persona prompts, dialogs and tools when loaded.
-            await orchestrator.reload_from_config(
-                self.core_lifecycle.astrbot_config.get("subagent_orchestrator", {})
+            orchestrator_config = self.core_lifecycle.astrbot_config.get(
+                "subagent_orchestrator", {}
             )
+            if not isinstance(orchestrator_config, dict):
+                orchestrator_config = {}
+            await orchestrator.reload_from_config(orchestrator_config)
         return {"message": "人格更新成功"}
 
     async def delete_persona(self, data: object) -> dict:

--- a/tests/unit/test_persona_service_subagents.py
+++ b/tests/unit/test_persona_service_subagents.py
@@ -88,3 +88,16 @@ async def test_persona_update_without_subagent_orchestrator(persona_core):
     )
     persona = await persona_core.persona_mgr.get_persona("custom")
     assert persona.system_prompt == "New prompt"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalid_config", [None, [], "invalid", False])
+async def test_persona_update_with_non_object_subagent_config(persona_core, invalid_config):
+    persona_core.astrbot_config["subagent_orchestrator"] = invalid_config
+    result = await PersonaService(persona_core).update_persona(
+        {"persona_id": "custom", "system_prompt": "New prompt"}
+    )
+    assert result == {"message": "人格更新成功"}
+    persona = await persona_core.persona_mgr.get_persona("custom")
+    assert persona.system_prompt == "New prompt"
+    assert persona_core.subagent_orchestrator.handoffs == []

--- a/tests/unit/test_persona_service_subagents.py
+++ b/tests/unit/test_persona_service_subagents.py
@@ -1,0 +1,90 @@
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+
+import astrbot.api  # Initialize the public API before importing persona modules.
+from astrbot.core.db.sqlite import SQLiteDatabase
+from astrbot.core.persona_mgr import PersonaManager
+from astrbot.core.provider.func_tool_manager import FunctionToolManager
+from astrbot.core.subagent_orchestrator import SubAgentOrchestrator
+from astrbot.dashboard.services.persona_service import PersonaService
+
+
+@pytest_asyncio.fixture
+async def persona_core(tmp_path):
+    db = SQLiteDatabase(str(tmp_path / "personas.db"))
+    await db.initialize()
+    db.inited = True
+    try:
+        manager = PersonaManager(db, SimpleNamespace(default_conf={}))
+        await manager.initialize()
+        await manager.create_persona(
+            "custom", "Old prompt", ["Old question", "Old answer"], tools=["old_tool"]
+        )
+        config = {
+            "agents": [
+                {"name": "planner", "persona_id": "custom"},
+                {"name": "inline", "system_prompt": "Inline prompt", "tools": []},
+            ]
+        }
+        orchestrator = SubAgentOrchestrator(FunctionToolManager(), manager)
+        await orchestrator.reload_from_config(config)
+        yield SimpleNamespace(
+            persona_mgr=manager,
+            subagent_orchestrator=orchestrator,
+            astrbot_config={"subagent_orchestrator": config},
+        )
+    finally:
+        await db.engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_persona_update_refreshes_subagent_without_saving_config(persona_core):
+    service = PersonaService(persona_core)
+    orchestrator = persona_core.subagent_orchestrator
+    previous_handoff = orchestrator.handoffs[0]
+    assert previous_handoff.agent.instructions == "Old prompt"
+
+    await service.update_persona(
+        {
+            "persona_id": "custom",
+            "system_prompt": "New prompt",
+            "begin_dialogs": ["New question", "New answer"],
+            "tools": ["new_tool"],
+        }
+    )
+
+    persisted = await persona_core.persona_mgr.get_persona("custom")
+    assert persisted.system_prompt == "New prompt"
+    agent = orchestrator.handoffs[0].agent
+    assert agent.instructions == "New prompt"
+    assert agent.begin_dialogs == [
+        {"role": "user", "content": "New question", "_no_save": True},
+        {"role": "assistant", "content": "New answer", "_no_save": True},
+    ]
+    assert agent.tools == ["new_tool"]
+    assert orchestrator.handoffs[1].agent.instructions == "Inline prompt"
+    assert orchestrator.handoffs[1].agent.tools == []
+    # Requests already holding a handoff keep their existing snapshot.
+    assert previous_handoff.agent.instructions == "Old prompt"
+
+
+@pytest.mark.asyncio
+async def test_failed_persona_update_does_not_replace_handoffs(persona_core):
+    previous_handoffs = persona_core.subagent_orchestrator.handoffs
+    with pytest.raises(ValueError, match="does not exist"):
+        await PersonaService(persona_core).update_persona(
+            {"persona_id": "missing", "system_prompt": "New prompt"}
+        )
+    assert persona_core.subagent_orchestrator.handoffs is previous_handoffs
+
+
+@pytest.mark.asyncio
+async def test_persona_update_without_subagent_orchestrator(persona_core):
+    persona_core.subagent_orchestrator = None
+    await PersonaService(persona_core).update_persona(
+        {"persona_id": "custom", "system_prompt": "New prompt"}
+    )
+    persona = await persona_core.persona_mgr.get_persona("custom")
+    assert persona.system_prompt == "New prompt"


### PR DESCRIPTION
Fixes #9939.

Updating a persona through the dashboard currently persists the new prompt but leaves subagent handoffs using their previous snapshot. Users must save the subagent configuration again or restart AstrBot before the new prompt takes effect.

### Modifications

- Reload subagent handoffs from the existing configuration after a successful dashboard persona update, using the same path as saving subagent configuration.
- Refresh persona prompts, processed opening dialogs and tool selections for subsequent requests. Existing requests keep the handoff objects they already hold.
- Add regression coverage using real SQLite, PersonaManager, PersonaService and SubAgentOrchestrator; only the application container/configuration are lightweight stand-ins. Cover successful updates, unchanged inline agents, failed saves, an absent orchestrator and non-object subagent configuration.
- Normalize non-object subagent configuration (including explicit null) to an empty configuration before reloading, so a persisted persona update does not fail with AttributeError. Empty configuration clears obsolete handoffs.
- No request/response schema changes or new dependencies.

- [x] This is NOT a breaking change.

### Verification Steps and Test Results

1. Create a persona with an old prompt and a subagent referencing it.
2. Update the persona through PersonaService, without saving subagent configuration.
3. Verify both the stored persona and the next handoff contain the new prompt, dialogs and tools.

All four non-object configuration cases (null, list, string, boolean) also failed before normalization and pass after it.

The original regression test failed before the fix: SQLite contained `New prompt` while the handoff retained `Old prompt`. It passes after the fix.

Validation on Windows with Python 3.12.13:

- `python -m pytest -q tests/unit/test_persona_service_subagents.py tests/unit/test_subagent_orchestrator.py tests/test_main.py tests/test_cli_run.py tests/test_cli_init.py`: 31 passed.
- `ruff format .` and `ruff format --check .`: 504 files formatted.
- `ruff check .`: passed.
- `scripts/smoke_startup_check.py`: passed against localhost with isolated temporary data.

No external LLM calls were made. This verifies the backend state used as the subagent system prompt, rather than model-generated replies. The full test suite was not run.

### Checklist

- [x] No new feature requiring prior discussion; this fixes the behavior reported in #9939.
- [x] Relevant tests and verification steps are provided above.
- [x] No new dependencies introduced.
- [x] No malicious code introduced.

## Summary by Sourcery

Refresh subagent persona state after successful dashboard updates without changing request or response schemas.

Bug Fixes:
- Refresh subagent handoffs after dashboard persona updates so subsequent requests use the latest prompts, opening dialogs, and tool selections while preserving snapshots held by existing requests.
- Handle missing or non-object subagent configuration safely during persona refresh, including clearing obsolete handoffs when configuration is empty.

Tests:
- Add regression coverage for successful persona refreshes, unchanged inline agents, failed updates, absent orchestrators, and invalid subagent configurations.