### PR TITLE
feat: enhance slider robustness

### DIFF
--- a/dashboard/src/components/shared/ConfigItemRenderer.vue
+++ b/dashboard/src/components/shared/ConfigItemRenderer.vue
@@ -145,23 +145,28 @@
       hide-details
     ></v-text-field>
 
-    <div
-      v-else-if="itemMeta?.type === 'int' || itemMeta?.type === 'float'"
-      class="d-flex align-center gap-3"
-    >
-      <v-slider
-        v-if="itemMeta?.slider"
-        :model-value="toNumber(numericTemp ?? modelValue)"
-        @update:model-value="val => { numericTemp = val; emitUpdate(toNumber(val)) }"
-        @end="numericTemp = null"
-        :min="itemMeta?.slider?.min ?? 0"
-        :max="itemMeta?.slider?.max ?? 100"
-        :step="itemMeta?.slider?.step ?? 1"
-        color="primary"
-        density="compact"
-        hide-details
-        style="flex: 1"
-      ></v-slider>
+    <div v-else-if="itemMeta?.type === 'int' || itemMeta?.type === 'float'" class="d-flex align-center gap-3">
+      <div v-if="itemMeta?.slider" style="flex: 3; display: flex; align-items: center; gap: 8px">
+        <span style="min-width: 5px; text-align: right;">
+          {{ itemMeta?.slider?.min ?? 0 }}
+        </span>
+
+        <v-slider :model-value="toNumber(numericTemp ?? modelValue)"
+          @update:model-value="val => { numericTemp = val; emitUpdate(toNumber(val)) }" 
+          @end="numericTemp = null"
+          :min="itemMeta?.slider?.min ?? 0" 
+          :max="itemMeta?.slider?.max ?? 100" 
+          :step="itemMeta?.slider?.step ?? 1"
+          color="primary" 
+          density="compact" 
+          hide-details 
+          style="flex: 1"></v-slider>
+
+        <span style="min-width: 5px; text-align: left;">
+          {{ itemMeta?.slider?.max ?? 100 }}
+        </span>
+      </div>
+
       <v-text-field
         :model-value="numericTemp ?? modelValue"
         @update:model-value="val => (numericTemp = val)"
@@ -171,7 +176,7 @@
         class="config-field"
         type="number"
         hide-details
-        style="flex: 1"
+        style="flex: 2"
       ></v-text-field>
     </div>
 

