### PR TITLE
feat(webchat): enable reasoning display by default

### DIFF
--- a/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
+++ b/astrbot/core/pipeline/process_stage/method/agent_sub_stages/internal.py
@@ -152,6 +152,10 @@ class InternalAgentSubStage(Stage):
             if (enable_streaming := event.get_extra("enable_streaming")) is not None:
                 streaming_response = bool(enable_streaming)
 
+            show_reasoning = self.show_reasoning
+            if (enable_reasoning := event.get_extra("enable_reasoning")) is not None:
+                show_reasoning = bool(enable_reasoning)
+
             has_provider_request = event.get_extra("provider_request") is not None
             has_valid_message = bool(event.message_str and event.message_str.strip())
             has_media_content = any(
@@ -300,7 +304,7 @@ class InternalAgentSubStage(Stage):
                                     self.max_step,
                                     self.show_tool_use,
                                     self.show_tool_call_result,
-                                    show_reasoning=self.show_reasoning,
+                                    show_reasoning=show_reasoning,
                                     buffer_intermediate_messages=self.buffer_intermediate_messages,
                                 ),
                             ),
@@ -331,7 +335,7 @@ class InternalAgentSubStage(Stage):
                                     self.max_step,
                                     self.show_tool_use,
                                     self.show_tool_call_result,
-                                    show_reasoning=self.show_reasoning,
+                                    show_reasoning=show_reasoning,
                                     buffer_intermediate_messages=self.buffer_intermediate_messages,
                                 ),
                             ),
@@ -362,7 +366,7 @@ class InternalAgentSubStage(Stage):
                             self.show_tool_use,
                             self.show_tool_call_result,
                             stream_to_general,
-                            show_reasoning=self.show_reasoning,
+                            show_reasoning=show_reasoning,
                             buffer_intermediate_messages=self.buffer_intermediate_messages,
                         ):
                             yield

--- a/astrbot/core/pipeline/result_decorate/stage.py
+++ b/astrbot/core/pipeline/result_decorate/stage.py
@@ -286,9 +286,13 @@ class ResultDecorateStage(Stage):
                     "provider configured.",
                 )
 
+            show_reasoning = self.show_reasoning
+            if (enable_reasoning := event.get_extra("enable_reasoning")) is not None:
+                show_reasoning = bool(enable_reasoning)
+
             if (
                 not should_tts
-                and self.show_reasoning
+                and show_reasoning
                 and event.get_extra("_llm_reasoning_content")
             ):
                 # inject reasoning content to chain

--- a/astrbot/core/platform/sources/webchat/request_flags.py
+++ b/astrbot/core/platform/sources/webchat/request_flags.py
@@ -4,6 +4,7 @@ WEBCHAT_REQUEST_FLAG_DEFAULTS = {
     "enable_inline_genui": True,
     "enable_default_system_prompt": True,
     "enable_streaming": True,
+    "enable_reasoning": True,
 }
 
 

--- a/astrbot/dashboard/schemas.py
+++ b/astrbot/dashboard/schemas.py
@@ -129,6 +129,7 @@ class ChatFlags(BaseModel):
     enable_inline_genui: bool = True
     enable_default_system_prompt: bool = True
     enable_streaming: bool = True
+    enable_reasoning: bool = True
 
 
 class ChatMessageRegenerateRequest(OpenModel):

--- a/dashboard/src/api/generated/openapi-v1/types.gen.ts
+++ b/dashboard/src/api/generated/openapi-v1/types.gen.ts
@@ -83,6 +83,10 @@ export type ChatFlags = {
      * Enable streaming model output for this request. This value takes priority over the legacy top-level enable_streaming field.
      */
     enable_streaming?: boolean;
+    /**
+     * Display reasoning content for this WebChat request independently of the global display_reasoning_text setting.
+     */
+    enable_reasoning?: boolean;
 };
 
 export type ChatMessagePatchRequest = {

--- a/dashboard/src/components/chat/Chat.vue
+++ b/dashboard/src/components/chat/Chat.vue
@@ -364,6 +364,7 @@
             :staged-files="stagedNonImageFiles"
             :disabled="sending"
             :enable-streaming="enableStreaming"
+            :enable-reasoning="enableReasoning"
             :is-recording="isRecording"
             :is-running="
               Boolean(currSessionId && isSessionRunning(currSessionId))
@@ -378,6 +379,7 @@
             @send="sendCurrentMessage"
             @stop="stopCurrentSession"
             @toggle-streaming="toggleStreaming"
+            @toggle-reasoning="enableReasoning = !enableReasoning"
             @remove-image="removeImage"
             @remove-audio="removeAudio"
             @remove-file="removeFile"
@@ -449,6 +451,7 @@
             :staged-files="stagedNonImageFiles"
             :disabled="sending"
             :enable-streaming="enableStreaming"
+            :enable-reasoning="enableReasoning"
             :is-recording="isRecording"
             :is-running="
               Boolean(currSessionId && isSessionRunning(currSessionId))
@@ -465,6 +468,7 @@
             @send="sendCurrentMessage"
             @stop="stopCurrentSession"
             @toggle-streaming="toggleStreaming"
+            @toggle-reasoning="enableReasoning = !enableReasoning"
             @remove-image="removeImage"
             @remove-audio="removeAudio"
             @remove-file="removeFile"
@@ -743,6 +747,7 @@ const threadSelection = reactive<{
   selectedText: "",
 });
 const enableStreaming = ref(true);
