### PR TITLE
fix: preserve shared preference deletion visibility

### DIFF
--- a/astrbot/core/utils/shared_preferences.py
+++ b/astrbot/core/utils/shared_preferences.py
@@ -16,6 +16,7 @@ from .astrbot_path import get_astrbot_data_path
 
 _VT = TypeVar("_VT")
 _MISSING = object()
+_DELETED = object()
 logger = logging.getLogger("astrbot")
 _WriteOperation = tuple[
     str,
@@ -52,6 +53,9 @@ class SharedPreferences:
         # See https://github.com/AstrBotDevs/AstrBot/pull/9649 for the original
         # deadlock scenario and design rationale.
         self._cache: dict[tuple[str, str, str], Any] = {}
+        # Deletions must mask database values until queued writes are persisted.
+        # Scope markers also cover historical keys that were never cached.
+        self._cleared_scopes: set[tuple[str, str]] = set()
         self._cache_lock = threading.RLock()
         self._cache_initialized = False
         self._initializing = False
@@ -83,8 +87,9 @@ class SharedPreferences:
             if action == "put" and key is not None:
                 self._cache[(scope, scope_id, key)] = deepcopy(value)
             elif action == "remove" and key is not None:
-                self._cache.pop((scope, scope_id, key), None)
+                self._cache[(scope, scope_id, key)] = _DELETED
             elif action == "clear":
+                self._cleared_scopes.add((scope, scope_id))
                 keys = [
                     cache_key
                     for cache_key in self._cache
@@ -288,8 +293,12 @@ class SharedPreferences:
             return default
         with self._cache_lock:
             value = self._cache.get((scope, scope_id, key), _MISSING)
+            if value is _DELETED:
+                return default
             if value is not _MISSING:
                 return deepcopy(value)
+            if (scope, scope_id) in self._cleared_scopes:
+                return default
         preference = await self.db_helper.get_preference(scope, scope_id, key)
         if preference is None:
             return default
@@ -483,8 +492,12 @@ class SharedPreferences:
         resolved_scope_id = scope_id or "unknown"
         with self._cache_lock:
             value = self._cache.get((resolved_scope, resolved_scope_id, key), _MISSING)
+            if value is _DELETED:
+                return default
             if value is not _MISSING:
                 return default if value is None else deepcopy(value)
+            if (resolved_scope, resolved_scope_id) in self._cleared_scopes:
+                return default
         # Overlay miss: fall back to a point query through a dedicated
         # synchronous database connection. This briefly blocks the calling
         # thread (unavoidable for a synchronous API), but never touches the
@@ -560,17 +573,21 @@ class SharedPreferences:
                 )
                 persisted = []
 
-        values = {
-            (preference.scope, preference.scope_id, preference.key): preference
-            for preference in persisted
-        }
         with self._cache_lock:
+            values = {
+                (preference.scope, preference.scope_id, preference.key): preference
+                for preference in persisted
+                if (preference.scope, preference.scope_id) not in self._cleared_scopes
+            }
             for (cache_scope, cache_scope_id, cache_key), value in self._cache.items():
                 if (
                     cache_scope == scope
                     and (scope_id is None or cache_scope_id == scope_id)
                     and (key is None or cache_key == key)
                 ):
+                    if value is _DELETED:
+                        values.pop((cache_scope, cache_scope_id, cache_key), None)
+                        continue
                     values[(cache_scope, cache_scope_id, cache_key)] = Preference(
                         scope=cache_scope,
                         scope_id=cache_scope_id,

--- a/tests/unit/test_shared_preferences.py
+++ b/tests/unit/test_shared_preferences.py
@@ -8,6 +8,72 @@ from astrbot.core.db.sqlite import SQLiteDatabase
 from astrbot.core.utils.shared_preferences import SharedPreferences
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["remove", "clear"])
+@pytest.mark.parametrize("reader", ["sync", "async", "range"])
+@pytest.mark.parametrize("cached", [False, True])
+async def test_pending_deletion_hides_persisted_values(
+    preferences, action, reader, cached
+):
+    store, database = preferences
+    if cached:
+        await store.put_async("plugin", "example", "state", "old")
+    else:
+        await database.insert_preference_or_update(
+            "plugin", "example", "state", {"val": "old"}
+        )
+
+    # The writer cannot run before the following synchronous read. Async reads
+    # must also see the deletion immediately, without depending on writer timing.
+    if action == "remove":
+        store.remove("state", scope="plugin", scope_id="example")
+    else:
+        store.clear(scope="plugin", scope_id="example")
+
+    if reader == "sync":
+        assert store.get("state", "missing", "plugin", "example") == "missing"
+    elif reader == "async":
+        assert (
+            await store.get_async("plugin", "example", "state", "missing") == "missing"
+        )
+    else:
+        assert store.range_get("plugin", "example") == []
+
+    await store.flush()
+    assert await database.get_preference("plugin", "example", "state") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["remove", "clear"])
+async def test_put_after_deletion_is_visible_and_preserves_other_scopes(
+    preferences, action
+):
+    store, database = preferences
+    for scope, scope_id in [
+        ("plugin", "example"),
+        ("plugin", "other"),
+        ("umo", "example"),
+    ]:
+        await store.put_async(scope, scope_id, "state", "old")
+    if action == "remove":
+        store.remove("state", scope="plugin", scope_id="example")
+    else:
+        store.clear(scope="plugin", scope_id="example")
+    store.put("state", "new", scope="plugin", scope_id="example")
+
+    assert store.get("state", scope="plugin", scope_id="example") == "new"
+    assert await store.get_async("plugin", "example", "state") == "new"
+    values = {
+        (item.scope_id, item.key): item.value["val"]
+        for item in store.range_get("plugin")
+    }
+    assert values == {("example", "state"): "new", ("other", "state"): "old"}
+    assert store.get("state", scope="umo", scope_id="example") == "old"
+    await store.flush()
+    persisted = await database.get_preference("plugin", "example", "state")
+    assert persisted.value == {"val": "new"}
+
+
 @pytest_asyncio.fixture
 async def preferences(tmp_path):
     database = SQLiteDatabase(str(tmp_path / "preferences.db"))
