### PR TITLE
fix: keep the newer SessionWaiter registration when an older one finishes

### DIFF
--- a/astrbot/core/utils/session_waiter.py
+++ b/astrbot/core/utils/session_waiter.py
@@ -143,7 +143,12 @@ class SessionWaiter:
 
     def _cleanup(self, error: Exception | None = None) -> None:
         """清理会话"""
-        USER_SESSIONS.pop(self.session_id, None)
+        # register_wait() lets a newer waiter replace this one under the same
+        # session_id. Only drop the registry entry if it still points at this
+        # waiter, otherwise the newer waiter becomes unreachable for trigger()
+        # and its future can only time out.
+        if USER_SESSIONS.get(self.session_id) is self:
+            USER_SESSIONS.pop(self.session_id, None)
         try:
             FILTERS.remove(self.session_filter)
         except ValueError:

--- a/tests/test_session_waiter.py
+++ b/tests/test_session_waiter.py
@@ -1,0 +1,72 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from astrbot.core.utils import session_waiter as sw
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    sw.USER_SESSIONS.clear()
+    sw.FILTERS.clear()
+    yield
+    sw.USER_SESSIONS.clear()
+    sw.FILTERS.clear()
+
+
+def _waiter(session_id: str) -> sw.SessionWaiter:
+    waiter = sw.SessionWaiter(sw.DefaultSessionFilter(), session_id, False)
+    sw.FILTERS.append(waiter.session_filter)
+    return waiter
+
+
+async def _finish(waiter: sw.SessionWaiter) -> None:
+    """Stop the waiter and let its keep-alive task exit."""
+    waiter.session_controller.stop()
+    event = waiter.session_controller.current_event
+    if event is not None:
+        event.set()
+    await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_finished_waiter_keeps_newer_registration_for_same_session():
+    old, new = _waiter("same"), _waiter("same")
+    handler = AsyncMock()
+
+    task_old = asyncio.create_task(old.register_wait(handler, timeout=10))
+    await asyncio.sleep(0)
+    task_new = asyncio.create_task(new.register_wait(handler, timeout=10))
+    await asyncio.sleep(0)
+    assert sw.USER_SESSIONS["same"] is new
+
+    await _finish(old)
+    await task_old
+
+    # The newer waiter must still be registered and reachable.
+    assert sw.USER_SESSIONS["same"] is new
+    assert not new.session_controller.future.done()
+
+    event = MagicMock()
+    event.get_messages.return_value = []
+    await sw.SessionWaiter.trigger("same", event)
+    handler.assert_awaited_once()
+    assert handler.await_args.args[0] is new.session_controller
+
+    await _finish(new)
+    await task_new
+    assert "same" not in sw.USER_SESSIONS
+
+
+@pytest.mark.asyncio
+async def test_finished_waiter_removes_its_own_registration():
+    waiter = _waiter("solo")
+    task = asyncio.create_task(waiter.register_wait(AsyncMock(), timeout=10))
+    await asyncio.sleep(0)
+    assert sw.USER_SESSIONS["solo"] is waiter
+
+    await _finish(waiter)
+    await task
+    assert "solo" not in sw.USER_SESSIONS
+    assert waiter.session_filter not in sw.FILTERS


### PR DESCRIPTION
### Motivation / 动机

Fixes #9996. `register_wait()` can replace the `USER_SESSIONS` entry of a `session_id` with a newer `SessionWaiter`, but the older waiter's `_cleanup()` always ran `USER_SESSIONS.pop(self.session_id, None)`. So when waiter A finished, timed out or was cancelled after waiter B had registered for the same session, B's entry was removed while B's future was still pending: `trigger()` could not find B any more and B could only time out. This happens whenever the same user starts an interactive flow twice.

### Modifications / 改动点

- `SessionWaiter._cleanup()` only removes the registry entry if it still points at the waiter being cleaned up (`USER_SESSIONS.get(self.session_id) is self`). Removing the filter and stopping the controller are unchanged.
- New `tests/test_session_waiter.py`: registering A then B for the same session, stopping A keeps B registered and reachable (`trigger()` runs B's handler with B's controller), and B still cleans up after itself; plus the plain single-waiter cleanup case. The first test fails on `master` and passes with the fix.

### Verification / 验证

```
uv run pytest tests/test_session_waiter.py   (2 passed)
ruff check / ruff format --check on the changed files
```

### Checklist / 检查清单

- [x] 我已经确认了我的更改不会引入新的错误 / I have confirmed my changes do not introduce new errors
- [x] 我已经添加了必要的测试 / I have added the necessary tests
- [ ] 我已经更新了相关文档 (if needed) / I have updated the relevant documentation (if needed)

## Summary by Sourcery

Prevent stale session waiters from removing newer registrations and leaving interactive flows unreachable.

Bug Fixes:
- Preserve a newer session waiter registration when an older waiter finishes, times out, or is cancelled for the same session.
- Ensure single-waiter registrations are still removed during cleanup.

Tests:
- Add coverage for replacement waiter cleanup, triggering the newer waiter, and normal single-waiter cleanup.