+const enableReasoning = ref(true);
 const sendShortcut = ref<"enter" | "shift_enter">("enter");
 let composerResizeObserver: ResizeObserver | null = null;
 const {
@@ -1400,6 +1405,7 @@ async function sendCurrentMessage() {
       parts: outgoingParts,
       transport: transportMode.value,
       enableStreaming: enableStreaming.value,
+      enableReasoning: enableReasoning.value,
       selectedProvider: selection?.providerId || "",
       selectedModel: selection?.modelName || "",
       userRecord,
@@ -1521,6 +1527,7 @@ async function saveMessageEdit() {
         sessionId: currSessionId.value,
         sourceRecord: target,
         enableStreaming: enableStreaming.value,
+        enableReasoning: enableReasoning.value,
         selectedProvider: selection?.providerId || "",
         selectedModel: selection?.modelName || "",
       });
@@ -1556,6 +1563,7 @@ async function handleRegenerateMessage(
     effectiveSelection?.providerId || "",
     effectiveSelection?.modelName || "",
     enableStreaming.value,
+    enableReasoning.value,
   );
 }
 

--- a/dashboard/src/components/chat/ChatInput.vue
+++ b/dashboard/src/components/chat/ChatInput.vue
@@ -166,6 +166,22 @@
                 }}
               </v-list-item-title>
             </v-list-item>
+            <v-list-item
+              class="styled-menu-item"
+              rounded="md"
+              @click="$emit('toggleReasoning')"
+            >
+              <template v-slot:prepend>
+                <v-icon icon="mdi-brain" size="small"></v-icon>
+              </template>
+              <v-list-item-title>
+                {{
+                  enableReasoning
+                    ? tm("reasoning.enabled")
+                    : tm("reasoning.disabled")
+                }}
+              </v-list-item-title>
+            </v-list-item>
           </StyledMenu>
 
         </div>