@@ -19,6 +85,41 @@ async def preferences(tmp_path):
     finally:
         await store.close()
         await database.engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["remove", "clear"])
+async def test_async_deletion_is_visible_while_persistence_is_pending(
+    preferences, monkeypatch, action
+):
+    store, database = preferences
+    await store.put_async("plugin", "example", "state", "old")
+    started = asyncio.Event()
+    release = asyncio.Event()
+    method_name = "remove_preference" if action == "remove" else "clear_preferences"
+    original = getattr(database, method_name)
+
+    async def delayed_delete(*args):
+        started.set()
+        await release.wait()
+        await original(*args)
+
+    monkeypatch.setattr(database, method_name, delayed_delete)
+    operation = (
+        store.remove_async("plugin", "example", "state")
+        if action == "remove"
+        else store.clear_async("plugin", "example")
+    )
+    task = asyncio.create_task(operation)
+    try:
+        await asyncio.wait_for(started.wait(), timeout=2)
+        assert not task.done()
+        assert await store.get_async("plugin", "example", "state") is None
+        assert store.get("state", scope="plugin", scope_id="example") is None
+        assert store.range_get("plugin", "example") == []
+    finally:
+        release.set()
+        await task
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Deleting or clearing a shared preference currently removes its in-memory overlay entry. A subsequent read falls back to SQLite and can return the old value before the queued deletion is persisted. This affects synchronous callers and concurrent readers while an asynchronous deletion is awaiting persistence.

For example, after persisting `state = "old"`, calling `remove("state", scope="plugin", scope_id="example")` followed immediately by `get("state", "missing", scope="plugin", scope_id="example")` returns `"old"`. With this change it returns `"missing"`.

### Modifications / 改动点

- Represent individual deletions with a tombstone in the process-local overlay.
- Track cleared scopes so historical keys that were never cached are also hidden. Subsequent puts take precedence over the scope marker.
- Apply deletion visibility to synchronous and asynchronous point reads and synchronous range reads.
- Add SQLite regression coverage for historical/cached values, remove/clear operations, replacement writes, scope isolation, and reads while asynchronous persistence is deliberately paused.

Deletion markers follow the existing process-local overlay lifetime; they do not preload the preferences table or enumerate historical keys during a clear.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

Verification performed on Windows with Python 3.12.8, using an isolated environment with the dependencies needed for the targeted tests. Ruff and pyupgrade match the repository's pinned versions (0.15.22 and 3.21.2).

Before the fix, the 12 new parametrized deletion/read regression cases failed by returning the persisted old value. After the fix:

```text
python -m pytest tests/unit/test_shared_preferences.py tests/test_code_quality_typing.py -q --tb=short --disable-warnings
27 passed, 46 warnings in 10.98s

ruff format --check .
569 files already formatted

ruff check .
All checks passed!

pyupgrade --py312-plus astrbot/core/utils/shared_preferences.py tests/unit/test_shared_preferences.py
# Passed without changes.

git diff --check
# Passed.
```

Warnings come from intentionally exercising the supported deprecated synchronous APIs. The full integration suite and application startup smoke test were not run.

---

### Checklist / 检查清单

- [ ] If there are new features added in the PR, I have discussed them with the authors through issues/emails, etc. (Not applicable: bug fix.)
- [x] My changes have been well-tested, and verification steps and test results have been provided above.
- [x] I have ensured that no new dependencies are introduced, OR new dependencies have been added to the appropriate dependency files. (No new project dependencies.)
- [x] My changes do not introduce malicious code.

## Summary by Sourcery

Preserve shared-preference deletion visibility until queued persistence completes.

Bug Fixes:
- Ensure pending shared-preference removals and scope clears immediately hide persisted values from synchronous, asynchronous, and range reads.
- Allow replacement writes after deletion while preserving values in other scopes.

Enhancements:
- Track process-local deletion state for both cached and historical preferences without preloading or enumerating stored keys.

Tests:
- Add SQLite regression coverage for deletion visibility, replacement writes, scope isolation, and reads while asynchronous persistence is pending.