### PR TITLE
fix(star): bind and unload hooks registered from plugin submodules

### DIFF
--- a/astrbot/core/star/star_handler.py
+++ b/astrbot/core/star/star_handler.py
@@ -6,9 +6,38 @@ from dataclasses import dataclass, field
 from typing import Any, Generic, Literal, TypeVar, overload
 
 from .filter import HandlerFilter
-from .star import star_map
+from .star import StarMetadata, star_map
 
 T = TypeVar("T", bound="StarHandlerMetadata")
+
+
+def plugin_package_root(plugin: StarMetadata) -> str | None:
+    """The module subtree a plugin owns, derived from its root directory.
+
+    ``module_path`` points at the entry module (``...my_plugin.main``), but a
+    plugin may define hooks in sibling modules (``...my_plugin.hooks``), so
+    matching needs the package root (``...my_plugin``).
+    """
+    if not plugin.root_dir_name:
+        return None
+    base = "astrbot.builtin_stars." if plugin.reserved else "data.plugins."
+    return base + plugin.root_dir_name
+
+
+def plugin_for_handler_module(module_path: str) -> StarMetadata | None:
+    """Resolve the plugin a handler module belongs to.
+
+    ``star_map`` is keyed by entry module, so a helper-module handler misses
+    the exact lookup; fall back to matching the plugin's package root.
+    """
+    plugin = star_map.get(module_path)
+    if plugin is not None:
+        return plugin
+    for plugin in star_map.values():
+        root = plugin_package_root(plugin)
+        if root and (module_path == root or module_path.startswith(root + ".")):
+            return plugin
+    return None
 
 
 class StarHandlerRegistry(Generic[T]):
@@ -162,12 +191,12 @@ class StarHandlerRegistry(Generic[T]):
                 continue
             # 过滤启用状态
             if only_activated:
-                plugin = star_map.get(handler.handler_module_path)
+                plugin = plugin_for_handler_module(handler.handler_module_path)
                 if not (plugin and plugin.activated):
                     continue
             # 过滤插件白名单
             if plugins_name is not None and plugins_name != ["*"]:
-                plugin = star_map.get(handler.handler_module_path)
+                plugin = plugin_for_handler_module(handler.handler_module_path)
                 if not plugin:
                     continue
                 if (
@@ -191,16 +220,21 @@ class StarHandlerRegistry(Generic[T]):
     def get_handlers_by_module_name(
         self,
         module_name: str,
+        plugin_package: str | None = None,
     ) -> list[StarHandlerMetadata]:
-        # A plugin's hooks can live in helper modules under its package root;
-        # an exact match misses those, leaving them unbound at load and
-        # leaked at unload.
-        prefix = module_name + "."
+        # A plugin's hooks can live in helper modules beside or below its
+        # entry module; an exact match misses those, leaving them unbound at
+        # load and leaked at unload. The caller that knows the plugin's root
+        # directory passes the package root so sibling modules match too.
+        prefixes = [module_name + "."]
+        if plugin_package and plugin_package != module_name:
+            prefixes.append(plugin_package + ".")
         return [
             handler
             for handler in self._handlers
             if handler.handler_module_path == module_name
-            or handler.handler_module_path.startswith(prefix)
+            or handler.handler_module_path == plugin_package
+            or any(handler.handler_module_path.startswith(p) for p in prefixes)
         ]
 
     def clear(self) -> None:

--- a/astrbot/core/star/star_handler.py
+++ b/astrbot/core/star/star_handler.py
@@ -192,10 +192,15 @@ class StarHandlerRegistry(Generic[T]):
         self,
         module_name: str,
     ) -> list[StarHandlerMetadata]:
+        # A plugin's hooks can live in helper modules under its package root;
+        # an exact match misses those, leaving them unbound at load and
+        # leaked at unload.
+        prefix = module_name + "."
         return [
             handler
             for handler in self._handlers
             if handler.handler_module_path == module_name
+            or handler.handler_module_path.startswith(prefix)
         ]
 
     def clear(self) -> None:

--- a/astrbot/core/star/star_manager.py
+++ b/astrbot/core/star/star_manager.py
@@ -51,7 +51,11 @@ from .context import Context
 from .error_messages import format_plugin_error
 from .filter.permission import PermissionType, PermissionTypeFilter
 from .star import star_map, star_registry
-from .star_handler import EventType, star_handlers_registry
+from .star_handler import (
+    EventType,
+    plugin_package_root,
+    star_handlers_registry,
+)
 from .updater import PLUGIN_METADATA_FILENAMES, _PluginUpdater
 
 try:
