### PR TITLE
fix: mark system reminders as temporary to stop history growth (#10033)

### DIFF
--- a/astrbot/core/astr_main_agent.py
+++ b/astrbot/core/astr_main_agent.py
@@ -1014,7 +1014,9 @@ def _append_system_reminders(
         system_content = (
             "<system_reminder>" + "\n".join(system_parts) + "</system_reminder>"
         )
-        req.extra_user_content_parts.append(TextPart(text=system_content))
+        req.extra_user_content_parts.append(
+            TextPart(text=system_content).mark_as_temp()
+        )
 
 
 async def _decorate_llm_request(

--- a/tests/unit/test_astr_main_agent.py
+++ b/tests/unit/test_astr_main_agent.py
@@ -265,12 +265,18 @@ def test_append_system_reminders_includes_weekday(mock_event):
         "<system_reminder>Current datetime: "
         "2026-06-08 12:34 (UTC), Weekday: Monday</system_reminder>"
     ]
+    # The datetime reminder is provider-facing only and must not be persisted
+    # into conversation history.
+    assert req.extra_user_content_parts[0]._no_save is True
 
 
 def test_local_mode_prompt_uses_windows_powershell_51():
-    with patch("astrbot.core.astr_main_agent.platform.system", return_value="Windows"), patch(
-        "astrbot.core.astr_main_agent.resolve_windows_shell",
-        return_value="powershell.exe",
+    with (
+        patch("astrbot.core.astr_main_agent.platform.system", return_value="Windows"),
+        patch(
+            "astrbot.core.astr_main_agent.resolve_windows_shell",
+            return_value="powershell.exe",
+        ),
     ):
         prompt = ama._build_local_mode_prompt()
 
@@ -280,9 +286,12 @@ def test_local_mode_prompt_uses_windows_powershell_51():
 
 
 def test_local_mode_prompt_hints_pwsh_when_resolved():
-    with patch("astrbot.core.astr_main_agent.platform.system", return_value="Windows"), patch(
-        "astrbot.core.astr_main_agent.resolve_windows_shell",
-        return_value="pwsh.exe",
+    with (
+        patch("astrbot.core.astr_main_agent.platform.system", return_value="Windows"),
+        patch(
+            "astrbot.core.astr_main_agent.resolve_windows_shell",
+            return_value="pwsh.exe",
+        ),
     ):
         prompt = ama._build_local_mode_prompt()
 
@@ -292,9 +301,12 @@ def test_local_mode_prompt_hints_pwsh_when_resolved():
 
 
 def test_local_mode_prompt_ignores_pwsh_on_non_windows():
-    with patch("astrbot.core.astr_main_agent.platform.system", return_value="Linux"), patch(
-        "astrbot.core.astr_main_agent.resolve_windows_shell",
-        return_value="pwsh.exe",
+    with (
+        patch("astrbot.core.astr_main_agent.platform.system", return_value="Linux"),
+        patch(
+            "astrbot.core.astr_main_agent.resolve_windows_shell",
+            return_value="pwsh.exe",
+        ),
     ):
         prompt = ama._build_local_mode_prompt()
 


### PR DESCRIPTION
## Problem

`_append_system_reminders` appended the per-request `<system_reminder>` block (current datetime, user identifier, group name) without `TextPart.mark_as_temp()`, so it was persisted into conversation history every round and never cleaned up. This grows the context linearly and can trigger context compression earlier (extra LLM cost + latency).

The knowledge-base injection in the same file already calls `.mark_as_temp()` correctly, so this is an omission.

## Fix

Mark the appended reminder as temporary so it is filtered out on persistence.

## Verification

- `pytest tests/unit/test_astr_main_agent.py::test_append_system_reminders_includes_weekday` passes, now also asserting `_no_save is True`.

Closes #10033

## Summary by Sourcery

Mark system reminders as temporary to keep transient request context out of conversation history.

Bug Fixes:
- Prevent per-request system reminders from being persisted in conversation history, avoiding unbounded context growth and unnecessary compression cost.

Tests:
- Verify that appended system reminders are marked as non-persistent temporary content.