### PR TITLE
fix: make TTS voice replies work when streaming output is enabled

### DIFF
--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import base64
+import random
 from collections.abc import AsyncGenerator
 from dataclasses import replace
 
@@ -225,6 +226,39 @@ class InternalAgentSubStage(Stage):
             if await call_event_hook(event, EventType.OnWaitingLLMRequestEvent):
                 return
 
+            stream_to_general = (
+                self.unsupported_streaming_strategy == "turn_off"
+                and not event.platform_meta.support_streaming_message
+            )
+
+            # When the reply would be streamed but TTS voice replies are
+            # enabled, streaming delivery bypasses the result decorate stage
+            # (the only place text is converted into voice messages). Roll the
+            # dice before the agent runner is built and reset, so forced
+            # replies are created without streaming. Live mode has its own
+            # streaming TTS pipeline and is excluded.
+            if (
+                streaming_response
+                and not stream_to_general
+                and event.get_extra("action_type") != "live"
+            ):
+                tts_cfg = self.ctx.astrbot_config.get("provider_tts_settings", {})
+                if tts_cfg.get("enable"):
+                    try:
+                        tts_prob = float(tts_cfg.get("trigger_probability", 1.0))
+                    except (TypeError, ValueError):
+                        tts_prob = 1.0
+                    if random.random() < max(0.0, min(tts_prob, 1.0)):
+                        # Only force when a usable TTS provider exists, so a
+                        # misconfigured TTS setup cannot silently disable
+                        # streaming for regular chat replies.
+                        tts_provider = await self.ctx.plugin_manager.context.get_using_tts_provider_async(
+                            event.unified_msg_origin
+                        )
+                        if tts_provider is not None:
+                            event.set_extra("tts_forced", True)
+                            streaming_response = False
+
             async with session_lock_manager.acquire_lock(event.unified_msg_origin):
                 logger.debug("acquired session lock for llm request")
                 agent_runner: AgentRunner | None = None
@@ -268,11 +302,6 @@ class InternalAgentSubStage(Stage):
                             logger.error(error_message)
                             await self._send_llm_error_message(event, error_message)
                             return
-
-                    stream_to_general = (
-                        self.unsupported_streaming_strategy == "turn_off"
-                        and not event.platform_meta.support_streaming_message
-                    )
 
                     if await call_event_hook(event, EventType.OnLLMRequestEvent, req):
                         if reset_coro:

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -252,9 +252,14 @@ class InternalAgentSubStage(Stage):
                         # Only force when a usable TTS provider exists, so a
                         # misconfigured TTS setup cannot silently disable
                         # streaming for regular chat replies.
-                        tts_provider = await self.ctx.plugin_manager.context.get_using_tts_provider_async(
-                            event.unified_msg_origin
-                        )
+                        try:
+                            tts_provider = await self.ctx.plugin_manager.context.get_using_tts_provider_async(
+                                event.unified_msg_origin
+                            )
+                        except ValueError:
+                            # The session may resolve to a provider of the
+                            # wrong type; treat it as no usable TTS provider.
+                            tts_provider = None
                         if tts_provider is not None:
                             event.set_extra("tts_forced", True)
                             streaming_response = False

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/third_party.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/third_party.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+import random
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from typing import TYPE_CHECKING
 
@@ -334,6 +335,36 @@ class ThirdPartyAgentSubStage(Stage):
             and not event.platform_meta.support_streaming_message
         )
         streaming_used = streaming_response and not stream_to_general
+
+        # When the reply would be streamed but TTS voice replies are enabled,
+        # streaming delivery bypasses the result decorate stage (the only place
+        # where text is converted into voice messages). Roll the dice once here
+        # so a fraction of replies controlled by
+        # provider_tts_settings.trigger_probability are fully generated first
+        # and then voiced, while the rest keep the streaming behavior.
+        tts_cfg = self.ctx.astrbot_config.get("provider_tts_settings", {})
+        if streaming_used and tts_cfg.get("enable"):
+            try:
+                tts_prob = float(tts_cfg.get("trigger_probability", 1.0))
+            except (TypeError, ValueError):
+                tts_prob = 1.0
+            if random.random() < max(0.0, min(tts_prob, 1.0)):
+                # Only force when a usable TTS provider exists, so a
+                # misconfigured TTS setup cannot silently disable streaming
+                # for regular chat replies.
+                tts_provider = (
+                    await self.ctx.plugin_manager.context.get_using_tts_provider_async(
+                        event.unified_msg_origin
+                    )
+                )
+                if tts_provider is not None:
+                    event.set_extra("tts_forced", True)
+                    # ``streaming_response`` is passed to the runner reset
+                    # below, so it must be disabled as well, otherwise the
+                    # runner still streams while the non-streaming handler is
+                    # selected.
+                    streaming_response = False
+                    streaming_used = False
 
         runner_closed = False
         stream_consumed = False

--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/third_party.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/third_party.py
@@ -352,11 +352,14 @@ class ThirdPartyAgentSubStage(Stage):
                 # Only force when a usable TTS provider exists, so a
                 # misconfigured TTS setup cannot silently disable streaming
                 # for regular chat replies.
-                tts_provider = (
-                    await self.ctx.plugin_manager.context.get_using_tts_provider_async(
+                try:
+                    tts_provider = await self.ctx.plugin_manager.context.get_using_tts_provider_async(
                         event.unified_msg_origin
                     )
-                )
+                except ValueError:
+                    # The session may resolve to a provider of the wrong
+                    # type; treat it as no usable TTS provider.
+                    tts_provider = None
                 if tts_provider is not None:
                     event.set_extra("tts_forced", True)
                     # ``streaming_response`` is passed to the runner reset

--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -273,11 +273,22 @@ class ResultDecorateStage(Stage):
                 )
             )
 