@@ -1255,6 +1259,7 @@ class PluginManager:
                     related_handlers = (
                         star_handlers_registry.get_handlers_by_module_name(
                             metadata.module_path,
+                            plugin_package=plugin_package_root(metadata),
                         )
                     )
                     for handler in related_handlers:
@@ -1376,6 +1381,7 @@ class PluginManager:
                 full_names = []
                 for handler in star_handlers_registry.get_handlers_by_module_name(
                     metadata.module_path,
+                    plugin_package=plugin_package_root(metadata),
                 ):
                     full_names.append(handler.handler_full_name)
 
@@ -1888,6 +1894,7 @@ class PluginManager:
                 break
         for handler in star_handlers_registry.get_handlers_by_module_name(
             plugin_module_path,
+            plugin_package=plugin_package_root(plugin) if plugin else None,
         ):
             logger.info(
                 f"Removed handler {handler.handler_name} from plugin {plugin_name} "

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -2449,3 +2449,106 @@ async def test_repeated_deactivated_loads_bind_handlers_once_when_activated(
         llm_tools.func_list = original_func_list
         cast(Any, plugin_manager_pm.context).stars.remove(metadata)
         _clear_star_runtime_state()
+
+
+@pytest.mark.asyncio
+async def test_submodule_hook_binds_on_activation_and_unloads_with_plugin(
+    plugin_manager_pm: PluginManager, monkeypatch
+):
+    """A hook defined in a helper submodule of a plugin package must bind at
+    activation and unload with the plugin (#9938: the exact-module match left
+    such handlers raw, so calling them raised "missing positional argument").
+    """
+    _clear_star_runtime_state()
+    plugin_name = "demo_plugin"
+    module_path = f"data.plugins.{plugin_name}.main"
+    submodule_path = f"{module_path}.hooks"
+
+    class DemoPlugin:
+        def __init__(self, context):
+            self.context = context
+
+        async def initialize(self):
+            pass
+
+    metadata = star_manager_module.StarMetadata(
+        name=plugin_name,
+        author="AstrBot Team",
+        desc="Demo plugin",
+        version="1.0.0",
+        root_dir_name=plugin_name,
+        module_path=module_path,
+        star_cls_type=cast(Any, DemoPlugin),
+        star_cls=None,
+        activated=False,
+    )
+    cast(Any, plugin_manager_pm.context).stars.append(metadata)
+    star_manager_module.star_map[module_path] = metadata
+    star_manager_module.star_registry.append(metadata)
+
+    async def raw_hook_handler(plugin, event):
+        return plugin, event
+
+    raw_hook_handler.__module__ = submodule_path
+    hook_handler = StarHandlerMetadata(
+        event_type=EventType.OnDecoratingResultEvent,
+        handler_full_name=f"{submodule_path}_raw_hook_handler",
+        handler_name="raw_hook_handler",
+        handler_module_path=submodule_path,
+        handler=raw_hook_handler,
+        event_filters=[],
+    )
+    star_manager_module.star_handlers_registry.append(hook_handler)
+
+    preferences = {"inactivated_plugins": [module_path], "inactivated_llm_tools": []}
+
+    async def mock_global_get(key, default=None):
+        return preferences.get(key, default)
+
+    async def mock_global_put(key, value):
+        preferences[key] = value
+
+    async def mock_import_plugin_with_dependency_recovery(
+        path, module_str, root_dir_name, requirements_path, *, reserved=False
+    ):
+        del module_str, root_dir_name, requirements_path, reserved
+        assert path == module_path
+        return ModuleType(module_path)
+
+    async def mock_sync_command_configs():
+        return None
+
+    monkeypatch.setattr(star_manager_module.sp, "global_get", mock_global_get)
+    monkeypatch.setattr(star_manager_module.sp, "global_put", mock_global_put)
+    monkeypatch.setattr(
+        plugin_manager_pm,
+        "_get_plugin_modules",
+        lambda: [{"pname": plugin_name, "module": "main"}],
+    )
+    monkeypatch.setattr(
+        plugin_manager_pm,
+        "_import_plugin_with_dependency_recovery",
+        mock_import_plugin_with_dependency_recovery,
+    )
+    monkeypatch.setattr(plugin_manager_pm, "_load_plugin_metadata", lambda **_: None)
+    monkeypatch.setattr(
+        star_manager_module, "sync_command_configs", mock_sync_command_configs
+    )
+
+    try:
+        success, error = await plugin_manager_pm.load(specified_module_path=module_path)
+        assert success is True and error is None
+        assert hook_handler.handler is raw_hook_handler  # deactivated: stays raw
+
+        await plugin_manager_pm.turn_on_plugin(plugin_name)
+
+        assert isinstance(hook_handler.handler, functools.partial)
+        assert hook_handler.handler.func is raw_hook_handler
+        assert hook_handler.handler.args == (metadata.star_cls,)
+        assert await hook_handler.handler("event") == (metadata.star_cls, "event")
+
+        await plugin_manager_pm._unbind_plugin(plugin_name, module_path)
+        assert hook_handler not in star_manager_module.star_handlers_registry
+    finally:
+        cast(Any, plugin_manager_pm.context).stars.remove(metadata)
+        _clear_star_runtime_state()

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -2462,7 +2462,9 @@ async def test_submodule_hook_binds_on_activation_and_unloads_with_plugin(
     _clear_star_runtime_state()
     plugin_name = "demo_plugin"
     module_path = f"data.plugins.{plugin_name}.main"
-    submodule_path = f"{module_path}.hooks"
+    # Sibling of the entry module: the common real-world layout from #9938
+    # (my_plugin/hooks.py next to my_plugin/main.py), not a child of it.
+    submodule_path = f"data.plugins.{plugin_name}.hooks"
 
     class DemoPlugin:
         def __init__(self, context):
@@ -2546,6 +2548,16 @@ async def test_submodule_hook_binds_on_activation_and_unloads_with_plugin(
         assert hook_handler.handler.func is raw_hook_handler
         assert hook_handler.handler.args == (metadata.star_cls,)
         assert await hook_handler.handler("event") == (metadata.star_cls, "event")
+
+        # The pipeline must actually select the bound handler: star_map is
+        # keyed by the entry module, so dispatch needs the package-aware
+        # lookup, not an exact star_map.get(handler_module_path).
+        selected = (
+            star_manager_module.star_handlers_registry.get_handlers_by_event_type(
+                EventType.OnDecoratingResultEvent
+            )
+        )
+        assert hook_handler in selected
 
         await plugin_manager_pm._unbind_plugin(plugin_name, module_path)
         assert hook_handler not in star_manager_module.star_handlers_registry


### PR DESCRIPTION
### Motivation / 动机

Fixes #9938. A hook defined in a helper submodule of a plugin package (e.g. `my_plugin/hooks.py` imported from the entry module) was never bound to the plugin instance, so the pipeline called the raw function and raised `TypeError: on_decorating_result() missing 1 required positional argument: 'event'`.

插件的钩子如果写在辅助子模块里（而不是入口主模块），加载时不会被绑定到插件实例，管线调用裸函数直接报缺参。

### Modifications / 改动点

- `astrbot/core/star/star_handler.py`: `get_handlers_by_module_name` now matches the whole plugin package (entry module plus anything under it). Handler registration records `handler.__module__` (where the hook is defined), but both the load/`turn_on_plugin` binding loop and `_unbind_plugin` matched on the exact entry module only, so submodule hooks were never bound and were also leaked in the registry at unload.
- `tests/test_plugin_manager.py`: new regression test.

### Test Results / 测试结果

New test `test_submodule_hook_binds_on_activation_and_unloads_with_plugin`: registers an `on_decorating_result` hook under `<plugin>.main.hooks`, loads the plugin deactivated twice (handler stays raw), activates it and asserts the handler is a `functools.partial` bound to the live instance and callable with just the event, then unbinds and asserts the handler leaves the registry.

- Red on unmodified master (fails at the binding assertion), green here.
- Full `tests/test_plugin_manager.py`: 63 passed.
- `ruff format` + `ruff check` clean on both touched files.

Environment: macOS arm64, Python 3.12 via `uv run pytest`.

---

### Checklist / 检查清单

- [x] 😊 This is a bug fix for an existing issue (#9938); no new feature. / 这是针对已有 issue 的修复，无新功能。
- [x] 👀 My changes have been well-tested, with verification steps and results above. / 改动已充分测试，验证步骤与结果见上。
- [x] 🤓 No new dependencies introduced. / 未引入新依赖。
- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

## Summary by Sourcery

Fix plugin lifecycle handling so hooks registered from helper submodules are bound, dispatched, and unloaded with their owning plugin.

Bug Fixes:
- Bind hooks defined in plugin submodules to the plugin instance during activation and remove them correctly when the plugin is unloaded.
- Resolve plugin ownership for submodule handlers so activation filtering and event dispatch select them correctly.

Tests:
- Add regression coverage confirming submodule hooks remain raw while inactive, bind on activation, dispatch correctly, and are removed on unload.