### PR TITLE
feat: include Python version in metrics uploads

### DIFF
--- a/astrbot/core/utils/metrics.py
+++ b/astrbot/core/utils/metrics.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import platform
 import socket
 import sys
 import uuid
@@ -192,6 +193,7 @@ class Metric:
         payload_metrics = dict(metrics_data)
         payload_metrics["v"] = VERSION
         payload_metrics["os"] = sys.platform
+        payload_metrics["python_version"] = platform.python_version()
         try:
             payload_metrics["hn"] = socket.gethostname()
         except Exception:


### PR DESCRIPTION
Metrics uploads currently include the AstrBot version and operating system but omit the Python runtime version. Add `python_version` using `platform.python_version()` so runtime usage can be measured.

Closes #9960.

### Modifications

- Include the full Python version (for example, `3.12.12`) in the shared metrics payload for both immediate and batched uploads.
- [x] This is not a breaking change.

### Verification Steps and Test Results

- `uv run --no-sync ruff format .`: 504 files unchanged.
- `uv run --no-sync ruff check .`: all checks passed.
- `git diff --check`: passed.
- Local smoke check with mocked HTTP: immediate and batched uploads both include the runtime version, batched counters remain correct, and both the environment variable and configuration opt-outs prevent uploads.

### Checklist

- [x] The feature was requested in #9960.
- [x] Verification steps and results are provided above.
- [x] No new dependencies are introduced.
- [x] No malicious code is introduced.

## Summary by Sourcery

New Features:
- Include the full Python runtime version in metrics upload payloads.