### PR TITLE
fix: reuse local image files in tool results

### DIFF
--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -26,8 +26,8 @@ from tenacity import (
 
 from astrbot import logger
 from astrbot.core.agent.message import ImageURLPart, TextPart, ThinkPart
-from astrbot.core.agent.tool import FunctionTool, ToolSet
-from astrbot.core.agent.tool_image_cache import tool_image_cache
+from astrbot.core.agent.tool import FunctionTool, LocalImageContent, ToolSet
+from astrbot.core.agent.tool_image_cache import CachedImage, tool_image_cache
 from astrbot.core.exceptions import EmptyModelOutputError
 from astrbot.core.message.components import Json
 from astrbot.core.message.message_event_result import (
@@ -1060,8 +1060,12 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                     # Build user message with images for LLM to review
                     image_parts = []
                     for cached_img in cached_images:
-                        img_data = tool_image_cache.get_image_base64_by_path(
-                            cached_img.file_path, cached_img.mime_type
+                        img_data = (
+                            (cached_img.base64_data, cached_img.mime_type)
+                            if cached_img.base64_data is not None
+                            else tool_image_cache.get_image_base64_by_path(
+                                cached_img.file_path, cached_img.mime_type
+                            )
                         )
                         if img_data:
                             base64_data, mime_type = img_data
@@ -1250,16 +1254,31 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                             if isinstance(content_item, TextContent):
                                 result_parts.append(content_item.text)
                             elif isinstance(content_item, ImageContent):
-                                # Cache the image instead of sending directly
-                                cached_img = tool_image_cache.save_image(
-                                    base64_data=content_item.data,
-                                    tool_call_id=func_tool_id,
-                                    tool_name=func_tool_name,
-                                    index=index,
-                                    mime_type=content_item.mimeType or "image/png",
-                                )
+                                if (
+                                    isinstance(content_item, LocalImageContent)
+                                    and Path(content_item.file_path).is_file()
+                                ):
+                                    # Reuse the original path and keep its compressed
+                                    # preview in memory instead of writing a copy.
+                                    cached_img = CachedImage(
+                                        tool_call_id=func_tool_id,
+                                        tool_name=func_tool_name,
+                                        file_path=content_item.file_path,
+                                        mime_type=content_item.mimeType or "image/png",
+                                        base64_data=content_item.data,
+                                    )
+                                    image_notice = "Image available at"
+                                else:
+                                    cached_img = tool_image_cache.save_image(
+                                        base64_data=content_item.data,
+                                        tool_call_id=func_tool_id,
+                                        tool_name=func_tool_name,
+                                        index=index,
+                                        mime_type=content_item.mimeType or "image/png",
+                                    )
+                                    image_notice = "Image returned and cached at"
                                 result_parts.append(
-                                    f"Image returned and cached at path='{cached_img.file_path}'. "
+                                    f"{image_notice} path='{cached_img.file_path}'. "
                                     f"Review the image below. Use send_message_to_user to send it to the user if satisfied, "
                                     f"with type='image' and path='{cached_img.file_path}'."
                                 )

--- a/astrbot/core/agent/runners/tool_loop_agent_runner.py
+++ b/astrbot/core/agent/runners/tool_loop_agent_runner.py
@@ -27,7 +27,7 @@ from tenacity import (
 from astrbot import logger
 from astrbot.core.agent.message import ImageURLPart, TextPart, ThinkPart
 from astrbot.core.agent.tool import FunctionTool, LocalImageContent, ToolSet
-from astrbot.core.agent.tool_image_cache import CachedImage, tool_image_cache
+from astrbot.core.agent.tool_image_cache import tool_image_cache
 from astrbot.core.exceptions import EmptyModelOutputError
 from astrbot.core.message.components import Json
 from astrbot.core.message.message_event_result import (
@@ -71,10 +71,10 @@ else:
 
 @dataclass(slots=True)
 class _HandleFunctionToolsResult:
-    kind: T.Literal["message_chain", "tool_call_result_blocks", "cached_image"]
+    kind: T.Literal["message_chain", "tool_call_result_blocks", "image_parts"]
     message_chain: MessageChain | None = None
     tool_call_result_blocks: list[ToolCallMessageSegment] | None = None
-    cached_image: T.Any = None
+    image_parts: list[TextPart | ImageURLPart] | None = None
 
     @classmethod
     def from_message_chain(cls, chain: MessageChain) -> "_HandleFunctionToolsResult":
@@ -87,8 +87,10 @@ class _HandleFunctionToolsResult:
         return cls(kind="tool_call_result_blocks", tool_call_result_blocks=blocks)
 
     @classmethod
-    def from_cached_image(cls, image: T.Any) -> "_HandleFunctionToolsResult":
-        return cls(kind="cached_image", cached_image=image)
+    def from_image_parts(
+        cls, parts: list[TextPart | ImageURLPart]
+    ) -> "_HandleFunctionToolsResult":
+        return cls(kind="image_parts", image_parts=parts)
 
 
 @dataclass(slots=True)
@@ -997,16 +999,15 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                     llm_resp.tools_call_ids = requery_resp.tools_call_ids
 
             tool_call_result_blocks = []
-            cached_images = []  # Collect cached images for LLM visibility
+            image_parts = []
             try:
                 async for result in self._handle_function_tools(self.req, llm_resp):
                     if result.kind == "tool_call_result_blocks":
                         if result.tool_call_result_blocks is not None:
                             tool_call_result_blocks = result.tool_call_result_blocks
-                    elif result.kind == "cached_image":
-                        if result.cached_image is not None:
-                            # Collect cached image info
-                            cached_images.append(result.cached_image)
+                    elif result.kind == "image_parts":
+                        if result.image_parts is not None:
+                            image_parts.extend(result.image_parts)
                     elif result.kind == "message_chain":
                         chain = result.message_chain
                         if chain is None or chain.type is None:
@@ -1049,46 +1050,19 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                 tool_calls_result.to_openai_messages_model()
             )
 
-            # If there are cached images and the model supports image input,
-            # append a user message with images so LLM can see them
-            if cached_images:
+            # Append tool images only when the model supports image input.
+            if image_parts:
                 modalities = self.provider.provider_config.get("modalities", [])
                 supports_image = (
                     not modalities or "image" in modalities
                 )  # Empty list is treated as unconfigured for backward compatibility
                 if supports_image:
-                    # Build user message with images for LLM to review
-                    image_parts = []
-                    for cached_img in cached_images:
-                        img_data = (
-                            (cached_img.base64_data, cached_img.mime_type)
-                            if cached_img.base64_data is not None
-                            else tool_image_cache.get_image_base64_by_path(
-                                cached_img.file_path, cached_img.mime_type
-                            )
-                        )
-                        if img_data:
-                            base64_data, mime_type = img_data
-                            image_parts.append(
-                                TextPart(
-                                    text=f"[Image from tool '{cached_img.tool_name}', path='{cached_img.file_path}']"
-                                )
-                            )
-                            image_parts.append(
-                                ImageURLPart(
-                                    image_url=ImageURLPart.ImageURL(
-                                        url=f"data:{mime_type};base64,{base64_data}",
-                                        id=cached_img.file_path,
-                                    )
-                                )
-                            )
-                    if image_parts:
-                        self.run_context.messages.append(
-                            Message(role="user", content=image_parts)
-                        )
-                        logger.debug(
-                            f"Appended {len(cached_images)} cached image(s) to context for LLM review"
-                        )
+                    self.run_context.messages.append(
+                        Message(role="user", content=image_parts)
+                    )
+                    logger.debug(
+                        f"Appended {len(image_parts) // 2} tool image(s) to context for LLM review"
+                    )
 
             self.req.append_tool_calls_result(tool_calls_result)
 
@@ -1251,6 +1225,27 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
 
                         result_parts: list[str] = []
                         for index, content_item in enumerate(res.content):
+                            if isinstance(content_item, EmbeddedResource):
+                                resource = content_item.resource
+                                if isinstance(resource, TextResourceContents):
+                                    result_parts.append(resource.text)
+                                    continue
+                                if (
+                                    isinstance(resource, BlobResourceContents)
+                                    and resource.mimeType
+                                    and resource.mimeType.startswith("image/")
+                                ):
+                                    content_item = ImageContent(
+                                        type="image",
+                                        data=resource.blob,
+                                        mimeType=resource.mimeType,
+                                    )
+                                else:
+                                    result_parts.append(
+                                        "The tool has returned a data type that is not supported."
+                                    )
+                                    continue
+
                             if isinstance(content_item, TextContent):
                                 result_parts.append(content_item.text)
                             elif isinstance(content_item, ImageContent):
@@ -1258,15 +1253,7 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                                     isinstance(content_item, LocalImageContent)
                                     and Path(content_item.file_path).is_file()
                                 ):
-                                    # Reuse the original path and keep its compressed
-                                    # preview in memory instead of writing a copy.
-                                    cached_img = CachedImage(
-                                        tool_call_id=func_tool_id,
-                                        tool_name=func_tool_name,
-                                        file_path=content_item.file_path,
-                                        mime_type=content_item.mimeType or "image/png",
-                                        base64_data=content_item.data,
-                                    )
+                                    image_path = content_item.file_path
                                     image_notice = "Image available at"
                                 else:
                                     cached_img = tool_image_cache.save_image(
@@ -1276,46 +1263,27 @@ class ToolLoopAgentRunner(BaseAgentRunner[TContext]):
                                         index=index,
                                         mime_type=content_item.mimeType or "image/png",
                                     )
+                                    image_path = cached_img.file_path
                                     image_notice = "Image returned and cached at"
                                 result_parts.append(
-                                    f"{image_notice} path='{cached_img.file_path}'. "
+                                    f"{image_notice} path='{image_path}'. "
                                     f"Review the image below. Use send_message_to_user to send it to the user if satisfied, "
-                                    f"with type='image' and path='{cached_img.file_path}'."
+                                    f"with type='image' and path='{image_path}'."
                                 )
-                                # Yield image info for LLM visibility (will be handled in step())
-                                yield _HandleFunctionToolsResult.from_cached_image(
-                                    cached_img
+                                # Use the tool's image data directly for model input.
+                                yield _HandleFunctionToolsResult.from_image_parts(
+                                    [
+                                        TextPart(
+                                            text=f"[Image from tool '{func_tool_name}', path='{image_path}']"
+                                        ),
+                                        ImageURLPart(
+                                            image_url=ImageURLPart.ImageURL(
+                                                url=f"data:{content_item.mimeType or 'image/png'};base64,{content_item.data}",
+                                                id=image_path,
+                                            )
+                                        ),
+                                    ]
                                 )
-                            elif isinstance(content_item, EmbeddedResource):
-                                resource = content_item.resource
-                                if isinstance(resource, TextResourceContents):
-                                    result_parts.append(resource.text)
-                                elif (
-                                    isinstance(resource, BlobResourceContents)
-                                    and resource.mimeType
-                                    and resource.mimeType.startswith("image/")
-                                ):
-                                    # Cache the image instead of sending directly
-                                    cached_img = tool_image_cache.save_image(
-                                        base64_data=resource.blob,
-                                        tool_call_id=func_tool_id,
-                                        tool_name=func_tool_name,
-                                        index=index,
-                                        mime_type=resource.mimeType,
-                                    )
-                                    result_parts.append(
-                                        f"Image returned and cached at path='{cached_img.file_path}'. "
-                                        f"Review the image below. Use send_message_to_user to send it to the user if satisfied, "
-                                        f"with type='image' and path='{cached_img.file_path}'."
-                                    )
-                                    # Yield image info for LLM visibility
-                                    yield _HandleFunctionToolsResult.from_cached_image(
-                                        cached_img
-                                    )
-                                else:
-                                    result_parts.append(
-                                        "The tool has returned a data type that is not supported."
-                                    )
                         if result_parts:
                             inline_result = "\n\n".join(result_parts)
                             inline_result = await self._materialize_large_tool_result(

--- a/astrbot/core/agent/tool.py
+++ b/astrbot/core/agent/tool.py
@@ -16,6 +16,13 @@ ParametersType = dict[str, Any]
 ToolExecResult = str | mcp.types.CallToolResult
 
 
+class LocalImageContent(mcp.types.ImageContent):
+    """An image preview whose original file is already on the AstrBot host."""
+
+    file_path: str
+    """Absolute local path to reuse when sending the original image."""
+
+
 @dataclass
 class ToolSchema:
     """A class representing the schema of a tool for function calling."""

--- a/astrbot/core/agent/tool_image_cache.py
+++ b/astrbot/core/agent/tool_image_cache.py
@@ -27,6 +27,8 @@ class CachedImage:
     """The MIME type of the image."""
     created_at: float = field(default_factory=time.time)
     """Timestamp when the image was cached."""
+    base64_data: str | None = None
+    """Optional preview data, which may differ from the original file's format."""
 
 
 class ToolImageCache:

--- a/astrbot/core/agent/tool_image_cache.py
+++ b/astrbot/core/agent/tool_image_cache.py
@@ -27,8 +27,6 @@ class CachedImage:
     """The MIME type of the image."""
     created_at: float = field(default_factory=time.time)
     """Timestamp when the image was cached."""
-    base64_data: str | None = None
-    """Optional preview data, which may differ from the original file's format."""
 
 
 class ToolImageCache:

--- a/astrbot/core/computer/file_read_utils.py
+++ b/astrbot/core/computer/file_read_utils.py
@@ -14,7 +14,7 @@ import mcp
 
 from astrbot.core.agent.context.token_counter import EstimateTokenCounter
 from astrbot.core.agent.message import Message
-from astrbot.core.agent.tool import ToolExecResult
+from astrbot.core.agent.tool import LocalImageContent, ToolExecResult
 from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
 from astrbot.core.utils.media_utils import (
     IMAGE_COMPRESS_DEFAULT_MAX_SIZE,
@@ -701,17 +701,16 @@ async def read_file_tool_result(
         compressed_base64_data = str(compressed_payload.get("base64", "") or "")
         if not compressed_base64_data:
             return "Error reading file: compressed image payload is empty."
-        return mcp.types.CallToolResult(
-            content=[
-                mcp.types.ImageContent(
-                    type="image",
-                    data=compressed_base64_data,
-                    mimeType=str(
-                        compressed_payload.get("mime_type", "") or "image/jpeg"
-                    ),
-                )
-            ]
+        image_content = mcp.types.ImageContent(
+            type="image",
+            data=compressed_base64_data,
+            mimeType=str(compressed_payload.get("mime_type", "") or "image/jpeg"),
         )
+        if local_mode:
+            image_content = LocalImageContent(
+                **image_content.model_dump(), file_path=str(Path(path).resolve())
+            )
+        return mcp.types.CallToolResult(content=[image_content])
 
     if offset is None and limit is None:
         if validation_error := _validate_full_text_read_request(probe):

--- a/tests/test_computer_fs_tools.py
+++ b/tests/test_computer_fs_tools.py
@@ -13,6 +13,7 @@ from mcp.types import CallToolResult, ImageContent
 from PIL import Image
 
 from astrbot.core.agent.run_context import ContextWrapper
+from astrbot.core.agent.tool import LocalImageContent
 from astrbot.core.computer import file_read_utils
 from astrbot.core.computer.booters.local import LocalBooter
 from astrbot.core.tools.computer_tools import fs as fs_tools
@@ -562,6 +563,40 @@ async def test_file_read_tool_returns_image_call_tool_result_for_images(
     assert isinstance(result, CallToolResult)
     assert len(result.content) == 1
     assert isinstance(result.content[0], ImageContent)
+    assert isinstance(result.content[0], LocalImageContent)
+    assert result.content[0].file_path == str(image_path.resolve())
+    assert result.content[0].mimeType == "image/jpeg"
+    assert base64.b64decode(result.content[0].data).startswith(b"\xff\xd8\xff")
+
+
+@pytest.mark.asyncio
+async def test_sandbox_image_read_does_not_reuse_host_path(monkeypatch, tmp_path):
+    """A sandbox path is not a host file reference even when the host path exists."""
+    image_path = tmp_path / "sample.png"
+    Image.new("RGB", (32, 16), color=(255, 0, 0)).save(image_path)
+    image_bytes = image_path.read_bytes()
+    encoded_image = base64.b64encode(image_bytes).decode("ascii")
+    monkeypatch.setattr(
+        file_read_utils,
+        "_exec_python_json",
+        AsyncMock(
+            side_effect=[
+                {"sample_b64": encoded_image, "size_bytes": len(image_bytes)},
+                {"base64": encoded_image},
+            ]
+        ),
+    )
+
+    result = await file_read_utils.read_file_tool_result(
+        SimpleNamespace(),
+        local_mode=False,
+        path=str(image_path),
+        offset=None,
+        limit=None,
+    )
+
+    assert isinstance(result, CallToolResult)
+    assert type(result.content[0]) is ImageContent
     assert result.content[0].mimeType == "image/jpeg"
     assert base64.b64decode(result.content[0].data).startswith(b"\xff\xd8\xff")
 

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -918,7 +918,7 @@ async def test_tool_result_includes_all_calltoolresult_content(
 ):
     """工具返回多个 content 项时，tool result 应包含全部内容。"""
 
-    from astrbot.core.agent.tool_image_cache import tool_image_cache
+    from astrbot.core.agent.tool_image_cache import CachedImage, tool_image_cache
 
     mock_provider.should_call_tools = True
     mock_provider.max_calls_before_normal_response = 1
@@ -937,8 +937,11 @@ async def test_tool_result_includes_all_calltoolresult_content(
                 "mime_type": mime_type,
             }
         )
-        return SimpleNamespace(
-            file_path=f"/tmp/{tool_call_id}_{index}.png", mime_type=mime_type
+        return CachedImage(
+            tool_call_id=tool_call_id,
+            tool_name=tool_name,
+            file_path=f"/tmp/{tool_call_id}_{index}.png",
+            mime_type=mime_type,
         )
 
     monkeypatch.setattr(tool_image_cache, "save_image", fake_save_image)
@@ -972,6 +975,154 @@ async def test_tool_result_includes_all_calltoolresult_content(
             "mime_type": "image/png",
         }
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("already_cached", [False, True])
+async def test_repeated_local_image_reads_reuse_original_file(
+    runner,
+    mock_provider,
+    provider_request,
+    mock_hooks,
+    monkeypatch,
+    tmp_path,
+    already_cached,
+):
+    """Repeated reads keep the original file and expose the compressed preview."""
+    import base64
+
+    from PIL import Image
+
+    from astrbot.core.agent.tool_image_cache import tool_image_cache
+    from astrbot.core.computer.booters.local import LocalBooter
+    from astrbot.core.computer.file_read_utils import read_file_tool_result
+
+    cache_dir = tmp_path / "tool_images"
+    cache_dir.mkdir()
+    image_path = (cache_dir if already_cached else tmp_path) / "original.png"
+    Image.new("RGB", (32, 16), color=(255, 0, 0)).save(image_path)
+    original_bytes = image_path.read_bytes()
+    monkeypatch.setattr(tool_image_cache, "_cache_dir", str(cache_dir))
+    mock_provider.max_calls_before_normal_response = 2
+    original_text_chat = mock_provider.text_chat
+
+    async def text_chat(**kwargs):
+        response = await original_text_chat(**kwargs)
+        if response.tools_call_ids:
+            response.tools_call_ids = [f"call_read_{mock_provider.call_count}"]
+        return response
+
+    monkeypatch.setattr(mock_provider, "text_chat", text_chat)
+
+    async def execute(**kwargs):
+        yield await read_file_tool_result(
+            LocalBooter(),
+            local_mode=True,
+            path=str(image_path),
+            offset=None,
+            limit=None,
+        )
+
+    await runner.reset(
+        provider=mock_provider,
+        request=provider_request,
+        run_context=ContextWrapper(context=None),
+        tool_executor=SimpleNamespace(execute=execute),
+        agent_hooks=mock_hooks,
+        streaming=False,
+    )
+    async for _ in runner.step_until_done(3):
+        pass
+
+    assert image_path.read_bytes() == original_bytes
+    assert set(cache_dir.iterdir()) == ({image_path} if already_cached else set())
+    tool_messages = [m for m in runner.run_context.messages if m.role == "tool"]
+    assert len(tool_messages) == 2
+    for message in tool_messages:
+        assert f"Image available at path='{image_path}'." in str(message.content)
+        assert f"type='image' and path='{image_path}'" in str(message.content)
+    previews = [
+        part.image_url
+        for message in runner.run_context.messages
+        if message.role == "user" and isinstance(message.content, list)
+        for part in message.content
+        if isinstance(part, ImageURLPart)
+    ]
+    assert len(previews) == 2
+    for preview in previews:
+        assert preview.id == str(image_path)
+        assert preview.url.startswith("data:image/jpeg;base64,")
+        assert base64.b64decode(preview.url.split(",", 1)[1]).startswith(
+            b"\xff\xd8\xff"
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("image_kind", ["inline", "embedded", "missing_local"])
+async def test_tool_images_without_local_file_are_cached(
+    runner,
+    mock_provider,
+    provider_request,
+    mock_hooks,
+    monkeypatch,
+    tmp_path,
+    image_kind,
+):
+    """Images without a reusable local file retain their cache and model preview."""
+    from mcp.types import (
+        BlobResourceContents,
+        CallToolResult,
+        EmbeddedResource,
+        ImageContent,
+    )
+
+    from astrbot.core.agent.tool import LocalImageContent
+    from astrbot.core.agent.tool_image_cache import tool_image_cache
+
+    cache_dir = tmp_path / "tool_images"
+    monkeypatch.setattr(tool_image_cache, "_cache_dir", str(cache_dir))
+    mock_provider.max_calls_before_normal_response = 1
+    if image_kind == "embedded":
+        content = EmbeddedResource(
+            type="resource",
+            resource=BlobResourceContents(
+                uri="file:///sandbox/image.png", mimeType="image/png", blob="dGVzdA=="
+            ),
+        )
+    elif image_kind == "missing_local":
+        content = LocalImageContent(
+            type="image",
+            data="dGVzdA==",
+            mimeType="image/png",
+            file_path=str(tmp_path / "missing.png"),
+        )
+    else:
+        content = ImageContent(type="image", data="dGVzdA==", mimeType="image/png")
+
+    async def execute(**kwargs):
+        yield CallToolResult(content=[content])
+
+    await runner.reset(
+        provider=mock_provider,
+        request=provider_request,
+        run_context=ContextWrapper(context=None),
+        tool_executor=SimpleNamespace(execute=execute),
+        agent_hooks=mock_hooks,
+        streaming=False,
+    )
+    async for _ in runner.step_until_done(3):
+        pass
+
+    cached_path = cache_dir / "call_123_0.png"
+    assert cached_path.read_bytes() == b"test"
+    assert any(
+        part.image_url.url == "data:image/png;base64,dGVzdA=="
+        and part.image_url.id == str(cached_path)
+        for message in runner.run_context.messages
+        if message.role == "user" and isinstance(message.content, list)
+        for part in message.content
+        if isinstance(part, ImageURLPart)
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_loop_agent_runner.py
+++ b/tests/test_tool_loop_agent_runner.py
@@ -1058,6 +1058,7 @@ async def test_repeated_local_image_reads_reuse_original_file(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("supports_images", [False, True])
 @pytest.mark.parametrize("image_kind", ["inline", "embedded", "missing_local"])
 async def test_tool_images_without_local_file_are_cached(
     runner,
@@ -1067,6 +1068,7 @@ async def test_tool_images_without_local_file_are_cached(
     monkeypatch,
     tmp_path,
     image_kind,
+    supports_images,
 ):
     """Images without a reusable local file retain their cache and model preview."""
     from mcp.types import (
@@ -1081,7 +1083,14 @@ async def test_tool_images_without_local_file_are_cached(
 
     cache_dir = tmp_path / "tool_images"
     monkeypatch.setattr(tool_image_cache, "_cache_dir", str(cache_dir))
+    read_cached_image = MagicMock(
+        side_effect=AssertionError("Model input must use the tool's image data")
+    )
+    monkeypatch.setattr(tool_image_cache, "get_image_base64_by_path", read_cached_image)
     mock_provider.max_calls_before_normal_response = 1
+    mock_provider.provider_config["modalities"] = (
+        ["image", "tool_use"] if supports_images else ["tool_use"]
+    )
     if image_kind == "embedded":
         content = EmbeddedResource(
             type="resource",
@@ -1115,14 +1124,20 @@ async def test_tool_images_without_local_file_are_cached(
 
     cached_path = cache_dir / "call_123_0.png"
     assert cached_path.read_bytes() == b"test"
-    assert any(
-        part.image_url.url == "data:image/png;base64,dGVzdA=="
-        and part.image_url.id == str(cached_path)
+    read_cached_image.assert_not_called()
+    previews = [
+        part.image_url
         for message in runner.run_context.messages
         if message.role == "user" and isinstance(message.content, list)
         for part in message.content
         if isinstance(part, ImageURLPart)
-    )
+    ]
+    if supports_images:
+        assert len(previews) == 1
+        assert previews[0].url == "data:image/png;base64,dGVzdA=="
+        assert previews[0].id == str(cached_path)
+    else:
+        assert previews == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Reading the same local image repeatedly created a new `data/temp/tool_images/<tool_call_id>_<index>.jpg` on every tool call, even when the source image was already in that directory. Local image reads now reuse the original file path while continuing to provide the compressed JPEG preview to the model.

### Modifications

- Carry the absolute host file path in a local image tool result and reuse it for image references and sending.
- Build model image message parts directly from the image data returned by the tool. Local previews do not pass through `CachedImage`, and model input does not re-read disk caches. `CachedImage` only describes files on disk; conversation image retention follows the existing context behavior.
- Preserve disk caching for sandbox images, ordinary inline/embedded images, and local images whose source file has disappeared.
- Add regression coverage for repeated reads, existing cache files, original-file preservation, JPEG previews, sandbox path isolation, cache fallbacks, direct use of tool image data, and models without image support.

- [x] This is not a breaking change.

### Screenshots or Test Results

Validated using the project Python environment with an isolated temporary runtime root:

```text
python -m pytest tests/test_tool_loop_agent_runner.py tests/test_computer_fs_tools.py tests/test_storage_cleaner.py -q
86 passed, 1 warning in 3.12s

ruff format .
504 files left unchanged

ruff check .
All checks passed!

git diff --check
Passed
```

The warning is an existing `audioop` deprecation warning.

### Checklist

- [x] Changes are tested; verification commands and results are provided above.
- [x] No new dependencies are introduced.
- [x] No malicious code is introduced.

## Summary by Sourcery

Reuse local image paths in tool results while continuing to provide compressed previews to the model.

Bug Fixes:
- Reuse existing local image files in tool results instead of creating duplicate cached files on repeated reads.

Enhancements:
- Preserve compressed JPEG previews for model input while carrying reusable local file paths for user-facing image delivery.
- Retain caching and preview behavior for sandbox, inline, embedded, and unavailable local images.

Tests:
- Add regression coverage for repeated local image reads, cache reuse, preview preservation, sandbox isolation, and fallback caching.