### PR TITLE
fix(dashboard): batch automatic log console scrolling

### DIFF
--- a/dashboard/src/components/shared/ConsoleDisplayer.vue
+++ b/dashboard/src/components/shared/ConsoleDisplayer.vue
@@ -79,6 +79,7 @@ export default {
       maxRetryAttempts: 10,
       baseRetryDelay: 1000,
       lastEventId: null,
+      scrollAnimationFrame: null,
     };
   },
   computed: {
@@ -129,6 +130,10 @@ export default {
       "fullscreenchange",
       this.handleFullscreenChange,
     );
+    if (this.scrollAnimationFrame !== null) {
+      cancelAnimationFrame(this.scrollAnimationFrame);
+      this.scrollAnimationFrame = null;
+    }
     if (this.eventSource) {
       this.eventSource.close();
       this.eventSource = null;
@@ -375,8 +380,14 @@ export default {
       span.classList.add("console-log-line", "fade-in");
       this.appendLogContent(span, log);
       ele.appendChild(span);
-      if (this.autoScroll) {
-        ele.scrollTop = ele.scrollHeight;
+      if (this.autoScroll && this.scrollAnimationFrame === null) {
+        // Scroll once per frame so a batch of logs does not force layout per line.
+        this.scrollAnimationFrame = requestAnimationFrame(() => {
+          this.scrollAnimationFrame = null;
+          if (this.autoScroll) {
+            ele.scrollTop = ele.scrollHeight;
+          }
+        });
       }
     },
   },


### PR DESCRIPTION
Fixes #9988.

With automatic scrolling enabled, `printLog()` appends a row and immediately reads `scrollHeight`. Loading history or redrawing a filter repeats that write/read cycle for every visible log, forcing synchronous layout each time. In the reporter's trace, an 8.75-second main-thread task contains 468 layout events totaling about 8.34 seconds.

### Modifications

- Coalesce automatic scrolling into one pending `requestAnimationFrame` callback, so rows appended within a frame share one layout read and scroll.
- Recheck `autoScroll` when the callback runs and cancel the pending frame when the component unmounts.
- Keep log rendering, filtering, deduplication, and SSE handling unchanged.

- [x] This is NOT a breaking change.

### Verification Steps and Test Results

Tested the actual mounted console component in Chromium 145 on Windows, using 1,000 synthetic logs and three paired runs. The baseline used the original `printLog` method from `6494ac2` bound to the same component; the fixed method used this branch. Timings include the scheduled animation frame, and layout counts/duration come from Chrome DevTools Protocol metrics.

| Median per 1,000-log batch | Before | After |
| --- | ---: | ---: |
| Layout events | 1,000 | 1 |
| Layout time | 553.7 ms | 72.5 ms |
| Batch processing and frame completion | 840.1 ms | 328.4 ms |

These are local synthetic-workload measurements, not timings from the reporter's machine.

Browser checks passed for preserving all 1,000 rows in order, duplicate history, level-filter redraws, excluding user-chat logs, automatic scrolling disabled, disabling it while a frame is pending, successive SSE message-handler batches, and unmounting with a pending frame. No uncaught page errors occurred. The built dashboard also rendered successfully against an isolated local AstrBot 4.27.2 container with synthetic history responses.

To verify interactively, open **Data & Logs → Logs** with a large history and automatic scrolling enabled, record a Performance trace, then toggle log levels. Layout should no longer repeat once per appended row. Also disable automatic scrolling, read older logs while new logs arrive, and navigate away with logging active.

Additional checks:

```text
cd dashboard
node --test tests/*.test.mjs   # 41 passed
pnpm build                   # vue-tsc and Vite passed

# From repository root:
ruff format .                # 504 files unchanged
ruff check .                 # All checks passed
git diff --check             # Passed
```

### Checklist

- New feature discussion: not applicable; this is a bug fix.
- [x] The change has been tested, with verification steps and results provided above.
- [x] No new dependencies are introduced.
- [x] The change does not introduce malicious code.

AI assistance: implemented and tested with OpenAI Codex.

## Summary by Sourcery

Improve dashboard log console performance by batching automatic scrolling during log ingestion and rendering.

Bug Fixes:
- Batch automatic console scrolling into a single animation-frame update to eliminate per-log synchronous layout work during large log loads and redraws.

Enhancements:
- Cancel pending scroll updates when automatic scrolling is disabled at execution time or when the console component unmounts, while preserving existing log rendering and event handling.