### PR TITLE
fix(webui): fall back to WebChat session titles in conversation history

### DIFF
--- a/astrbot/core/db/sqlite.py
+++ b/astrbot/core/db/sqlite.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from deprecated import deprecated
-from sqlalchemy import CursorResult, Row, case, not_
+from sqlalchemy import CursorResult, Row, case, literal, not_
 from sqlalchemy.dialects.sqlite import dialect as sqlite_dialect
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -46,6 +46,31 @@ from astrbot.core.sentinels import NOT_GIVEN
 
 TxResult = T.TypeVar("TxResult")
 CRON_FIELD_NOT_SET = object()
+
+
+def _webchat_session_title_match(keyword: str):
+    """Build a correlated EXISTS condition matching WebChat session titles.
+
+    WebChat generates its title on the platform session instead of the
+    conversation row, so the conversation is matched through the unified
+    message origin suffix ``!<session_id>``.
+
+    Args:
+        keyword: Search text matched against the session display name.
+
+    Returns:
+        A SQLAlchemy EXISTS expression usable inside a conversation query.
+    """
+    return (
+        select(1)
+        .where(col(PlatformSession.display_name).ilike(f"%{keyword}%"))
+        .where(
+            col(ConversationV2.user_id).like(
+                literal("%!").concat(col(PlatformSession.session_id)),
+            )
+        )
+        .exists()
+    )
 
 
 class SQLiteDatabase(BaseDatabase):
@@ -362,6 +387,8 @@ class SQLiteDatabase(BaseDatabase):
 
             if platform_ids:
                 conditions.append(col(ConversationV2.platform_id).in_(platform_ids))
+            # WebChat titles live on the platform session, not on the
+            # conversation row, so the search also matches session titles.
             if search_query:
                 escaped_search_query = json.dumps(
                     search_query,
@@ -374,6 +401,7 @@ class SQLiteDatabase(BaseDatabase):
                         col(ConversationV2.conversation_id).ilike(f"%{search_query}%"),
                         col(ConversationV2.content).ilike(f"%{search_query}%"),
                         col(ConversationV2.content).ilike(f"%{escaped_search_query}%"),
+                        _webchat_session_title_match(search_query),
                     )
                 )
             keyword_query = str(kwargs.get("keyword_query") or "").strip()
@@ -387,6 +415,7 @@ class SQLiteDatabase(BaseDatabase):
                         col(ConversationV2.title).ilike(f"%{keyword_query}%"),
                         col(ConversationV2.content).ilike(f"%{keyword_query}%"),
                         col(ConversationV2.content).ilike(f"%{escaped_keyword_query}%"),
+                        _webchat_session_title_match(keyword_query),
                     )
                 )
             message_types = kwargs.get("message_types") or []

--- a/astrbot/dashboard/services/conversation_service.py
+++ b/astrbot/dashboard/services/conversation_service.py
@@ -91,6 +91,7 @@ class ConversationService:
         )
         umos = sorted({conv.user_id for conv in conversations if conv.user_id})
         alias_map = build_umo_alias_map(await self.db_helper.get_umo_aliases(umos))
+        webchat_titles = await self._get_webchat_titles(conversations)
 
         return {
             "conversations": [
@@ -98,6 +99,7 @@ class ConversationService:
                     conversation,
                     alias_map,
                     include_history=include_history,
+                    webchat_title=webchat_titles.get(conversation.user_id, ""),
                 )
                 for conversation in conversations
             ],
@@ -149,11 +151,14 @@ class ConversationService:
         if not conversation:
             raise ConversationServiceError("对话不存在")
 
