### PR TITLE
fix: honor computer runtime settings in proactive agents

### DIFF
--- a/astrbot/core/astr_agent_tool_exec.py
+++ b/astrbot/core/astr_agent_tool_exec.py
@@ -255,7 +255,7 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
         event = run_context.context.event
         cfg = ctx.get_config(umo=event.unified_msg_origin)
         provider_settings = cfg.get("provider_settings", {})
-        runtime = str(provider_settings.get("computer_use_runtime", "local"))
+        runtime = str(provider_settings.get("computer_use_runtime", "none"))
         tool_mgr = (
             ctx.get_llm_tool_manager()
             if hasattr(ctx, "get_llm_tool_manager")

--- a/astrbot/core/astr_agent_tool_exec.py
+++ b/astrbot/core/astr_agent_tool_exec.py
@@ -556,6 +556,9 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
         cron_event.role = event.role
         cfg = ctx.get_config(umo=event.unified_msg_origin) or {}
         provider_settings = cfg.get("provider_settings") or {}
+        persona_config = (
+            cfg.get("agent_runner", {}).get("config", {}).get("persona", {})
+        )
         agent_max_step = coerce_int_config(
             cfg.get("agent_runner", {})
             .get("config", {})
@@ -568,6 +571,12 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
         config = MainAgentBuildConfig(
             tool_call_timeout=run_context.tool_call_timeout,
             streaming_response=provider_settings.get("stream", False),
+            llm_safety_mode=persona_config.get("safety_mode", True),
+            safety_mode_strategy=persona_config.get(
+                "safety_mode_strategy", "system_prompt"
+            ),
+            computer_use_runtime=provider_settings.get("computer_use_runtime", "none"),
+            sandbox_cfg=provider_settings.get("sandbox", {}),
             provider_settings=provider_settings,
         )
 

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -205,7 +205,7 @@ class MainAgentBuildConfig:
     """This will inject healthy and safe system prompt into the main agent,
     to prevent LLM output harmful information"""
     safety_mode_strategy: str = "system_prompt"
-    computer_use_runtime: str = "local"
+    computer_use_runtime: str = "none"
     """The runtime for agent computer use: none, local, or sandbox."""
     sandbox_cfg: dict = field(default_factory=dict)
     add_cron_tools: bool = True

--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -568,7 +568,7 @@ async def _ensure_persona_and_skills(
         req.system_prompt += CHATUI_SPECIAL_DEFAULT_PERSONA_PROMPT
 
     # Inject skills prompt
-    runtime = cfg.get("computer_use_runtime", "local")
+    runtime = cfg.get("computer_use_runtime", "none")
     skill_manager = SkillManager()
     skills = skill_manager.list_skills(active_only=True, runtime=runtime)
     skills = _filter_skills_for_current_config(skills, cfg)

--- a/astrbot/core/computer/computer_client.py
+++ b/astrbot/core/computer/computer_client.py
@@ -556,7 +556,7 @@ async def get_booter(
 ) -> ComputerBooter:
     config = context.get_config(umo=session_id)
 
-    runtime = config.get("provider_settings", {}).get("computer_use_runtime", "local")
+    runtime = config.get("provider_settings", {}).get("computer_use_runtime", "none")
     if runtime == "local":
         return get_local_booter()
     elif runtime == "none":

--- a/astrbot/core/cron/manager.py
+++ b/astrbot/core/cron/manager.py
@@ -442,6 +442,9 @@ class CronJobManager:
             cron_event.role = "admin"
 
         provider_settings = cfg.get("provider_settings", {}) or {}
+        persona_config = (
+            cfg.get("agent_runner", {}).get("config", {}).get("persona", {})
+        )
         tool_call_timeout = (
             cfg.get("agent_runner", {})
             .get("config", {})
@@ -459,8 +462,13 @@ class CronJobManager:
         )
         config = MainAgentBuildConfig(
             tool_call_timeout=tool_call_timeout,
-            llm_safety_mode=False,
+            llm_safety_mode=persona_config.get("safety_mode", True),
+            safety_mode_strategy=persona_config.get(
+                "safety_mode_strategy", "system_prompt"
+            ),
             streaming_response=False,
+            computer_use_runtime=provider_settings.get("computer_use_runtime", "none"),
+            sandbox_cfg=provider_settings.get("sandbox", {}),
             provider_settings=provider_settings,
         )
         req = ProviderRequest()

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -122,7 +122,7 @@ class InternalAgentSubStage(Stage):
             "safety_mode_strategy", "system_prompt"
         )
 
-        self.computer_use_runtime = settings.get("computer_use_runtime")
+        self.computer_use_runtime = settings.get("computer_use_runtime", "none")
         self.sandbox_cfg = settings.get("sandbox", {})
 
         # Proactive capability configuration

--- a/astrbot/core/tools/computer_tools/python.py
+++ b/astrbot/core/tools/computer_tools/python.py
@@ -13,6 +13,7 @@ from astrbot.core.message.message_event_result import MessageChain
 from ..registry import builtin_tool
 from .util import (
     check_admin_permission,
+    is_local_runtime,
     workspace_root_for_context,
 )
 
@@ -133,6 +134,8 @@ class LocalPythonTool(FunctionTool):
     ) -> ToolExecResult:
         if permission_error := check_admin_permission(context, "Python execution"):
             return permission_error
+        if not is_local_runtime(context):
+            return "Error executing code: only local runtime is supported."
         sb = get_local_booter()
         effective_timeout = (
             min(timeout, context.tool_call_timeout)

--- a/astrbot/core/tools/computer_tools/util.py
+++ b/astrbot/core/tools/computer_tools/util.py
@@ -50,7 +50,7 @@ def is_local_runtime(context: ContextWrapper[AstrAgentContext]) -> bool:
         umo=context.context.event.unified_msg_origin
     )
     provider_settings = cfg.get("provider_settings", {})
-    runtime = str(provider_settings.get("computer_use_runtime", "local"))
+    runtime = str(provider_settings.get("computer_use_runtime", "none"))
     return runtime == "local"
 
 

--- a/astrbot/dashboard/services/skills_service.py
+++ b/astrbot/dashboard/services/skills_service.py
@@ -252,7 +252,7 @@ class SkillsService:
         provider_settings = self.core_lifecycle.astrbot_config.get(
             "provider_settings", {}
         )
-        runtime = provider_settings.get("computer_use_runtime", "local")
+        runtime = provider_settings.get("computer_use_runtime", "none")
         skill_mgr = SkillManager()
         skills = skill_mgr.list_skills(
             active_only=False,

--- a/dashboard/src/components/extension/SkillsSection.vue
+++ b/dashboard/src/components/extension/SkillsSection.vue
@@ -1803,7 +1803,7 @@ export default {
         const config = res?.data?.data?.config || {};
         const providerSettings = config?.provider_settings || {};
         const currentRuntime =
-          providerSettings?.computer_use_runtime || "local";
+          providerSettings?.computer_use_runtime || "none";
         const booter = providerSettings?.sandbox?.booter || "";
         neoEnabled.value =
           currentRuntime === "sandbox" && booter === "shipyard_neo";

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -10,6 +10,7 @@ import zipfile
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 from urllib.parse import parse_qs, urlsplit, urlunsplit
 
 import jwt
@@ -77,7 +78,7 @@ def test_skills_service_marks_inactive_plugin_skills(monkeypatch):
         ),
     ]
     skill_manager = SimpleNamespace(
-        list_skills=lambda **_kwargs: skills,
+        list_skills=MagicMock(return_value=skills),
         get_sandbox_skills_cache_status=lambda: {},
     )
     plugins = [
@@ -107,6 +108,10 @@ def test_skills_service_marks_inactive_plugin_skills(monkeypatch):
 
     result = SkillsService(core_lifecycle).get_skills()
 
+    assert result["runtime"] == "none"
+    skill_manager.list_skills.assert_called_once_with(
+        active_only=False, runtime="none", show_sandbox_path=False
+    )
     assert [skill["name"] for skill in result["skills"]] == [
         "local-skill",
         "active-plugin-skill",

--- a/tests/unit/test_astr_agent_tool_exec.py
+++ b/tests/unit/test_astr_agent_tool_exec.py
@@ -48,7 +48,8 @@ class _DoneRunner:
         return SimpleNamespace(role="assistant", completion_text="done")
 
 
-def test_build_handoff_toolset_keeps_permission_guards_for_default_tools():
+@pytest.mark.parametrize("runtime", ["none", "local", "sandbox", None])
+def test_build_handoff_toolset_keeps_permission_guards_for_default_tools(runtime):
     mgr = FunctionToolManager()
     plugin_tool = FunctionTool(
         name="admin_only_mcp",
@@ -59,10 +60,9 @@ def test_build_handoff_toolset_keeps_permission_guards_for_default_tools():
     mgr.func_list = [plugin_tool, handoff]
 
     event = _DummyEvent()
+    provider_settings = {} if runtime is None else {"computer_use_runtime": runtime}
     context = SimpleNamespace(
-        get_config=lambda **_kwargs: {
-            "provider_settings": {"computer_use_runtime": "none"}
-        },
+        get_config=lambda **_kwargs: {"provider_settings": provider_settings},
         get_llm_tool_manager=lambda: mgr,
     )
     run_context = ContextWrapper(context=SimpleNamespace(event=event, context=context))
@@ -72,6 +72,15 @@ def test_build_handoff_toolset_keeps_permission_guards_for_default_tools():
     assert toolset is not None
     assert isinstance(toolset.get_tool("admin_only_mcp"), _PermissionGuardedTool)
     assert toolset.get_tool("transfer_to_child") is None
+    assert (toolset.get_tool("astrbot_execute_python") is not None) == (
+        runtime == "local"
+    )
+    assert (toolset.get_tool("astrbot_execute_ipython") is not None) == (
+        runtime == "sandbox"
+    )
+    assert (toolset.get_tool("astrbot_execute_shell") is not None) == (
+        runtime in {"local", "sandbox"}
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_astr_main_agent.py
+++ b/tests/unit/test_astr_main_agent.py
@@ -1160,14 +1160,21 @@ class TestEnsurePersonaAndSkills:
         req = ProviderRequest()
         req.conversation = MagicMock(persona_id="no-skills")
 
-        await module._ensure_persona_and_skills(req, {}, mock_context, mock_event)
+        await module._ensure_persona_and_skills(
+            req, {"computer_use_runtime": "local"}, mock_context, mock_event
+        )
 
         assert "Workspace scoped skill." not in req.system_prompt
         assert "## Skills" not in req.system_prompt
 
     @pytest.mark.asyncio
-    async def test_ensure_skills_skips_workspace_skills_in_sandbox_runtime(
+    @pytest.mark.parametrize(
+        "runtime_settings",
+        [{}, {"computer_use_runtime": "none"}, {"computer_use_runtime": "sandbox"}],
+    )
+    async def test_ensure_skills_skips_workspace_skills_outside_local_runtime(
         self,
+        runtime_settings,
         monkeypatch,
         tmp_path,
         mock_event,
@@ -1214,7 +1221,7 @@ class TestEnsurePersonaAndSkills:
 
         await module._ensure_persona_and_skills(
             req,
-            {"computer_use_runtime": "sandbox"},
+            runtime_settings,
             mock_context,
             mock_event,
         )

--- a/tests/unit/test_astr_main_agent.py
+++ b/tests/unit/test_astr_main_agent.py
@@ -10,8 +10,11 @@ import pytest
 from astrbot.core import astr_main_agent as ama
 from astrbot.core.agent.mcp_client import MCPTool
 from astrbot.core.agent.message import Message, dump_messages_with_checkpoints
+from astrbot.core.agent.run_context import ContextWrapper
 from astrbot.core.agent.tool import FunctionTool, ToolSet
+from astrbot.core.astr_agent_tool_exec import FunctionToolExecutor
 from astrbot.core.conversation_mgr import Conversation
+from astrbot.core.cron.manager import CronJobManager
 from astrbot.core.message.components import File, Image, Plain, Reply, Video
 from astrbot.core.platform.astr_message_event import AstrMessageEvent
 from astrbot.core.platform.platform_metadata import PlatformMetadata
@@ -142,6 +145,95 @@ def _setup_conversation_for_build(conv_mgr, cid: str = "conv-id") -> MagicMock:
     return conversation
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("entrypoint", ["cron", "background"])
+@pytest.mark.parametrize("runtime", ["none", "local", "sandbox", None])
+@pytest.mark.parametrize("safety_mode", [True, False])
+async def test_proactive_agent_respects_runtime_and_safety_settings(
+    entrypoint,
+    runtime,
+    safety_mode,
+    mock_context,
+    mock_provider,
+    mock_event,
+    mock_conversation,
+    tmp_path,
+):
+    """Build real proactive requests without loading tools outside the runtime."""
+    provider_settings = {
+        "computer_use_require_admin": False,
+        "sandbox": {"booter": "cua"},
+    }
+    if runtime is not None:
+        provider_settings["computer_use_runtime"] = runtime
+    mock_context.get_config.return_value = {
+        "admins_id": [],
+        "provider_settings": provider_settings,
+        "agent_runner": {"config": {"persona": {"safety_mode": safety_mode}}},
+    }
+    mock_context.get_using_provider_async.return_value = mock_provider
+    mock_context.get_using_provider_async.side_effect = None
+    mock_event.unified_msg_origin = "test:FriendMessage:user123"
+    mock_event.role = "member"
+
+    with (
+        patch.object(
+            ama, "_get_session_conv", AsyncMock(return_value=mock_conversation)
+        ),
+        patch.object(ama, "_decorate_llm_request", AsyncMock()),
+        patch.object(ama, "_apply_kb", AsyncMock()),
+        patch.object(
+            ama, "_get_workspace_path_for_umo", AsyncMock(return_value=tmp_path)
+        ),
+        patch.object(ama, "AstrAgentContext"),
+        patch.object(ama, "AgentRunner") as runner_cls,
+        patch("astrbot.core.cron.manager.persist_agent_history", AsyncMock()),
+        patch("astrbot.core.astr_agent_tool_exec.persist_agent_history", AsyncMock()),
+    ):
+        runner = runner_cls.return_value
+        runner.reset = AsyncMock()
+        runner.step_until_done.return_value.__aiter__.return_value = []
+        runner.get_final_llm_resp.return_value = None
+
+        if entrypoint == "cron":
+            manager = CronJobManager(MagicMock())
+            manager.ctx = mock_context
+            await manager._woke_main_agent(
+                message="run scheduled task",
+                session_str=mock_event.unified_msg_origin,
+                delivery_session_str=mock_event.unified_msg_origin,
+                extras={"cron_job": {"id": "job-1"}, "cron_payload": {}},
+            )
+        else:
+            await FunctionToolExecutor._wake_main_agent_for_background_result(
+                ContextWrapper(
+                    context=MagicMock(context=mock_context, event=mock_event)
+                ),
+                task_id="task-1",
+                tool_name="long_tool",
+                result_text="done",
+                tool_args={},
+                note="task finished",
+                summary_name="BackgroundTask",
+            )
+
+        runner.reset.assert_awaited_once()
+        request = runner.reset.call_args.kwargs["request"]
+
+    tool_names = request.func_tool.names()
+    assert "send_message_to_user" in tool_names
+    assert "future_task" in tool_names
+    assert ("astrbot_execute_python" in tool_names) == (runtime == "local")
+    if runtime == "sandbox":
+        assert "astrbot_execute_ipython" in tool_names
+        assert "astrbot_cua_screenshot" in tool_names
+        assert "CUA Desktop Control" in request.system_prompt
+    else:
+        assert "astrbot_execute_ipython" not in tool_names
+    assert ("astrbot_execute_shell" in tool_names) == (runtime in {"local", "sandbox"})
+    assert (ama.LLM_SAFETY_MODE_SYSTEM_PROMPT in request.system_prompt) == safety_mode
+
+
 def test_append_system_reminders_includes_weekday(mock_event):
     """Test datetime reminder includes weekday information."""
     req = ProviderRequest(prompt="Hello")
@@ -235,6 +327,7 @@ class TestMainAgentBuildConfig:
         assert config.kb_agentic_mode is False
         assert config.file_extract_enabled is False
         assert config.llm_safety_mode is True
+        assert config.computer_use_runtime == "none"
 
     def test_config_with_custom_values(self):
         """Test MainAgentBuildConfig with custom values."""

--- a/tests/unit/test_computer.py
+++ b/tests/unit/test_computer.py
@@ -513,6 +513,28 @@ class TestBoxliteBooter:
 class TestComputerClient:
     """Tests for computer_client module functions."""
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("runtime", [None, "none", "local"])
+    async def test_get_booter_requires_explicit_runtime(self, runtime):
+        """An omitted runtime must not start or reuse a computer environment."""
+        from astrbot.core.computer import computer_client
+
+        provider_settings = {} if runtime is None else {"computer_use_runtime": runtime}
+        context = MagicMock()
+        context.get_config.return_value = {"provider_settings": provider_settings}
+        with (
+            patch.object(computer_client, "get_local_booter") as get_local_booter,
+            patch.object(computer_client, "session_booter", {"session": MagicMock()}),
+        ):
+            if runtime == "local":
+                result = await computer_client.get_booter(context, "session")
+                assert result is get_local_booter.return_value
+                get_local_booter.assert_called_once_with()
+            else:
+                with pytest.raises(RuntimeError, match="disabled by configuration"):
+                    await computer_client.get_booter(context, "session")
+                get_local_booter.assert_not_called()
+
     def test_get_local_booter(self):
         """Test get_local_booter returns singleton LocalBooter."""
         from astrbot.core.computer import computer_client

--- a/tests/unit/test_python_tools.py
+++ b/tests/unit/test_python_tools.py
@@ -1,6 +1,6 @@
 import platform
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -26,7 +26,47 @@ def test_local_python_tool_description_contains_os():
 
 
 @pytest.mark.asyncio
-async def test_local_python_tool_uses_session_workspace(tmp_path, monkeypatch):
+@pytest.mark.parametrize("runtime", ["none", "sandbox", "invalid", None])
+@pytest.mark.parametrize("role", ["member", "admin"])
+async def test_local_python_tool_rejects_nonlocal_runtime(runtime, role, monkeypatch):
+    """Reject retained local tools before accessing the host, regardless of role."""
+    get_local_booter = MagicMock()
+    workspace_root = AsyncMock()
+    monkeypatch.setattr(
+        "astrbot.core.tools.computer_tools.python.get_local_booter", get_local_booter
+    )
+    monkeypatch.setattr(
+        "astrbot.core.tools.computer_tools.python.workspace_root_for_context",
+        workspace_root,
+    )
+    context = ContextWrapper(
+        context=SimpleNamespace(
+            event=SimpleNamespace(
+                unified_msg_origin="onebot:FriendMessage:user123", role=role
+            ),
+            context=SimpleNamespace(
+                get_config=lambda **_kwargs: {
+                    "provider_settings": {
+                        "computer_use_runtime": runtime,
+                        "computer_use_require_admin": False,
+                    }
+                }
+            ),
+        )
+    )
+
+    result = await LocalPythonTool().call(context, code="print('ok')")
+
+    get_local_booter.assert_not_called()
+    workspace_root.assert_not_awaited()
+    assert result == "Error executing code: only local runtime is supported."
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("runtime_settings", [{}, {"computer_use_runtime": "local"}])
+async def test_local_python_tool_uses_session_workspace(
+    tmp_path, monkeypatch, runtime_settings
+):
     """Local Python execution should use the same workspace as local shell."""
     tool = LocalPythonTool()
     python_exec = AsyncMock(
@@ -55,7 +95,10 @@ async def test_local_python_tool_uses_session_workspace(tmp_path, monkeypatch):
             event=event,
             context=SimpleNamespace(
                 get_config=lambda **_kwargs: {
-                    "provider_settings": {"computer_use_require_admin": True}
+                    "provider_settings": {
+                        **runtime_settings,
+                        "computer_use_require_admin": True,
+                    }
                 }
             ),
         ),

--- a/tests/unit/test_python_tools.py
+++ b/tests/unit/test_python_tools.py
@@ -26,9 +26,20 @@ def test_local_python_tool_description_contains_os():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("runtime", ["none", "sandbox", "invalid", None])
+@pytest.mark.parametrize(
+    "runtime_settings",
+    [
+        {},
+        {"computer_use_runtime": "none"},
+        {"computer_use_runtime": "sandbox"},
+        {"computer_use_runtime": "invalid"},
+        {"computer_use_runtime": None},
+    ],
+)
 @pytest.mark.parametrize("role", ["member", "admin"])
-async def test_local_python_tool_rejects_nonlocal_runtime(runtime, role, monkeypatch):
+async def test_local_python_tool_rejects_nonlocal_runtime(
+    runtime_settings, role, monkeypatch
+):
     """Reject retained local tools before accessing the host, regardless of role."""
     get_local_booter = MagicMock()
     workspace_root = AsyncMock()
@@ -47,7 +58,7 @@ async def test_local_python_tool_rejects_nonlocal_runtime(runtime, role, monkeyp
             context=SimpleNamespace(
                 get_config=lambda **_kwargs: {
                     "provider_settings": {
-                        "computer_use_runtime": runtime,
+                        **runtime_settings,
                         "computer_use_require_admin": False,
                     }
                 }
@@ -63,10 +74,7 @@ async def test_local_python_tool_rejects_nonlocal_runtime(runtime, role, monkeyp
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("runtime_settings", [{}, {"computer_use_runtime": "local"}])
-async def test_local_python_tool_uses_session_workspace(
-    tmp_path, monkeypatch, runtime_settings
-):
+async def test_local_python_tool_uses_session_workspace(tmp_path, monkeypatch):
     """Local Python execution should use the same workspace as local shell."""
     tool = LocalPythonTool()
     python_exec = AsyncMock(
@@ -96,7 +104,7 @@ async def test_local_python_tool_uses_session_workspace(
             context=SimpleNamespace(
                 get_config=lambda **_kwargs: {
                     "provider_settings": {
-                        **runtime_settings,
+                        "computer_use_runtime": "local",
                         "computer_use_require_admin": True,
                     }
                 }


### PR DESCRIPTION
Cron and background-result wake-ups omitted the session's computer runtime when building the main agent, so disabled or sandbox configurations could receive local tools. These paths now inherit the runtime and sandbox settings, and local Python rejects execution outside local mode even if a tool instance was retained.

### Modifications

- Pass runtime, sandbox configuration, and persona safety settings through both proactive wake-up paths.
- Default missing `computer_use_runtime` to `none` consistently in agent construction, normal chat, persona/skill loading, handoff tool construction, local-runtime checks, computer-booter selection, and dashboard skill metadata/capability checks.
- Check the effective runtime before local Python accesses the host booter or creates a workspace, while preserving the existing administrator permission check.
- Preserve explicitly configured local and sandbox behavior. Omitted runtime now disables computer access; callers that need local tools must select `local` explicitly.
- Cover disabled/missing/local/sandbox configuration, CUA tool selection, safety settings, retained Python tools, workspace skill exclusion, handoffs, and cached computer environments with regression tests.

### Test Results

- Original regression cases: 23 failed before the initial fix; all 28 targeted cases passed after it.
- Missing-runtime follow-up: 6 failures reproduced before aligning the remaining defaults; all 23 focused cases passed after the change.
- Full Python suite: **2370 passed, 2 failed** with `uv run --no-sync pytest tests -q --tb=short --disable-warnings` on macOS/Python 3.12. Both failures are unrelated log-capture assertions in `tests/unit/test_dashboard_dist_resolution.py`; the exact same two failures were reproduced in a detached worktree at the preceding commit `6a7052c02`. The warnings appear on stdout but are absent from `caplog.text`.
- `cd dashboard && pnpm typecheck`: passed.
- `uv run --no-sync ruff format .`: 504 files unchanged.
- `uv run --no-sync ruff check .`, Ruff checks on changed test files, and `git diff --check`: passed.

The new request-building tests mock external LLM and sandbox execution. Explicit local execution retains workspace and timeout behavior; sandbox wake-ups select sandbox Python and the configured CUA tools. Disabled runtime retains scheduled-task and message-delivery tools without loading computer tools.

### Checklist

- [x] Changes are covered by regression and compatibility tests.
- [x] No new dependencies.
- [x] No backend API or schema changes.
- [x] No malicious code introduced.
