### PR TITLE
fix: propagate Xinference rerank failures instead of returning empty results

### DIFF
--- a/astrbot/core/provider/sources/xinference_rerank_source.py
+++ b/astrbot/core/provider/sources/xinference_rerank_source.py
@@ -90,8 +90,7 @@ class XinferenceRerankProvider(RerankProvider):
         top_n: int | None = None,
     ) -> list[RerankResult]:
         if not self.model:
-            logger.error("Xinference rerank model is not initialized.")
-            return []
+            raise RuntimeError("Xinference rerank model is not initialized")
         try:
             response = await self.model.rerank(documents, query, top_n)
             results = response.get("results", [])
@@ -110,9 +109,12 @@ class XinferenceRerankProvider(RerankProvider):
                 for result in results
             ]
         except Exception as e:
+            # An empty list reads as a legitimate empty rerank to the caller,
+            # which would overwrite the fused candidates with nothing (#10000).
+            # Propagate so the retrieval manager keeps the unreranked results.
             logger.error(f"Xinference rerank failed: {e}")
             logger.debug(f"Xinference rerank failed with exception: {e}", exc_info=True)
-            return []
+            raise
 
     async def terminate(self) -> None:
         """关闭客户端会话"""

--- a/tests/test_xinference_rerank_source.py
+++ b/tests/test_xinference_rerank_source.py
@@ -1,0 +1,38 @@
+"""Regression tests for the Xinference rerank provider failure contract (#10000).
+
+The provider used to swallow upstream failures and return an empty list,
+which the retrieval manager read as a legitimate empty rerank result and
+used to overwrite the fused candidates. Failures now propagate so the
+manager can fall back to the unreranked results.
+"""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from astrbot.core.provider.sources.xinference_rerank_source import (
+    XinferenceRerankProvider,
+)
+
+
+@pytest.fixture
+def provider() -> XinferenceRerankProvider:
+    instance = XinferenceRerankProvider.__new__(XinferenceRerankProvider)
+    instance.model = Mock()
+    return instance
+
+
+@pytest.mark.asyncio
+async def test_rerank_failure_propagates_instead_of_empty_list(provider):
+    provider.model.rerank = AsyncMock(side_effect=RuntimeError("upstream down"))
+
+    with pytest.raises(RuntimeError, match="upstream down"):
+        await provider.rerank(query="q", documents=["a", "b"])
+
+
+@pytest.mark.asyncio
+async def test_uninitialized_model_raises_instead_of_empty_list(provider):
+    provider.model = None
+
+    with pytest.raises(RuntimeError, match="not initialized"):
+        await provider.rerank(query="q", documents=["a"])


### PR DESCRIPTION
## What this PR does

The Xinference rerank provider no longer swallows failures as an empty list. An upstream rerank error or an uninitialized model now raises, matching the contract the other rerank providers already follow (TEI raises on network and HTTP errors) and the behavior the retrieval manager is built around.

## Why

Fixes #10000. The retrieval manager preserves the fused candidates only when reranking raises (`except` around `_rerank` keeps the unreranked results with a warning). Because the Xinference provider returned `[]` on failure instead, the manager treated the outage as a legitimate empty rerank and overwrote the fused candidates with nothing, so a transient upstream failure silently turned every knowledge-base query into zero matches until it recovered.

## How it's tested

New regression file `tests/test_xinference_rerank_source.py` pins both failure paths: an exception from the upstream model call propagates instead of returning `[]`, and an uninitialized model raises instead of returning `[]`. Verified red-first (both fail against current master), then green with the change. Full rerank source suite (`test_bailian` + `test_vllm` + `test_xinference`) passes 23/23, and the knowledge-base/retrieval tests pass 15/15. `ruff format` and `ruff check` are clean.

## Summary by Sourcery

Preserve retrieval results when Xinference reranking fails by allowing errors to reach the retrieval fallback path.

Bug Fixes:
- Propagate Xinference rerank failures and uninitialized-model errors so retrieval can preserve unreranked candidates instead of treating failures as empty results.

Tests:
- Add regression coverage for upstream rerank failures and uninitialized Xinference models.