### PR TITLE
fix(agent): deliver skills-like fallback replies when streaming

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -947,29 +947,38 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                     logger.warning(
                         "skills_like tool re-query returned no tool calls; fallback to assistant response."
                     )
-                    if llm_resp.reasoning_content:
-                        yield AgentResponse(
-                            type="llm_result",
-                            data=AgentResponseData(
-                                chain=MessageChain(type="reasoning").message(
-                                    llm_resp.reasoning_content,
-                                ),
-                            ),
-                        )
-                    if llm_resp.result_chain:
-                        yield AgentResponse(
-                            type="llm_result",
-                            data=AgentResponseData(chain=llm_resp.result_chain),
-                        )
-                    elif llm_resp.completion_text:
-                        yield AgentResponse(
-                            type="llm_result",
-                            data=AgentResponseData(
-                                chain=MessageChain().message(llm_resp.completion_text),
-                            ),
-                        )
-
                     await self._complete_with_assistant_response(llm_resp)
+                    # Re-query uses text_chat(), so its reply has no stream chunks.
+                    # Emit it after hooks, retaining llm_result for non-streaming consumers.
+                    response_types = (
+                        ("streaming_delta", "llm_result")
+                        if self.streaming
+                        else ("llm_result",)
+                    )
+                    for response_type in response_types:
+                        if llm_resp.reasoning_content:
+                            yield AgentResponse(
+                                type=response_type,
+                                data=AgentResponseData(
+                                    chain=MessageChain(type="reasoning").message(
+                                        llm_resp.reasoning_content,
+                                    ),
+                                ),
+                            )
+                        if llm_resp.result_chain:
+                            yield AgentResponse(
+                                type=response_type,
+                                data=AgentResponseData(chain=llm_resp.result_chain),
+                            )
+                        elif llm_resp.completion_text:
+                            yield AgentResponse(
+                                type=response_type,
+                                data=AgentResponseData(
+                                    chain=MessageChain().message(
+                                        llm_resp.completion_text
+                                    ),
+                                ),
+                            )
                     return
                 else:
                     llm_resp.tools_call_name = requery_resp.tools_call_name

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -947,37 +947,48 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                     logger.warning(
                         "skills_like tool re-query returned no tool calls; fallback to assistant response."
                     )
+                    if llm_resp.reasoning_content:
+                        yield AgentResponse(
+                            type="llm_result",
+                            data=AgentResponseData(
+                                chain=MessageChain(type="reasoning").message(
+                                    llm_resp.reasoning_content,
+                                ),
+                            ),
+                        )
+                    if llm_resp.result_chain:
+                        yield AgentResponse(
+                            type="llm_result",
+                            data=AgentResponseData(chain=llm_resp.result_chain),
+                        )
+                    elif llm_resp.completion_text:
+                        yield AgentResponse(
+                            type="llm_result",
+                            data=AgentResponseData(
+                                chain=MessageChain().message(llm_resp.completion_text),
+                            ),
+                        )
+
                     await self._complete_with_assistant_response(llm_resp)
                     # Re-query uses text_chat(), so its reply has no stream chunks.
-                    # Emit it after hooks, retaining llm_result for non-streaming consumers.
-                    response_types = (
-                        ("streaming_delta", "llm_result")
-                        if self.streaming
-                        else ("llm_result",)
-                    )
-                    for response_type in response_types:
+                    # Supply them after hooks without changing llm_result ordering.
+                    if self.streaming:
                         if llm_resp.reasoning_content:
                             yield AgentResponse(
-                                type=response_type,
+                                type="streaming_delta",
                                 data=AgentResponseData(
                                     chain=MessageChain(type="reasoning").message(
                                         llm_resp.reasoning_content,
                                     ),
                                 ),
                             )
-                        if llm_resp.result_chain:
+                        chain = llm_resp.result_chain
+                        if not chain and llm_resp.completion_text:
+                            chain = MessageChain().message(llm_resp.completion_text)
+                        if chain:
                             yield AgentResponse(
-                                type=response_type,
-                                data=AgentResponseData(chain=llm_resp.result_chain),
-                            )
-                        elif llm_resp.completion_text:
-                            yield AgentResponse(
-                                type=response_type,
-                                data=AgentResponseData(
-                                    chain=MessageChain().message(
-                                        llm_resp.completion_text
-                                    ),
-                                ),
+                                type="streaming_delta",
+                                data=AgentResponseData(chain=chain),
                             )
                     return
                 else:

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -18,8 +18,10 @@ from astrbot.core.agent.message import ImageURLPart, Message, TextPart
 from astrbot.core.agent.run_context import ContextWrapper
 from astrbot.core.agent.runners.tool_loop_agent_runner import ToolLoopAgentRunner
 from astrbot.core.agent.tool import FunctionTool, ToolSet
+from astrbot.core.astr_agent_run_util import run_agent
 from astrbot.core.astr_agent_tool_exec import FunctionToolExecutor
 from astrbot.core.exceptions import EmptyModelOutputError
