### PR TITLE
fix: keep inline Face components in the same bubble during segmented reply

### DIFF
--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -101,29 +101,26 @@ class RespondStage(Stage):
     ) -> list[list[BaseMessageComponent]]:
         """Build the bubbles sent by segmented reply.
 
-        Every Plain and every non-inline component starts a new bubble; a
-        Face attaches to the preceding text bubble, or to the following
-        Plain when the chain starts with a Face, so an inline emoji never
-        becomes a bubble of its own while adjacent Plain components keep
-        their deliberate split (#10047, #3959).
+        Plain and non-inline components start a new bubble; a Face attaches
+        to the preceding text bubble and glues the Plain following it back
+        into the same bubble, so an inline emoji never becomes a bubble of
+        its own and never leaves the next clause as a bubble of its own
+        (#10047). Adjacent Plain components without an emoji between them —
+        the output of segmentation-words (#3959) — keep their deliberate
+        split.
         """
         segments: list[list[BaseMessageComponent]] = []
         for comp in chain:
-            if (
-                comp.type == ComponentType.Face
-                and segments
-                and segments[-1][-1].type in (ComponentType.Plain, ComponentType.Face)
+            prev_type = segments[-1][-1].type if segments else None
+            if prev_type == ComponentType.Face and comp.type == ComponentType.Plain:
+                segments[-1].append(comp)
+            elif comp.type == ComponentType.Face and prev_type in (
+                ComponentType.Plain,
+                ComponentType.Face,
             ):
                 segments[-1].append(comp)
-                continue
-            segments.append([comp])
-        if (
-            len(segments) >= 2
-            and segments[0][0].type == ComponentType.Face
-            and segments[1][0].type == ComponentType.Plain
-        ):
-            segments[1][:0] = segments[0]
-            segments.pop(0)
+            else:
+                segments.append([comp])
         return segments
 
     async def _calc_comp_interval(

--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -49,10 +49,6 @@ class RespondStage(Stage):
         Comp.Unknown: lambda comp: bool(comp.text and comp.text.strip()),
     }
 
-    # Inline components that belong to the sentence itself; segmented reply
-    # keeps a run of them in the same bubble instead of splitting the text.
-    INLINE_SEGMENT_TYPES = {ComponentType.Plain, ComponentType.Face}
-
     async def initialize(self, ctx: PipelineContext) -> None:
         self.ctx = ctx
         self.config = ctx.astrbot_config
@@ -103,24 +99,31 @@ class RespondStage(Stage):
     def _group_segment_chain(
         chain: list[BaseMessageComponent],
     ) -> list[list[BaseMessageComponent]]:
-        """Group consecutive inline components into one bubble per group.
+        """Build the bubbles sent by segmented reply.
 
-        Each returned segment is either a run of inline components (a whole
-        sentence with inline faces) or a single component that is sent on
-        its own.
+        Every Plain and every non-inline component starts a new bubble; a
+        Face attaches to the preceding text bubble, or to the following
+        Plain when the chain starts with a Face, so an inline emoji never
+        becomes a bubble of its own while adjacent Plain components keep
+        their deliberate split (#10047, #3959).
         """
         segments: list[list[BaseMessageComponent]] = []
-        inline_group: list[BaseMessageComponent] = []
         for comp in chain:
-            if comp.type in RespondStage.INLINE_SEGMENT_TYPES:
-                inline_group.append(comp)
+            if (
+                comp.type == ComponentType.Face
+                and segments
+                and segments[-1][-1].type in (ComponentType.Plain, ComponentType.Face)
+            ):
+                segments[-1].append(comp)
                 continue
-            if inline_group:
-                segments.append(inline_group)
-                inline_group = []
             segments.append([comp])
-        if inline_group:
-            segments.append(inline_group)
+        if (
+            len(segments) >= 2
+            and segments[0][0].type == ComponentType.Face
+            and segments[1][0].type == ComponentType.Plain
+        ):
+            segments[1][:0] = segments[0]
+            segments.pop(0)
         return segments
 
     async def _calc_comp_interval(

--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -49,6 +49,10 @@ class RespondStage(Stage):
         Comp.Unknown: lambda comp: bool(comp.text and comp.text.strip()),
     }
 
+    # Inline components that belong to the sentence itself; segmented reply
+    # keeps a run of them in the same bubble instead of splitting the text.
+    INLINE_SEGMENT_TYPES = {ComponentType.Plain, ComponentType.Face}
+
     async def initialize(self, ctx: PipelineContext) -> None:
         self.ctx = ctx
         self.config = ctx.astrbot_config
@@ -95,14 +99,50 @@ class RespondStage(Stage):
             word_count = len([c for c in text if c.isalnum()])
         return word_count
 
-    async def _calc_comp_interval(self, comp: BaseMessageComponent) -> float:
-        """分段回复 计算间隔时间"""
+    @staticmethod
+    def _group_segment_chain(
+        chain: list[BaseMessageComponent],
+    ) -> list[list[BaseMessageComponent]]:
+        """Group consecutive inline components into one bubble per group.
+
+        Each returned segment is either a run of inline components (a whole
+        sentence with inline faces) or a single component that is sent on
+        its own.
+        """
+        segments: list[list[BaseMessageComponent]] = []
+        inline_group: list[BaseMessageComponent] = []
+        for comp in chain:
+            if comp.type in RespondStage.INLINE_SEGMENT_TYPES:
+                inline_group.append(comp)
+                continue
+            if inline_group:
+                segments.append(inline_group)
+                inline_group = []
+            segments.append([comp])
+        if inline_group:
+            segments.append(inline_group)
+        return segments
+
+    async def _calc_comp_interval(
+        self,
+        comps: BaseMessageComponent | list[BaseMessageComponent],
+    ) -> float:
+        """分段回复 计算间隔时间
+
+        ``comps`` may also be a sequence of components sharing one bubble;
+        the log-method interval is then computed from the total Plain word
+        count of that bubble.
+        """
+        if isinstance(comps, list):
+            text = "".join(comp.text for comp in comps if isinstance(comp, Comp.Plain))
+        else:
+            text = comps.text if isinstance(comps, Comp.Plain) else ""
         if self.interval_method == "log":
-            if isinstance(comp, Comp.Plain):
-                wc = await self._word_cnt(comp.text)
-                i = math.log(wc + 1, self.log_base)
-                return random.uniform(i, i + 0.5)
-            return random.uniform(1, 1.75)
+            if not text:
+                return random.uniform(1, 1.75)
+            wc = await self._word_cnt(text)
+            i = math.log(wc + 1, self.log_base)
+            return random.uniform(i, i + 0.5)
         # random
         return random.uniform(self.interval[0], self.interval[1])
 
@@ -273,19 +313,22 @@ class RespondStage(Stage):
                         f"actual_chain: {result.chain}",
                     )
                     return
-                for comp in result.chain:
-                    i = await self._calc_comp_interval(comp)
+                segments = self._group_segment_chain(result.chain)
+                for segment in segments:
+                    i = await self._calc_comp_interval(segment)
                     await asyncio.sleep(i)
                     try:
-                        if comp.type in need_separately:
-                            await event.send(result.derive([comp]))
+                        if segment[0].type in need_separately:
+                            await event.send(result.derive(segment))
                         else:
-                            await event.send(result.derive([*header_comps, comp]))
+                            await event.send(
+                                result.derive([*header_comps, *segment]),
+                            )
                             header_comps.clear()
                     except Exception as e:
                         logger.error(
                             "Failed to send the message chain: "
-                            f"chain = {MessageChain([comp])}, error = {e}",
+                            f"chain = {MessageChain(segment)}, error = {e}",
                             exc_info=True,
                         )
             else:

--- a/astrbot/core/pipeline/respond/stage.py
+++ b/astrbot/core/pipeline/respond/stage.py
@@ -130,19 +130,20 @@ class RespondStage(Stage):
         """分段回复 计算间隔时间
 
         ``comps`` may also be a sequence of components sharing one bubble;
-        the log-method interval is then computed from the total Plain word
-        count of that bubble.
+        the log-method interval is then computed from the Plain word counts
+        of that bubble, counted per component and summed.
         """
-        if isinstance(comps, list):
-            text = "".join(comp.text for comp in comps if isinstance(comp, Comp.Plain))
-        else:
-            text = comps.text if isinstance(comps, Comp.Plain) else ""
+        if not isinstance(comps, list):
+            comps = [comps]
         if self.interval_method == "log":
-            if not text:
-                return random.uniform(1, 1.75)
-            wc = await self._word_cnt(text)
-            i = math.log(wc + 1, self.log_base)
-            return random.uniform(i, i + 0.5)
+            wc = 0
+            for comp in comps:
+                if isinstance(comp, Comp.Plain):
+                    wc += await self._word_cnt(comp.text)
+            if wc:
+                i = math.log(wc + 1, self.log_base)
+                return random.uniform(i, i + 0.5)
+            return random.uniform(1, 1.75)
         # random
         return random.uniform(self.interval[0], self.interval[1])
 

--- a/tests/unit/test_respond_stage_segmented_reply.py
+++ b/tests/unit/test_respond_stage_segmented_reply.py
@@ -1,0 +1,56 @@
+"""Regression tests for segmented reply bubble grouping (#10047).
+
+With segmented reply enabled, every component used to be sent as its own
+message, so an inline Face in the middle of a sentence split the text into
+several bubbles. The stage now groups consecutive inline components
+(Plain / Face) so a sentence stays in one bubble.
+"""
+
+import math
+
+import pytest
+
+import astrbot.core.message.components as Comp
+from astrbot.core.pipeline.respond.stage import RespondStage
+
+
+def test_inline_face_stays_in_the_same_bubble_as_text():
+    stage = RespondStage()
+    chain = [
+        Comp.Plain(text="好的"),
+        Comp.Face(id=277),
+        Comp.Plain(text="，我知道了！"),
+    ]
+
+    segments = stage._group_segment_chain(chain)
+
+    assert len(segments) == 1
+    assert segments[0] == chain
+
+
+def test_components_that_need_separate_sending_stay_alone():
+    stage = RespondStage()
+    record = Comp.Record(file="file:///tmp/a.wav")
+    chain = [Comp.Plain(text="看这个"), record, Comp.Plain(text="好听吗")]
+
+    segments = stage._group_segment_chain(chain)
+
+    assert segments == [[chain[0]], [record], [chain[2]]]
+
+
+@pytest.mark.asyncio
+async def test_log_interval_for_a_bubble_uses_total_plain_word_count():
+    stage = RespondStage()
+    stage.interval_method = "log"
+    stage.log_base = 10.0
+
+    # "hello" + "world" -> 2 words -> log10(3) ~= 0.477
+    bubble = await stage._calc_comp_interval(
+        [Comp.Plain(text="hello"), Comp.Face(id=277), Comp.Plain(text="world")],
+    )
+    lower, upper = math.log(3, 10), math.log(3, 10) + 0.5
+    assert lower <= bubble <= upper
+
+    # A bubble without text keeps the non-Plain interval.
+    face_only = await stage._calc_comp_interval(Comp.Face(id=277))
+    assert 1 <= face_only <= 1.75

--- a/tests/unit/test_respond_stage_segmented_reply.py
+++ b/tests/unit/test_respond_stage_segmented_reply.py
@@ -2,8 +2,10 @@
 
 With segmented reply enabled, every component used to be sent as its own
 message, so an inline Face in the middle of a sentence split the text into
-several bubbles. The stage now groups consecutive inline components
-(Plain / Face) so a sentence stays in one bubble.
+several bubbles. The stage now attaches a Face to the preceding text bubble
+(or to the following Plain when the chain starts with a Face) while adjacent
+Plain components from the segmentation-words feature (#3959) keep their
+deliberate split.
 """
 
 import math
@@ -14,7 +16,7 @@ import astrbot.core.message.components as Comp
 from astrbot.core.pipeline.respond.stage import RespondStage
 
 
-def test_inline_face_stays_in_the_same_bubble_as_text():
+def test_inline_face_rides_with_the_preceding_text_bubble():
     stage = RespondStage()
     chain = [
         Comp.Plain(text="好的"),
@@ -24,8 +26,27 @@ def test_inline_face_stays_in_the_same_bubble_as_text():
 
     segments = stage._group_segment_chain(chain)
 
-    assert len(segments) == 1
-    assert segments[0] == chain
+    assert segments == [[chain[0], chain[1]], [chain[2]]]
+
+
+def test_leading_face_joins_the_following_text_bubble():
+    stage = RespondStage()
+    face = Comp.Face(id=277)
+    chain = [face, Comp.Plain(text="你好呀")]
+
+    segments = stage._group_segment_chain(chain)
+
+    assert segments == [[face, chain[1]]]
+
+
+def test_adjacent_plain_components_keep_separate_bubbles():
+    stage = RespondStage()
+    first = Comp.Plain(text="第一段。")
+    second = Comp.Plain(text="第二段。")
+
+    segments = stage._group_segment_chain([first, second])
+
+    assert segments == [[first], [second]]
 
 
 def test_components_that_need_separate_sending_stay_alone():
@@ -36,6 +57,17 @@ def test_components_that_need_separate_sending_stay_alone():
     segments = stage._group_segment_chain(chain)
 
     assert segments == [[chain[0]], [record], [chain[2]]]
+
+
+def test_face_after_media_stays_its_own_bubble():
+    stage = RespondStage()
+    record = Comp.Record(file="file:///tmp/a.wav")
+    face = Comp.Face(id=277)
+    chain = [Comp.Plain(text="听"), record, face]
+
+    segments = stage._group_segment_chain(chain)
+
+    assert segments == [[chain[0]], [record], [face]]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_respond_stage_segmented_reply.py
+++ b/tests/unit/test_respond_stage_segmented_reply.py
@@ -2,10 +2,10 @@
 
 With segmented reply enabled, every component used to be sent as its own
 message, so an inline Face in the middle of a sentence split the text into
-several bubbles. The stage now attaches a Face to the preceding text bubble
-(or to the following Plain when the chain starts with a Face) while adjacent
-Plain components from the segmentation-words feature (#3959) keep their
-deliberate split.
+several bubbles. The stage now treats an inline Face as glue: it attaches to
+the preceding text bubble and keeps the following Plain in the same bubble,
+while adjacent Plain components from the segmentation-words feature (#3959)
+keep their deliberate split.
 """
 
 import math
@@ -16,7 +16,7 @@ import astrbot.core.message.components as Comp
 from astrbot.core.pipeline.respond.stage import RespondStage
 
 
-def test_inline_face_rides_with_the_preceding_text_bubble():
+def test_inline_face_glues_the_whole_sentence_into_one_bubble():
     stage = RespondStage()
     chain = [
         Comp.Plain(text="好的"),
@@ -26,7 +26,7 @@ def test_inline_face_rides_with_the_preceding_text_bubble():
 
     segments = stage._group_segment_chain(chain)
 
-    assert segments == [[chain[0], chain[1]], [chain[2]]]
+    assert segments == [chain]
 
 
 def test_leading_face_joins_the_following_text_bubble():
@@ -68,6 +68,16 @@ def test_face_after_media_stays_its_own_bubble():
     segments = stage._group_segment_chain(chain)
 
     assert segments == [[chain[0]], [record], [face]]
+
+
+def test_face_glue_does_not_absorb_media():
+    stage = RespondStage()
+    record = Comp.Record(file="file:///tmp/a.wav")
+    chain = [Comp.Plain(text="好的"), Comp.Face(id=277), record]
+
+    segments = stage._group_segment_chain(chain)
+
+    assert segments == [[chain[0], chain[1]], [record]]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!--Please describe the motivation for this change: What problem does it solve? (e.g., Fixes XX issue, adds YY feature)-->

With `platform_settings.segmented_reply.enable: true`, the respond stage sends every component of the message chain as its own message. An inline QQ Face in the middle of text (e.g. `好的[Face:277]，我知道了！`) is therefore split into three separate bubbles: `好的` / `[Face:277]` / `，我知道了！`.

Fixes #10047

### Modifications / 改动点

- `astrbot/core/pipeline/respond/stage.py`: `_group_segment_chain()` now builds the segmented-reply bubbles: `Plain` and non-inline components start a new bubble, and a `Face` attaches to the preceding text bubble and glues the `Plain` following it into the same bubble, so an inline emoji never becomes (or creates) a bubble of its own. Adjacent `Plain` components without an emoji between them (segmentation-words output, #3959) keep their deliberate split.
- `_calc_comp_interval()` accepts a bubble (a list of components) and computes the log-method interval from the Plain word counts, counted per component and summed. Single-component behavior is unchanged.
- `tests/unit/test_respond_stage_segmented_reply.py`: regression tests for the glued sentence, leading Face, consecutive Plain split, Record staying alone, Face after media, glue stopping at media, and the interval calculation.

- [x] This is NOT a breaking change. / 这不是一个破坏性变更。
<!-- If your changes is a breaking change, please uncheck the checkbox above -->

### Screenshots or Test Results / 运行截图或测试结果

- `uv run pytest tests/unit` — 993 passed (10 deselected locally for an unrelated environment issue that also fails on clean master)
- `./scripts/pr_test_env.sh --profile neo` (repo-recommended local check set): `ruff format --check .` clean (504 files), `ruff check .` passed, Neo critical tests 13 passed, `main.py` startup smoke test on `http://localhost:6185` passed

---

### Checklist / 检查清单

<!--If merged, your code will serve tens of thousands of users! Please double-check the following items before submitting.-->
<!--如果分支被合并，您的代码将服务于数万名用户！在提交前，请核查一下几点内容。-->

- [ ] 😊 If there are new features added in the PR, I have discussed it with the authors through issues/emails, etc.
  / 如果 PR 中有新加入的功能，已经通过 Issue / 邮件等方式和作者讨论过。

- [x] 👀 My changes have been well-tested, **and "Verification Steps" and "Screenshots" have been provided above**.
  / 我的更改经过了良好的测试，**并已在上方提供了"验证步骤"和"运行截图"**。

- [x] 🤓 I have ensured that no new dependencies are introduced, OR if new dependencies are introduced, they have been added to the appropriate locations in `requirements.txt` and `pyproject.toml`.
  / 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到 `requirements.txt` 和 `pyproject.toml` 文件相应位置。

- [x] 😮 My changes do not introduce malicious code.
  / 我的更改没有引入恶意代码。

## Summary by Sourcery

Keep inline Face components with their surrounding text when sending segmented replies.

Bug Fixes:
- Keep inline Face components and their surrounding text in the same segmented-reply bubble instead of sending the emoji and following clause separately.

Enhancements:
- Preserve intentional splits between adjacent Plain components and keep non-inline components in separate bubbles while calculating reply intervals across all Plain text in a bubble.

Tests:
- Add regression coverage for inline and leading Faces, adjacent Plain splits, media boundaries, and grouped interval calculation.