### PR TITLE
fix: avoid blocking audio format probes

### DIFF
--- a/astrbot/core/utils/media_utils.py
+++ b/astrbot/core/utils/media_utils.py
@@ -1135,10 +1135,17 @@ async def convert_audio_format(
         Exception: Raised when ffmpeg is unavailable or conversion fails.
     """
     source_path = Path(audio_path)
-    if source_path.suffix.lower() == f".{output_format}" and (
-        not source_path.exists() or _get_audio_magic_type(audio_path) == output_format
-    ):
-        return audio_path
+    if source_path.suffix.lower() == f".{output_format}":
+        # The magic-byte probe performs synchronous file I/O. Keep it off the
+        # event loop because this helper is called while processing messages.
+        if not source_path.exists():
+            return audio_path
+
+        detected_format = await asyncio.to_thread(_get_audio_magic_type, audio_path)
+        if detected_format == output_format or (
+            output_format == "ogg" and detected_format == "opus"
+        ):
+            return audio_path
 
     if output_path is None:
         temp_dir = Path(get_astrbot_temp_path())

--- a/tests/test_media_utils.py
+++ b/tests/test_media_utils.py
@@ -505,6 +505,51 @@ async def test_convert_audio_format_keeps_missing_target_path():
 
 
 @pytest.mark.asyncio
+async def test_convert_audio_format_offloads_magic_byte_probe(tmp_path, monkeypatch):
+    source_path = tmp_path / "voice.wav"
+    source_path.write_bytes(b"RIFF\x24\x00\x00\x00WAVEfmt " + b"\x00" * 16)
+    probe_calls = []
+
+    async def fake_to_thread(func, *args):
+        probe_calls.append((func, args))
+        return "wav"
+
+    monkeypatch.setattr(media_utils.asyncio, "to_thread", fake_to_thread)
+
+    result = await media_utils.convert_audio_format(
+        str(source_path),
+        output_format="wav",
+    )
+
+    assert result == str(source_path)
+    assert probe_calls == [(media_utils._get_audio_magic_type, (str(source_path),))]
+
+
+@pytest.mark.asyncio
+async def test_convert_audio_format_keeps_ogg_opus_without_reencoding(
+    tmp_path, monkeypatch
+):
+    source_path = tmp_path / "voice.ogg"
+    source_path.write_bytes(b"OggS" + b"\x00" * 20 + b"OpusHead" + b"\x00" * 32)
+
+    async def fail_create_subprocess_exec(*args, **kwargs):
+        raise AssertionError("an Ogg/Opus source should not be re-encoded")
+
+    monkeypatch.setattr(
+        media_utils.asyncio,
+        "create_subprocess_exec",
+        fail_create_subprocess_exec,
+    )
+
+    result = await media_utils.convert_audio_format(
+        str(source_path),
+        output_format="ogg",
+    )
+
+    assert result == str(source_path)
+
+
+@pytest.mark.asyncio
 async def test_media_resolver_cleans_http_target_when_download_fails(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary

- run the synchronous audio magic-byte probe in `asyncio.to_thread` so audio conversion does not block the event loop
- preserve the no-op fast path for Ogg Opus input requested as Ogg
- add regression coverage for the asynchronous probe and Ogg/Opus fast path

## Context

Follow-up to #9329. The current `master` includes the file-content check from #9612, but the probe still performs synchronous file I/O inside `convert_audio_format`, and Ogg Opus files are needlessly re-encoded when Ogg output is requested. This PR keeps the correctness fix on the latest `master` while addressing those remaining cases.

## Validation

Per request, local tests were not run.

## Summary by Sourcery

Keep audio conversion responsive by offloading format probes and preserving compatible Ogg Opus inputs.

Bug Fixes:
- Prevent synchronous audio format detection from blocking the asyncio event loop.
- Avoid unnecessary re-encoding when Ogg Opus input is requested as Ogg.

Tests:
- Add regression coverage for asynchronous audio probing and the Ogg Opus no-op path.