### PR TITLE
chore: bump version to 4.28.0

### DIFF
--- a/astrbot/__init__.py
+++ b/astrbot/__init__.py
@@ -1,4 +1,4 @@
 import logging
 
-__version__ = "4.28.0-beta.1"
+__version__ = "4.28.0"
 logger = logging.getLogger("astrbot")

--- a/changelogs/v4.28.0.md
+++ b/changelogs/v4.28.0.md
@@ -1,8 +1,8 @@
 ## [4.28.0] - 2026-09-08
 
-> 四时之景不同，而乐亦无穷也。
->
-> Each season brings its own beauty, and the joy is endless.
+四时之景不同，而乐亦无穷也。
+
+Each season brings its own beauty, and the joy is endless.
 
 ### Major Additions
 

--- a/changelogs/v4.28.0.md
+++ b/changelogs/v4.28.0.md
@@ -1,0 +1,120 @@
+## [4.28.0] - 2026-09-08
+
+> 四时之景不同，而乐亦无穷也。
+>
+> Each season brings its own beauty, and the joy is endless.
+
+### Major Additions
+
+- Redesigned the WebUI pages for model providers, bots, and profiles, and consolidated logs, traces, conversation management, and data into the **Data & Logs** page. Removed the **Agent Runner** from model providers and embedded its settings into each profile. (#9820, #9825, #9821, #9883, #9846)
+- Redesigned the default and local T2I rendering. (#9803)
+- Enriched unified group metadata across messaging platform adapters. (#9851)
+- Automatically record readable names for unified message origins (UMOs), such as group and user names, making them easier to find in the WebUI. (#9909)
+- Added masked secret fields for sensitive values in the WebUI and plugin configurations. (#9824)
+- Added batch deletion to the WebUI skill management page. (#9906)
+- Added AnySearch as a built-in web search provider. (#9767)
+- Added support for password-style plugin configuration fields and masked sensitive profile fields by default. (#9824)
+
+### Major Optimizations
+
+- Improved how browser password managers recognize the WebUI login page. (#9830)
+- Adapted model provider icons for dark mode. (#9647)
+- Improved context handling for future-task agents. (#9818)
+- Made the skill editor dialog responsive on smaller screens. (#9873)
+- Stabilized the OpenAI tool schema order by sorting tools alphabetically by name. (#9798)
+
+### Major Fixes
+
+- Fixed an issue where DingTalk could remain in an unknown `CREATING` state after scanning the QR code, preventing app creation from continuing. (#9808)
+- Fixed an issue where commands in Lark groups would not trigger when the bot mention appeared before the command. (#9872)
+- Isolated rate limits by unified message origin (UMO). (#9814)
+- Aligned Anthropic API Base URL handling with the OpenAI API; `/v1` must now be included in the configured URL. (#9802)
+- Fixed cached-token usage accounting for Anthropic and Gemini. (#9880, #9881)
+- Applied the `max_agent_step` configuration to scheduled-task and background-task agents. (#9801)
+- Preserved text in Lark mixed text-and-image messages. (#9841)
+- Displayed the create-folder button in the mobile persona manager. (#9812)
+
+## 中文
+
+### 主要新增
+
+- 重新设计 WebUI 的模型提供商页、机器人页和配置文件页，并将日志、追踪、对话管理、数据页综合为「数据与日志」页。移除模型提供商的 “Agent 执行器”，将其内嵌到各个配置文件中。 (#9820, #9825, #9821, #9883, #9846)
+- 重新设计默认和本地的 T2I 渲染效果。 (#9803)
+- 丰富各消息平台适配器的统一群组元数据 (#9851)
+- 自动记录统一消息来源（UMO）的可读名称（如群名、用户名），方便在 WebUI 查询。 (#9909)
+- 为 WebUI 和插件配置中的敏感值新增掩码密钥字段。 (#9824)
+- 为 WebUI 技能管理页新增批量删除功能。 (#9906)
+- 新增 AnySearch 内置网页搜索服务商。 (#9767)
+- 支持插件配置项使用密码效果的字段，并默认将配置文件中敏感字段使用密码效果。 (#9824)
+
+### 主要优化
+
+- 改进浏览器自动记忆密码功能对 WebUI 登录页的识别逻辑。 (#9830)
+- 使模型提供商图标适配深色模式。 (#9647)
+- 优化未来任务 Agent 的上下文。 (#9818)
+- 使技能编辑器对话框适配小屏幕。 (#9873)
+- 按工具名字典序稳定 OpenAI 工具 Schema 的顺序。 (#9798)
+
+### 主要修复
+
+- 钉钉部分情况下扫码之后出现 CREATING 未知状态导致无法继续创建。 (#9808)
+- 修复飞书群里当 at 机器人在前而命令在后会无法触发命令的问题。 (#9872)
+- 按统一消息来源（UMO）隔离限流。 (#9814)
+- 使 Anthropic API Base URL 逻辑与 OpenAI API 保持一致，需要输入 /v1。 (#9802)
+- 修复 Anthropic 和 Gemini 有关缓存 token 的用量统计口径。 (#9880, #9881)
+- 将 max_agent_step 配置应用到定时任务和后台任务 Agent。 (#9801)
+- 保留飞书图文混合消息中的文本。 (#9841)
+- 在移动端的人格管理器中显示新建文件夹按钮。 (#9812)
+
+
+[4.28.0-beta.1]: https://github.com/AstrBotDevs/AstrBot/compare/v4.27.4...v4.28.0-beta.1
+
+## Changes Since 4.28.0-beta.1
+
+### Additions and Optimizations
+
+- Added Japanese localization for the WebUI and built-in plugins. (#9955)
+- Expanded syntax highlighting for common languages in ChatUI and added Go highlighting to the T2I renderer. (#9892)
+- Included the Python version in metrics uploads. (#9973)
+- Enabled unit test CI on Windows, macOS, and Linux, and fixed cross-platform test compatibility. (#9954)
+
+### Fixes
+
+- Added missing English translations in the WebUI. (#9896)
+- Fixed the namespace of the Chinese provider synchronization translations. (#9932)
+- Fixed remote sandbox skill archive paths on Windows hosts. (#8182)
+- Fixed plugin market detail pages displaying the wrong information for plugins with the same metadata name. (#9925)
+- Fixed serialization of Gemini thinking levels. (#9899)
+- Preserved user-defined content in dictionary-type configuration items. (#9958)
+- Preserved the existing context prefix during tool parameter re-query instead of modifying the initial system message. (#9957)
+- Removed the invalid “All” page size option from knowledge base document lists. (#9908)
+- Applied Markdown rendering to proactive QQ Official messages sent through `send_by_session`. (#9914)
+- Made proactive agents respect computer runtime settings and treated missing runtime settings as disabled. (#9971)
+- Included WebChat conversations in history lists by default and exposed WebChat in the bot ID filter. (#9910)
+- Isolated event loop watchdog stack dumps from other traceback output. (#9941)
+
+## 自 4.28.0-beta.1 以来的变更
+
+### 新增与优化
+
+- 为 WebUI 和内置插件新增日语本地化。 (#9955)
+- 扩展 ChatUI 常用语言的代码高亮，并为 T2I 渲染器加入 Go 语法高亮。 (#9892)
+- 在统计数据上报中包含 Python 版本。 (#9973)
+- 在 Windows、macOS 和 Linux 上启用单元测试 CI，并修复测试的跨平台兼容性。 (#9954)
+
+### 修复
+
+- 补齐 WebUI 缺失的英文翻译。 (#9896)
+- 修复中文模型提供商同步翻译的命名空间。 (#9932)
+- 修复 Windows 宿主机向远端沙箱同步技能时的压缩包路径。 (#8182)
+- 修复插件市场中 metadata name 相同的插件详情页显示错误信息的问题。 (#9925)
+- 修复 Gemini thinking level 的序列化。 (#9899)
+- 保留字典类型配置项中的用户自定义内容。 (#9958)
+- 工具参数补全请求保留已有上下文前缀，不再修改首条系统消息。 (#9957)
+- 移除知识库文档列表中无效的 “All” 分页选项。 (#9908)
+- 为通过 `send_by_session` 主动发送的 QQ 官方机器人消息应用 Markdown 渲染。 (#9914)
+- 使主动 Agent 遵循计算机运行时配置，并在缺少该配置时默认禁用计算机运行时。 (#9971)
+- 默认在对话历史列表中显示 WebChat 会话，并支持通过机器人 ID 筛选 WebChat。 (#9910)
+- 将事件循环看门狗的堆栈转储与其他 traceback 输出隔离。 (#9941)
+
+[4.28.0]: https://github.com/AstrBotDevs/AstrBot/compare/v4.28.0-beta.1...v4.28.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "AstrBot"
-version = "4.28.0-beta.1"
+version = "4.28.0"
 description = "Easy-to-use multi-platform LLM chatbot and development framework"
 readme = "README.md"
 license = { text = "AGPL-3.0-or-later" }


### PR DESCRIPTION
Prepare AstrBot 4.28.0 from master by synchronizing the project and package versions.

Reuse the 4.28.0-beta.1 changelog text, update the release heading and date, and append all 16 changes since beta.1 in English and Chinese. Add the selected Chinese epigraph with its English translation underneath.

Validation: `uv run ruff format .`, `uv run ruff check .`, and `git diff --check` passed. Verified that the beta changelog text is preserved, all 16 subsequent changes appear in both languages, and version metadata is synchronized at 4.28.0.

## Summary by Sourcery

Enhancements:
- Synchronize AstrBot version metadata for the 4.28.0 release and publish the corresponding bilingual changelog, including changes since beta.1.