### PR TITLE
feat(provider): add ScitiX as a built-in OpenAI-compatible provider preset

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1629,6 +1629,18 @@ CONFIG_METADATA_2 = {
                         "proxy": "",
                         "custom_headers": {},
                     },
+                    "ScitiX": {
+                        "id": "scitix",
+                        "provider": "scitix",
+                        "type": "openai_chat_completion",
+                        "provider_type": "chat_completion",
+                        "enable": True,
+                        "key": [],
+                        "api_base": "https://api.scitix.ai/model-api/v1",
+                        "timeout": 120,
+                        "proxy": "",
+                        "custom_headers": {},
+                    },
                     "PPIO": {
                         "id": "ppio",
                         "provider": "ppio",

--- a/dashboard/src/utils/providerUtils.js
+++ b/dashboard/src/utils/providerUtils.js
@@ -20,6 +20,7 @@ export function getProviderIcon(type) {
     'zhipu': 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/zhipu.svg',
     'nvidia': 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/nvidia-color.svg',
     'siliconflow': 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/siliconcloud.svg',
+    'scitix': 'https://avatars.githubusercontent.com/u/176687877?v=4',
     'moonshot': 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/kimi.svg',
     'kimi': 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/kimi.svg',
     'kimi-code': 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/kimi.svg',


### PR DESCRIPTION
Adds ScitiX (https://api.scitix.ai/model-api/v1) to the provider config templates so it shows up as a first-class preset in the provider dropdown, alongside SiliconFlow / PPIO / 302.AI. Uses the standard openai_chat_completion type; the user selects ScitiX and fills in their API key and model. Also registers the provider icon in the dashboard.

<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->
<!--请描述此项更改的动机：它解决了什么问题？（例如：修复了 XX issue，添加了 YY 功能）-->

### Modifications / 改动点
- `astrbot/core/config/default.py`: add the ScitiX preset (standard `openai_chat_completion` type, `api_base: https://api.scitix.ai/model-api/v1`). Users select ScitiX, then fill in their API key and model.
- `dashboard/src/utils/providerUtils.js`: register the provider icon.
<!--Please summarize your changes: What core files were modified? What functionality was implemented?-->
<!--请总结你的改动：哪些核心文件被修改了？实现了什么功能？-->

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果
Verified locally: config parses; an OpenAI `/chat/completions` request to `https://api.scitix.ai/model-api/v1` returns HTTP 200; the preset renders in the provider dropdown with its icon.
<!--Please paste screenshots, GIFs, or test logs here as evidence of executing the "Verification Steps" to prove this change is effective.-->
<!--请粘贴截图、GIF 或测试日志，作为执行“验证步骤”的证据，证明此改动有效。-->

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [ ] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Add ScitiX as a first-class provider option for OpenAI-compatible chat completions.

New Features:
- Add ScitiX as a built-in OpenAI-compatible provider preset with its API endpoint and standard chat-completion configuration.
- Display a ScitiX icon in the dashboard provider selector.