### PR TITLE
feat: support PPTX uploads in knowledge base

### DIFF
--- a/astrbot/core/knowledge_base/kb_helper.py
+++ b/astrbot/core/knowledge_base/kb_helper.py
@@ -282,6 +282,18 @@ class KBHelper:
                     parse_result = await parser.parse(file_content, file_name)
                 except KnowledgeBaseUploadError:
                     raise
+                except ValueError as exc:
+                    message = str(exc)
+                    if not message.startswith("暂时不支持的文件格式"):
+                        message = (
+                            "文档解析失败：无法读取或解析上传文件。"
+                            "请确认文件格式受支持且文件内容未损坏。"
+                        )
+                    raise KnowledgeBaseUploadError(
+                        stage="parsing",
+                        user_message=message,
+                        details={"file_name": file_name},
+                    ) from exc
                 except Exception as exc:
                     raise KnowledgeBaseUploadError(
                         stage="parsing",
@@ -334,6 +346,7 @@ class KBHelper:
                         ".md",
                         ".mdx",
                         ".mkd",
+                        ".pptx",
                         ".rst",
                         ".xls",
                         ".xlsx",

--- a/astrbot/core/knowledge_base/parsers/markitdown_parser.py
+++ b/astrbot/core/knowledge_base/parsers/markitdown_parser.py
@@ -10,7 +10,7 @@ from astrbot.core.knowledge_base.parsers.base import (
 
 
 class MarkitdownParser(BaseParser):
-    """解析 docx, xls, xlsx 格式"""
+    """解析 docx, xls, xlsx, pptx 格式"""
 
     async def parse(self, file_content: bytes, file_name: str) -> ParseResult:
         md = MarkItDown(enable_plugins=False)

--- a/astrbot/core/knowledge_base/parsers/util.py
+++ b/astrbot/core/knowledge_base/parsers/util.py
@@ -2,7 +2,17 @@ from .base import BaseParser
 
 
 async def select_parser(ext: str) -> BaseParser:
-    if ext in {".md", ".txt", ".markdown", ".rst", ".adoc", ".xlsx", ".docx", ".xls"}:
+    if ext in {
+        ".md",
+        ".txt",
+        ".markdown",
+        ".rst",
+        ".adoc",
+        ".xlsx",
+        ".docx",
+        ".xls",
+        ".pptx",
+    }:
         from .markitdown_parser import MarkitdownParser
 
         return MarkitdownParser()

--- a/dashboard/src/i18n/locales/en-US/features/knowledge-base/detail.json
+++ b/dashboard/src/i18n/locales/en-US/features/knowledge-base/detail.json
@@ -53,7 +53,7 @@
     "title": "Upload Document",
     "selectFile": "Select File",
     "dropzone": "Drop files here or click to select",
-    "supportedFormats": "Supported formats: .txt, .md, .markdown, .rst, .adoc, .pdf, .docx, .epub, .xls, .xlsx",
+    "supportedFormats": "Supported formats: .txt, .md, .markdown, .rst, .adoc, .pdf, .docx, .pptx, .epub, .xls, .xlsx",
     "maxSize": "Max file size: 128MB",
     "chunkSettings": "Chunk Settings",
     "batchSettings": "Batch Settings",

--- a/dashboard/src/i18n/locales/ja-JP/features/knowledge-base/detail.json
+++ b/dashboard/src/i18n/locales/ja-JP/features/knowledge-base/detail.json
@@ -53,7 +53,7 @@
     "title": "ドキュメントをアップロード",
     "selectFile": "ファイルを選択",
     "dropzone": "ここにファイルをドラッグ＆ドロップするか、クリックして選択",
-    "supportedFormats": "対応形式：.txt, .md, .markdown, .rst, .adoc, .pdf, .docx, .epub, .xls, .xlsx",
+    "supportedFormats": "対応形式：.txt, .md, .markdown, .rst, .adoc, .pdf, .docx, .pptx, .epub, .xls, .xlsx",
     "maxSize": "最大ファイルサイズ：128 MB",
     "chunkSettings": "チャンク設定",
     "batchSettings": "バッチ処理設定",

--- a/dashboard/src/i18n/locales/ru-RU/features/knowledge-base/detail.json
+++ b/dashboard/src/i18n/locales/ru-RU/features/knowledge-base/detail.json
@@ -53,7 +53,7 @@
         "title": "Добавление контента",
         "selectFile": "Файл",
         "dropzone": "Нажмите или перетащите файл сюда",
-        "supportedFormats": "Форматы: .txt, .md, .markdown, .rst, .adoc, .pdf, .docx, .epub, .xls, .xlsx",
+        "supportedFormats": "Форматы: .txt, .md, .markdown, .rst, .adoc, .pdf, .docx, .pptx, .epub, .xls, .xlsx",
         "maxSize": "Максимум: 128MB",
         "chunkSettings": "Фрагментация",
         "batchSettings": "Пакетная обработка",

--- a/dashboard/src/i18n/locales/zh-CN/features/knowledge-base/detail.json
+++ b/dashboard/src/i18n/locales/zh-CN/features/knowledge-base/detail.json
@@ -53,7 +53,7 @@
     "title": "上传文档",
     "selectFile": "选择文件",
     "dropzone": "拖放文件到这里或点击选择",
-    "supportedFormats": "支持的格式: .txt, .md, .markdown, .rst, .adoc, .pdf, .docx, .epub, .xls, .xlsx",
+    "supportedFormats": "支持的格式: .txt, .md, .markdown, .rst, .adoc, .pdf, .docx, .pptx, .epub, .xls, .xlsx",
     "maxSize": "最大文件大小: 128MB",
     "chunkSettings": "分块设置",
     "batchSettings": "批处理设置",

--- a/dashboard/src/views/knowledge-base/DocumentDetail.vue
+++ b/dashboard/src/views/knowledge-base/DocumentDetail.vue
@@ -398,6 +398,7 @@ const deleteChunk = async (chunk: any) => {
 const getFileIcon = (fileType: string) => {
   const type = fileType?.toLowerCase() || ''
   if (type.includes('pdf')) return 'mdi-file-pdf-box'
+  if (type.includes('ppt')) return 'mdi-file-powerpoint-box'
   if (type.includes('epub')) return 'mdi-book-open-page-variant'
   if (type.includes('md')) return 'mdi-language-markdown'
   if (type.includes('txt')) return 'mdi-file-document-outline'

--- a/dashboard/src/views/knowledge-base/components/DocumentsTab.vue
+++ b/dashboard/src/views/knowledge-base/components/DocumentsTab.vue
@@ -87,7 +87,7 @@
                 <p class="mt-4 text-h6">{{ t('upload.dropzone') }}</p>
                 <p class="text-caption text-medium-emphasis mt-2">{{ t('upload.supportedFormats') }}</p>
                 <p class="text-caption text-medium-emphasis">{{ t('upload.maxSize') }}</p>
-                <input ref="fileInput" type="file" multiple hidden accept=".txt,.md,.markdown,.rst,.adoc,.pdf,.docx,.epub,.xls,.xlsx"
+                <input ref="fileInput" type="file" multiple hidden accept=".txt,.md,.markdown,.rst,.adoc,.pdf,.docx,.pptx,.epub,.xls,.xlsx"
                   @change="handleFileSelect" />
               </div>
 
@@ -730,6 +730,7 @@ const deleteDocument = async () => {
 const getFileIcon = (fileType: string) => {
   const type = fileType?.toLowerCase() || ''
   if (type.includes('pdf')) return 'mdi-file-pdf-box'
+  if (type.includes('ppt')) return 'mdi-file-powerpoint-box'
   if (type.includes('epub')) return 'mdi-book-open-page-variant'
   if (type.includes('rst') || type.includes('adoc')) return 'mdi-file-document-outline'
   if (type.includes('md') || type.includes('markdown')) return 'mdi-language-markdown'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
   "aiofiles>=25.1.0",
   "rank-bm25>=0.2.2",
   "jieba>=0.42.1",
-  "markitdown-no-magika[docx,xls,xlsx]>=0.1.2",
+  "markitdown-no-magika[docx,xls,xlsx,pptx]>=0.1.2",
   "xinference-client",
   "tenacity>=9.1.2",
   "shipyard-python-sdk>=0.2.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ pysocks>=1.7.1
 aiofiles>=25.1.0
 rank-bm25>=0.2.2
 jieba>=0.42.1
-markitdown-no-magika[docx,xls,xlsx]>=0.1.2
+markitdown-no-magika[docx,xls,xlsx,pptx]>=0.1.2
 xinference-client
 tenacity>=9.1.2
 shipyard-python-sdk>=0.2.4

--- a/tests/test_kb_pptx_parser.py
+++ b/tests/test_kb_pptx_parser.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from astrbot.core.knowledge_base.parsers.markitdown_parser import MarkitdownParser
+from astrbot.core.knowledge_base.parsers.util import select_parser
+
+
+def _make_pptx_bytes() -> bytes:
+    from pptx import Presentation
+
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[0])
+    slide.shapes.title.text = "KB PPTX Slide Title"
+    buffer = io.BytesIO()
+    presentation.save(buffer)
+    return buffer.getvalue()
+
+
+@pytest.mark.asyncio
+async def test_select_parser_supports_pptx():
+    parser = await select_parser(".pptx")
+
+    assert isinstance(parser, MarkitdownParser)
+
+
+@pytest.mark.asyncio
+async def test_select_parser_rejects_legacy_ppt():
+    with pytest.raises(ValueError, match="暂时不支持的文件格式"):
+        await select_parser(".ppt")
+
+
+@pytest.mark.asyncio
+async def test_pptx_parser_extracts_slide_text():
+    pytest.importorskip("pptx")
+
+    result = await MarkitdownParser().parse(_make_pptx_bytes(), "slides.pptx")
+
+    assert result.media == []
+    assert "KB PPTX Slide Title" in result.text

--- a/tests/unit/test_kb_upload_atomicity.py
+++ b/tests/unit/test_kb_upload_atomicity.py
@@ -354,6 +354,7 @@ async def test_upload_document_cleans_up_on_storage_failure(
     ("file_name", "file_type"),
     [
         ("guide.docx", "docx"),
+        ("guide.pptx", "pptx"),
         ("guide.xlsx", "xlsx"),
         ("guide.xls", "xls"),
         ("guide.rst", "rst"),
@@ -417,6 +418,43 @@ async def test_upload_document_preserves_markdown_heading_paths(
     ]
     assert "Handbook > Installation\n\n### Linux" in contents[2]
     assert embedding_contents[2] == f"guide\n\n{contents[2]}"
+
+
+@pytest.mark.asyncio
+async def test_upload_document_rejects_legacy_ppt(
+    tmp_path: Path,
+    stub_provider_manager_module,
+) -> None:
+    """Legacy .ppt must fail as unsupported format, not as a corrupt file."""
+    KBHelper = _import_kb_helper()
+
+    helper = KBHelper.__new__(KBHelper)
+    helper.kb = KnowledgeBase(
+        kb_name="Test KB",
+        description="",
+        embedding_provider_id="emb",
+    )
+    helper.kb_db = MagicMock()
+    helper.kb_db.get_db = _failing_get_db()
+    helper.vec_db = AsyncMock()
+    helper.kb_medias_dir = tmp_path / "medias"
+    helper.chunker = AsyncMock()
+
+    with (
+        patch.object(helper, "_ensure_vec_db", new=AsyncMock()),
+        pytest.raises(KnowledgeBaseUploadError) as exc_info,
+    ):
+        await helper.upload_document(
+            file_name="slides.ppt",
+            file_content=b"not a pptx",
+            file_type="ppt",
+        )
+
+    assert exc_info.value.stage == "parsing"
+    assert "暂时不支持的文件格式" in exc_info.value.user_message
+    assert ".ppt" in exc_info.value.user_message
+    helper.chunker.chunk.assert_not_awaited()
+    helper.vec_db.insert_batch.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #10038

Knowledge base already parses Office files through MarkItDown (`docx` / `xls` / `xlsx`), but `.pptx` was not routed, not in the Markdown chunker whitelist, and not listed in the dashboard upload picker. This follows the existing Office path instead of adding a new parser.

### Modifications / 改动点

- Route `.pptx` to `MarkitdownParser` and enable the `pptx` extra of `markitdown-no-magika`.
- Chunk PPTX text with `MarkdownChunker`, same as `docx`.
- Surface `暂时不支持的文件格式` from `select_parser` instead of wrapping it as a corrupt-file parse error (legacy `.ppt` stays unsupported).
- Add `.pptx` to the dashboard accept list, file icons, and zh/en/ja/ru copy.
- Tests: parser routing, slide-text extraction, Markdown chunker whitelist, and `.ppt` rejection.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```
uv run pytest tests/test_kb_pptx_parser.py tests/unit/test_kb_upload_atomicity.py::test_upload_document_rejects_legacy_ppt tests/unit/test_kb_upload_atomicity.py::test_upload_document_preserves_markdown_heading_paths -q
11 passed
```

Independent Codex review (read-only): no blocking issues. Checks also included `uv lock --check`, locale JSON parse, and `git diff --check`.

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。
- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了“验证步骤”和“运行截图”**。
- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Support PPTX knowledge-base uploads while retaining clear rejection behavior for unsupported legacy PPT files.

New Features:
- Add support for uploading and parsing PPTX presentations in knowledge bases through the existing Office document pipeline.
- Expose PPTX uploads in the dashboard with localized format labels and PowerPoint file icons.

Bug Fixes:
- Preserve the user-facing unsupported-format error for legacy PPT files instead of reporting them as corrupted documents.

Enhancements:
- Enable Markdown chunking for extracted PPTX content alongside other supported Office formats.

Build:
- Enable the PPTX extra for the MarkItDown dependency in project and requirements configuration.

Tests:
- Add coverage for PPTX parser selection, slide-text extraction, upload handling, and legacy PPT rejection.