### PR TITLE
fix: batch console log rendering to avoid UI freeze (#9988)

### DIFF
--- a/dashboard/src/components/shared/ConsoleDisplayer.vue
+++ b/dashboard/src/components/shared/ConsoleDisplayer.vue
@@ -227,6 +227,10 @@ export default {
       if (!newLogs || newLogs.length === 0) return;
 
       let hasUpdate = false;
+      const termElement = document.getElementById("term");
+      // Batch the rendered log elements into a single fragment so that a large
+      // history payload only triggers one reflow instead of one per log line.
+      const fragment = termElement ? document.createDocumentFragment() : null;
 
       newLogs.forEach((log) => {
         const exists = this.localLogCache.some(
@@ -244,7 +248,9 @@ export default {
             this.isLevelSelected(log.level) &&
             !this.isHiddenByCategory(log)
           ) {
-            this.printLog(log.data);
+            if (fragment) {
+              fragment.appendChild(this.buildLogElement(log.data));
+            }
           }
         }
       });
@@ -255,6 +261,13 @@ export default {
         const maxSize = this.commonStore.log_cache_max_len || 200;
         if (this.localLogCache.length > maxSize) {
           this.localLogCache.splice(0, this.localLogCache.length - maxSize);
+        }
+      }
+
+      if (fragment && fragment.childNodes.length > 0) {
+        termElement.appendChild(fragment);
+        if (this.autoScroll) {
+          termElement.scrollTop = termElement.scrollHeight;
         }
       }
     },
@@ -290,19 +303,23 @@ export default {
 
     refreshDisplay() {
       const termElement = document.getElementById("term");
-      if (termElement) {
-        termElement.innerHTML = "";
+      if (!termElement) return;
 
-        if (this.localLogCache && this.localLogCache.length > 0) {
-          this.localLogCache.forEach((logItem) => {
-            if (
-              this.isLevelSelected(logItem.level) &&
-              !this.isHiddenByCategory(logItem)
-            ) {
-              this.printLog(logItem.data);
-            }
-          });
+      termElement.innerHTML = "";
+      if (!this.localLogCache || this.localLogCache.length === 0) return;
+
+      const fragment = document.createDocumentFragment();
+      this.localLogCache.forEach((logItem) => {
+        if (
+          this.isLevelSelected(logItem.level) &&
+          !this.isHiddenByCategory(logItem)
+        ) {
+          fragment.appendChild(this.buildLogElement(logItem.data));
         }
+      });
+      termElement.appendChild(fragment);
+      if (this.autoScroll) {
+        termElement.scrollTop = termElement.scrollHeight;
       }
     },
 
@@ -328,7 +345,7 @@ export default {
         /\[(DEBG|INFO|WARN|ERRO|CRIT|DEBUG|WARNING|ERROR|CRITICAL)\]/,
       );
       if (!levelMatch) {
-        element.innerText = `${log}`;
+        element.textContent = `${log}`;
         return;
       }
 
@@ -339,15 +356,15 @@ export default {
 
       const prefixSpan = document.createElement("span");
       prefixSpan.className = "console-log-prefix";
-      prefixSpan.innerText = prefix;
+      prefixSpan.textContent = prefix;
 
       const levelSpan = document.createElement("span");
       levelSpan.className = "console-log-level";
-      levelSpan.innerText = levelMatch[0];
+      levelSpan.textContent = levelMatch[0];
 
       const messageSpan = document.createElement("span");
       messageSpan.className = "console-log-message";
-      messageSpan.innerText = message;
+      messageSpan.textContent = message;
 
       element.classList.add("console-log-line--structured");
       element.appendChild(prefixSpan);
@@ -355,15 +372,10 @@ export default {
       element.appendChild(messageSpan);
     },
 
-    printLog(log) {
-      let ele = document.getElementById("term");
-      if (!ele) {
-        return;
-      }
-
-      let span = document.createElement("pre");
+    buildLogElement(log) {
+      const span = document.createElement("pre");
       let style = this.logColorAnsiMap["default"];
-      for (let key in this.logColorAnsiMap) {
+      for (const key in this.logColorAnsiMap) {
         if (log.startsWith(key)) {
           style = this.logColorAnsiMap[key];
           log = log.replace(key, "").replace("\u001b[0m", "");
@@ -374,10 +386,7 @@ export default {
       span.style = style;
       span.classList.add("console-log-line", "fade-in");
       this.appendLogContent(span, log);
-      ele.appendChild(span);
-      if (this.autoScroll) {
-        ele.scrollTop = ele.scrollHeight;
-      }
+      return span;
     },
   },
 };


### PR DESCRIPTION
## Problem

Entering the "Data & Logs → Logs" page froze the entire WebUI for seconds (~3s at 500 logs, much longer at 2000 logs) because `ConsoleDisplayer` rendered each historical log line with a separate `appendChild` plus a forced synchronous reflow (`scrollTop = scrollHeight`) per line, and used `innerText` which triggers a style recalc on every assignment.

## Fix

- Collect rendered log elements into a `DocumentFragment` and append once.
- Scroll to the bottom a single time after the batch.
- Use `textContent` instead of `innerText`.

This collapses O(n) reflows into one and eliminates the main-thread freeze.

## Verification

- 500 logs: ~3s freeze → near-instant.
- 2000 logs: very long freeze → under 1 second.

Closes #9988

## Summary by Sourcery

Optimize console log rendering to keep the WebUI responsive when displaying large log histories.

Bug Fixes:
- Prevent the logs page from freezing when rendering large batches of historical or refreshed console output.

Enhancements:
- Batch console log DOM updates and scrolling, and use more efficient text rendering to reduce layout work.