### PR TITLE
fix(core): don't crash startup when a plugin registers an already-created Task

### DIFF
--- a/astrbot/core/core_lifecycle.py
+++ b/astrbot/core/core_lifecycle.py
@@ -15,6 +15,8 @@ import threading
 import time
 import traceback
 from asyncio import Queue
+from collections.abc import Awaitable
+from typing import Any
 
 from astrbot.api import logger, sp
 from astrbot.core import LogBroker, LogManager
@@ -316,17 +318,12 @@ class AstrBotCoreLifecycle:
             )
         diagnostic_tasks = create_event_loop_diagnostic_tasks()
 
-        # 把插件中注册的所有协程函数注册到事件总线中并执行
-        extra_tasks = []
+        # Register every plugin-registered task on the event bus and run it
+        extra_tasks: list[asyncio.Task] = []
         for task in self.star_context._register_tasks:
-            if isinstance(task, asyncio.Task):
-                extra_tasks.append(task)
-            elif asyncio.iscoroutine(task):
-                extra_tasks.append(asyncio.create_task(task, name=task.__name__))
-            else:
-                logger.warning(
-                    f"忽略无法识别的插件注册任务（期望协程或 asyncio.Task）: {task!r}",
-                )
+            converted = self._to_task(task)
+            if converted is not None:
+                extra_tasks.append(converted)
         self.star_context._register_tasks.clear()
 
         tasks_ = [
@@ -344,6 +341,39 @@ class AstrBotCoreLifecycle:
             )
 
         self.start_time = int(time.time())
