### PR TITLE
fix: correct At/AtAll branch order in message outline

### DIFF
--- a/astrbot/core/platform/astr_message_event.py
+++ b/astrbot/core/platform/astr_message_event.py
@@ -153,10 +153,10 @@ class AstrMessageEvent(abc.ABC):
                 parts.append("[图片]")
             elif isinstance(i, Face):
                 parts.append(f"[表情:{i.id}]")
-            elif isinstance(i, At):
-                parts.append(f"[At:{i.qq}]")
             elif isinstance(i, AtAll):
                 parts.append("[At:全体成员]")
+            elif isinstance(i, At):
+                parts.append(f"[At:{i.qq}]")
             elif isinstance(i, Forward):
                 # 转发消息
                 parts.append("[转发消息]")

--- a/tests/unit/test_astr_message_event.py
+++ b/tests/unit/test_astr_message_event.py
@@ -267,8 +267,7 @@ class TestGetMessageOutline:
             session_id="session123",
         )
         outline = event.get_message_outline()
-        # AtAll format is "[At:all]" in the actual implementation
-        assert "[At:" in outline and "all" in outline.lower()
+        assert outline == "[At:全体成员]"
 
     def test_outline_with_face(self, platform_meta, astrbot_message):
         """Test outline with Face component."""


### PR DESCRIPTION
### Motivation / 动机

`AtAll` is a subclass of `At` (see `class AtAll(At)` in `astrbot/core/message/components.py`). In `AstrMessageEvent._outline_chain()`, the `isinstance(i, At)` branch was checked **before** `isinstance(i, AtAll)`, so every `AtAll` component matched the `At` branch and rendered as `[At:all]` — the `[At:全体成员]` branch has been unreachable dead code ever since it was introduced. This PR restores the intended rendering and fixes the unit test that had codified the buggy behavior.

### Modifications / 改动点

- Core file changed: `astrbot/core/platform/astr_message_event.py` (`_outline_chain()`, lines 156-159), tests/unit/test_astr_message_event.py (lines 270-271).

- Reason: The original elif logic checked `At` before `AtAll`. Since `AtAll` is a subclass of `At`, `AtAll` messages were always caught by the `At` branch, making the `AtAll` branch unreachable. This fix moves the subclass check first to ensure proper identification. Replace the weak assertion (which matched the buggy [At:all] output) with a strict equality check outline == "[At:全体成员]" in tests/unit/test_astr_message_event.py, so the test now asserts the intended behavior and will catch any regression of this bug.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

1. Unit tests (all pass, including the updated `test_outline_with_at_all`):

   ```bash
   uv run pytest tests/unit/test_astr_message_event.py -v
   ```

   Result: `79 passed, 1 warning` (the warning is a pre-existing `audioop` deprecation notice, unrelated to this change).

2. Before/after demonstration (run from the repo root):

   ```bash
   uv run python -c "from astrbot.core.message.components import At, AtAll, Plain; from astrbot.core.platform.astr_message_event import AstrMessageEvent; print(AstrMessageEvent._outline_chain(None, [Plain('hello'), At(qq='12345'), AtAll()]))"
   ```

   - Before this fix: `hello [At:12345] [At:all]`
   - After this fix: `hello [At:12345] [At:全体成员]`

3. Lint:

   ```bash
   uv run ruff format --check . && uv run ruff check .
   ```

   Both pass.

---

Reopened after refining the description — no code changes. The body now documents why the test assertion was updated (per Sourcery's earlier suggestion) and adds full verification steps.

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Render AtAll mentions correctly by prioritizing their handling over the general At component case.

Bug Fixes:
- Correct message outlines so AtAll components render as `[At:全体成员]` instead of being treated as regular At mentions.

Tests:
- Strengthen the AtAll outline test to require the exact intended output.