### PR TITLE
fix(ci): exclude temporary dashboard artifacts from PyPI source packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,14 +234,14 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: Dashboard-${{ steps.tag.outputs.tag }}
-          path: dashboard-artifact
+          path: ${{ runner.temp }}/dashboard-artifact
 
       - name: Unpack dashboard dist into package tree
         shell: bash
         run: |
           mkdir -p astrbot/dashboard/dist
-          unzip -q "dashboard-artifact/AstrBot-${{ steps.tag.outputs.tag }}-dashboard.zip" -d dashboard-artifact/unpacked
-          cp -r dashboard-artifact/unpacked/dist/. astrbot/dashboard/dist/
+          unzip -q "${RUNNER_TEMP}/dashboard-artifact/AstrBot-${{ steps.tag.outputs.tag }}-dashboard.zip" -d "${RUNNER_TEMP}/dashboard-artifact/unpacked"
+          cp -r "${RUNNER_TEMP}/dashboard-artifact/unpacked/dist/." astrbot/dashboard/dist/
 
       - name: Set up Python
         uses: actions/setup-python@v7


### PR DESCRIPTION
The PyPI release job downloads and unpacks the dashboard artifact inside the repository before `uv build`. Hatchling includes this staging directory in the source distribution, shipping both an extra copy of the dashboard and its ZIP alongside the required `astrbot/dashboard/dist/`.

Move artifact staging to the runner temporary directory and copy only the bundled dist into the package tree. The wheel already excludes these staging files; this fixes the redundant contents in the source distribution.

For the published 4.28.0 source archive, removing the staging directory in an in-memory repack reduced its size from 20.77 MiB to 9.43 MiB (54.6%).

Validation:
- Built an sdist and wheel in an isolated checkout using representative dashboard assets and the updated unpack step, including a temporary path containing spaces. Verified both retain the bundled assets and exclude `dashboard-artifact`.
- `ruff format .` and `ruff check .` passed.
- `git diff --check` passed.

## Summary by Sourcery

Keep dashboard release artifacts outside the repository during PyPI package builds to produce leaner source distributions.

Bug Fixes:
- Prevent temporary dashboard artifact files from being included in PyPI source distributions.

Build:
- Stage downloaded dashboard artifacts in the runner temporary directory while copying only the required dashboard distribution into the package tree.