+            # When an agent sub-stage already rolled the TTS dice for a reply
+            # that would otherwise stream ("tts_forced" is set), the roll has
+            # been consumed and the voice conversion below must not be rolled
+            # again. For ordinary non-streaming results the probability
+            # configured in provider_tts_settings applies as usual.
+            tts_trigger_probability = (
+                1.0
+                if event.get_extra("tts_forced", False)
+                else self.tts_trigger_probability
+            )
+
             should_tts = (
                 bool(self.ctx.astrbot_config["provider_tts_settings"]["enable"])
                 and result.is_llm_result()
                 and await SessionServiceManager.should_process_tts_request(event)
-                and random.random() <= self.tts_trigger_probability
+                and random.random() <= tts_trigger_probability
                 and tts_provider
             )
             if should_tts and not tts_provider:


### PR DESCRIPTION
## Problem

When both "streaming output" (`provider_settings.streaming_response`) and TTS voice replies are enabled (a `text_to_speech` provider configured, `provider_tts_settings.enable = true`), replies are **never** converted into voice messages. Users only ever receive streamed text, and `provider_tts_settings.trigger_probability` has no effect in this mode. The only workaround today is to disable streaming output globally, which is not documented and is invisible to most users.

### Why this happens

Text-to-voice conversion lives in exactly one place: `ResultDecorateStage` (see the "TTS" block in `result_decorate/stage.py`). That stage only processes fully generated, non-streaming results:

- `STREAMING_RESULT` results return early from the decorate stage and are delivered directly to the platform adapter by the respond stage.
- `STREAMING_FINISH` results are also skipped ("streaming output does not execute the following logic").

At the same time, the agent sub-stages (`InternalAgentSubStage` for the local tool-loop runner, `ThirdPartyAgentSubStage` for Dify/Coze/DashScope/DeerFlow runners) decide whether a reply streams purely from `provider_settings.streaming_response` and per-message `enable_streaming` flags. They never look at `provider_tts_settings`, so a reply that was meant to be voiced is silently streamed instead and bypasses the only TTS code path.

## Fix

Keep the probability decision in one place per reply path and make streaming respect it:

1. In `InternalAgentSubStage` and `ThirdPartyAgentSubStage`, right where the agent knows the reply will actually be streamed (`streaming_response and not stream_to_general`), roll the dice once. When `provider_tts_settings.enable` is on and the roll hits `trigger_probability`, and a usable TTS provider is configured for the session, mark the event with a `tts_forced` extra and switch the reply to non-streaming. The complete result then flows through `ResultDecorateStage` and is converted into a voice message.
   - In `InternalAgentSubStage` the roll happens **before** the agent runner is built and reset, so the runner itself is created without streaming; otherwise the runner still emits streaming deltas and the non-streaming path never produces the final result the decorate stage needs.
   - Live mode is excluded: it runs its own streaming TTS pipeline (`run_live_agent`) and must not be diverted.
   - The probability roll uses a strict comparison (`random.random() < probability`), so `trigger_probability = 0` can never force a voice reply.
   - The dice only forces non-streaming when a usable TTS provider actually exists for the session, so a misconfigured TTS setup cannot silently disable streaming for regular chat replies.
2. In `ResultDecorateStage`, consume the probability only once: when `tts_forced` is present, the dice was already rolled upstream, so the probability for that reply is `1.0`; ordinary non-streaming results keep using the configured `trigger_probability` as before.

Resulting behavior for any configuration that enables TTS:

| Streaming output | Probability roll | Behavior |
| --- | --- | --- |
| enabled | hit | reply is fully generated first, then sent as a TTS voice message |
| enabled | miss | reply is streamed as text (previous behavior) |
| disabled | hit | reply is sent as a TTS voice message (previous behavior) |
| disabled | miss | reply is sent as plain full text (previous behavior) |

Setting `trigger_probability` to `0` restores the previous behavior in every mode. When no TTS provider is enabled, nothing changes at all.

## Manual testing

Verified on a deployment running v4.26.8 (AstrBot docker image) with a QQ (aiocqhttp/NapCat) bot:

- TTS provider + streaming output enabled, `trigger_probability = 0.99`: roughly 99% of replies arrive as voice messages (logs show `TTS request` / `TTS result` only for those replies), the rest stream as text.
- `trigger_probability = 0.5`: voice and streamed text replies are interleaved at the expected ratio.
- `trigger_probability = 0`: all replies stream again, identical to the previous behavior.
- Streaming output disabled: voice replies follow `trigger_probability` exactly, unchanged from before this fix.
- Both agent families covered: the local runner path (`InternalAgentSubStage`, QQ group chat with tool-loop agent) and the third-party runner path (`ThirdPartyAgentSubStage`).

Code quality: `python -m ruff format` and `python -m ruff check` pass on all modified files (ruff 0.15.x, matching the project pin).

## Notes

- Comments added in English, following the project convention.
- No new configuration keys and no default value changes: `trigger_probability` already defaults to `1.0`, which now simply means "always voice" for streaming users instead of "never voice".
- `tts_forced` is only ever set when a stream would actually have happened for that reply; it has no side effects on non-streaming platforms or when TTS is disabled.
- This pull request supersedes #9982 (closed), which contained an earlier revision of the same change where the dice roll happened after the internal agent runner was built.

## Summary by Sourcery

Fix streamed agent replies so configured TTS responses can be delivered as voice messages without changing ordinary streaming behavior.

Bug Fixes:
- Allow TTS voice replies to work when streaming output is enabled by selectively switching eligible streamed responses to complete generation before voice conversion.

Enhancements:
- Coordinate TTS probability decisions across agent stages and result decoration so each reply is evaluated only once while preserving existing behavior for non-streaming replies, live mode, and unavailable TTS providers.