### PR TITLE
fix: restore session model fallback for proactive agents

### DIFF
--- a/astrbot/core/astr_agent_tool_exec.py
+++ b/astrbot/core/astr_agent_tool_exec.py
@@ -571,6 +571,10 @@ class FunctionToolExecutor(BaseFunctionToolExecutor[AstrAgentContext]):
         )
         config = MainAgentBuildConfig(
             tool_call_timeout=run_context.tool_call_timeout,
+            fallback_provider_ids=cfg.get("agent_runner", {})
+            .get("config", {})
+            .get("model", {})
+            .get("fallback_provider_ids", []),
             **resolve_context_compression_config(
                 cfg.get("agent_runner", {}).get("config", {}).get("compression", {})
             ),

--- a/astrbot/core/cron/manager.py
+++ b/astrbot/core/cron/manager.py
@@ -464,6 +464,10 @@ class CronJobManager:
         )
         config = MainAgentBuildConfig(
             tool_call_timeout=tool_call_timeout,
+            fallback_provider_ids=cfg.get("agent_runner", {})
+            .get("config", {})
+            .get("model", {})
+            .get("fallback_provider_ids", []),
             **resolve_context_compression_config(
                 cfg.get("agent_runner", {}).get("config", {}).get("compression", {})
             ),

--- a/tests/unit/test_astr_main_agent.py
+++ b/tests/unit/test_astr_main_agent.py
@@ -2,15 +2,19 @@
 
 import datetime
 import os
+from contextlib import nullcontext
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from astrbot.core import astr_main_agent as ama
+from astrbot.core.agent.hooks import BaseAgentRunHooks
 from astrbot.core.agent.mcp_client import MCPTool
 from astrbot.core.agent.message import Message, dump_messages_with_checkpoints
 from astrbot.core.agent.run_context import ContextWrapper
+from astrbot.core.agent.runners.base import AgentState
 from astrbot.core.agent.tool import FunctionTool, ToolSet
 from astrbot.core.astr_agent_tool_exec import FunctionToolExecutor
 from astrbot.core.config.agent_runner import resolve_context_compression_config
@@ -21,9 +25,10 @@ from astrbot.core.platform.astr_message_event import AstrMessageEvent
 from astrbot.core.platform.platform_metadata import PlatformMetadata
 from astrbot.core.provider import Provider
 from astrbot.core.provider import manager as provider_manager_module
-from astrbot.core.provider.entities import ProviderRequest, ProviderType
+from astrbot.core.provider.entities import LLMResponse, ProviderRequest, ProviderType
 from astrbot.core.provider.manager import ProviderManager
 from astrbot.core.skills.skill_manager import SkillInfo
+from astrbot.core.star.context import Context
 from astrbot.core.star.star import StarMetadata
 
 
@@ -115,6 +120,119 @@ def test_provider_supports_modality_requires_explicit_list():
 
     provider.provider_config = {"modalities": "image"}
     assert not ama._provider_supports_modality(provider, "image")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("entrypoint", ["cron", "background"])
+@pytest.mark.parametrize(
+    "scenario",
+    ["primary-success", "exception", "error-response", "all-fail", "unconfigured"],
+)
+async def test_proactive_agent_uses_session_fallback_models(
+    entrypoint, scenario, mock_context, mock_provider, mock_event, mock_conversation
+):
+    """Exercise real agent construction and failover from both wakeup entrypoints.
+
+    Args:
+        entrypoint: Proactive wakeup path to execute.
+        scenario: Provider outcomes and fallback configuration to exercise.
+        mock_context: Session context fixture.
+        mock_provider: Primary provider fixture.
+        mock_event: Originating message event fixture.
+        mock_conversation: Stored conversation fixture.
+    """
+    mock_context.mock_add_spec(Context)
+    calls = []
+    providers = {"primary": mock_provider}
+    for name in ("backup-1", "backup-2"):
+        providers[name] = MagicMock(spec=Provider)
+    for name, provider in providers.items():
+        provider.provider_config = {
+            "id": name,
+            "modalities": ["text", "tool_use"],
+            "max_context_tokens": 8192,
+        }
+        provider.get_model.return_value = name
+        if name == "primary" and scenario == "primary-success":
+            result = LLMResponse(role="assistant", completion_text="Primary completed.")
+        elif name == "primary" and scenario == "error-response":
+            result = LLMResponse(role="err", completion_text="Primary unavailable.")
+        elif name == "backup-2" and scenario != "all-fail":
+            result = LLMResponse(role="assistant", completion_text="Backup completed.")
+        else:
+            result = RuntimeError(f"{name} unavailable")
+        provider.text_chat = AsyncMock(side_effect=[result])
+        calls.append(provider.text_chat)
+
+    model = (
+        {}
+        if scenario == "unconfigured"
+        else {"fallback_provider_ids": ["backup-1", "backup-2"]}
+    )
+    mock_context.get_config.return_value = {
+        "agent_runner": {"config": {"model": model}},
+        "provider_settings": {},
+    }
+    mock_context.get_using_provider_async.side_effect = None
+    mock_context.get_using_provider_async.return_value = mock_provider
+    mock_context.get_provider_by_id.side_effect = providers.get
+    mock_event.unified_msg_origin = "test:FriendMessage:user123"
+    mock_event.role = "member"
+    runner = ama.AgentRunner()
+    failed = scenario in ("all-fail", "unconfigured")
+    expectation = (
+        pytest.raises(RuntimeError, match="Cron agent run ended in ERROR")
+        if entrypoint == "cron" and failed
+        else nullcontext()
+    )
+    with (
+        patch.object(
+            ama, "_get_session_conv", AsyncMock(return_value=mock_conversation)
+        ),
+        patch.object(ama, "_decorate_llm_request", AsyncMock()),
+        patch.object(ama, "_apply_kb", AsyncMock()),
+        patch.object(ama, "MAIN_AGENT_HOOKS", BaseAgentRunHooks()),
+        patch.object(ama, "AgentRunner", return_value=runner),
+        patch("astrbot.core.cron.manager.persist_agent_history", AsyncMock()),
+        patch("astrbot.core.astr_agent_tool_exec.persist_agent_history", AsyncMock()),
+        expectation,
+    ):
+        if entrypoint == "cron":
+            manager = CronJobManager(MagicMock())
+            manager.ctx = mock_context
+            await manager._woke_main_agent(
+                message="Run the scheduled task",
+                session_str=mock_event.unified_msg_origin,
+                extras={"cron_job": {"id": "job-1"}, "cron_payload": {}},
+            )
+        else:
+            await FunctionToolExecutor._wake_main_agent_for_background_result(
+                ContextWrapper(
+                    context=SimpleNamespace(event=mock_event, context=mock_context)
+                ),
+                task_id="task-1",
+                tool_name="background-tool",
+                result_text="Work finished.",
+                tool_args={},
+                note="Background task finished",
+                summary_name="BackgroundTask",
+            )
+
+    expected_calls = (
+        [1, 0, 0] if scenario in ("primary-success", "unconfigured") else [1, 1, 1]
+    )
+    assert [call.await_count for call in calls] == expected_calls
+    if failed:
+        assert runner.state == AgentState.ERROR
+    else:
+        assert runner.state == AgentState.DONE
+        response = runner.get_final_llm_resp()
+        assert response.role == "assistant"
+        assert response.completion_text == (
+            "Primary completed."
+            if scenario == "primary-success"
+            else "Backup completed."
+        )
 
 
 @pytest.fixture
@@ -269,9 +387,12 @@ def test_append_system_reminders_includes_weekday(mock_event):
 
 
 def test_local_mode_prompt_uses_windows_powershell_51():
-    with patch("astrbot.core.astr_main_agent.platform.system", return_value="Windows"), patch(
-        "astrbot.core.astr_main_agent.resolve_windows_shell",
-        return_value="powershell.exe",
+    with (
+        patch("astrbot.core.astr_main_agent.platform.system", return_value="Windows"),
+        patch(
+            "astrbot.core.astr_main_agent.resolve_windows_shell",
+            return_value="powershell.exe",
+        ),
     ):
         prompt = ama._build_local_mode_prompt()
 
@@ -281,9 +402,12 @@ def test_local_mode_prompt_uses_windows_powershell_51():
 
 
 def test_local_mode_prompt_hints_pwsh_when_resolved():
-    with patch("astrbot.core.astr_main_agent.platform.system", return_value="Windows"), patch(
-        "astrbot.core.astr_main_agent.resolve_windows_shell",
-        return_value="pwsh.exe",
+    with (
+        patch("astrbot.core.astr_main_agent.platform.system", return_value="Windows"),
+        patch(
+            "astrbot.core.astr_main_agent.resolve_windows_shell",
+            return_value="pwsh.exe",
+        ),
     ):
         prompt = ama._build_local_mode_prompt()
 
@@ -293,9 +417,12 @@ def test_local_mode_prompt_hints_pwsh_when_resolved():
 
 
 def test_local_mode_prompt_ignores_pwsh_on_non_windows():
-    with patch("astrbot.core.astr_main_agent.platform.system", return_value="Linux"), patch(
-        "astrbot.core.astr_main_agent.resolve_windows_shell",
-        return_value="pwsh.exe",
+    with (
+        patch("astrbot.core.astr_main_agent.platform.system", return_value="Linux"),
+        patch(
+            "astrbot.core.astr_main_agent.resolve_windows_shell",
+            return_value="pwsh.exe",
+        ),
     ):
         prompt = ama._build_local_mode_prompt()
 


### PR DESCRIPTION
Fixes #10026. Thanks to @srtriroha for the report and initial diagnosis.

When the session's primary model fails, ordinary chat can use configured fallback providers, but a scheduled future task currently ends in an error without trying them. Background tool-result wakeups have the same omission.

### Modifications

- Pass the current session's `agent_runner.config.model.fallback_provider_ids` into `MainAgentBuildConfig` in both proactive wakeup paths.
- Restore fallback behavior under the current configuration layout. The earlier fixes in #9054 and #9094 forwarded `provider_settings`; that is still present, but the builder now resolves fallback candidates from the explicit `fallback_provider_ids` field.
- Add 10 parametrized regression cases using the real agent builder and runner with mocked model calls. Both entrypoints cover primary success, a primary exception, a primary error response, exhaustion of all providers, and no configured fallback. Success cases exercise a failing first fallback followed by a working second fallback.

Retry counts and existing terminal error handling are unchanged. No new dependencies or configuration options.

- [x] This is NOT a breaking change.

### Verification Steps and Test Results

Windows, Python 3.12; base `6fb50cae9108ecb374232c54981d419d61239f7d`.

With the new tests and before the production fix:

```text
pytest tests/unit/test_astr_main_agent.py -k proactive_agent_uses_session_fallback_models -q
6 failed, 4 passed, 121 deselected
```

The failures show that the fallback providers are never called. After the fix:

```text
pytest tests/unit/test_astr_main_agent.py tests/unit/test_cron_manager.py tests/unit/test_cron_context_compression.py tests/unit/test_astr_agent_tool_exec.py tests/test_tool_loop_agent_runner.py -q
253 passed

ruff format --check .
ruff check .
# Passed; the changed test file was also explicitly formatted and linted.

python scripts/smoke_startup_check.py
Smoke test passed
```

Broader check: `pytest tests --test-profile=blocking -q` produced **2435 passed, 1 failed**. The sole failure, `test_dashscope_embedding_source.py::test_requires_api_key`, also reproduces on the unmodified base because `DASHSCOPE_API_KEY` is inherited from the local environment. Removing that variable only within the test subprocess gives **18 passed** for that file on the base and **271 passed** for that file plus the five relevant files on this branch. No tests were skipped to obtain those results.

### Checklist

- [x] Bug fix for an existing report; no new feature requiring discussion.
- [x] Tested, with verification steps and execution results above.
- [x] No new dependencies.
- [x] No malicious code introduced.

## Summary by Sourcery

Restore session-configured model failover for proactive agent executions.

Bug Fixes:
- Restore configured model fallback providers for scheduled proactive agent wakeups and background tool-result wakeups when the primary provider fails.

Tests:
- Add parametrized regression coverage for successful, failing, exhausted, and unconfigured provider scenarios across both proactive wakeup paths.