### PR TITLE
feat(provider): add DaoXE chat completion provider

### DIFF
--- a/astrbot/core/config/default.py
+++ b/astrbot/core/config/default.py
@@ -1521,6 +1521,18 @@ CONFIG_METADATA_2 = {
                         "proxy": "",
                         "custom_headers": {},
                     },
+                    "DaoXE": {
+                        "id": "daoxe",
+                        "provider": "daoxe",
+                        "type": "daoxe_chat_completion",
+                        "provider_type": "chat_completion",
+                        "enable": True,
+                        "key": [],
+                        "timeout": 120,
+                        "api_base": "https://api.daoxe.com/v1",
+                        "proxy": "",
+                        "custom_headers": {},
+                    },
                     "SSYCloud(胜算云)": {
                         "id": "ssycloud",
                         "provider": "ssycloud",

--- a/astrbot/core/provider/manager.py
+++ b/astrbot/core/provider/manager.py
@@ -459,6 +459,10 @@ class ProviderManager:
                 from .sources.openrouter_source import (
                     ProviderOpenRouter as ProviderOpenRouter,
                 )
+            case "daoxe_chat_completion":
+                from .sources.daoxe_source import (
+                    ProviderDaoXE as ProviderDaoXE,
+                )
             case "ssycloud_chat_completion":
                 from .sources.ssycloud_source import (
                     ProviderSSYCloud as ProviderSSYCloud,

--- a/astrbot/core/provider/sources/daoxe_source.py
+++ b/astrbot/core/provider/sources/daoxe_source.py
@@ -1,0 +1,42 @@
+import httpx
+from openai import AsyncOpenAI
+
+from ..register import register_provider_adapter
+from .openai_source import ProviderOpenAIOfficial
+
+
+@register_provider_adapter(
+    "daoxe_chat_completion", "DaoXE Chat Completion Provider Adapter"
+)
+class ProviderDaoXE(ProviderOpenAIOfficial):
+    """DaoXE provider using its OpenAI-compatible Chat Completions API."""
+
+    def __init__(self, provider_config: dict, provider_settings: dict) -> None:
+        """Initialize the DaoXE client with provider defaults.
+
+        Args:
+            provider_config: AstrBot provider source configuration.
+            provider_settings: Global provider settings.
+        """
+        if not provider_config.get("api_base"):
+            provider_config["api_base"] = "https://api.daoxe.com/v1"
+        super().__init__(provider_config, provider_settings)
+
+    async def get_models(self) -> list[str]:
+        """Return the account-scoped model catalog.
+
+        The live catalog changes as upstream vendors add or retire models, so
+        the list is read from the gateway's own ``/v1/models`` endpoint rather
+        than pinned here.
+
+        Returns:
+            Sorted model IDs visible to the configured API key.
+
+        Raises:
+            Exception: If the DaoXE model catalog endpoint is unavailable.
+        """
+        try:
+            response = await self.client.models.list()
+            return sorted(model.id for model in response.data)
+        except (httpx.HTTPError, Exception) as exc:
+            raise Exception(f"Failed to fetch DaoXE model list: {exc}") from exc

--- a/dashboard/src/components/provider/ProviderChatCompletionPanel.vue
+++ b/dashboard/src/components/provider/ProviderChatCompletionPanel.vue
@@ -269,7 +269,14 @@ const providerSourceFieldLinks = computed(() => (
           href: 'https://www.shengsuanyun.com/?from=CH_T70U2X9L'
         }
       }
-    : {}
+    : selectedProviderSource.value?.provider === 'daoxe'
+      ? {
+          key: {
+            label: tm('providerSources.getApiKey'),
+            href: 'https://docs.daoxe.com/'
+          }
+        }
+      : {}
 ))
 
 const showManualModelDialog = ref(false)

--- a/dashboard/src/composables/useProviderSources.ts
+++ b/dashboard/src/composables/useProviderSources.ts
@@ -345,6 +345,7 @@ export function useProviderSources(options: UseProviderSourcesOptions) {
     if (!source) return ''
     if (source.isPlaceholder) return source.templateKey || source.id || ''
     if (source.id === 'ssycloud') return 'ssycloud(胜算云)'
+    if (source.id === 'daoxe') return 'daoxe'
     return source.id
   }
 

