### PR TITLE
fix(cron): inherit fallback_provider_ids for scheduled agent runs

### DIFF
--- a/astrbot/core/cron/manager.py
+++ b/astrbot/core/cron/manager.py
@@ -475,6 +475,13 @@ class CronJobManager:
             computer_use_runtime=provider_settings.get("computer_use_runtime", "none"),
             sandbox_cfg=provider_settings.get("sandbox", {}),
             provider_settings=provider_settings,
+            # The interactive pipeline forwards this from agent_runner config;
+            # cron wakeups must inherit it too or a primary-model failure
+            # fails the whole scheduled run with no fallback (#10026).
+            fallback_provider_ids=cfg.get("agent_runner", {})
+            .get("config", {})
+            .get("model", {})
+            .get("fallback_provider_ids", []),
         )
         req = ProviderRequest()
         conv = await _get_session_conv(event=cron_event, plugin_context=self.ctx)

--- a/tests/unit/test_cron_manager.py
+++ b/tests/unit/test_cron_manager.py
@@ -550,6 +550,66 @@ class TestRunJob:
         mock_db.update_cron_job.assert_not_called()
 
 
+class TestCronFallbackProviders:
+    """Cron wakeups must inherit agent_runner fallback providers (#10026)."""
+
+    @pytest.mark.asyncio
+    async def test_woke_main_agent_forwards_fallback_provider_ids(
+        self, cron_manager, mock_context
+    ):
+        from types import SimpleNamespace
+
+        captured = {}
+
+        class FakeRunner:
+            state = AgentState.DONE
+
+            async def step_until_done(self, max_step):
+                return
+                yield  # pragma: no cover
+
+            def get_final_llm_resp(self):
+                return None
+
+        async def fake_build_main_agent(*, event, plugin_context, config, req):
+            captured["config"] = config
+            return SimpleNamespace(agent_runner=FakeRunner())
+
+        mock_context.get_config = MagicMock(
+            return_value={
+                "admins_id": [],
+                "agent_runner": {
+                    "config": {
+                        "model": {"fallback_provider_ids": ["backup-a", "backup-b"]}
+                    }
+                },
+            }
+        )
+        cron_manager.ctx = mock_context
+
+        with (
+            patch(
+                "astrbot.core.astr_main_agent.build_main_agent",
+                side_effect=fake_build_main_agent,
+            ),
+            patch(
+                "astrbot.core.astr_main_agent._get_session_conv",
+                new=AsyncMock(return_value=SimpleNamespace(history="[]")),
+            ),
+            patch(
+                "astrbot.core.cron.manager.persist_agent_history",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            await cron_manager._woke_main_agent(
+                message="run scheduled task",
+                session_str="test:FriendMessage:user123",
+                extras={"cron_job": {"id": "job-1"}, "cron_payload": {}},
+            )
+
+        assert captured["config"].fallback_provider_ids == ["backup-a", "backup-b"]
+
+
 class TestRunActiveAgentJob:
     """Tests for active agent cron job execution."""
 


### PR DESCRIPTION
## Motivation

Fixes #10026. The interactive pipeline forwards `agent_runner.config.model.fallback_provider_ids` into `MainAgentBuildConfig`, but the cron wakeup path (`cron/manager.py::_woke_main_agent`) left the field at its default, so a scheduled run had no fallback model to switch to when the primary model failed.

## Changes

- `_woke_main_agent` now reads `agent_runner.config.model.fallback_provider_ids` and passes it into `MainAgentBuildConfig`, matching the interactive pipeline.

## Tests

New regression test `test_woke_main_agent_forwards_fallback_provider_ids` drives the cron wakeup with fallback ids configured and asserts the build config carries them; red on current master, green here. Full `tests/unit/test_cron_manager.py` 45/45 green; ruff clean.

Signed-off-by: Yufeng He <40085740+he-yufeng@users.noreply.github.com>

## Summary by Sourcery

Propagate configured fallback provider IDs to scheduled agent runs and verify the behavior with a regression test.

Bug Fixes:
- Ensure scheduled agent runs inherit configured fallback providers so they can switch models when the primary provider fails.

Tests:
- Add regression coverage confirming cron wakeups propagate configured fallback provider IDs.