--- a/dashboard/src/components/shared/ConfigItemRenderer.vue
+++ b/dashboard/src/components/shared/ConfigItemRenderer.vue
@@ -300,6 +300,7 @@ const { getRaw } = useModuleI18n('features/config-metadata')
 const { configText } = usePluginI18n()
 
 function emitUpdate(val) {
+  val = validateNumericConfig(props.itemMeta?.type, val)
   if (
     props.itemMeta?._special === 'agent_runner_type'
     && props.configRoot?.agent_runner
@@ -329,6 +330,34 @@ const secretToggleIcon = computed(() => {
 function toNumber(val) {
   const n = parseFloat(val)
   return isNaN(n) ? 0 : n
+}
+
+function validateNumericConfig(modelType, rawValue) {
+  if (modelType === 'int' || modelType === 'float') {
+    // 如果有滑动条定义，应用边界限制
+    const slider = props.itemMeta?.slider
+    if (slider) {
+      const min = slider.min ?? 0
+      const max = slider.max ?? 100
+      return Math.max(min, Math.min(max, rawValue))
+    } else {
+      return rawValue
+    }
+  } else if (modelType === 'dict') {
+    Object.entries(rawValue).forEach(([key, value]) => {
+      const templatesSchema = props.itemMeta?.template_schema
+      const templateType = templatesSchema?.[key]?.type
+      const templateSlider = templatesSchema?.[key]?.slider
+      if ((templateType === 'int' || templateType === 'float') && templateSlider) {
+        const min = templateSlider.min ?? 0
+        const max = templateSlider.max ?? 100
+        rawValue[key] = Math.max(min, Math.min(max, value))
+      }
+    })
+    return rawValue
+  } else {
+    return rawValue
+  }
 }
 
 function getLabel(itemMeta, index, option) {

--- a/dashboard/src/components/shared/ObjectEditor.vue
+++ b/dashboard/src/components/shared/ObjectEditor.vue
@@ -51,18 +51,28 @@
                   :placeholder="t('core.common.objectEditor.placeholders.stringValue')"
                 ></v-text-field>
                 <div v-else-if="pair.type === 'number' || pair.type === 'float' || pair.type === 'int'" class="d-flex align-center gap-2 flex-grow-1">
-                  <v-slider
-                    v-if="pair.slider"
-                    :model-value="Number(pair.value) || 0"
-                    @update:model-value="pair.value = $event"
-                    :min="pair.slider.min"
-                    :max="pair.slider.max"
-                    :step="pair.slider.step"
-                    color="primary"
-                    density="compact"
-                    hide-details
-                    class="flex-grow-1"
-                  ></v-slider>
+                  <template v-if="pair.slider">
+                    <span style="min-width: 5px; text-align: right;">
+                      {{ pair.slider.min }}
+                    </span>
+
+                    <v-slider
+                      :model-value="Number(pair.value) || 0"
+                      @update:model-value="pair.value = $event"
+                      :min="pair.slider.min"
+                      :max="pair.slider.max"
+                      :step="pair.slider.step"
+                      color="primary"
+                      density="compact"
+                      hide-details
+                      class="flex-grow-1"
+                    ></v-slider>
+
+                    <span style="min-width: 5px; text-align: left;">
+                      {{ pair.slider.max }}
+                    </span>
+                  </template>
+                  
                   <v-text-field
                     v-model.number="pair.value"
                     type="number"
@@ -129,18 +139,29 @@
                   :placeholder="t('core.common.objectEditor.placeholders.stringValue')"
                 ></v-text-field>
                 <div v-else-if="template.type === 'number' || template.type === 'float' || template.type === 'int'" class="d-flex align-center ga-4 flex-grow-1">
-                  <v-slider
-                    v-if="template.slider"
-                    :model-value="Number(getTemplateValue(templateKey)) || 0"
-                    @update:model-value="updateTemplateValue(templateKey, $event)"
-                    :min="template.slider.min"
-                    :max="template.slider.max"
-                    :step="template.slider.step"
-                    color="primary"
-                    density="compact"
-                    hide-details
-                    class="flex-grow-1"
-                  ></v-slider>
+                  <template v-if="template.slider">
+                    <span style="min-width: 5px; text-align: right;">
+                      {{ template.slider.min }}
+                    </span>
+
+                    <v-slider
+                      :model-value="Number(getTemplateValue(templateKey)) || 0"
+                      @update:model-value="updateTemplateValue(templateKey, $event)"
+                      :min="template.slider.min"
+                      :max="template.slider.max"
+                      :step="template.slider.step"
+                      color="primary"
+                      density="compact"
+                      hide-details
+                      class="flex-grow-1"
+                    ></v-slider>
+
+                    <span style="min-width: 5px; text-align: left;">
+                      {{ template.slider.max }}
+                    </span>
+                  </template>
+                  
+
                   <v-text-field
                     :model-value="getTemplateValue(templateKey)"
                     @update:model-value="updateTemplateValue(templateKey, $event)"


### PR DESCRIPTION
本次提交主要增加了插件配置项关于数值配置的健壮性：
1. 修复了存在slider时，通过文本域填入数值会超过限制的缺陷。
2. 增加了slider边界的标注，放置于slider两侧。

### Modifications / 改动点
主要修改了两个前端文件。
#### 添加了函数，在emitUpdate函数一进入就检验合法性，并把合法的数值发送出去。

文件位置：`dashboard\src\components\shared\ConfigItemRenderer.vue`
```
function validateNumericConfig(modelType, rawValue) {
  if (modelType === 'int' || modelType === 'float') {
    // 如果有滑动条定义，应用边界限制
    const slider = props.itemMeta?.slider
    if (slider) {
      const min = slider.min ?? 0
      const max = slider.max ?? 100
      return Math.max(min, Math.min(max, rawValue))
    } else {
      return rawValue
    }
  } else if (modelType === 'dict') {
    Object.entries(rawValue).forEach(([key, value]) => {
      const templatesSchema = props.itemMeta?.template_schema
      const templateType = templatesSchema?.[key]?.type
      const templateSlider = templatesSchema?.[key]?.slider
      if ((templateType === 'int' || templateType === 'float') && templateSlider) {
        const min = templateSlider.min ?? 0
        const max = templateSlider.max ?? 100
        rawValue[key] = Math.max(min, Math.min(max, value))
      }
    })
    return rawValue
  } else {
    return rawValue
  }
}
```
执行位置：
```
function emitUpdate(val) {
  val = validateNumericConfig(props.itemMeta?.type, val)
  ...
}
```
#### 为Slider添加边界标注。
配置项为type=int, type=float：在`dashboard\src\components\shared\ConfigItemRenderer.vue`中
```
<div v-if="itemMeta?.slider" style="flex: 3; display: flex; align-items: center; gap: 8px">
    <span style="min-width: 5px; text-align: right;">
      {{ itemMeta?.slider?.min ?? 0 }}
    </span>

    <v-slider :model-value="toNumber(numericTemp ?? modelValue)"
      @update:model-value="val => { numericTemp = val; emitUpdate(toNumber(val)) }" 
      @end="numericTemp = null"
      :min="itemMeta?.slider?.min ?? 0" 
      :max="itemMeta?.slider?.max ?? 100" 
      :step="itemMeta?.slider?.step ?? 1"
      color="primary" 
      density="compact" 
      hide-details 
      style="flex: 1"></v-slider>

    <span style="min-width: 5px; text-align: left;">
      {{ itemMeta?.slider?.max ?? 100 }}
    </span>
  </div>
```
配置项为type=dict：在`dashboard\src\components\shared\ObjectEditor.vue`中
唯一两处v-slider都包裹在span中。
```
<span style="min-width: 5px; text-align: right;">
  {{ pair.slider.min }}
</span>
<v-slider>...</v-slider>
<span style="min-width: 5px; text-align: left;">
  {{ pair.slider.max }}
</span>
```

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果
修改前，可以超出范围。
<img width="1392" height="1070" alt="1" src="https://github.com/user-attachments/assets/d6c3fe61-2b56-41c3-8e13-af1156edd75d" />
修改后，增加边界标签，且自动检测数值合法性。
<img width="1118" height="752" alt="2" src="https://github.com/user-attachments/assets/2fe1a778-237f-4f60-b7a4-44ba74eebc45" />

---

### Checklist / 检查清单


- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. 
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Keep numeric slider configurations within their defined bounds and show those bounds directly in the configuration editor.

Bug Fixes:
- Enforce slider-defined minimum and maximum values for numeric configuration updates, including numeric fields nested in dictionary configurations.

Enhancements:
- Display slider minimum and maximum values alongside numeric configuration controls for clearer bounds.