### PR TITLE
fix: preserve image attachment paths after event cleanup

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -1471,7 +1471,7 @@ async def build_main_agent(
                         event.track_temporary_local_file(image_path)
                     req.image_urls.append(image_path)
                     req.extra_user_content_parts.append(
-                        TextPart(text=f"[Image Attachment: path {image_path}]")
+                        TextPart(text=f"[Image Attachment: path {path}]")
                     )
                 elif isinstance(comp, Record):
                     audio_path = await comp.convert_to_file_path()
@@ -1509,7 +1509,7 @@ async def build_main_agent(
                             if _is_generated_compressed_image_path(path, image_path):
                                 event.track_temporary_local_file(image_path)
                             req.image_urls.append(image_path)
-                            _append_quoted_image_attachment(req, image_path)
+                            _append_quoted_image_attachment(req, path)
                         elif isinstance(reply_comp, Record):
                             audio_path = await reply_comp.convert_to_file_path()
                             req.audio_urls.append(audio_path)

--- a/astrbot/core/pipeline/preprocess_stage/stage.py
+++ b/astrbot/core/pipeline/preprocess_stage/stage.py
@@ -131,9 +131,9 @@ class PreProcessStage(Stage):
             elif isinstance(component, Image):
                 try:
                     original_path = await component.convert_to_file_path()
-                    self._track_temp_media(event, original_path)
                     image_path = await ensure_jpeg(original_path)
-                    self._track_temp_media(event, image_path)
+                    if image_path != original_path:
+                        self._track_temp_media(event, original_path)
                     component.file = image_path
                     component.path = image_path
                     # Image.convert_to_file_path() prefers url, so keep it aligned.
@@ -167,9 +167,9 @@ class PreProcessStage(Stage):
                     elif isinstance(reply_comp, Image):
                         try:
                             original_path = await reply_comp.convert_to_file_path()
-                            self._track_temp_media(event, original_path)
                             image_path = await ensure_jpeg(original_path)
-                            self._track_temp_media(event, image_path)
+                            if image_path != original_path:
+                                self._track_temp_media(event, original_path)
                             reply_comp.file = image_path
                             reply_comp.path = image_path
                             # Image.convert_to_file_path() prefers url, so keep it aligned.

--- a/astrbot/core/pipeline/preprocess_stage/stage.py
+++ b/astrbot/core/pipeline/preprocess_stage/stage.py
@@ -131,10 +131,6 @@ class PreProcessStage(Stage):
             elif isinstance(component, Image):
                 try:
                     original_path = await component.convert_to_file_path()
-                    # Keep the local reference even if JPEG conversion fails.
-                    component.file = original_path
-                    component.path = original_path
-                    component.url = original_path
                     image_path = await ensure_jpeg(original_path)
                     if image_path != original_path:
                         self._track_temp_media(event, original_path)
@@ -171,10 +167,6 @@ class PreProcessStage(Stage):
                     elif isinstance(reply_comp, Image):
                         try:
                             original_path = await reply_comp.convert_to_file_path()
-                            # Keep the local reference even if JPEG conversion fails.
-                            reply_comp.file = original_path
-                            reply_comp.path = original_path
-                            reply_comp.url = original_path
                             image_path = await ensure_jpeg(original_path)
                             if image_path != original_path:
                                 self._track_temp_media(event, original_path)

--- a/astrbot/core/pipeline/preprocess_stage/stage.py
+++ b/astrbot/core/pipeline/preprocess_stage/stage.py
@@ -131,6 +131,10 @@ class PreProcessStage(Stage):
             elif isinstance(component, Image):
                 try:
                     original_path = await component.convert_to_file_path()
+                    # Keep the local reference even if JPEG conversion fails.
+                    component.file = original_path
+                    component.path = original_path
+                    component.url = original_path
                     image_path = await ensure_jpeg(original_path)
                     if image_path != original_path:
                         self._track_temp_media(event, original_path)
@@ -167,6 +171,10 @@ class PreProcessStage(Stage):
                     elif isinstance(reply_comp, Image):
                         try:
                             original_path = await reply_comp.convert_to_file_path()
+                            # Keep the local reference even if JPEG conversion fails.
+                            reply_comp.file = original_path
+                            reply_comp.path = original_path
+                            reply_comp.url = original_path
                             image_path = await ensure_jpeg(original_path)
                             if image_path != original_path:
                                 self._track_temp_media(event, original_path)

--- a/astrbot/core/platform/sources/mattermost/mattermost_adapter.py
+++ b/astrbot/core/platform/sources/mattermost/mattermost_adapter.py
@@ -230,12 +230,10 @@ class MattermostPlatformAdapter(Platform):
             )
 
         if file_ids:
-            (
-                attachment_components,
-                temp_paths,
-            ) = await self.client.parse_post_attachments(file_ids)
+            attachment_components, _ = await self.client.parse_post_attachments(
+                file_ids
+            )
             abm.message.extend(attachment_components)
-            setattr(abm, "temporary_file_paths", temp_paths)
 
         abm.message_str = self._build_message_str(
             abm.message,

--- a/astrbot/core/platform/sources/mattermost/mattermost_event.py
+++ b/astrbot/core/platform/sources/mattermost/mattermost_event.py
@@ -23,8 +23,6 @@ class MattermostMessageEvent(AstrMessageEvent):
     ) -> None:
         super().__init__(message_str, message_obj, platform_meta, session_id)
         self.client = client
-        for path in getattr(message_obj, "temporary_file_paths", []):
-            self.track_temporary_local_file(path)
 
     async def send(self, message: MessageChain) -> None:
         await self.client.send_message_chain(self.get_session_id(), message)

--- a/tests/test_mattermost_adapter.py
+++ b/tests/test_mattermost_adapter.py
@@ -6,10 +6,12 @@ import pytest
 
 import astrbot.api.message_components as Comp
 from astrbot.api.platform import Group
+from astrbot.core.pipeline.preprocess_stage import stage as preprocess_stage
 from astrbot.core.platform.sources.mattermost.client import MattermostClient
 from astrbot.core.platform.sources.mattermost.mattermost_adapter import (
     MattermostPlatformAdapter,
 )
+from astrbot.core.utils import media_utils
 from tests.fixtures.helpers import make_platform_config
 
 
@@ -114,6 +116,75 @@ async def test_mattermost_parse_post_attachments_maps_media_types(tmp_path):
         path = Path(temp_path)
         assert path.exists()
         assert path.name.endswith(Path(expected_name).suffix)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("image_kind", ["png", "jpeg", "invalid"])
+async def test_mattermost_attachments_follow_preprocessing_cleanup_rules(
+    tmp_path, monkeypatch, image_kind
+):
+    import wave
+
+    from PIL import Image as PILImage
+
+    monkeypatch.setattr(media_utils, "get_astrbot_temp_path", lambda: str(tmp_path))
+    monkeypatch.setattr(
+        preprocess_stage, "get_astrbot_temp_path", lambda: str(tmp_path)
+    )
+    image_path = tmp_path / f"image.{image_kind}"
+    if image_kind == "invalid":
+        image_path.write_bytes(b"not an image")
+    else:
+        PILImage.new("RGB", (2, 2), (255, 0, 0)).save(image_path)
+    audio_path = tmp_path / "voice.wav"
+    with wave.open(str(audio_path), "wb") as audio_file:
+        audio_file.setparams((1, 2, 8000, 0, "NONE", "not compressed"))
+        audio_file.writeframes(b"\x00\x00" * 80)
+    video_path = tmp_path / "clip.mp4"
+    video_path.write_bytes(b"video")
+    document_path = tmp_path / "report.pdf"
+    document_path.write_bytes(b"document")
+    downloaded_paths = [image_path, audio_path, video_path, document_path]
+    image = Comp.Image.fromFileSystem(str(image_path))
+    adapter = _build_adapter()
+    adapter.client.parse_post_attachments = AsyncMock(
+        return_value=(
+            [
+                image,
+                Comp.Record(file=str(audio_path), url=str(audio_path)),
+                Comp.Video.fromFileSystem(str(video_path)),
+                Comp.File(name="report.pdf", file=str(document_path)),
+            ],
+            [str(path) for path in downloaded_paths],
+        )
+    )
+    message = await adapter.convert_message(
+        post={
+            "id": "post-1",
+            "channel_id": "channel-1",
+            "user_id": "user-1",
+            "message": "hello",
+            "file_ids": ["img", "audio", "video", "doc"],
+        },
+        data={"channel_type": "D", "sender_name": "alice"},
+    )
+    event = adapter.create_event(message)
+    assert event._temporary_local_files == []
+    stage = preprocess_stage.PreProcessStage()
+    stage.config = {}
+    stage.platform_settings = {}
+    stage.stt_settings = {"enable": False}
+
+    await stage.process(event)
+    event.cleanup_temporary_local_files()
+
+    assert image_path.exists() == (image_kind != "png")
+    assert not audio_path.exists()
+    assert video_path.exists()
+    assert document_path.exists()
+    assert Path(await image.convert_to_file_path()).exists()
+    if image_kind == "png":
+        assert image.file != str(image_path)
 
 
 @pytest.mark.asyncio

--- a/tests/test_mattermost_adapter.py
+++ b/tests/test_mattermost_adapter.py
@@ -188,6 +188,64 @@ async def test_mattermost_attachments_follow_preprocessing_cleanup_rules(
 
 
 @pytest.mark.asyncio
+async def test_mattermost_converted_audio_retains_downloaded_source(
+    tmp_path, monkeypatch
+):
+    import wave
+
+    from astrbot.core.platform.sources.mattermost import client as mattermost_client
+
+    monkeypatch.setattr(
+        mattermost_client, "get_astrbot_temp_path", lambda: str(tmp_path)
+    )
+    monkeypatch.setattr(
+        preprocess_stage, "get_astrbot_temp_path", lambda: str(tmp_path)
+    )
+    wav_path = tmp_path / "converted.wav"
+    with wave.open(str(wav_path), "wb") as audio_file:
+        audio_file.setparams((1, 2, 8000, 0, "NONE", "not compressed"))
+        audio_file.writeframes(b"\x00\x00" * 80)
+    resolver = MagicMock()
+    resolver.return_value.to_path = AsyncMock(return_value=str(wav_path))
+    monkeypatch.setattr(mattermost_client, "MediaResolver", resolver)
+    adapter = _build_adapter()
+    adapter.client.get_file_info = AsyncMock(
+        return_value={"name": "voice.ogg", "mime_type": "audio/ogg"}
+    )
+    adapter.client.download_file = AsyncMock(return_value=b"downloaded ogg bytes")
+    message = await adapter.convert_message(
+        post={
+            "id": "post-1",
+            "channel_id": "channel-1",
+            "user_id": "user-1",
+            "file_ids": ["voice"],
+        },
+        data={"channel_type": "D", "sender_name": "alice"},
+    )
+    source_path = tmp_path / "mattermost_voice.ogg"
+    resolver.assert_called_once_with(
+        str(source_path), media_type="audio", default_suffix=".wav"
+    )
+    resolver.return_value.to_path.assert_awaited_once_with(target_format="wav")
+    assert any(
+        isinstance(comp, Comp.Record) and comp.file == str(wav_path)
+        for comp in message.message
+    )
+    event = adapter.create_event(message)
+    assert event._temporary_local_files == []
+    stage = preprocess_stage.PreProcessStage()
+    stage.config = {}
+    stage.platform_settings = {}
+    stage.stt_settings = {"enable": False}
+
+    await stage.process(event)
+    event.cleanup_temporary_local_files()
+
+    assert source_path.read_bytes() == b"downloaded ogg bytes"
+    assert not wav_path.exists()
+
+
+@pytest.mark.asyncio
 async def test_mattermost_get_group_returns_members_and_channel_admins():
     adapter = _build_adapter()
     adapter.client.get_channel = AsyncMock(

--- a/tests/test_mattermost_adapter.py
+++ b/tests/test_mattermost_adapter.py
@@ -188,64 +188,6 @@ async def test_mattermost_attachments_follow_preprocessing_cleanup_rules(
 
 
 @pytest.mark.asyncio
-async def test_mattermost_converted_audio_retains_downloaded_source(
-    tmp_path, monkeypatch
-):
-    import wave
-
-    from astrbot.core.platform.sources.mattermost import client as mattermost_client
-
-    monkeypatch.setattr(
-        mattermost_client, "get_astrbot_temp_path", lambda: str(tmp_path)
-    )
-    monkeypatch.setattr(
-        preprocess_stage, "get_astrbot_temp_path", lambda: str(tmp_path)
-    )
-    wav_path = tmp_path / "converted.wav"
-    with wave.open(str(wav_path), "wb") as audio_file:
-        audio_file.setparams((1, 2, 8000, 0, "NONE", "not compressed"))
-        audio_file.writeframes(b"\x00\x00" * 80)
-    resolver = MagicMock()
-    resolver.return_value.to_path = AsyncMock(return_value=str(wav_path))
-    monkeypatch.setattr(mattermost_client, "MediaResolver", resolver)
-    adapter = _build_adapter()
-    adapter.client.get_file_info = AsyncMock(
-        return_value={"name": "voice.ogg", "mime_type": "audio/ogg"}
-    )
-    adapter.client.download_file = AsyncMock(return_value=b"downloaded ogg bytes")
-    message = await adapter.convert_message(
-        post={
-            "id": "post-1",
-            "channel_id": "channel-1",
-            "user_id": "user-1",
-            "file_ids": ["voice"],
-        },
-        data={"channel_type": "D", "sender_name": "alice"},
-    )
-    source_path = tmp_path / "mattermost_voice.ogg"
-    resolver.assert_called_once_with(
-        str(source_path), media_type="audio", default_suffix=".wav"
-    )
-    resolver.return_value.to_path.assert_awaited_once_with(target_format="wav")
-    assert any(
-        isinstance(comp, Comp.Record) and comp.file == str(wav_path)
-        for comp in message.message
-    )
-    event = adapter.create_event(message)
-    assert event._temporary_local_files == []
-    stage = preprocess_stage.PreProcessStage()
-    stage.config = {}
-    stage.platform_settings = {}
-    stage.stt_settings = {"enable": False}
-
-    await stage.process(event)
-    event.cleanup_temporary_local_files()
-
-    assert source_path.read_bytes() == b"downloaded ogg bytes"
-    assert not wav_path.exists()
-
-
-@pytest.mark.asyncio
 async def test_mattermost_get_group_returns_members_and_channel_admins():
     adapter = _build_adapter()
     adapter.client.get_channel = AsyncMock(

--- a/tests/test_preprocess_stage.py
+++ b/tests/test_preprocess_stage.py
@@ -7,6 +7,7 @@ import pytest
 from astrbot.core.message.components import Image, Plain, Reply
 from astrbot.core.pipeline.preprocess_stage import stage as preprocess_stage
 from astrbot.core.pipeline.preprocess_stage.stage import PreProcessStage
+from astrbot.core.platform.astr_message_event import AstrMessageEvent
 from astrbot.core.utils import media_utils
 
 
@@ -29,7 +30,7 @@ class FakeEvent:
 
 
 @pytest.mark.asyncio
-async def test_preprocess_preserves_image_formats_and_tracks_temp_files(
+async def test_preprocess_preserves_image_formats_without_tracking_temp_files(
     tmp_path, monkeypatch
 ):
     from PIL import Image as PILImage
@@ -88,18 +89,64 @@ async def test_preprocess_preserves_image_formats_and_tracks_temp_files(
     assert isinstance(main_image, Image)
     assert main_image.file == main_image.path == main_image.url
     assert main_image.file.endswith(".png")
-    assert main_image.file in event.temporary_local_files
+    assert main_image.file not in event.temporary_local_files
     with PILImage.open(main_image.file) as processed_img:
         assert processed_img.format == "PNG"
         assert processed_img.getpixel((0, 0))[3] == 128
 
     assert reply_image.file == reply_image.path == reply_image.url
     assert reply_image.file.endswith(".gif")
-    assert reply_image.file in event.temporary_local_files
+    assert reply_image.file not in event.temporary_local_files
     with PILImage.open(reply_image.file) as processed_img:
         assert processed_img.format == "GIF"
         assert processed_img.is_animated
         assert processed_img.n_frames == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("quoted", [False, True])
+@pytest.mark.parametrize("source_kind", ["png", "jpeg", "invalid"])
+async def test_preprocess_image_cleanup_preserves_usable_file(
+    tmp_path, monkeypatch, quoted, source_kind
+):
+    from pathlib import Path
+
+    from PIL import Image as PILImage
+
+    monkeypatch.setattr(media_utils, "get_astrbot_temp_path", lambda: str(tmp_path))
+    monkeypatch.setattr(
+        preprocess_stage, "get_astrbot_temp_path", lambda: str(tmp_path)
+    )
+    source_path = tmp_path / f"source.{source_kind}"
+    if source_kind == "invalid":
+        source_path.write_bytes(b"not an image")
+    else:
+        PILImage.new("RGB", (2, 2), (255, 0, 0)).save(source_path)
+
+    image = Image.fromFileSystem(str(source_path))
+    event = FakeEvent([Reply(id="reply-1", chain=[image])] if quoted else [image])
+    stage = PreProcessStage()
+    stage.config = {}
+    stage.platform_settings = {}
+    stage.stt_settings = {"enable": False}
+
+    await stage.process(event)
+
+    if source_kind == "png":
+        assert event.temporary_local_files == [str(source_path)]
+        assert image.file == image.path == image.url
+        assert image.file != str(source_path)
+        with PILImage.open(image.file) as processed_img:
+            assert processed_img.format == "JPEG"
+    else:
+        assert event.temporary_local_files == []
+
+    # Exercise event cleanup to verify that the usable image survives.
+    AstrMessageEvent.cleanup_temporary_local_files(
+        SimpleNamespace(_temporary_local_files=event.temporary_local_files)
+    )
+    assert source_path.exists() == (source_kind != "png")
+    assert Path(await image.convert_to_file_path()).exists()
 
 
 @pytest.mark.asyncio

--- a/tests/test_preprocess_stage.py
+++ b/tests/test_preprocess_stage.py
@@ -1,8 +1,6 @@
 import base64
 from io import BytesIO
-from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
 
 import pytest
 
@@ -149,49 +147,6 @@ async def test_preprocess_image_cleanup_preserves_usable_file(
     )
     assert source_path.exists() == (source_kind != "png")
     assert Path(await image.convert_to_file_path()).exists()
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("quoted", [False, True])
-@pytest.mark.parametrize("remote", [False, True])
-async def test_failed_image_conversion_keeps_materialized_reference(
-    tmp_path, monkeypatch, quoted, remote
-):
-    monkeypatch.setattr(media_utils, "get_astrbot_temp_path", lambda: str(tmp_path))
-    monkeypatch.setattr(
-        preprocess_stage, "get_astrbot_temp_path", lambda: str(tmp_path)
-    )
-    invalid_bytes = b"not an image"
-    if remote:
-        image_ref = "https://example.com/image.png"
-        download = AsyncMock(
-            side_effect=lambda url, target: Path(target).write_bytes(invalid_bytes)
-        )
-        monkeypatch.setattr(media_utils, "download_file", download)
-    else:
-        image_ref = "data:image/png;base64," + base64.b64encode(invalid_bytes).decode()
-    image = Image(file=image_ref)
-    event = FakeEvent([Reply(id="reply-1", chain=[image])] if quoted else [image])
-    stage = PreProcessStage()
-    stage.config = {}
-    stage.platform_settings = {}
-    stage.stt_settings = {"enable": False}
-
-    await stage.process(event)
-
-    files = list(tmp_path.iterdir())
-    assert len(files) == 1
-    local_path = files[0]
-    assert image.file == image.path == image.url == str(local_path)
-    assert event.temporary_local_files == []
-    AstrMessageEvent.cleanup_temporary_local_files(
-        SimpleNamespace(_temporary_local_files=event.temporary_local_files)
-    )
-    assert local_path.read_bytes() == invalid_bytes
-    assert await image.convert_to_file_path() == str(local_path)
-    assert list(tmp_path.iterdir()) == files
-    if remote:
-        download.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_preprocess_stage.py
+++ b/tests/test_preprocess_stage.py
@@ -1,6 +1,8 @@
 import base64
 from io import BytesIO
+from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -147,6 +149,49 @@ async def test_preprocess_image_cleanup_preserves_usable_file(
     )
     assert source_path.exists() == (source_kind != "png")
     assert Path(await image.convert_to_file_path()).exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("quoted", [False, True])
+@pytest.mark.parametrize("remote", [False, True])
+async def test_failed_image_conversion_keeps_materialized_reference(
+    tmp_path, monkeypatch, quoted, remote
+):
+    monkeypatch.setattr(media_utils, "get_astrbot_temp_path", lambda: str(tmp_path))
+    monkeypatch.setattr(
+        preprocess_stage, "get_astrbot_temp_path", lambda: str(tmp_path)
+    )
+    invalid_bytes = b"not an image"
+    if remote:
+        image_ref = "https://example.com/image.png"
+        download = AsyncMock(
+            side_effect=lambda url, target: Path(target).write_bytes(invalid_bytes)
+        )
+        monkeypatch.setattr(media_utils, "download_file", download)
+    else:
+        image_ref = "data:image/png;base64," + base64.b64encode(invalid_bytes).decode()
+    image = Image(file=image_ref)
+    event = FakeEvent([Reply(id="reply-1", chain=[image])] if quoted else [image])
+    stage = PreProcessStage()
+    stage.config = {}
+    stage.platform_settings = {}
+    stage.stt_settings = {"enable": False}
+
+    await stage.process(event)
+
+    files = list(tmp_path.iterdir())
+    assert len(files) == 1
+    local_path = files[0]
+    assert image.file == image.path == image.url == str(local_path)
+    assert event.temporary_local_files == []
+    AstrMessageEvent.cleanup_temporary_local_files(
+        SimpleNamespace(_temporary_local_files=event.temporary_local_files)
+    )
+    assert local_path.read_bytes() == invalid_bytes
+    assert await image.convert_to_file_path() == str(local_path)
+    assert list(tmp_path.iterdir()) == files
+    if remote:
+        download.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_astr_main_agent.py
+++ b/tests/unit/test_astr_main_agent.py
@@ -1746,14 +1746,33 @@ class TestBuildMainAgent:
         assert result is None
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("quoted", [False, True])
+    @pytest.mark.parametrize("compression_enabled", [False, True])
     async def test_build_main_agent_with_images(
-        self, mock_event, mock_context, mock_provider
+        self,
+        mock_event,
+        mock_context,
+        mock_provider,
+        tmp_path,
+        monkeypatch,
+        quoted,
+        compression_enabled,
     ):
-        """Test building main agent with image attachments."""
+        """Keep attachment paths usable after compressed visual input is cleaned up."""
+        from types import SimpleNamespace
+
+        from PIL import Image as PILImage
+
+        from astrbot.core.utils import media_utils
+
         module = ama
-        mock_image = MagicMock(spec=Image)
-        mock_image.convert_to_file_path = AsyncMock(return_value="/path/to/image.jpg")
-        mock_event.message_obj.message = [mock_image]
+        monkeypatch.setattr(media_utils, "get_astrbot_temp_path", lambda: str(tmp_path))
+        source_path = tmp_path / "image.jpg"
+        PILImage.new("RGB", (8, 8), (255, 0, 0)).save(source_path)
+        image = Image.fromFileSystem(str(source_path))
+        mock_event.message_obj.message = (
+            [Reply(id="reply-1", chain=[image])] if quoted else [image]
+        )
 
         mock_context.get_provider_by_id.return_value = None
         mock_context.get_using_provider.return_value = mock_provider
@@ -1773,10 +1792,43 @@ class TestBuildMainAgent:
             result = await module.build_main_agent(
                 event=mock_event,
                 plugin_context=mock_context,
-                config=module.MainAgentBuildConfig(tool_call_timeout=60),
+                config=module.MainAgentBuildConfig(
+                    tool_call_timeout=60,
+                    provider_settings={
+                        "image_compress_enabled": compression_enabled,
+                        "image_compress_options": {"max_size": 2},
+                    },
+                ),
             )
 
         assert result is not None
+        request = result.provider_request
+        label = "Image Attachment in quoted message" if quoted else "Image Attachment"
+        assert f"[{label}: path {source_path}]" in [
+            part.text for part in request.extra_user_content_parts
+        ]
+        assert len(request.image_urls) == 1
+        visual_path = Path(request.image_urls[0])
+        if compression_enabled:
+            assert visual_path != source_path
+            with PILImage.open(visual_path) as visual_image:
+                assert visual_image.size == (2, 2)
+            mock_event.track_temporary_local_file.assert_called_once_with(
+                str(visual_path)
+            )
+        else:
+            assert visual_path == source_path
+            mock_event.track_temporary_local_file.assert_not_called()
+        AstrMessageEvent.cleanup_temporary_local_files(
+            SimpleNamespace(
+                _temporary_local_files=[
+                    call.args[0]
+                    for call in mock_event.track_temporary_local_file.call_args_list
+                ]
+            )
+        )
+        assert source_path.exists()
+        assert visual_path.exists() == (not compression_enabled)
 
     @pytest.mark.asyncio
     async def test_build_main_agent_skips_caption_when_main_provider_supports_images(


### PR DESCRIPTION
Image attachment text currently exposes compressed image paths that are deleted when the event finishes. Image preprocessing also deletes the image files needed by later tasks. Preserve the preprocessed image and reference its path in the model request so subsequent tool calls can reuse it after event cleanup.

### Modifications

- For current and quoted images, register the original temporary file for deletion only after JPEG conversion returns a different path. Keep the converted output, unchanged images, and originals whose conversion fails.
- Put the pre-compression image path in attachment text while continuing to send compressed images as visual input and clean up those compressed copies when the event finishes.
- Remove Mattermost's attachment-path metadata and blanket event cleanup registration. Its attachments still follow the common image and audio preprocessing rules.

Retained files remain in the existing storage locations and are still subject to temporary-directory capacity cleanup and manual cache cleanup; this change does not provide permanent storage.

- [x] This is not a breaking change.

### Screenshots or Test Results

- `uv run pytest tests/test_preprocess_stage.py tests/test_mattermost_adapter.py tests/unit/test_astr_main_agent.py -q` — 140 passed.
- Tests cover current and quoted images, successful and failed conversion, unchanged formats, compression enabled and disabled, Mattermost attachments, and file survival after event cleanup.
- `ruff format .`, `ruff check .`, and `git diff --check` — passed.

### Checklist

- [x] Changes have been tested, with verification commands and results provided above.
- [x] No new dependencies are introduced.
- [x] Changes do not introduce malicious code.

## Summary by Sourcery

Preserve image attachment files needed by later model and tool calls after event cleanup.

Bug Fixes:
- Preserve usable original image paths in attachment text after event cleanup while continuing to use and clean up compressed visual copies.

Enhancements:
- Align image preprocessing cleanup with whether JPEG conversion creates a replacement file, including quoted and Mattermost attachments.
- Route Mattermost attachment files through the shared media preprocessing and cleanup behavior instead of blanket event-level cleanup.

Tests:
- Add coverage for current and quoted images, conversion outcomes, compression settings, Mattermost attachments, and file survival after cleanup.

