### PR TITLE
fix(kb): keep the requested chunk parameters when URL cleaning falls back

### DIFF
--- a/astrbot/core/knowledge_base/kb_helper.py
+++ b/astrbot/core/knowledge_base/kb_helper.py
@@ -834,9 +834,12 @@ class KBHelper:
 
         if not cleaning_provider_id:
             logger.warning(
-                "启用了内容清洗，但未提供 cleaning_provider_id，跳过清洗并使用默认分块。"
+                "启用了内容清洗，但未提供 cleaning_provider_id，跳过清洗并使用指定参数分块: "
+                f"chunk_size={chunk_size}, chunk_overlap={chunk_overlap}"
             )
-            return await self.chunker.chunk(content)
+            return await self.chunker.chunk(
+                content, chunk_size=chunk_size, chunk_overlap=chunk_overlap
+            )
 
         if progress_callback:
             await progress_callback("cleaning", 0, 100)
@@ -891,5 +894,7 @@ class KBHelper:
 
         except Exception as e:
             logger.error(f"使用 Provider '{cleaning_provider_id}' 清洗内容失败: {e}")
-            # 清洗失败，返回默认分块结果，保证流程不中断
-            return await self.chunker.chunk(content)
+            # 清洗失败，回退到普通分块，但保留本次传入的分块参数，保证流程不中断
+            return await self.chunker.chunk(
+                content, chunk_size=chunk_size, chunk_overlap=chunk_overlap
+            )

--- a/tests/test_kb_clean_rechunk_fallback.py
+++ b/tests/test_kb_clean_rechunk_fallback.py
@@ -1,0 +1,69 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from astrbot.core.knowledge_base.kb_helper import KBHelper
+
+
+class _RecordingChunker:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def chunk(self, text: str, **kwargs) -> list[str]:
+        self.calls.append(kwargs)
+        size = kwargs.get("chunk_size", 500)
+        return [text[i : i + size] for i in range(0, len(text), size)]
+
+
+def _helper(chunker: _RecordingChunker, provider_error: Exception | None = None):
+    helper = KBHelper.__new__(KBHelper)
+    helper.chunker = chunker
+    helper.prov_mgr = AsyncMock()
+    helper.prov_mgr.get_provider_by_id = AsyncMock(side_effect=provider_error)
+    return helper
+
+
+CONTENT = "x" * 1000
+PARAMS = {"chunk_size": 128, "chunk_overlap": 16}
+
+
+@pytest.mark.asyncio
+async def test_missing_cleaning_provider_keeps_requested_chunk_params():
+    chunker = _RecordingChunker()
+    helper = _helper(chunker)
+
+    chunks = await helper._clean_and_rechunk_content(
+        CONTENT, "https://example.com", enable_cleaning=True, **PARAMS
+    )
+
+    assert chunker.calls == [PARAMS]
+    assert max(len(c) for c in chunks) <= 128
+
+
+@pytest.mark.asyncio
+async def test_failed_cleaning_provider_lookup_keeps_requested_chunk_params():
+    chunker = _RecordingChunker()
+    helper = _helper(chunker, provider_error=RuntimeError("provider unavailable"))
+
+    chunks = await helper._clean_and_rechunk_content(
+        CONTENT,
+        "https://example.com",
+        enable_cleaning=True,
+        cleaning_provider_id="llm-1",
+        **PARAMS,
+    )
+
+    assert chunker.calls == [PARAMS]
+    assert max(len(c) for c in chunks) <= 128
+
+
+@pytest.mark.asyncio
+async def test_cleaning_disabled_still_passes_chunk_params():
+    chunker = _RecordingChunker()
+    helper = _helper(chunker)
+
+    await helper._clean_and_rechunk_content(
+        CONTENT, "https://example.com", enable_cleaning=False, **PARAMS
+    )
+
+    assert chunker.calls == [PARAMS]

--- a/tests/test_kb_clean_rechunk_fallback.py
+++ b/tests/test_kb_clean_rechunk_fallback.py
@@ -2,6 +2,9 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+# Importing the core lifecycle first resolves the import cycle between
+# astrbot.core.provider.manager and astrbot.core.knowledge_base.
+import astrbot.core.core_lifecycle  # noqa: F401
 from astrbot.core.knowledge_base.kb_helper import KBHelper
 
 


### PR DESCRIPTION
### Motivation / 动机

Fixes #9999. `KBHelper._clean_and_rechunk_content()` fell back to `self.chunker.chunk(content)` in two places: when cleaning is enabled but no `cleaning_provider_id` is given, and when `get_provider_by_id` fails. Both fallbacks dropped the `chunk_size` / `chunk_overlap` requested for this upload and used the shared chunker's defaults (500/100), so a request for 128/16 was stored as 500-character chunks. Since `upload_document(pre_chunked_text=...)` uses those chunks as they are, the later size parameters could not correct it. The normal (cleaning disabled) path already forwarded the parameters.

### Modifications / 改动点

- Both fallback branches now call `self.chunker.chunk(content, chunk_size=chunk_size, chunk_overlap=chunk_overlap)`; the warning log for the missing provider id names the parameters that are used.
- New `tests/test_kb_clean_rechunk_fallback.py`: with a recording chunker and a provider manager whose lookup raises, both fallback paths (and the cleaning-disabled path) receive `chunk_size=128, chunk_overlap=16` and produce chunks of at most 128 characters. The two fallback tests fail on `master` and pass with the fix.

### Verification / 验证

```
uv run pytest tests/test_kb_clean_rechunk_fallback.py   (3 passed)
ruff check / ruff format --check on the changed files
```

### Checklist / 检查清单

- [x] 我已经确认了我的更改不会引入新的错误 / I have confirmed my changes do not introduce new errors
- [x] 我已经添加了必要的测试 / I have added the necessary tests
- [ ] 我已经更新了相关文档 (if needed) / I have updated the relevant documentation (if needed)

## Summary by Sourcery

Keep requested chunking parameters when falling back to ordinary chunking during knowledge-base content processing.

Bug Fixes:
- Preserve the upload-specific chunk size and overlap when content cleaning is skipped or cleaning provider lookup fails.

Enhancements:
- Clarify fallback logging to report the chunking parameters being used.

Tests:
- Add coverage for cleaning fallbacks and the existing cleaning-disabled path to verify requested chunk parameters are retained and chunk sizes remain bounded.