### PR TITLE
fix(cron): record active-agent job failure when the runner ends in ERROR

### DIFF
--- a/astrbot/core/agent/runners/base.py
+++ b/astrbot/core/agent/runners/base.py
@@ -58,6 +58,12 @@ class BaseAgentRunner(T.Generic[TContext]):
         """
         ...
 
+    @property
+    def state(self) -> AgentState:
+        """The current agent state (read-only; transitions go through
+        `_transition_state`)."""
+        return self._state
+
     def _transition_state(self, new_state: AgentState) -> None:
         """Transition the agent state."""
         if self._state != new_state:

--- a/astrbot/core/cron/manager.py
+++ b/astrbot/core/cron/manager.py
@@ -11,6 +11,7 @@ from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
 
 from astrbot import logger
+from astrbot.core.agent.runners.base import AgentState
 from astrbot.core.agent.tool import ToolSet
 from astrbot.core.cron.events import CronMessageEvent
 from astrbot.core.db import BaseDatabase
@@ -496,14 +497,24 @@ class CronJobManager:
             event=cron_event, plugin_context=self.ctx, config=config, req=req
         )
         if not result:
-            logger.error("Failed to build main agent for cron job.")
-            return
+            raise RuntimeError("Failed to build main agent for cron job.")
 
         runner = result.agent_runner
         async for _ in runner.step_until_done(agent_max_step):
             # agent will send message to user via using tools
             pass
         llm_resp = runner.get_final_llm_resp()
+        if runner.state == AgentState.ERROR:
+            # The run failed (e.g. malformed function call at max steps) but
+            # no exception escapes the runner; without this the job was
+            # recorded as completed with last_error=NULL and the user saw
+            # only intermediate messages (#9980).
+            detail = (
+                f": {llm_resp.completion_text}"
+                if llm_resp and llm_resp.completion_text
+                else ""
+            )
+            raise RuntimeError(f"Cron agent run ended in ERROR state{detail}")
         cron_meta = extras.get("cron_job", {}) if extras else {}
         summary_note = (
             f"[CronJob] {cron_meta.get('name') or cron_meta.get('id', 'unknown')}: {cron_meta.get('description', '')} "

--- a/tests/unit/test_cron_manager.py
+++ b/tests/unit/test_cron_manager.py
@@ -2,11 +2,13 @@
 
 import json
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from zoneinfo import ZoneInfo
 
 import pytest
 
+from astrbot.core.agent.runners.base import AgentState
 from astrbot.core.cron.manager import (
     CronJobManager,
     CronJobSchedulingError,
@@ -548,40 +550,6 @@ class TestRunJob:
         mock_db.update_cron_job.assert_not_called()
 
 
-class TestRunBasicJob:
-    """Tests for _run_basic_job method."""
-
-    @pytest.mark.asyncio
-    async def test_run_basic_job_sync_handler(self, cron_manager, sample_cron_job):
-        """Test running a basic job with sync handler."""
-        handler = MagicMock(return_value=None)
-        cron_manager._basic_handlers["test-job-id"] = handler
-        sample_cron_job.payload = {"arg1": "value1"}
-
-        await cron_manager._run_basic_job(sample_cron_job)
-
-        handler.assert_called_once_with(arg1="value1")
-
-    @pytest.mark.asyncio
-    async def test_run_basic_job_async_handler(self, cron_manager, sample_cron_job):
-        """Test running a basic job with async handler."""
-        async_handler = AsyncMock()
-        cron_manager._basic_handlers["test-job-id"] = async_handler
-        sample_cron_job.payload = {}
-
-        await cron_manager._run_basic_job(sample_cron_job)
-
-        async_handler.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_run_basic_job_no_handler(self, cron_manager, sample_cron_job):
-        """Test running a basic job without handler."""
-        sample_cron_job.job_id = "no-handler-job"
-
-        with pytest.raises(RuntimeError, match="handler not found"):
-            await cron_manager._run_basic_job(sample_cron_job)
-
-
 class TestRunActiveAgentJob:
     """Tests for active agent cron job execution."""
 
@@ -612,6 +580,8 @@ class TestRunActiveAgentJob:
         conv.history = json.dumps(history)
 
         class FakeRunner:
+            state = AgentState.DONE
+
             def step_until_done(self, max_step):
                 async def gen():
                     if False:
@@ -680,6 +650,8 @@ class TestRunActiveAgentJob:
         """Test the cron agent runner receives max_agent_step from provider settings."""
 
         class _StepCapturingRunner:
+            state = AgentState.DONE
+
             def __init__(self):
                 self.captured_max_step = None
 
@@ -736,6 +708,112 @@ class TestRunActiveAgentJob:
             )
 
         assert runner.captured_max_step == expected_max_step
+
+    @pytest.mark.asyncio
+    async def test_agent_error_state_marks_job_failed(
+        self, cron_manager, mock_db, mock_context
+    ):
+        """A runner ending in AgentState.ERROR must not record 'completed'."""
+
+        job = CronJob(
+            job_id="active-job",
+            name="Active",
+            job_type="active_agent",
+            cron_expression="0 9 * * *",
+            enabled=True,
+            persistent=True,
+            payload={"note": "check something"},
+        )
+        mock_db.get_cron_job.return_value = job
+        cron_manager.ctx = mock_context
+
+        class FakeRunner:
+            state = AgentState.ERROR
+
+            async def step_until_done(self, max_step):
+                return
+                yield  # pragma: no cover
+
+            def get_final_llm_resp(self):
+                resp = MagicMock()
+                resp.completion_text = "malformed_function_call"
+                return resp
+
+        fake_result = SimpleNamespace(agent_runner=FakeRunner())
+        with (
+            patch(
+                "astrbot.core.astr_main_agent.build_main_agent",
+                new=AsyncMock(return_value=fake_result),
+            ),
+            patch(
+                "astrbot.core.astr_main_agent._get_session_conv",
+                new=AsyncMock(return_value=SimpleNamespace(history="[]")),
+            ),
+        ):
+            await cron_manager._run_job("active-job")
+        status_calls = [c.kwargs for c in mock_db.update_cron_job.call_args_list]
+        final = status_calls[-1]
+        assert final["status"] == "failed"
+        assert "malformed_function_call" in final["last_error"]
+
+    @pytest.mark.asyncio
+    async def test_agent_build_failure_marks_job_failed(
+        self, cron_manager, mock_db, mock_context
+    ):
+        """A main-agent build failure must not record 'completed' either."""
+        job = CronJob(
+            job_id="active-job",
+            name="Active",
+            job_type="active_agent",
+            cron_expression="0 9 * * *",
+            enabled=True,
+            persistent=True,
+            payload={"note": "check something"},
+        )
+        mock_db.get_cron_job.return_value = job
+        cron_manager.ctx = mock_context
+        with (
+            patch(
+                "astrbot.core.astr_main_agent.build_main_agent",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "astrbot.core.astr_main_agent._get_session_conv",
+                new=AsyncMock(return_value=SimpleNamespace(history="[]")),
+            ),
+        ):
+            await cron_manager._run_job("active-job")
+        status_calls = [c.kwargs for c in mock_db.update_cron_job.call_args_list]
+        final = status_calls[-1]
+        assert final["status"] == "failed"
+        assert "build main agent" in final["last_error"]
+
+    """Tests for _run_basic_job method."""
+
+    @pytest.mark.asyncio
+    async def test_run_basic_job_sync_handler(self, cron_manager, sample_cron_job):
+        """Test running a basic job with sync handler."""
+        handler = MagicMock(return_value=None)
+        cron_manager._basic_handlers["test-job-id"] = handler
+        sample_cron_job.payload = {"arg1": "value1"}
+        await cron_manager._run_basic_job(sample_cron_job)
+        handler.assert_called_once_with(arg1="value1")
+
+    @pytest.mark.asyncio
+    async def test_run_basic_job_async_handler(self, cron_manager, sample_cron_job):
+        """Test running a basic job with async handler."""
+        async_handler = AsyncMock()
+        cron_manager._basic_handlers["test-job-id"] = async_handler
+        sample_cron_job.payload = {}
+        await cron_manager._run_basic_job(sample_cron_job)
+        async_handler.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_basic_job_no_handler(self, cron_manager, sample_cron_job):
+        """Test running a basic job without handler."""
+        sample_cron_job.job_id = "no-handler-job"
+        with pytest.raises(RuntimeError, match="handler not found"):
+            await cron_manager._run_basic_job(sample_cron_job)
 
 
 class TestGetNextRunTime:


### PR DESCRIPTION
## Motivation

Fixes the status-propagation half of #9980. A cron `active_agent` job whose runner ends in `AgentState.ERROR` (e.g. malformed function call at max steps) was recorded as `status=completed, last_error=NULL`, so the user saw only intermediate messages and the task looked like it never fired.

## Changes

- `_woke_main_agent` raises when the runner ends in `AgentState.ERROR` (carrying the final error text when the run produced one) and when the main agent cannot be built; `_run_job`'s existing exception handler records both as `failed` with `last_error`.
- `BaseAgentRunner` gains a read-only `state` property so callers stop reaching into `_state`.

The repeated-tool-call half of #9980 (why the model looped one tool 30 times on a long inherited history) is a separate root cause and is not touched here.

## Tests

Two new `_run_job` regression tests in `tests/unit/test_cron_manager.py`: runner ends in ERROR → `status=failed` with the detail in `last_error`; agent build failure → same. Both red on current master, green here. Full file 44/44 green; ruff format + check clean.

## Summary by Sourcery

Propagate active-agent execution failures to cron job status and error details instead of reporting unsuccessful runs as completed.

Bug Fixes:
- Record active-agent cron jobs as failed, including the runner’s final error detail, when execution ends in an error state or the main agent cannot be built.

Enhancements:
- Expose the agent runner’s current state through a read-only property instead of requiring callers to access internal state.

Tests:
- Add regression coverage for active-agent runner failures and main-agent construction failures being persisted as failed jobs.