@@ -355,6 +371,7 @@ interface Props {
   stagedFiles?: StagedFileInfo[];
   disabled: boolean;
   enableStreaming: boolean;
+  enableReasoning: boolean;
   isRecording: boolean;
   isRunning: boolean;
   sessionId?: string | null;
@@ -383,6 +400,7 @@ const emit = defineEmits<{
   send: [];
   stop: [];
   toggleStreaming: [];
+  toggleReasoning: [];
   removeImage: [index: number];
   removeAudio: [];
   removeFile: [index: number];

--- a/dashboard/src/components/chat/StandaloneChat.vue
+++ b/dashboard/src/components/chat/StandaloneChat.vue
@@ -177,6 +177,7 @@
         :staged-files="stagedNonImageFiles"
         :disabled="sending || initializing"
         :enable-streaming="enableStreaming"
+        :enable-reasoning="enableReasoning"
         :is-recording="false"
         :is-running="Boolean(currSessionId && isSessionRunning(currSessionId))"
         :session-id="currSessionId || null"
@@ -186,6 +187,7 @@
         @send="sendCurrentMessage"
         @stop="stopCurrentSession"
         @toggle-streaming="enableStreaming = !enableStreaming"
+        @toggle-reasoning="enableReasoning = !enableReasoning"
         @remove-image="removeImage"
         @remove-audio="removeAudio"
         @remove-file="removeFile"
@@ -258,6 +260,7 @@ const currentSession = ref<Session | null>(null);
 const draft = ref("");
 const initializing = ref(false);
 const enableStreaming = ref(true);
+const enableReasoning = ref(true);
 const shouldStickToBottom = ref(true);
 const messagesContainer = ref<HTMLElement | null>(null);
 const inputRef = ref<InstanceType<typeof ChatInput> | null>(null);
@@ -362,6 +365,7 @@ async function sendCurrentMessage() {
     parts,
     transport: transportMode.value,
     enableStreaming: enableStreaming.value,
+    enableReasoning: enableReasoning.value,
     selectedProvider: selection?.providerId || "",
     selectedModel: selection?.modelName || "",
     userRecord,

--- a/dashboard/src/composables/useMessages.ts
+++ b/dashboard/src/composables/useMessages.ts
@@ -4,11 +4,15 @@ import { fetchWithAuth } from "@/api/http";
 
 export type TransportMode = "sse" | "websocket";
 
-export function buildChatRequestFlags(enableStreaming = true) {
+export function buildChatRequestFlags(
+  enableStreaming = true,
+  enableReasoning = true,
+) {
   return {
     enable_inline_genui: true,
     enable_default_system_prompt: true,
     enable_streaming: enableStreaming,
+    enable_reasoning: enableReasoning,
   };
 }
 
@@ -109,6 +113,7 @@ interface SendMessageStreamOptions {
   parts: MessagePart[];
   transport: TransportMode;
   enableStreaming?: boolean;
+  enableReasoning?: boolean;
   selectedProvider?: string;
   selectedModel?: string;
   userRecord?: ChatRecord;
@@ -121,6 +126,7 @@ interface ContinueEditedMessageOptions {
   sessionId: string;
   sourceRecord: ChatRecord;
   enableStreaming?: boolean;
+  enableReasoning?: boolean;
   selectedProvider?: string;
   selectedModel?: string;
 }
@@ -374,6 +380,7 @@ export function useMessages(options: UseMessagesOptions) {
     parts,
     transport,
     enableStreaming = true,
+    enableReasoning = true,
     selectedProvider = "",
     selectedModel = "",
     botRecord,
@@ -389,6 +396,7 @@ export function useMessages(options: UseMessagesOptions) {
         botRecord,
         userRecord,
         enableStreaming,
+        enableReasoning,
         selectedProvider,
         selectedModel,
       );
@@ -401,6 +409,7 @@ export function useMessages(options: UseMessagesOptions) {
       botRecord,
       userRecord,
       enableStreaming,
+      enableReasoning,
       selectedProvider,
       selectedModel,
       skipUserHistory,
@@ -449,6 +458,7 @@ export function useMessages(options: UseMessagesOptions) {
     sessionId,
     sourceRecord,
     enableStreaming = true,
+    enableReasoning = true,
     selectedProvider = "",
     selectedModel = "",
   }: ContinueEditedMessageOptions) {
@@ -476,6 +486,7 @@ export function useMessages(options: UseMessagesOptions) {
       botRecord,
       undefined,
       enableStreaming,
+      enableReasoning,
       selectedProvider,
       selectedModel,
       true,
@@ -489,6 +500,7 @@ export function useMessages(options: UseMessagesOptions) {
     selectedProvider = "",
     selectedModel = "",
     enableStreaming = true,
+    enableReasoning = true,
   ) {
     if (!sessionId || botRecord.id == null) return;
     const targetMessageId = botRecord.id;
@@ -524,7 +536,7 @@ export function useMessages(options: UseMessagesOptions) {
           body: JSON.stringify({
             selected_provider: selectedProvider,
             selected_model: selectedModel,
-            flags: buildChatRequestFlags(enableStreaming),
+            flags: buildChatRequestFlags(enableStreaming, enableReasoning),
           }),
           signal: abort.signal,
         },
@@ -619,6 +631,7 @@ export function useMessages(options: UseMessagesOptions) {
     botRecord: ChatRecord,
     userRecord: ChatRecord | undefined,
     enableStreaming: boolean,
+    enableReasoning: boolean,
     selectedProvider: string,
     selectedModel: string,
     skipUserHistory = false,
@@ -645,7 +658,7 @@ export function useMessages(options: UseMessagesOptions) {
       body: JSON.stringify({
         session_id: sessionId,
         message: parts.map(partToPayload),
-        flags: buildChatRequestFlags(enableStreaming),
+        flags: buildChatRequestFlags(enableStreaming, enableReasoning),
         selected_provider: selectedProvider,
         selected_model: selectedModel,
         _skip_user_history: skipUserHistory,
@@ -770,6 +783,7 @@ export function useMessages(options: UseMessagesOptions) {
     botRecord: ChatRecord,
     userRecord: ChatRecord | undefined,
     enableStreaming: boolean,
+    enableReasoning: boolean,
     selectedProvider: string,
     selectedModel: string,
   ) {
@@ -795,7 +809,7 @@ export function useMessages(options: UseMessagesOptions) {
       session_id: sessionId,
       message_id: messageId,
       message: parts.map(partToPayload),
-      flags: buildChatRequestFlags(enableStreaming),
+      flags: buildChatRequestFlags(enableStreaming, enableReasoning),
       selected_provider: selectedProvider,
       selected_model: selectedModel,
     });

--- a/dashboard/src/i18n/locales/en-US/features/chat.json
+++ b/dashboard/src/i18n/locales/en-US/features/chat.json
@@ -115,6 +115,8 @@
     "title": "Config"
   },
   "reasoning": {
+    "enabled": "Reasoning enabled",
+    "disabled": "Reasoning disabled",
     "thinking": "Thinking Process",
     "summarySeparator": ", ",
     "thinkSummary": "Thought {count} times",

--- a/dashboard/src/i18n/locales/ja-JP/features/chat.json
+++ b/dashboard/src/i18n/locales/ja-JP/features/chat.json
@@ -115,6 +115,8 @@
     "title": "設定"
   },
   "reasoning": {
+    "enabled": "思考内容の表示：オン",
+    "disabled": "思考内容の表示：オフ",
     "thinking": "思考プロセス",
     "summarySeparator": "、",
     "thinkSummary": "思考 {count} 回",

--- a/dashboard/src/i18n/locales/ru-RU/features/chat.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/chat.json
@@ -115,6 +115,8 @@
     "title": "Конфигурация"
   },
   "reasoning": {
+    "enabled": "Рассуждения включены",
+    "disabled": "Рассуждения выключены",
     "thinking": "Рассуждение",
     "summarySeparator": ", ",
     "thinkSummary": "Размышлений: {count}",

--- a/dashboard/src/i18n/locales/zh-CN/features/chat.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/chat.json
@@ -115,6 +115,8 @@
     "title": "配置文件"
   },
   "reasoning": {
+    "enabled": "思考内容已开启",
+    "disabled": "思考内容已关闭",
     "thinking": "思考过程",
     "summarySeparator": "，",
     "thinkSummary": "思考了 {count} 次",

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -7118,6 +7118,11 @@
             "type": "boolean",
             "default": true,
             "description": "Enable streaming model output for this request. This value takes priority over the legacy top-level enable_streaming field."
+          },
+          "enable_reasoning": {
+            "type": "boolean",
+            "default": true,
+            "description": "Display reasoning content for this WebChat request independently of the global display_reasoning_text setting."
           }
         },
         "additionalProperties": false

--- a/openspec/openapi-v1.yaml
+++ b/openspec/openapi-v1.yaml
@@ -5547,6 +5547,10 @@ components:
           type: boolean
           default: true
           description: Enable streaming model output for this request. This value takes priority over the legacy top-level enable_streaming field.
+        enable_reasoning:
+          type: boolean
+          default: true
+          description: Display reasoning content for this WebChat request independently of the global display_reasoning_text setting.
       additionalProperties: false
 
     ChatRequest:

--- a/tests/test_chat_route.py
+++ b/tests/test_chat_route.py
@@ -448,6 +448,7 @@ async def test_chat_stream_forwards_normalized_request_flags(chat_service_instan
             "enable_inline_genui": True,
             "enable_default_system_prompt": False,
             "enable_streaming": False,
+            "enable_reasoning": True,
         }
         assert "enable_streaming" not in payload
     finally:

--- a/tests/unit/test_webchat_request_flags.py
+++ b/tests/unit/test_webchat_request_flags.py
@@ -10,6 +10,7 @@ def test_webchat_request_flags_use_defaults():
         "enable_inline_genui": True,
         "enable_default_system_prompt": True,
         "enable_streaming": True,
+        "enable_reasoning": True,
     }
 
 
@@ -29,6 +30,7 @@ def test_webchat_request_flags_prefer_nested_flags():
         "enable_inline_genui": False,
         "enable_default_system_prompt": False,
         "enable_streaming": True,
+        "enable_reasoning": True,
     }
 
 


### PR DESCRIPTION
WebChat currently follows the shared reasoning display setting, so enabling reasoning also affects other adapters. This change enables reasoning by default in WebChat and adds a request-level toggle alongside streaming output.

Closes #10016.

### Modifications

- Add `flags.enable_reasoning` with a default of `true`, including the API schema and regenerated frontend client.
- Forward the toggle through message sending, regeneration, and edited-message continuation in the dashboard and standalone chat.
- Resolve the override in `InternalAgentSubStage` and non-streaming result decoration, preserving the configured behavior for other adapters.
- Add toggle labels to the existing reasoning translations in all four languages.

- [x] This is NOT a breaking change.

### Screenshots or Test Results

- `ruff format .` and `ruff check .` passed.
- Tests were not rerun on the final changes, as requested by the maintainer.

### Checklist

- [x] The feature is discussed in #10016.
- [ ] Changes have been fully tested and screenshots provided.
- [x] No new dependencies are introduced.
- [x] No malicious code is introduced.

## Summary by Sourcery

Enable WebChat reasoning display by default while supporting per-request control across message sending, editing, and regeneration.

New Features:
- Add a request-level reasoning display toggle to WebChat, enabled by default and available in dashboard and standalone chat controls.

Enhancements:
- Allow request-level reasoning preferences to override global reasoning display behavior without affecting other adapters.

Documentation:
- Document the new WebChat reasoning flag in the API schemas and add localized toggle labels.

Tests:
- Update WebChat request flag and route tests for the new default reasoning option.