### PR TITLE
fix: resolve persisted current conversation before deletion

### DIFF
--- a/astrbot/core/conversation_mgr.py
+++ b/astrbot/core/conversation_mgr.py
@@ -149,7 +149,7 @@ class ConversationManager:
 
         """
         if not conversation_id:
-            conversation_id = self.session_conversations.get(unified_msg_origin)
+            conversation_id = await self.get_curr_conversation_id(unified_msg_origin)
         if conversation_id:
             await self.db.delete_conversation(cid=conversation_id)
             curr_cid = await self.get_curr_conversation_id(unified_msg_origin)


### PR DESCRIPTION
Fixes #9997.

After a restart, `delete_conversation(umo)` can silently skip deletion because the current conversation ID is persisted but the in-memory cache is empty. Resolve the current selection from persistent storage when needed so the database record is deleted.

### Modifications / 改动点

- In `astrbot/core/conversation_mgr.py`, use `await self.get_curr_conversation_id(unified_msg_origin)` when the caller omits the conversation ID. This reuses the existing cache and persistent-storage lookup.
- Explicit conversation IDs and the existing selection cleanup behavior remain unchanged.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

- Reproduced the cold-cache failure before the fix; all 6 temporary mocked deletion cases passed afterward (not included in this PR).
- 13 tests passed, including existing conversation list/command tests.
- `ruff format .`, `ruff check .`, and `git diff --check` passed.

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Bug Fixes:
- Ensure deleting the current conversation resolves its persisted selection after restart, even when the in-memory conversation cache is empty.