### PR TITLE
fix(kb): recognize indented Markdown code fences

### DIFF
--- a/astrbot/core/knowledge_base/chunking/markdown.py
+++ b/astrbot/core/knowledge_base/chunking/markdown.py
@@ -312,7 +312,7 @@ class MarkdownChunker(BaseChunker):
     def _find_fenced_code_ranges(text: str) -> list[tuple[int, int]]:
         """找到所有围栏代码块的 (start, end) 范围"""
         ranges: list[tuple[int, int]] = []
-        fence_pattern = re.compile(r"^(`{3,}|~{3,})", re.MULTILINE)
+        fence_pattern = re.compile(r"^ {0,3}(`{3,}|~{3,})", re.MULTILINE)
         matches = list(fence_pattern.finditer(text))
 
         i = 0

--- a/tests/unit/test_kb_upload_atomicity.py
+++ b/tests/unit/test_kb_upload_atomicity.py
@@ -350,6 +350,7 @@ async def test_upload_document_cleans_up_on_storage_failure(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("fence", ["```", "~~~"])
 @pytest.mark.parametrize(
     ("file_name", "file_type"),
     [
@@ -364,6 +365,7 @@ async def test_upload_document_cleans_up_on_storage_failure(
 async def test_upload_document_preserves_markdown_heading_paths(
     file_name: str,
     file_type: str,
+    fence: str,
     tmp_path: Path,
     stub_provider_manager_module,
 ) -> None:
@@ -384,10 +386,17 @@ async def test_upload_document_preserves_markdown_heading_paths(
     helper.kb_medias_dir = tmp_path / "medias"
     helper.chunker = AsyncMock()
 
+    code_block = (
+        f"   {fence}python\n"
+        "# This is a code comment\n"
+        "print(123)\n"
+        f"   {fence}"
+    )
     parse_result = MagicMock(
         text=(
             "# Handbook\n\nOverview.\n\n"
             "## Installation\n\nInstall the package.\n\n"
+            f"{code_block}\n\n"
             "### Linux\n\nRun the command."
         ),
         media=[],
@@ -415,6 +424,8 @@ async def test_upload_document_preserves_markdown_heading_paths(
     embedding_contents = helper.vec_db.insert_batch.await_args.kwargs[
         "embedding_contents"
     ]
+    assert len(contents) == 3
+    assert code_block in contents[1]
     assert "Handbook > Installation\n\n### Linux" in contents[2]
     assert embedding_contents[2] == f"guide\n\n{contents[2]}"
 


### PR DESCRIPTION
Markdown code fences may have up to three leading spaces, but `MarkdownChunker` only recognizes fences at column zero. When an indented code block contains a line such as `# This is a code comment`, the chunker treats that line as a document heading, splits the code block, and assigns the false heading as context for later sections.

For example, a document with `Handbook > Installation > Linux` headings and an indented Python code block under Installation produces four chunks. The Linux chunk inherits `This is a code comment` instead of `Handbook > Installation`. With this change, it produces three chunks, preserves the entire code block, and retains the correct heading path.

This follows the [CommonMark fenced-code-block indentation rule](https://spec.commonmark.org/0.31.2/#fenced-code-blocks).

### Modifications

- Allow zero to three leading spaces when locating opening and closing code fences.
- Extend the existing upload heading-context regression test with indented backtick and tilde code blocks. Check both code-block integrity and the following section's parent headings.

- [x] This is not a breaking change.

### Verification steps and test results

Tested locally on Windows with Python 3.12.14:

- Before the production fix: all 12 extended heading-context cases failed, exposing the extra chunk and incorrect parent heading.
- After the fix: `tests/unit/test_kb_upload_atomicity.py` — **24 passed**. These existing tests exercise upload/chunking with mocked parser output and storage; they do not call external embedding services.
- Additional local chunker checks — **48/48 passed**, covering both fence types, every combination of 0–3 spaces on opening/closing fences, unclosed blocks, four-space/tab exclusions, and shorter inner/longer closing fences. The same checks passed 10/48 on the baseline.
- `ruff format .`, `ruff check .`, and `git diff --check` passed; pre-commit's Ruff and pyupgrade hooks also passed on both changed files.

To rerun the repository regression tests:

```sh
uv run pytest tests/unit/test_kb_upload_atomicity.py -q
```

### Checklist

- [x] This is a bug fix; no new feature is introduced.
- [x] The change has been tested, with verification steps and results above.
- [x] No new dependencies are introduced.
- [x] The change contains no malicious code.

Developed with OpenAI Codex assistance.

## Summary by Sourcery

Preserve indented Markdown code fences and maintain correct heading context when chunking documents.

Bug Fixes:
- Recognize Markdown fenced code blocks indented by up to three spaces so headings inside them no longer split chunks or corrupt heading context.

Tests:
- Extend heading-context regression coverage to indented backtick and tilde fences, verifying code-block preservation and subsequent section hierarchy.