+from astrbot.core.message.message_event_result import MessageChain
 from astrbot.core.provider.entities import LLMResponse, ProviderRequest, TokenUsage
 from astrbot.core.provider.provider import Provider
 
@@ -1653,7 +1655,8 @@ async def test_follow_up_ticket_not_consumed_when_no_next_tool_call(
 
 
 @pytest.mark.asyncio
-async def test_skills_like_requery_passes_extra_user_content_parts():
+@pytest.mark.parametrize("streaming", [False, True])
+async def test_skills_like_requery_passes_extra_user_content_parts(streaming):
     """skills-like 模式 re-query 时应传递 extra_user_content_parts（如 image_caption）"""
     from astrbot.core.agent.message import TextPart
 
@@ -1719,6 +1722,7 @@ async def test_skills_like_requery_passes_extra_user_content_parts():
         tool_executor=cast(Any, MockToolExecutor()),
         agent_hooks=MockHooks(),
         tool_schema_mode="skills_like",
+        streaming=streaming,
     )
 
     async for _ in runner.step():
@@ -1731,6 +1735,136 @@ async def test_skills_like_requery_passes_extra_user_content_parts():
     parts = captured_kwargs["extra_user_content_parts"]
     assert len(parts) == 1
     assert parts[0].text == "<image_caption>一张猫的照片</image_caption>"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("streaming", "stream_to_general", "show_reasoning"),
