### PR TITLE
fix(provider): opt in server-side tool invocations for gemini built-in tools

### DIFF
--- a/astrbot/core/provider/sources/gemini_source.py
+++ b/astrbot/core/provider/sources/gemini_source.py
@@ -220,6 +220,13 @@ class ProviderGoogleGenAI(Provider):
                     )
                 )
             )
+            if any(
+                t.google_search or t.code_execution or t.url_context for t in tool_list
+            ):
+                # The Gemini API rejects requests that combine built-in tools
+                # (google_search / code_execution / url_context) with function
+                # calling unless server-side tool invocations are opted in.
+                tool_config.include_server_side_tool_invocations = True
 
         # oper thinking config
         thinking_config = None

--- a/tests/test_gemini_source.py
+++ b/tests/test_gemini_source.py
@@ -206,6 +206,69 @@ def test_gemini_extract_usage_without_cache_keeps_full_prompt_tokens():
     assert usage.output == 20
 
 
+def _make_func_toolset() -> SimpleNamespace:
+    func_desc = {
+        "function_declarations": [
+            {
+                "name": "search",
+                "description": "Search the web",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ]
+    }
+    return SimpleNamespace(get_func_desc_google_genai_style=lambda: func_desc)
+
+
+@pytest.mark.asyncio
+async def test_gemini_server_side_tool_invocations_enabled_with_builtin_and_functions():
+    model = "gemini-3.8-flash"
+    provider = ProviderGoogleGenAI.__new__(ProviderGoogleGenAI)
+    provider.provider_config = {"gm_native_search": True}
+    provider.provider_settings = {}
+    provider.model_name = model
+    provider.safety_settings = []
+
+    config = await provider._prepare_query_config(
+        {"model": model}, tools=_make_func_toolset()
+    )
+
+    assert config.tool_config is not None
+    assert config.tool_config.include_server_side_tool_invocations is True
+
+
+@pytest.mark.asyncio
+async def test_gemini_server_side_tool_invocations_unset_without_builtin_tools():
+    model = "gemini-3.8-flash"
+    provider = ProviderGoogleGenAI.__new__(ProviderGoogleGenAI)
+    provider.provider_config = {}
+    provider.provider_settings = {}
+    provider.model_name = model
+    provider.safety_settings = []
+
+    config = await provider._prepare_query_config(
+        {"model": model}, tools=_make_func_toolset()
+    )
+
+    assert config.tool_config is not None
+    assert config.tool_config.include_server_side_tool_invocations is None
+
+
+@pytest.mark.asyncio
+async def test_gemini_tool_config_absent_with_only_builtin_tools():
+    model = "gemini-3.8-flash"
+    provider = ProviderGoogleGenAI.__new__(ProviderGoogleGenAI)
+    provider.provider_config = {"gm_native_search": True}
+    provider.provider_settings = {}
+    provider.model_name = model
+    provider.safety_settings = []
+
+    config = await provider._prepare_query_config({"model": model})
+
+    assert config.tool_config is None
+    assert config.tools is not None
+    assert any(t.google_search for t in config.tools)
+
+
 @pytest.mark.asyncio
 async def test_gemini_get_models_retries_transient_request_error(monkeypatch):
     monkeypatch.setattr(request_retry, "REQUEST_RETRY_WAIT_MIN_S", 0)


### PR DESCRIPTION
Fixes #9937 (built-in tool + function calling 400 error)

## Problem

With the `google_gemini` API format, enabling any built-in tool (e.g. native search) while function calling tools are also declared makes every request fail with:

```
400 {'error': {'message': 'Please enable tool_config.include_server_side_tool_invocations to use Built-in tools with Function calling.'}}
```

Root cause: `_prepare_query_config` builds `ToolConfig` with only `function_calling_config` and never sets `include_server_side_tool_invocations`, while the Gemini API requires opting in whenever built-in tools and function declarations coexist in one request.

## Fix

In `ProviderGoogleGenAI._prepare_query_config`, when function declarations and any built-in tool (`google_search` / `code_execution` / `url_context`) are both present in the tool list, set `tool_config.include_server_side_tool_invocations = True`.

Requests containing only one kind of tool are unchanged: the flag stays unset for function-calling-only requests, and `tool_config` remains `None` for built-in-tool-only requests.

## Scope note

The second error reported in #9937 (functionResponse `name`/`id` mismatch, e.g. `call_513417` vs `web_search_exa`) is a separate root cause already covered by #9760 / #9761 and is intentionally not addressed here.

## Testing

- `uv run pytest tests/test_gemini_source.py` — 14 passed (3 new regression tests: flag enabled when both tool kinds coexist, flag unset for function-calling-only, `tool_config` absent for built-in-tool-only)
- `uv run pytest tests/ -k 'provider or gemini or tool'` — 435 passed
- `ruff format` / `ruff check` clean

## Summary by Sourcery

Allow Gemini requests to combine built-in tools with function calling without triggering API validation errors.

Bug Fixes:
- Enable Gemini server-side tool invocations when built-in tools and function-calling declarations are used together, preventing API request failures.

Tests:
- Add regression coverage for mixed-tool requests and unchanged behavior for function-calling-only and built-in-tool-only requests.