### PR TITLE
fix(kb): do not turn Xinference rerank failures into empty retrieval results

### DIFF
--- a/tests/test_xinference_rerank_source.py
+++ b/tests/test_xinference_rerank_source.py
@@ -1,0 +1,96 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Importing the core lifecycle first resolves the import cycle between
+# astrbot.core.provider.manager and astrbot.core.knowledge_base.
+import astrbot.core.core_lifecycle  # noqa: F401
+from astrbot.core.knowledge_base.retrieval.manager import (
+    RetrievalManager,
+    RetrievalResult,
+)
+from astrbot.core.provider.entities import RerankResult
+from astrbot.core.provider.sources.xinference_rerank_source import (
+    XinferenceRerankProvider,
+)
+
+
+def _provider(model=None) -> XinferenceRerankProvider:
+    provider = XinferenceRerankProvider.__new__(XinferenceRerankProvider)
+    provider.model = model
+    return provider
+
+
+@pytest.mark.asyncio
+async def test_rerank_raises_when_model_is_not_initialized():
+    with pytest.raises(RuntimeError, match="not initialized"):
+        await _provider(model=None).rerank("query", ["doc"])
+
+
+@pytest.mark.asyncio
+async def test_rerank_propagates_upstream_failures():
+    model = MagicMock()
+    model.rerank = AsyncMock(side_effect=ConnectionError("xinference unavailable"))
+
+    with pytest.raises(ConnectionError, match="xinference unavailable"):
+        await _provider(model=model).rerank("query", ["doc a", "doc b"])
+
+
+@pytest.mark.asyncio
+async def test_rerank_maps_results():
+    model = MagicMock()
+    model.rerank = AsyncMock(
+        return_value={"results": [{"index": 1, "relevance_score": 0.9}]}
+    )
+
+    results = await _provider(model=model).rerank("query", ["doc a", "doc b"], 1)
+
+    model.rerank.assert_awaited_once_with(["doc a", "doc b"], "query", 1)
+    assert results == [RerankResult(index=1, relevance_score=0.9)]
+
+
+def _result(i: int) -> RetrievalResult:
+    return RetrievalResult(
+        chunk_id=f"chunk-{i}",
+        doc_id="doc",
+        doc_name="doc.md",
+        kb_id="kb",
+        kb_name="kb",
+        content=f"content {i}",
+        score=1.0 - i / 10,
+        metadata={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_manager_keeps_fused_results_when_rerank_returns_nothing():
+    manager = RetrievalManager.__new__(RetrievalManager)
+    provider = MagicMock()
+    provider.rerank = AsyncMock(return_value=[])
+    fused = [_result(0), _result(1), _result(2)]
+
+    reranked = await manager._rerank(
+        query="query", results=fused, top_k=2, rerank_provider=provider
+    )
+
+    assert reranked == fused[:2]
+
+
+@pytest.mark.asyncio
+async def test_manager_applies_rerank_scores():
+    manager = RetrievalManager.__new__(RetrievalManager)
+    provider = MagicMock()
+    provider.rerank = AsyncMock(
+        return_value=[
+            RerankResult(index=1, relevance_score=0.95),
+            RerankResult(index=0, relevance_score=0.10),
+        ]
+    )
+    fused = [_result(0), _result(1)]
+
+    reranked = await manager._rerank(
+        query="query", results=fused, top_k=2, rerank_provider=provider
+    )
+
+    assert [r.chunk_id for r in reranked] == ["chunk-1", "chunk-0"]
+    assert [r.score for r in reranked] == [0.95, 0.10]


### PR DESCRIPTION
### Motivation / 动机

Fixes #10000. `XinferenceRerankProvider.rerank()` returned `[]` when the model was not initialized or the upstream call raised. `RetrievalManager.retrieve()` only keeps the fused candidates when the rerank call raises, so it treated the `[]` as a valid rerank result and replaced the non-empty candidates with nothing: a temporary Xinference outage looked like "no matches" in the knowledge base, and the degradation path that already exists for exceptions never ran.

### Modifications / 改动点

- `xinference_rerank_source.py`: `rerank()` raises `RuntimeError` when the model is not initialized and re-raises upstream failures after logging them (the vLLM and NVIDIA providers already raise; `RerankProvider.test()` and the dashboard's provider test also treat an empty result as an error, so nothing downstream relied on the silent `[]`).
- `retrieval/manager.py`: `_rerank()` keeps the fused candidates (with a warning) when a provider answers non-empty input with no results at all. A rerank of non-empty candidates never legitimately scores none of them, and this also protects against other providers that still return `[]` on transport problems.
- New `tests/test_xinference_rerank_source.py`: provider raises when uninitialized and propagates upstream errors, maps successful results; the manager keeps the fused results for an empty rerank answer and still applies real rerank scores. Three of the five tests fail on `master` and pass with the fix.

### Verification / 验证

```
uv run pytest tests/test_xinference_rerank_source.py   (5 passed)
ruff check / ruff format --check on the changed files
```

### Checklist / 检查清单

- [x] 我已经确认了我的更改不会引入新的错误 / I have confirmed my changes do not introduce new errors
- [x] 我已经添加了必要的测试 / I have added the necessary tests
- [ ] 我已经更新了相关文档 (if needed) / I have updated the relevant documentation (if needed)

## Summary by Sourcery

Ensure reranking failures degrade to the existing retrieval results instead of producing empty search results.

Bug Fixes:
- Prevent Xinference rerank failures from being interpreted as empty knowledge-base retrieval results.
- Preserve fused retrieval candidates when reranking returns no results for a non-empty input.

Tests:
- Add coverage for Xinference provider initialization failures, upstream errors, successful result mapping, and retrieval fallback behavior.