--- a/dashboard/src/utils/providerUtils.js
+++ b/dashboard/src/utils/providerUtils.js
@@ -46,6 +46,7 @@ export function getProviderIcon(type) {
     'groq': 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/groq.svg',
     'aihubmix': 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/aihubmix-color.svg',
     'openrouter': 'https://cdn.jsdelivr.net/npm/@lobehub/icons-static-svg@latest/icons/openrouter.svg',
+    'daoxe': 'https://daoxe.com/favicon.ico',
     'ssycloud': 'https://admin.shengsuanyun.com/assets/logo-BoujJhP-.png',
     "tokenpony": "https://tokenpony.cn/tokenpony-web/logo.png",
     "compshare": "https://compshare.cn/favicon.ico",

--- a/tests/test_daoxe_source.py
+++ b/tests/test_daoxe_source.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from astrbot.core.config.default import CONFIG_METADATA_2
+from astrbot.core.provider.sources.daoxe_source import ProviderDaoXE
+
+
+def _make_provider(overrides: dict | None = None) -> ProviderDaoXE:
+    config = {
+        "id": "daoxe-test",
+        "provider": "daoxe",
+        "type": "daoxe_chat_completion",
+        "model": "test-model",
+        "key": ["test-key"],
+    }
+    if overrides:
+        config.update(overrides)
+    return ProviderDaoXE(config, {})
+
+
+def test_daoxe_template_uses_expected_defaults():
+    templates = CONFIG_METADATA_2["provider_group"]["metadata"]["provider"][
+        "config_template"
+    ]
+
+    template = templates["DaoXE"]
+    assert template["type"] == "daoxe_chat_completion"
+    assert template["api_base"] == "https://api.daoxe.com/v1"
+    assert template["custom_headers"] == {}
+
+
+def test_daoxe_provider_sets_default_endpoint():
+    provider = _make_provider()
+
+    assert str(provider.client.base_url) == "https://api.daoxe.com/v1/"
+
+
+def test_daoxe_provider_keeps_custom_endpoint():
+    provider = _make_provider({"api_base": "https://my-clone.example.com/v1"})
+
+    assert str(provider.client.base_url) == "https://my-clone.example.com/v1/"
+
+
+@pytest.mark.asyncio
+async def test_daoxe_model_list_returns_sorted_ids():
+    provider = _make_provider()
+
+    provider.client.models.list = AsyncMock(
+        return_value=SimpleNamespace(
+            data=[
+                SimpleNamespace(id="z-model"),
+                SimpleNamespace(id="a-model"),
+            ]
+        )
+    )
+
+    assert await provider.get_models() == ["a-model", "z-model"]
+
+
+@pytest.mark.asyncio
+async def test_daoxe_model_list_raises_on_failure():
+    provider = _make_provider()
+
+    provider.client.models.list = AsyncMock(
+        side_effect=RuntimeError("boom")
+    )
+
+    with pytest.raises(Exception, match="Failed to fetch DaoXE model list"):
+        await provider.get_models()


### PR DESCRIPTION
Adds DaoXE (https://daoxe.com) as a chat completion provider, following the SSYCloud provider pattern (#9659):

- OpenAI-compatible source (`daoxe_source.py`) with a default `api_base` of `https://api.daoxe.com/v1` and a `get_models` implementation that reads the account-scoped catalog from the gateway's own `/v1/models` endpoint
- config template in `default.py`, dynamic-import wiring in `manager.py`
- dashboard display name, provider icon, and a "Get API Key" link pointing to the DaoXE docs
- source tests covering defaults, custom-endpoint override, sorted model list, and the failure path

Disclosure: I'm affiliated with DaoXE; this contribution only adds standard OpenAI-compatible client wiring, no bundled keys or credentials.

## Summary by Sourcery

Add DaoXE chat completion support across provider configuration, runtime registration, and the dashboard.

New Features:
- Add DaoXE as an OpenAI-compatible chat completion provider with account-scoped model discovery.
- Expose DaoXE configuration and API-key guidance in the dashboard, including its display name and provider icon.

Tests:
- Add coverage for DaoXE defaults, custom endpoints, sorted model discovery, and catalog failures.