### PR TITLE
fix: reduce Telegram log spam from polling and conflict errors (#10027)

### DIFF
--- a/astrbot/core/log.py
+++ b/astrbot/core/log.py
@@ -203,6 +203,8 @@ class LogManager:
         "asyncio": logging.WARNING,
         "tzlocal": logging.WARNING,
         "apscheduler": logging.WARNING,
+        "httpx": logging.WARNING,
+        "httpcore": logging.WARNING,
     }
 
     @classmethod

--- a/astrbot/core/platform/sources/telegram/tg_adapter.py
+++ b/astrbot/core/platform/sources/telegram/tg_adapter.py
@@ -290,12 +290,19 @@ class TelegramPlatformAdapter(Platform):
                 await asyncio.sleep(self._polling_restart_delay)
 
     def _on_polling_error(self, error: Exception) -> None:
+        # Non-network errors (e.g. Conflict when two bot instances poll the
+        # same token) have a clear cause; log a concise message instead of a
+        # full traceback to avoid filling the log.
+        if not isinstance(error, NetworkError):
+            logger.error(
+                f"Telegram polling request failed: {type(error).__name__}: {error!s}"
+            )
+            return
+
         logger.error(
             f"Telegram polling request failed: {type(error).__name__}: {error!s}",
             exc_info=error,
         )
-        if not isinstance(error, NetworkError):
-            return
 
         if self._loop is None:
             return


### PR DESCRIPTION
## Problem

The Telegram adapter floods the log in two ways:

1. **Polling requests**: `python-telegram-bot` performs `getUpdates` through `httpx`, and httpx logs every request at INFO level. `httpx`/`httpcore` were missing from `LogManager._NOISY_LOGGER_LEVELS`, so those per-request lines (one every ~10s) leaked into the log.
2. **Conflict errors**: `_on_polling_error` logged a full traceback for every polling error, including non-network errors such as `Conflict` (which happens when two bot instances poll the same token).

## Fix

- Add `httpx` and `httpcore` to `_NOISY_LOGGER_LEVELS` so their request-level logging is suppressed.
- In `_on_polling_error`, log a concise one-line message for non-network errors and keep the full traceback only for `NetworkError`, which still needs it for the recovery logic.

## Notes

The `409 Conflict` itself is caused by two bot instances polling the same token and is not an AstrBot bug; this change only stops it from spamming a full traceback.

Closes #10027

## Summary by Sourcery

Bug Fixes:
- Reduce Telegram log spam by suppressing routine httpx and httpcore request logs and shortening non-network polling errors to one-line messages.