+    [
+        (True, False, False),
+        (True, False, True),
+        (True, True, True),
+        (False, False, True),
+    ],
+)
+@pytest.mark.parametrize("use_result_chain", [False, True])
+async def test_skills_like_requery_reply_reaches_stream_bridge_once(
+    runner,
+    provider_request,
+    mock_tool_executor,
+    mock_hooks,
+    streaming,
+    stream_to_general,
+    show_reasoning,
+    use_result_chain,
+):
+    """Deliver a non-streaming re-query reply through the real runner and bridge."""
+    final_text = "The search is complete: two pushes."
+    reasoning = "The existing tool result is sufficient."
+
+    class RequeryReplyProvider(MockProvider):
+        async def text_chat(self, **kwargs) -> LLMResponse:
+            self.call_count += 1
+            if self.call_count == 1:
+                return LLMResponse(
+                    role="assistant",
+                    completion_text="Let me check.",
+                    tools_call_name=["test_tool"],
+                    tools_call_args=[{}],
+                    tools_call_ids=["select_tool"],
+                )
+            assert self.call_count == 2
+            return LLMResponse(
+                role="assistant",
+                completion_text=None if use_result_chain else final_text,
+                result_chain=MessageChain().message(final_text)
+                if use_result_chain
+                else None,
+                reasoning_content=reasoning,
+            )
+
+    provider = RequeryReplyProvider()
+    event = MagicMock()
+    event.is_stopped.return_value = False
+    event.get_extra.return_value = None
+    event.get_platform_name.return_value = "lark"
+    await runner.reset(
+        provider=provider,
+        request=provider_request,
+        run_context=ContextWrapper(context=MockAgentContext(event)),
+        tool_executor=mock_tool_executor,
+        agent_hooks=mock_hooks,
+        streaming=streaming,
+        tool_schema_mode="skills_like",
+    )
+    original_step = runner.step
+    final_events = []
+    hooks_at_emission = []
+
+    async def recorded_step():
+        async for response in original_step():
+            chain = response.data["chain"]
+            if chain.get_plain_text() in (final_text, reasoning):
+                final_events.append((response.type, chain.type))
+                hooks_at_emission.append(mock_hooks.agent_done_called)
+            yield response
+
+    runner.step = recorded_step
+    chains = [
+        chain
+        async for chain in run_agent(
+            runner,
+            stream_to_general=stream_to_general,
+            show_reasoning=show_reasoning,
+        )
+    ]
+    assert sum(chain.get_plain_text() == final_text for chain in chains) == 1
+    assert sum(chain.get_plain_text() == "Let me check." for chain in chains) == 1
+    assert sum(chain.get_plain_text() == reasoning for chain in chains) == int(
+        streaming and not stream_to_general and show_reasoning
+    )
+    expected_types = ["streaming_delta", "llm_result"] if streaming else ["llm_result"]
+    assert final_events == [
+        (response_type, chain_type)
+        for response_type in expected_types
+        for chain_type in ("reasoning", None)
+    ]
+    assert all(hooks_at_emission)
+    assert runner.done()
+    assert runner.get_final_llm_resp().completion_text == final_text
+    assert runner.run_context.messages[-1].content[-1].text == final_text
+    assert not mock_hooks.tool_start_called
+    assert provider.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_normal_streaming_reply_is_not_duplicated_by_stream_bridge(
+    runner,
+    mock_provider,
+    provider_request,
+    mock_tool_executor,
+    mock_hooks,
+):
+    mock_provider.should_call_tools = False
+    event = MagicMock()
+    event.is_stopped.return_value = False
+    event.get_extra.return_value = None
+    event.get_platform_name.return_value = "lark"
+    await runner.reset(
+        provider=mock_provider,
+        request=provider_request,
+        run_context=ContextWrapper(context=MockAgentContext(event)),
+        tool_executor=mock_tool_executor,
+        agent_hooks=mock_hooks,
+        streaming=True,
+        tool_schema_mode="skills_like",
+    )
+
+    chains = [chain async for chain in run_agent(runner)]
+
+    assert [chain.get_plain_text() for chain in chains] == ["这是我的最终回答"]
+    assert mock_provider.call_count == 1
+    assert runner.done()
 
 
 def test_skills_like_requery_preserves_existing_context_prefix():

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -1823,13 +1823,14 @@ async def test_skills_like_requery_reply_reaches_stream_bridge_once(
     assert sum(chain.get_plain_text() == reasoning for chain in chains) == int(
         streaming and not stream_to_general and show_reasoning
     )
-    expected_types = ["streaming_delta", "llm_result"] if streaming else ["llm_result"]
+    expected_types = ["llm_result", "streaming_delta"] if streaming else ["llm_result"]
     assert final_events == [
         (response_type, chain_type)
         for response_type in expected_types
         for chain_type in ("reasoning", None)
     ]
-    assert all(hooks_at_emission)
+    # Preserve existing llm_result ordering; only new deltas follow the hooks.
+    assert hooks_at_emission == [False, False] + ([True, True] if streaming else [])
     assert runner.done()
     assert runner.get_final_llm_resp().completion_text == final_text
     assert runner.run_context.messages[-1].content[-1].text == final_text


### PR DESCRIPTION
Fixes #10024

### Motivation

With `skills_like` and streaming enabled, a tool-schema re-query can return a plain assistant reply instead of another tool call. The re-query uses non-streaming `text_chat()`, but this fallback only emits `llm_result`. The streaming bridge consumes `streaming_delta`, so the final reply is saved to history without reaching the user.

### Modifications

- In the no-tool re-query fallback only, emit the reply as `streaming_delta` when streaming is enabled, while retaining `llm_result` for non-streaming and stream-to-general consumers.
- Append the new streaming events after the existing `_complete_with_assistant_response()` call, so they use the post-hook reply. Do not move the existing `llm_result` emissions or hook invocation.
- Preserve reasoning as a separate chain so the bridge's reasoning visibility setting still applies.
- Leave the generic stream bridge unchanged: forwarding every `llm_result` there would duplicate ordinary streamed replies.

No new settings, dependencies, platform-specific changes, or changes to cron notification policy.

Scope: **only the missing streaming events in #10024**. The existing non-streaming/stream-to-general `llm_result`-before-hook behavior is preserved. The separate hook-ordering issue #9788 is left to #9789 / #9835; this PR no longer changes that ordering. The production diff only adds 20 lines in the fallback branch.

- [x] This is NOT a breaking change.

### Verification Steps and Test Results

Based on upstream `master` at `6fb50cae9`.

Added regressions exercise the real `ToolLoopAgentRunner`, its schema re-query, and `run_agent()` with a deterministic fake provider/event. Coverage includes:

- Plain `completion_text` and `result_chain` fallback replies.
- Streaming with reasoning hidden/shown, non-streaming, and stream-to-general delivery.
- Exactly-once final reply and intermediate text delivery.
- Original complete-result events remaining before hooks, and only the newly added streaming deltas being emitted after hooks.
- Retained complete-result events and final history content.
- Ordinary streaming replies remaining single-delivery.
- Existing successful re-query/tool execution coverage extended to streaming mode.

Before the fix, the new regression matrix fails (including missing final replies on the streaming cases); the ordinary streaming control passes. After the fix:

```text
python -m pytest tests/test_tool_loop_agent_runner.py tests/test_astr_agent_run_util.py \
  tests/unit/test_astr_main_agent.py tests/unit/test_astr_agent_tool_exec.py \
  tests/unit/test_agent_runner_config.py tests/agent -q

317 passed, 1 warning
```

The warning is the existing Python `audioop` deprecation warning.

```text
ruff format .       # Ruff 0.15.22: 504 files left unchanged
ruff check .        # All checks passed
git diff --check    # clean
```

Tests are local and deterministic; no real provider calls or platform messages were sent, and the production deployment was not modified. This is not a live Feishu end-to-end test.

### Checklist

- [x] Changes are tested, with verification commands and results above.
- [x] No new dependencies are introduced.
- [x] No malicious code is introduced.

## Summary by Sourcery

Ensure assistant replies produced by skills-like tool-schema re-queries reach streaming consumers without duplication.

Bug Fixes:
- Deliver fallback assistant replies from skills-like streaming re-queries to users exactly once.
- Preserve reasoning visibility and ensure agent-done hooks run before fallback stream content is emitted.

Enhancements:
- Extend regression coverage across streaming, reasoning, result-chain, and stream-to-general delivery paths while confirming ordinary streaming replies are not duplicated.

Tests:
- Add deterministic integration-style coverage for the real tool-loop runner, streaming bridge, hook ordering, response persistence, and final history content.