+
+    @staticmethod
+    def _to_task(task: Awaitable[Any]) -> asyncio.Task | None:
+        """Convert a plugin-registered awaitable into an ``asyncio.Task``.
+
+        ``Context.register_task`` accepts ``Awaitable``, so coroutines,
+        ``asyncio.Task``, ``asyncio.Future`` and any object implementing
+        ``__await__`` are valid inputs and must all be scheduled.
+
+        ``_task_wrapper`` and ``stop`` rely on ``get_name()`` and ``cancel()``
+        of ``asyncio.Task``, so any other valid awaitable is wrapped into a
+        real Task instead of being dropped silently.
+
+        Args:
+            task: The awaitable registered through ``Context.register_task``.
+
+        Returns:
+            A schedulable ``asyncio.Task``, or ``None`` if the input is not
+            awaitable.
+        """
+        if isinstance(task, asyncio.Task):
+            return task
+        if asyncio.iscoroutine(task):
+            return asyncio.create_task(task, name=task.__name__)
+        if not isinstance(task, Awaitable):
+            logger.warning(f"Skipping non-awaitable plugin-registered task: {task!r}")
+            return None
+
+        async def _await_registered() -> Any:
+            return await task
+
+        name = getattr(task, "__name__", None) or type(task).__name__
+        return asyncio.create_task(_await_registered(), name=name)
 
     async def _task_wrapper(self, task: asyncio.Task) -> None:
         """异步任务包装器, 用于处理异步任务执行中出现的各种异常.

--- a/astrbot/core/core_lifecycle.py
+++ b/astrbot/core/core_lifecycle.py
@@ -319,7 +319,15 @@ class AstrBotCoreLifecycle:
         # 把插件中注册的所有协程函数注册到事件总线中并执行
         extra_tasks = []
         for task in self.star_context._register_tasks:
-            extra_tasks.append(asyncio.create_task(task, name=task.__name__))  # type: ignore
+            if isinstance(task, asyncio.Task):
+                extra_tasks.append(task)
+            elif asyncio.iscoroutine(task):
+                extra_tasks.append(asyncio.create_task(task, name=task.__name__))
+            else:
+                logger.warning(
+                    f"忽略无法识别的插件注册任务（期望协程或 asyncio.Task）: {task!r}",
+                )
+        self.star_context._register_tasks.clear()
 
         tasks_ = [
             event_bus_task,

--- a/tests/unit/test_core_lifecycle.py
+++ b/tests/unit/test_core_lifecycle.py
@@ -1000,3 +1000,93 @@ class TestAstrBotCoreLifecycleLoadPipelineScheduler:
 
         with pytest.raises(ValueError, match="配置文件 .* 不存在"):
             await lifecycle.reload_pipeline_scheduler("nonexistent")
+
+
+class TestAstrBotCoreLifecycleRegisteredTasks:
+    @staticmethod
+    def _make_lifecycle(mock_log_broker, mock_db, registered: list):
+        lifecycle = AstrBotCoreLifecycle(mock_log_broker, mock_db)
+        lifecycle.event_bus = MagicMock()
+        lifecycle.event_bus.dispatch = AsyncMock()
+        lifecycle.cron_manager = None
+        lifecycle.temp_dir_cleaner = None
+        lifecycle.star_context = MagicMock()
+        lifecycle.star_context._register_tasks = registered
+        lifecycle.curr_tasks = []
+        return lifecycle
+
+    @staticmethod
+    async def _cleanup(lifecycle: AstrBotCoreLifecycle):
+        for task in lifecycle.curr_tasks:
+            task.cancel()
+        for task in lifecycle.curr_tasks:
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_load_schedules_coroutine_registered_task(
+        self, mock_log_broker, mock_db
+    ):
+        started = asyncio.Event()
+
+        async def background():
+            started.set()
+
+        registered = [background()]
+        lifecycle = self._make_lifecycle(mock_log_broker, mock_db, registered)
+
+        with patch(
+            "astrbot.core.core_lifecycle.create_event_loop_diagnostic_tasks",
+            return_value=[],
+        ):
+            lifecycle._load()
+
+        await asyncio.wait_for(started.wait(), timeout=1)
+        assert registered == []
+        assert len(lifecycle.curr_tasks) == 2
+
+        await self._cleanup(lifecycle)
+
+    @pytest.mark.asyncio
+    async def test_load_reuses_already_created_task(self, mock_log_broker, mock_db):
+        started = asyncio.Event()
+
+        async def background():
+            started.set()
+
+        existing = asyncio.create_task(background())
+        lifecycle = self._make_lifecycle(mock_log_broker, mock_db, [existing])
+
+        with patch(
+            "astrbot.core.core_lifecycle.create_event_loop_diagnostic_tasks",
+            return_value=[],
+        ):
+            lifecycle._load()
+
+        await asyncio.wait_for(started.wait(), timeout=1)
+        assert existing.get_name() in [t.get_name() for t in lifecycle.curr_tasks]
+        assert lifecycle.star_context._register_tasks == []
+
+        await self._cleanup(lifecycle)
+
+    @pytest.mark.asyncio
+    async def test_load_skips_unrecognized_awaitable(self, mock_log_broker, mock_db):
+        future = asyncio.get_running_loop().create_future()
+        lifecycle = self._make_lifecycle(mock_log_broker, mock_db, [future])
+
+        with (
+            patch(
+                "astrbot.core.core_lifecycle.create_event_loop_diagnostic_tasks",
+                return_value=[],
+            ),
+            patch("astrbot.core.core_lifecycle.logger") as mock_logger,
+        ):
+            lifecycle._load()
+
+        mock_logger.warning.assert_called_once()
+        assert len(lifecycle.curr_tasks) == 1
+
+        await self._cleanup(lifecycle)
+        future.cancel()

--- a/tests/unit/test_core_lifecycle.py
+++ b/tests/unit/test_core_lifecycle.py
@@ -1071,10 +1071,20 @@ class TestAstrBotCoreLifecycleRegisteredTasks:
 
         await self._cleanup(lifecycle)
 
+    class _CustomAwaitable:
+        """Any object implementing __await__ is a valid Awaitable."""
+
+        def __await__(self):
+            async def _inner():
+                return "done"
+
+            return _inner().__await__()
+
     @pytest.mark.asyncio
-    async def test_load_skips_unrecognized_awaitable(self, mock_log_broker, mock_db):
-        future = asyncio.get_running_loop().create_future()
-        lifecycle = self._make_lifecycle(mock_log_broker, mock_db, [future])
+    async def test_load_skips_non_awaitable_registered_task(
+        self, mock_log_broker, mock_db
+    ):
+        lifecycle = self._make_lifecycle(mock_log_broker, mock_db, [object()])
 
         with (
             patch(
@@ -1087,6 +1097,49 @@ class TestAstrBotCoreLifecycleRegisteredTasks:
 
         mock_logger.warning.assert_called_once()
         assert len(lifecycle.curr_tasks) == 1
+        assert lifecycle.star_context._register_tasks == []
 
         await self._cleanup(lifecycle)
-        future.cancel()
+
+    @pytest.mark.asyncio
+    async def test_load_schedules_future_registered_task(self, mock_log_broker, mock_db):
+        future = asyncio.get_running_loop().create_future()
+        lifecycle = self._make_lifecycle(mock_log_broker, mock_db, [future])
+
+        with patch(
+            "astrbot.core.core_lifecycle.create_event_loop_diagnostic_tasks",
+            return_value=[],
+        ):
+            lifecycle._load()
+
+        # asyncio.Future is a valid Awaitable too and must be scheduled, not dropped
+        assert len(lifecycle.curr_tasks) == 2
+        assert "Future" in [task.get_name() for task in lifecycle.curr_tasks]
+        assert lifecycle.star_context._register_tasks == []
+
+        future.set_result("done")
+        await asyncio.sleep(0)
+        await self._cleanup(lifecycle)
+
+    @pytest.mark.asyncio
+    async def test_load_schedules_custom_awaitable_registered_task(
+        self, mock_log_broker, mock_db
+    ):
+        lifecycle = self._make_lifecycle(mock_log_broker, mock_db, [self._CustomAwaitable()])
+
+        with (
+            patch(
+                "astrbot.core.core_lifecycle.create_event_loop_diagnostic_tasks",
+                return_value=[],
+            ),
+            patch("astrbot.core.core_lifecycle.logger") as mock_logger,
+        ):
+            lifecycle._load()
+
+        assert len(lifecycle.curr_tasks) == 2
+        assert "_CustomAwaitable" in [t.get_name() for t in lifecycle.curr_tasks]
+        mock_logger.warning.assert_not_called()
+        assert lifecycle.star_context._register_tasks == []
+
+        await asyncio.sleep(0)
+        await self._cleanup(lifecycle)


### PR DESCRIPTION
### Motivation / 动机

`Context.register_task(task: Awaitable, desc: str)` is typed as accepting any `Awaitable`, but `AstrBotCoreLifecycle._load()` assumes every registered item is a coroutine object and evaluates `task.__name__`:

```python
extra_tasks.append(asyncio.create_task(task, name=task.__name__))
```

`asyncio.Task` **is** a valid `Awaitable`, but it has no `__name__` attribute (it exposes `get_name()` instead). So a plugin that calls `asyncio.create_task()` on its own coroutine and then registers the resulting Task raises:

```
AttributeError: '_asyncio.Task' object has no attribute '__name__'
```

That exception propagates through `_load()` → `core_lifecycle.start()` → `initial_loader.start()` → `asyncio.run()`, so **the entire process exits during startup**. A single plugin can take the whole app down, and the trigger is easy to hit because the API's own type hint explicitly permits `Awaitable`. In practice the crash surfaces right after the WebUI banner and is followed by a cascade of `LifespanFailureError` / `CancelledError` noise that hides the real cause.

The same line also breaks on any other non-coroutine awaitable (e.g. `asyncio.Future`), with the identical failure mode.

### Modifications / 改动点

`astrbot/core/core_lifecycle.py` — `_load()` now honours the declared `Awaitable` contract instead of assuming coroutines:

- Reuse an already-created `asyncio.Task` as-is, so `_task_wrapper` / `stop()` keep working with `get_name()` and `cancel()`.
- Keep scheduling coroutine objects exactly as before (task name still comes from `__name__`).
- Wrap every other valid `Awaitable` — `asyncio.Future`, or any object implementing `__await__` — into a real `asyncio.Task` so it is actually scheduled, instead of being dropped.
- Log a warning and skip only inputs that are not awaitable at all.
- Clear `_register_tasks` after consuming it — it is a `Context` *class* variable that was never cleared, so any second load would re-schedule the very same tasks.

`tests/unit/test_core_lifecycle.py` — new `TestAstrBotCoreLifecycleRegisteredTasks` class with 5 cases covering: the coroutine path, the already-created-`Task` path (the reported regression), the `asyncio.Future` path, the custom-`__await__` path, and the non-awaitable path.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。

### Screenshots or Test Results / 运行截图或测试结果

```console
$ python -m pytest tests/unit/test_core_lifecycle.py -q
31 passed, 1 warning in 7.92s

$ python -m ruff format --check .
504 files already formatted

$ python -m ruff check .
All checks passed!
```

Reverting **only** the `core_lifecycle.py` change (keeping the new tests) makes all five new tests fail, confirming they are genuine regression tests:

```console
$ python -m pytest tests/unit/test_core_lifecycle.py -q -k RegisteredTasks
>           extra_tasks.append(asyncio.create_task(task, name=task.__name__))  # type: ignore
                                                              ^^^^^^^^^^^^^
E           AttributeError: '_CustomAwaitable' object has no attribute '__name__'. Did you mean: '__ne__'?
astrbot\core\core_lifecycle.py:322: AttributeError
=========================== short test summary info ============================
FAILED tests/unit/test_core_lifecycle.py::TestAstrBotCoreLifecycleRegisteredTasks::test_load_schedules_coroutine_registered_task
FAILED tests/unit/test_core_lifecycle.py::TestAstrBotCoreLifecycleRegisteredTasks::test_load_reuses_already_created_task - AttributeError: '_asyncio.Task' object has no attribute '__name__'.
FAILED tests/unit/test_core_lifecycle.py::TestAstrBotCoreLifecycleRegisteredTasks::test_load_skips_non_awaitable_registered_task - AttributeError: 'object' object has no attribute '__name__'.
FAILED tests/unit/test_core_lifecycle.py::TestAstrBotCoreLifecycleRegisteredTasks::test_load_schedules_future_registered_task - AttributeError: '_asyncio.Future' object has no attribute '__name__'.
FAILED tests/unit/test_core_lifecycle.py::TestAstrBotCoreLifecycleRegisteredTasks::test_load_schedules_custom_awaitable_registered_task - AttributeError: '_CustomAwaitable' object has no attribute '__name__'.
5 failed, 26 deselected, 1 warning in 21.77s
```

---

### Checklist / 检查清单

- [x] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc. / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。
- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**. / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。
- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`. / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 My changes do not introduce malicious code. / 我的更改没有引入恶意代码。

## Summary by Sourcery

Handle plugin-registered awaitables safely during core lifecycle startup.

Bug Fixes:
- Prevent startup crashes when plugins register already-created tasks or other supported awaitables.
- Skip invalid non-awaitable registrations with a warning instead of aborting the application.

Enhancements:
- Reuse existing asyncio tasks, wrap supported awaitables for lifecycle management, and clear registered tasks after loading.

Tests:
- Add coverage for coroutine, task, future, custom awaitable, and invalid registered-task handling.