+        webchat_titles = await self._get_webchat_titles([conversation])
         alias_map = build_umo_alias_map(await self.db_helper.get_umo_aliases([user_id]))
         return {
             "user_id": user_id,
             "cid": cid,
-            "title": conversation.title,
+            "title": conversation.title
+            or webchat_titles.get(conversation.user_id, "")
+            or None,
             "persona_id": conversation.persona_id,
             "history": conversation.history,
             "created_at": conversation.created_at,
@@ -250,12 +255,15 @@ class ConversationService:
                     failed_items.append(f"user_id:{user_id}, cid:{cid} - 对话不存在")
                     continue
 
+                webchat_titles = await self._get_webchat_titles([conversation])
                 content = json.loads(conversation.history)
                 export_record = {
                     "cid": cid,
                     "user_id": user_id,
                     "platform_id": conversation.platform_id,
-                    "title": conversation.title,
+                    "title": conversation.title
+                    or webchat_titles.get(conversation.user_id, "")
+                    or None,
                     "persona_id": conversation.persona_id,
                     "created_at": conversation.created_at,
                     "updated_at": conversation.updated_at,
@@ -320,12 +328,72 @@ class ConversationService:
             "failed_items": failed_items,
         }
 
+    @staticmethod
+    def _webchat_session_id(user_id: str | None) -> str:
+        """Extract the WebChat session ID from a unified message origin.
+
+        Args:
+            user_id: Unified message origin such as
+                ``webchat:FriendMessage:webchat!creator!session_id``.
+
+        Returns:
+            The trailing session ID segment, or an empty string when the
+            origin does not carry one.
+        """
+        umo = user_id or ""
+        if "!" not in umo:
+            return ""
+        return umo.rsplit("!", 1)[-1]
+
+    async def _get_webchat_titles(self, conversations) -> dict[str, str]:
+        """Resolve WebChat session titles for conversations.
+
+        WebChat generates and stores its title on the platform session while
+        the conversation history reads the conversation title column, so the
+        session display name is used as a fallback. Title lookup failures only
+        degrade the fallback instead of failing the whole request.
+
+        Args:
+            conversations: Conversation objects returned by the conversation manager.
+
+        Returns:
+            Mapping from unified message origin to the WebChat session title.
+        """
+        session_ids: dict[str, str] = {}
+        for conversation in conversations:
+            if conversation.platform_id != "webchat":
+                continue
+            session_id = self._webchat_session_id(conversation.user_id)
+            if session_id:
+                session_ids[conversation.user_id] = session_id
+        if not session_ids:
+            return {}
+
+        try:
+            sessions = await self.db_helper.get_platform_sessions_by_ids(
+                list(set(session_ids.values())),
+            )
+        except Exception as exc:
+            logger.warning(f"查询 WebChat 会话标题失败: {exc!s}")
+            return {}
+
+        display_names = {
+            session.session_id: session.display_name
+            for session in sessions
+            if session.display_name
+        }
+        return {
+            user_id: display_names.get(session_id, "")
+            for user_id, session_id in session_ids.items()
+        }
+
     def _serialize_conversation(
         self,
         conversation,
         alias_map: dict,
         *,
         include_history: bool,
+        webchat_title: str = "",
     ) -> dict:
         """Serialize a conversation for a list response.
 
@@ -333,6 +401,8 @@ class ConversationService:
             conversation: Conversation object returned by the manager.
             alias_map: UMO aliases keyed by unified message origin.
             include_history: Whether to include the serialized message history.
+            webchat_title: WebChat session title used when the conversation
+                itself has no title.
 
         Returns:
             Conversation data suitable for a dashboard API response.
@@ -341,7 +411,7 @@ class ConversationService:
             "platform_id": conversation.platform_id,
             "user_id": conversation.user_id,
             "cid": conversation.cid,
-            "title": conversation.title,
+            "title": conversation.title or webchat_title or None,
             "persona_id": conversation.persona_id,
             "token_usage": conversation.token_usage,
             "created_at": conversation.created_at,

--- a/tests/test_conversation_list.py
+++ b/tests/test_conversation_list.py
@@ -7,7 +7,7 @@ from sqlalchemy import event, text
 from sqlalchemy import inspect as sqlalchemy_inspect
 
 from astrbot.core.conversation_mgr import ConversationManager
-from astrbot.core.db.po import ConversationV2
+from astrbot.core.db.po import ConversationV2, PlatformSession
 from astrbot.core.db.sqlite import SQLiteDatabase
 
 
@@ -310,3 +310,76 @@ async def test_multi_platform_summary_uses_global_order_index(
         in ordered_queries[0]
     )
     assert "content" not in ordered_queries[0].split("FROM", 1)[0]
+
+
+@pytest.mark.asyncio
+async def test_webchat_session_title_matches_search_and_keyword(tmp_path: Path):
+    """WebChat session titles participate in both search paths."""
+    db = SQLiteDatabase(str(tmp_path / "webchat_titles.db"))
+    await db.initialize()
+
+    matched_session_id = "session-with-title"
+    async with db.get_db() as session:
+        async with session.begin():
+            session.add_all(
+                [
+                    ConversationV2(
+                        conversation_id="webchat-titled",
+                        platform_id="webchat",
+                        user_id=(
+                            "webchat:FriendMessage:"
+                            f"webchat!astrbot!{matched_session_id}"
+                        ),
+                        content=[{"role": "user", "content": "hello"}],
+                        created_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+                        updated_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+                    ),
+                    ConversationV2(
+                        conversation_id="webchat-other",
+                        platform_id="webchat",
+                        user_id="webchat:FriendMessage:webchat!astrbot!other-session",
+                        content=[{"role": "user", "content": "hello"}],
+                        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                        updated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                    ),
+                    PlatformSession(
+                        session_id=matched_session_id,
+                        platform_id="webchat",
+                        creator="astrbot",
+                        display_name="美食推荐晚餐食谱",
+                    ),
+                    PlatformSession(
+                        session_id="other-session",
+                        platform_id="webchat",
+                        creator="astrbot",
+                        display_name="成都旅行三日游计划",
+                    ),
+                ]
+            )
+
+    conversations, total = await db.get_filtered_conversations(
+        page=1,
+        page_size=10,
+        search_query="美食",
+        include_history=False,
+    )
+    assert total == 1
+    assert [item.conversation_id for item in conversations] == ["webchat-titled"]
+
+    conversations, total = await db.get_filtered_conversations(
+        page=1,
+        page_size=10,
+        keyword_query="成都",
+        include_history=False,
+    )
+    assert total == 1
+    assert [item.conversation_id for item in conversations] == ["webchat-other"]
+
+    conversations, total = await db.get_filtered_conversations(
+        page=1,
+        page_size=10,
+        search_query="不存在的会话标题",
+        include_history=False,
+    )
+    assert total == 0
+    assert conversations == []

--- a/tests/test_fastapi_v1_dashboard.py
+++ b/tests/test_fastapi_v1_dashboard.py
@@ -106,6 +106,11 @@ class FakeDb:
     async def get_conversation_platform_ids(self) -> list[str]:
         return ["webchat-main"]
 
+    async def get_platform_sessions_by_ids(
+        self, _session_ids: list[str]
+    ) -> list[object]:
+        return []
+
     def add_api_key(self, raw_key: str, scopes: list[str]) -> None:
         self.api_keys[ApiKeyService.hash_key(raw_key)] = FakeApiKey(
             key_id="config-key",


### PR DESCRIPTION
### Modifications / 改动点

- Fall back to the WebChat session title when a conversation has no title of its own:
  - `astrbot/dashboard/services/conversation_service.py`: resolve `platform_sessions.display_name` with one batched lookup and use it for the conversation list, the conversation detail and the JSONL export; a failed title lookup only drops the fallback instead of failing the request.
  - `astrbot/core/db/sqlite.py`: the conversation search matches WebChat session titles through a correlated `EXISTS` subquery on `platform_sessions`, so both the `search` and `keyword` paths stay a single query with no session-ID list, no result cap and no expression-tree growth.
- Added database-level tests in `tests/test_conversation_list.py` covering session-title matching through `search_query` and `keyword_query` plus a negative case; the dashboard fakes stay in sync with the existing interfaces.

**Motivation**: WebChat generates a conversation title with the current model and stores it on the platform session (`astrbot/core/astr_main_agent.py::_handle_webchat` calls `update_platform_session(display_name=...)`), while the conversation history pages read `conversations.title`. WebChat rows therefore always rendered as "Untitled Conversation" in 对话数据 → 对话 even though the title is visible in WebChat, and the generated title could not be found through search either. This change only fills the gap for WebChat conversations that have no title of their own, so manually edited conversation titles keep priority.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Local verification (Node v25 / pnpm v11, Python 3.14):

- `ruff format --check` and `ruff check` — passed
- `pytest tests/test_conversation_list.py tests/test_fastapi_v1_dashboard.py` — 95 passed
- Full local instance (core + WebUI) seeded with WebChat conversations whose `conversations.title` is `NULL` and whose `platform_sessions.display_name` is set:
  - conversation list, conversation detail and JSONL export all return the session title (e.g. `美食推荐晚餐食谱`)
  - `keyword=美食` and the legacy `search=成都` parameter both match the WebChat conversation

<img width="756" height="488" alt="shot_titles_new_ui" src="https://github.com/user-attachments/assets/8cf85c84-f7b0-429e-95b6-be7bb70a4383" />

(Actually this edit didn't change much of the front-end interface)

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Fall back to WebChat-generated session titles across conversation history while preserving explicitly assigned conversation titles.

Bug Fixes:
- Use WebChat platform-session display names as fallback titles for untitled conversation list entries, conversation details and JSONL exports.
- Include matching WebChat session titles in conversation searches using both the current keyword and legacy search parameters.

Enhancements:
- Match WebChat session titles directly inside the conversation query with a correlated EXISTS subquery, avoiding an extra round trip and a result cap.

Tests:
- Add database-level coverage for session-title matching and keep the dashboard test fakes in sync.
