### PR TITLE
fix(kb): scale chunk_overlap with the heading-reduced budget in MarkdownChunker

### DIFF
--- a/astrbot/core/knowledge_base/chunking/markdown.py
+++ b/astrbot/core/knowledge_base/chunking/markdown.py
@@ -129,11 +129,14 @@ class MarkdownChunker(BaseChunker):
                 # 扣除前缀长度，确保添加前缀后不超过 chunk_size
                 prefix_len = self._estimate_prefix_length(heading_path)
                 effective_chunk_size = max(chunk_size // 4, chunk_size - prefix_len)
+                effective_overlap = self._scale_overlap(
+                    chunk_overlap, chunk_size, effective_chunk_size
+                )
 
                 sub_chunks = await self._fallback_chunker.chunk(
                     section_text,
                     chunk_size=effective_chunk_size,
-                    chunk_overlap=chunk_overlap,
+                    chunk_overlap=effective_overlap,
                 )
                 for i, sub_chunk in enumerate(sub_chunks):
                     chunk_text = self._apply_heading_context(
@@ -142,6 +145,22 @@ class MarkdownChunker(BaseChunker):
                     raw_chunks.append((chunk_text, True))
 
         return raw_chunks
+
+    @staticmethod
+    def _scale_overlap(
+        chunk_overlap: int, chunk_size: int, effective_chunk_size: int
+    ) -> int:
+        """按正文预算等比缩放重叠长度。
+
+        标题前缀会压缩子块可用的 chunk_size，而外部传入的 chunk_overlap 是针对
+        完整 chunk_size 配置的。原样传递会让合法配置在内部变成
+        overlap >= effective_chunk_size，被递归分块器拒绝。保持
+        overlap / chunk_size 的比例，并确保结果严格小于 effective_chunk_size。
+        """
+        if chunk_size <= 0 or effective_chunk_size >= chunk_size:
+            return chunk_overlap
+        scaled = chunk_overlap * effective_chunk_size // chunk_size
+        return max(0, min(scaled, effective_chunk_size - 1))
 
     def _build_context_prefix(self, heading_path: list[str]) -> str:
         """构建标题路径前缀"""

--- a/tests/test_markdown_chunker.py
+++ b/tests/test_markdown_chunker.py
@@ -2,7 +2,17 @@ import pytest
 
 from astrbot.core.knowledge_base.chunking.markdown import MarkdownChunker
 
-LONG_HEADING_DOC = "# " + "A" * 200 + "\n\n## Child\n" + "B" * 600
+# 600 characters of body made of unique markers (w000 ... w119), so a lost
+# body segment is detected even though overlapping chunks duplicate text.
+BODY_MARKERS = [f"w{i:03d}" for i in range(120)]
+BODY = " ".join(BODY_MARKERS) + " "
+LONG_HEADING_DOC = "# " + "A" * 200 + "\n\n## Child\n" + BODY
+
+
+def _assert_body_preserved(chunks: list[str]) -> None:
+    joined = "\n".join(chunks)
+    missing = [marker for marker in BODY_MARKERS if marker not in joined]
+    assert not missing, f"body markers lost during chunking: {missing}"
 
 
 @pytest.mark.asyncio
@@ -14,9 +24,7 @@ async def test_long_heading_prefix_keeps_valid_overlap_configuration():
     chunks = await chunker.chunk(LONG_HEADING_DOC)
 
     assert chunks
-    assert "".join(chunks).count("B") >= 600
-    # The overlap now scales with the reduced budget instead of exceeding it.
-    assert all("B" * 65 not in chunk for chunk in chunks)
+    _assert_body_preserved(chunks)
 
 
 @pytest.mark.asyncio
@@ -26,7 +34,7 @@ async def test_overlap_override_is_scaled_too():
     chunks = await chunker.chunk(LONG_HEADING_DOC, chunk_size=256, chunk_overlap=100)
 
     assert chunks
-    assert "".join(chunks).count("B") >= 600
+    _assert_body_preserved(chunks)
 
 
 @pytest.mark.asyncio
@@ -38,6 +46,7 @@ async def test_without_heading_context_behaviour_is_unchanged():
     chunks = await chunker.chunk(LONG_HEADING_DOC)
 
     assert chunks
+    _assert_body_preserved(chunks)
     assert all(len(chunk) <= 256 for chunk in chunks)
 
 

--- a/tests/test_markdown_chunker.py
+++ b/tests/test_markdown_chunker.py
@@ -1,0 +1,55 @@
+import pytest
+
+from astrbot.core.knowledge_base.chunking.markdown import MarkdownChunker
+
+LONG_HEADING_DOC = "# " + "A" * 200 + "\n\n## Child\n" + "B" * 600
+
+
+@pytest.mark.asyncio
+async def test_long_heading_prefix_keeps_valid_overlap_configuration():
+    """A valid (chunk_size, chunk_overlap) pair must stay valid for the
+    recursive fallback even when the heading prefix shrinks the body budget."""
+    chunker = MarkdownChunker(chunk_size=256, chunk_overlap=100)
+
+    chunks = await chunker.chunk(LONG_HEADING_DOC)
+
+    assert chunks
+    assert "".join(chunks).count("B") >= 600
+    # The overlap now scales with the reduced budget instead of exceeding it.
+    assert all("B" * 65 not in chunk for chunk in chunks)
+
+
+@pytest.mark.asyncio
+async def test_overlap_override_is_scaled_too():
+    chunker = MarkdownChunker(chunk_size=1024, chunk_overlap=50)
+
+    chunks = await chunker.chunk(LONG_HEADING_DOC, chunk_size=256, chunk_overlap=100)
+
+    assert chunks
+    assert "".join(chunks).count("B") >= 600
+
+
+@pytest.mark.asyncio
+async def test_without_heading_context_behaviour_is_unchanged():
+    chunker = MarkdownChunker(
+        chunk_size=256, chunk_overlap=100, include_heading_context=False
+    )
+
+    chunks = await chunker.chunk(LONG_HEADING_DOC)
+
+    assert chunks
+    assert all(len(chunk) <= 256 for chunk in chunks)
+
+
+@pytest.mark.parametrize(
+    ("overlap", "size", "effective", "expected"),
+    [
+        (100, 256, 64, 25),  # proportional to the reduced budget
+        (100, 256, 256, 100),  # no reduction, untouched
+        (100, 256, 300, 100),  # larger budget, untouched
+        (255, 256, 64, 63),  # never reaches the effective size
+        (0, 256, 64, 0),
+    ],
+)
+def test_scale_overlap(overlap, size, effective, expected):
+    assert MarkdownChunker._scale_overlap(overlap, size, effective) == expected


### PR DESCRIPTION
### Motivation / 动机

Fixes #9998. `MarkdownChunker._sections_to_chunks` deducts the inherited heading prefix from the `chunk_size` it hands to the recursive fallback chunker (`effective_chunk_size = max(chunk_size // 4, chunk_size - prefix_len)`), but passed the caller's `chunk_overlap` through unchanged. A valid external configuration such as `chunk_size=256, chunk_overlap=100` therefore became `overlap=100 >= effective_chunk_size=64` for a section under a long heading, and `RecursiveCharacterChunker` raised `chunk_overlap must be less than chunk_size`, failing a Markdown upload at the chunking stage. The same document chunks fine with `include_heading_context=False`.

### Modifications / 改动点

- New `MarkdownChunker._scale_overlap(chunk_overlap, chunk_size, effective_chunk_size)`: when the body budget was reduced, the overlap is scaled proportionally (`100/256` → `25/64`) and always kept strictly below the effective chunk size; when the budget is not reduced the overlap is untouched.
- `_sections_to_chunks` passes the scaled overlap to the fallback chunker.
- New `tests/test_markdown_chunker.py`: the reproducer from the issue (200-char parent heading, `## Child`, 600 chars of body, `chunk_size=256, chunk_overlap=100`) now chunks without error and keeps all body text, also when the sizes are passed as `chunk()` overrides; `include_heading_context=False` is unchanged; parametrized cases for `_scale_overlap`. The reproducer tests fail on `master` and pass with the fix.

### Verification / 验证

```
uv run pytest tests/test_markdown_chunker.py   (8 passed)
ruff check / ruff format --check on the changed files
```

### Checklist / 检查清单

- [x] 我已经确认了我的更改不会引入新的错误 / I have confirmed my changes do not introduce new errors
- [x] 我已经添加了必要的测试 / I have added the necessary tests
- [ ] 我已经更新了相关文档 (if needed) / I have updated the relevant documentation (if needed)

## Summary by Sourcery

Keep Markdown chunk overlap valid when inherited heading context reduces the available body budget.

Bug Fixes:
- Prevent Markdown chunking failures when heading context reduces the effective chunk size by scaling overlap proportionally and keeping it below the fallback chunk size.

Tests:
- Add regression coverage for long heading prefixes, chunk-size overrides, heading-context-disabled behavior, and overlap scaling.