### PR TITLE
perf(dashboard): reduce bundled font and diagram assets

### DIFF
--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -61,6 +61,18 @@ export default defineConfig(({ command }) => ({
     // Only run MDI subsetting during production builds, skip in dev server
     ...(command === 'build' ? [mdiSubset()] : []),
     t2iShikiRuntimeAsset(),
+    {
+      name: 'katex-woff2-only',
+      enforce: 'pre',
+      transform(source, id) {
+        if (!/\/katex\/dist\/katex(?:\.min)?\.css$/.test(id.split('?')[0])) return;
+        // Keep one font format per face instead of shipping three identical glyph sets.
+        return source.replace(/src:[^;}]+/g, (declaration) => {
+          const woff2 = declaration.match(/url\([^)]*\.woff2\)\s*format\(["']woff2["']\)/);
+          return woff2 ? `src:${woff2[0]}` : declaration;
+        });
+      },
+    },
     vue({
       template: {
         compilerOptions: {
@@ -82,10 +94,6 @@ export default defineConfig(({ command }) => ({
       {
         find: /^stream-monaco$/,
         replacement: fileURLToPath(new URL('./src/utils/streamMonacoDisabled.js', import.meta.url))
-      },
-      {
-        find: 'mermaid',
-        replacement: 'mermaid/dist/mermaid.js'
       },
       {
         find: '@',


### PR DESCRIPTION
The dashboard ships three copies of each KaTeX font face and forces Mermaid through its bundled UMD entry. Keep only WOFF2 font sources and let Vite resolve Mermaid's normal ESM entry so shared diagram modules can be bundled without the UMD duplication.

This PR is based directly on `master`. It does not depend on #10022 or #10023 and includes no PDF or workspace changes. No dependencies, diagram types, font glyphs, or CDN requirements are added or removed; browsers without WOFF2 support lose the legacy font fallback.

### Validation

- Clean frozen-lockfile installs and `pnpm build` passed before and after the change (including Vue/TypeScript checking).
- With identical ZIP DEFLATE level 9 settings: **5,992,646 → 5,265,325 bytes**, saving **710 KiB (12.1%)**. These are local master builds; CI uses different packaging settings.
- All 19 KaTeX WOFF2 files are byte-for-byte unchanged. No KaTeX WOFF/TTF files remain, and all generated CSS asset references resolve.
- The Mermaid ESM API and flowchart, sequence, class, state, ER, and pie parsers passed under both default and dark configurations in a DOM environment. Browser layout/visual testing was not run.
- `ruff format .`, `ruff check .`, and `git diff --check` passed.

## Summary by Sourcery

Reduce dashboard bundle size by eliminating redundant KaTeX font assets and Mermaid UMD duplication.

Enhancements:
- Reduce dashboard bundle size by shipping only KaTeX WOFF2 font assets and resolving Mermaid through its standard ESM entry.

Build:
- Update Vite asset processing to remove redundant KaTeX font formats and avoid Mermaid's bundled UMD entry.